### PR TITLE
feat(xo-server/server.get): method to get a single server

### DIFF
--- a/packages/xo-server/src/api/server.js
+++ b/packages/xo-server/src/api/server.js
@@ -56,6 +56,18 @@ remove.params = {
 
 // -------------------------------------------------------------------
 
+export function get({ id }) {
+  return this.getXenServer(id)
+}
+
+get.description = 'get a registered Xen server'
+
+get.permission = 'admin'
+
+get.params = {
+  id: { type: 'string' },
+}
+
 // TODO: remove this function when users are integrated to the main
 // collection.
 export function getAll() {


### PR DESCRIPTION
This is a convenience method requested by an API user.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`) (none)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
- [x] `CHANGELOG.unreleased.md`: (too low level)
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (too low level)
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
