### PR TITLE
chore(@xen-orchestra/fs): Test fs.truncate

### DIFF
--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -401,7 +401,7 @@ export default class RemoteHandlerAbstract {
   }
 
   async truncate(file: string, len: number): Promise<void> {
-    throw new Error('Not implemented')
+    await this._truncate(file, len)
   }
 
   async unlink(file: string, { checksum = true }: Object = {}): Promise<void> {

--- a/@xen-orchestra/fs/src/fs.spec.js
+++ b/@xen-orchestra/fs/src/fs.spec.js
@@ -350,5 +350,35 @@ handlers.forEach(url => {
         }
       )
     })
+
+    describe('#truncate()', () => {
+      forOwn(
+        {
+          'inbound truncates': (() => {
+            const length = random(0, TEST_DATA_LEN)
+
+            const expected = Buffer.alloc(length)
+            TEST_DATA.copy(expected)
+
+            return { length, expected }
+          })(),
+          'outbound truncates': (() => {
+            const length = random(TEST_DATA_LEN + 1, TEST_DATA_LEN * 2)
+
+            const expected = Buffer.alloc(length)
+            TEST_DATA.copy(expected)
+
+            return { length, expected }
+          })(),
+        },
+        ({ length, expected }, title) => {
+          it(title, async () => {
+            await handler.outputFile('file', TEST_DATA)
+            await handler.truncate('file', length)
+            await expect(await handler.readFile('file')).toEqual(expected)
+          })
+        }
+      )
+    })
   })
 })

--- a/@xen-orchestra/fs/src/fs.spec.js
+++ b/@xen-orchestra/fs/src/fs.spec.js
@@ -354,20 +354,15 @@ handlers.forEach(url => {
     describe('#truncate()', () => {
       forOwn(
         {
-          'inbound truncates': (() => {
+          'shrinks file': (() => {
             const length = random(0, TEST_DATA_LEN)
-
-            const expected = Buffer.alloc(length)
-            TEST_DATA.copy(expected)
-
+            const expected = TEST_DATA.slice(0, length)
             return { length, expected }
           })(),
-          'outbound truncates': (() => {
-            const length = random(TEST_DATA_LEN + 1, TEST_DATA_LEN * 2)
-
+          'grows file': (() => {
+            const length = random(TEST_DATA_LEN, TEST_DATA_LEN * 2)
             const expected = Buffer.alloc(length)
             TEST_DATA.copy(expected)
-
             return { length, expected }
           })(),
         },


### PR DESCRIPTION
- [x] PR reference the relevant issue
- [x] if UI changes, a screenshot has been added to the PR
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)