### PR TITLE
fix(xo-server/remotes): always JSON encode benchmarks

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -6,6 +6,7 @@
 
 - [Pool/Patches] Fix "an error has occurred" in "Applied patches" [#4192](https://github.com/vatesfr/xen-orchestra/issues/4192) (PR [#4193](https://github.com/vatesfr/xen-orchestra/pull/4193))
 - [Backup NG] Fix report sent even though "Never" is selected [#4092](https://github.com/vatesfr/xen-orchestra/issues/4092) (PR [#4178](https://github.com/vatesfr/xen-orchestra/pull/4178))
+- [Remotes] Fix issues after a config import (PR [#4197](https://github.com/vatesfr/xen-orchestra/pull/4197))
 
 ### Released packages
 

--- a/packages/xo-server/src/models/remote.js
+++ b/packages/xo-server/src/models/remote.js
@@ -22,4 +22,16 @@ export class Remotes extends Collection {
     })
     return remotes
   }
+
+  _update(remotes) {
+    return super._update(
+      remotes.map(remote => {
+        const { benchmarks } = remote
+        if (benchmarks !== undefined) {
+          remote.benchmarks = JSON.stringify(benchmarks)
+        }
+        return remote
+      })
+    )
+  }
 }

--- a/packages/xo-server/src/xo-mixins/remotes.js
+++ b/packages/xo-server/src/xo-mixins/remotes.js
@@ -168,19 +168,12 @@ export default class {
   }
 
   @synchronized()
-  async _updateRemote(id, { benchmarks, url, ...props }) {
+  async _updateRemote(id, { url, ...props }) {
     const remote = await this._getRemote(id)
 
     // url is handled separately to take care of obfuscated values
     if (typeof url === 'string') {
       remote.url = format(sensitiveValues.merge(parse(url), parse(remote.url)))
-    }
-
-    if (
-      benchmarks !== undefined ||
-      (benchmarks = remote.benchmarks) !== undefined
-    ) {
-      remote.benchmarks = JSON.stringify(benchmarks)
     }
 
     patch(remote, props)


### PR DESCRIPTION
See xoa-support#1464

Fix an issue when restoring from config.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (irrelevant)
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
