### PR TITLE
fix(xo-web/tooltip): tooltip disappearing when children change

### DIFF
--- a/packages/xo-web/src/common/tooltip/index.js
+++ b/packages/xo-web/src/common/tooltip/index.js
@@ -81,18 +81,6 @@ export default class Tooltip extends Component {
     this._removeListeners()
   }
 
-  componentWillReceiveProps(props) {
-    if (props.children !== this.props.children) {
-      this._removeListeners()
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.children !== this.props.children) {
-      this._addListeners()
-    }
-  }
-
   _addListeners() {
     const node = (this._node = ReactDOM.findDOMNode(this))
 
@@ -116,15 +104,18 @@ export default class Tooltip extends Component {
     this._node = null
   }
 
-  _showTooltip = () => {
+  _showTooltip = event => {
     const { props } = this
 
-    instance.setState({
-      className: props.className,
-      content: props.content,
-      show: true,
-      style: props.style,
-    })
+    instance.setState(
+      {
+        className: props.className,
+        content: props.content,
+        show: true,
+        style: props.style,
+      },
+      () => this._updateTooltip(event)
+    )
   }
 
   _hideTooltip = () => {


### PR DESCRIPTION
- Don't remove the listeners when the children change
  (The children change but the `<Tooltip />` is still there)
- Don't add new listeners when the children change
- Update the tooltip on `mouseenter` so the position is correct
  even when the tooltipped elements appears under the cursor

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
