### PR TITLE
fix(xo-web/Backup-ng/logs): ability to retry a single failed/interrupted VM backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - update the xentools search item to return the version number of installed xentools [#3015](https://github.com/vatesfr/xen-orchestra/issues/3015)
 - Fix Nagios backup reports [#2991](https://github.com/vatesfr/xen-orchestra/issues/2991)
+- Fix the retry of a single failed/interrupted VM backup [#2912](https://github.com/vatesfr/xen-orchestra/issues/2912#issuecomment-395480321)
 
 ## **5.20.0** (2018-05-31)
 

--- a/packages/xo-server/src/xo-mixins/backups-ng-logs.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng-logs.js
@@ -59,11 +59,12 @@ export default {
           (data.type === 'backup' || data.key === undefined) &&
           (runId === undefined || runId === id)
         ) {
-          const { jobId } = data
+          const { scheduleId, jobId } = data
           consolidated[id] = started[id] = {
             data: data.data,
             id,
             jobId,
+            scheduleId,
             start: time,
             status: runningJobs[jobId] === id ? 'pending' : 'interrupted',
           }

--- a/packages/xo-web/src/xo-app/logs/log-alert-body.js
+++ b/packages/xo-web/src/xo-app/logs/log-alert-body.js
@@ -174,7 +174,8 @@ export default [
                   8
                 )}) <TaskStateInfos status={taskLog.status} />{' '}
                 {scheduleId !== undefined &&
-                  taskLog.status === 'failure' && (
+                  (taskLog.status === 'failure' ||
+                    taskLog.status === 'interrupted') && (
                     <ActionButton
                       handler={effects.restartVmJob}
                       icon='run'
@@ -320,6 +321,7 @@ export default [
                   })}
                 </ul>
                 <TaskDate label='taskStart' value={taskLog.start} />
+                <br />
                 {taskLog.end !== undefined && (
                   <div>
                     <TaskDate label='taskEnd' value={taskLog.end} />

--- a/packages/xo-web/src/xo-app/logs/log-alert-body.js
+++ b/packages/xo-web/src/xo-app/logs/log-alert-body.js
@@ -174,8 +174,8 @@ export default [
                   8
                 )}) <TaskStateInfos status={taskLog.status} />{' '}
                 {scheduleId !== undefined &&
-                  (taskLog.status === 'failure' ||
-                    taskLog.status === 'interrupted') && (
+                  taskLog.status !== 'success' &&
+                  taskLog.status !== 'pending' && (
                     <ActionButton
                       handler={effects.restartVmJob}
                       icon='run'


### PR DESCRIPTION
Fixes #2912

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] CHANGELOG updated
- [x] documentation updated

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and readd a reviewer

### List of packages to release

> No need to mention xo-server and xo-web.
