### PR TITLE
Servers infos should not refresh while a field is being edited

### DIFF
--- a/app/modules/settings/servers/index.js
+++ b/app/modules/settings/servers/index.js
@@ -38,8 +38,13 @@ export default angular.module('settings.servers', [
         this.servers = servers
       })
     }
+    const refreshServersIfUnfocused = () => {
+      if (!$scope.isFocused) {
+        refreshServers()
+      }
+    }
 
-    const interval = $interval(refreshServers, 10e3)
+    const interval = $interval(refreshServersIfUnfocused, 10e3)
     $scope.$on('$destroy', () => {
       $interval.cancel(interval)
     })

--- a/app/modules/settings/servers/view.jade
+++ b/app/modules/settings/servers/view.jade
@@ -23,11 +23,27 @@
                 i.xo-icon-failure.fa-lg(tooltip="Disconnected")
               span.input-group-addon.hidden-xs(ng-if="server.status === 'connecting'")
                 i.fa.fa-cog.fa-lg.fa-spin(tooltip="Connecting...")
-              input.form-control(type="text", ng-model="server.host")
+              input.form-control(
+                type="text",
+                ng-model="server.host",
+                ng-focus="$parent.isFocused = true",
+                ng-blur="$parent.isFocused = false"
+              )
           td
-            input.form-control(type="text", ng-model="server.username")
+            input.form-control(
+              type="text",
+              ng-model="server.username",
+              ng-focus="$parent.isFocused = true",
+              ng-blur="$parent.isFocused = false"
+            )
           td
-            input.form-control(type="password", ng-model="server.password", placeholder="Fill to change the password")
+            input.form-control(
+              type="password",
+              ng-model="server.password",
+              placeholder="Fill to change the password",
+              ng-focus="$parent.isFocused = true",
+              ng-blur="$parent.isFocused = false"
+            )
           td.text-center
             button.btn.btn-default(
               ng-if="server.status === 'disconnected'",


### PR DESCRIPTION
In servers settings view, when the Host, User or Password text field is being edited (ie the field has focus), `refreshServers` (which is called every 3 seconds) is disabled.
