### PR TITLE
feat(xo-server/xen-servers): add metadata to PoolAlreadyConnected

### DIFF
--- a/packages/xo-server/src/xo-mixins/xen-servers.js
+++ b/packages/xo-server/src/xo-mixins/xen-servers.js
@@ -20,8 +20,11 @@ import { Servers } from '../models/server'
 // ===================================================================
 
 class PoolAlreadyConnected extends BaseError {
-  constructor() {
-    super("the server's pool is already connected")
+  constructor(poolId, connectedServerId, connectingServerId) {
+    super('this pool is already connected')
+    this.poolId = poolId
+    this.connectedServerId = connectedServerId
+    this.connectingServerId = connectingServerId
   }
 }
 
@@ -267,7 +270,11 @@ export default class {
       const serverIdsByPool = this._serverIdsByPool
       const poolId = xapi.pool.$id
       if (serverIdsByPool[poolId] !== undefined) {
-        throw new PoolAlreadyConnected()
+        throw new PoolAlreadyConnected(
+          poolId,
+          serverIdsByPool[poolId],
+          server.id
+        )
       }
 
       serverIdsByPool[poolId] = server.id


### PR DESCRIPTION
I'm open to suggestion for better field names.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`) (none)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [x] CHANGELOG: (irrelevant)
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (irrelevant)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
