### PR TITLE
feat(xo-web/vm/attachDisk): warning message when VDI is already attached

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -9,6 +9,7 @@
 
 - [VM/copy, VM/export] Only show zstd option when it's supported [#3892](https://github.com/vatesfr/xen-orchestra/issues/3892) (PRs [#4326](https://github.com/vatesfr/xen-orchestra/pull/4326) [#4368](https://github.com/vatesfr/xen-orchestra/pull/4368))
 - [SDN Controller] Let the user choose on which PIF to create a private network (PR [#4379](https://github.com/vatesfr/xen-orchestra/pull/4379))
+- [VM/Attach disk] Display confirmation modal when VDI is already attached [#3381](https://github.com/vatesfr/xen-orchestra/issues/3381) (PR [#4366](https://github.com/vatesfr/xen-orchestra/pull/4366))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/intl/locales/es.js
+++ b/packages/xo-web/src/common/intl/locales/es.js
@@ -1827,7 +1827,7 @@ export default {
   vdiAction: 'Acción',
 
   // Original text: "Attach disk"
-  vdiAttachDeviceButton: 'Adjuntar disco',
+  vdiAttachDevice: 'Adjuntar disco',
 
   // Original text: "New disk"
   vbdCreateDeviceButton: 'Nuevo disco',

--- a/packages/xo-web/src/common/intl/locales/fr.js
+++ b/packages/xo-web/src/common/intl/locales/fr.js
@@ -1865,7 +1865,7 @@ export default {
   vdiAction: 'Action',
 
   // Original text: "Attach disk"
-  vdiAttachDeviceButton: 'Attacher un disque',
+  vdiAttachDevice: 'Attacher un disque',
 
   // Original text: "New disk"
   vbdCreateDeviceButton: 'Nouveau disque',

--- a/packages/xo-web/src/common/intl/locales/he.js
+++ b/packages/xo-web/src/common/intl/locales/he.js
@@ -1557,7 +1557,7 @@ export default {
   vdiAction: undefined,
 
   // Original text: 'Attach disk'
-  vdiAttachDeviceButton: undefined,
+  vdiAttachDevice: undefined,
 
   // Original text: 'New disk'
   vbdCreateDeviceButton: undefined,

--- a/packages/xo-web/src/common/intl/locales/hu.js
+++ b/packages/xo-web/src/common/intl/locales/hu.js
@@ -1773,7 +1773,7 @@ export default {
   vdiAction: 'Művelet',
 
   // Original text: "Attach disk"
-  vdiAttachDeviceButton: 'Diszk Hozzácsatolás',
+  vdiAttachDevice: 'Diszk Hozzácsatolás',
 
   // Original text: "New disk"
   vbdCreateDeviceButton: 'Új diszk',

--- a/packages/xo-web/src/common/intl/locales/pl.js
+++ b/packages/xo-web/src/common/intl/locales/pl.js
@@ -1567,7 +1567,7 @@ export default {
   vdiAction: 'Akcja',
 
   // Original text: "Attach disk"
-  vdiAttachDeviceButton: 'Dołącz dysk',
+  vdiAttachDevice: 'Dołącz dysk',
 
   // Original text: "New disk"
   vbdCreateDeviceButton: 'Nowy dysk',

--- a/packages/xo-web/src/common/intl/locales/pt.js
+++ b/packages/xo-web/src/common/intl/locales/pt.js
@@ -1564,7 +1564,7 @@ export default {
   vdiAction: 'Ação',
 
   // Original text: "Attach disk"
-  vdiAttachDeviceButton: 'Anexar disco',
+  vdiAttachDevice: 'Anexar disco',
 
   // Original text: "New disk"
   vbdCreateDeviceButton: 'Novo disco',

--- a/packages/xo-web/src/common/intl/locales/tr.js
+++ b/packages/xo-web/src/common/intl/locales/tr.js
@@ -2303,7 +2303,7 @@ export default {
   vdiAction: 'Aksiyon',
 
   // Original text: "Attach disk"
-  vdiAttachDeviceButton: 'Disk tak',
+  vdiAttachDevice: 'Disk tak',
 
   // Original text: "New disk"
   vbdCreateDeviceButton: 'Yeni disk',

--- a/packages/xo-web/src/common/intl/locales/zh.js
+++ b/packages/xo-web/src/common/intl/locales/zh.js
@@ -1176,7 +1176,7 @@ export default {
   vdiAction: '操作',
 
   // Original text: "Attach disk"
-  vdiAttachDeviceButton: '附加磁盘',
+  vdiAttachDevice: '附加磁盘',
 
   // Original text: "New disk"
   vbdCreateDeviceButton: '新建磁盘',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1004,7 +1004,7 @@ const messages = {
   vbdCreateDeviceButton: 'New disk',
   vdiAttachDevice: 'Attach disk',
   vdiAttachDeviceConfirm:
-    'The selected VDI is already attached. Are you sure you want to continue?',
+    'The selected VDI is already attached to this VM. Are you sure you want to continue?',
   vdiBootOrder: 'Boot order',
   vdiNameLabel: 'Name',
   vdiNameDescription: 'Description',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1001,8 +1001,10 @@ const messages = {
   containerRestart: 'Restart this container',
 
   // ----- VM disk tab -----
-  vdiAttachDeviceButton: 'Attach disk',
   vbdCreateDeviceButton: 'New disk',
+  vdiAttachDevice: 'Attach disk',
+  vdiAttachDeviceConfirm:
+    'The selected VDI is already attached. Are you sure you want to continue?',
   vdiBootOrder: 'Boot order',
   vdiNameLabel: 'Name',
   vdiNameDescription: 'Description',

--- a/packages/xo-web/src/xo-app/vm/tab-disks.js
+++ b/packages/xo-web/src/xo-app/vm/tab-disks.js
@@ -41,7 +41,6 @@ import {
   filter,
   find,
   forEach,
-  isEmpty,
   get,
   groupBy,
   map,
@@ -461,13 +460,13 @@ class AttachDisk extends Component {
         mode: readOnly || !_isFreeForWriting(vdi) ? 'RO' : 'RW',
       }).then(onClose)
 
-    return isEmpty(filter(vbds, { VDI: vdi.id, VM: vm.id, attached: true }))
-      ? _attachDisk()
-      : confirm({
+    return some(vbds, { VDI: vdi.id, VM: vm.id })
+      ? confirm({
           body: _('vdiAttachDeviceConfirm'),
           icon: 'alarm',
           title: _('vdiAttachDevice'),
         }).then(_attachDisk)
+      : _attachDisk()
   }
 
   render() {

--- a/packages/xo-web/src/xo-app/vm/tab-disks.js
+++ b/packages/xo-web/src/xo-app/vm/tab-disks.js
@@ -460,6 +460,7 @@ class AttachDisk extends Component {
         mode: readOnly || !_isFreeForWriting(vdi) ? 'RO' : 'RW',
       }).then(onClose)
 
+    // check if the selected VDI is already attached to this VM.
     return some(vbds, { VDI: vdi.id, VM: vm.id })
       ? confirm({
           body: _('vdiAttachDeviceConfirm'),


### PR DESCRIPTION
fixes #3381 
required #4373 

### Screenshots

![Capture d’écran de 2019-08-01 10-05-29](https://user-images.githubusercontent.com/7724491/62276727-fa340600-b444-11e9-9d03-8a07c9a05028.png)

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (none)
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
