### PR TITLE
chore(lint-staged): rewritten in JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "exec-promise": "^0.7.0",
     "flow-bin": "^0.66.0",
     "globby": "^8.0.0",
+    "golike-defer": "^0.4.1",
     "husky": "^0.14.3",
     "jest": "^22.0.4",
     "lodash": "^4.17.4",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "exec-promise": "^0.7.0",
     "flow-bin": "^0.66.0",
     "globby": "^8.0.0",
-    "golike-defer": "^0.4.1",
     "husky": "^0.14.3",
     "jest": "^22.0.4",
     "lodash": "^4.17.4",

--- a/scripts/lint-staged
+++ b/scripts/lint-staged
@@ -18,15 +18,8 @@ const testFiles = files =>
 const { execFileSync, spawnSync } = require('child_process')
 const { readFileSync, writeFileSync } = require('fs')
 
-const run = (command, args, opts) => {
-  const { status } = spawnSync(
-    command,
-    args,
-    Object.assign({
-      stdio: 'inherit',
-      opts,
-    })
-  )
+const run = (command, args) => {
+  const { status } = spawnSync(command, args, { stdio: 'inherit' })
   if (status !== 0) {
     process.exit(status)
   }

--- a/scripts/lint-staged
+++ b/scripts/lint-staged
@@ -50,8 +50,7 @@ const gitDiffIndex = () => gitDiff('index', ['--cached', 'HEAD'])
 
 // -----------------------------------------------------------------------------
 
-let files = gitDiffIndex()
-files = files.filter(_ => _.endsWith('.js'))
+const files = gitDiffIndex().filter(_ => _.endsWith('.js'))
 if (files.length === 0) {
   return
 }

--- a/scripts/lint-staged
+++ b/scripts/lint-staged
@@ -48,37 +48,36 @@ const gitDiff = (what, args = []) =>
 const gitDiffFiles = (files = []) => gitDiff('files', files)
 const gitDiffIndex = () => gitDiff('index', ['--cached', 'HEAD'])
 
-function main () {
-  let files = gitDiffIndex()
-  files = files.filter(_ => _.endsWith('.js'))
-  if (files.length === 0) {
-    return
-  }
+// -----------------------------------------------------------------------------
 
-  // save the list of files with unstaged changes
-  let unstaged = gitDiffFiles(files)
+let files = gitDiffIndex()
+files = files.filter(_ => _.endsWith('.js'))
+if (files.length === 0) {
+  return
+}
 
-  // format all files
-  formatFiles(files)
+// save the list of files with unstaged changes
+let unstaged = gitDiffFiles(files)
+
+if (unstaged.length !== 0) {
+  // refresh the list of files with unstaged changes, maybe the
+  // changes have been reverted by the formatting
+  run('git', ['update-index', '-q', '--refresh'])
+  unstaged = gitDiffFiles(unstaged)
 
   if (unstaged.length !== 0) {
-    // refresh the list of files with unstaged changes, maybe the
-    // changes have been reverted by the formatting
-    run('git', ['update-index', '-q', '--refresh'])
-    unstaged = gitDiffFiles(unstaged)
-
-    if (unstaged.length !== 0) {
-      const contents = unstaged.map(name => readFileSync(name))
-      process.on('exit', () =>
-        unstaged.map((name, i) => writeFileSync(name, contents[i]))
-      )
-      run('git', ['checkout'].concat(unstaged))
-      formatFiles(unstaged)
-    }
+    const contents = unstaged.map(name => readFileSync(name))
+    process.on('exit', () =>
+      unstaged.map((name, i) => writeFileSync(name, contents[i]))
+    )
+    run('git', ['checkout'].concat(unstaged))
+    formatFiles(unstaged)
   }
-
-  testFiles(files)
-
-  run('git', ['add'].concat(files))
 }
-main()
+
+// format all files
+formatFiles(files)
+
+testFiles(files)
+
+run('git', ['add'].concat(files))

--- a/scripts/lint-staged
+++ b/scripts/lint-staged
@@ -1,52 +1,78 @@
-#!/bin/sh
+#!/usr/bin/env node
 
-set -eu
-
-format_files () {
-  prettier --write "$@"
-  eslint --ignore-pattern '!*' --fix "$@"
+const formatFiles = files => {
+  run('./node_modules/.bin/prettier', ['--write'].concat(files))
+  run(
+    './node_modules/.bin/eslint',
+    ['--ignore-pattern', '!*', '--fix'].concat(files)
+  )
 }
-test_files () {
-  jest --findRelatedTests --passWithNoTests "$@"
-}
+const testFiles = files =>
+  run(
+    './node_modules/.bin/jest',
+    ['--findRelatedTests', '--passWithNoTests'].concat(files)
+  )
 
-# compute the list of staged files we are interested in
-set --
-buf=$(mktemp -u)
-git diff-index --cached --diff-filter=AM --name-only HEAD > "$buf"
-while IFS= read -r file
-do
-  case "$file" in
-    *.js)
-      set -- "$@" "$file";;
-  esac
-done < "$buf"
-rm -f "$buf"
+// -----------------------------------------------------------------------------
 
-if [ $# -eq 0 ]
-then
-  exit
-fi
+const defer = require('golike-defer').default
+const { execFileSync, spawnSync } = require('child_process')
+const { readFileSync, writeFileSync } = require('fs')
 
-format_files "$@"
+const run = (command, args, opts) =>
+  spawnSync(
+    command,
+    args,
+    Object.assign({
+      stdio: 'inherit',
+      opts,
+    })
+  )
 
-# stash unstaged changes
-if stash=$(git stash create --keep-index --quiet)
-then
-  # remove those changes from the worktree
-  git checkout .
+const gitDiff = (what, args = []) =>
+  execFileSync(
+    'git',
+    [
+      'diff-' + what,
+      '--diff-filter=AM',
+      '--ignore-submodules',
+      '--name-only',
+    ].concat(args),
+    { encoding: 'utf8' }
+  )
+    .split('\n')
+    .filter(_ => _ !== '')
+const gitDiffFiles = (files = []) => gitDiff('files', files)
+const gitDiffIndex = () => gitDiff('index', ['--cached', 'HEAD'])
 
-  format_files "$@"
-
-  # unstash on exit
-  on_exit () {
-    git read-tree HEAD
-    git checkout $stash "$@"
+defer($defer => {
+  let files = gitDiffIndex()
+  files = files.filter(_ => _.endsWith('.js'))
+  if (files.length === 0) {
+    return
   }
-  trap 'GIT_INDEX_FILE=$buf on_exit "$@"; rm -f "$buf"' EXIT
-fi
 
-test_files "$@"
+  // save the list of files with unstaged changes
+  let unstaged = gitDiffFiles(files)
 
-# add any changes made by the commands
-git add "$@"
+  // format all files
+  formatFiles(files)
+
+  if (unstaged.length !== 0) {
+    // refresh the list of files with unstaged changes, maybe the
+    // changes have been reverted by the formatting
+    run('git', ['update-index', '-q', '--refresh'])
+    unstaged = gitDiffFiles(unstaged)
+
+    if (unstaged.length !== 0) {
+      const contents = unstaged.map(name => readFileSync(name))
+      $defer(() => unstaged.map((name, i) => writeFileSync(name, contents[i])))
+      run('git', ['checkout'].concat(unstaged))
+      formatFiles(unstaged)
+    }
+  }
+
+  testFiles(files)
+
+  run('git', ['add'].concat(files))
+})()

--- a/scripts/lint-staged
+++ b/scripts/lint-staged
@@ -15,7 +15,6 @@ const testFiles = files =>
 
 // -----------------------------------------------------------------------------
 
-const defer = require('golike-defer').default
 const { execFileSync, spawnSync } = require('child_process')
 const { readFileSync, writeFileSync } = require('fs')
 
@@ -29,7 +28,7 @@ const run = (command, args, opts) => {
     })
   )
   if (status !== 0) {
-    throw status
+    process.exit(status)
   }
 }
 
@@ -49,7 +48,7 @@ const gitDiff = (what, args = []) =>
 const gitDiffFiles = (files = []) => gitDiff('files', files)
 const gitDiffIndex = () => gitDiff('index', ['--cached', 'HEAD'])
 
-defer($defer => {
+function main () {
   let files = gitDiffIndex()
   files = files.filter(_ => _.endsWith('.js'))
   if (files.length === 0) {
@@ -70,7 +69,9 @@ defer($defer => {
 
     if (unstaged.length !== 0) {
       const contents = unstaged.map(name => readFileSync(name))
-      $defer(() => unstaged.map((name, i) => writeFileSync(name, contents[i])))
+      process.on('exit', () =>
+        unstaged.map((name, i) => writeFileSync(name, contents[i]))
+      )
       run('git', ['checkout'].concat(unstaged))
       formatFiles(unstaged)
     }
@@ -79,4 +80,5 @@ defer($defer => {
   testFiles(files)
 
   run('git', ['add'].concat(files))
-})()
+}
+main()

--- a/scripts/lint-staged
+++ b/scripts/lint-staged
@@ -19,8 +19,8 @@ const defer = require('golike-defer').default
 const { execFileSync, spawnSync } = require('child_process')
 const { readFileSync, writeFileSync } = require('fs')
 
-const run = (command, args, opts) =>
-  spawnSync(
+const run = (command, args, opts) => {
+  const { status } = spawnSync(
     command,
     args,
     Object.assign({
@@ -28,6 +28,10 @@ const run = (command, args, opts) =>
       opts,
     })
   )
+  if (status !== 0) {
+    throw status
+  }
+}
 
 const gitDiff = (what, args = []) =>
   execFileSync(

--- a/scripts/lint-staged
+++ b/scripts/lint-staged
@@ -51,6 +51,9 @@ if (files.length === 0) {
 // save the list of files with unstaged changes
 let unstaged = gitDiffFiles(files)
 
+// format all files
+formatFiles(files)
+
 if (unstaged.length !== 0) {
   // refresh the list of files with unstaged changes, maybe the
   // changes have been reverted by the formatting
@@ -66,9 +69,6 @@ if (unstaged.length !== 0) {
     formatFiles(unstaged)
   }
 }
-
-// format all files
-formatFiles(files)
 
 testFiles(files)
 


### PR DESCRIPTION
- simpler code, no need to hack around the shell
- no more double formatting
- no longer use git stash, simply cache files in memory