### PR TITLE
fix(xo-web): don't show a spinner on empty selectors

### DIFF
--- a/packages/xo-web/src/common/form/select.js
+++ b/packages/xo-web/src/common/form/select.js
@@ -23,7 +23,6 @@ export default class Select extends React.PureComponent {
     maxHeight: 200,
 
     multi: ReactSelect.defaultProps.multi,
-    options: [],
     required: ReactSelect.defaultProps.required,
     simpleValue: ReactSelect.defaultProps.simpleValue,
     valueKey: ReactSelect.defaultProps.valueKey,
@@ -32,7 +31,7 @@ export default class Select extends React.PureComponent {
   static propTypes = {
     autoSelectSingleOption: PropTypes.bool, // default to props.required
     maxHeight: PropTypes.number,
-    options: PropTypes.array.isRequired, // cannot be an object
+    options: PropTypes.array, // cannot be an object
   }
 
   _cellMeasurerCache = new CellMeasurerCache({

--- a/packages/xo-web/src/common/form/select.js
+++ b/packages/xo-web/src/common/form/select.js
@@ -1,5 +1,4 @@
 import classNames from 'classnames'
-import isEmpty from 'lodash/isEmpty'
 import PropTypes from 'prop-types'
 import React from 'react'
 import ReactSelect from 'react-select'
@@ -165,7 +164,7 @@ export default class Select extends React.PureComponent {
         backspaceToRemoveMessage=''
         clearable={multi || !props.required}
         closeOnSelect={!multi}
-        isLoading={!props.disabled && isEmpty(props.options)}
+        isLoading={!props.disabled && props.options == null}
         style={SELECT_STYLE}
         valueRenderer={props.optionRenderer}
         {...props}


### PR DESCRIPTION
fixes #4525

### Screenshots

![Capture d’écran de 2019-10-31 15-29-00](https://user-images.githubusercontent.com/7724491/67955832-78927680-fbf3-11e9-9796-3bf370ac7b4e.png)
![Capture d’écran de 2019-10-31 15-28-18](https://user-images.githubusercontent.com/7724491/67955833-78927680-fbf3-11e9-954e-2fdcd54bba0d.png)

### Check list

> Check if done.
>
> Strikethrough if not relevant: ~~example~~ ([doc](https://help.github.com/en/articles/basic-writing-and-formatting-syntax)).

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ]  ~~documentation updated~~
-  ~~`CHANGELOG.unreleased.md`:~~
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] ~unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))~
  - [ ] ~if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)~
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
