### PR TITLE
feat(logs/backup-ng): support ticket with attached log

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Logs] Ability to report a bug with attached log (PR [#4201](https://github.com/vatesfr/xen-orchestra/pull/4201))
 
 ### Bug fixes
 

--- a/packages/xo-web/package.json
+++ b/packages/xo-web/package.json
@@ -130,6 +130,7 @@
     "reselect": "^2.5.4",
     "rimraf": "^3.0.0",
     "semver": "^6.0.0",
+    "strip-ansi": "^5.2.0",
     "styled-components": "^3.1.5",
     "uglify-es": "^3.3.4",
     "uncontrollable-input": "^0.1.1",

--- a/packages/xo-web/package.json
+++ b/packages/xo-web/package.json
@@ -34,6 +34,7 @@
     "@nraynaud/novnc": "0.6.1",
     "@xen-orchestra/cron": "^1.0.6",
     "@xen-orchestra/defined": "^0.0.0",
+    "@xen-orchestra/log": "^0.2.0",
     "@xen-orchestra/template": "^0.1.0",
     "ansi_up": "^4.0.3",
     "asap": "^2.0.6",

--- a/packages/xo-web/src/common/plans.js
+++ b/packages/xo-web/src/common/plans.js
@@ -1,0 +1,7 @@
+export const XOA_PLAN_FREE = 1
+export const XOA_PLAN_STARTER = 2
+export const XOA_PLAN_ENTERPRISE = 3
+export const XOA_PLAN_PREMIUM = 4
+export const XOA_PLAN_SOURCES = 5
+
+export default +process.env.XOA_PLAN

--- a/packages/xo-web/src/common/plans.js
+++ b/packages/xo-web/src/common/plans.js
@@ -1,6 +1,0 @@
-export const XOA_PLAN_CURRENT = +process.env.XOA_PLAN
-export const XOA_PLAN_FREE = 1
-export const XOA_PLAN_STARTER = 2
-export const XOA_PLAN_ENTERPRISE = 3
-export const XOA_PLAN_PREMIUM = 4
-export const XOA_PLAN_SOURCES = 5

--- a/packages/xo-web/src/common/plans.js
+++ b/packages/xo-web/src/common/plans.js
@@ -1,7 +1,6 @@
+export const XOA_PLAN_CURRENT = +process.env.XOA_PLAN
 export const XOA_PLAN_FREE = 1
 export const XOA_PLAN_STARTER = 2
 export const XOA_PLAN_ENTERPRISE = 3
 export const XOA_PLAN_PREMIUM = 4
 export const XOA_PLAN_SOURCES = 5
-
-export default +process.env.XOA_PLAN

--- a/packages/xo-web/src/common/report-bug-button.js
+++ b/packages/xo-web/src/common/report-bug-button.js
@@ -3,7 +3,9 @@ import currentPlan, { XOA_PLAN_FREE, XOA_PLAN_SOURCES } from 'plans'
 import decorate from 'apply-decorators'
 import PropTypes from 'prop-types'
 import React from 'react'
+import stripAnsi from 'strip-ansi'
 import xoaUpdater from 'xoa-updater'
+import { checkXoa } from 'xo'
 import { createBinaryFile } from 'utils'
 import { identity, omit } from 'lodash'
 import { injectState, provideState } from 'reaclette'
@@ -55,6 +57,12 @@ const reportOnSupportPanel = async ({
       JSON.stringify(await xoaUpdater.getLocalManifest(), null, 2)
     ),
     'manifest.json'
+  )
+
+  formData.append(
+    'attachments',
+    createBinaryFile(stripAnsi(await checkXoa())),
+    'xoaCheck.txt'
   )
 
   const res = await post(SUPPORT_PANEL_URL, formData)

--- a/packages/xo-web/src/common/report-bug-button.js
+++ b/packages/xo-web/src/common/report-bug-button.js
@@ -1,9 +1,9 @@
 import _ from 'intl'
+import * as xoaPlans from 'xoa-plans'
 import decorate from 'apply-decorators'
 import PropTypes from 'prop-types'
 import React from 'react'
 import stripAnsi from 'strip-ansi'
-import xoaPlans from 'xoa-plans'
 import xoaUpdater from 'xoa-updater'
 import { checkXoa } from 'xo'
 import { createBinaryFile } from 'utils'
@@ -18,7 +18,6 @@ import ActionRowButton from './action-row-button'
 
 const logger = createLogger('report-bug-button')
 
-export const CAN_REPORT_BUG = xoaPlans.CURRENT > xoaPlans.FREE
 const SUPPORT_PANEL_URL = './api/support/create/ticket'
 
 const reportOnGithub = ({ formatMessage, message, title }) => {

--- a/packages/xo-web/src/common/report-bug-button.js
+++ b/packages/xo-web/src/common/report-bug-button.js
@@ -1,5 +1,5 @@
 import _ from 'intl'
-import createLogger from '@xen-orchestra/log'
+import { createLogger } from '@xen-orchestra/log'
 import currentPlan, { XOA_PLAN_FREE, XOA_PLAN_SOURCES } from 'plans'
 import decorate from 'apply-decorators'
 import PropTypes from 'prop-types'

--- a/packages/xo-web/src/common/report-bug-button.js
+++ b/packages/xo-web/src/common/report-bug-button.js
@@ -6,7 +6,7 @@ import React from 'react'
 import stripAnsi from 'strip-ansi'
 import xoaUpdater from 'xoa-updater'
 import { checkXoa } from 'xo'
-import { createBinaryFile } from 'utils'
+import { createBlobFromString } from 'utils'
 import { createLogger } from '@xen-orchestra/log'
 import { identity, omit } from 'lodash'
 import { injectState, provideState } from 'reaclette'
@@ -61,7 +61,7 @@ const reportOnSupportPanel = async ({
         manifest =>
           formData.append(
             'attachments',
-            createBinaryFile(JSON.stringify(manifest, null, 2)),
+            createBlobFromString(JSON.stringify(manifest, null, 2)),
             'manifest.json'
           ),
         error => logger.warn('cannot get the local manifest', { error })
@@ -72,7 +72,7 @@ const reportOnSupportPanel = async ({
         xoaCheck =>
           formData.append(
             'attachments',
-            createBinaryFile(stripAnsi(xoaCheck)),
+            createBlobFromString(stripAnsi(xoaCheck)),
             'xoaCheck.txt'
           ),
         error => logger.warn('cannot get the xoa check', { error })

--- a/packages/xo-web/src/common/report-bug-button.js
+++ b/packages/xo-web/src/common/report-bug-button.js
@@ -1,13 +1,13 @@
 import _ from 'intl'
-import { createLogger } from '@xen-orchestra/log'
-import currentPlan, { XOA_PLAN_FREE, XOA_PLAN_SOURCES } from 'plans'
 import decorate from 'apply-decorators'
 import PropTypes from 'prop-types'
 import React from 'react'
 import stripAnsi from 'strip-ansi'
+import xoaPlans from 'xoa-plans'
 import xoaUpdater from 'xoa-updater'
 import { checkXoa } from 'xo'
 import { createBinaryFile } from 'utils'
+import { createLogger } from '@xen-orchestra/log'
 import { identity, omit } from 'lodash'
 import { injectState, provideState } from 'reaclette'
 import { post } from 'fetch'
@@ -17,7 +17,7 @@ import ActionRowButton from './action-row-button'
 
 const logger = createLogger('report-bug-button')
 
-export const CAN_REPORT_BUG = currentPlan > XOA_PLAN_FREE
+export const CAN_REPORT_BUG = xoaPlans.CURRENT > xoaPlans.FREE
 const SUPPORT_PANEL_URL = './api/support/create/ticket'
 
 const reportOnGithub = ({ formatMessage, message, title }) => {
@@ -85,7 +85,7 @@ const reportOnSupportPanel = async ({
 }
 
 export const reportBug =
-  currentPlan === XOA_PLAN_SOURCES ? reportOnGithub : reportOnSupportPanel
+  xoaPlans.CURRENT === xoaPlans.SOURCES ? reportOnGithub : reportOnSupportPanel
 
 const REPORT_BUG_BUTTON_PROP_TYPES = {
   files: PropTypes.arrayOf(

--- a/packages/xo-web/src/common/report-bug-button.js
+++ b/packages/xo-web/src/common/report-bug-button.js
@@ -56,7 +56,7 @@ const reportOnSupportPanel = async ({
 
   await Promise.all([
     timeout
-      .call(xoaUpdater.getLocalManifest(), 6e4)
+      .call(xoaUpdater.getLocalManifest(), 5e3)
       .then(
         manifest =>
           formData.append(
@@ -67,7 +67,7 @@ const reportOnSupportPanel = async ({
         error => logger.warn('cannot get the local manifest', { error })
       ),
     timeout
-      .call(checkXoa(), 6e4)
+      .call(checkXoa(), 5e3)
       .then(
         xoaCheck =>
           formData.append(

--- a/packages/xo-web/src/common/report-bug-button.js
+++ b/packages/xo-web/src/common/report-bug-button.js
@@ -64,7 +64,7 @@ const reportOnSupportPanel = async ({
             createBinaryFile(JSON.stringify(manifest, null, 2)),
             'manifest.json'
           ),
-        error => logger.error('cannot get the local manifest', { error })
+        error => logger.warn('cannot get the local manifest', { error })
       ),
     checkXoa().then(
       xoaCheck =>
@@ -73,7 +73,7 @@ const reportOnSupportPanel = async ({
           createBinaryFile(stripAnsi(xoaCheck)),
           'xoaCheck.txt'
         ),
-      error => logger.error('cannot get the xoa check', { error })
+      error => logger.warn('cannot get the xoa check', { error })
     ),
   ])
 

--- a/packages/xo-web/src/common/report-bug-button.js
+++ b/packages/xo-web/src/common/report-bug-button.js
@@ -1,13 +1,21 @@
 import _ from 'intl'
+import currentPlan, { XOA_PLAN_FREE, XOA_PLAN_SOURCES } from 'plans'
+import decorate from 'apply-decorators'
 import PropTypes from 'prop-types'
 import React from 'react'
+import xoaUpdater from 'xoa-updater'
+import { createBinaryFile } from 'utils'
+import { identity, omit } from 'lodash'
+import { injectState, provideState } from 'reaclette'
+import { post } from 'fetch'
 
 import ActionButton from './action-button'
 import ActionRowButton from './action-row-button'
 
-export const CAN_REPORT_BUG = __DEV__ && process.env.XOA_PLAN > 1
+export const CAN_REPORT_BUG = currentPlan > XOA_PLAN_FREE
+const SUPPORT_PANEL_URL = './api/support/create/ticket'
 
-export const reportBug = ({ formatMessage, message, title }) => {
+const reportOnGithub = ({ formatMessage, message, title }) => {
   const encodedTitle = encodeURIComponent(title == null ? '' : title)
   const encodedMessage = encodeURIComponent(
     message == null
@@ -18,38 +26,94 @@ export const reportBug = ({ formatMessage, message, title }) => {
   )
 
   window.open(
-    process.env.XOA_PLAN < 5
-      ? `https://xen-orchestra.com/#!/member/support?title=${encodedTitle}&message=${encodedMessage}`
-      : `https://github.com/vatesfr/xen-orchestra/issues/new?title=${encodedTitle}&body=${encodedMessage}`
+    `https://github.com/vatesfr/xen-orchestra/issues/new?title=${encodedTitle}&body=${encodedMessage}`
   )
 }
 
-const ReportBugButton = ({
-  formatMessage,
+const reportOnSupportPanel = async ({
+  files = [],
+  formatMessage = identity,
   message,
-  rowButton,
   title,
-  ...props
 }) => {
-  const Button = rowButton ? ActionRowButton : ActionButton
-  return (
-    <Button
-      {...props}
-      data-formatMessage={formatMessage}
-      data-message={message}
-      data-title={title}
-      handler={reportBug}
+  const { FormData, open } = window
+
+  const formData = new FormData()
+  if (title !== undefined) {
+    formData.append('title', title)
+  }
+  if (message !== undefined) {
+    formData.append('message', formatMessage(message))
+  }
+  files.forEach(({ content, name }) => {
+    formData.append('attachments', content, name)
+  })
+
+  formData.append(
+    'attachments',
+    createBinaryFile(
+      JSON.stringify(await xoaUpdater.getLocalManifest(), null, 2)
+    ),
+    'manifest.json'
+  )
+
+  const res = await post(SUPPORT_PANEL_URL, formData)
+  if (res.status !== 200) {
+    throw new Error('cannot get the new ticket URL')
+  }
+  open(await res.text())
+}
+
+export const reportBug =
+  currentPlan === XOA_PLAN_SOURCES ? reportOnGithub : reportOnSupportPanel
+
+const REPORT_BUG_BUTTON_PROP_TYPES = {
+  files: PropTypes.arrayOf(
+    PropTypes.shape({
+      content: PropTypes.oneOfType([
+        PropTypes.instanceOf(window.Blob),
+        PropTypes.instanceOf(window.File),
+      ]).isRequired,
+      name: PropTypes.string.isRequired,
+    })
+  ),
+  formatMessage: PropTypes.func,
+  message: PropTypes.string,
+  rowButton: PropTypes.bool,
+  title: PropTypes.string,
+}
+
+const ReportBugButton = decorate([
+  provideState({
+    effects: {
+      async reportBug() {
+        const { files, formatMessage, message, title } = this.props
+        await reportBug({
+          files,
+          formatMessage,
+          message,
+          title,
+        })
+      },
+    },
+    computed: {
+      Button: (state, { rowButton }) =>
+        rowButton ? ActionRowButton : ActionButton,
+      buttonProps: (state, props) =>
+        omit(props, Object.keys(REPORT_BUG_BUTTON_PROP_TYPES)),
+    },
+  }),
+  injectState,
+  ({ state, effects }) => (
+    <state.Button
+      {...state.buttonProps}
+      handler={effects.reportBug}
       icon='bug'
       tooltip={_('reportBug')}
     />
-  )
-}
+  ),
+])
 
-ReportBugButton.propTypes = {
-  formatMessage: PropTypes.func,
-  message: PropTypes.string.isRequired,
-  rowButton: PropTypes.bool,
-  title: PropTypes.string.isRequired,
-}
+ReportBugButton.propTypes = REPORT_BUG_BUTTON_PROP_TYPES
 
 export { ReportBugButton as default }

--- a/packages/xo-web/src/common/utils.js
+++ b/packages/xo-web/src/common/utils.js
@@ -550,21 +550,24 @@ export const getIscsiPaths = pbd => {
 
 // ===================================================================
 
-export const createBinaryFile = str =>
+export const createBlobFromString = str =>
   new window.Blob([str], {
     type: 'text/plain',
   })
 
 // ===================================================================
 
-export const formatDate = ms => new Date(ms).toISOString().replace(/:/g, '_')
+// Format a date in ISO 8601 in a safe way to be used in filenames
+// (even on Windows).
+export const safeDateFormat = ms =>
+  new Date(ms).toISOString().replace(/:/g, '_')
 
 // ===================================================================
 
 export const downloadLog = ({ log, date, type }) => {
   const anchor = document.createElement('a')
-  anchor.href = window.URL.createObjectURL(createBinaryFile(log))
-  anchor.download = `${formatDate(date)} - ${type}.log`
+  anchor.href = window.URL.createObjectURL(createBlobFromString(log))
+  anchor.download = `${safeDateFormat(date)} - ${type}.log`
   anchor.style.display = 'none'
   document.body.appendChild(anchor)
   anchor.click()

--- a/packages/xo-web/src/common/utils.js
+++ b/packages/xo-web/src/common/utils.js
@@ -550,15 +550,21 @@ export const getIscsiPaths = pbd => {
 
 // ===================================================================
 
-export const downloadLog = ({ log, date, type }) => {
-  const file = new window.Blob([log], {
+export const createBinaryFile = str =>
+  new window.Blob([str], {
     type: 'text/plain',
   })
+
+// ===================================================================
+
+export const formatDate = ms => new Date(ms).toISOString().replace(/:/g, '_')
+
+// ===================================================================
+
+export const downloadLog = ({ log, date, type }) => {
   const anchor = document.createElement('a')
-  anchor.href = window.URL.createObjectURL(file)
-  anchor.download = `${new Date(date)
-    .toISOString()
-    .replace(/:/g, '_')} - ${type}.log`
+  anchor.href = window.URL.createObjectURL(createBinaryFile(log))
+  anchor.download = `${formatDate(date)} - ${type}.log`
   anchor.style.display = 'none'
   document.body.appendChild(anchor)
   anchor.click()

--- a/packages/xo-web/src/common/xoa-plans.js
+++ b/packages/xo-web/src/common/xoa-plans.js
@@ -1,0 +1,7 @@
+export const CURRENT = +process.env.XOA_PLAN
+
+export const FREE = 1
+export const STARTER = 2
+export const ENTERPRISE = 3
+export const PREMIUM = 4
+export const SOURCES = 5

--- a/packages/xo-web/src/xo-app/logs/backup-ng/log-alert-header.js
+++ b/packages/xo-web/src/xo-app/logs/backup-ng/log-alert-header.js
@@ -1,4 +1,5 @@
 import _ from 'intl'
+import * as xoaPlans from 'xoa-plans'
 import ActionButton from 'action-button'
 import addSubscriptions from 'add-subscriptions'
 import Button from 'button'
@@ -7,9 +8,8 @@ import CopyToClipboard from 'react-copy-to-clipboard'
 import decorate from 'apply-decorators'
 import Icon from 'icon'
 import React from 'react'
-import ReportBugButton, { CAN_REPORT_BUG } from 'report-bug-button'
+import ReportBugButton from 'report-bug-button'
 import Tooltip from 'tooltip'
-import xoaPlans from 'xoa-plans'
 import { createBlobFromString, downloadLog, safeDateFormat } from 'utils'
 import { get, ifDef } from '@xen-orchestra/defined'
 import { injectState, provideState } from 'reaclette'
@@ -115,7 +115,7 @@ export default decorate([
             <Icon icon='download' />
           </Button>
         </Tooltip>
-        {CAN_REPORT_BUG && <ReportBugButton {...state.reportBugProps} />}
+        <ReportBugButton {...state.reportBugProps} />
         {state.jobFailed && log.scheduleId !== undefined && (
           <ButtonGroup>
             <ActionButton

--- a/packages/xo-web/src/xo-app/logs/backup-ng/log-alert-header.js
+++ b/packages/xo-web/src/xo-app/logs/backup-ng/log-alert-header.js
@@ -4,16 +4,16 @@ import addSubscriptions from 'add-subscriptions'
 import Button from 'button'
 import ButtonGroup from 'button-group'
 import CopyToClipboard from 'react-copy-to-clipboard'
-import currentPlan, { XOA_PLAN_SOURCES } from 'plans'
 import decorate from 'apply-decorators'
 import Icon from 'icon'
 import React from 'react'
 import ReportBugButton, { CAN_REPORT_BUG } from 'report-bug-button'
 import Tooltip from 'tooltip'
-import { createBinaryFile, downloadLog, formatDate } from 'utils'
+import { createBlobFromString, downloadLog, safeDateFormat } from 'utils'
 import { get, ifDef } from '@xen-orchestra/defined'
 import { injectState, provideState } from 'reaclette'
 import { keyBy } from 'lodash'
+import { XOA_PLAN_CURRENT, XOA_PLAN_SOURCES } from 'plans'
 import {
   runBackupNgJob,
   subscribeBackupNgJobs,
@@ -72,20 +72,20 @@ export default decorate([
           size: 'small',
           title: 'Backup job failed',
         }
-        if (currentPlan === XOA_PLAN_SOURCES) {
+        if (XOA_PLAN_CURRENT === XOA_PLAN_SOURCES) {
           props.message = `\`\`\`json\n${formattedLog}\n\`\`\``
         } else {
-          const formattedDate = ifDef(log.start, formatDate)
+          const formattedDate = ifDef(log.start, safeDateFormat)
           props.files = [
             {
-              content: createBinaryFile(formattedLog),
+              content: createBlobFromString(formattedLog),
               name: `${formattedDate} - log.json`,
             },
           ]
           const job = jobs[log.jobId]
           if (job !== undefined) {
             props.files.push({
-              content: createBinaryFile(JSON.stringify(job, null, 2)),
+              content: createBlobFromString(JSON.stringify(job, null, 2)),
               name: 'job.json',
             })
           }

--- a/packages/xo-web/src/xo-app/logs/backup-ng/log-alert-header.js
+++ b/packages/xo-web/src/xo-app/logs/backup-ng/log-alert-header.js
@@ -9,11 +9,11 @@ import Icon from 'icon'
 import React from 'react'
 import ReportBugButton, { CAN_REPORT_BUG } from 'report-bug-button'
 import Tooltip from 'tooltip'
+import xoaPlans from 'xoa-plans'
 import { createBlobFromString, downloadLog, safeDateFormat } from 'utils'
 import { get, ifDef } from '@xen-orchestra/defined'
 import { injectState, provideState } from 'reaclette'
 import { keyBy } from 'lodash'
-import { XOA_PLAN_CURRENT, XOA_PLAN_SOURCES } from 'plans'
 import {
   runBackupNgJob,
   subscribeBackupNgJobs,
@@ -72,7 +72,7 @@ export default decorate([
           size: 'small',
           title: 'Backup job failed',
         }
-        if (XOA_PLAN_CURRENT === XOA_PLAN_SOURCES) {
+        if (xoaPlans.CURRENT === xoaPlans.SOURCES) {
           props.message = `\`\`\`json\n${formattedLog}\n\`\`\``
         } else {
           const formattedDate = ifDef(log.start, safeDateFormat)

--- a/packages/xo-web/src/xo-app/settings/logs/index.js
+++ b/packages/xo-web/src/xo-app/settings/logs/index.js
@@ -11,8 +11,8 @@ import styles from './index.css'
 import { addSubscriptions, downloadLog } from 'utils'
 import { alert } from 'modal'
 import { createSelector } from 'selectors'
-import { CAN_REPORT_BUG, reportBug } from 'report-bug-button'
 import { get } from '@xen-orchestra/defined'
+import { reportBug } from 'report-bug-button'
 import {
   deleteApiLog,
   deleteApiLogs,
@@ -118,7 +118,6 @@ const INDIVIDUAL_ACTIONS = [
     label: _('logDownload'),
   },
   {
-    disabled: !CAN_REPORT_BUG,
     handler: log =>
       reportBug({
         formatMessage,

--- a/packages/xo-web/src/xo-app/xoa/notifications/index.js
+++ b/packages/xo-web/src/xo-app/xoa/notifications/index.js
@@ -8,7 +8,7 @@ import React from 'react'
 import SortedTable from 'sorted-table'
 import { addSubscriptions } from 'utils'
 import { alert } from 'modal'
-import { CAN_REPORT_BUG, reportBug } from 'report-bug-button'
+import { reportBug } from 'report-bug-button'
 import { filter, some } from 'lodash'
 import { FormattedDate } from 'react-intl'
 import { injectState, provideState } from 'reaclette'
@@ -69,7 +69,6 @@ const COLUMNS = [
 
 const ACTIONS = [
   {
-    disabled: !CAN_REPORT_BUG,
     label: _('messageReply'),
     handler: notification =>
       reportBug({


### PR DESCRIPTION
Related to support-panel#24

The specification is in  `support-panel` repository

**This must not be merged before the support of this in support-panel is released**


### Precedent behavior

To report a bug, open source users and users with plan click on the button `Report bug`, then, `xo` redirect them to `Github`/`Gitlab` with filling the message with the log.

### Issue
`Gitlab` don't support a long message

### Solution
- Keeping the same behavior for open source users
- Joining the log instead of filling the message for users with plan

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
