### PR TITLE
feat(xen-api#{get,put}Resource): add 24h timeout on HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Released packages
 
+- xen-api v0.24.0
 - @xen-orchestra/fs v0.6.0
 - xo-server v5.33.0
 - xo-web v5.33.0


### PR DESCRIPTION
The Xen API does not support longer requests and it's necessary to properly detect broken requests.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`) (none)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [x] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (irrelevant)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
