### PR TITLE
feat(xo-server/backup-ng): log delete old backups task when is not delta backup

### DIFF
--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -1191,11 +1191,20 @@ export default class BackupNg {
                   )
                 ): any)
 
+                const deleteOldBackups = () =>
+                  wrapTask(
+                    {
+                      logger,
+                      message: 'clean',
+                      parentId: taskId,
+                    },
+                    this._deleteFullVmBackups(handler, oldBackups)
+                  )
                 const deleteFirst = getSetting(settings, 'deleteFirst', [
                   remoteId,
                 ])
                 if (deleteFirst) {
-                  await this._deleteFullVmBackups(handler, oldBackups)
+                  await deleteOldBackups()
                 }
 
                 await wrapTask(
@@ -1211,7 +1220,7 @@ export default class BackupNg {
                 await handler.outputFile(metadataFilename, jsonMetadata)
 
                 if (!deleteFirst) {
-                  await this._deleteFullVmBackups(handler, oldBackups)
+                  await deleteOldBackups()
                 }
               }
             )
@@ -1242,9 +1251,18 @@ export default class BackupNg {
                   listReplicatedVms(xapi, scheduleId, srId, vmUuid)
                 )
 
+                const deleteOldBackups = () =>
+                  wrapTask(
+                    {
+                      logger,
+                      message: 'clean',
+                      parentId: taskId,
+                    },
+                    this._deleteVms(xapi, oldVms)
+                  )
                 const deleteFirst = getSetting(settings, 'deleteFirst', [srId])
                 if (deleteFirst) {
-                  await this._deleteVms(xapi, oldVms)
+                  await deleteOldBackups()
                 }
 
                 const vm = await xapi.barrier(
@@ -1276,7 +1294,7 @@ export default class BackupNg {
                 ])
 
                 if (!deleteFirst) {
-                  await this._deleteVms(xapi, oldVms)
+                  await deleteOldBackups()
                 }
               }
             )

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -508,12 +508,12 @@ const disableVmHighAvailability = async (xapi: Xapi, vm: Vm) => {
 // │  │  │  ├─ task.warning(message: string)
 // │  │  │  └─ task.end(result: { size: number })
 // │  │  │
-// │  │  │  // in case of a full backup
+// │  │  │  // in case of a full mode
 // │  │  ├─ task.start(message: 'clean')
 // │  │  │  ├─ task.warning(message: string)
 // │  │  │  └─ task.end
 // │  │  │
-// │  │  │ // in case of a delta backup
+// │  │  │ // in case of a delta mode
 // │  │  ├─ task.start(message: 'merge')
 // │  │  │  ├─ task.warning(message: string)
 // │  │  │  └─ task.end(result: { size: number })

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -507,9 +507,17 @@ const disableVmHighAvailability = async (xapi: Xapi, vm: Vm) => {
 // │  │  ├─ task.start(message: 'transfer')
 // │  │  │  ├─ task.warning(message: string)
 // │  │  │  └─ task.end(result: { size: number })
+// │  │  │
+// │  │  │  // in case of a full backup
+// │  │  ├─ task.start(message: 'clean')
+// │  │  │  ├─ task.warning(message: string)
+// │  │  │  └─ task.end
+// │  │  │
+// │  │  │ // in case of a delta backup
 // │  │  ├─ task.start(message: 'merge')
 // │  │  │  ├─ task.warning(message: string)
 // │  │  │  └─ task.end(result: { size: number })
+// │  │  │
 // │  │  └─ task.end
 // │  └─ task.end
 // └─ job.end


### PR DESCRIPTION
The log of deleting old backups in case of a full backup is needed for testing the `deleteFirst` property.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer
1. if necessary, update your PR, and re- add a reviewer
