### PR TITLE
Add server description to index listing

### DIFF
--- a/views/servers/index.templet
+++ b/views/servers/index.templet
@@ -42,6 +42,7 @@
 		<thead>
 			<tr>
 				<th>Name</th>
+				<th>Description</th>
 				<th>Memory</th>
 				<th>Addresses</th>
 				<th>Uptime</th>
@@ -55,6 +56,7 @@
 <script type="text/html" id="tpl-host">
 	<% var mem_usage = 100-Math.round(100*memory.free/memory.total) %>
 	<td><a href="{$base_path}/servers/<%= id %>"><%= name %></a></td>
+	<td><%= description || "<i>none</i>" %></td>
 	<td>
 		<div class="progress progress-info progress-small" title="<%= mem_usage %>%">
 			<div class="bar" style="width: <%= mem_usage %>%"></div>


### PR DESCRIPTION
Our pool is somewhat heterogeneous (and brought to you by the magic which is xe pool-join --force)

Having the server description as well as its name is useful on the index page.
