### PR TITLE
fix(xo-web/JSON schema object input): clear when un-use

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -10,6 +10,7 @@
 ### Bug fixes
 
 - [Home] Always sort the items by their names as a secondary sort criteria [#3983](https://github.com/vatesfr/xen-orchestra/issues/3983) (PR [#4047](https://github.com/vatesfr/xen-orchestra/pull/4047))
+- [Plugins] Properly remove optional settings when unchecking _Fill information_ (PR [#4076](https://github.com/vatesfr/xen-orchestra/pull/4076))
 - [Remotes] Fixes `spawn mount EMFILE` error during backup
 - Properly redirect to sign in page instead of being stuck in a refresh loop
 - [Backup-ng] No more false positives when list matching VMs on Home page [#4078](https://github.com/vatesfr/xen-orchestra/issues/4078) (PR [#4085](https://github.com/vatesfr/xen-orchestra/pull/4085))

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -10,10 +10,10 @@
 ### Bug fixes
 
 - [Home] Always sort the items by their names as a secondary sort criteria [#3983](https://github.com/vatesfr/xen-orchestra/issues/3983) (PR [#4047](https://github.com/vatesfr/xen-orchestra/pull/4047))
-- [Plugins] Properly remove optional settings when unchecking _Fill information_ (PR [#4076](https://github.com/vatesfr/xen-orchestra/pull/4076))
 - [Remotes] Fixes `spawn mount EMFILE` error during backup
 - Properly redirect to sign in page instead of being stuck in a refresh loop
 - [Backup-ng] No more false positives when list matching VMs on Home page [#4078](https://github.com/vatesfr/xen-orchestra/issues/4078) (PR [#4085](https://github.com/vatesfr/xen-orchestra/pull/4085))
+- [Plugins] Properly remove optional settings when unchecking _Fill information_ (PR [#4076](https://github.com/vatesfr/xen-orchestra/pull/4076))
 
 ### Released packages
 

--- a/packages/xo-web/src/common/json-schema-input/object-input.js
+++ b/packages/xo-web/src/common/json-schema-input/object-input.js
@@ -6,6 +6,7 @@ import { keyBy, map } from 'lodash'
 
 import _ from '../intl'
 import Component from '../base-component'
+import getEventValue from '../get-event-value'
 import { EMPTY_OBJECT } from '../utils'
 
 import GenericInput from './generic-input'
@@ -31,6 +32,14 @@ export default class ObjectInput extends Component {
       ...this.props.value,
       [key]: value,
     })
+  }
+
+  _onUseChange = event => {
+    const use = getEventValue(event)
+    if (!use) {
+      this.props.onChange()
+    }
+    this.setState({ use })
   }
 
   _getRequiredProps = createSelector(
@@ -67,7 +76,7 @@ export default class ObjectInput extends Component {
               <input
                 checked={use}
                 disabled={disabled}
-                onChange={this.linkState('use')}
+                onChange={this._onUseChange}
                 type='checkbox'
               />{' '}
               {_('fillOptionalInformations')}


### PR DESCRIPTION
For example: it's currently not possible to remove optional fields in plugins' configs.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`) (none)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [ ] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (irrelevant)
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
