### PR TITLE
fix(xo-server/deleteVm): build disks list before deleting VM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@
 
 ### Bug fixes
 
-[OVA Import] Allow import of files bigger than 127GB (PR [#3451](https://github.com/vatesfr/xen-orchestra/pull/3451))
-[File restore] Fix a path issue when going back to the parent folder (PR [#3446](https://github.com/vatesfr/xen-orchestra/pull/3446))
-[File restore] Fix a minor issue when showing which selected files are redundant (PR [#3447](https://github.com/vatesfr/xen-orchestra/pull/3447))
-[Memory] Fix a major leak [#2580](https://github.com/vatesfr/xen-orchestra/issues/2580) [#2820](https://github.com/vatesfr/xen-orchestra/issues/2820)  (PR [#3453](https://github.com/vatesfr/xen-orchestra/pull/3453))
-[NFS Remotes] Fix `already mounted` race condition [#3380](https://github.com/vatesfr/xen-orchestra/issues/3380)  (PR [#3460](https://github.com/vatesfr/xen-orchestra/pull/3460))
+- [OVA Import] Allow import of files bigger than 127GB (PR [#3451](https://github.com/vatesfr/xen-orchestra/pull/3451))
+- [File restore] Fix a path issue when going back to the parent folder (PR [#3446](https://github.com/vatesfr/xen-orchestra/pull/3446))
+- [File restore] Fix a minor issue when showing which selected files are redundant (PR [#3447](https://github.com/vatesfr/xen-orchestra/pull/3447))
+- [Memory] Fix a major leak [#2580](https://github.com/vatesfr/xen-orchestra/issues/2580) [#2820](https://github.com/vatesfr/xen-orchestra/issues/2820) (PR [#3453](https://github.com/vatesfr/xen-orchestra/pull/3453))
+- [NFS Remotes] Fix `already mounted` race condition [#3380](https://github.com/vatesfr/xen-orchestra/issues/3380) (PR [#3460](https://github.com/vatesfr/xen-orchestra/pull/3460))
+- Fix `Cannot read property 'type' of undefined` when deleting a VM (PR [#3465](https://github.com/vatesfr/xen-orchestra/pull/3465))
 
 ### Released packages
 

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -674,6 +674,7 @@ export default class Xapi extends XapiBase {
       })
     }
 
+    // must be done before destroying the VM
     const disks = getVmDisks(vm)
 
     // this cannot be done in parallel, otherwise disks and snapshots will be

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -674,6 +674,8 @@ export default class Xapi extends XapiBase {
       })
     }
 
+    const disks = getVmDisks(vm)
+
     // this cannot be done in parallel, otherwise disks and snapshots will be
     // destroyed even if this fails
     await this.call('VM.destroy', $ref)
@@ -684,7 +686,7 @@ export default class Xapi extends XapiBase {
       )::ignoreErrors(),
 
       deleteDisks &&
-        asyncMap(getVmDisks(vm), ({ $ref: vdiRef }) => {
+        asyncMap(disks, ({ $ref: vdiRef }) => {
           let onFailure = () => {
             onFailure = vdi => {
               console.error(


### PR DESCRIPTION
Otherwise there is a race condition and VBD records might have been removed from cache before listing the VM disks due to destroying the VM.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`) (none)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [x] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (irrelevant)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
