### PR TITLE
fix(xo-server/xen-servers): error on connecting a connected server

### DIFF
--- a/packages/xo-server/src/xo-mixins/xen-servers.js
+++ b/packages/xo-server/src/xo-mixins/xen-servers.js
@@ -293,6 +293,10 @@ export default class {
   async connectXenServer(id) {
     const server = (await this._getXenServer(id)).properties
 
+    if (this._getXenServerStatus(id) !== 'disconnected') {
+      throw new Error('the server is already connected')
+    }
+
     const xapi = (this._xapis[server.id] = new Xapi({
       allowUnauthorized: server.allowUnauthorized,
       readOnly: server.readOnly,


### PR DESCRIPTION
**The issue**:

On connecting a connected server, the XAPI of the connected server is removed from the cache. Which cause future connection troubles due to not cleaning correctly the pool cache on disconnecting it.

**Step to reproduce it**

- Add a server
- connect it
- re-connect it.
- disconnect it.
- connect it

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
