### PR TITLE
Fix SR creation when using options or NFSv4

### DIFF
--- a/packages/xo-server/src/api/sr.js
+++ b/packages/xo-server/src/api/sr.js
@@ -204,8 +204,8 @@ export async function createNfs ({
   }
 
   //  if NFS options given
-  if (nfsVersion) {
-    deviceConfig.options = nfsVersion
+  if (nfsOptions) {
+    deviceConfig.options = nfsOptions
   }
 
   const srRef = await xapi.call(


### PR DESCRIPTION
NFSv4 SR creation currently fails.

From SMlog:
```
SM: [31976] ['mount.nfs4', '<ip>:/srv/nfs0', '/var/run/sr-mount/<uuid>', '-o', 'soft,proto=tcp,vers=4,acdirmin=0,acdirmax=0,timeo=1000,retrans=12,4']
SM: [31976] FAILED in util.pread: (rc 32) stdout: '', stderr: 'mount.nfs4: an incorrect mount option was specified 
```

If you look carefully at the options string, there's a `,4` that shouldn't appear there.

This PR should fix the issue.