### PR TITLE
fix(fs/smb#list): throws ENOTDIR instead of SMB error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [Backup NG logs] Handle failed restores (PR [#3648](https://github.com/vatesfr/xen-orchestra/pull/3648))
 - [Self/New VM] Incorrect limit computation [#3658](https://github.com/vatesfr/xen-orchestra/issues/3658)
 - [Plugins] Don't expose credentials in config to users (PR [#3671](https://github.com/vatesfr/xen-orchestra/pull/3671))
+- [Backup NG] Errors listing backups on SMB remotes with extraneous files (PR [#3685](https://github.com/vatesfr/xen-orchestra/pull/3685))
 
 ### Released packages
 


### PR DESCRIPTION
Fixes support#1014

This is more in line of other handlers and fix an issue in Backup NG where listing VM backups would fail when there are files in `xo-vm-backups/`.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [x] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (irrelevant)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
