### PR TITLE
fix(xo-server/Xapi#_importOvaVm): `userdevice` must be string not a number

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -9,6 +9,7 @@
 
 - [Charts] Fixed the chart lines sometimes changing order/color (PR [#4221](https://github.com/vatesfr/xen-orchestra/pull/4221))
 - Prevent non-admin users to access admin pages with URL
+- [Import] Fix import OVA files (PR [#4232](https://github.com/vatesfr/xen-orchestra/pull/4232))
 
 ### Released packages
 

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1398,7 +1398,7 @@ export default class Xapi extends XapiBase {
         $defer.onFailure(() => this._deleteVdi(vdi.$ref))
 
         return this.createVbd({
-          userdevice: disk.position,
+          userdevice: `${disk.position}`,
           vdi,
           vm,
         })

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1398,7 +1398,7 @@ export default class Xapi extends XapiBase {
         $defer.onFailure(() => this._deleteVdi(vdi.$ref))
 
         return this.createVbd({
-          userdevice: `${disk.position}`,
+          userdevice: String(disk.position),
           vdi,
           vm,
         })


### PR DESCRIPTION
Fixes xoa-support#1479

 XAPI has changed the type of VBD.userdevice to string

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [ ] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
