### PR TITLE
fix(backup/new): better month and week days layout to prevent overlapping

### DIFF
--- a/src/common/scheduling.js
+++ b/src/common/scheduling.js
@@ -32,8 +32,10 @@ const MIN_PREVIEWS = 5
 const MAX_PREVIEWS = 20
 
 const MONTHS = [
-  [ 0, 1, 2, 3, 4, 5 ],
-  [ 6, 7, 8, 9, 10, 11 ]
+  [ 0, 1, 2 ],
+  [ 3, 4, 5 ],
+  [ 6, 7, 8 ],
+  [ 9, 10, 11 ]
 ]
 
 const DAYS = (() => {
@@ -52,7 +54,11 @@ const DAYS = (() => {
   return days
 })()
 
-const WEEK_DAYS = [[ 0, 1, 2, 3, 4, 5, 6 ]]
+const WEEK_DAYS = [
+  [ 0, 1, 2 ],
+  [ 3, 4, 5 ],
+  [ 6 ]
+]
 
 const HOURS = (() => {
   const hours = []


### PR DESCRIPTION
Fixes #1488
