### PR TITLE
feat(xo-server/delta NG): mark successfully exported snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug fixes
 
 - [Backup NG] Fix `Cannot read property 'uuid' of undefined` when a disk is removed from a VM to backup (PR [#3479](https://github.com/vatesfr/xen-orchestra/pull/3479))
+- [Backup NG] Fix unexpected full after failure, interruption or basic rolling snapshot (PR [#3485](https://github.com/vatesfr/xen-orchestra/pull/3485))
 
 ### Released packages
 

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -901,7 +901,7 @@ export default class BackupNg {
 
       // JFT 2018-10-02: support previous snapshots which did not have this
       // entry, can be removed after 2018-12.
-      if (baseSnapshot !== undefined) {
+      if (baseSnapshot === undefined) {
         baseSnapshot = last(snapshots)
       }
     }


### PR DESCRIPTION
Allows runs after failure/interruption to be deltas.
Also, allows some schedules to only do rolling snapshots without breaking the exports.

Thanks a lot to @Samuel-BF for PR #3466.

### Check list

> Check items when done or if not relevant

- [ ] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [x] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (irrelevant)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
