### PR TITLE
fix(xo-server/vm.delete): fix template handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [Self/New VM] `not enough … available in the set …` error in some cases (PR [#3667](https://github.com/vatesfr/xen-orchestra/pull/3667))
 - [Backup NG] Errors listing backups on SMB remotes with extraneous files (PR [#3685](https://github.com/vatesfr/xen-orchestra/pull/3685))
 - [Remotes] Don't expose credentials to users [#3682](https://github.com/vatesfr/xen-orchestra/issues/3682) (PR [#3687](https://github.com/vatesfr/xen-orchestra/pull/3687))
+- [VM Templates] Fix deletion [#3498](https://github.com/vatesfr/xen-orchestra/issues/3498) (PR [#3695](https://github.com/vatesfr/xen-orchestra/pull/3695))
 
 ### Released packages
 

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -659,7 +659,7 @@ export default class Xapi extends XapiBase {
     vm = await this.barrier($ref)
 
     if (!force && 'destroy' in vm.blocked_operations) {
-      throw forbiddenOperation('destroy', vm.blocked_operations.reason)
+      throw forbiddenOperation('destroy', vm.blocked_operations.destroy.reason)
     }
 
     if (

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -662,9 +662,12 @@ export default class Xapi extends XapiBase {
       throw forbiddenOperation('destroy', vm.blocked_operations.reason)
     }
 
-    // if (!forceDeleteDefaultTemplate && vm.other_config.default_template === 'true') {
-    //   throw forbiddenOperation('destroy', 'VM is default template')
-    // }
+    if (
+      !forceDeleteDefaultTemplate &&
+      vm.other_config.default_template === 'true'
+    ) {
+      throw forbiddenOperation('destroy', 'VM is default template')
+    }
 
     // It is necessary for suspended VMs to be shut down
     // to be able to delete their VDIs.


### PR DESCRIPTION
Fixes #3498

It seems a recent version of XenServer forbids from destroying VM templates directly, we need to set `is_a_template` to `false` before calling`VM.destroy`.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
