### PR TITLE
feat(xo-web): new backup/health view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add Backup deprecation message and link to Backup NG migration blog post [#3089](https://github.com/vatesfr/xen-orchestra/issues/3089)
 - [Backup NG] Ability to cancel a running backup job [#3047](https://github.com/vatesfr/xen-orchestra/issues/3047)
 - [Backup NG form] Ability to enable/disable a schedule [#3062](https://github.com/vatesfr/xen-orchestra/issues/3062)
+- New backup/health view with non-existent backup snapshots table [#3090](https://github.com/vatesfr/xen-orchestra/issues/3090)
 
 ### Bugs
 

--- a/packages/xo-web/src/xo-app/backup/health/index.js
+++ b/packages/xo-web/src/xo-app/backup/health/index.js
@@ -1,0 +1,111 @@
+import _ from 'intl'
+import Component from 'base-component'
+import Icon from 'icon'
+import NoObjects from 'no-objects'
+import React from 'react'
+import SortedTable from 'sorted-table'
+import { Card, CardHeader, CardBlock } from 'card'
+import { connectStore } from 'utils'
+import { Container, Row, Col } from 'grid'
+import { FormattedRelative, FormattedTime } from 'react-intl'
+import { includes, map } from 'lodash'
+import { deleteSnapshot, deleteSnapshots } from 'xo'
+import {
+  createGetObject,
+  createSelector,
+  createGetObjectsOfType,
+  createCollectionWrapper,
+} from 'selectors'
+
+const VmColContainer = connectStore(() => ({
+  container: createGetObject(),
+}))(({ container }) => <span>{container.name_label}</span>)
+
+const SNAPSHOT_COLUMNS = [
+  {
+    name: _('snapshotDate'),
+    itemRenderer: vm => (
+      <span>
+        <FormattedTime
+          day='numeric'
+          hour='numeric'
+          minute='numeric'
+          month='long'
+          value={vm.snapshot_time * 1000}
+          year='numeric'
+        />{' '}
+        (<FormattedRelative value={vm.snapshot_time * 1000} />)
+      </span>
+    ),
+    sortCriteria: vm => vm.snapshot_time,
+    sortOrder: 'desc',
+  },
+  {
+    name: _('vmNameLabel'),
+    itemRenderer: vm => vm.name_label,
+    sortCriteria: vm => vm.name_label,
+  },
+  {
+    name: _('vmNameDescription'),
+    itemRenderer: vm => vm.name_description,
+    sortCriteria: vm => vm.name_description,
+  },
+  {
+    name: _('vmContainer'),
+    itemRenderer: vm => <VmColContainer id={vm.$container} />,
+  },
+]
+
+const ACTIONS = [
+  {
+    label: _('deleteSnapshots'),
+    individualLabel: _('deleteSnapshot'),
+    icon: 'delete',
+    level: 'danger',
+    handler: deleteSnapshots,
+    individualHandler: deleteSnapshot,
+  },
+]
+
+@connectStore(() => {
+  const getSnapshots = createGetObjectsOfType('VM-snapshot')
+
+  return {
+    loneSnapshots: getSnapshots.filter(
+      createSelector(
+        createCollectionWrapper((_, props) => map(props.schedules, 'id')),
+        scheduleIds => _ => {
+          const scheduleId = _.other['xo:backup:schedule']
+          return scheduleId !== undefined && !includes(scheduleIds, scheduleId)
+        }
+      )
+    ),
+  }
+})
+export default class Health extends Component {
+  render () {
+    return (
+      <Container>
+        <Row className='lone-snapshots'>
+          <Col>
+            <Card>
+              <CardHeader>
+                <Icon icon='vm' /> {_('vmSnapshotsRelatedToNonExistentBackups')}
+              </CardHeader>
+              <CardBlock>
+                <NoObjects
+                  actions={ACTIONS}
+                  collection={this.props.loneSnapshots}
+                  columns={SNAPSHOT_COLUMNS}
+                  component={SortedTable}
+                  emptyMessage={_('noSnapshots')}
+                  shortcutsTarget='.lone-snapshots'
+                />
+              </CardBlock>
+            </Card>
+          </Col>
+        </Row>
+      </Container>
+    )
+  }
+}

--- a/packages/xo-web/src/xo-app/backup/index.js
+++ b/packages/xo-web/src/xo-app/backup/index.js
@@ -11,6 +11,7 @@ import Edit from './edit'
 import Overview from './overview'
 import Restore from './restore'
 import FileRestore from './file-restore'
+import Health from './health'
 
 const DeprecatedMsg = () => (
   <div className='alert alert-warning'>
@@ -43,6 +44,10 @@ const HEADER = (
             <Icon icon='menu-backup-file-restore' />{' '}
             {_('backupFileRestorePage')}
           </NavLink>
+          <NavLink to='/backup/health'>
+            <Icon icon='menu-dashboard-health' />{' '}
+            {_('overviewHealthDashboardPage')}
+          </NavLink>
         </NavTabs>
       </Col>
     </Row>
@@ -55,6 +60,7 @@ const Backup = routes('overview', {
   overview: Overview,
   restore: Restore,
   'file-restore': FileRestore,
+  health: Health,
 })(({ children }) => (
   <Page header={HEADER} title='backupPage' formatTitle>
     {children}

--- a/packages/xo-web/src/xo-app/dashboard/health/index.js
+++ b/packages/xo-web/src/xo-app/dashboard/health/index.js
@@ -112,12 +112,12 @@ const SR_COLUMNS = [
       sr.size > 1 && (
         <Tooltip
           content={_('spaceLeftTooltip', {
-            used: Math.round(sr.physical_usage / sr.size * 100),
+            used: Math.round((sr.physical_usage / sr.size) * 100),
             free: formatSize(sr.size - sr.physical_usage),
           })}
         >
           <meter
-            value={sr.physical_usage / sr.size * 100}
+            value={(sr.physical_usage / sr.size) * 100}
             min='0'
             max='100'
             optimum='40'
@@ -400,15 +400,6 @@ const ALARM_COLUMNS = [
   const getOrphanVmSnapshots = createGetObjectsOfType('VM-snapshot')
     .filter([snapshot => !snapshot.$snapshot_of])
     .sort()
-  const getLoneBackupSnapshots = createGetObjectsOfType('VM-snapshot').filter(
-    createSelector(
-      createCollectionWrapper((_, props) => map(props.schedules, 'id')),
-      scheduleIds => _ => {
-        const scheduleId = _.other['xo:backup:schedule']
-        return scheduleId !== undefined && !includes(scheduleIds, scheduleId)
-      }
-    )
-  )
   const getUserSrs = createGetObjectsOfType('SR').filter([isSrWritable])
   const getVdiSrs = createGetObjectsOfType('SR').pick(
     createSelector(getOrphanVdiSnapshots, snapshots => map(snapshots, '$SR'))
@@ -424,7 +415,6 @@ const ALARM_COLUMNS = [
     vdiOrphaned: getOrphanVdiSnapshots,
     vdiSr: getVdiSrs,
     vmOrphaned: getOrphanVmSnapshots,
-    vmBackupSnapshots: getLoneBackupSnapshots,
   }
 })
 export default class Health extends Component {
@@ -507,11 +497,6 @@ export default class Health extends Component {
 
   _getVmOrphaned = createFilter(
     () => this.props.vmOrphaned,
-    this._getPoolPredicate
-  )
-
-  _getVmBackupSnapshots = createFilter(
-    () => this.props.vmBackupSnapshots,
     this._getPoolPredicate
   )
 
@@ -630,24 +615,6 @@ export default class Health extends Component {
                   component={SortedTable}
                   emptyMessage={_('noOrphanedObject')}
                   shortcutsTarget='.orphaned-vms'
-                />
-              </CardBlock>
-            </Card>
-          </Col>
-        </Row>
-        <Row className='snapshot-vms'>
-          <Col>
-            <Card>
-              <CardHeader>
-                <Icon icon='vm' /> {_('vmSnapshotsRelatedToNonExistentBackups')}
-              </CardHeader>
-              <CardBlock>
-                <NoObjects
-                  collection={this._getVmBackupSnapshots()}
-                  columns={VM_COLUMNS}
-                  component={SortedTable}
-                  emptyMessage={_('noSnapshots')}
-                  shortcutsTarget='.snapshot-vms'
                 />
               </CardBlock>
             </Card>

--- a/packages/xo-web/src/xo-app/menu/index.js
+++ b/packages/xo-web/src/xo-app/menu/index.js
@@ -205,6 +205,11 @@ export default class Menu extends Component {
             icon: 'menu-backup-file-restore',
             label: 'backupFileRestorePage',
           },
+          {
+            to: '/backup/health',
+            icon: 'menu-dashboard-health',
+            label: 'overviewHealthDashboardPage',
+          },
         ],
       },
       isAdmin && {


### PR DESCRIPTION
Fixes #3090

Move "VM snapshots related to non-existent backups" table
from dashboard/health to backup/health

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] CHANGELOG updated
- [x] documentation updated

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and readd a reviewer

### List of packages to release

> No need to mention xo-server and xo-web.

### Screenshots

![capture_2018-06-25_12 18 01](https://user-images.githubusercontent.com/10992860/41858496-56af27d0-789a-11e8-9f86-e3ce1ac28e54.png)

