### PR TITLE
 fix(xo-web/backup-ng): transfer/merge tasks not displayed in the logs

### DIFF
--- a/packages/xo-web/src/xo-app/logs/backup-ng/log-alert-body.js
+++ b/packages/xo-web/src/xo-app/logs/backup-ng/log-alert-body.js
@@ -283,7 +283,7 @@ const TaskLi = ({ className, task, ...props }) => {
   if (
     (Component = defined(
       () => COMPONENT_BY_TYPE[task.data.type.toLowerCase()],
-      COMPONENT_BY_MESSAGE[task.message]
+      () => COMPONENT_BY_MESSAGE[task.message]
     )) === undefined
   ) {
     return null

--- a/packages/xo-web/src/xo-app/logs/backup-ng/log-alert-body.js
+++ b/packages/xo-web/src/xo-app/logs/backup-ng/log-alert-body.js
@@ -283,6 +283,8 @@ const TaskLi = ({ className, task, ...props }) => {
   if (
     (Component = defined(
       () => COMPONENT_BY_TYPE[task.data.type.toLowerCase()],
+
+      // work-around to not let defined handle the component as a safety function
       () => COMPONENT_BY_MESSAGE[task.message]
     )) === undefined
   ) {


### PR DESCRIPTION
Introduced by 865d2df124a55576df089c8ba7e2d682a5362710

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
