### PR TITLE
chore(xo-server): use VM.domain_type when available

### DIFF
--- a/packages/xo-server/src/xapi-object-to-xo.js
+++ b/packages/xo-server/src/xapi-object-to-xo.js
@@ -10,7 +10,12 @@ import {
   mapToArray,
   parseXml,
 } from './utils'
-import { isHostRunning, isVmHvm, isVmRunning, parseDateTime } from './xapi'
+import {
+  getVmDomainType,
+  isHostRunning,
+  isVmRunning,
+  parseDateTime,
+} from './xapi'
 import { useUpdateSystem } from './xapi/utils'
 
 // ===================================================================
@@ -225,7 +230,8 @@ const TRANSFORMS = {
       other_config: otherConfig,
     } = obj
 
-    const isHvm = isVmHvm(obj)
+    const domainType = getVmDomainType(obj)
+    const isHvm = domainType === 'hvm'
     const isRunning = isVmRunning(obj)
     const xenTools = (() => {
       if (!isRunning || !metrics) {
@@ -343,11 +349,7 @@ const TRANSFORMS = {
       startTime: metrics && toTimestamp(metrics.start_time),
       tags: obj.tags,
       VIFs: link(obj, 'VIFs'),
-      virtualizationMode: isHvm
-        ? guestMetrics !== undefined && guestMetrics.PV_drivers_detected
-          ? 'pvhvm'
-          : 'hvm'
-        : 'pv',
+      virtualizationMode: domainType,
 
       // <=> Are the Xen Server tools installed?
       //

--- a/packages/xo-server/src/xapi/utils.js
+++ b/packages/xo-server/src/xapi/utils.js
@@ -143,7 +143,18 @@ export const isHostRunning = host => {
 
 // -------------------------------------------------------------------
 
-export const isVmHvm = vm => Boolean(vm.HVM_boot_policy)
+export const getVmDomainType = vm => {
+  const dt = vm.domain_type
+  if (
+    dt !== undefined && // XS < 7.5
+    dt !== 'unspecified' // detection failed
+  ) {
+    return dt
+  }
+  return vm.HVM_boot_policy === '' ? 'pv' : 'hvm'
+}
+
+export const isVmHvm = vm => getVmDomainType(vm) === 'hvm'
 
 const VM_RUNNING_POWER_STATES = {
   Running: true,


### PR DESCRIPTION
And fallback to our previous detection when unavailable.

Starting from this commit, `virtualizationMode` will no longer contain `'pvhvm'`, this must be computed UI side by using both `virtualizationMode` and `xenTools` properties.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`) (none)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [x] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
