### PR TITLE
fix(xo-web/home): fix intermediary no matching objects display

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@
 - [Patching] Avoid overloading XCP-ng by reducing the frequency of yum update checks [#4358](https://github.com/vatesfr/xen-orchestra/issues/4358) (PR [#4477](https://github.com/vatesfr/xen-orchestra/pull/4477))
 - [Network] Fix inability to create a bonded network (PR [#4489](https://github.com/vatesfr/xen-orchestra/pull/4489))
 - [Backup restore & Replication] Don't copy `sm_config` to new VDIs which might leads to useless coalesces [#4482](https://github.com/vatesfr/xen-orchestra/issues/4482) (PR [#4484](https://github.com/vatesfr/xen-orchestra/pull/4484))
-- [Home] Show spinner on filtering objects instead of displaying an intermediary "no results" display [#4420](https://github.com/vatesfr/xen-orchestra/issues/4420) (PR [#4456](https://github.com/vatesfr/xen-orchestra/pull/4456)
+- [Home] Fix intermediary "no results" display showed on filtering items [#4420](https://github.com/vatesfr/xen-orchestra/issues/4420) (PR [#4456](https://github.com/vatesfr/xen-orchestra/pull/4456)
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 - [Patching] Avoid overloading XCP-ng by reducing the frequency of yum update checks [#4358](https://github.com/vatesfr/xen-orchestra/issues/4358) (PR [#4477](https://github.com/vatesfr/xen-orchestra/pull/4477))
 - [Network] Fix inability to create a bonded network (PR [#4489](https://github.com/vatesfr/xen-orchestra/pull/4489))
 - [Backup restore & Replication] Don't copy `sm_config` to new VDIs which might leads to useless coalesces [#4482](https://github.com/vatesfr/xen-orchestra/issues/4482) (PR [#4484](https://github.com/vatesfr/xen-orchestra/pull/4484))
+- [Home] Show spinner on filtering objects instead of displaying an intermediary "no results" display [#4420](https://github.com/vatesfr/xen-orchestra/issues/4420) (PR [#4456](https://github.com/vatesfr/xen-orchestra/pull/4456)
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 

--- a/packages/xo-web/src/common/store/actions.js
+++ b/packages/xo-web/src/common/store/actions.js
@@ -30,13 +30,9 @@ export const selectLang = createAction('SELECT_LANG', lang => lang)
 export const connected = createAction('CONNECTED')
 export const disconnected = createAction('DISCONNECTED')
 
-export const updateObjects = createAction(
-  'UPDATE_OBJECTS',
-  (updates, initialFetch) => ({
-    initialFetch,
-    updates,
-  })
-)
+export const fetchObjects = createAction('FETCH_OBJECTS', objects => objects)
+export const updateObjects = createAction('UPDATE_OBJECTS', updates => updates)
+
 export const updatePermissions = createAction(
   'UPDATE_PERMISSIONS',
   permissions => permissions

--- a/packages/xo-web/src/common/store/actions.js
+++ b/packages/xo-web/src/common/store/actions.js
@@ -30,7 +30,13 @@ export const selectLang = createAction('SELECT_LANG', lang => lang)
 export const connected = createAction('CONNECTED')
 export const disconnected = createAction('DISCONNECTED')
 
-export const updateObjects = createAction('UPDATE_OBJECTS', updates => updates)
+export const updateObjects = createAction(
+  'UPDATE_OBJECTS',
+  (updates, initialFetch) => ({
+    initialFetch,
+    updates,
+  })
+)
 export const updatePermissions = createAction(
   'UPDATE_PERMISSIONS',
   permissions => permissions

--- a/packages/xo-web/src/common/store/actions.js
+++ b/packages/xo-web/src/common/store/actions.js
@@ -30,7 +30,7 @@ export const selectLang = createAction('SELECT_LANG', lang => lang)
 export const connected = createAction('CONNECTED')
 export const disconnected = createAction('DISCONNECTED')
 
-export const fetchObjects = createAction('FETCH_OBJECTS', objects => objects)
+export const markObjectsFetched = createAction('OBJECTS_FETCHED')
 export const updateObjects = createAction('UPDATE_OBJECTS', updates => updates)
 
 export const updatePermissions = createAction(

--- a/packages/xo-web/src/common/store/actions.js
+++ b/packages/xo-web/src/common/store/actions.js
@@ -32,7 +32,6 @@ export const disconnected = createAction('DISCONNECTED')
 
 export const markObjectsFetched = createAction('OBJECTS_FETCHED')
 export const updateObjects = createAction('UPDATE_OBJECTS', updates => updates)
-
 export const updatePermissions = createAction(
   'UPDATE_PERMISSIONS',
   permissions => permissions

--- a/packages/xo-web/src/common/store/reducer.js
+++ b/packages/xo-web/src/common/store/reducer.js
@@ -1,4 +1,5 @@
 import cookies from 'cookies-js'
+import { groupBy } from 'lodash'
 
 import invoke from '../invoke'
 
@@ -100,7 +101,7 @@ export default {
     {
       [actions.updateObjects]: (
         { all, byType: prevByType, fetched = false },
-        { updates, initialFetch }
+        updates
       ) => {
         const byType = { ...prevByType }
         const get = type => {
@@ -128,12 +129,13 @@ export default {
           }
         }
 
-        if (initialFetch) {
-          fetched = true
-        }
-
         return { all, byType, fetched }
       },
+      [actions.fetchObjects]: (_, all) => ({
+        all,
+        byType: groupBy(all, 'type'),
+        fetched: true,
+      }),
     }
   ),
 

--- a/packages/xo-web/src/common/store/reducer.js
+++ b/packages/xo-web/src/common/store/reducer.js
@@ -98,7 +98,10 @@ export default {
       byType: {},
     },
     {
-      [actions.updateObjects]: ({ all, byType: prevByType }, updates) => {
+      [actions.updateObjects]: (
+        { all, byType: prevByType, fetched = false },
+        { updates, initialFetch }
+      ) => {
         const byType = { ...prevByType }
         const get = type => {
           const curr = byType[type]
@@ -125,7 +128,11 @@ export default {
           }
         }
 
-        return { all, byType, fetched: true }
+        if (initialFetch) {
+          fetched = true
+        }
+
+        return { all, byType, fetched }
       },
     }
   ),

--- a/packages/xo-web/src/common/store/reducer.js
+++ b/packages/xo-web/src/common/store/reducer.js
@@ -1,5 +1,4 @@
 import cookies from 'cookies-js'
-import { groupBy } from 'lodash'
 
 import invoke from '../invoke'
 
@@ -97,10 +96,11 @@ export default {
     {
       all: {}, // Mutable for performance!
       byType: {},
+      fetched: false,
     },
     {
       [actions.updateObjects]: (
-        { all, byType: prevByType, fetched = false },
+        { all, byType: prevByType, fetched },
         updates
       ) => {
         const byType = { ...prevByType }
@@ -131,9 +131,8 @@ export default {
 
         return { all, byType, fetched }
       },
-      [actions.fetchObjects]: (_, all) => ({
-        all,
-        byType: groupBy(all, 'type'),
+      [actions.markObjectsFetched]: state => ({
+        ...state,
         fetched: true,
       }),
     }

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -149,7 +149,7 @@ export const connectStore = store => {
         parseNdJson(data, object => {
           objects[object.id] = object
         })
-        store.dispatch(updateObjects(objects))
+        store.dispatch(updateObjects(objects, true))
       })
   })
   xo.on('notification', notification => {

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -43,7 +43,7 @@ import { noop, resolveId, resolveIds } from '../utils'
 import {
   connected,
   disconnected,
-  fetchObjects,
+  markObjectsFetched,
   signedIn,
   signedOut,
   updateObjects,
@@ -150,7 +150,8 @@ export const connectStore = store => {
         parseNdJson(data, object => {
           objects[object.id] = object
         })
-        store.dispatch(fetchObjects(objects))
+        store.dispatch(updateObjects(objects))
+        store.dispatch(markObjectsFetched())
       })
   })
   xo.on('notification', notification => {

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -43,6 +43,7 @@ import { noop, resolveId, resolveIds } from '../utils'
 import {
   connected,
   disconnected,
+  fetchObjects,
   signedIn,
   signedOut,
   updateObjects,
@@ -149,7 +150,7 @@ export const connectStore = store => {
         parseNdJson(data, object => {
           objects[object.id] = object
         })
-        store.dispatch(updateObjects(objects, true))
+        store.dispatch(fetchObjects(objects))
       })
   })
   xo.on('notification', notification => {

--- a/packages/xo-web/src/xo-app/home/index.js
+++ b/packages/xo-web/src/xo-app/home/index.js
@@ -1156,7 +1156,7 @@ export default class Home extends Component {
       noResourceSets,
     } = this.props
 
-    if (!areObjectsFetched || this._getFilter() === undefined) {
+    if (!areObjectsFetched) {
       return (
         <CenterPanel>
           <h2>

--- a/packages/xo-web/src/xo-app/home/index.js
+++ b/packages/xo-web/src/xo-app/home/index.js
@@ -314,7 +314,6 @@ const DEFAULT_TYPE = 'VM'
   )
 
   return {
-    areObjectsFetched,
     noServersConnected,
   }
 })
@@ -327,23 +326,12 @@ class NoObjectsWithoutServers extends Component {
 
   render() {
     const {
-      areObjectsFetched,
       isAdmin,
       isPoolAdmin,
       noRegisteredServers,
       noResourceSets,
       noServersConnected,
     } = this.props
-
-    if (!areObjectsFetched) {
-      return (
-        <CenterPanel>
-          <h2>
-            <img src='assets/loading.svg' />
-          </h2>
-        </CenterPanel>
-      )
-    }
 
     if (noServersConnected && isAdmin) {
       return (
@@ -461,6 +449,7 @@ const NoObjects = props =>
   const type = (_, props) => props.location.query.t || DEFAULT_TYPE
 
   return {
+    areObjectsFetched,
     isAdmin,
     isPoolAdmin: getIsPoolAdmin,
     items: createSelector(
@@ -1160,7 +1149,22 @@ export default class Home extends Component {
   // ---------------------------------------------------------------------------
 
   render() {
-    const { isAdmin, isPoolAdmin, noResourceSets } = this.props
+    const {
+      areObjectsFetched,
+      isAdmin,
+      isPoolAdmin,
+      noResourceSets,
+    } = this.props
+
+    if (!areObjectsFetched || this._getFilter() === undefined) {
+      return (
+        <CenterPanel>
+          <h2>
+            <img src='assets/loading.svg' />
+          </h2>
+        </CenterPanel>
+      )
+    }
 
     const nItems = this._getNumberOfItems()
 


### PR DESCRIPTION
Fixes #4420

**The issue**

Sometimes we got an intermediary "no result" display on applying a filter on home items, it's due to a race condition between the initial fetch of objects and their updates.

![image](https://user-images.githubusercontent.com/21563339/63836828-9edd3100-c97a-11e9-993a-3cbcc826a3d3.png)

**The solution**

Displaying a spinner when the initial fetch of objects is not yet finished.

![image](https://user-images.githubusercontent.com/21563339/63837012-f2e81580-c97a-11e9-99bb-544fd7cd69e2.png)


### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
