### PR TITLE
fix(xo-web/menu/xoa): display icon when no notifications nor updates

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -10,6 +10,7 @@
 ### Bug fixes
 
 - [Continuous Replication] Fix VHD size guess for empty files [#4105](https://github.com/vatesfr/xen-orchestra/issues/4105)  (PR [#4107](https://github.com/vatesfr/xen-orchestra/pull/4107))
+- [Menu] XOA: Display icon when no notifications nor updates [#4012](https://github.com/vatesfr/xen-orchestra/issues/4012) (PR [#4068](https://github.com/vatesfr/xen-orchestra/pull/4068)
 
 ### Released packages
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -10,7 +10,7 @@
 ### Bug fixes
 
 - [Continuous Replication] Fix VHD size guess for empty files [#4105](https://github.com/vatesfr/xen-orchestra/issues/4105)  (PR [#4107](https://github.com/vatesfr/xen-orchestra/pull/4107))
-- [Menu] XOA: Display icon when no notifications nor updates [#4012](https://github.com/vatesfr/xen-orchestra/issues/4012) (PR [#4068](https://github.com/vatesfr/xen-orchestra/pull/4068)
+- [Menu] XOA: Fixed empty slot when menu is collapsed [#4012](https://github.com/vatesfr/xen-orchestra/issues/4012) (PR [#4068](https://github.com/vatesfr/xen-orchestra/pull/4068)
 
 ### Released packages
 

--- a/packages/xo-web/src/common/selectors.js
+++ b/packages/xo-web/src/common/selectors.js
@@ -213,6 +213,8 @@ export const getStatus = state => state.status
 
 export const getUser = state => state.user
 
+export const getXoaState = state => state.xoaUpdaterState
+
 export const getCheckPermissions = invoke(() => {
   const getPredicate = create(
     state => state.permissions,

--- a/packages/xo-web/src/xo-app/menu/index.js
+++ b/packages/xo-web/src/xo-app/menu/index.js
@@ -532,8 +532,7 @@ export default class Menu extends Component {
 const MenuLinkItem = props => {
   const { item } = props
   const { to, icon, label, subMenu, pill, extra } = item
-  const extraIsArray = Array.isArray(extra)
-  const _extra = extraIsArray ? extra.find(e => e !== null) : extra
+  const _extra = extra !== undefined ? extra.find(e => e !== null) : undefined
 
   return (
     <li className='nav-item xo-menu-item'>
@@ -556,10 +555,8 @@ const MenuLinkItem = props => {
         {pill > 0 && <span className='tag tag-pill tag-primary'>{pill}</span>}
         {_extra}
         <span className={styles.hiddenCollapsed}>
-          {extraIsArray &&
-            extra.map(e =>
-              e !== null && e !== _extra ? <span>{e}</span> : null
-            )}
+          {extra !== undefined &&
+            extra.map(e => (e !== null && e !== _extra ? e : null))}
         </span>
       </Link>
       {subMenu && <SubMenu items={subMenu} />}

--- a/packages/xo-web/src/xo-app/menu/index.js
+++ b/packages/xo-web/src/xo-app/menu/index.js
@@ -25,7 +25,7 @@ import {
   getXoaState,
   isAdmin,
 } from 'selectors'
-import { every, isEmpty, map } from 'lodash'
+import { every, identity, isEmpty, map } from 'lodash'
 
 import styles from './index.css'
 
@@ -258,8 +258,10 @@ export default class Menu extends Component {
         icon: 'menu-xoa',
         label: 'xoa',
         extra: [
-          !isAdmin || xoaState === 'upToDate' ? null : <UpdateTag />,
-          noNotifications ? null : <NotificationTag />,
+          !isAdmin || xoaState === 'upToDate' ? null : (
+            <UpdateTag key='update' />
+          ),
+          noNotifications ? null : <NotificationTag key='notification' />,
         ],
         subMenu: [
           isAdmin && {
@@ -553,10 +555,9 @@ const MenuLinkItem = props => {
           &nbsp;
         </span>
         {pill > 0 && <span className='tag tag-pill tag-primary'>{pill}</span>}
-        {_extra}
+        <span className={styles.hiddenUncollapsed}>{_extra}</span>
         <span className={styles.hiddenCollapsed}>
-          {extra !== undefined &&
-            extra.map(e => (e !== null && e !== _extra ? e : null))}
+          {extra !== undefined && extra.map(identity)}
         </span>
       </Link>
       {subMenu && <SubMenu items={subMenu} />}


### PR DESCRIPTION
fixes #4012

### Screenshots

![Capture d’écran de 2019-03-27 17-00-14](https://user-images.githubusercontent.com/7724491/55092016-1d733100-50b2-11e9-9525-d1fd92b90c52.png)

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
