### PR TITLE
chore(xo-server/createNetwork): set other_config.automatic to false

### DIFF
--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -2011,7 +2011,9 @@ export default class Xapi extends XapiBase {
       name_label: name,
       name_description: description,
       MTU: asInteger(mtu),
-      other_config: {},
+      // Set automatic to false so XenCenter does not get confused
+      // https://citrix.github.io/xenserver-sdk/#network
+      other_config: { automatic: 'false' },
     })
     $defer.onFailure(() => this.call('network.destroy', networkRef))
     if (pifId) {


### PR DESCRIPTION
Fixes #2818

If a network has its other_config.automatic value set to any value other than
false then XenCenter's New VM wizard will create a VIF connected to this network
See https://citrix.github.io/xenserver-sdk/#network