### PR TITLE
change cloud-init configdrive to nocloud type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [VM migration] Display hosts' free memory [#3264](https://github.com/vatesfr/xen-orchestra/issues/3264) (PR [#3832](https://github.com/vatesfr/xen-orchestra/pull/3832))
 - [Plugins] New field to filter displayed plugins (PR [#3832](https://github.com/vatesfr/xen-orchestra/pull/3871))
 - Ability to copy ID of "unknown item"s [#3833](https://github.com/vatesfr/xen-orchestra/issues/3833) (PR [#3856](https://github.com/vatesfr/xen-orchestra/pull/3856))
+- [Cloud-Init] switch config drive type to `nocloud` to prepare for the passing of network config (PR [#3877](https://github.com/vatesfr/xen-orchestra/pull/3877))
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [VM migration] Display hosts' free memory [#3264](https://github.com/vatesfr/xen-orchestra/issues/3264) (PR [#3832](https://github.com/vatesfr/xen-orchestra/pull/3832))
 - [Plugins] New field to filter displayed plugins (PR [#3832](https://github.com/vatesfr/xen-orchestra/pull/3871))
+- [Cloud-Init] switch config drive type to `nocloud` to prepare for the passing of network config (PR [#3877](https://github.com/vatesfr/xen-orchestra/pull/3877))
 
 ### Bug fixes
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -24,10 +24,11 @@ to create a [GitHub pull request](https://help.github.com/articles/using-pull-re
 
 
 1. Create a branch for your work
-2. Create a pull request for this branch against the `master` branch
-3. Push into the branch until the pull request is ready to merge
-4. Avoid unnecessary merges: keep you branch up to date by regularly rebasing `git rebase origin/master`
-5. When ready to merge, clean up the history (reorder commits, squash some of them together, rephrase messages): `git rebase -i origin/master`
+2. Add a summary of your changes to `CHANGELOG.md` under the `next` section, if your changes do not relate to an existing changelog item
+3. Create a pull request for this branch against the `master` branch
+4. Push into the branch until the pull request is ready to merge
+5. Avoid unnecessary merges: keep you branch up to date by regularly rebasing `git rebase origin/master`
+6. When ready to merge, clean up the history (reorder commits, squash some of them together, rephrase messages): `git rebase -i origin/master`
 
 ### Issue triage
 

--- a/packages/xo-server/src/fatfs-buffer.js
+++ b/packages/xo-server/src/fatfs-buffer.js
@@ -16,6 +16,7 @@
 //   }
 // })
 
+import assert from 'assert'
 import { boot16 as fat16 } from 'fatfs/structs'
 
 const SECTOR_SIZE = 512
@@ -23,7 +24,10 @@ const SECTOR_SIZE = 512
 const TEN_MIB = 10 * 1024 * 1024
 
 // Creates a 10MB buffer and initializes it as a FAT 16 volume.
-export function init() {
+export function init({ label: 'cidata    ' } = {}) {
+  assert.strictEqual(typeof label, 'string')
+  assert.strictEqual(label.length, 11)
+  
   const buf = Buffer.alloc(TEN_MIB)
 
   // https://github.com/natevw/fatfs/blob/master/structs.js
@@ -47,7 +51,7 @@ export function init() {
       Reserved1: 0,
       BootSig: 41,
       VolID: 895111106,
-      VolLab: 'cidata    ',
+      VolLab: label,
       FilSysType: 'FAT16   ',
     },
     buf

--- a/packages/xo-server/src/fatfs-buffer.js
+++ b/packages/xo-server/src/fatfs-buffer.js
@@ -47,7 +47,7 @@ export function init() {
       Reserved1: 0,
       BootSig: 41,
       VolID: 895111106,
-      VolLab: 'NO NAME    ',
+      VolLab: 'cidata    ',
       FilSysType: 'FAT16   ',
     },
     buf

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -2338,14 +2338,12 @@ export default class Xapi extends XapiBase {
     // Then, generate a FAT fs
     const fs = promisifyAll(fatfs.createFileSystem(fatfsBuffer(buffer)))
 
-    await fs.mkdir('openstack')
-    await fs.mkdir('openstack/latest')
     await Promise.all([
       fs.writeFile(
-        'openstack/latest/meta_data.json',
-        '{\n    "uuid": "' + vm.uuid + '"\n}\n'
+        'meta-data',
+        'instance-id: ' + vm.uuid + '\n'
       ),
-      fs.writeFile('openstack/latest/user_data', config),
+      fs.writeFile('user-data', config),
     ])
 
     // ignore errors, I (JFT) don't understand why they are emitted

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -2327,7 +2327,7 @@ export default class Xapi extends XapiBase {
     const sr = this.getObject(srId)
 
     // First, create a small VDI (10MB) which will become the ConfigDrive
-    const buffer = fatfsBufferInit()
+    const buffer = fatfsBufferInit({ label: 'cidata    ' })
     const vdi = await this.createVdi({
       name_label: 'XO CloudConfigDrive',
       size: buffer.length,


### PR DESCRIPTION
built, tested, and properly working with cloud-init and cloud templates. The configdrive label is properly changed to `cidata`:

```
root@nocloudtest:/mnt# lsblk -o name,mountpoint,label,size,uuid |grep cidata
xvdb    /mnt       cidata   10M 355A-4FC2
```
The `meta-data` file is properly created with the instance-id as specified by the cloud-init `nocloud` drive requirements:

```
root@nocloudtest:/mnt# cat meta-data
instance-id: 743ae8ed-3edb-a7be-6c11-f8c711f440b4
```

And user entered data is passed properly to a `user-data` file in the correct place:

```
root@nocloudtest:/mnt# cat user-data
#cloud-config
manage_etc_hosts: true
hostname: nocloudtest
fqdn: nocloud.home.lan
```

Cloud-init properly detects the `nocloud` drive type now and uses it to configure the VM:
```
util.py[DEBUG]: Cloud-init v. 0.7.9 finished at Thu, 17 Jan 2019 07:02:41 +0000. Datasource DataSourceNoCloud [seed=/dev/xvdb][dsmode=net].  Up 19.84 seconds
util.py[DEBUG]: Writing to /var/lib/cloud/instance/boot-finished - wb: [420] 51 bytes
```

This will not change any cloud-init behavior on it's own, but once we are now presenting a `nocloud` drive type, we will be able to pass network settings to the VM via a `network-config` file