### PR TITLE
feat(xo-server/backup-ng): emit warning task when zstd is choose but not supported

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Backup NG/logs] Show warning when not supported zstd compression is selected [#3892](https://github.com/vatesfr/xen-orchestra/issues/3892) (PR [#4375](https://github.com/vatesfr/xen-orchestra/pull/4375)
+
 ### Released packages
 
 > Packages will be released in the order they are here, therefore, they should

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [Backup NG/logs] Show warning when not supported zstd compression is selected [#3892](https://github.com/vatesfr/xen-orchestra/issues/3892) (PR [#4375](https://github.com/vatesfr/xen-orchestra/pull/4375)
+- [Backup NG/logs] Show warning when zstd compression is selected but not supported [#3892](https://github.com/vatesfr/xen-orchestra/issues/3892) (PR [#4375](https://github.com/vatesfr/xen-orchestra/pull/4375)
 
 ### Released packages
 

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -1147,13 +1147,15 @@ export default class BackupNg {
       }
 
       const compress = getJobCompression(job)
+      const { $pool: pool } = snapshot
       if (
         compress === 'zstd' &&
-        snapshot.$pool.restrictions.restrict_zstd_export !== 'false'
+        pool.restrictions.restrict_zstd_export !== 'false'
       ) {
         logger.warning(
-          `Zstd is not supported on the pool ${snapshot.$pool.name_label ||
-            snapshot.$pool.uuid}, the VM will be exported without compression`,
+          `Zstd is not supported on the pool ${
+            pool.name_label !== '' ? pool.name_label : pool.uuid
+          }, the VM will be exported without compression`,
           {
             event: 'task.warning',
             taskId,

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -1153,9 +1153,7 @@ export default class BackupNg {
         pool.restrictions.restrict_zstd_export !== 'false'
       ) {
         logger.warning(
-          `Zstd is not supported on the pool ${
-            pool.name_label !== '' ? pool.name_label : pool.uuid
-          }, the VM will be exported without compression`,
+          `Zstd is not supported on the pool ${pool.name_label}, the VM will be exported without compression`,
           {
             event: 'task.warning',
             taskId,

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -1146,6 +1146,20 @@ export default class BackupNg {
         $defer.call(xapi, 'deleteVm', snapshot)
       }
 
+      const compress = getJobCompression(job)
+      if (
+        compress === 'zstd' &&
+        snapshot.$pool.restrictions.restrict_zstd_export !== 'false'
+      ) {
+        logger.warning(
+          `Zstd is not supported on the pool ${snapshot.$pool.name_label ||
+            snapshot.$pool.uuid}, the VM will be exported without compression`,
+          {
+            event: 'task.warning',
+            taskId,
+          }
+        )
+      }
       let xva: any = await wrapTask(
         {
           logger,
@@ -1153,7 +1167,7 @@ export default class BackupNg {
           parentId: taskId,
         },
         xapi.exportVm($cancelToken, snapshot, {
-          compress: getJobCompression(job),
+          compress,
         })
       )
       const exportTask = xva.task

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -1147,7 +1147,7 @@ export default class BackupNg {
       }
 
       const compress = getJobCompression(job)
-      const { $pool: pool } = snapshot
+      const pool = snapshot.$pool
       if (
         compress === 'zstd' &&
         pool.restrictions.restrict_zstd_export !== 'false'

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -1146,12 +1146,13 @@ export default class BackupNg {
         $defer.call(xapi, 'deleteVm', snapshot)
       }
 
-      const compress = getJobCompression(job)
+      let compress = getJobCompression(job)
       const pool = snapshot.$pool
       if (
         compress === 'zstd' &&
         pool.restrictions.restrict_zstd_export !== 'false'
       ) {
+        compress = false
         logger.warning(
           `Zstd is not supported on the pool ${pool.name_label}, the VM will be exported without compression`,
           {


### PR DESCRIPTION
See  #3892

**Screenshots**

![image](https://user-images.githubusercontent.com/21563339/61935841-a11f2a80-af8b-11e9-8661-837c5465fd77.png)


### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
