### PR TITLE
chore(xo-server/XapiStats): improve the cache implementation

### DIFF
--- a/packages/xo-server/package.json
+++ b/packages/xo-server/package.json
@@ -35,6 +35,7 @@
     "@iarna/toml": "^2.2.1",
     "@xen-orchestra/async-map": "^0.0.0",
     "@xen-orchestra/cron": "^1.0.3",
+    "@xen-orchestra/defined": "^0.0.0",
     "@xen-orchestra/emit-async": "^0.0.0",
     "@xen-orchestra/fs": "^0.7.1",
     "@xen-orchestra/log": "^0.1.4",

--- a/packages/xo-server/package.json
+++ b/packages/xo-server/package.json
@@ -35,7 +35,6 @@
     "@iarna/toml": "^2.2.1",
     "@xen-orchestra/async-map": "^0.0.0",
     "@xen-orchestra/cron": "^1.0.3",
-    "@xen-orchestra/defined": "^0.0.0",
     "@xen-orchestra/emit-async": "^0.0.0",
     "@xen-orchestra/fs": "^0.7.1",
     "@xen-orchestra/log": "^0.1.4",

--- a/packages/xo-server/src/xapi-stats.js
+++ b/packages/xo-server/src/xapi-stats.js
@@ -322,7 +322,10 @@ export default class XapiStats {
 
     // stats are out of date
     if (stepStats.localTimestamp + step < getCurrentTimestamp()) {
-      delete stats[step]
+      delete statsByObject[hostUuid][step]
+      if (vmUuid !== undefined) {
+        delete stats[step]
+      }
       return
     }
 

--- a/packages/xo-server/src/xapi-stats.js
+++ b/packages/xo-server/src/xapi-stats.js
@@ -315,23 +315,24 @@ export default class XapiStats {
     return lastTimestamp
   }
 
-  _getStats(hostUuid, step, vmUuid) {
-    const hostStats = this._statsByObject[hostUuid][step]
-
-    // Return host stats
-    if (vmUuid === undefined) {
-      return {
-        interval: step,
-        ...hostStats,
-      }
+  _getCachedStats(uuid, step) {
+    const stats = this._statsByObject[uuid]
+    if (stats === undefined) {
+      return
     }
 
-    // Return vm stats
-    return {
-      interval: step,
-      endTimestamp: hostStats.endTimestamp,
-      ...this._statsByObject[vmUuid][step],
+    const stepStats = stats[step]
+    if (stepStats === undefined) {
+      return
     }
+
+    // stats are out of date
+    if (stepStats.localTimestamp + step < getCurrentTimestamp) {
+      delete stats[step]
+      return
+    }
+
+    return stepStats
   }
 
   @synchronized.withKey((_, { host }) => host.uuid)
@@ -350,15 +351,12 @@ export default class XapiStats {
     // Limit the number of http requests
     const hostUuid = host.uuid
 
-    if (
-      !(
-        vmUuid !== undefined &&
-        get(this._statsByObject, [vmUuid, step]) === undefined
-      ) &&
-      get(this._statsByObject, [hostUuid, step, 'localTimestamp']) + step >
-        getCurrentTimestamp()
-    ) {
-      return this._getStats(hostUuid, step, vmUuid)
+    const stats = this._getCachedStats(
+      vmUuid !== undefined ? vmUuid : hostUuid,
+      step
+    )
+    if (stats !== undefined) {
+      return stats
     }
 
     const timestamp = await this._getNextTimestamp(xapi, host, step)
@@ -368,6 +366,8 @@ export default class XapiStats {
         `Unable to get the true granularity: ${json.meta.step}`
       )
     }
+
+    const localTimestamp = getCurrentTimestamp()
 
     // It exists data
     if (json.data.length !== 0) {
@@ -430,15 +430,16 @@ export default class XapiStats {
             0,
             metricValues.length - RRD_POINTS_PER_STEP[step]
           )
+
+          const stats = this._statsByObject[uuid][step]
+          stats.endTimestamp = json.meta.end
+          stats.localTimestamp = localTimestamp
+          stats.step = step
         })
       }
     }
 
-    // Update timestamp
-    const hostStats = this._statsByObject[hostUuid][step]
-    hostStats.endTimestamp = json.meta.end
-    hostStats.localTimestamp = getCurrentTimestamp()
-    return this._getStats(hostUuid, step, vmUuid)
+    return this._getCachedStats(hostUuid, step, vmUuid)
   }
 
   getHostStats(xapi, hostId, granularity) {

--- a/packages/xo-server/src/xapi-stats.js
+++ b/packages/xo-server/src/xapi-stats.js
@@ -1,4 +1,3 @@
-import defined from '@xen-orchestra/defined'
 import JSON5 from 'json5'
 import limitConcurrency from 'limit-concurrency-decorator'
 import synchronized from 'decorator-synchronized'
@@ -84,7 +83,7 @@ const combineStats = (stats, path, combineValues) =>
 // targetPath: [a, b, c] => a.b.c
 const getValuesFromDepth = (obj, targetPath, lastChildDefaultValue = []) => {
   if (typeof targetPath === 'string') {
-    return (obj[targetPath] = defined(obj[targetPath], lastChildDefaultValue))
+    return (obj[targetPath] = obj[targetPath] ?? lastChildDefaultValue)
   }
 
   forEach(targetPath, (path, key) => {
@@ -320,7 +319,7 @@ export default class XapiStats {
   _getCachedStats(hostUuid, step, vmUuid) {
     const statsByObject = this._statsByObject
 
-    const stats = statsByObject[defined(vmUuid, hostUuid)]
+    const stats = statsByObject[vmUuid ?? hostUuid]
     if (stats === undefined) {
       return
     }
@@ -451,9 +450,8 @@ export default class XapiStats {
       }
     }
 
-    return defined(
-      get(this._statsByObject, [defined(vmUuid, hostUuid), step]),
-      {
+    return (
+      this._statsByObject[vmUuid ?? hostUuid]?.[step] ?? {
         endTimestamp: localTimestamp,
         interval: step,
         stats: {},

--- a/packages/xo-server/src/xapi-stats.js
+++ b/packages/xo-server/src/xapi-stats.js
@@ -363,15 +363,15 @@ export default class XapiStats {
         }
 
         const xoObjectStats = createGetProperty(this._statsByObject, uuid, {})
-        const stepStats = xoObjectStats[step]
+        let stepStats = xoObjectStats[step]
         if (
           stepStats === undefined ||
           stepStats.localTimestamp !== localTimestamp
         ) {
-          xoObjectStats[step] = {
+          stepStats = xoObjectStats[step] = {
             endTimestamp: json.meta.end,
-            localTimestamp: localTimestamp,
             interval: step,
+            localTimestamp,
           }
         }
 

--- a/packages/xo-server/src/xapi-stats.js
+++ b/packages/xo-server/src/xapi-stats.js
@@ -430,7 +430,7 @@ export default class XapiStats {
               : {}
           )
 
-          const stepStats = getValuesFromDepth(xoObjStats, step, {
+          const stepStats = getValuesFromDepth(xoObjStats, String(step), {
             endTimestamp: json.meta.end,
             localTimestamp: localTimestamp,
             interval: step,

--- a/packages/xo-server/src/xapi-stats.js
+++ b/packages/xo-server/src/xapi-stats.js
@@ -362,14 +362,18 @@ export default class XapiStats {
           return
         }
 
-        const stepStats = createGetProperty(
-          createGetProperty(this._statsByObject, uuid, {}),
-          step,
-          {}
-        )
-        stepStats.endTimestamp = json.meta.end
-        stepStats.localTimestamp = localTimestamp
-        stepStats.interval = step
+        const xoObjectStats = createGetProperty(this._statsByObject, uuid, {})
+        const stepStats = xoObjectStats[step]
+        if (
+          stepStats === undefined ||
+          stepStats.localTimestamp !== localTimestamp
+        ) {
+          xoObjectStats[step] = {
+            endTimestamp: json.meta.end,
+            localTimestamp: localTimestamp,
+            interval: step,
+          }
+        }
 
         const path =
           metric.getPath !== undefined

--- a/packages/xo-server/src/xapi-stats.js
+++ b/packages/xo-server/src/xapi-stats.js
@@ -323,7 +323,8 @@ export default class XapiStats {
 
     const actualStep = json.meta.step
     if (json.data.length > 0) {
-      // got data are organized from the recent to the oldest
+      // fetched data is organized from the newest to the oldest
+      // but this implementation requires it in the other direction
       json.data.reverse()
       json.meta.legend.forEach((legend, index) => {
         const [, type, uuid, metricType] = /^AVERAGE:([^:]+):(.+):(.+)$/.exec(

--- a/packages/xo-server/src/xapi-stats.js
+++ b/packages/xo-server/src/xapi-stats.js
@@ -321,7 +321,7 @@ export default class XapiStats {
     const optimumTimestamp = currentTimeStamp - maxDuration + step
     const json = await this._getJson(xapi, host, optimumTimestamp, step)
 
-    const gotStep = json.meta.step
+    const actualStep = json.meta.step
     if (json.data.length > 0) {
       // got data are organized from the recent to the oldest
       json.data.reverse()
@@ -341,14 +341,14 @@ export default class XapiStats {
         }
 
         const xoObjectStats = createGetProperty(this._statsByObject, uuid, {})
-        let stepStats = xoObjectStats[gotStep]
+        let stepStats = xoObjectStats[actualStep]
         if (
           stepStats === undefined ||
           stepStats.endTimestamp !== json.meta.end
         ) {
-          stepStats = xoObjectStats[gotStep] = {
+          stepStats = xoObjectStats[actualStep] = {
             endTimestamp: json.meta.end,
-            interval: gotStep,
+            interval: actualStep,
           }
         }
 
@@ -374,9 +374,9 @@ export default class XapiStats {
       })
     }
 
-    if (gotStep !== step) {
+    if (actualStep !== step) {
       throw new FaultyGranularity(
-        `Unable to get the true granularity: ${gotStep}`
+        `Unable to get the true granularity: ${actualStep}`
       )
     }
 


### PR DESCRIPTION
In this PR, we improve the cache architecture.

In the implementation, we cache object by its UUID. If it not present in the cache we fetch the stats by host.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] CHANGELOG:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
