### PR TITLE
fix(xo-web/task): fix hidden notification by search field

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Task] fix hidden notification by search field [#3874](https://github.com/vatesfr/xen-orchestra/issues/3874) (PR [#4305](https://github.com/vatesfr/xen-orchestra/pull/4305)
+
 ### Released packages
 
 > Packages will be released in the order they are here, therefore, they should

--- a/packages/xo-web/src/index.scss
+++ b/packages/xo-web/src/index.scss
@@ -208,17 +208,16 @@ $select-input-height: 40px; // Bootstrap input height
   top: 10px;
 }
 
-
 .notify-item {
   border-radius: 5px;
   border: 1px solid black;
   margin: 5px 10px;
   width: 250px;
-  // "input-group" (https://github.com/vatesfr/xen-orchestra/blob/master/packages/xo-web/src/common/sorted-table/index.js#L82) ,
-  // "form-control" for input(https://github.com/vatesfr/xen-orchestra/blob/master/packages/xo-web/src/common/sorted-table/index.js#L104)
-  // and "input-group-btn" (https://github.com/vatesfr/xen-orchestra/blob/master/packages/xo-web/src/common/sorted-table/index.js#L118) have hidden the notification.
-  // In bootstrap, The "z-index: 3" is for focused "form-control" (https://github.com/twbs/bootstrap/blob/master/scss/_input-group.scss#L30TOL34)
-  // so the problem is solved by adding "z-index: 3".
+  // Workaround to prevent some bootstrap elements from hiding the notifications.
+  // In bootstrap, ".input-group .form-control" and ".input-group > .input-group-btn > .btn"
+  // have "z-index: 2" and "z-index: 3" if they are hovered, focused or active.
+  // (https://github.com/twbs/bootstrap/blob/v4.0.0-alpha.5/scss/_input-group.scss#L18-L37)
+  // (https://github.com/twbs/bootstrap/blob/v4.0.0-alpha.5/scss/_input-group.scss#L177-L187)
   z-index: 3;
   &.success {
     background: $alert-success-bg;

--- a/packages/xo-web/src/index.scss
+++ b/packages/xo-web/src/index.scss
@@ -208,11 +208,18 @@ $select-input-height: 40px; // Bootstrap input height
   top: 10px;
 }
 
+
 .notify-item {
   border-radius: 5px;
   border: 1px solid black;
   margin: 5px 10px;
   width: 250px;
+  // "input-group" (https://github.com/vatesfr/xen-orchestra/blob/master/packages/xo-web/src/common/sorted-table/index.js#L82) ,
+  // "form-control" for input(https://github.com/vatesfr/xen-orchestra/blob/master/packages/xo-web/src/common/sorted-table/index.js#L104)
+  // and "input-group-btn" (https://github.com/vatesfr/xen-orchestra/blob/master/packages/xo-web/src/common/sorted-table/index.js#L118) have hidden the notification.
+  // In bootstrap, The "z-index: 3" is for focused "form-control" (https://github.com/twbs/bootstrap/blob/master/scss/_input-group.scss#L30TOL34)
+  // so the problem is solved by adding "z-index: 3".
+  z-index: 3;
   &.success {
     background: $alert-success-bg;
     border-color: $alert-success-border;


### PR DESCRIPTION
fixes #3874

I put `z-index: 3` because it's `3` for focused [form-control](https://github.com/twbs/bootstrap/blob/master/scss/_input-group.scss#L30TOL34)

### Screenshots

![Capture d’écran de 2019-06-25 12-45-05](https://user-images.githubusercontent.com/7724491/60092430-4bb2ec00-9747-11e9-8086-8ec0a367de6c.png)

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (none)
- [ ] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
