### PR TITLE
Fixes #3805 - Fix LUNs not showing up when adding a new HBA SR

### DIFF
--- a/packages/xo-server/src/api/sr.js
+++ b/packages/xo-server/src/api/sr.js
@@ -431,7 +431,7 @@ export async function probeHba({ host }) {
       hba: hbaDevice.hba.trim(),
       path: hbaDevice.path.trim(),
       scsiId: hbaDevice.SCSIid.trim(),
-      size: hbaDevice.size.trim(),
+      size: +hbaDevice.size.trim(),
       vendor: hbaDevice.vendor.trim(),
     })
   })

--- a/packages/xo-web/src/xo-app/new/sr/index.js
+++ b/packages/xo-web/src/xo-app/new/sr/index.js
@@ -56,7 +56,7 @@ class SelectScsiId extends Component {
     () => this.props.options,
     options =>
       map(options, ({ vendor, path, size, scsiId }) => ({
-        label: `${vendor} - ${path} (${formatSize(+size)})`,
+        label: `${vendor} - ${path} (${formatSize(size)})`,
         value: scsiId,
       }))
   )

--- a/packages/xo-web/src/xo-app/new/sr/index.js
+++ b/packages/xo-web/src/xo-app/new/sr/index.js
@@ -56,7 +56,7 @@ class SelectScsiId extends Component {
     () => this.props.options,
     options =>
       map(options, ({ vendor, path, size, scsiId }) => ({
-        label: `${vendor} - ${path} (${formatSize(size)})`,
+        label: `${vendor} - ${path} (${formatSize(parseInt(size))})`,
         value: scsiId,
       }))
   )

--- a/packages/xo-web/src/xo-app/new/sr/index.js
+++ b/packages/xo-web/src/xo-app/new/sr/index.js
@@ -56,7 +56,7 @@ class SelectScsiId extends Component {
     () => this.props.options,
     options =>
       map(options, ({ vendor, path, size, scsiId }) => ({
-        label: `${vendor} - ${path} (${formatSize(parseInt(size))})`,
+        label: `${vendor} - ${path} (${formatSize(+size)})`,
         value: scsiId,
       }))
   )


### PR DESCRIPTION
This fixes an exception thrown when list of discovered HBAs return string
instead of integer as disk size.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
