### PR TITLE
use standard js isNaN function.

### DIFF
--- a/app/scripts/filters.coffee
+++ b/app/scripts/filters.coffee
@@ -91,7 +91,7 @@ angular.module('xoWebApp')
         return 'N/A' if value[1] is 0
 
         result = 100 * value[0] / value[1]
-        if Number.isNaN result
+        if isNaN result
           return 'N/A'
 
         value = result


### PR DESCRIPTION
Number.isNaN does not exist in safari. 

The replacement isNaN is supported in all browsers: http://www.w3schools.com/jsref/jsref_isnan.asp
