### PR TITLE
feat(xo-web/logs): ability to filter logs by the VM name

### DIFF
--- a/packages/xo-web/src/xo-app/logs/backup-ng-logs.js
+++ b/packages/xo-web/src/xo-app/logs/backup-ng-logs.js
@@ -15,7 +15,7 @@ import { connectStore, formatSize, formatSpeed } from 'utils'
 import { createGetObjectsOfType } from 'selectors'
 import { FormattedDate } from 'react-intl'
 import { injectState, provideState } from 'reaclette'
-import { isEmpty, groupBy, keyBy } from 'lodash'
+import { isEmpty, groupBy, map, keyBy } from 'lodash'
 import { subscribeBackupNgJobs, subscribeBackupNgLogs } from 'xo'
 import { toggleState } from 'reaclette-utils'
 import { VmItem, SrItem } from 'render-xo-item'
@@ -338,7 +338,7 @@ export default decorate([
     },
     computed: {
       backupLogs: (_, { logs, vms }) =>
-        defined(logs.backup, []).map(log =>
+        map(logs.backup, log =>
           log.tasks !== undefined
             ? {
                 ...log,

--- a/packages/xo-web/src/xo-app/logs/backup-ng-logs.js
+++ b/packages/xo-web/src/xo-app/logs/backup-ng-logs.js
@@ -336,6 +336,25 @@ export default decorate([
     effects: {
       toggleState,
     },
+    computed: {
+      backupLogs: (_, { logs, vms }) =>
+        defined(logs.backup, []).map(log =>
+          log.tasks !== undefined
+            ? {
+                ...log,
+                vmNames: (() => {
+                  let names
+                  log.tasks.forEach(task => {
+                    const vm = vms[task.data.id]
+                    vm !== undefined &&
+                      (names || (names = [])).push(vm.name_label)
+                  })
+                  return names
+                })(),
+              }
+            : log
+        ),
+    },
   }),
   injectState,
   ({ state, effects, logs, jobs, srs, vms }) => (
@@ -353,7 +372,7 @@ export default decorate([
           />
         </h2>
         <NoObjects
-          collection={logs && defined(logs.backup, [])}
+          collection={logs && state.backupLogs}
           columns={LOG_BACKUP_COLUMNS}
           component={SortedTable}
           data-jobs={jobs}

--- a/packages/xo-web/src/xo-app/logs/backup-ng-logs.js
+++ b/packages/xo-web/src/xo-app/logs/backup-ng-logs.js
@@ -342,15 +342,10 @@ export default decorate([
           log.tasks !== undefined
             ? {
                 ...log,
-                vmNames: (() => {
-                  let names
-                  log.tasks.forEach(task => {
-                    const vm = vms[task.data.id]
-                    vm !== undefined &&
-                      (names || (names = [])).push(vm.name_label)
-                  })
-                  return names
-                })(),
+                // "vmNames" can contains undefined entries
+                vmNames: map(log.tasks, ({ data }) =>
+                  get(() => vms[data.id].name_label)
+                ),
               }
             : log
         ),


### PR DESCRIPTION
Fixes #2947

To be able to filter logs by the VM name, a property in the top level is needed.

In this PR, the property is `vmNames` and its only injected when the VMs tasks exists.

`vmNames` is an array which contains all found VMs name. It can be `undefined` if none VM is found.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [ ] documentation updated

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
