### PR TITLE
(xo-web: create-network): single-server private network

### DIFF
--- a/packages/xo-web/src/common/xo/create-network-modal/index.js
+++ b/packages/xo-web/src/common/xo/create-network-modal/index.js
@@ -23,7 +23,7 @@ class CreateNetworkModalBody extends Component {
       pool: container.$pool,
       name: refs.name.value,
       description: refs.description.value,
-      pif: refs.pif.value.id,
+      pif: refs.pif.value && refs.pif.value.id,
       mtu: refs.mtu.value,
       vlan: refs.vlan.value,
     }


### PR DESCRIPTION
The select of interface will not be required with this addition.