### PR TITLE
fix(vm/action-bar): hide migrate button when the vm is halted

### DIFF
--- a/src/xo-app/vm/action-bar.js
+++ b/src/xo-app/vm/action-bar.js
@@ -82,12 +82,6 @@ const vmActionBarByState = {
         pending={includes(vm.current_operations, 'clone')}
       />}
       {!isSelfUser && <Action
-        handler={migrateVm}
-        icon='vm-migrate'
-        label={_('migrateVmLabel')}
-        pending={includes(vm.current_operations, 'pool_migrate')}
-      />}
-      {!isSelfUser && <Action
         handler={snapshotVm}
         icon='vm-snapshot'
         label={_('snapshotVmLabel')}


### PR DESCRIPTION
Fixes #2233