### PR TITLE
Fix empty <dd> issues and alignment of information in <dl>s

### DIFF
--- a/views/servers/show.templet
+++ b/views/servers/show.templet
@@ -86,18 +86,21 @@
 					%></dd>
 					<dt>UUID:</dt>
 					<dd><%= uuid %></dd>
-					<br/>
+				</dl>
+				<dl class="dl-horizontal">
 					<dt>Hostname:</dt>
 					<dd><%= hostname %></dd>
 					<% for (var i = 0; i < PIFs.length; ++i)
 					{{
 						var PIF = PIFs[i];
-						%><dt><%= PIF.name %></dt><dd><%= PIF.IP %></dd><%
+						%><dt><%= PIF.name %></dt><dd><%= PIF.IP || "&nbsp;" %></dd><%
 					} %>
-					<br/>
+				</dl>
+				<dl class="dl-horizontal">
 					<dt>XCP version:</dt>
 					<dd><%= software_version.platform_version %></dd>
-					<br/>
+				</dl>
+				<dl class="dl-horizontal">
 					<% for (var i = 0; i < CPUs.length; ++i)
 					{{
 						var CPU = CPUs[i];

--- a/views/vms/show.templet
+++ b/views/vms/show.templet
@@ -105,7 +105,8 @@
 				} %></dd>
 				<dt>UUID:</dt>
 				<dd><%= id %></dd>
-				<br/>
+			</dl>
+			<dl class="dl-horizontal">
 				<dt>OS boot parameters:</dt>
 				<dd><%= HVM_boot_params.length ? HVM_boot_params.join(" ") : "<i>none</i>" %></dd>
 			</dl>


### PR DESCRIPTION
On Firefox 19 using the XO sytle, empty <dd> blocks collapse into
nothing, and lower ones reflow upwards, including <br/> blocks.

Remove <br/>s from the middle of <dl> blocks and split into seperate
<dl> blocks to limit the effect of the reflowing.

Insert &nbsp;s into the PIF list to prevent the empty <dd> blocks from
reflowing together, allowing the IP addreses to match up with their
correct PIF.
