### PR TITLE
fix(xo-web/new-vm): only create the cloud config drive when its option is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Delete schedules with their job [#3108](https://github.com/vatesfr/xen-orchestra/issues/3108) (PR [3124](https://github.com/vatesfr/xen-orchestra/pull/3124))
 - Remote creation: correctly reset form [#3140](https://github.com/vatesfr/xen-orchestra/issues/3140) (PR [3141](https://github.com/vatesfr/xen-orchestra/pull/3141))
 - Make cloud config templates available for all users [3147](https://github.com/vatesfr/xen-orchestra/issues/3147) (PR [3148](https://github.com/vatesfr/xen-orchestra/pull/3148))
+- [New VM] Only create the cloud config drive when its option is enabled [3161](https://github.com/vatesfr/xen-orchestra/issues/3161) (PR [3162](https://github.com/vatesfr/xen-orchestra/pull/3162))
 
 ### Released packages
 

--- a/packages/xo-web/src/xo-app/new-vm/index.js
+++ b/packages/xo-web/src/xo-app/new-vm/index.js
@@ -353,7 +353,7 @@ export default class NewVm extends BaseComponent {
           }),
           ''
         )}`
-      } else {
+      } else if (state.installMethod === 'customConfig') {
         const replacer = this._buildTemplate(
           defined(state.customConfig, DEFAULT_CLOUD_CONFIG_TEMPLATE)
         )


### PR DESCRIPTION
This bug has been introduced by the PR: #3054

Fixes #3161

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
