### PR TITLE
feat(xo-server/backupNg.runJob): new param `settings`

### DIFF
--- a/packages/xo-server/src/api/backup-ng.js
+++ b/packages/xo-server/src/api/backup-ng.js
@@ -123,10 +123,14 @@ getJob.params = {
 export async function runJob({
   id,
   schedule,
+  settings,
   vm,
   vms = vm !== undefined ? [vm] : undefined,
 }) {
-  return this.runJobSequence([id], await this.getSchedule(schedule), vms)
+  return this.runJobSequence([id], await this.getSchedule(schedule), {
+    settings,
+    vms,
+  })
 }
 
 runJob.permission = 'admin'
@@ -137,6 +141,13 @@ runJob.params = {
   },
   schedule: {
     type: 'string',
+  },
+  settings: {
+    type: 'object',
+    properties: {
+      '*': { type: 'object' },
+    },
+    optional: true,
   },
   vm: {
     type: 'string',


### PR DESCRIPTION
Can be used to override certain job settings, the format is the same as the `settings` field in the job.

Related to xoa-support#1583

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [x] `CHANGELOG.unreleased.md`: (low level)
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (low level)
- [ ] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
