### PR TITLE
fix(xo-server/network.create): return network id instead of  xapi object

### DIFF
--- a/packages/xo-server-test/sample.config.toml
+++ b/packages/xo-server-test/sample.config.toml
@@ -3,6 +3,9 @@
   email = ''
   password = ''
 
+[pools]
+  default = ''
+
 [servers]
   [servers.default]
     username = ''

--- a/packages/xo-server-test/src/issues/index.spec.js
+++ b/packages/xo-server-test/src/issues/index.spec.js
@@ -24,4 +24,14 @@ describe('issue', () => {
       expect(vm.cpuCap).toBe(undefined)
     })
   })
+
+  test('4523', async () => {
+    const id = await xo.call('network.create', {
+      name: 'XO Test',
+      pool: config.pools.default,
+    })
+    expect(typeof id).toBe('string')
+
+    await xo.call('network.delete', { id })
+  })
 })

--- a/packages/xo-server/src/api/network.js
+++ b/packages/xo-server/src/api/network.js
@@ -1,3 +1,4 @@
+import xapiObjectToXo from '../xapi-object-to-xo'
 import { mapToArray } from '../utils'
 
 export function getBondModes() {
@@ -12,13 +13,15 @@ export async function create({
   mtu = 1500,
   vlan = 0,
 }) {
-  return this.getXapi(pool).createNetwork({
-    name,
-    description,
-    pifId: pif && this.getObject(pif, 'PIF')._xapiId,
-    mtu: +mtu,
-    vlan: +vlan,
-  })
+  return xapiObjectToXo(
+    await this.getXapi(pool).createNetwork({
+      name,
+      description,
+      pifId: pif && this.getObject(pif, 'PIF')._xapiId,
+      mtu: +mtu,
+      vlan: +vlan,
+    })
+  )
 }
 
 create.params = {

--- a/packages/xo-server/src/api/network.js
+++ b/packages/xo-server/src/api/network.js
@@ -21,7 +21,7 @@ export async function create({
       mtu: +mtu,
       vlan: +vlan,
     })
-  )
+  ).id
 }
 
 create.params = {


### PR DESCRIPTION
### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
