### PR TITLE
fix(xo-web/vm/attachDisk): fix checking VDI mode

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 - [SDN Controller] Better detect host shutting down to adapt network topology (PR [#4314](https://github.com/vatesfr/xen-orchestra/pull/4314))
 - [SR/General] Display VDI VM name in SR usage graph (PR [#4370](https://github.com/vatesfr/xen-orchestra/pull/4370))
 - [SDN Controller] Add new hosts to pool's private networks (PR [#4382](https://github.com/vatesfr/xen-orchestra/pull/4382))
+- [Attach disk] Fix checking VDI mode (PR [#4373](https://github.com/vatesfr/xen-orchestra/pull/4373))
 
 ### Released packages
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@
 - [SDN Controller] Better detect host shutting down to adapt network topology (PR [#4314](https://github.com/vatesfr/xen-orchestra/pull/4314))
 - [SR/General] Display VDI VM name in SR usage graph (PR [#4370](https://github.com/vatesfr/xen-orchestra/pull/4370))
 - [SDN Controller] Add new hosts to pool's private networks (PR [#4382](https://github.com/vatesfr/xen-orchestra/pull/4382))
-- [Attach disk] Fix checking VDI mode (PR [#4373](https://github.com/vatesfr/xen-orchestra/pull/4373))
+- [VM/Attach disk] Fix checking VDI mode (PR [#4373](https://github.com/vatesfr/xen-orchestra/pull/4373))
 
 ### Released packages
 

--- a/packages/xo-web/src/xo-app/vm/tab-disks.js
+++ b/packages/xo-web/src/xo-app/vm/tab-disks.js
@@ -867,7 +867,7 @@ export default class TabDisks extends Component {
   ]
 
   render() {
-    const { srs, vbds, vdis, vm } = this.props
+    const { allVbds, srs, vdis, vm } = this.props
 
     const { attachDisk, bootOrder, newDisk } = this.state
 
@@ -916,7 +916,7 @@ export default class TabDisks extends Component {
                 <AttachDisk
                   checkSr={this._getCheckSr()}
                   vm={vm}
-                  vbds={vbds}
+                  vbds={allVbds}
                   onClose={this._toggleAttachDisk}
                 />
                 <hr />

--- a/packages/xo-web/src/xo-app/vm/tab-disks.js
+++ b/packages/xo-web/src/xo-app/vm/tab-disks.js
@@ -449,7 +449,7 @@ class AttachDisk extends Component {
 
     const _isFreeForWriting = vdi =>
       vdi.$VBDs.length === 0 ||
-      some(vdi.$VBDs, id => {
+      every(vdi.$VBDs, id => {
         const vbd = vbds[id]
         return !vbd || !vbd.attached || vbd.read_only
       })


### PR DESCRIPTION
In check VDI mode:  we will never find the VBD not attached to the current VM. 

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`) (none)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (none)
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
