### PR TITLE
fix(self-service): make it controlled and multiple fixes

### DIFF
--- a/src/common/editable/index.js
+++ b/src/common/editable/index.js
@@ -406,9 +406,8 @@ export class XoSelect extends Editable {
       <span>{this.props.value[this.props.labelProp]}</span>
   }
 
-  _onChange = object => {
-    object ? this._save() : this._closeEdition()
-  }
+  _onChange = object =>
+    object && this._save()
 
   _renderEdition () {
     const {

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -462,3 +462,20 @@ export const htmlFileToStream = file => {
 
   return stream
 }
+
+// ===================================================================
+
+export const resolveId = value =>
+  (value != null && typeof value === 'object' && 'id' in value)
+    ? value.id
+    : value
+
+export const resolveIds = params => {
+  for (const key in params) {
+    const param = params[key]
+    if (param != null && typeof param === 'object' && 'id' in param) {
+      params[key] = param.id
+    }
+  }
+  return params
+}

--- a/src/common/xo/index.js
+++ b/src/common/xo/index.js
@@ -24,7 +24,7 @@ import invoke from '../invoke'
 import logError from '../log-error'
 import { alert, confirm } from '../modal'
 import { error, info, success } from '../notification'
-import { noop, rethrow, tap } from '../utils'
+import { noop, rethrow, tap, resolveId, resolveIds } from '../utils'
 import {
   connected,
   disconnected,
@@ -267,23 +267,6 @@ export const apiMethods = _call('system.getMethodsInfo')
 export const serverVersion = _call('system.getServerVersion')
 
 export const getXoServerTimezone = _call('system.getServerTimezone')
-
-// ===================================================================
-
-const resolveId = value =>
-  (value != null && typeof value === 'object' && 'id' in value)
-    ? value.id
-    : value
-
-const resolveIds = params => {
-  for (const key in params) {
-    const param = params[key]
-    if (param != null && typeof param === 'object' && 'id' in param) {
-      params[key] = param.id
-    }
-  }
-  return params
-}
 
 // XO --------------------------------------------------------------------------
 

--- a/src/xo-app/new-vm/index.js
+++ b/src/xo-app/new-vm/index.js
@@ -647,7 +647,7 @@ export default class NewVm extends BaseComponent {
 
     this.context.router.push({
       pathname,
-      query: { resourceSet: resourceSet.id }
+      query: resourceSet && { resourceSet: resourceSet.id }
     })
     this._reset()
   }
@@ -656,7 +656,7 @@ export default class NewVm extends BaseComponent {
 
     this.context.router.push({
       pathname,
-      query: { pool: pool.id }
+      query: pool && { pool: pool.id }
     })
     this._reset()
   }

--- a/src/xo-app/self/helpers.js
+++ b/src/xo-app/self/helpers.js
@@ -1,9 +1,15 @@
 import _ from 'intl'
+import filter from 'lodash/filter'
+import forEach from 'lodash/forEach'
+import includes from 'lodash/includes'
+import intersection from 'lodash/intersection'
 import keyBy from 'lodash/keyBy'
 import map from 'lodash/map'
 import propTypes from 'prop-types'
 import React, { Component } from 'react'
+import reduce from 'lodash/reduce'
 import renderXoItem from 'render-xo-item'
+import { resolveIds } from 'utils'
 
 import {
   subscribeGroups,
@@ -65,4 +71,26 @@ export class Subjects extends Component {
       </div>
     )
   }
+}
+
+export const computeAvailableHosts = (pools, srs, hostsByPool) => {
+  const validHosts = reduce(
+    hostsByPool,
+    (result, hosts, poolId) =>
+      includes(resolveIds(pools), poolId)
+        ? result.concat(hosts)
+        : result,
+    []
+  )
+
+  const availableHosts = filter(validHosts, host => {
+    let kept = false
+
+    forEach(srs, sr =>
+      !(kept = intersection(sr.$PBDs, host.$PBDs).length > 0)
+    )
+
+    return kept
+  })
+  return availableHosts
 }

--- a/src/xo-app/vm/tab-network.js
+++ b/src/xo-app/vm/tab-network.js
@@ -113,11 +113,7 @@ class VifItem extends BaseComponent {
   _getIps = createSelector(
     () => this.props.vif.allowedIpv4Addresses || EMPTY_ARRAY,
     () => this.props.vif.allowedIpv6Addresses || EMPTY_ARRAY,
-    (...args) => {
-      const result = concat(...args)
-      console.log('_getIps', result)
-      return result
-    }
+    (...args) => concat(...args)
   )
   _getIpPredicate = createSelector(
     this._getIps,

--- a/src/xo-app/vm/tab-network.js
+++ b/src/xo-app/vm/tab-network.js
@@ -113,7 +113,7 @@ class VifItem extends BaseComponent {
   _getIps = createSelector(
     () => this.props.vif.allowedIpv4Addresses || EMPTY_ARRAY,
     () => this.props.vif.allowedIpv6Addresses || EMPTY_ARRAY,
-    (...args) => concat(...args)
+    concat
   )
   _getIpPredicate = createSelector(
     this._getIps,


### PR DESCRIPTION
Fixes:
- VIF IP edition was not possible if the current IP's IP-pool did not exist anymore
- VM creation: removing the pool/resource set in the selector was broken
- Prevent selecting a negative number as an IP pool quantity
- Prevent deleting a resource set that hasn't been created yet
- Remove console.log