### PR TITLE
Fix the memory bars for 100%

### DIFF
--- a/public/js/xo.js
+++ b/public/js/xo.js
@@ -325,7 +325,7 @@
 					};
 				}
 
-				if ((bar.value = Math.round(bar.value)) < 0)
+				if ((bar.value = Math.round(bar.value)) <= 0)
 				{
 					bar.value += 100;
 				}


### PR DESCRIPTION
When a host's free memory rounds to 0, the associated progress bar
would end up as 0% rater than 100%.  Now, completely full hosts are
correctly displayed.
