### PR TITLE
fix(xo-server/vm): fix "vm.set_domain_type" is not a function on XS < 7.5

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [VM/Advanced] Fix "vm.set_domain_type" is not a function on switching virtualization mode (PV/HVM) [#4348](https://github.com/vatesfr/xen-orchestra/issues/4348) (PR [#4504](https://github.com/vatesfr/xen-orchestra/pull/4504))
+- [VM/Advanced] Fix `"vm.set_domain_type" is not a function` error on switching virtualization mode (PV/HVM) [#4348](https://github.com/vatesfr/xen-orchestra/issues/4348) (PR [#4504](https://github.com/vatesfr/xen-orchestra/pull/4504))
 
 ### Released packages
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [VM/Advanced] Fix "vm.set_domain_type" is not a function on switching virtualization mode (PV/HVM) [#4348](https://github.com/vatesfr/xen-orchestra/issues/4348) (PR [#4504](https://github.com/vatesfr/xen-orchestra/pull/4504))
+
 ### Released packages
 
 > Packages will be released in the order they are here, therefore, they should

--- a/packages/xo-server/src/xapi/mixins/vm.js
+++ b/packages/xo-server/src/xapi/mixins/vm.js
@@ -276,13 +276,11 @@ export default {
         if (virtualizationMode !== 'pv' && virtualizationMode !== 'hvm') {
           throw new Error(`The virtualization mode must be 'pv' or 'hvm'`)
         }
-        return vm
-          .set_domain_type(virtualizationMode)
-          ::pCatch({ code: 'MESSAGE_METHOD_UNKNOWN' }, () =>
-            vm.set_HVM_boot_policy(
+        return vm.set_domain_type !== undefined
+          ? vm.set_domain_type(virtualizationMode)
+          : vm.set_HVM_boot_policy(
               virtualizationMode === 'hvm' ? 'Boot order' : ''
             )
-          )
       },
     },
 


### PR DESCRIPTION
Fixes #4348
Introduced by https://github.com/vatesfr/xen-orchestra/commit/3196c7ca09d212330058716af5d17c11260d1355#diff-a20130cea265330a92852ddcd3a425ebR286

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
