### PR TITLE
feat(new-vm): create mutiple VMs with a name pattern (fix #949)

### DIFF
--- a/src/common/intl/messages.js
+++ b/src/common/intl/messages.js
@@ -632,6 +632,7 @@ var messages = {
   newVmSelectResourceSet: 'Select a resource set:',
   newVmMultipleVmsPattern: 'Name pattern:',
   newVmMultipleVmsPatternPlaceholder: 'e.g.: \\{name\\}_%',
+  newVmFirstIndex: 'First index:',
 
   // ----- Self -----
   resourceSets: 'Resource sets',

--- a/src/common/intl/messages.js
+++ b/src/common/intl/messages.js
@@ -630,6 +630,8 @@ var messages = {
   newVmCreateVmsConfirm: 'Are you sure you want to create {nbVms} VMs?',
   newVmMultipleVms: 'Multiple VMs:',
   newVmSelectResourceSet: 'Select a resource set:',
+  newVmMultipleVmsPattern: 'Name pattern:',
+  newVmMultipleVmsPatternPlaceholder: 'e.g.: \\{name\\}_%',
 
   // ----- Self -----
   resourceSets: 'Resource sets',

--- a/src/xo-app/new-vm/index.js
+++ b/src/xo-app/new-vm/index.js
@@ -675,10 +675,7 @@ export default class NewVm extends BaseComponent {
           {_('newVmFirstIndex')}
           &nbsp;&nbsp;
           <DebounceInput
-            className={classNames(
-              styles.small,
-              'form-control'
-            )}
+            className={'form-control'}
             debounceTimeout={DEBOUNCE_TIMEOUT}
             disabled={!multipleVms}
             onChange={this._getOnChange('seqStart')}

--- a/src/xo-app/new-vm/index.js
+++ b/src/xo-app/new-vm/index.js
@@ -86,10 +86,10 @@ const LineItem = ({ children }) => (
     {children}
   </div>
 )
-const Item = ({ label, children }) => (
+const Item = ({ label, children, className }) => (
   <span className={styles.item}>
     {label && <span>{_(label)}&nbsp;</span>}
-    <span className={styles.input}>{children}</span>
+    <span className={classNames(styles.input, className)}>{children}</span>
   </span>
 )
 
@@ -650,44 +650,42 @@ export default class NewVm extends BaseComponent {
           />
         </Item>
       </SectionContent>
-      <SectionContent column>
-        <LineItem>
-          <Item>
-            {_('newVmMultipleVms')}
-            &nbsp;&nbsp;
-            <Toggle value={multipleVms} onChange={this._getOnChange('multipleVms')} />
-          </Item>
-          <Item>
-            {_('newVmMultipleVmsPattern')}
-            &nbsp;&nbsp;
-            <DebounceInput
-              className='form-control'
-              debounceTimeout={DEBOUNCE_TIMEOUT}
-              disabled={!multipleVms}
-              onChange={this._getOnChange('namePattern')}
-              placeholder={formatMessage(messages.newVmMultipleVmsPatternPlaceholder)}
-              value={namePattern}
-            />
-          </Item>
-          <Item>
-            <div className='input-group'>
-              <DebounceInput
-                className='form-control'
-                debounceTimeout={DEBOUNCE_TIMEOUT}
-                disabled={!multipleVms}
-                max={NB_VMS_MAX}
-                min={NB_VMS_MIN}
-                onChange={this._getOnChange('nbVms')}
-                type='number'
-                value={nbVms}
-              />
-              <span className='input-group-btn'>
-                <Button bsStyle='secondary' disabled={!multipleVms} onClick={this._updateNbVms}><Icon icon='arrow-right' /></Button>
-              </span>
-            </div>
-            <a className={styles.refreshNames} onClick={this._updateNameLabels}><Icon icon='refresh' /></a>
-          </Item>
-        </LineItem>
+      <SectionContent>
+        <Item>
+          {_('newVmMultipleVms')}
+          &nbsp;&nbsp;
+          <Toggle value={multipleVms} onChange={this._getOnChange('multipleVms')} />
+        </Item>
+        <Item>
+          {_('newVmMultipleVmsPattern')}
+          &nbsp;&nbsp;
+          <DebounceInput
+            className='form-control'
+            debounceTimeout={DEBOUNCE_TIMEOUT}
+            disabled={!multipleVms}
+            onChange={this._getOnChange('namePattern')}
+            placeholder={formatMessage(messages.newVmMultipleVmsPatternPlaceholder)}
+            value={namePattern}
+          />
+        </Item>
+        <Item className='input-group'>
+          <DebounceInput
+            className='form-control'
+            debounceTimeout={DEBOUNCE_TIMEOUT}
+            disabled={!multipleVms}
+            max={NB_VMS_MAX}
+            min={NB_VMS_MIN}
+            onChange={this._getOnChange('nbVms')}
+            type='number'
+            value={nbVms}
+          />
+          <span className='input-group-btn'>
+            <Button bsStyle='secondary' disabled={!multipleVms} onClick={this._updateNbVms}><Icon icon='arrow-right' /></Button>
+          </span>
+        </Item>
+        <Item>
+          <a className={styles.refreshNames} onClick={this._updateNameLabels}><Icon icon='refresh' /></a>
+        </Item>
         {multipleVms && <LineItem>
           {map(nameLabels, (nameLabel, index) =>
             <Item key={`nameLabel_${index}`}>


### PR DESCRIPTION
Pattern options:
- {name}: text in the "Name" input field
- {description}: text in the "Description" input field
- {template}: name_label of the selected template
- {pool}: name_label of the selected pool
- %: index (1, 2, 3, ...)
