### PR TITLE
feat(xo-web/usage): show the item if there's only 1 'other'

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+  - [Usage graph] show the item if there's only 1 "other" [#4392](https://github.com/vatesfr/xen-orchestra/issues/4392) (PR [#4419](https://github.com/vatesfr/xen-orchestra/pull/4419))
+  
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,8 +7,6 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-  - [Usage graph] show the item if there's only 1 "other" [#4392](https://github.com/vatesfr/xen-orchestra/issues/4392) (PR [#4419](https://github.com/vatesfr/xen-orchestra/pull/4419))
-  
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”

--- a/packages/xo-web/src/common/usage/index.js
+++ b/packages/xo-web/src/common/usage/index.js
@@ -18,17 +18,25 @@ const Usage = ({ total, children }) => {
   const nOthers = othersValues.length
   return (
     <span className='usage'>
-      {React.Children.map(
-        children,
-        (child, index) =>
-          child.props.value > limit && cloneElement(child, { total })
+      {nOthers > 1 ? (
+        <span>
+          {React.Children.map(
+            children,
+            (child, index) =>
+              child.props.value > limit && cloneElement(child, { total })
+          )}
+          <Element
+            others
+            tooltip={_('others', { nOthers })}
+            total={total}
+            value={othersTotal}
+          />
+        </span>
+      ) : (
+        React.Children.map(children, (child, index) =>
+          cloneElement(child, { total })
+        )
       )}
-      <Element
-        others
-        tooltip={_('others', { nOthers })}
-        total={total}
-        value={othersTotal}
-      />
     </span>
   )
 }


### PR DESCRIPTION
fixes #4392

### Screenshots

![Capture du 2019-08-09 09-52-01](https://user-images.githubusercontent.com/7724491/62763693-773a2d80-ba8c-11e9-9900-a31da044e3f7.png)
![Capture d’écran de 2019-08-09 09-52-19](https://user-images.githubusercontent.com/7724491/62763694-773a2d80-ba8c-11e9-8417-3a6f7dbc24b6.png)


### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] `CHANGELOG.unreleased.md`: (none)
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (none)
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
