### PR TITLE
feat(xo-server/jobs): implement cancelation

### DIFF
--- a/packages/xo-server/src/api/job.js
+++ b/packages/xo-server/src/api/job.js
@@ -1,5 +1,12 @@
 // FIXME so far, no acls for jobs
 
+export function cancel ({ runId }) {
+  return this.cancelJobRun(runId)
+}
+
+cancel.permission = 'admin'
+cancel.description = 'Cancel a current run'
+
 export async function getAll () {
   return /* await */ this.getAllJobs('call')
 }

--- a/packages/xo-server/src/xo-mixins/jobs/index.js
+++ b/packages/xo-server/src/xo-mixins/jobs/index.js
@@ -266,7 +266,7 @@ export default class Jobs {
 
       const status = await executor({
         app,
-        token,
+        cancelToken: token,
         data: data_,
         job,
         logger,


### PR DESCRIPTION
Related to #3047

This is the first step toward Backup NG cancelation, the server side stuff should be ok (but need testing), so the next step is to expose it in the UI.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] CHANGELOG updated (will be updated when exposed in the UI)
- [x] documentation updated

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and readd a reviewer

### List of packages to release

> No need to mention xo-server and xo-web.
