### PR TITLE
fix(xo-server-backup-reports): not display size and speed if not have a transfer/merge

### DIFF
--- a/packages/xo-server-backup-reports/src/index.js
+++ b/packages/xo-server-backup-reports/src/index.js
@@ -67,7 +67,7 @@ const formatSpeed = (bytes, milliseconds) =>
         scale: 'binary',
         unit: 'B/s',
       })
-    : 0
+    : 'N/A'
 
 const logError = e => {
   console.error('backup report error:', e)

--- a/packages/xo-server-backup-reports/src/index.js
+++ b/packages/xo-server-backup-reports/src/index.js
@@ -62,10 +62,12 @@ const formatSize = bytes =>
   })
 
 const formatSpeed = (bytes, milliseconds) =>
-  humanFormat(bytes * 1e3 / milliseconds, {
-    scale: 'binary',
-    unit: 'B/s',
-  })
+  milliseconds > 0
+    ? humanFormat(bytes * 1e3 / milliseconds, {
+        scale: 'binary',
+        unit: 'B/s',
+      })
+    : 0
 
 const logError = e => {
   console.error('backup report error:', e)
@@ -243,21 +245,19 @@ class BackupReportsXoPlugin {
           const operationInfoText = []
           if (operationLog.status === 'success') {
             const size = operationLog.result.size
-            if (size > 0) {
-              if (operationLog.message === 'merge') {
-                globalMergeSize += size
-              } else {
-                globalTransferSize += size
-              }
-
-              operationInfoText.push(
-                `      - **Size**: ${formatSize(size)}`,
-                `      - **Speed**: ${formatSpeed(
-                  size,
-                  operationLog.end - operationLog.start
-                )}`
-              )
+            if (operationLog.message === 'merge') {
+              globalMergeSize += size
+            } else {
+              globalTransferSize += size
             }
+
+            operationInfoText.push(
+              `      - **Size**: ${formatSize(size)}`,
+              `      - **Speed**: ${formatSpeed(
+                size,
+                operationLog.end - operationLog.start
+              )}`
+            )
           } else {
             operationInfoText.push(
               `      - **Error**: ${get(operationLog.result, 'message')}`

--- a/packages/xo-server-backup-reports/src/index.js
+++ b/packages/xo-server-backup-reports/src/index.js
@@ -243,19 +243,21 @@ class BackupReportsXoPlugin {
           const operationInfoText = []
           if (operationLog.status === 'success') {
             const size = operationLog.result.size
-            if (operationLog.message === 'merge') {
-              globalMergeSize += size
-            } else {
-              globalTransferSize += size
-            }
+            if (size > 0) {
+              if (operationLog.message === 'merge') {
+                globalMergeSize += size
+              } else {
+                globalTransferSize += size
+              }
 
-            operationInfoText.push(
-              `      - **Size**: ${formatSize(size)}`,
-              `      - **Speed**: ${formatSpeed(
-                size,
-                operationLog.end - operationLog.start
-              )}`
-            )
+              operationInfoText.push(
+                `      - **Size**: ${formatSize(size)}`,
+                `      - **Speed**: ${formatSpeed(
+                  size,
+                  operationLog.end - operationLog.start
+                )}`
+              )
+            }
           } else {
             operationInfoText.push(
               `      - **Error**: ${get(operationLog.result, 'message')}`


### PR DESCRIPTION
### Check list

- [x] if UI changes, a screenshot has been added to the PR
- [ ] CHANGELOG updated
- [x] documentation updated

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and readd a reviewer

### List of packages to release

> No need to mention xo-server and xo-web.
