### PR TITLE
Use desktop notification when available and when the browser is minified

### DIFF
--- a/app/node_modules/xo-notify/index.js
+++ b/app/node_modules/xo-notify/index.js
@@ -11,7 +11,56 @@ export default angular.module('xo-notify', [
   angularAnimate,
   angularNotifyToaster
 ])
-  .service('xoNotify', (toaster) => {
+  .service('xoNotify', (toaster, $window, $document) => {
+    const Notification = $window.Notification ||
+    /* Chrome & ff-html5notifications plugin */$window.webkitNotifications ||
+    /* Firefox Mobile */ navigator.mozNotification /* useless on mobile since page should be in front */ ||
+      {
+        permission: 'not capable',
+        requestPermission: function () {
+        }
+      }
+
+    // Set the name of the hidden property and the change event for visibility
+    let hidden_property, visibility_change_event, is_document_hidden
+    is_document_hidden = false
+    if (typeof $document.prop('hidden') !== 'undefined') { // Opera 12.10 and Firefox 18 and later support
+      hidden_property = 'hidden'
+      visibility_change_event = 'visibilitychange'
+    } else if (typeof $document.prop('mozHidden') !== 'undefined') {
+      hidden_property = 'mozHidden'
+      visibility_change_event = 'mozvisibilitychange'
+    } else if (typeof $document.prop('msHidden') !== 'undefined') {
+      hidden_property = 'msHidden'
+      visibility_change_event = 'msvisibilitychange'
+    } else if (typeof $document.prop('webkitHidden') !== 'undefined') {
+      hidden_property = 'webkitHidden'
+      visibility_change_event = 'webkitvisibilitychange'
+    }
+
+    if (typeof $document.prop(hidden_property) !== 'undefined') {
+      is_document_hidden = $document.prop(hidden_property)
+      $document.on(visibility_change_event, function () {
+        is_document_hidden = $document.prop(hidden_property)
+      })
+    }
+
+    $document.ready(function () { // some browser allow to ask for permission
+      Notification.requestPermission(function (permission) {
+        if (!('permission' in Notification)) {
+          Notification.permission = permission
+        }
+      })
+    })
+
+    $document.on('click', function () { // other force us to wit for a user interaction
+      Notification.requestPermission(function (permission) {
+        if (!('permission' in Notification)) {
+          Notification.permission = permission
+        }
+      })
+    })
+
     function makeNotifier (level) {
       return function notifier (options) {
         if (isString(options)) {
@@ -19,12 +68,29 @@ export default angular.module('xo-notify', [
         } else if (!options.message) {
           throw new Error('missing message')
         }
-
-        toaster.pop(
-          level,
-          options.title || 'Xen-Orchestra',
-          options.message
-        )
+        if (Notification.permission === 'granted' && is_document_hidden) {
+          const n = new Notification(options.title || 'Xen-Orchestra', {
+            body: options.message,
+            icon: 'images/logo_small.png'// ,
+            // tag: model.get('tag')
+          })
+          n.onclose = function () {
+            /* should I do something when notif is closed ? */
+          }
+          n.onshow = function () {
+            setTimeout(function () {
+              if (n) {
+                n.close()
+              }
+            }, 5000)
+          }
+        } else {
+          toaster.pop(
+            level,
+            options.title || 'Xen-Orchestra',
+            options.message
+          )
+        }
       }
     }
 


### PR DESCRIPTION
Implements #401 
If desktop notification are availables, ask for user permission
If user gave permission, and browser is minified/hidden, show a desktop notification 

On every other case, use toaster
