### PR TITLE
fix(xo-server/listReplicatedVms): dont use `snapshot_time`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [New VM] Selecting multiple VMs and clicking Create then Cancel used to redirect to Home [#3268](https://github.com/vatesfr/xen-orchestra/issues/3268) (PR [#3371](https://github.com/vatesfr/xen-orchestra/pull/3371))
 - [Remotes] `cannot read 'properties' of undefined` error (PR [#3382](https://github.com/vatesfr/xen-orchestra/pull/3382))
 - [Servers] Various issues when adding a new server [#3385](https://github.com/vatesfr/xen-orchestra/issues/3385) (PR [#3388](https://github.com/vatesfr/xen-orchestra/pull/3388))
+- [Backup NG] Always delete the correct old replications [#3391](https://github.com/vatesfr/xen-orchestra/issues/3391) (PR [#3394](https://github.com/vatesfr/xen-orchestra/pull/3394))
 
 ### Released packages
 

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -104,6 +104,13 @@ type Metadata = MetadataDelta | MetadataFull
 const compareSnapshotTime = (a: Vm, b: Vm): number =>
   a.snapshot_time < b.snapshot_time ? -1 : 1
 
+// 2018-09-07, JFT: this is a work-around, we used to use `snapshot_time` for
+// this, but this value is not always kept in VM imported from snapshots.
+//
+// We should use a specific value set in `other_config`.
+const compareNameLabelTimestamp = (a: Vm, b: Vm): number =>
+  a.name_label.slice(-17, -1) < b.name_label.slice(-17, -1) ? -1 : 1
+
 const compareTimestamp = (a: Metadata, b: Metadata): number =>
   a.timestamp - b.timestamp
 
@@ -183,9 +190,7 @@ const listReplicatedVms = (
     }
   }
 
-  // the replicated VMs have been created from a snapshot, therefore we can use
-  // `snapshot_time` as the creation time
-  return values(vms).sort(compareSnapshotTime)
+  return values(vms).sort(compareNameLabelTimestamp)
 }
 
 const importers: $Dict<

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -104,12 +104,15 @@ type Metadata = MetadataDelta | MetadataFull
 const compareSnapshotTime = (a: Vm, b: Vm): number =>
   a.snapshot_time < b.snapshot_time ? -1 : 1
 
-// 2018-09-07, JFT: this is a work-around, we used to use `snapshot_time` for
-// this, but this value is not always kept in VM imported from snapshots.
-//
-// We should use a specific value set in `other_config`.
+const getReplicatedVmDatetime = (vm: Vm) => {
+  const {
+    'xo:backup:datetime': datetime = vm.name_label.slice(-17, -1),
+  } = vm.other_config
+  return datetime
+}
+
 const compareNameLabelTimestamp = (a: Vm, b: Vm): number =>
-  a.name_label.slice(-17, -1) < b.name_label.slice(-17, -1) ? -1 : 1
+  getReplicatedVmDatetime(a) < getReplicatedVmDatetime(b) ? -1 : 1
 
 const compareTimestamp = (a: Metadata, b: Metadata): number =>
   a.timestamp - b.timestamp
@@ -767,6 +770,7 @@ export default class BackupNg {
           parentId: taskId,
         },
         xapi._updateObjectMapProperty(vm, 'other_config', {
+          'xo:backup:datetime': null,
           'xo:backup:job': null,
           'xo:backup:schedule': null,
           'xo:backup:vm': null,
@@ -878,6 +882,7 @@ export default class BackupNg {
         parentId: taskId,
       },
       xapi._updateObjectMapProperty(snapshot, 'other_config', {
+        'xo:backup:datetime': snapshot.snapshot_time,
         'xo:backup:job': jobId,
         'xo:backup:schedule': scheduleId,
         'xo:backup:vm': vmUuid,

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -111,7 +111,7 @@ const getReplicatedVmDatetime = (vm: Vm) => {
   return datetime
 }
 
-const compareNameLabelTimestamp = (a: Vm, b: Vm): number =>
+const compareReplicatedVmDatetime = (a: Vm, b: Vm): number =>
   getReplicatedVmDatetime(a) < getReplicatedVmDatetime(b) ? -1 : 1
 
 const compareTimestamp = (a: Metadata, b: Metadata): number =>
@@ -193,7 +193,7 @@ const listReplicatedVms = (
     }
   }
 
-  return values(vms).sort(compareNameLabelTimestamp)
+  return values(vms).sort(compareReplicatedVmDatetime)
 }
 
 const importers: $Dict<


### PR DESCRIPTION
It is not always set on VMs imported from snapshots, use the timestamp
in the name_label for the moment.

Fixes #3391

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [x] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (no user visible changes)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
