### PR TITLE
fix(vhd-lib): fix geometry computation for more than 2^28 sectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug fixes
 
+[Imports] Allow import of files bigger than 127GB (PR [#3451](https://github.com/vatesfr/xen-orchestra/pull/3451) )
 [File restore] Fix a path issue when going back to the parent folder (PR [#3446](https://github.com/vatesfr/xen-orchestra/pull/3446))
 [File restore] Fix a minor issue when showing which selected files are redundant (PR [#3447](https://github.com/vatesfr/xen-orchestra/pull/3447))
 
@@ -31,7 +32,6 @@
 
 ### Bug fixes
 
-- [Imports] Allow import of files bigger than 127GB
 - [Remotes] Rename connect(ed)/disconnect(ed) to enable(d)/disable(d) [#3323](https://github.com/vatesfr/xen-orchestra/issues/3323) (PR [#3396](https://github.com/vatesfr/xen-orchestra/pull/3396))
 - [Remotes] Fix error appears twice on testing (PR [#3399](https://github.com/vatesfr/xen-orchestra/pull/3399))
 - [Backup NG] Don't fail on VMs with empty VBDs (like CDs or floppy disks) (PR [#3410](https://github.com/vatesfr/xen-orchestra/pull/3410))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Bug fixes
 
+- [Imports] Allow import of files bigger than 127GB
 - [Remotes] Rename connect(ed)/disconnect(ed) to enable(d)/disable(d) [#3323](https://github.com/vatesfr/xen-orchestra/issues/3323) (PR [#3396](https://github.com/vatesfr/xen-orchestra/pull/3396))
 - [Remotes] Fix error appears twice on testing (PR [#3399](https://github.com/vatesfr/xen-orchestra/pull/3399))
 - [Backup NG] Don't fail on VMs with empty VBDs (like CDs or floppy disks) (PR [#3410](https://github.com/vatesfr/xen-orchestra/pull/3410))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Released packages
 
+- vhd-lib v0.3.1
+- xo-vmdk-to-vhd v0.1.4
 - xo-server v5.28.0
 - xo-web v5.28.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Bug fixes
 
-[Imports] Allow import of files bigger than 127GB (PR [#3451](https://github.com/vatesfr/xen-orchestra/pull/3451) )
+[OVA Import] Allow import of files bigger than 127GB (PR [#3451](https://github.com/vatesfr/xen-orchestra/pull/3451))
 [File restore] Fix a path issue when going back to the parent folder (PR [#3446](https://github.com/vatesfr/xen-orchestra/pull/3446))
 [File restore] Fix a minor issue when showing which selected files are redundant (PR [#3447](https://github.com/vatesfr/xen-orchestra/pull/3447))
 

--- a/packages/vhd-lib/src/_computeGeometryForSize.js
+++ b/packages/vhd-lib/src/_computeGeometryForSize.js
@@ -1,13 +1,10 @@
 import { SECTOR_SIZE } from './_constants'
 
 export default function computeGeometryForSize (size) {
-  const totalSectors = Math.ceil(size / 512)
+  const totalSectors = Math.min(Math.ceil(size / 512), 65535 * 16 * 255)
   let sectorsPerTrackCylinder
   let heads
   let cylinderTimesHeads
-  if (totalSectors > 65535 * 16 * 255) {
-    throw Error('disk is too big')
-  }
   // straight copypasta from the file spec appendix on CHS Calculation
   if (totalSectors >= 65535 * 16 * 63) {
     sectorsPerTrackCylinder = 255


### PR DESCRIPTION
Fixes https://gitlab.com/vates/xoa-support/issues/942 
It was a bug in the disk geometry computation.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated

