### PR TITLE
fix(xo-web/xoa): fix email quirk

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -4,6 +4,8 @@
 
 ### Bug fixes
 
+- [XOA] Don't require editing the _email_ field in case of re-registration (PR [#4259](https://github.com/vatesfr/xen-orchestra/pull/4259))
+
 ### Released packages
 
 - xo-server v5.43.0

--- a/packages/xo-web/src/xo-app/xoa/update/index.js
+++ b/packages/xo-web/src/xo-app/xoa/update/index.js
@@ -120,7 +120,10 @@ const Updates = decorate([
       linkState,
       onChannelChange: (_, channel) => ({ channel }),
       async register() {
-        const { state } = this
+        const {
+          props: { xoaRegisterState },
+          state,
+        } = this
 
         const { isRegistered } = state
         if (isRegistered) {
@@ -130,7 +133,7 @@ const Updates = decorate([
               body: (
                 <p>
                   {_('alreadyRegisteredModalText', {
-                    email: this.props.xoaRegisterState.email,
+                    email: xoaRegisterState.email,
                   })}
                 </p>
               ),
@@ -144,7 +147,7 @@ const Updates = decorate([
         }
 
         state.askRegisterAgain = false
-        const { email, password } = state
+        const { email = xoaRegisterState.email, password } = state
         await xoaUpdater.register(email, password, isRegistered)
 
         return initialRegistrationState()
@@ -471,7 +474,7 @@ const Updates = decorate([
                   </div>{' '}
                   <div className='form-group'>
                     <Password
-                      disabled={state.email === undefined}
+                      disabled={helper(state, xoaRegisterState, 'email') === ''}
                       name='password'
                       onChange={effects.linkState}
                       placeholder={formatMessage(


### PR DESCRIPTION
No longer require to edit the email to unlock the password field.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`) (none)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (irrelevant)
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
