### PR TITLE
feat(xo-web/editable): blur always submits

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -4,7 +4,7 @@
 
 - [VM migration] Display same-pool hosts first in the selector [#3262](https://github.com/vatesfr/xen-orchestra/issues/3262) (PR [#3890](https://github.com/vatesfr/xen-orchestra/pull/3890))
 - [Home/VM] Sort VM by start time [#3955](https://github.com/vatesfr/xen-orchestra/issues/3955) (PR [#3970](https://github.com/vatesfr/xen-orchestra/pull/3970))
-- [Editable fields] Unfocusing (clicking outside) submit the change instead of canceling (PR [#3980](https://github.com/vatesfr/xen-orchestra/pull/3980))
+- [Editable fields] Unfocusing (clicking outside) submits the change instead of canceling (PR [#3980](https://github.com/vatesfr/xen-orchestra/pull/3980))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -4,6 +4,7 @@
 
 - [VM migration] Display same-pool hosts first in the selector [#3262](https://github.com/vatesfr/xen-orchestra/issues/3262) (PR [#3890](https://github.com/vatesfr/xen-orchestra/pull/3890))
 - [Home/VM] Sort VM by start time [#3955](https://github.com/vatesfr/xen-orchestra/issues/3955) (PR [#3970](https://github.com/vatesfr/xen-orchestra/pull/3970))
+- [Editable fields] Unfocusing (clicking outside) submit the change instead of canceling (PR [#3980](https://github.com/vatesfr/xen-orchestra/pull/3980))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/editable/index.js
+++ b/packages/xo-web/src/common/editable/index.js
@@ -104,9 +104,7 @@ class Editable extends Component {
     )
   }
 
-  _save() {
-    return this.__save(() => this.value, this.props.onChange)
-  }
+  _save = () => this.__save(() => this.value, this.props.onChange)
 
   async __save(getValue, saveValue) {
     const { props } = this
@@ -275,7 +273,7 @@ export class Text extends Editable {
         {...extraProps}
         autoFocus
         defaultValue={value}
-        onBlur={this._closeEdition}
+        onBlur={this._save}
         onInput={this._onInput}
         onKeyDown={this._onKeyDown}
         readOnly={saving}
@@ -492,10 +490,10 @@ export class Size extends Editable {
     return this.props.children || formatSize(this.props.value)
   }
 
-  _closeEditionIfUnfocused = () => {
+  _saveIfUnfocused = () => {
     this._focused = false
     setTimeout(() => {
-      !this._focused && this._closeEdition()
+      !this._focused && this._save()
     }, 10)
   }
 
@@ -512,7 +510,7 @@ export class Size extends Editable {
         // SizeInput uses `input-group` which makes it behave as a block element (display: table).
         // `form-inline` to use it as an inline element
         className='form-inline'
-        onBlur={this._closeEditionIfUnfocused}
+        onBlur={this._saveIfUnfocused}
         onFocus={this._focus}
         onKeyDown={this._onKeyDown}
       >


### PR DESCRIPTION
Previous behavior (blur cancels) was surprising to users.

Enter still submits and Escape still cancels.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR (no visible changes)
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (no related doc)
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
