### PR TITLE
fix(xo-server/xen-servers): handle loosing connection case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - [Self] Display sorted Resource Sets [#3818](https://github.com/vatesfr/xen-orchestra/issues/3818) (PR [#3823](https://github.com/vatesfr/xen-orchestra/pull/3823))
 - [Servers] Correctly report connecting status (PR [#3838](https://github.com/vatesfr/xen-orchestra/pull/3838))
+- [Servers] Fix cannot reconnect to a server after connection has been lost [#3839](https://github.com/vatesfr/xen-orchestra/issues/3839) (PR [#3841](https://github.com/vatesfr/xen-orchestra/pull/3841))
 
 ### Released packages
 

--- a/packages/xo-server/src/xo-mixins/xen-servers.js
+++ b/packages/xo-server/src/xo-mixins/xen-servers.js
@@ -375,6 +375,12 @@ export default class {
       xapi.watchEvents()
 
       this.updateXenServer(id, { error: null })::ignoreErrors()
+
+      xapi.on('disconnected', () => {
+        xapi.xo.uninstall()
+        delete this._xapis[server.id]
+        delete this._serverIdsByPool[poolId]
+      })
     } catch (error) {
       delete this._xapis[server.id]
       xapi.disconnect()::ignoreErrors()

--- a/packages/xo-server/src/xo-mixins/xen-servers.js
+++ b/packages/xo-server/src/xo-mixins/xen-servers.js
@@ -376,7 +376,7 @@ export default class {
 
       this.updateXenServer(id, { error: null })::ignoreErrors()
 
-      xapi.on('disconnected', () => {
+      xapi.once('disconnected', () => {
         xapi.xo.uninstall()
         delete this._xapis[server.id]
         delete this._serverIdsByPool[poolId]


### PR DESCRIPTION
Fixes #3839

It update the local collection on loosing the connection to a pool.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
