### PR TITLE
feat(xo-server/xen-servers): update server's host when redirecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - [Perf alert] Ability to trigger an alarm if a host/VM/SR usage value is below the threshold [#3612](https://github.com/vatesfr/xen-orchestra/issues/3612) (PR [#3675](https://github.com/vatesfr/xen-orchestra/pull/3675))
+- [Servers] Update the server's host on redirecting to the master [#2238](https://github.com/vatesfr/xen-orchestra/issues/2238) (PR [#3706](https://github.com/vatesfr/xen-orchestra/pull/3706))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/xen-servers.js
+++ b/packages/xo-server/src/xo-mixins/xen-servers.js
@@ -360,7 +360,7 @@ export default class {
       const isPoolMasterConnected = some(
         this._xapis,
         xapi =>
-          xapi.pool != null &&
+          xapi.pool !== null &&
           hostname === xapi.getObject(xapi.pool.master).address
       )
       if (isPoolMasterConnected) {

--- a/packages/xo-server/src/xo-mixins/xen-servers.js
+++ b/packages/xo-server/src/xo-mixins/xen-servers.js
@@ -356,6 +356,7 @@ export default class {
     xapi.xo.install()
 
     const onRedirect = ({ protocol, hostname, port }) => {
+      // FIXME: race condition with the master's connection at the xo-server restart
       const isPoolMasterConnected = some(
         this._xapis,
         xapi =>


### PR DESCRIPTION
See #2238

This PR handle the case when a user attempt to connect to a slave.

On connecting to a slave, the connection is redirected to the master and the `redirect` event is emitted by `XAPI`.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
