### PR TITLE
fix(xo-server): `vm.xenTools.*` must be numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Bugs
 
+- update the xentools search item to return the version number of installed xentools [#3015](https://github.com/vatesfr/xen-orchestra/issues/3015)
+
 ## **5.19.0** (2018-05-01)
 
 ### Enhancements

--- a/packages/xo-server/src/xapi-object-to-xo.js
+++ b/packages/xo-server/src/xapi-object-to-xo.js
@@ -246,6 +246,7 @@ const TRANSFORMS = {
       return {
         major: +major,
         minor: +minor,
+        version: +`${major}.${minor}`,
       }
     })()
 

--- a/packages/xo-server/src/xapi-object-to-xo.js
+++ b/packages/xo-server/src/xapi-object-to-xo.js
@@ -244,8 +244,8 @@ const TRANSFORMS = {
       }
 
       return {
-        major,
-        minor,
+        major: +major,
+        minor: +minor,
       }
     })()
 


### PR DESCRIPTION
Fixes #3015

### Check list

- [ ] if UI changes, a screenshot has been added to the PR
- [x] CHANGELOG updated
- [ ] documentation updated

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and readd a reviewer

### List of packages to release

> No need to mention xo-server and xo-web.
