### PR TITLE
fix(xo-server/vm.set): setting VCPUs_live

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Task] fix hidden notification by search field [#3874](https://github.com/vatesfr/xen-orchestra/issues/3874) (PR [#4305](https://github.com/vatesfr/xen-orchestra/pull/4305)
+- [VM] Number of CPUs not correctly changed on running VMs
 
 ### Released packages
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Task] fix hidden notification by search field [#3874](https://github.com/vatesfr/xen-orchestra/issues/3874) (PR [#4305](https://github.com/vatesfr/xen-orchestra/pull/4305)
-- [VM] Number of CPUs not correctly changed on running VMs
+- [VM] Number of CPUs not correctly changed on running VMs (PR [#4360](https://github.com/vatesfr/xen-orchestra/pull/4360)
 
 ### Released packages
 

--- a/packages/xo-server/src/xapi/mixins/vm.js
+++ b/packages/xo-server/src/xapi/mixins/vm.js
@@ -306,7 +306,9 @@ export default {
       get: vm => +vm.VCPUs_at_startup,
       set: [
         'VCPUs_at_startup',
-        (value, vm) => isVmRunning(vm) && vm.set_VCPUs_number_live(value),
+        (value, vm) =>
+          isVmRunning(vm) &&
+          vm.$xapi.call('VM.set_VCPUs_number_live', vm.$ref, String(value)),
       ],
     },
 


### PR DESCRIPTION
Caused by 3196c7ca09d212330058716af5d17c11260d1355

Fixes xoa-support#1632

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR (irrelevant)
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (irrelevant)
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
