### PR TITLE
feat(xo-web/VM): display VDI size in migrate modal

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,7 @@
 - [XOA/Update] Ability to select release channel [#4200](https://github.com/vatesfr/xen-orchestra/issues/4200) (PR [#4202](https://github.com/vatesfr/xen-orchestra/pull/4202))
 - [User] Forget connection tokens on password change or on demand [#4214](https://github.com/vatesfr/xen-orchestra/issues/4214) (PR [#4224](https://github.com/vatesfr/xen-orchestra/pull/4224))
 - [Settings/Logs] LICENCE_RESTRICTION errors: suggest XCP-ng as an Open Source alternative [#3876](https://github.com/vatesfr/xen-orchestra/issues/3876) (PR [#4238](https://github.com/vatesfr/xen-orchestra/pull/4238))
+- [VM/Migrate] Display vdi size on migrate modal [#2534](https://github.com/vatesfr/xen-orchestra/issues/2534) (PR [#4250](https://github.com/vatesfr/xen-orchestra/pull/4250))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,7 +7,7 @@
 - [XOA/Update] Ability to select release channel [#4200](https://github.com/vatesfr/xen-orchestra/issues/4200) (PR [#4202](https://github.com/vatesfr/xen-orchestra/pull/4202))
 - [User] Forget connection tokens on password change or on demand [#4214](https://github.com/vatesfr/xen-orchestra/issues/4214) (PR [#4224](https://github.com/vatesfr/xen-orchestra/pull/4224))
 - [Settings/Logs] LICENCE_RESTRICTION errors: suggest XCP-ng as an Open Source alternative [#3876](https://github.com/vatesfr/xen-orchestra/issues/3876) (PR [#4238](https://github.com/vatesfr/xen-orchestra/pull/4238))
-- [VM/Migrate] Display vdi size on migrate modal [#2534](https://github.com/vatesfr/xen-orchestra/issues/2534) (PR [#4250](https://github.com/vatesfr/xen-orchestra/pull/4250))
+- [VM/Migrate] Display VDI size on migrate modal [#2534](https://github.com/vatesfr/xen-orchestra/issues/2534) (PR [#4250](https://github.com/vatesfr/xen-orchestra/pull/4250))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/render-xo-item.js
+++ b/packages/xo-web/src/common/render-xo-item.js
@@ -283,7 +283,7 @@ export const Vdi = decorate([
       sr: getSr(state, props),
     })
   }),
-  ({ id, sr, vdi }) => {
+  ({ id, showSize, showSr, sr, vdi }) => {
     if (vdi === undefined) {
       return unknowItem(id, 'VDI')
     }
@@ -291,8 +291,11 @@ export const Vdi = decorate([
     return (
       <span>
         <Icon icon='disk' /> {vdi.name_label}
-        {sr !== undefined && (
+        {sr !== undefined && showSr && (
           <span className='text-muted'> - {sr.name_label}</span>
+        )}
+        {showSize && (
+          <span className='text-muted'> ({formatSize(vdi.size)})</span>
         )}
       </span>
     )
@@ -302,10 +305,13 @@ export const Vdi = decorate([
 Vdi.propTypes = {
   id: PropTypes.string.isRequired,
   self: PropTypes.bool,
+  showSize: PropTypes.bool,
 }
 
 Vdi.defaultProps = {
   self: false,
+  showSize: false,
+  showSr: false,
 }
 
 // ===================================================================
@@ -432,8 +438,8 @@ const xoItemToRender = {
   // XO objects.
   pool: ({ id }) => <Pool id={id} />,
 
-  VDI: ({ id }) => <Vdi id={id} />,
-  'VDI-resourceSet': ({ id }) => <Vdi id={id} self />,
+  VDI: ({ id }) => <Vdi id={id} showSr />,
+  'VDI-resourceSet': ({ id }) => <Vdi id={id} self showSr />,
 
   // Pool objects.
   'VM-template': ({ id }) => <VmTemplate id={id} />,

--- a/packages/xo-web/src/common/xo/choose-sr-for-each-vdis-modal/index.js
+++ b/packages/xo-web/src/common/xo/choose-sr-for-each-vdis-modal/index.js
@@ -2,8 +2,8 @@ import Collapse from 'collapse'
 import Component from 'base-component'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { formatSize } from 'utils'
 import { map } from 'lodash'
+import { Vdi } from 'render-xo-item'
 
 import _ from '../../intl'
 import SingleLineRow from '../../single-line-row'
@@ -87,8 +87,7 @@ export default class ChooseSrForEachVdisModal extends Component {
               {map(props.vdis, vdi => (
                 <SingleLineRow key={vdi.uuid}>
                   <Col size={6}>
-                    {vdi.name_label || vdi.name}{' '}
-                    <span className='text-muted'>({formatSize(vdi.size)})</span>
+                    <Vdi id={vdi.id} showSize />
                   </Col>
                   <Col size={6}>
                     <SelectSr

--- a/packages/xo-web/src/common/xo/choose-sr-for-each-vdis-modal/index.js
+++ b/packages/xo-web/src/common/xo/choose-sr-for-each-vdis-modal/index.js
@@ -2,6 +2,7 @@ import Collapse from 'collapse'
 import Component from 'base-component'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { formatSize } from 'utils'
 import { map } from 'lodash'
 
 import _ from '../../intl'
@@ -85,7 +86,10 @@ export default class ChooseSrForEachVdisModal extends Component {
               </SingleLineRow>
               {map(props.vdis, vdi => (
                 <SingleLineRow key={vdi.uuid}>
-                  <Col size={6}>{vdi.name_label || vdi.name}</Col>
+                  <Col size={6}>
+                    {vdi.name_label || vdi.name}{' '}
+                    <span className='text-muted'>({formatSize(vdi.size)})</span>
+                  </Col>
                   <Col size={6}>
                     <SelectSr
                       onChange={sr =>


### PR DESCRIPTION
- [x] PR reference the relevant issue 
- [x] if UI changes, a screenshot has been added to the PR
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

Fixes #2534

![vdi_size](https://user-images.githubusercontent.com/25125613/58419848-fc1bca80-808b-11e9-9149-caa0184a96df.png)
