### PR TITLE
fix(xo-web/exportVm,copyVm): VM container can be undefined

### DIFF
--- a/packages/xo-web/src/common/xo/copy-vm-modal/index.js
+++ b/packages/xo-web/src/common/xo/copy-vm-modal/index.js
@@ -15,7 +15,7 @@ import { SelectSr } from '../../select-objects'
   {
     isZstdSupported: createSelector(
       createGetObject((_, { vm }) => vm.$container),
-      container => container.zstdSupported
+      container => container === undefined || container.zstdSupported
     ),
   },
   { withRef: true }

--- a/packages/xo-web/src/common/xo/export-vm-modal/index.js
+++ b/packages/xo-web/src/common/xo/export-vm-modal/index.js
@@ -12,7 +12,7 @@ import { createGetObject, createSelector } from '../../selectors'
   {
     isZstdSupported: createSelector(
       createGetObject((_, { vm }) => vm.$container),
-      container => container.zstdSupported
+      container => container === undefined || container.zstdSupported
     ),
   },
   { withRef: true }


### PR DESCRIPTION
VM container can be undefined in case of a user not have ACLs on the pool/host

Introduced by a00e3e6f4128e022afdd4224449665966afd17eb 10d5228eb220438d09185ccca3e0c9147e807f44

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
