### PR TITLE
feat(xo-server/api): use per message deflate

### DIFF
--- a/packages/xo-server/config.json
+++ b/packages/xo-server/config.json
@@ -2,6 +2,13 @@
 //
 // See sample.config.yaml to override.
 {
+  "apiWebSocketOptions": {
+    // https://github.com/websockets/ws#websocket-compression
+    // "perMessageDeflate": {
+    //   "threshold": 524288 // 512kiB
+    // }
+  },
+
   "http": {
     "listen": [
       {
@@ -27,6 +34,7 @@
 
     "mounts": {}
   },
+
   "datadir": "/var/lib/xo-server/data",
 
   // Should users be created on first sign in?

--- a/packages/xo-server/src/index.js
+++ b/packages/xo-server/src/index.js
@@ -59,7 +59,7 @@ const log = createLogger('xo:main')
 
 const DEPRECATED_ENTRIES = ['users', 'servers']
 
-async function loadConfiguration () {
+async function loadConfiguration() {
   const config = await appConf.load('xo-server', {
     appDir: joinPath(__dirname, '..'),
     ignoreUnknownFormats: true,
@@ -79,7 +79,7 @@ async function loadConfiguration () {
 
 // ===================================================================
 
-function createExpressApp () {
+function createExpressApp() {
   const app = createExpress()
 
   app.use(helmet())
@@ -111,7 +111,7 @@ function createExpressApp () {
   return app
 }
 
-async function setUpPassport (express, xo) {
+async function setUpPassport(express, xo) {
   const strategies = { __proto__: null }
   xo.registerPassportStrategy = strategy => {
     passport.use(strategy)
@@ -214,7 +214,7 @@ async function setUpPassport (express, xo) {
 
 // ===================================================================
 
-async function registerPlugin (pluginPath, pluginName) {
+async function registerPlugin(pluginPath, pluginName) {
   const plugin = require(pluginPath)
   const { description, version = 'unknown' } = (() => {
     try {
@@ -257,7 +257,7 @@ async function registerPlugin (pluginPath, pluginName) {
 
 const logPlugin = createLogger('xo:plugin')
 
-function registerPluginWrapper (pluginPath, pluginName) {
+function registerPluginWrapper(pluginPath, pluginName) {
   logPlugin.info(`register ${pluginName}`)
 
   return registerPlugin.call(this, pluginPath, pluginName).then(
@@ -274,7 +274,7 @@ function registerPluginWrapper (pluginPath, pluginName) {
 const PLUGIN_PREFIX = 'xo-server-'
 const PLUGIN_PREFIX_LENGTH = PLUGIN_PREFIX.length
 
-async function registerPluginsInPath (path) {
+async function registerPluginsInPath(path) {
   const files = await readdir(path).catch(error => {
     if (error.code === 'ENOENT') {
       return []
@@ -295,7 +295,7 @@ async function registerPluginsInPath (path) {
   )
 }
 
-async function registerPlugins (xo) {
+async function registerPlugins(xo) {
   await Promise.all(
     mapToArray(
       [`${__dirname}/../node_modules/`, '/usr/local/lib/node_modules/'],
@@ -306,7 +306,7 @@ async function registerPlugins (xo) {
 
 // ===================================================================
 
-async function makeWebServerListen (
+async function makeWebServerListen(
   webServer,
   {
     certificate,
@@ -348,7 +348,7 @@ async function makeWebServerListen (
   }
 }
 
-async function createWebServer ({ listen, listenOptions }) {
+async function createWebServer({ listen, listenOptions }) {
   const webServer = stoppable(new WebServer())
 
   await Promise.all(
@@ -433,8 +433,10 @@ const setUpStaticFiles = (express, opts) => {
 
 // ===================================================================
 
-const setUpApi = (webServer, xo, verboseLogsOnErrors) => {
+const setUpApi = (webServer, xo, config) => {
   const webSocketServer = new WebSocket.Server({
+    ...config.apiWebSocketOptions,
+
     noServer: true,
   })
   xo.on('stop', () => pFromCallback(cb => webSocketServer.close(cb)))
@@ -547,7 +549,7 @@ ${name} v${version}`)(require('../package.json'))
 
 // ===================================================================
 
-export default async function main (args) {
+export default async function main(args) {
   // makes sure the global Promise has not been changed by a lib
   assert(global.Promise === require('bluebird'))
 
@@ -640,7 +642,7 @@ export default async function main (args) {
   })
 
   // Must be set up before the static files.
-  setUpApi(webServer, xo, config.verboseApiLogsOnErrors)
+  setUpApi(webServer, xo, config)
 
   setUpProxies(express, config.http.proxies, xo)
 


### PR DESCRIPTION
Related to #3699

**Questions**
- should we apply it selectively for some messages?
   - only big messages: > 512kiB
- should we enable this by default?
   - yes, starting from 2019-01 (one month of tests)

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [x] CHANGELOG: (not enabled for the moment)
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (irrelevant)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
