### PR TITLE
feat(xo-web): make many objects' UUID copiable

### DIFF
--- a/packages/xo-web/package.json
+++ b/packages/xo-web/package.json
@@ -33,7 +33,6 @@
     "@julien-f/freactal": "0.1.0",
     "@nraynaud/novnc": "0.6.1",
     "@xen-orchestra/cron": "^1.0.3",
-    "xo-vmdk-to-vhd": "0.1.0",
     "ansi_up": "^3.0.0",
     "asap": "^2.0.6",
     "babel-core": "^6.26.0",
@@ -60,6 +59,7 @@
     "classnames": "^2.2.3",
     "complex-matcher": "^0.3.0",
     "cookies-js": "^1.2.2",
+    "copy-to-clipboard": "^3.0.8",
     "d3": "^5.0.0",
     "debounce-input-decorator": "^0.1.0",
     "enzyme": "^3.3.0",
@@ -137,7 +137,8 @@
     "xo-acl-resolver": "^0.2.3",
     "xo-common": "^0.1.1",
     "xo-lib": "^0.8.0",
-    "xo-remote-parser": "^0.3"
+    "xo-remote-parser": "^0.3",
+    "xo-vmdk-to-vhd": "0.1.0"
   },
   "scripts": {
     "build": "NODE_ENV=production gulp build",

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -41,6 +41,7 @@ const messages = {
 
   // ----- Copiable component -----
   copyToClipboard: 'Copy to clipboard',
+  copyUuid: 'Copy {uuid}',
 
   // ----- Pills -----
   pillMaster: 'Master',

--- a/packages/xo-web/src/common/sorted-table/index.js
+++ b/packages/xo-web/src/common/sorted-table/index.js
@@ -209,13 +209,21 @@ class IndividualAction extends Component {
     (disabled, item, userData) =>
       isFunction(disabled) ? disabled(item, userData) : disabled
   )
+  _getLabel = createSelector(
+    () => this.props.label,
+    () => this.props.item,
+    () => this.props.userData,
+    (label, item, userData) =>
+      isFunction(label) ? label(item, userData) : label
+  )
+
   _executeAction = () => {
     const p = this.props
     return p.handler(p.item, p.userData)
   }
 
   render () {
-    const { icon, item, label, level, redirectOnSuccess, userData } = this.props
+    const { icon, item, level, redirectOnSuccess, userData } = this.props
 
     return (
       <ActionRowButton
@@ -226,7 +234,7 @@ class IndividualAction extends Component {
         handler={this._executeAction}
         icon={icon}
         redirectOnSuccess={redirectOnSuccess}
-        tooltip={label}
+        tooltip={this._getLabel()}
       />
     )
   }
@@ -240,6 +248,13 @@ class GroupedAction extends Component {
     (disabled, selectedItems, userData) =>
       isFunction(disabled) ? disabled(selectedItems, userData) : disabled
   )
+  _getLabel = createSelector(
+    () => this.props.label,
+    () => this.props.selectedItems,
+    () => this.props.userData,
+    (label, selectedItems, userData) =>
+      isFunction(label) ? label(selectedItems, userData) : label
+  )
 
   _executeAction = () => {
     const p = this.props
@@ -247,7 +262,7 @@ class GroupedAction extends Component {
   }
 
   render () {
-    const { icon, label, level } = this.props
+    const { icon, level } = this.props
 
     return (
       <ActionRowButton
@@ -255,7 +270,7 @@ class GroupedAction extends Component {
         disabled={this._getIsDisabled()}
         handler={this._executeAction}
         icon={icon}
-        tooltip={label}
+        tooltip={this._getLabel()}
       />
     )
   }

--- a/packages/xo-web/src/xo-app/host/tab-network.js
+++ b/packages/xo-web/src/xo-app/host/tab-network.js
@@ -1,5 +1,6 @@
 import _ from 'intl'
 import Component from 'base-component'
+import copy from 'copy-to-clipboard'
 import React from 'react'
 import Icon from 'icon'
 import pick from 'lodash/pick'
@@ -284,6 +285,11 @@ const COLUMNS = [
 ]
 
 const INDIVIDUAL_ACTIONS = [
+  {
+    handler: pif => copy(pif.uuid),
+    icon: 'clipboard',
+    label: pif => _('copyUuid', { uuid: pif.uuid }),
+  },
   {
     handler: deletePif,
     icon: 'delete',

--- a/packages/xo-web/src/xo-app/pool/tab-network.js
+++ b/packages/xo-web/src/xo-app/pool/tab-network.js
@@ -3,6 +3,7 @@ import ActionRowButton from 'action-row-button'
 import BaseComponent from 'base-component'
 import Button from 'button'
 import ButtonGroup from 'button-group'
+import copy from 'copy-to-clipboard'
 import Icon from 'icon'
 import isEmpty from 'lodash/isEmpty'
 import map from 'lodash/map'
@@ -280,6 +281,11 @@ class NetworkActions extends Component {
 
     return (
       <ButtonGroup>
+        <ActionRowButton
+          handler={() => copy(network.uuid)}
+          icon='clipboard'
+          tooltip={_('copyUuid', { uuid: network.uuid })}
+        />
         <ActionRowButton
           disabled={disableNetworkDelete}
           handler={deleteNetwork}

--- a/packages/xo-web/src/xo-app/vm/tab-disks.js
+++ b/packages/xo-web/src/xo-app/vm/tab-disks.js
@@ -1,6 +1,7 @@
 import _, { messages } from 'intl'
 import ActionButton from 'action-button'
 import Component from 'base-component'
+import copy from 'copy-to-clipboard'
 import HTML5Backend from 'react-dnd-html5-backend'
 import Icon from 'icon'
 import IsoDevice from 'iso-device'
@@ -655,6 +656,11 @@ export default class TabDisks extends Component {
       handler: this._migrateVdi,
       icon: 'vdi-migrate',
       label: _('vdiMigrate'),
+    },
+    {
+      handler: vdi => copy(vdi.uuid),
+      icon: 'clipboard',
+      label: vdi => _('copyUuid', { uuid: vdi.uuid }),
     },
   ]
 

--- a/packages/xo-web/src/xo-app/vm/tab-network.js
+++ b/packages/xo-web/src/xo-app/vm/tab-network.js
@@ -2,6 +2,7 @@ import _, { messages } from 'intl'
 import ActionButton from 'action-button'
 import ActionRowButton from 'action-row-button'
 import BaseComponent from 'base-component'
+import copy from 'copy-to-clipboard'
 import Icon from 'icon'
 import propTypes from 'prop-types-decorator'
 import React from 'react'
@@ -351,6 +352,11 @@ const GROUPED_ACTIONS = [
   },
 ]
 const INDIVIDUAL_ACTIONS = [
+  {
+    handler: vif => copy(vif.uuid),
+    icon: 'clipboard',
+    label: vif => _('copyUuid', { uuid: vif.uuid }),
+  },
   {
     disabled: vif => vif.attached,
     handler: deleteVif,

--- a/packages/xo-web/src/xo-app/vm/tab-snapshots.js
+++ b/packages/xo-web/src/xo-app/vm/tab-snapshots.js
@@ -1,4 +1,5 @@
 import _ from 'intl'
+import copy from 'copy-to-clipboard'
 import Icon from 'icon'
 import React, { Component } from 'react'
 import SortedTable from 'sorted-table'
@@ -91,6 +92,11 @@ const INDIVIDUAL_ACTIONS = [
     icon: 'snapshot-revert',
     label: _('revertSnapshot'),
     level: 'warning',
+  },
+  {
+    handler: snapshot => copy(snapshot.uuid),
+    icon: 'clipboard',
+    label: snapshot => _('copyUuid', { uuid: snapshot.uuid }),
   },
   {
     handler: deleteSnapshot,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3157,7 +3157,7 @@ copy-props@^2.0.1:
     each-props "^1.3.0"
     is-plain-object "^2.0.1"
 
-copy-to-clipboard@^3:
+copy-to-clipboard@^3, copy-to-clipboard@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.0.8.tgz#f4e82f4a8830dce4666b7eb8ded0c9bcc313aba9"
   dependencies:


### PR DESCRIPTION
Fixes #2925

- host/tab-network
- pool/tab-network
- vm/tab-disks
- vm/tab-network
- vm/tab-snapshots