### PR TITLE
feat(xen-api): _wrapRecord()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Released packages
 
+- xen-api v0.20.0
 - xo-server-usage-report v0.7.0
 - xo-server v5.29.0
 - xo-web v5.29.0

--- a/packages/xen-api/src/index.js
+++ b/packages/xen-api/src/index.js
@@ -224,6 +224,7 @@ export class Xapi extends EventEmitter {
     this._auth = opts.auth
     this._pool = null
     this._readOnly = Boolean(opts.readOnly)
+    this._RecordsByType = createObject(null)
     this._sessionId = null
     const url = (this._url = parseUrl(opts.url))
 
@@ -969,11 +970,7 @@ export class Xapi extends EventEmitter {
   }
 
   _wrapRecord (type, ref, data) {
-    let RecordsByType = this._RecordsByType
-    if (RecordsByType === undefined) {
-      RecordsByType = this._RecordsByType = { __proto__: null }
-    }
-
+    const RecordsByType = this._RecordsByType
     let Record = RecordsByType[type]
     if (Record === undefined) {
       const fields = getKeys(data)

--- a/packages/xen-api/src/index.js
+++ b/packages/xen-api/src/index.js
@@ -974,6 +974,7 @@ export class Xapi extends EventEmitter {
     let Record = RecordsByType[type]
     if (Record === undefined) {
       const fields = getKeys(data)
+      const nFields = fields.length
       const xapi = this
 
       const objectsByRef = this._objectsByRef
@@ -984,9 +985,10 @@ export class Xapi extends EventEmitter {
           $id: { value: data.uuid || ref },
           $ref: { value: ref },
         })
-        fields.forEach(field => {
+        for (let i = 0; i < nFields; ++i) {
+          const field = fields[i]
           this[field] = data[field]
-        })
+        }
       }
 
       const getters = { $pool: this._getPool }

--- a/packages/xen-api/src/index.js
+++ b/packages/xen-api/src/index.js
@@ -210,6 +210,15 @@ const getTaskResult = task => {
 
 // -------------------------------------------------------------------
 
+const RESERVED_FIELDS = {
+  id: true,
+  pool: true,
+  ref: true,
+  type: true,
+}
+
+// -------------------------------------------------------------------
+
 const CONNECTED = 'connected'
 const CONNECTING = 'connecting'
 const DISCONNECTED = 'disconnected'
@@ -998,10 +1007,12 @@ export class Xapi extends EventEmitter {
           return xapi.setField(this, field, value)
         }
 
+        const $field = (field in RESERVED_FIELDS ? '$$' : '$') + field
+
         const value = data[field]
         if (isArray(value)) {
           if (value.length === 0 || isOpaqueRef(value[0])) {
-            getters[`$${field}`] = function () {
+            getters[$field] = function () {
               const value = this[field]
               return value.length === 0 ? value : value.map(getObjectByRef)
             }
@@ -1013,7 +1024,7 @@ export class Xapi extends EventEmitter {
               .then(noop)
           }
         } else if (value !== null && typeof value === 'object') {
-          getters[`$${field}`] = function () {
+          getters[$field] = function () {
             const value = this[field]
             const result = {}
             getKeys(value).forEach(key => {
@@ -1025,7 +1036,7 @@ export class Xapi extends EventEmitter {
             return xapi.setFieldEntries(this, field, entries)
           }
         } else if (isOpaqueRef(value)) {
-          getters[`$${field}`] = function () {
+          getters[$field] = function () {
             return objectsByRef[this[field]]
           }
         }


### PR DESCRIPTION
All records of a same type are now instances of a same class.

Objectives:

- reduced memory usage and perf enhancement due to:
   - mutualization of fields and methods via prototype
   - mutualization of hidden classes
- easier manipulation via helper methods:
   - `await pool.set_name_label('my pool')`
   - `await pool.update_other_config({ foo: 'bar', baz: null })`

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`) (none)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [x] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (irrelevant)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
