### PR TITLE
fix(xo-web): getResourceCatalog calls

### DIFF
--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -346,7 +346,7 @@ export const subscribeRoles = createSubscription(
 export const subscribeIpPools = createSubscription(() => _call('ipPool.getAll'))
 
 export const subscribeResourceCatalog = createSubscription(() =>
-  _call('cloud.getResourceCatalog')
+  _call('cloud.getResourceCatalog', { filters: {} })
 )
 
 export const subscribeHubResourceCatalog = createSubscription(() =>

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -2875,7 +2875,7 @@ export const fixHostNotInXosanNetwork = (xosanSr, host) =>
 
 // XOSAN packs -----------------------------------------------------------------
 
-export const getResourceCatalog = ({ filters } = {}) =>
+export const getResourceCatalog = ({ filters }) =>
   _call('cloud.getResourceCatalog', { filters })
 
 export const getAllResourceCatalog = () => _call('cloud.getAllResourceCatalog')

--- a/packages/xo-web/src/xo-app/xosan/new-xosan.js
+++ b/packages/xo-web/src/xo-app/xosan/new-xosan.js
@@ -112,7 +112,7 @@ export default class NewXosan extends Component {
   }
 
   _checkPacks = pool =>
-    getResourceCatalog().then(
+    getResourceCatalog({ filters: {} }).then(
       catalog => {
         if (catalog === undefined || catalog.xosan === undefined) {
           this.setState({


### PR DESCRIPTION

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [x] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [x] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [x] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
