### PR TITLE
fix(xo-server/network.set): missing param definition

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,7 +18,7 @@
 - [VM/Advanced] Fix `"vm.set_domain_type" is not a function` error on switching virtualization mode (PV/HVM) [#4348](https://github.com/vatesfr/xen-orchestra/issues/4348) (PR [#4504](https://github.com/vatesfr/xen-orchestra/pull/4504))
 - [Backup NG/logs] Show warning when zstd compression is selected but not supported [#3892](https://github.com/vatesfr/xen-orchestra/issues/3892) (PR [#4375](https://github.com/vatesfr/xen-orchestra/pull/4375)
 - [Patches] Fix patches installation for CH 8.0 (PR [#4511](https://github.com/vatesfr/xen-orchestra/pull/4511))
-- [Network] Fix inability to set a network name (PR [4510](https://github.com/vatesfr/xen-orchestra/pull/4510))
+- [Network] Fix inability to set a network name [#4514](https://github.com/vatesfr/xen-orchestra/issues/4514) (PR [4510](https://github.com/vatesfr/xen-orchestra/pull/4510))
 
 ### Released packages
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@
 - [VM/Advanced] Fix `"vm.set_domain_type" is not a function` error on switching virtualization mode (PV/HVM) [#4348](https://github.com/vatesfr/xen-orchestra/issues/4348) (PR [#4504](https://github.com/vatesfr/xen-orchestra/pull/4504))
 - [Backup NG/logs] Show warning when zstd compression is selected but not supported [#3892](https://github.com/vatesfr/xen-orchestra/issues/3892) (PR [#4375](https://github.com/vatesfr/xen-orchestra/pull/4375)
 - [Patches] Fix patches installation for CH 8.0 (PR [#4511](https://github.com/vatesfr/xen-orchestra/pull/4511))
+- [Network] Fix inability to set a network name (PR [4510](https://github.com/vatesfr/xen-orchestra/pull/4510))
 
 ### Released packages
 

--- a/packages/xo-server-test/src/_xoConnection.js
+++ b/packages/xo-server-test/src/_xoConnection.js
@@ -129,13 +129,13 @@ class XoConnection extends Xo {
   }
 
   async createTempNetwork(params) {
-    const network = await this.call('network.create', {
+    const id = await this.call('network.create', {
       name: 'XO Test',
       pool: config.pools.default,
       ...params,
     })
-    this._tempResourceDisposers.push('network.delete', { id: network.uuid })
-    return network
+    this._tempResourceDisposers.push('network.delete', { id })
+    return this.getOrWaitObject(id)
   }
 
   async createTempRemote(params) {

--- a/packages/xo-server-test/src/_xoConnection.js
+++ b/packages/xo-server-test/src/_xoConnection.js
@@ -116,6 +116,16 @@ class XoConnection extends Xo {
     return job
   }
 
+  async createTempNetwork(params) {
+    const id = await this.call('network.create', {
+      name: 'XO Test',
+      pool: config.pools.default,
+      ...params,
+    })
+    this._tempResourceDisposers.push('network.delete', { id })
+    return this.getOrWaitObject(id)
+  }
+
   async createTempVm(params) {
     const id = await this.call('vm.create', {
       name_label: 'XO Test',
@@ -126,16 +136,6 @@ class XoConnection extends Xo {
     return this.waitObjectState(id, vm => {
       if (vm.type !== 'VM') throw new Error('retry')
     })
-  }
-
-  async createTempNetwork(params) {
-    const id = await this.call('network.create', {
-      name: 'XO Test',
-      pool: config.pools.default,
-      ...params,
-    })
-    this._tempResourceDisposers.push('network.delete', { id })
-    return this.getOrWaitObject(id)
   }
 
   async createTempRemote(params) {

--- a/packages/xo-server-test/src/_xoConnection.js
+++ b/packages/xo-server-test/src/_xoConnection.js
@@ -128,6 +128,16 @@ class XoConnection extends Xo {
     })
   }
 
+  async createTempNetwork(params) {
+    const network = await this.call('network.create', {
+      name: 'XO Test',
+      pool: config.pools.default,
+      ...params,
+    })
+    this._tempResourceDisposers.push('network.delete', { id: network.uuid })
+    return network
+  }
+
   async createTempRemote(params) {
     const remote = await this.call('remote.create', params)
     this._tempResourceDisposers.push('remote.delete', { id: remote.id })

--- a/packages/xo-server-test/src/issues/index.spec.js
+++ b/packages/xo-server-test/src/issues/index.spec.js
@@ -25,16 +25,6 @@ describe('issue', () => {
     })
   })
 
-  test('4523', async () => {
-    const id = await xo.call('network.create', {
-      name: 'XO Test',
-      pool: config.pools.default,
-    })
-    expect(typeof id).toBe('string')
-
-    await xo.call('network.delete', { id })
-  })
-
   test('4514', async () => {
     await xo.createTempServer(config.servers.default)
 
@@ -47,5 +37,15 @@ describe('issue', () => {
     await xo.waitObjectState(id, ({ name_label }) => {
       expect(name_label).toBe(newName)
     })
+  })
+
+  test('4523', async () => {
+    const id = await xo.call('network.create', {
+      name: 'XO Test',
+      pool: config.pools.default,
+    })
+    expect(typeof id).toBe('string')
+
+    await xo.call('network.delete', { id })
   })
 })

--- a/packages/xo-server-test/src/issues/index.spec.js
+++ b/packages/xo-server-test/src/issues/index.spec.js
@@ -34,4 +34,19 @@ describe('issue', () => {
 
     await xo.call('network.delete', { id })
   })
+
+  test('4514', async () => {
+    await xo.createTempServer(config.servers.default)
+
+    const oldName = 'Old XO Test name'
+    const network = await xo.createTempNetwork({ name: oldName })
+    expect(network.name_label).toBe(oldName)
+
+    const id = network.uuid
+    const newName = 'New XO Test name'
+    await xo.call('network.set', { id, name_label: newName })
+    await xo.waitObjectState(id, ({ name_label: nameLabel }) => {
+      expect(nameLabel).toBe(newName)
+    })
+  })
 })

--- a/packages/xo-server-test/src/issues/index.spec.js
+++ b/packages/xo-server-test/src/issues/index.spec.js
@@ -39,14 +39,13 @@ describe('issue', () => {
     await xo.createTempServer(config.servers.default)
 
     const oldName = 'Old XO Test name'
-    const network = await xo.createTempNetwork({ name: oldName })
-    expect(network.name_label).toBe(oldName)
+    const { id, name_label } = await xo.createTempNetwork({ name: oldName })
+    expect(name_label).toBe(oldName)
 
-    const id = network.uuid
     const newName = 'New XO Test name'
     await xo.call('network.set', { id, name_label: newName })
-    await xo.waitObjectState(id, ({ name_label: nameLabel }) => {
-      expect(nameLabel).toBe(newName)
+    await xo.waitObjectState(id, ({ name_label }) => {
+      expect(name_label).toBe(newName)
     })
   })
 })

--- a/packages/xo-server/src/api/network.js
+++ b/packages/xo-server/src/api/network.js
@@ -111,6 +111,9 @@ export async function set({
 }
 
 set.params = {
+  id: {
+    type: 'string',
+  },
   automatic: {
     type: 'boolean',
     optional: true,

--- a/packages/xo-server/src/api/network.js
+++ b/packages/xo-server/src/api/network.js
@@ -111,9 +111,6 @@ export async function set({
 }
 
 set.params = {
-  id: {
-    type: 'string',
-  },
   automatic: {
     type: 'boolean',
     optional: true,
@@ -121,6 +118,9 @@ set.params = {
   defaultIsLocked: {
     type: 'boolean',
     optional: true,
+  },
+  id: {
+    type: 'string',
   },
   name_description: {
     type: 'string',


### PR DESCRIPTION
Fixes #4514

See https://xcp-ng.org/forum/topic/962/why-are-you-using-xcp-ng-center/96

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
