### PR TITLE
fix(xo-web/network): fix inability to create a bonded network

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 - [PBD] Obfuscate cifs password from device config [#4384](https://github.com/vatesfr/xen-orchestra/issues/4384) (PR [#4401](https://github.com/vatesfr/xen-orchestra/pull/4401))
 - [XOSAN] Fix "invalid parameters" error on creating a SR (PR [#4478](https://github.com/vatesfr/xen-orchestra/pull/4478))
 - [Patching] Avoid overloading XCP-ng by reducing the frequency of yum update checks [#4358](https://github.com/vatesfr/xen-orchestra/issues/4358) (PR [#4477](https://github.com/vatesfr/xen-orchestra/pull/4477))
+- [Network] Fix inability to create a bonded network (PR [#4489](https://github.com/vatesfr/xen-orchestra/pull/4489))
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 

--- a/packages/xo-web/src/xo-app/new/network/index.js
+++ b/packages/xo-web/src/xo-app/new/network/index.js
@@ -188,12 +188,6 @@ const NewNetwork = decorate([
         pifs,
         vlan,
       } = state
-      const poolIds = [pool.id]
-      const pifIds = [pif.id]
-      for (const network of networks) {
-        poolIds.push(network.pool.id)
-        pifIds.push(network.pif.id)
-      }
       return bonded
         ? createBondedNetwork({
             bondMode: bondMode.value,
@@ -205,13 +199,21 @@ const NewNetwork = decorate([
           })
         : isPrivate
         ? networks.length > 0
-          ? createCrossPoolPrivateNetwork({
-              xoPoolIds: poolIds,
-              networkName: name,
-              networkDescription: description,
-              encapsulation: encapsulation,
-              xoPifIds: pifIds,
-            })
+          ? (() => {
+              const poolIds = [pool.id]
+              const pifIds = [pif.id]
+              for (const network of networks) {
+                poolIds.push(network.pool.id)
+                pifIds.push(network.pif.id)
+              }
+              return createCrossPoolPrivateNetwork({
+                xoPoolIds: poolIds,
+                networkName: name,
+                networkDescription: description,
+                encapsulation: encapsulation,
+                xoPifIds: pifIds,
+              })
+            })()
           : createPrivateNetwork({
               poolId: pool.id,
               networkName: name,


### PR DESCRIPTION
xoa-support#1725

Introduced by https://github.com/vatesfr/xen-orchestra/commit/3890d4d9d1c3740e0c8ab5ac690733f83a62cc0d#diff-5632246dd4a437bd0840d99fca67913dR192

**The issue**

`pif` property is `undefined` in case of bonded networks

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
