### PR TITLE
feat(xo-server/listVmBackupsNg): implement debounce

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 - [SDN Controller] Add possibility to encrypt private networks (PR [#4441](https://github.com/vatesfr/xen-orchestra/pull/4441))
 - [SDN Controller] Ability to configure MTU for private networks (PR [#4491](https://github.com/vatesfr/xen-orchestra/pull/4491))
 - [VM Export] Filenames are now prefixed with datetime [#4503](https://github.com/vatesfr/xen-orchestra/issues/4503)
+- [Backups] Improve performance by caching VM backups listing
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 - [SDN Controller] Add possibility to encrypt private networks (PR [#4441](https://github.com/vatesfr/xen-orchestra/pull/4441))
 - [SDN Controller] Ability to configure MTU for private networks (PR [#4491](https://github.com/vatesfr/xen-orchestra/pull/4491))
 - [VM Export] Filenames are now prefixed with datetime [#4503](https://github.com/vatesfr/xen-orchestra/issues/4503)
-- [Backups] Improve performance by caching VM backups listing
+- [Backups] Improve performance by caching VM backups listing (PR [#4509](https://github.com/vatesfr/xen-orchestra/pull/4509))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/_pDebounceWithKey.js
+++ b/packages/xo-server/src/_pDebounceWithKey.js
@@ -20,8 +20,12 @@ const defaultKeyFn = () => []
 // the same result
 //
 // similar to `p-debounce` with `leading` set to `true` but with key support
-export default (fn, delay, keyFn = defaultKeyFn) => {
+//
+// - `delay`: number of milliseconds to cache the response, a function can be
+//   passed to use a custom delay for a call based on its parameters
+export const debounceWithKey = (fn, delay, keyFn = defaultKeyFn) => {
   const cache = new MultiKeyMap()
+  const delayFn = typeof delay === 'number' ? () => delay : delay
   return function() {
     const keys = ensureArray(keyFn.apply(this, arguments))
     let promise = cache.get(keys)
@@ -30,10 +34,15 @@ export default (fn, delay, keyFn = defaultKeyFn) => {
       const remove = scheduleRemoveCacheEntry.bind(
         cache,
         keys,
-        Date.now() + delay
+        Date.now() + delayFn.apply(this, arguments)
       )
       promise.then(remove, remove)
     }
     return promise
   }
 }
+
+debounceWithKey.decorate = (...params) => (target, name, descriptor) => ({
+  ...descriptor,
+  value: debounceWithKey(descriptor.value, ...params),
+})

--- a/packages/xo-server/src/xapi/mixins/patching.js
+++ b/packages/xo-server/src/xapi/mixins/patching.js
@@ -6,7 +6,7 @@ import { filter, find, pickBy, some } from 'lodash'
 
 import ensureArray from '../../_ensureArray'
 import { debounce } from '../../decorators'
-import debounceWithKey from '../../_pDebounceWithKey'
+import { debounceWithKey } from '../../_pDebounceWithKey'
 import { forEach, mapFilter, mapToArray, parseXml } from '../../utils'
 
 import { extractOpaqueRef, useUpdateSystem } from '../utils'

--- a/packages/xo-server/src/xo-mixins/metadata-backups.js
+++ b/packages/xo-server/src/xo-mixins/metadata-backups.js
@@ -3,7 +3,7 @@ import asyncMap from '@xen-orchestra/async-map'
 import createLogger from '@xen-orchestra/log'
 import { fromEvent, ignoreErrors } from 'promise-toolbox'
 
-import debounceWithKey from '../_pDebounceWithKey'
+import { debounceWithKey } from '../_pDebounceWithKey'
 import parseDuration from '../_parseDuration'
 import { type Xapi } from '../xapi'
 import {


### PR DESCRIPTION
Fixes xoa-support#1676

For now, the delay is set to 10s which is the duration used by xo-web's
subscription, which makes it enough to make it independent of the number of
clients.

In the future, this should probably be longer and configurable, but this
requires invalidating the cache in case of changes (creation/deletion of
backups) and explicit requests from the users, which will be implemented in
another PR.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR (none)
- [x] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test) (none)
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated (irrelevant)
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
