### PR TITLE
fix(xo-web/new-network): PIF should not be required

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -4,6 +4,8 @@
 
 ### Bug fixes
 
+- [New network] PIF was wrongly required which prevented from creating a private network (PR [#4010](https://github.com/vatesfr/xen-orchestra/pull/4010))
+
 ### Released packages
 
 - xo-server v5.37.0

--- a/packages/xo-web/src/xo-app/new/network/index.js
+++ b/packages/xo-web/src/xo-app/new/network/index.js
@@ -92,7 +92,7 @@ const NewNetwork = decorate([
             description,
             mtu,
             name,
-            pif: pif.id,
+            pif: pif && pif.id,
             pool: pool.id,
             vlan,
           })
@@ -160,7 +160,7 @@ const NewNetwork = decorate([
                       multi={bonded}
                       onChange={effects.onChangePif}
                       predicate={pifPredicate}
-                      required
+                      required={bonded}
                       value={bonded ? pifs : pif}
                     />
                     <label>{_('newNetworkName')}</label>

--- a/packages/xo-web/src/xo-app/new/network/index.js
+++ b/packages/xo-web/src/xo-app/new/network/index.js
@@ -92,7 +92,7 @@ const NewNetwork = decorate([
             description,
             mtu,
             name,
-            pif: pif && pif.id,
+            pif: pif == null ? undefined : pif.id,
             pool: pool.id,
             vlan,
           })


### PR DESCRIPTION
Introduced by 7a2a88b7ad93e95d890c6e2d97d131cc564fa2e3

Requiring a PIF prevents from creating private networks

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
