### PR TITLE
fix(xo-server/patching): install XCP-ng patches host by host

### DIFF
--- a/packages/xo-server/src/xapi/mixins/patching.js
+++ b/packages/xo-server/src/xapi/mixins/patching.js
@@ -346,6 +346,8 @@ export default {
       )
     }
 
+    // XCP-ng hosts need to be updated one at a time starting with the pool master
+    // https://github.com/vatesfr/xen-orchestra/issues/4468
     hosts = hosts.sort(({ $ref }) => ($ref === this.pool.master ? -1 : 1))
     for (const host of hosts) {
       const update = await this.call(

--- a/packages/xo-server/src/xapi/mixins/patching.js
+++ b/packages/xo-server/src/xapi/mixins/patching.js
@@ -1,4 +1,3 @@
-import asyncMap from '@xen-orchestra/async-map'
 import createLogger from '@xen-orchestra/log'
 import deferrable from 'golike-defer'
 import unzip from 'julien-f-unzip'
@@ -337,7 +336,7 @@ export default {
 
   // INSTALL -------------------------------------------------------------------
 
-  _xcpUpdate(hosts) {
+  async _xcpUpdate(hosts) {
     if (hosts === undefined) {
       hosts = filter(this.objects.all, { $type: 'host' })
     } else {
@@ -347,7 +346,8 @@ export default {
       )
     }
 
-    return asyncMap(hosts, async host => {
+    hosts = hosts.sort(({ $ref }) => ($ref === this.pool.master ? -1 : 1))
+    for (const host of hosts) {
       const update = await this.call(
         'host.call_plugin',
         host.$ref,
@@ -364,7 +364,7 @@ export default {
           String(Date.now() / 1000)
         )
       }
-    })
+    }
   },
 
   // Legacy XS patches: upload a patch on a pool before installing it


### PR DESCRIPTION
Fixes #4468

To prevent issues where 2 hosts try to modify the XAPI DB at the same time

### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
- [ ] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
