### PR TITLE
fix(xo-server/backup NG): retention checks

### DIFF
--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -734,7 +734,7 @@ export default class BackupNg {
       if (remotes.length === 0) {
         exportRetention = 0
       }
-    } else if (remotes.length === 0) {
+    } else if (exportRetention === 0 && remotes.length === 0) {
       throw new Error('export retention must be 0 without remotes')
     }
 

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -762,7 +762,7 @@ export default class BackupNg {
       exportRetention === 0 &&
       snapshotRetention === 0
     ) {
-      throw new Error('export and snapshot retentions cannot both be 0')
+      throw new Error('copy, export and snapshot retentions cannot both be 0')
     }
 
     if (

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -762,7 +762,7 @@ export default class BackupNg {
       exportRetention === 0 &&
       snapshotRetention === 0
     ) {
-      throw new Error('export and snapshots retentions cannot both be 0')
+      throw new Error('export and snapshot retentions cannot both be 0')
     }
 
     if (

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -718,30 +718,51 @@ export default class BackupNg {
     const { id: jobId, settings } = job
     const { id: scheduleId } = schedule
 
-    const exportRetention: number = getSetting(settings, 'exportRetention', [
+    let exportRetention: number = getSetting(settings, 'exportRetention', [
       scheduleId,
     ])
+    let copyRetention: number | void = getSetting(settings, 'copyRetention', [
+      scheduleId,
+    ])
+
+    const remotes = unboxIds(job.remotes)
+    if (copyRetention === undefined) {
+      // if copyRetention is not defined, it uses exportRetention's value due to
+      // previous implementation which did not support copyRetention
+      copyRetention = exportRetention
+
+      if (remotes.length === 0) {
+        exportRetention = 0
+      }
+    } else if (remotes.length === 0) {
+      throw new Error('export retention must be 0 without remotes')
+    }
+
+    const srs = unboxIds(job.srs)
+    if (copyRetention !== 0 && srs.length === 0) {
+      throw new Error('copy retention must be 0 without SRs')
+    }
+
+    if (
+      remotes.length !== 0 &&
+      srs.length !== 0 &&
+      (copyRetention === 0) !== (exportRetention === 0)
+    ) {
+      throw new Error('both or neither copy and export retentions must be 0')
+    }
+
     const snapshotRetention: number = getSetting(
       settings,
       'snapshotRetention',
       [scheduleId]
     )
 
-    if (exportRetention === 0) {
-      if (snapshotRetention === 0) {
-        throw new Error('export and snapshots retentions cannot both be 0')
-      }
-    }
-
-    const copyRetention: number = getSetting(
-      settings,
-      'copyRetention',
-      [scheduleId],
-      exportRetention
-    )
-
-    if ((copyRetention === 0) !== (exportRetention === 0)) {
-      throw new Error('both or neither copy and export rententions should be 0')
+    if (
+      copyRetention === 0 &&
+      exportRetention === 0 &&
+      snapshotRetention === 0
+    ) {
+      throw new Error('export and snapshots retentions cannot both be 0')
     }
 
     if (
@@ -831,12 +852,7 @@ export default class BackupNg {
       return
     }
 
-    const remotes = unboxIds(job.remotes)
-    const srs = unboxIds(job.srs)
     const nTargets = remotes.length + srs.length
-    if (nTargets === 0) {
-      throw new Error('export retention must be 0 without remotes and SRs')
-    }
 
     const now = Date.now()
     const vmDir = getVmBackupDir(vmUuid)

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -734,7 +734,7 @@ export default class BackupNg {
       if (remotes.length === 0) {
         exportRetention = 0
       }
-    } else if (exportRetention === 0 && remotes.length === 0) {
+    } else if (exportRetention !== 0 && remotes.length === 0) {
       throw new Error('export retention must be 0 without remotes')
     }
 


### PR DESCRIPTION
They were broken by the introduction of `copyRetention`.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`) (none)
- [x] if UI changes, a screenshot has been added to the PR (none
- [x] CHANGELOG updated (the bug has not been released)
- [x] documentation updated

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and readd a reviewer

### List of packages to release

> No need to mention xo-server and xo-web.
