### PR TITLE
fix(xo-server/xen-servers): invalid parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bug fixes
 
+- [Servers] Fix deleting server on joining a pool [#2238](https://github.com/vatesfr/xen-orchestra/issues/2238) (PR [#3728](https://github.com/vatesfr/xen-orchestra/pull/3728))
+
 ### Released packages
 
 - xen-api v0.22.0

--- a/packages/xo-server/src/xo-mixins/xen-servers.js
+++ b/packages/xo-server/src/xo-mixins/xen-servers.js
@@ -1,4 +1,5 @@
 import createLogger from '@xen-orchestra/log'
+import { findKey } from 'lodash'
 import { ignoreErrors } from 'promise-toolbox'
 import { noSuchObject } from 'xo-common/api-errors'
 
@@ -459,6 +460,8 @@ export default class {
       throw e
     }
 
-    await this.unregisterXenServer(sourceId)
+    this.unregisterXenServer(
+      findKey(this._xapis, candidate => candidate === sourceXapi)
+    )::ignoreErrors()
   }
 }

--- a/packages/xo-server/src/xo-mixins/xen-servers.js
+++ b/packages/xo-server/src/xo-mixins/xen-servers.js
@@ -441,12 +441,12 @@ export default class {
     return this._stats.getSrStats(this.getXapi(srId), srId, granularity)
   }
 
-  async mergeXenPools(sourceId, targetId, force = false) {
-    const sourceXapi = this.getXapi(sourceId)
+  async mergeXenPools(sourcePoolId, targetPoolId, force = false) {
+    const sourceXapi = this.getXapi(sourcePoolId)
     const {
       _auth: { user, password },
       _url: { hostname },
-    } = this.getXapi(targetId)
+    } = this.getXapi(targetPoolId)
 
     // We don't want the events of the source XAPI to interfere with
     // the events of the new XAPI.


### PR DESCRIPTION
See #2238

`unregisterXenServer` should be called with the server id instead of the pool id.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
