### PR TITLE
fix(select): multi select should not close on item selection

### DIFF
--- a/src/common/form/select.js
+++ b/src/common/form/select.js
@@ -127,6 +127,7 @@ export default class Select extends Component {
   render () {
     return (
       <ReactSelect
+        closeOnSelect={!this.props.multi}
         {...this.props}
         backspaceToRemoveMessage=''
         menuRenderer={this._renderMenu}


### PR DESCRIPTION
New default behaviour introduced by react-select v1.0.0-rc.9