### PR TITLE
chore(react-select): autofocus → autoFocus

### DIFF
--- a/src/common/form/select-plain-object.js
+++ b/src/common/form/select-plain-object.js
@@ -101,7 +101,7 @@ export default class SelectPlainObject extends Component {
 
     return (
       <Select
-        autofocus={props.autoFocus}
+        autoFocus={props.autoFocus}
         disabled={props.disabled}
         multi={props.multi}
         onChange={this._handleChange}

--- a/src/common/select-objects.js
+++ b/src/common/select-objects.js
@@ -248,7 +248,7 @@ export class GenericSelect extends Component {
     const select = (
       <Select
         {...{
-          autofocus: autoFocus,
+          autoFocus,
           clearable,
           disabled,
           multi,


### PR DESCRIPTION
[`autofocus` is deprecated](https://github.com/JedWatson/react-select#select-props).