### PR TITLE
VMDK-VHD: expose file length on the stream object

### DIFF
--- a/packages/vhd-lib/vhd.integ.spec.js
+++ b/packages/vhd-lib/vhd.integ.spec.js
@@ -107,12 +107,13 @@ test('ReadableSparseVHDStream can handle a sparse file', async () => {
     },
   ]
   const fileSize = blockSize * 110
-  const stream = createReadableSparseStream(
+  const stream = await createReadableSparseStream(
     fileSize,
     blockSize,
     blocks.map(b => b.offsetBytes),
     blocks
   )
+  expect(stream.length).toEqual(4197888)
   const pipe = stream.pipe(createWriteStream('output.vhd'))
   await fromEvent(pipe, 'finish')
   await execa('vhd-util', ['check', '-t', '-i', '-n', 'output.vhd'])


### PR DESCRIPTION
This looks suspiciously like my last PR, but it's for the VMDK to VHD stream.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
