### PR TITLE
feat(xo-server): admin account from XenStore

### DIFF
--- a/packages/xo-server/src/_XenStore.js
+++ b/packages/xo-server/src/_XenStore.js
@@ -1,0 +1,5 @@
+import fromCallback from 'promise-toolbox/fromCallback'
+import { execFile } from 'child_process'
+
+export const read = key =>
+  fromCallback(cb => execFile('xenstore-read', [key], cb))

--- a/packages/xo-server/src/xo-mixins/subjects.js
+++ b/packages/xo-server/src/xo-mixins/subjects.js
@@ -4,6 +4,7 @@ import { ignoreErrors } from 'promise-toolbox'
 import { hash, needsRehash, verify } from 'hashy'
 import { invalidCredentials, noSuchObject } from 'xo-common/api-errors'
 
+import * as XenStore from '../_XenStore'
 import { Groups } from '../models/group'
 import { Users } from '../models/user'
 import { forEach, isEmpty, lightSet, mapToArray } from '../utils'
@@ -68,8 +69,12 @@ export default class {
       )
 
       if (!(await usersDb.exists())) {
-        const email = 'admin@admin.net'
-        const password = 'admin'
+        const {
+          email = 'admin@admin.net',
+          password = 'admin',
+        } = await XenStore.read('vm-data/admin-account')
+          .then(JSON.parse)
+          .catch(() => ({}))
 
         await this.createUser({ email, password, permission: 'admin' })
         log.info(`Default user created: ${email} with password ${password}`)


### PR DESCRIPTION
XenStore can be used to pass the credentials of the default admin account to xo-server:

`vm-data/admin-account` entry:

```json
{ "email": "admin@admin.net", "password": "admin" }
```

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`) (none)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [x] `CHANGELOG.unreleased.md`: (irrelevant)
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (tool low level)
- [x] **I have tested added/updated features** (and impacted code) (simulated)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
