### PR TITLE
feat(homeVm): add sparklines in the expanded home VM view. Fixes #2469

### DIFF
--- a/src/common/xo-sparklines.js
+++ b/src/common/xo-sparklines.js
@@ -73,36 +73,16 @@ export const XvdSparkLines = propTypes({
   )
 })
 
-export const VifSparkLines = propTypes({
+export const NetworkSparkLines = propTypes({
   data: propTypes.object.isRequired
 })(({ data, width = WIDTH, height = HEIGHT, strokeWidth = STROKE_WIDTH }) => {
-  const { vifs } = data.stats
+  const { pifs, vifs: ifs = pifs } = data.stats
 
-  if (!vifs) {
-    return templateError
-  }
-
-  return (
-    <Sparklines style={STYLE} data={computeObjectsAvg(vifs)} min={0} width={width} height={height}>
+  return ifs === undefined
+    ? templateError
+    : <Sparklines style={STYLE} data={computeObjectsAvg(ifs)} min={0} width={width} height={height}>
       <SparklinesLine style={{ strokeWidth, stroke: '#eca649', fill: '#eca649', fillOpacity: 0.5 }} color='#ffd633' />
     </Sparklines>
-  )
-})
-
-export const PifSparkLines = propTypes({
-  data: propTypes.object.isRequired
-})(({ data, width = WIDTH, height = HEIGHT, strokeWidth = STROKE_WIDTH }) => {
-  const { pifs } = data.stats
-
-  if (!pifs) {
-    return templateError
-  }
-
-  return (
-    <Sparklines style={STYLE} data={computeObjectsAvg(pifs)} min={0} width={width} height={height}>
-      <SparklinesLine style={{ strokeWidth, stroke: '#eca649', fill: '#eca649', fillOpacity: 0.5 }} color='#ffd633' />
-    </Sparklines>
-  )
 })
 
 export const LoadSparkLines = propTypes({

--- a/src/xo-app/home/host-item.js
+++ b/src/xo-app/home/host-item.js
@@ -31,54 +31,9 @@ import {
   createGetObjectsOfType,
   createSelector
 } from 'selectors'
-import {
-  CpuSparkLines,
-  LoadSparkLines,
-  PifSparkLines
-} from 'xo-sparklines'
 
+import MiniStats from './mini-stats'
 import styles from './index.css'
-
-const MINI_STATS_PROPS = {
-  height: 10,
-  strokeWidth: 0.2,
-  width: 50
-}
-class MiniStats extends Component {
-  _fetch = () => {
-    fetchHostStats(this.props.hostId).then(stats => {
-      this.setState({ stats })
-    })
-  }
-
-  componentWillMount () {
-    this._fetch()
-    this.subscriptionId = setInterval(this._fetch, 5e3)
-  }
-  componentWillUnmount () {
-    clearInterval(this.subscriptionId)
-  }
-
-  render () {
-    const { stats } = this.state
-
-    if (!stats) {
-      return <Icon icon='loading' />
-    }
-
-    return <Row>
-      <Col mediumSize={4} className={styles.itemExpanded}>
-        <CpuSparkLines data={stats} {...MINI_STATS_PROPS} />
-      </Col>
-      <Col mediumSize={4} className={styles.itemExpanded}>
-        <PifSparkLines data={stats} {...MINI_STATS_PROPS} />
-      </Col>
-      <Col mediumSize={4} className={styles.itemExpanded}>
-        <LoadSparkLines data={stats} {...MINI_STATS_PROPS} />
-      </Col>
-    </Row>
-  }
-}
 
 @connectStore(() => ({
   container: createGetObject((_, props) => props.item.$pool),
@@ -97,6 +52,7 @@ export default class HostItem extends Component {
   }
 
   _addTag = tag => addTag(this.props.item.id, tag)
+  _fetchStats = () => fetchHostStats(this.props.item.id)
   _removeTag = tag => removeTag(this.props.item.id, tag)
   _setNameDescription = nameDescription => editHost(this.props.item, { name_description: nameDescription })
   _setNameLabel = nameLabel => editHost(this.props.item, { name_label: nameLabel })
@@ -212,7 +168,7 @@ export default class HostItem extends Component {
             </span>
           </Col>
           <Col mediumSize={6} className={styles.itemExpanded}>
-            <MiniStats hostId={this.props.item} />
+            <MiniStats fetch={this._fetchStats} />
           </Col>
         </Row>
       }

--- a/src/xo-app/home/host-item.js
+++ b/src/xo-app/home/host-item.js
@@ -197,9 +197,6 @@ export default class HostItem extends Component {
       </BlockLink>
       {(this.state.expanded || expandAll) &&
         <Row>
-          <Col mediumSize={6} className={styles.itemExpanded}>
-            <MiniStats hostId={this.props.item} />
-          </Col>
           <Col mediumSize={2} className={styles.itemExpanded} style={{ marginTop: '0.3rem' }}>
             <span>
               {host.cpus.cores}x <Icon icon='cpu' />
@@ -213,6 +210,9 @@ export default class HostItem extends Component {
             <span style={{fontSize: '1.4em'}}>
               <HomeTags type='host' labels={host.tags} onDelete={this._removeTag} onAdd={this._addTag} />
             </span>
+          </Col>
+          <Col mediumSize={6} className={styles.itemExpanded}>
+            <MiniStats hostId={this.props.item} />
           </Col>
         </Row>
       }

--- a/src/xo-app/home/mini-stats.js
+++ b/src/xo-app/home/mini-stats.js
@@ -1,0 +1,62 @@
+import Component from 'base-component'
+import Icon from 'icon'
+import propTypes from 'prop-types-decorator'
+import React from 'react'
+import { Col, Row } from 'grid'
+import {
+  CpuSparkLines,
+  LoadSparkLines,
+  NetworkSparkLines,
+  XvdSparkLines
+} from 'xo-sparklines'
+
+import styles from './index.css'
+
+const MINI_STATS_PROPS = {
+  height: 10,
+  strokeWidth: 0.2,
+  width: 50
+}
+
+@propTypes({
+  fetchStats: propTypes.func.isRequired
+})
+export default class MiniStats extends Component {
+  _fetch = () => {
+    this.props.fetch().then(stats => {
+      this.setState({ stats })
+      this._timeout = setTimeout(this._fetch, 5e3)
+    })
+  }
+
+  componentWillMount () {
+    this._fetch()
+  }
+
+  componentWillUnmount () {
+    clearTimeout(this._timeout)
+  }
+
+  render () {
+    const { stats } = this.state
+
+    if (stats === undefined) {
+      return <Icon icon='loading' />
+    }
+
+    return <Row>
+      <Col mediumSize={4} className={styles.itemExpanded}>
+        <CpuSparkLines data={stats} {...MINI_STATS_PROPS} />
+      </Col>
+      <Col mediumSize={4} className={styles.itemExpanded}>
+        <NetworkSparkLines data={stats} {...MINI_STATS_PROPS} />
+      </Col>
+      <Col mediumSize={4} className={styles.itemExpanded}>
+        {stats.stats.load !== undefined
+          ? <LoadSparkLines data={stats} {...MINI_STATS_PROPS} />
+          : <XvdSparkLines data={stats} {...MINI_STATS_PROPS} />
+        }
+      </Col>
+    </Row>
+  }
+}

--- a/src/xo-app/home/vm-item.js
+++ b/src/xo-app/home/vm-item.js
@@ -36,54 +36,9 @@ import {
   createSelector,
   createSumBy
 } from 'selectors'
-import {
-  CpuSparkLines,
-  VifSparkLines,
-  XvdSparkLines
-} from 'xo-sparklines'
 
+import MiniStats from './mini-stats'
 import styles from './index.css'
-
-const MINI_STATS_PROPS = {
-  height: 10,
-  strokeWidth: 0.2,
-  width: 50
-}
-class MiniStats extends Component {
-  _fetch = () => {
-    fetchVmStats(this.props.vmId).then(stats => {
-      this.setState({ stats })
-    })
-  }
-
-  componentWillMount () {
-    this._fetch()
-    this.subscriptionId = setInterval(this._fetch, 5e3)
-  }
-  componentWillUnmount () {
-    clearInterval(this.subscriptionId)
-  }
-
-  render () {
-    const { stats } = this.state
-
-    if (!stats) {
-      return <Icon icon='loading' />
-    }
-
-    return <Row>
-      <Col mediumSize={4} className={styles.itemExpanded}>
-        <CpuSparkLines data={stats} {...MINI_STATS_PROPS} />
-      </Col>
-      <Col mediumSize={4} className={styles.itemExpanded}>
-        <VifSparkLines data={stats} {...MINI_STATS_PROPS} />
-      </Col>
-      <Col mediumSize={4} className={styles.itemExpanded}>
-        <XvdSparkLines data={stats} {...MINI_STATS_PROPS} />
-      </Col>
-    </Row>
-  }
-}
 
 @addSubscriptions({
   resourceSets: subscribeResourceSets
@@ -110,6 +65,7 @@ export default class VmItem extends Component {
   )
 
   _addTag = tag => addTag(this.props.item.id, tag)
+  _fetchStats = () => fetchVmStats(this.props.item.id)
   _migrateVm = host => migrateVm(this.props.item, host)
   _removeTag = tag => removeTag(this.props.item.id, tag)
   _setNameDescription = nameDescription => editVm(this.props.item, { name_description: nameDescription })
@@ -232,7 +188,7 @@ export default class VmItem extends Component {
             </span>
           </Col>
           <Col mediumSize={6} className={styles.itemExpanded}>
-            {this._isRunning && <MiniStats vmId={this.props.item} />}
+            {this._isRunning && <MiniStats fetch={this._fetchStats} />}
           </Col>
         </Row>
       }

--- a/src/xo-app/host/tab-console.js
+++ b/src/xo-app/host/tab-console.js
@@ -13,7 +13,7 @@ import { Container, Row, Col } from 'grid'
 import {
   CpuSparkLines,
   MemorySparkLines,
-  PifSparkLines,
+  NetworkSparkLines,
   LoadSparkLines
 } from 'xo-sparklines'
 
@@ -59,7 +59,7 @@ export default class extends Component {
           <Col mediumSize={3}>
             <Icon icon='network' size={2} />
             {' '}
-            <PifSparkLines data={statsOverview} />
+            <NetworkSparkLines data={statsOverview} />
           </Col>
           <Col mediumSize={3}>
             <Icon icon='disk' size={2} />

--- a/src/xo-app/host/tab-general.js
+++ b/src/xo-app/host/tab-general.js
@@ -16,7 +16,7 @@ import { createString, createProperty, toString } from 'complex-matcher'
 import {
   CpuSparkLines,
   MemorySparkLines,
-  PifSparkLines,
+  NetworkSparkLines,
   LoadSparkLines
 } from 'xo-sparklines'
 
@@ -44,7 +44,7 @@ export default ({
       </Col>
       <Col mediumSize={3}>
         <BlockLink to={`/hosts/${host.id}/network`}><h2>{host.$PIFs.length}x <Icon icon='network' size='lg' /></h2></BlockLink>
-        <BlockLink to={`/hosts/${host.id}/stats`}>{statsOverview && <PifSparkLines data={statsOverview} />}</BlockLink>
+        <BlockLink to={`/hosts/${host.id}/stats`}>{statsOverview && <NetworkSparkLines data={statsOverview} />}</BlockLink>
       </Col>
       <Col mediumSize={3}>
         <BlockLink to={`/hosts/${host.id}/storage`}><h2>{host.$PBDs.length}x <Icon icon='disk' size='lg' /></h2></BlockLink>

--- a/src/xo-app/vm/tab-console.js
+++ b/src/xo-app/vm/tab-console.js
@@ -14,7 +14,7 @@ import { Container, Row, Col } from 'grid'
 import {
   CpuSparkLines,
   MemorySparkLines,
-  VifSparkLines,
+  NetworkSparkLines,
   XvdSparkLines
 } from 'xo-sparklines'
 
@@ -89,7 +89,7 @@ export default class TabConsole extends Component {
             <p>
               <Icon icon='network' size={2} />
               {' '}
-              <VifSparkLines data={statsOverview} />
+              <NetworkSparkLines data={statsOverview} />
             </p>
           </Col>
           <Col mediumSize={3}>

--- a/src/xo-app/vm/tab-general.js
+++ b/src/xo-app/vm/tab-general.js
@@ -27,7 +27,7 @@ import {
 import {
   CpuSparkLines,
   MemorySparkLines,
-  VifSparkLines,
+  NetworkSparkLines,
   XvdSparkLines
 } from 'xo-sparklines'
 
@@ -78,7 +78,7 @@ export default connectStore(() => {
     </Col>
     <Col mediumSize={3}>
       <BlockLink to={`/vms/${vm.id}/network`}><h2>{vm.VIFs.length}x <Icon icon='network' size='lg' /></h2></BlockLink>
-      <BlockLink to={`/vms/${vm.id}/stats`}>{statsOverview && <VifSparkLines data={statsOverview} />}</BlockLink>
+      <BlockLink to={`/vms/${vm.id}/stats`}>{statsOverview && <NetworkSparkLines data={statsOverview} />}</BlockLink>
     </Col>
     <Col mediumSize={3}>
       <BlockLink to={`/vms/${vm.id}/disks`}><h2>{formatSize(vmTotalDiskSpace)} <Icon icon='disk' size='lg' /></h2></BlockLink>


### PR DESCRIPTION
* moved home/host stats to the right for more consistency with home/VM view
* works well from small to big screens