### PR TITLE
fix(Backup-ng): report sent even though "Never" is selected

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -4,8 +4,11 @@
 
 ### Bug fixes
 
+- [Backup NG] Fix report sent even though "Never" is selected [#4092](https://github.com/vatesfr/xen-orchestra/issues/4092) (PR [#4178](https://github.com/vatesfr/xen-orchestra/pull/4178))
+
 ### Released packages
 
+- xo-server-backup-reports v0.16.1
 - @xen-orchestra/fs v0.9.0
 - vhd-lib v0.7.0
 - xo-server v5.41.0

--- a/packages/xo-server-backup-reports/src/index.js
+++ b/packages/xo-server-backup-reports/src/index.js
@@ -245,6 +245,8 @@ class BackupReportsXoPlugin {
       if (
         !force &&
         (reportWhen === 'never' ||
+          // Introduced by: https://github.com/vatesfr/xen-orchestra/pull/2869/commits/753ee994f2948bbaca9d3161eaab82329a682773#diff-9c044ab8a42ed6576ea927a64c1ec3ebR105
+          reportWhen === 'Never' ||
           (reportWhen === 'failure' && log.status === 'success'))
       ) {
         return

--- a/packages/xo-server-backup-reports/src/index.js
+++ b/packages/xo-server-backup-reports/src/index.js
@@ -245,7 +245,8 @@ class BackupReportsXoPlugin {
       if (
         !force &&
         (reportWhen === 'never' ||
-          // Introduced by: https://github.com/vatesfr/xen-orchestra/pull/2869/commits/753ee994f2948bbaca9d3161eaab82329a682773#diff-9c044ab8a42ed6576ea927a64c1ec3ebR105
+          // Handle improper value introduced by:
+          // https://github.com/vatesfr/xen-orchestra/commit/753ee994f2948bbaca9d3161eaab82329a682773#diff-9c044ab8a42ed6576ea927a64c1ec3ebR105
           reportWhen === 'Never' ||
           (reportWhen === 'failure' && log.status === 'success'))
       ) {

--- a/packages/xo-web/src/xo-app/backup-ng/new/index.js
+++ b/packages/xo-web/src/xo-app/backup-ng/new/index.js
@@ -126,7 +126,7 @@ const REPORT_WHEN_FILTER_OPTIONS = [
   },
   {
     label: 'reportWhenNever',
-    value: 'Never',
+    value: 'never',
   },
 ]
 


### PR DESCRIPTION
Fixes #4092

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
