### PR TITLE
chore(xo-server-sdn-controller): only use _getOrWaitObject when stric…

### DIFF
--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -336,7 +336,7 @@ class SDNController extends EventEmitter {
             starCenter: starCenterRef,
           })
           for (const poolNetwork of poolNetworks) {
-            const network = await xapi.getObjectByRef(poolNetwork.network)
+            const network = xapi.getObjectByRef(poolNetwork.network)
             const newCenter = await this._electNewCenter(network, true)
             poolNetwork.starCenter = newCenter?.$ref
             if (newCenter != null) {
@@ -399,7 +399,7 @@ class SDNController extends EventEmitter {
         `PIF: '${pif.device}' of network: '${pif.$network.name_label}' host: '${pif.$host.name_label}' has been plugged`
       )
 
-      const starCenter = await pif.$xapi.getObjectByRef(poolNetwork.starCenter)
+      const starCenter = pif.$xapi.getObjectByRef(poolNetwork.starCenter)
       await this._addHostToNetwork(pif.$host, pif.$network, starCenter)
     }
   }
@@ -425,7 +425,7 @@ class SDNController extends EventEmitter {
         }
       }
       for (const tunnel of tunnels) {
-        const accessPIF = await xapi.getObjectByRef(tunnel.access_PIF)
+        const accessPIF = xapi.getObjectByRef(tunnel.access_PIF)
         if (accessPIF.host !== host.$ref) {
           continue
         }
@@ -452,15 +452,13 @@ class SDNController extends EventEmitter {
           )
         }
 
-        const starCenter = await host.$xapi.getObjectByRef(
-          poolNetwork.starCenter
-        )
+        const starCenter = host.$xapi.getObjectByRef(poolNetwork.starCenter)
         await this._addHostToNetwork(host, accessPIF.$network, starCenter)
       }
     } else {
       const poolNetworks = filter(this._poolNetworks, { starCenter: host.$ref })
       for (const poolNetwork of poolNetworks) {
-        const network = await host.$xapi.getObjectByRef(poolNetwork.network)
+        const network = host.$xapi.getObjectByRef(poolNetwork.network)
         log.debug(
           `Star center host: '${host.name_label}' of network: '${network.name_label}' in pool: '${host.$pool.name_label}' is no longer reachable, electing a new host`
         )

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -336,7 +336,7 @@ class SDNController extends EventEmitter {
             starCenter: starCenterRef,
           })
           for (const poolNetwork of poolNetworks) {
-            const network = await xapi._getOrWaitObject(poolNetwork.network)
+            const network = await xapi.getObjectByRef(poolNetwork.network)
             const newCenter = await this._electNewCenter(network, true)
             poolNetwork.starCenter = newCenter?.$ref
             if (newCenter != null) {
@@ -399,9 +399,7 @@ class SDNController extends EventEmitter {
         `PIF: '${pif.device}' of network: '${pif.$network.name_label}' host: '${pif.$host.name_label}' has been plugged`
       )
 
-      const starCenter = await pif.$xapi._getOrWaitObject(
-        poolNetwork.starCenter
-      )
+      const starCenter = await pif.$xapi.getObjectByRef(poolNetwork.starCenter)
       await this._addHostToNetwork(pif.$host, pif.$network, starCenter)
     }
   }
@@ -427,7 +425,7 @@ class SDNController extends EventEmitter {
         }
       }
       for (const tunnel of tunnels) {
-        const accessPIF = await xapi._getOrWaitObject(tunnel.access_PIF)
+        const accessPIF = await xapi.getObjectByRef(tunnel.access_PIF)
         if (accessPIF.host !== host.$ref) {
           continue
         }
@@ -454,7 +452,7 @@ class SDNController extends EventEmitter {
           )
         }
 
-        const starCenter = await host.$xapi._getOrWaitObject(
+        const starCenter = await host.$xapi.getObjectByRef(
           poolNetwork.starCenter
         )
         await this._addHostToNetwork(host, accessPIF.$network, starCenter)
@@ -462,7 +460,7 @@ class SDNController extends EventEmitter {
     } else {
       const poolNetworks = filter(this._poolNetworks, { starCenter: host.$ref })
       for (const poolNetwork of poolNetworks) {
-        const network = await host.$xapi._getOrWaitObject(poolNetwork.network)
+        const network = await host.$xapi.getObjectByRef(poolNetwork.network)
         log.debug(
           `Star center host: '${host.name_label}' of network: '${network.name_label}' in pool: '${host.$pool.name_label}' is no longer reachable, electing a new host`
         )


### PR DESCRIPTION
…ly necessary

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
