### PR TITLE
fix(form/toggle): refresh when `set` is used on non-controlled compon…

### DIFF
--- a/src/common/form/toggle/index.js
+++ b/src/common/form/toggle/index.js
@@ -49,6 +49,10 @@ export default class Toggle extends Component {
     }
 
     this.refs.input.checked = Boolean(value)
+
+    if (this.props.value == null) {
+      this.forceUpdate()
+    }
   }
 
   _onChange = event => {

--- a/src/common/form/toggle/index.js
+++ b/src/common/form/toggle/index.js
@@ -49,10 +49,7 @@ export default class Toggle extends Component {
     }
 
     this.refs.input.checked = Boolean(value)
-
-    if (this.props.value == null) {
-      this.forceUpdate()
-    }
+    this.forceUpdate()
   }
 
   _onChange = event => {


### PR DESCRIPTION
…ent (fix #1339)
