### PR TITLE
Use config-2 label in XO ConfigDrive volume creaton for more compatib…

### DIFF
--- a/packages/xo-server/src/fatfs-buffer.js
+++ b/packages/xo-server/src/fatfs-buffer.js
@@ -47,7 +47,7 @@ export function init () {
       Reserved1: 0,
       BootSig: 41,
       VolID: 895111106,
-      VolLab: 'NO NAME    ',
+      VolLab: 'config-2   ',
       FilSysType: 'FAT16   ',
     },
     buf


### PR DESCRIPTION
Some OS are trying to find a volume with label 'config-2' for cloud-init. Just provide it during creation of the XO ConfigDrive volume