### PR TITLE
feat(xen-api/{get,put}Resource): add inactivity detection

### DIFF
--- a/packages/xen-api/src/index.js
+++ b/packages/xen-api/src/index.js
@@ -580,6 +580,7 @@ export class Xapi extends EventEmitter {
     }
 
     const doRequest = httpRequest.put.bind(
+      undefined,
       $cancelToken,
       this._url,
       host && {

--- a/packages/xen-api/src/index.js
+++ b/packages/xen-api/src/index.js
@@ -583,14 +583,14 @@ export class Xapi extends EventEmitter {
       undefined,
       $cancelToken,
       this._url,
-      host && {
+      host !== undefined && {
         hostname: this.getObject(host).address,
       },
       {
         body,
         headers,
-        query,
         pathname,
+        query,
         rejectUnauthorized: !this._allowUnauthorized,
 
         // this is an inactivity timeout (unclear in Node doc)
@@ -598,8 +598,8 @@ export class Xapi extends EventEmitter {
       }
     )
 
-    // if a stream, sends a dummy request to probe for a
-    // redirection before consuming body
+    // if body is a stream, sends a dummy request to probe for a redirection
+    // before consuming body
     const response = await (isStream
       ? doRequest({
           body: '',


### PR DESCRIPTION
Also clean up the code.

**Reviewers:** lots of indentation changes, you should [ignore whitespaces and use side-by-side diff](https://github.com/vatesfr/xen-orchestra/pull/4090/files?diff=split&w=1).

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`) (none)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [ ] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (irrelevant)
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
