### PR TITLE
Do not make a new full export after an interrupted delta backup job

### DIFF
--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -884,12 +884,20 @@ export default class BackupNg {
         'xo:backup:job': jobId,
         'xo:backup:schedule': scheduleId,
         'xo:backup:vm': vmUuid,
+        'xo:backup:status': 'running',
       })
     )
 
     snapshot = await xapi.barrier(snapshot.$ref)
 
-    let baseSnapshot = mode === 'delta' ? last(snapshots) : undefined
+    let baseSnapshot =
+      mode === 'delta'
+        ? last(
+            snapshots.filter(
+              _ => _.other_config['xo:backup:status'] !== 'running'
+            )
+          )
+        : undefined
     snapshots.push(snapshot)
 
     // snapshots to delete due to the snapshot retention settings
@@ -1439,6 +1447,17 @@ export default class BackupNg {
     } else {
       throw new Error(`no exporter for backup mode ${mode}`)
     }
+
+    await wrapTask(
+      {
+        logger,
+        message: 'modify metadata of snapshot',
+        parentId: taskId,
+      },
+      xapi._updateObjectMapProperty(snapshot, 'other_config', {
+        'xo:backup:status': 'done',
+      })
+    )
   }
 
   async _deleteDeltaVmBackups (


### PR DESCRIPTION
# Issue 

When a delta backup job does not complete (e.g. when the XO service restarts), the backup is marked as 'interrupted', which is exact, and the snapshot for this backup remains on the web server (along with previous snapshots). But for the next delta backup run, the presence of the snapshot corresponding to an interrupted backup blocks XO from doing a delta backup and it makes a full backup instead.

# Solution

To prevent this, I added a field "xo:backup:status" to the snapshot, which is initially set to "running" and is then corrected to "done" when the backup has ended. Then, the baseSnapshot for the next run is the last which has not "xo:backup:status = running".

# Notes

- This solution is probably not the most elegant. And I placed the update of xo:backup:status at the end of the backup function, which may not be the most relevant place.
- I tested only for delta backups (and it works), i didn't tested the effect on other types of backups.
- As a temporary workaround, users can delete the snapshot corresponding to interrupted backups, the the next backup is a delta one.

# Check list

- [X] CHANGELOG:
   - Do not make a new full export after an interrupted delta backup job
