### PR TITLE
fix(xo-server/patching): bad semver check for update system

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 
 - [VM/Advanced] Fix `"vm.set_domain_type" is not a function` error on switching virtualization mode (PV/HVM) [#4348](https://github.com/vatesfr/xen-orchestra/issues/4348) (PR [#4504](https://github.com/vatesfr/xen-orchestra/pull/4504))
 - [Backup NG/logs] Show warning when zstd compression is selected but not supported [#3892](https://github.com/vatesfr/xen-orchestra/issues/3892) (PR [#4375](https://github.com/vatesfr/xen-orchestra/pull/4375)
+- [Patches] Fix patches installation for CH 8.0 (PR [#4511](https://github.com/vatesfr/xen-orchestra/pull/4511))
 
 ### Released packages
 

--- a/packages/xo-server/src/xapi/utils.js
+++ b/packages/xo-server/src/xapi/utils.js
@@ -332,7 +332,7 @@ export const makeEditObject = specs => {
 
 export const useUpdateSystem = host => {
   // Match Xen Center's condition: https://github.com/xenserver/xenadmin/blob/f3a64fc54bbff239ca6f285406d9034f57537d64/XenModel/Utils/Helpers.cs#L420
-  return versionSatisfies(host.software_version.platform_version, '^2.1.1')
+  return versionSatisfies(host.software_version.platform_version, '>=2.1.1')
 }
 
 export const canSrHaveNewVdiOfSize = (sr, minSize) =>


### PR DESCRIPTION
So far, in order to know if we needed to use the "new" patching system, we were checking that the pool master's `software_version.platform_version` satisfied `^2.1.1` (instead of `>=2.1.1` like [XenCenter does](https://github.com/xenserver/xenadmin/blob/f3a64fc54bbff239ca6f285406d9034f57537d64/XenModel/Utils/Helpers.cs#L420)). This broke the installation and the display of missing patches for CH 8.0 whose `software_version.platform_version` is `3.0.0`.

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
