### PR TITLE
feat(xen-api): add call params to errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Released packages
 
+- xen-api v0.21.0
 - xo-common v0.2.0
 - xo-acl-resolver v0.4.0
 - xo-server v5.30.0

--- a/packages/xen-api/src/_replaceSensitiveValues.js
+++ b/packages/xen-api/src/_replaceSensitiveValues.js
@@ -1,0 +1,17 @@
+import mapValues from 'lodash/mapValues'
+
+export default function replaceSensitiveValues (value, replacement) {
+  function helper (value, name) {
+    if (name === 'password' && typeof value === 'string') {
+      return replacement
+    }
+
+    if (typeof value !== 'object' || value === null) {
+      return value
+    }
+
+    return Array.isArray(value) ? value.map(helper) : mapValues(value, helper)
+  }
+
+  return helper(value)
+}

--- a/packages/xen-api/src/index.js
+++ b/packages/xen-api/src/index.js
@@ -30,6 +30,7 @@ import {
 } from 'promise-toolbox'
 
 import autoTransport from './transports/auto'
+import replaceSensitiveValues from './_replaceSensitiveValues'
 
 const debug = createDebug('xen-api')
 
@@ -93,7 +94,7 @@ class XapiError extends BaseError {
     this.params = params
 
     // slots than can be assigned later
-    this.method = undefined
+    this.call = undefined
     this.url = undefined
     this.task = undefined
   }
@@ -1071,7 +1072,10 @@ Xapi.prototype._transportCall = reduce(
           error = wrapError(error)
         }
 
-        error.method = method
+        error.call = {
+          method,
+          params: replaceSensitiveValues(args, '*obfuscated*'),
+        }
         throw error
       })
     },

--- a/packages/xen-api/src/index.js
+++ b/packages/xen-api/src/index.js
@@ -1074,7 +1074,7 @@ Xapi.prototype._transportCall = reduce(
 
         error.call = {
           method,
-          params: replaceSensitiveValues(args, '*obfuscated*'),
+          params: replaceSensitiveValues(args, '* obfuscated *'),
         }
         throw error
       })


### PR DESCRIPTION
It also moves `.method` to `.call.method`, but it appears it was not currently used in our code.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`) (none)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [x] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
