### PR TITLE
chore(xo-server): move some calls to `Xapi#callAsync`

### DIFF
--- a/packages/xo-server/src/api/pbd.js
+++ b/packages/xo-server/src/api/pbd.js
@@ -5,7 +5,7 @@
 
 async function delete_({ PBD }) {
   // TODO: check if PBD is attached before
-  await this.getXapi(PBD).call('PBD.destroy', PBD._xapiRef)
+  await this.getXapi(PBD).callAsync('PBD.destroy', PBD._xapiRef)
 }
 export { delete_ as delete }
 
@@ -37,7 +37,7 @@ disconnect.resolve = {
 
 export async function connect({ PBD }) {
   // TODO: check if PBD is attached before
-  await this.getXapi(PBD).call('PBD.plug', PBD._xapiRef)
+  await this.getXapi(PBD).callAsync('PBD.plug', PBD._xapiRef)
 }
 
 connect.params = {

--- a/packages/xo-server/src/api/pif.js
+++ b/packages/xo-server/src/api/pif.js
@@ -15,7 +15,7 @@ export function getIpv6ConfigurationModes() {
 
 async function delete_({ pif }) {
   // TODO: check if PIF is attached before
-  await this.getXapi(pif).call('PIF.destroy', pif._xapiRef)
+  await this.getXapi(pif).callAsync('PIF.destroy', pif._xapiRef)
 }
 export { delete_ as delete }
 
@@ -32,7 +32,7 @@ delete_.resolve = {
 
 export async function disconnect({ pif }) {
   // TODO: check if PIF is attached before
-  await this.getXapi(pif).call('PIF.unplug', pif._xapiRef)
+  await this.getXapi(pif).callAsync('PIF.unplug', pif._xapiRef)
 }
 
 disconnect.params = {
@@ -47,7 +47,7 @@ disconnect.resolve = {
 
 export async function connect({ pif }) {
   // TODO: check if PIF is attached before
-  await this.getXapi(pif).call('PIF.plug', pif._xapiRef)
+  await this.getXapi(pif).callAsync('PIF.plug', pif._xapiRef)
 }
 
 connect.params = {

--- a/packages/xo-server/src/api/sr.js
+++ b/packages/xo-server/src/api/sr.js
@@ -35,7 +35,7 @@ set.resolve = {
 // -------------------------------------------------------------------
 
 export async function scan({ SR }) {
-  await this.getXapi(SR).call('SR.scan', SR._xapiRef)
+  await this.getXapi(SR).callAsync('SR.scan', SR._xapiRef)
 }
 
 scan.params = {

--- a/packages/xo-server/src/api/vm.js
+++ b/packages/xo-server/src/api/vm.js
@@ -1083,7 +1083,7 @@ stop.resolve = {
 // -------------------------------------------------------------------
 
 export async function suspend({ vm }) {
-  await this.getXapi(vm).call('VM.suspend', vm._xapiRef)
+  await this.getXapi(vm).callAsync('VM.suspend', vm._xapiRef)
 }
 
 suspend.params = {
@@ -1097,7 +1097,7 @@ suspend.resolve = {
 // -------------------------------------------------------------------
 
 export async function pause({ vm }) {
-  await this.getXapi(vm).call('VM.pause', vm._xapiRef)
+  await this.getXapi(vm).callAsync('VM.pause', vm._xapiRef)
 }
 
 pause.params = {

--- a/packages/xo-server/src/api/xosan.js
+++ b/packages/xo-server/src/api/xosan.js
@@ -269,10 +269,10 @@ export async function fixHostNotInNetwork({ xosanSr, host }) {
   if (pif) {
     const newIP = _findIPAddressOutsideList(usedAddresses, HOST_FIRST_NUMBER)
     reconfigurePifIP(xapi, pif, newIP)
-    await xapi.call('PIF.plug', pif.$ref)
+    await xapi.callAsync('PIF.plug', pif.$ref)
     const PBD = find(xosanSr.$PBDs, pbd => pbd.$host.$id === host)
     if (PBD) {
-      await xapi.call('PBD.plug', PBD.$ref)
+      await xapi.callAsync('PBD.plug', PBD.$ref)
     }
     const sshKey = await getOrCreateSshKey(xapi)
     await callPlugin(xapi, host, 'receive_ssh_keys', {
@@ -809,7 +809,7 @@ export const createSR = defer(async function(
     })
     CURRENT_POOL_OPERATIONS[poolId] = { ...OPERATION_OBJECT, state: 6 }
     log.debug('scanning new SR')
-    await xapi.call('SR.scan', xosanSrRef)
+    await xapi.callAsync('SR.scan', xosanSrRef)
     await this.rebindLicense({
       licenseId: license.id,
       oldBoundObjectId: tmpBoundObjectId,
@@ -884,7 +884,7 @@ async function createVDIOnLVMWithoutSizeLimit(xapi, lvmSr, diskSize) {
   if (result.exit !== 0) {
     throw Error('Could not create volume ->' + result.stdout)
   }
-  await xapi.call('SR.scan', xapi.getObject(lvmSr).$ref)
+  await xapi.callAsync('SR.scan', xapi.getObject(lvmSr).$ref)
   const vdi = find(xapi.getObject(lvmSr).$VDIs, vdi => vdi.uuid === uuid)
   if (vdi != null) {
     await xapi.setSrProperties(vdi.$ref, {
@@ -989,7 +989,7 @@ async function replaceBrickOnSameVM(
     await xapi.disconnectVbd(previousVBD)
     await xapi.deleteVdi(previousVBD.VDI)
     CURRENT_POOL_OPERATIONS[poolId] = { ...OPERATION_OBJECT, state: 4 }
-    await xapi.call('SR.scan', xapi.getObject(xosansr).$ref)
+    await xapi.callAsync('SR.scan', xapi.getObject(xosansr).$ref)
   } finally {
     delete CURRENT_POOL_OPERATIONS[poolId]
   }
@@ -1068,7 +1068,7 @@ export async function replaceBrick({
       await xapi.deleteVm(previousVMEntry.vm, true)
     }
     CURRENT_POOL_OPERATIONS[poolId] = { ...OPERATION_OBJECT, state: 3 }
-    await xapi.call('SR.scan', xapi.getObject(xosansr).$ref)
+    await xapi.callAsync('SR.scan', xapi.getObject(xosansr).$ref)
   } finally {
     delete CURRENT_POOL_OPERATIONS[poolId]
   }
@@ -1115,7 +1115,7 @@ async function _prepareGlusterVm(
   const firstVif = newVM.$VIFs[0]
   if (xosanNetwork.$id !== firstVif.$network.$id) {
     try {
-      await xapi.call('VIF.move', firstVif.$ref, xosanNetwork.$ref)
+      await xapi.callAsync('VIF.move', firstVif.$ref, xosanNetwork.$ref)
     } catch (error) {
       if (error.code === 'MESSAGE_METHOD_UNKNOWN') {
         // VIF.move has been introduced in xenserver 7.0
@@ -1330,7 +1330,7 @@ export const addBricks = defer(async function(
     data.nodes = data.nodes.concat(newNodes)
     await xapi.xo.setData(xosansr, 'xosan_config', data)
     CURRENT_POOL_OPERATIONS[poolId] = { ...OPERATION_OBJECT, state: 2 }
-    await xapi.call('SR.scan', xapi.getObject(xosansr).$ref)
+    await xapi.callAsync('SR.scan', xapi.getObject(xosansr).$ref)
   } finally {
     delete CURRENT_POOL_OPERATIONS[poolId]
   }
@@ -1382,7 +1382,7 @@ export const removeBricks = defer(async function($defer, { xosansr, bricks }) {
     )
     remove(data.nodes, node => ips.includes(node.vm.ip))
     await xapi.xo.setData(xosansr.id, 'xosan_config', data)
-    await xapi.call('SR.scan', xapi.getObject(xosansr._xapiId).$ref)
+    await xapi.callAsync('SR.scan', xapi.getObject(xosansr._xapiId).$ref)
     await asyncMap(brickVMs, vm => xapi.deleteVm(vm.vm, true))
   } finally {
     delete CURRENT_POOL_OPERATIONS[xapi.pool.$id]

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -2044,7 +2044,7 @@ export default class Xapi extends XapiBase {
     const vdi = this.getObject(vdiId)
 
     const snap = await this._getOrWaitObject(
-      await this.callAsync('VDI.snapshot', vdi.$ref)
+      await this.callAsync('VDI.snapshot', vdi.$ref).then(extractOpaqueRef)
     )
 
     if (nameLabel) {

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -378,12 +378,12 @@ export default class Xapi extends XapiBase {
     await pSettle(
       mapToArray(vms, vm => {
         if (!vm.is_control_domain) {
-          return this.call('VM.suspend', vm.$ref)
+          return this.callAsync('VM.suspend', vm.$ref)
         }
       })
     )
     await this.call('host.disable', host.$ref)
-    await this.call('host.shutdown', host.$ref)
+    await this.callAsync('host.shutdown', host.$ref)
   }
 
   // =================================================================
@@ -396,7 +396,7 @@ export default class Xapi extends XapiBase {
     await this.call('host.disable', ref)
 
     try {
-      await this.call('host.evacuate', ref)
+      await this.callAsync('host.evacuate', ref)
     } catch (error) {
       if (!force) {
         await this.call('host.enable', ref)
@@ -411,7 +411,7 @@ export default class Xapi extends XapiBase {
   }
 
   async forgetHost(hostId) {
-    await this.call('host.destroy', this.getObject(hostId).$ref)
+    await this.callAsync('host.destroy', this.getObject(hostId).$ref)
   }
 
   async ejectHostFromPool(hostId) {
@@ -461,18 +461,18 @@ export default class Xapi extends XapiBase {
   }
 
   async powerOnHost(hostId) {
-    await this.call('host.power_on', this.getObject(hostId).$ref)
+    await this.callAsync('host.power_on', this.getObject(hostId).$ref)
   }
 
   async rebootHost(hostId, force = false) {
     const host = this.getObject(hostId)
 
     await this._clearHost(host, force)
-    await this.call('host.reboot', host.$ref)
+    await this.callAsync('host.reboot', host.$ref)
   }
 
   async restartHostAgent(hostId) {
-    await this.call('host.restart_agent', this.getObject(hostId).$ref)
+    await this.callAsync('host.restart_agent', this.getObject(hostId).$ref)
   }
 
   async setRemoteSyslogHost(hostId, syslogDestination) {
@@ -487,7 +487,7 @@ export default class Xapi extends XapiBase {
     const host = this.getObject(hostId)
 
     await this._clearHost(host, force)
-    await this.call('host.shutdown', host.$ref)
+    await this.callAsync('host.shutdown', host.$ref)
   }
 
   // =================================================================
@@ -501,7 +501,7 @@ export default class Xapi extends XapiBase {
       }`
     )
 
-    return this.call('VM.clone', vm.$ref, nameLabel)
+    return this.callAsync('VM.clone', vm.$ref, nameLabel).then(extractOpaqueRef)
   }
 
   // Copy a VM: make a normal copy of a VM and all its VDIs.
@@ -717,7 +717,7 @@ export default class Xapi extends XapiBase {
     // It is necessary for suspended VMs to be shut down
     // to be able to delete their VDIs.
     if (vm.power_state !== 'Halted') {
-      await this.call('VM.hard_shutdown', $ref)
+      await this.callAsync('VM.hard_shutdown', $ref)
     }
 
     await Promise.all([
@@ -735,7 +735,7 @@ export default class Xapi extends XapiBase {
 
     // this cannot be done in parallel, otherwise disks and snapshots will be
     // destroyed even if this fails
-    await this.call('VM.destroy', $ref)
+    await this.callAsync('VM.destroy', $ref)
 
     return Promise.all([
       asyncMap(vm.$snapshots, snapshot =>
@@ -1654,7 +1654,7 @@ export default class Xapi extends XapiBase {
           false, // Start paused?
           false // Skip pre-boot checks?
         )
-      : this.call('VM.start_on', vm.$ref, host.$ref, false, false)
+      : this.callAsync('VM.start_on', vm.$ref, host.$ref, false, false)
   }
 
   async startVm(vmId, hostId, force) {
@@ -1827,14 +1827,14 @@ export default class Xapi extends XapiBase {
     })
 
     if (isVmRunning(vm)) {
-      await this.call('VBD.plug', vbdRef)
+      await this.callAsync('VBD.plug', vbdRef)
     }
   }
 
   _cloneVdi(vdi) {
     log.debug(`Cloning VDI ${vdi.name_label}`)
 
-    return this.call('VDI.clone', vdi.$ref)
+    return this.callAsync('VDI.clone', vdi.$ref).then(extractOpaqueRef)
   }
 
   async createVdi({
@@ -1857,7 +1857,7 @@ export default class Xapi extends XapiBase {
     log.debug(`Creating VDI ${name_label} on ${sr.name_label}`)
 
     return this._getOrWaitObject(
-      await this.call('VDI.create', {
+      await this.callAsync('VDI.create', {
         name_description,
         name_label,
         other_config,
@@ -1869,7 +1869,7 @@ export default class Xapi extends XapiBase {
         type,
         virtual_size: size !== undefined ? parseSize(size) : virtual_size,
         xenstore_data,
-      })
+      }).then(extractOpaqueRef)
     )
   }
 
@@ -1923,7 +1923,7 @@ export default class Xapi extends XapiBase {
     log.debug(`Deleting VDI ${vdiRef}`)
 
     try {
-      await this.call('VDI.destroy', vdiRef)
+      await this.callAsync('VDI.destroy', vdiRef)
     } catch (error) {
       if (error?.code !== 'HANDLE_INVALID') {
         throw error
@@ -1936,7 +1936,7 @@ export default class Xapi extends XapiBase {
       `Resizing VDI ${vdi.name_label} from ${vdi.virtual_size} to ${size}`
     )
 
-    return this.call('VDI.resize', vdi.$ref, size)
+    return this.callAsync('VDI.resize', vdi.$ref, size)
   }
 
   _getVmCdDrive(vm) {
@@ -1950,7 +1950,7 @@ export default class Xapi extends XapiBase {
   async _ejectCdFromVm(vm) {
     const cdDrive = this._getVmCdDrive(vm)
     if (cdDrive) {
-      await this.call('VBD.eject', cdDrive.$ref)
+      await this.callAsync('VBD.eject', cdDrive.$ref)
     }
   }
 
@@ -1958,16 +1958,16 @@ export default class Xapi extends XapiBase {
     const cdDrive = await this._getVmCdDrive(vm)
     if (cdDrive) {
       try {
-        await this.call('VBD.insert', cdDrive.$ref, cd.$ref)
+        await this.callAsync('VBD.insert', cdDrive.$ref, cd.$ref)
       } catch (error) {
         if (!force || error.code !== 'VBD_NOT_EMPTY') {
           throw error
         }
 
-        await this.call('VBD.eject', cdDrive.$ref)::ignoreErrors()
+        await this.callAsync('VBD.eject', cdDrive.$ref)::ignoreErrors()
 
         // Retry.
-        await this.call('VBD.insert', cdDrive.$ref, cd.$ref)
+        await this.callAsync('VBD.insert', cdDrive.$ref, cd.$ref)
       }
 
       if (bootable !== Boolean(cdDrive.bootable)) {
@@ -1984,7 +1984,7 @@ export default class Xapi extends XapiBase {
   }
 
   async connectVbd(vbdId) {
-    await this.call('VBD.plug', vbdId)
+    await this.callAsync('VBD.plug', vbdId)
   }
 
   async _disconnectVbd(vbd) {
@@ -2044,7 +2044,7 @@ export default class Xapi extends XapiBase {
     const vdi = this.getObject(vdiId)
 
     const snap = await this._getOrWaitObject(
-      await this.call('VDI.snapshot', vdi.$ref)
+      await this.callAsync('VDI.snapshot', vdi.$ref)
     )
 
     if (nameLabel) {
@@ -2172,7 +2172,7 @@ export default class Xapi extends XapiBase {
     )
 
     if (currently_attached && isVmRunning(vm)) {
-      await this.call('VIF.plug', vifRef)
+      await this.callAsync('VIF.plug', vifRef)
     }
 
     return vifRef
@@ -2200,7 +2200,7 @@ export default class Xapi extends XapiBase {
       // https://citrix.github.io/xenserver-sdk/#network
       other_config: { automatic: 'false' },
     })
-    $defer.onFailure(() => this.call('network.destroy', networkRef))
+    $defer.onFailure(() => this.callAsync('network.destroy', networkRef))
     if (pifId) {
       await this.call(
         'pool.create_VLAN_from_PIF',
@@ -2239,7 +2239,7 @@ export default class Xapi extends XapiBase {
     await Promise.all(
       mapToArray(
         vlans,
-        vlan => vlan !== NULL_REF && this.call('VLAN.destroy', vlan)
+        vlan => vlan !== NULL_REF && this.callAsync('VLAN.destroy', vlan)
       )
     )
 
@@ -2254,7 +2254,7 @@ export default class Xapi extends XapiBase {
         newPifs,
         pifRef =>
           !wasAttached[this.getObject(pifRef).host] &&
-          this.call('PIF.unplug', pifRef)::ignoreErrors()
+          this.callAsync('PIF.unplug', pifRef)::ignoreErrors()
       )
     )
   }
@@ -2285,7 +2285,7 @@ export default class Xapi extends XapiBase {
     await Promise.all(
       mapToArray(
         vlans,
-        vlan => vlan !== NULL_REF && this.call('VLAN.destroy', vlan)
+        vlan => vlan !== NULL_REF && this.callAsync('VLAN.destroy', vlan)
       )
     )
 
@@ -2294,7 +2294,7 @@ export default class Xapi extends XapiBase {
       mapToArray(bonds, bond => this.call('Bond.destroy', bond))
     )
 
-    await this.call('network.destroy', network.$ref)
+    await this.callAsync('network.destroy', network.$ref)
   }
 
   // =================================================================

--- a/packages/xo-server/src/xapi/mixins/networking.js
+++ b/packages/xo-server/src/xapi/mixins/networking.js
@@ -4,13 +4,13 @@ import { makeEditObject } from '../utils'
 
 export default {
   async _connectVif(vif) {
-    await this.call('VIF.plug', vif.$ref)
+    await this.callAsync('VIF.plug', vif.$ref)
   },
   async connectVif(vifId) {
     await this._connectVif(this.getObject(vifId))
   },
   async _deleteVif(vif) {
-    await this.call('VIF.destroy', vif.$ref)
+    await this.callAsync('VIF.destroy', vif.$ref)
   },
   async deleteVif(vifId) {
     const vif = this.getObject(vifId)
@@ -20,7 +20,7 @@ export default {
     await this._deleteVif(vif)
   },
   async _disconnectVif(vif) {
-    await this.call('VIF.unplug_force', vif.$ref)
+    await this.callAsync('VIF.unplug_force', vif.$ref)
   },
   async disconnectVif(vifId) {
     await this._disconnectVif(this.getObject(vifId))

--- a/packages/xo-server/src/xapi/mixins/storage.js
+++ b/packages/xo-server/src/xapi/mixins/storage.js
@@ -35,7 +35,7 @@ export default {
   },
 
   _plugPbd(pbd) {
-    return this.call('PBD.plug', pbd.$ref)
+    return this.callAsync('PBD.plug', pbd.$ref)
   },
 
   async plugPbd(id) {
@@ -43,7 +43,7 @@ export default {
   },
 
   _unplugPbd(pbd) {
-    return this.call('PBD.unplug', pbd.$ref)
+    return this.callAsync('PBD.unplug', pbd.$ref)
   },
 
   async unplugPbd(id) {

--- a/packages/xo-server/src/xapi/mixins/vm.js
+++ b/packages/xo-server/src/xapi/mixins/vm.js
@@ -94,7 +94,7 @@ export default {
 
     // Creates the VDIs and executes the initial steps of the
     // installation.
-    await this.call('VM.provision', vmRef)
+    await this.callAsync('VM.provision', vmRef)
 
     let vm = await this._getOrWaitObject(vmRef)
 
@@ -493,7 +493,7 @@ export default {
     if (snapshotBefore) {
       await this._snapshotVm(snapshot.$snapshot_of)
     }
-    await this.call('VM.revert', snapshot.$ref)
+    await this.callAsync('VM.revert', snapshot.$ref)
     if (snapshot.snapshot_info['power-state-at-snapshot'] === 'Running') {
       const vm = await this.barrier(snapshot.snapshot_of)
       if (vm.power_state === 'Halted') {
@@ -506,11 +506,11 @@ export default {
 
   async resumeVm(vmId) {
     // the force parameter is always true
-    return this.call('VM.resume', this.getObject(vmId).$ref, false, true)
+    await this.callAsync('VM.resume', this.getObject(vmId).$ref, false, true)
   },
 
   async unpauseVm(vmId) {
-    return this.call('VM.unpause', this.getObject(vmId).$ref)
+    await this.callAsync('VM.unpause', this.getObject(vmId).$ref)
   },
 
   rebootVm(vmId, { hard = false } = {}) {
@@ -521,7 +521,7 @@ export default {
   },
 
   shutdownVm(vmId, { hard = false } = {}) {
-    return this.call(
+    return this.callAsync(
       `VM.${hard ? 'hard' : 'clean'}_shutdown`,
       this.getObject(vmId).$ref
     ).then(noop)


### PR DESCRIPTION
Fixes #4226

`.callAsync` is more robust to disconnections than `.call` and should be used for all non-instantaneous calls.

Unfortunately the result can be embedded into XML, you should either not use the result or add `.then(extractOpaquerRef)` if you are expecting an opaque ref.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [x] `CHANGELOG.unreleased.md`: (low level)
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (low level)
- [ ] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
