### PR TITLE
feat(xo-server/xosan): use `XOSAN` as VM tag

### DIFF
--- a/packages/xo-server/src/api/xosan.js
+++ b/packages/xo-server/src/api/xosan.js
@@ -1123,7 +1123,7 @@ async function _prepareGlusterVm(
       }
     }
   }
-  await xapi.addTag(newVM.$id, `XOSAN-${xapi.pool.name_label}`)
+  await xapi.addTag(newVM.$id, 'XOSAN')
   await xapi.editVm(newVM, {
     name_label: `XOSAN - ${lvmSr.name_label} - ${
       host.name_label


### PR DESCRIPTION
It previously was `XOSAN-${pool.name_label}` which is unnecessary, not easy to use for filtering and problematic for #2128.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`) (none)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [ ] CHANGELOG: (not sure it makes sense for users)
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (irrelevant)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
