### PR TITLE
(xo-web: VM/ Advanced): display 'Not installed' when Xen tools is not installed. 

### DIFF
--- a/packages/xo-server/src/xapi-object-to-xo.js
+++ b/packages/xo-server/src/xapi-object-to-xo.js
@@ -227,11 +227,15 @@ const TRANSFORMS = {
         return
       }
 
-      if (!guestMetrics) {
+      if (guestMetrics === undefined) {
         return false
       }
 
       const { major, minor } = guestMetrics.PV_drivers_version
+
+      if (major === undefined || minor === undefined) {
+        return false
+      }
 
       return {
         major,

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -933,6 +933,7 @@ const messages = {
   defaultCpuCap: 'Default ({value, number})',
   pvArgsLabel: 'PV args',
   xenToolsStatus: 'Xen tools version',
+  xenToolsNotInstalled: 'Not installed',
   osName: 'OS name',
   osKernel: 'OS kernel',
   autoPowerOn: 'Auto power on',

--- a/packages/xo-web/src/xo-app/vm/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/vm/tab-advanced.js
@@ -585,7 +585,9 @@ export default class TabAdvanced extends Component {
                 <tr>
                   <th>{_('xenToolsStatus')}</th>
                   <td>
-                    {vm.xenTools && `${vm.xenTools.major}.${vm.xenTools.minor}`}
+                    {vm.xenTools
+                      ? `${vm.xenTools.major}.${vm.xenTools.minor}`
+                      : _('xenToolsNotInstalled')}
                   </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
fix #2911
