### PR TITLE
fix(xo-server-test/backup-ng): clear logs cache before fetch them

### DIFF
--- a/packages/xo-server-test/src/_xoConnection.js
+++ b/packages/xo-server-test/src/_xoConnection.js
@@ -211,7 +211,7 @@ class XoConnection extends Xo {
   }
 
   getBackupLogs(filter) {
-    return this.call('backupNg.getLogs', filter, true)
+    return this.call('backupNg.getLogs', { _forceRefresh: true, ...filter })
   }
 
   async _cleanDisposers(disposers) {

--- a/packages/xo-server-test/src/_xoConnection.js
+++ b/packages/xo-server-test/src/_xoConnection.js
@@ -210,9 +210,8 @@ class XoConnection extends Xo {
     return backups
   }
 
-  async getBackupLogs(filter) {
-    await this.call('backupNg.clearLogsCache')
-    return this.call('backupNg.getLogs', filter)
+  getBackupLogs(filter) {
+    return this.call('backupNg.getLogs', filter, true)
   }
 
   async _cleanDisposers(disposers) {

--- a/packages/xo-server-test/src/_xoConnection.js
+++ b/packages/xo-server-test/src/_xoConnection.js
@@ -210,6 +210,11 @@ class XoConnection extends Xo {
     return backups
   }
 
+  async getBackupLogs(filter) {
+    await this.call('backupNg.clearLogsCache')
+    return this.call('backupNg.getLogs', filter)
+  }
+
   async _cleanDisposers(disposers) {
     for (let n = disposers.length - 1; n > 0; ) {
       const params = disposers[n--]

--- a/packages/xo-server-test/src/backupNg/backupNg.spec.js
+++ b/packages/xo-server-test/src/backupNg/backupNg.spec.js
@@ -221,7 +221,7 @@ describe('backupNg', () => {
       expect(typeof schedule).toBe('object')
 
       await xo.call('backupNg.runJob', { id: jobId, schedule: schedule.id })
-      const [log] = await xo.call('backupNg.getLogs', {
+      const [log] = await xo.getBackupLogs({
         scheduleId: schedule.id,
       })
       expect(log.warnings).toMatchSnapshot()
@@ -260,7 +260,7 @@ describe('backupNg', () => {
           tasks: [vmTask],
           ...log
         },
-      ] = await xo.call('backupNg.getLogs', {
+      ] = await xo.getBackupLogs({
         jobId,
         scheduleId: schedule.id,
       })
@@ -319,7 +319,7 @@ describe('backupNg', () => {
           tasks: [task],
           ...log
         },
-      ] = await xo.call('backupNg.getLogs', {
+      ] = await xo.getBackupLogs({
         jobId,
         scheduleId: schedule.id,
       })
@@ -415,7 +415,7 @@ describe('backupNg', () => {
         tasks: [{ tasks: subTasks, ...vmTask }],
         ...log
       },
-    ] = await xo.call('backupNg.getLogs', {
+    ] = await xo.getBackupLogs({
       jobId,
       scheduleId: schedule.id,
     })
@@ -506,7 +506,7 @@ describe('backupNg', () => {
       expect(backups.length).toBe(exportRetention)
     )
 
-    const backupLogs = await xo.call('backupNg.getLogs', {
+    const backupLogs = await xo.getBackupLogs({
       jobId,
       scheduleId: schedule.id,
     })

--- a/packages/xo-server/src/api/backup-ng.js
+++ b/packages/xo-server/src/api/backup-ng.js
@@ -196,7 +196,9 @@ export async function getLogs({
 
   ...filter
 }) {
-  await this.getBackupNgLogs(REMOVE_CACHE_ENTRY)
+  if (_forceRefresh) {
+    await this.getBackupNgLogs(REMOVE_CACHE_ENTRY)
+  }
   return this.getBackupNgLogsSorted({ after, before, limit, filter })
 }
 

--- a/packages/xo-server/src/api/backup-ng.js
+++ b/packages/xo-server/src/api/backup-ng.js
@@ -197,6 +197,16 @@ getLogs.params = {
   '*': { type: 'any' },
 }
 
+export function clearLogsCache() {
+  return this.clearBackupNgLogs()
+}
+
+clearLogsCache.permission = 'admin'
+
+clearLogsCache.params = {
+  runId: { type: 'string', optional: true },
+}
+
 // -----------------------------------------------------------------------------
 
 export function deleteVmBackup({ id }) {

--- a/packages/xo-server/src/api/backup-ng.js
+++ b/packages/xo-server/src/api/backup-ng.js
@@ -200,16 +200,6 @@ getLogs.params = {
   '*': { type: 'any' },
 }
 
-export function clearLogsCache() {
-  return this.clearBackupNgLogs()
-}
-
-clearLogsCache.permission = 'admin'
-
-clearLogsCache.params = {
-  runId: { type: 'string', optional: true },
-}
-
 // -----------------------------------------------------------------------------
 
 export function deleteVmBackup({ id }) {

--- a/packages/xo-server/src/api/backup-ng.js
+++ b/packages/xo-server/src/api/backup-ng.js
@@ -184,8 +184,11 @@ getAllLogs.params = {
   ndjson: { type: 'boolean', optional: true },
 }
 
-export function getLogs({ after, before, limit, ...filter }) {
-  return this.getBackupNgLogsSorted({ after, before, limit, filter })
+export function getLogs({ after, before, limit, ...filter }, _forceRefresh) {
+  return this.getBackupNgLogsSorted(
+    { after, before, limit, filter },
+    _forceRefresh
+  )
 }
 
 getLogs.permission = 'admin'

--- a/packages/xo-server/src/api/backup-ng.js
+++ b/packages/xo-server/src/api/backup-ng.js
@@ -184,13 +184,16 @@ getAllLogs.params = {
   ndjson: { type: 'boolean', optional: true },
 }
 
-export function getLogs(
-  { after, before, limit, ...filter },
+export function getLogs({
+  after,
+  before,
+  limit,
 
   // it's a temporary work-around which will be removed
   // when the consolidated logs will be stored in the DB
-  _forceRefresh
-) {
+  _forceRefresh,
+  ...filter
+}) {
   return this.getBackupNgLogsSorted(
     { after, before, limit, filter },
     _forceRefresh

--- a/packages/xo-server/src/api/backup-ng.js
+++ b/packages/xo-server/src/api/backup-ng.js
@@ -184,7 +184,13 @@ getAllLogs.params = {
   ndjson: { type: 'boolean', optional: true },
 }
 
-export function getLogs({ after, before, limit, ...filter }, _forceRefresh) {
+export function getLogs(
+  { after, before, limit, ...filter },
+
+  // it's a temporary work-around which will be removed
+  // when the consolidated logs will be stored in the DB
+  _forceRefresh
+) {
   return this.getBackupNgLogsSorted(
     { after, before, limit, filter },
     _forceRefresh

--- a/packages/xo-server/src/api/backup-ng.js
+++ b/packages/xo-server/src/api/backup-ng.js
@@ -185,7 +185,7 @@ getAllLogs.params = {
   ndjson: { type: 'boolean', optional: true },
 }
 
-export async function getLogs({
+export function getLogs({
   after,
   before,
   limit,

--- a/packages/xo-server/src/api/backup-ng.js
+++ b/packages/xo-server/src/api/backup-ng.js
@@ -197,7 +197,7 @@ export async function getLogs({
   ...filter
 }) {
   if (_forceRefresh) {
-    await this.getBackupNgLogs(REMOVE_CACHE_ENTRY)
+    this.getBackupNgLogs(REMOVE_CACHE_ENTRY)
   }
   return this.getBackupNgLogsSorted({ after, before, limit, filter })
 }

--- a/packages/xo-server/src/api/backup-ng.js
+++ b/packages/xo-server/src/api/backup-ng.js
@@ -3,6 +3,7 @@ import { fromCallback } from 'promise-toolbox'
 import { pipeline } from 'readable-stream'
 
 import createNdJsonStream from '../_createNdJsonStream'
+import { REMOVE_CACHE_ENTRY } from '../_pDebounceWithKey'
 import { safeDateFormat } from '../utils'
 
 export function createJob({ schedules, ...job }) {
@@ -184,20 +185,19 @@ getAllLogs.params = {
   ndjson: { type: 'boolean', optional: true },
 }
 
-export function getLogs({
+export async function getLogs({
   after,
   before,
   limit,
 
-  // it's a temporary work-around which will be removed
+  // TODO: it's a temporary work-around which should be removed
   // when the consolidated logs will be stored in the DB
-  _forceRefresh,
+  _forceRefresh = false,
+
   ...filter
 }) {
-  return this.getBackupNgLogsSorted(
-    { after, before, limit, filter },
-    _forceRefresh
-  )
+  await this.getBackupNgLogs(REMOVE_CACHE_ENTRY)
+  return this.getBackupNgLogsSorted({ after, before, limit, filter })
 }
 
 getLogs.permission = 'admin'

--- a/packages/xo-server/src/xo-mixins/backups-ng-logs.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng-logs.js
@@ -1,7 +1,7 @@
 import ms from 'ms'
 import { forEach, isEmpty, iteratee, sortedIndexBy } from 'lodash'
 
-import { debounceWithKey } from '../_pDebounceWithKey'
+import { debounceWithKey, REMOVE_CACHE_ENTRY } from '../_pDebounceWithKey'
 
 const isSkippedError = error =>
   error.message === 'no disks found' ||
@@ -241,5 +241,9 @@ export default {
     logs = logs.slice(i, j)
 
     return logs
+  },
+
+  clearBackupNgLogs(runId) {
+    return this.getBackupNgLogs(REMOVE_CACHE_ENTRY, runId)
   },
 }

--- a/packages/xo-server/src/xo-mixins/backups-ng-logs.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng-logs.js
@@ -1,7 +1,7 @@
 import ms from 'ms'
 import { forEach, isEmpty, iteratee, sortedIndexBy } from 'lodash'
 
-import { debounceWithKey, REMOVE_CACHE_ENTRY } from '../_pDebounceWithKey'
+import { debounceWithKey } from '../_pDebounceWithKey'
 
 const isSkippedError = error =>
   error.message === 'no disks found' ||
@@ -199,14 +199,7 @@ export default {
     }
   ),
 
-  async getBackupNgLogsSorted(
-    { after, before, filter, limit },
-    _forceRefresh = false
-  ) {
-    if (_forceRefresh) {
-      await this.getBackupNgLogs(REMOVE_CACHE_ENTRY)
-    }
-
+  async getBackupNgLogsSorted({ after, before, filter, limit }) {
     let logs = await this.getBackupNgLogs()
 
     // convert to array

--- a/packages/xo-server/src/xo-mixins/backups-ng-logs.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng-logs.js
@@ -199,7 +199,14 @@ export default {
     }
   ),
 
-  async getBackupNgLogsSorted({ after, before, filter, limit }) {
+  async getBackupNgLogsSorted(
+    { after, before, filter, limit },
+    _forceRefresh = false
+  ) {
+    if (_forceRefresh) {
+      await this.getBackupNgLogs(REMOVE_CACHE_ENTRY)
+    }
+
     let logs = await this.getBackupNgLogs()
 
     // convert to array
@@ -241,9 +248,5 @@ export default {
     logs = logs.slice(i, j)
 
     return logs
-  },
-
-  clearBackupNgLogs(runId) {
-    return this.getBackupNgLogs(REMOVE_CACHE_ENTRY, runId)
   },
 }


### PR DESCRIPTION
See a6d182e92d5f2699394a1af3af93592a9e022463

**The issue**

`xo-server-test` execute sequentially multiple backups and validate their execution using logs. The issue is that the logs are not up-to-date in the second fetch because the method returns the previous cached response.

**The solution**

Add `_forceRefresh` param to `backupNg.getLogs` to be able to clear the method cache. It's just a work-around which will be removed once the consolidated logs will be stored in the DB.

### Check list

> Check if done.
>
> Strikethrough if not relevant: ~~example~~ ([doc](https://help.github.com/en/articles/basic-writing-and-formatting-syntax)).

- [ ] ~~PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)~~
- [ ] ~~if UI changes, a screenshot has been added to the PR~~
- [ ] ~~documentation updated~~
- `CHANGELOG.unreleased.md`:
  - [ ] ~~enhancement/bug fix entry added~~
  - [ ] ~~list of packages to release updated (`${name} v${new version}`)~~
- **I have tested added/updated features** (and impacted code)
  - [ ] ~~unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))~~
  - [ ] ~~if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)~~
  - [ ] ~~at least manual testing~~

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
