### PR TITLE
feat(xo-server/api): `sr.probeZfs` and `sr.createFile`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,9 @@ module.exports = {
     },
   },
   rules: {
+    // disabled because XAPI objects are using camel case
+    camelcase: ['off'],
+
     'no-console': ['error', { allow: ['warn', 'error'] }],
     'no-var': 'error',
     'node/no-extraneous-import': 'error',

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,7 +8,7 @@
 - [User] Forget connection tokens on password change or on demand [#4214](https://github.com/vatesfr/xen-orchestra/issues/4214) (PR [#4224](https://github.com/vatesfr/xen-orchestra/pull/4224))
 - [Settings/Logs] LICENCE_RESTRICTION errors: suggest XCP-ng as an Open Source alternative [#3876](https://github.com/vatesfr/xen-orchestra/issues/3876) (PR [#4238](https://github.com/vatesfr/xen-orchestra/pull/4238))
 - [VM/Migrate] Display VDI size on migrate modal [#2534](https://github.com/vatesfr/xen-orchestra/issues/2534) (PR [#4250](https://github.com/vatesfr/xen-orchestra/pull/4250))
-- [SR/Create] Add API to discover ZFS pools on current host (PR [#4258](https://github.com/vatesfr/xen-orchestra/pull/4258))
+- [SR/Create] Add API to discover ZFS pools on current host [#4260](https://github.com/vatesfr/xen-orchestra/issues/4260) (PR [#4258](https://github.com/vatesfr/xen-orchestra/pull/4258))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,6 +8,7 @@
 - [User] Forget connection tokens on password change or on demand [#4214](https://github.com/vatesfr/xen-orchestra/issues/4214) (PR [#4224](https://github.com/vatesfr/xen-orchestra/pull/4224))
 - [Settings/Logs] LICENCE_RESTRICTION errors: suggest XCP-ng as an Open Source alternative [#3876](https://github.com/vatesfr/xen-orchestra/issues/3876) (PR [#4238](https://github.com/vatesfr/xen-orchestra/pull/4238))
 - [VM/Migrate] Display VDI size on migrate modal [#2534](https://github.com/vatesfr/xen-orchestra/issues/2534) (PR [#4250](https://github.com/vatesfr/xen-orchestra/pull/4250))
+- [SR/Create] Add API to discover ZFS pools on current host (PR [#4258](https://github.com/vatesfr/xen-orchestra/pull/4258))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,7 +8,7 @@
 - [User] Forget connection tokens on password change or on demand [#4214](https://github.com/vatesfr/xen-orchestra/issues/4214) (PR [#4224](https://github.com/vatesfr/xen-orchestra/pull/4224))
 - [Settings/Logs] LICENCE_RESTRICTION errors: suggest XCP-ng as an Open Source alternative [#3876](https://github.com/vatesfr/xen-orchestra/issues/3876) (PR [#4238](https://github.com/vatesfr/xen-orchestra/pull/4238))
 - [VM/Migrate] Display VDI size on migrate modal [#2534](https://github.com/vatesfr/xen-orchestra/issues/2534) (PR [#4250](https://github.com/vatesfr/xen-orchestra/pull/4250))
-- [SR/Create] Add API to discover ZFS pools on current host [#4260](https://github.com/vatesfr/xen-orchestra/issues/4260) (PR [#4258](https://github.com/vatesfr/xen-orchestra/pull/4258))
+- [SR/Create] Add API to create File type SR and to discover ZFS pools on an host [#4260](https://github.com/vatesfr/xen-orchestra/issues/4260) (PR [#4258](https://github.com/vatesfr/xen-orchestra/pull/4258))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,7 +8,6 @@
 - [User] Forget connection tokens on password change or on demand [#4214](https://github.com/vatesfr/xen-orchestra/issues/4214) (PR [#4224](https://github.com/vatesfr/xen-orchestra/pull/4224))
 - [Settings/Logs] LICENCE_RESTRICTION errors: suggest XCP-ng as an Open Source alternative [#3876](https://github.com/vatesfr/xen-orchestra/issues/3876) (PR [#4238](https://github.com/vatesfr/xen-orchestra/pull/4238))
 - [VM/Migrate] Display VDI size on migrate modal [#2534](https://github.com/vatesfr/xen-orchestra/issues/2534) (PR [#4250](https://github.com/vatesfr/xen-orchestra/pull/4250))
-- [SR/Create] Add API to create File type SR and to discover ZFS pools on an host [#4260](https://github.com/vatesfr/xen-orchestra/issues/4260) (PR [#4258](https://github.com/vatesfr/xen-orchestra/pull/4258))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/api/sr.js
+++ b/packages/xo-server/src/api/sr.js
@@ -180,6 +180,43 @@ createIso.resolve = {
 }
 
 // -------------------------------------------------------------------
+
+export async function createFile({
+  host,
+  nameLabel,
+  nameDescription,
+  location,
+}) {
+  const xapi = this.getXapi(host)
+  const deviceConfig = { location }
+  const srRef = await xapi.call(
+    'SR.create',
+    host._xapiRef,
+    deviceConfig,
+    '0',
+    nameLabel,
+    nameDescription,
+    'file',
+    'user',
+    false,
+    {}
+  )
+  const sr = await xapi.call('SR.get_record', srRef)
+  return sr.uuid
+}
+
+createFile.params = {
+  host: { type: 'string' },
+  nameLabel: { type: 'string' },
+  nameDescription: { type: 'string' },
+  location: { type: 'string' },
+}
+
+createFile.resolve = {
+  host: ['host', 'host', 'administrate'],
+}
+
+// -------------------------------------------------------------------
 // NFS SR
 
 // This functions creates a NFS SR

--- a/packages/xo-server/src/api/sr.js
+++ b/packages/xo-server/src/api/sr.js
@@ -414,7 +414,10 @@ export async function probeZfs({ host }) {
     )
     return JSON.parse(result)
   } catch (error) {
-    if (error.code === 'XENAPI_MISSING_PLUGIN') {
+    if (
+      error.code === 'XENAPI_MISSING_PLUGIN' ||
+      error.code === 'UNKNOWN_XENAPI_PLUGIN_FUNCTION'
+    ) {
       return {}
     } else {
       throw error

--- a/packages/xo-server/src/api/sr.js
+++ b/packages/xo-server/src/api/sr.js
@@ -189,11 +189,11 @@ export async function createFile({
 }) {
   const xapi = this.getXapi(host)
   return xapi.createSr({
-    host,
-    nameLabel,
-    nameDescription,
+    hostRef: host._xapiRef,
+    name_label: nameLabel,
+    name_description: nameDescription,
     type: 'file',
-    deviceConfig: { location },
+    device_config: { location },
   })
 }
 

--- a/packages/xo-server/src/api/sr.js
+++ b/packages/xo-server/src/api/sr.js
@@ -188,21 +188,13 @@ export async function createFile({
   location,
 }) {
   const xapi = this.getXapi(host)
-  const deviceConfig = { location }
-  const srRef = await xapi.call(
-    'SR.create',
-    host._xapiRef,
-    deviceConfig,
-    '0',
+  return xapi.createSr({
+    host,
     nameLabel,
     nameDescription,
-    'file',
-    'user',
-    false,
-    {}
-  )
-  const sr = await xapi.call('SR.get_record', srRef)
-  return sr.uuid
+    type: 'file',
+    deviceConfig: { location },
+  })
 }
 
 createFile.params = {
@@ -401,7 +393,24 @@ createExt.resolve = {
 // -------------------------------------------------------------------
 // This function helps to detect all ZFS pools
 // Return a dict of pools with their parameters { <poolname>: {<paramdict>}}
-
+// example output (the parameter mountpoint is of interest):
+// {"tank":
+// {
+//    "setuid": "on", "relatime": "off", "referenced": "24K", "written": "24K", "zoned": "off", "primarycache": "all",
+//    "logbias": "latency", "creation": "Mon May 27 17:24 2019", "sync": "standard", "snapdev": "hidden",
+//    "dedup": "off", "sharenfs": "off", "usedbyrefreservation": "0B", "sharesmb": "off", "createtxg": "1",
+//    "canmount": "on", "mountpoint": "/tank", "casesensitivity": "sensitive", "utf8only": "off", "xattr": "on",
+//    "dnodesize": "legacy", "mlslabel": "none", "objsetid": "54", "defcontext": "none", "rootcontext": "none",
+//    "mounted": "yes", "compression": "off", "overlay": "off", "logicalused": "47K", "usedbysnapshots": "0B",
+//    "filesystem_count": "none", "copies": "1", "snapshot_limit": "none", "aclinherit": "restricted",
+//    "compressratio": "1.00x", "readonly": "off", "version": "5", "normalization": "none", "filesystem_limit": "none",
+//    "type": "filesystem", "secondarycache": "all", "refreservation": "none", "available": "17.4G", "used": "129K",
+//    "exec": "on", "refquota": "none", "refcompressratio": "1.00x", "quota": "none", "keylocation": "none",
+//    "snapshot_count": "none", "fscontext": "none", "vscan": "off", "reservation": "none", "atime": "on",
+//    "recordsize": "128K", "usedbychildren": "105K", "usedbydataset": "24K", "guid": "656061077639704004",
+//    "pbkdf2iters": "0", "checksum": "on", "special_small_blocks": "0", "redundant_metadata": "all",
+//    "volmode": "default", "devices": "on", "keyformat": "none", "logicalreferenced": "12K", "acltype": "off",
+//    "nbmand": "off", "context": "none", "encryption": "off", "snapdir": "hidden"}}
 export async function probeZfs({ host }) {
   const xapi = this.getXapi(host)
   try {

--- a/packages/xo-server/src/api/sr.js
+++ b/packages/xo-server/src/api/sr.js
@@ -362,6 +362,38 @@ createExt.resolve = {
 }
 
 // -------------------------------------------------------------------
+// This function helps to detect all ZFS pools
+// Return a dict of pools with their parameters { <poolname>: {<paramdict>}}
+
+export async function probeZfs({ host }) {
+  const xapi = this.getXapi(host)
+  try {
+    const result = await xapi.call(
+      'host.call_plugin',
+      host._xapiRef,
+      'zfs.py',
+      'list_zfs_pools',
+      {}
+    )
+    return JSON.parse(result)
+  } catch (error) {
+    if (error.code === 'XENAPI_MISSING_PLUGIN') {
+      return {}
+    } else {
+      throw error
+    }
+  }
+}
+
+probeZfs.params = {
+  host: { type: 'string' },
+}
+
+probeZfs.resolve = {
+  host: ['host', 'host', 'administrate'],
+}
+
+// -------------------------------------------------------------------
 // This function helps to detect all NFS shares (exports) on a NFS server
 // Return a table of exports with their paths and ACLs
 

--- a/packages/xo-server/src/xapi/mixins/storage.js
+++ b/packages/xo-server/src/xapi/mixins/storage.js
@@ -89,6 +89,7 @@ export default {
     hostRef,
     name_label, // eslint-disable-line camelcase
     name_description = '', // eslint-disable-line camelcase
+    size = 0,
     type,
     device_config = {}, // eslint-disable-line camelcase
     shared = false,
@@ -97,7 +98,7 @@ export default {
       'SR.create',
       hostRef,
       device_config,
-      '0',
+      size,
       name_label,
       name_description,
       type,

--- a/packages/xo-server/src/xapi/mixins/storage.js
+++ b/packages/xo-server/src/xapi/mixins/storage.js
@@ -84,4 +84,28 @@ export default {
     })
     return unhealthyVdis
   },
+
+  async createSr({
+    host,
+    nameLabel,
+    nameDescription,
+    type,
+    deviceConfig,
+    shared = false,
+  }) {
+    const srRef = await this.call(
+      'SR.create',
+      host._xapiRef,
+      deviceConfig,
+      '0',
+      nameLabel,
+      nameDescription,
+      type, // SR LVM
+      'user', // recommended by Citrix
+      shared,
+      {}
+    )
+
+    return (await this.barrier(srRef)).uuid
+  },
 }

--- a/packages/xo-server/src/xapi/mixins/storage.js
+++ b/packages/xo-server/src/xapi/mixins/storage.js
@@ -93,20 +93,21 @@ export default {
     name_description = '',
     name_label,
     shared = false,
-    size = 0,
+    physical_size = 0,
+    sm_config = {},
     type,
   }) {
     const srRef = await this.call(
       'SR.create',
       hostRef,
       device_config,
-      size,
+      physical_size,
       name_label,
       name_description,
       type,
       content_type,
       shared,
-      {}
+      sm_config
     )
 
     return (await this.barrier(srRef)).uuid

--- a/packages/xo-server/src/xapi/mixins/storage.js
+++ b/packages/xo-server/src/xapi/mixins/storage.js
@@ -86,20 +86,20 @@ export default {
   },
 
   async createSr({
-    host,
-    nameLabel,
-    nameDescription,
+    hostRef,
+    name_label, // eslint-disable-line camelcase
+    name_description = '', // eslint-disable-line camelcase
     type,
-    deviceConfig,
+    device_config = {}, // eslint-disable-line camelcase
     shared = false,
   }) {
     const srRef = await this.call(
       'SR.create',
-      host._xapiRef,
-      deviceConfig,
+      hostRef,
+      device_config,
       '0',
-      nameLabel,
-      nameDescription,
+      name_label,
+      name_description,
       type,
       'user', // recommended by Citrix
       shared,

--- a/packages/xo-server/src/xapi/mixins/storage.js
+++ b/packages/xo-server/src/xapi/mixins/storage.js
@@ -100,7 +100,7 @@ export default {
       '0',
       nameLabel,
       nameDescription,
-      type, // SR LVM
+      type,
       'user', // recommended by Citrix
       shared,
       {}

--- a/packages/xo-server/src/xapi/mixins/storage.js
+++ b/packages/xo-server/src/xapi/mixins/storage.js
@@ -87,12 +87,14 @@ export default {
 
   async createSr({
     hostRef,
-    name_label, // eslint-disable-line camelcase
-    name_description = '', // eslint-disable-line camelcase
+
+    content_type = 'user', // recommended by Citrix
+    device_config = {},
+    name_description = '',
+    name_label,
+    shared = false,
     size = 0,
     type,
-    device_config = {}, // eslint-disable-line camelcase
-    shared = false,
   }) {
     const srRef = await this.call(
       'SR.create',
@@ -102,7 +104,7 @@ export default {
       name_label,
       name_description,
       type,
-      'user', // recommended by Citrix
+      content_type,
       shared,
       {}
     )


### PR DESCRIPTION
Server side of #4260

 - this PR is linked to https://github.com/xcp-ng/xcp-ng-updater/pull/5
 - It can be merged independently.
 - it needs some UI work (but the UI person probably needs an XCP-NG adequately configured)
 - the list of ZFS pools is accessed with `sr.probeZfs`
 - create the ZFS SR by creating a File SR (`sr.createFile`) whose `location` is the parameter `mountpoint` from the list of pools.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (server-side, not directly exposed))
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
