### PR TITLE
fix(xo-web): update checks for Cloud plugin

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [XOSAN] Fix "Install Cloud plugin" warning (PR [#4631](https://github.com/vatesfr/xen-orchestra/pull/4631))
 
 ### Released packages
 

--- a/packages/xo-web/src/common/intl/locales/fr.js
+++ b/packages/xo-web/src/common/intl/locales/fr.js
@@ -3896,10 +3896,10 @@ export default {
   xosanCommunity: 'XOSAN non disponible pour la Community Edition',
 
   // Original text: "Install cloud plugin first"
-  xosanInstallCloudPlugin: 'Installer le plugin cloud avant',
+  xosanInstallCloudPlugin: 'Installer le plugin XOA avant',
 
   // Original text: "Load cloud plugin first"
-  xosanLoadCloudPlugin: 'Charger le plugin cloud avant',
+  xosanLoadCloudPlugin: 'Charger le plugin XOA avant',
 
   // Original text: "Loading…"
   xosanLoading: 'Chargement…',

--- a/packages/xo-web/src/common/intl/locales/tr.js
+++ b/packages/xo-web/src/common/intl/locales/tr.js
@@ -4864,10 +4864,10 @@ export default {
   xosanState_scanningSr: 'SR taranıyor...',
 
   // Original text: "Install cloud plugin first"
-  xosanInstallCloudPlugin: 'Önce bulut eklentisini kurun',
+  xosanInstallCloudPlugin: 'Önce XOA eklentisini kurun',
 
   // Original text: "Load cloud plugin first"
-  xosanLoadCloudPlugin: 'Önce bulut eklentisini yükleyin',
+  xosanLoadCloudPlugin: 'Önce XOA eklentisini yükleyin',
 
   // Original text: "Register your appliance first"
   xosanRegister: "Önce XOSAN'ın kaydını yapın",

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2110,8 +2110,8 @@ const messages = {
   xosanState_creatingSr: 'Creating SR…',
   xosanState_scanningSr: 'Scanning SR…',
   // Pack download modal
-  xosanInstallCloudPlugin: 'Install cloud plugin first',
-  xosanLoadCloudPlugin: 'Load cloud plugin first',
+  xosanInstallCloudPlugin: 'Install XOA plugin first',
+  xosanLoadCloudPlugin: 'Load XOA plugin first',
   xosanNoPackFound:
     'No compatible XOSAN pack found for your XenServer versions.',
   // SR tab XOSAN

--- a/packages/xo-web/src/xo-app/xosan/index.js
+++ b/packages/xo-web/src/xo-app/xosan/index.js
@@ -376,12 +376,12 @@ export default class Xosan extends Component {
   _getError = createSelector(
     () => this.props.plugins,
     plugins => {
-      const cloudPlugin = find(plugins, { id: 'cloud' })
-      if (!cloudPlugin) {
+      const xoaPlugin = find(plugins, { id: 'xoa' })
+      if (!xoaPlugin) {
         return _('xosanInstallCloudPlugin')
       }
 
-      if (!cloudPlugin.loaded) {
+      if (!xoaPlugin.loaded) {
         return _('xosanLoadCloudPlugin')
       }
     }


### PR DESCRIPTION
See #4615
Introduced by fd063743658b04aeeaddc46fa7fc05ce47a24b45

- Every time we checked if the Cloud plugin was installed, we now need to check
  if the XOA plugin is installed
- Update the warning messages mentioning the Cloud plugin

### Check list

> Check if done.
>
> Strikethrough if not relevant: ~~example~~ ([doc](https://help.github.com/en/articles/basic-writing-and-formatting-syntax)).

- [ ] ~~PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)~~
- [ ] ~~if UI changes, a screenshot has been added to the PR~~
- [ ] ~~documentation updated~~
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] ~~list of packages to release updated (`${name} v${new version}`)~~
- **I have tested added/updated features** (and impacted code)
  - [ ] ~~unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))~~
  - [ ] ~~if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)~~
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
