### PR TITLE
Feedback when disconnecting a host from an SR does not work (See #810)

### DIFF
--- a/app/modules/sr/index.js
+++ b/app/modules/sr/index.js
@@ -113,13 +113,13 @@ export default angular.module('xoWebApp.sr', [
     $scope.connectPBD = function (id) {
       console.log('Connect PBD', id)
 
-      return xoApi.call('pbd.connect', {id: id})
+      return xo.pbd.connect(id)
     }
 
     $scope.disconnectPBD = function (id) {
       console.log('Disconnect PBD', id)
 
-      return xoApi.call('pbd.disconnect', {id: id})
+      return xo.pbd.disconnect(id)
     }
 
     $scope.reconnectAllHosts = function () {

--- a/app/node_modules/xo/index.js
+++ b/app/node_modules/xo/index.js
@@ -82,7 +82,7 @@ export default angular.module('xo', [
               } else if (code === 5) {
                 message = error.data
               } else if (code === 6) {
-                message = error.message
+                message = error.message[0].toUpperCase() + error.message.slice(1) + '.'
               }
             }
 

--- a/app/node_modules/xo/index.js
+++ b/app/node_modules/xo/index.js
@@ -81,6 +81,8 @@ export default angular.module('xo', [
                 message = 'You don\'t have the permission.'
               } else if (code === 5) {
                 message = error.data
+              } else if (code === 6) {
+                message = error.message
               }
             }
 
@@ -182,8 +184,9 @@ export default angular.module('xo', [
       },
 
       pbd: {
-        delete: action('Delete PBD'),
-        disconnect: action('Disconnect PBD')
+        delete: action('Delete PBD', 'pbd.delete'),
+        disconnect: action('Disconnect PBD', 'pbd.disconnect'),
+        connect: action('Connect PBD', 'pbd.connect')
       },
 
       server: {


### PR DESCRIPTION
- `xo.pbd.disconnect` instead of `xoApi.call(...)` so the error management is not bypassed.
- Error management: Display the error message in the notify box when the error code is 6.
