### PR TITLE
chore(xo-server-sdn-controller): move default values to public API

### DIFF
--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -206,7 +206,11 @@ class SDNController extends EventEmitter {
   async load() {
     // Expose method to create pool-wide private network
     const createPrivateNetwork = params =>
-      this._createPrivateNetwork({ ...params, vni: ++this._prevVni })
+      this._createPrivateNetwork({
+        encrypted: false,
+        ...params,
+        vni: ++this._prevVni,
+      })
 
     createPrivateNetwork.description =
       'Creates a pool-wide private network on a selected pool'
@@ -224,9 +228,9 @@ class SDNController extends EventEmitter {
     }
 
     // Expose method to create cross-pool private network
-    const createCrossPoolPrivateNetwork = this._createCrossPoolPrivateNetwork.bind(
-      this
-    )
+    const createCrossPoolPrivateNetwork = params =>
+      this._createCrossPoolPrivateNetwork({ encrypted: false, ...params })
+
     createCrossPoolPrivateNetwork.description =
       'Creates a cross-pool private network on selected pools'
     createCrossPoolPrivateNetwork.params = {
@@ -405,7 +409,7 @@ class SDNController extends EventEmitter {
     encapsulation,
     xoPif,
     vni,
-    encrypted = false,
+    encrypted,
   }) {
     const pool = this._xo.getXapiObject(xoPool)
     await this._setPoolControllerIfNeeded(pool)
@@ -466,7 +470,7 @@ class SDNController extends EventEmitter {
     networkDescription,
     encapsulation,
     xoPifIds,
-    encrypted = false,
+    encrypted,
   }) {
     const uuid = uuidv4()
     const crossPoolNetwork = {


### PR DESCRIPTION
### Check list

> Check items when done or if not relevant

- [x] PR reference the relevant issue (e.g. `Fixes #007`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
- [x] `CHANGELOG.unreleased.md`:
   - enhancement/bug fix entry added
   - list of packages to release updated (`${name} v${new version}`)
- [x] documentation updated
- [x] **I have tested added/updated features** (and impacted code)

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer
