### PR TITLE
fix(xo-web/logs): logs not fetched yet and logs not exists differentiation

### DIFF
--- a/packages/xo-web/src/xo-app/logs/backup-ng-logs.js
+++ b/packages/xo-web/src/xo-app/logs/backup-ng-logs.js
@@ -320,9 +320,10 @@ export default decorate([
     logs: cb =>
       subscribeBackupNgLogs(logs =>
         cb(
-          groupBy(logs, log =>
-            log.message === 'restore' ? 'restore' : 'backup'
-          )
+          logs &&
+            groupBy(logs, log =>
+              log.message === 'restore' ? 'restore' : 'backup'
+            )
         )
       ),
     jobs: cb => subscribeBackupNgJobs(jobs => cb(keyBy(jobs, 'id'))),
@@ -352,7 +353,7 @@ export default decorate([
           />
         </h2>
         <NoObjects
-          collection={defined(() => logs.backup, [])}
+          collection={logs && defined(logs.backup, [])}
           columns={LOG_BACKUP_COLUMNS}
           component={SortedTable}
           data-jobs={jobs}
@@ -370,7 +371,7 @@ export default decorate([
           />
         </h2>
         <NoObjects
-          collection={defined(() => logs.restore, [])}
+          collection={logs && defined(logs.restore, [])}
           columns={LOG_RESTORE_COLUMNS}
           component={SortedTable}
           data-jobs={jobs}


### PR DESCRIPTION
**NoObjects:**

The `NoObjects` is a wrapper which shows a spinner if a collection is `undefined` and a default message if it's empty.

**The Issue:**

In the line `323`, `groupBy` always returns an object even if `logs` is `undefined`.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
