### PR TITLE
feat(xo-web/sorted-table): make url state dynamic

### DIFF
--- a/packages/xo-web/src/common/sorted-table/index.js
+++ b/packages/xo-web/src/common/sorted-table/index.js
@@ -542,7 +542,7 @@ export default class SortedTable extends Component {
   }
 
   _checkUpdatePage() {
-    const { page } = this.state
+    const page = this.getPage()
     if (page === 1) {
       return
     }

--- a/packages/xo-web/src/common/sorted-table/index.js
+++ b/packages/xo-web/src/common/sorted-table/index.js
@@ -532,10 +532,12 @@ export default class SortedTable extends Component {
   }
 
   _setFilter = filter => {
+    this.setState({
+      highlighted: undefined,
+    })
     this._updateQueryString({
       filter,
       page: 1,
-      highlighted: undefined,
     })
   }
 

--- a/packages/xo-web/src/common/sorted-table/index.js
+++ b/packages/xo-web/src/common/sorted-table/index.js
@@ -479,17 +479,15 @@ export default class SortedTable extends Component {
   }
 
   _sort = columnId => {
-    const { state } = this
     let sortOrder
-
-    if (state.selectedColumn === columnId) {
-      sortOrder = state.sortOrder === 'desc' ? 'asc' : 'desc'
+    if (this.getSelectedColumnId() === columnId) {
+      sortOrder = this.getSortOrder() === 'desc' ? 'asc' : 'desc'
     } else {
       sortOrder =
         this.props.columns[columnId].sortOrder === 'desc' ? 'desc' : 'asc'
     }
 
-    this._setVisibleState({
+    this._updateQueryString({
       selectedColumn: columnId,
       sortOrder,
     })
@@ -514,8 +512,12 @@ export default class SortedTable extends Component {
     this._checkUpdatePage()
   }
 
-  _saveUrlState = () => {
-    const { filter, page, selectedColumn, sortOrder } = this.state
+  _updateQueryString({
+    filter = this.getFilter(),
+    page = this.getPage(),
+    selectedColumn = this.getSelectedColumnId(),
+    sortOrder = this.getSortOrder(),
+  }) {
     const { router } = this.context
     const { location } = router
     router.replace({
@@ -529,13 +531,8 @@ export default class SortedTable extends Component {
     })
   }
 
-  // update state in the state and update the URL param
-  _setVisibleState(state) {
-    this.setState(state, this.props.stateUrlParam && this._saveUrlState)
-  }
-
   _setFilter = filter => {
-    this._setVisibleState({
+    this._updateQueryString({
       filter,
       page: 1,
       highlighted: undefined,
@@ -561,7 +558,7 @@ export default class SortedTable extends Component {
   }
 
   _setPage(page) {
-    this._setVisibleState({ page })
+    this._updateQueryString({ page })
   }
   _setPage = this._setPage.bind(this)
 

--- a/packages/xo-web/src/common/sorted-table/index.js
+++ b/packages/xo-web/src/common/sorted-table/index.js
@@ -1,7 +1,7 @@
 import * as CM from 'complex-matcher'
 import _ from 'intl'
 import classNames from 'classnames'
-import defined, { get } from '@xen-orchestra/defined'
+import defined from '@xen-orchestra/defined'
 import DropdownMenu from 'react-bootstrap-4/lib/DropdownMenu' // https://phabricator.babeljs.io/T6662 so Dropdown.Menu won't work like https://react-bootstrap.github.io/components.html#btn-dropdowns-custom
 import DropdownToggle from 'react-bootstrap-4/lib/DropdownToggle' // https://phabricator.babeljs.io/T6662 so Dropdown.Toggle won't work https://react-bootstrap.github.io/components.html#btn-dropdowns-custom
 import PropTypes from 'prop-types'
@@ -334,20 +334,7 @@ export default class SortedTable extends Component {
 
     const state = (this.state = {
       all: false, // whether all items are selected (accross pages)
-      sortOrder: props.columns[0].sortOrder === 'desc' ? 'desc' : 'asc',
     })
-
-    const urlState = get(
-      () => context.router.location.query[props.stateUrlParam]
-    )
-
-    let matches
-    if (
-      urlState !== undefined &&
-      (matches = URL_STATE_RE.exec(urlState)) !== null
-    ) {
-      state.sortOrder = matches[3] !== undefined ? 'desc' : 'asc'
-    }
 
     this._getSelectedColumn = () =>
       this.props.columns[this.getSelectedColumnId()]
@@ -385,7 +372,7 @@ export default class SortedTable extends Component {
             ? object => sortCriteria(object, userData)
             : sortCriteria
       ),
-      () => this.state.sortOrder
+      this.getSortOrder
     )
 
     this._getVisibleItems = createPager(
@@ -721,6 +708,14 @@ export default class SortedTable extends Component {
             defaultColumnIndex,
             (index = findIndex(columns, 'default')) !== -1 ? index : 0
           )
+  )
+
+  getSortOrder = createSelector(
+    () => this._getParsedQueryString().sortOrder,
+    this.getSelectedColumnId,
+    () => this.props.columns,
+    (sortOrder, selectedColumnIndex, columns) =>
+      defined(sortOrder, columns[selectedColumnIndex].sortOrder, 'asc')
   )
 
   _getGroupedActions = createSelector(

--- a/packages/xo-web/src/common/sorted-table/index.js
+++ b/packages/xo-web/src/common/sorted-table/index.js
@@ -343,7 +343,6 @@ export default class SortedTable extends Component {
 
     const state = (this.state = {
       all: false, // whether all items are selected (accross pages)
-      filter: defined(() => props.filters[props.defaultFilter], ''),
       page: 1,
       selectedColumn,
       sortOrder:
@@ -359,7 +358,6 @@ export default class SortedTable extends Component {
       urlState !== undefined &&
       (matches = URL_STATE_RE.exec(urlState)) !== null
     ) {
-      state.filter = matches[4]
       const page = matches[1]
       if (page !== undefined) {
         state.page = +page
@@ -393,7 +391,7 @@ export default class SortedTable extends Component {
       createFilter(
         getAllItems,
         createSelector(
-          () => this.state.filter,
+          this.getFilter,
           filter => {
             try {
               return CM.parse(filter).createPredicate()
@@ -703,6 +701,32 @@ export default class SortedTable extends Component {
     const { target } = event
     this._selectItem(+target.name, target.checked, event.nativeEvent.shiftKey)
   }
+
+  _getParsedQueryString = createSelector(
+    () => this.context.router.location.query[this.props.stateUrlParam],
+    urlState => {
+      let matches
+      const [page, selectedColumnIndex, sortOrder, filter] =
+        urlState !== undefined &&
+        (matches = URL_STATE_RE.exec(urlState)) !== null
+          ? matches
+          : []
+      return {
+        filter,
+        page,
+        selectedColumnIndex,
+        sortOrder,
+      }
+    }
+  )
+
+  getFilter = createSelector(
+    () => this._getParsedQueryString().filter,
+    () => this.props.filters,
+    () => this.props.defaultFilter,
+    (filter, filters, defaultFilter) =>
+      defined(filter, () => filters[defaultFilter], '')
+  )
 
   _getGroupedActions = createSelector(
     () => this.props.groupedActions,

--- a/packages/xo-web/src/common/sorted-table/index.js
+++ b/packages/xo-web/src/common/sorted-table/index.js
@@ -634,8 +634,12 @@ class SortedTable extends Component {
   _getParsedQueryString = createSelector(
     () => this.props.router.location.query[this.props.stateUrlParam],
     urlState => {
+      let matches
       const [, page, selectedColumnId, sortOrder, filter] =
-        URL_STATE_RE.exec(urlState) || []
+        urlState !== undefined &&
+        (matches = URL_STATE_RE.exec(urlState)) !== null
+          ? matches
+          : []
       return {
         filter,
         page,

--- a/packages/xo-web/src/common/sorted-table/index.js
+++ b/packages/xo-web/src/common/sorted-table/index.js
@@ -343,7 +343,6 @@ export default class SortedTable extends Component {
 
     const state = (this.state = {
       all: false, // whether all items are selected (accross pages)
-      page: 1,
       selectedColumn,
       sortOrder:
         props.columns[selectedColumn].sortOrder === 'desc' ? 'desc' : 'asc',
@@ -358,10 +357,6 @@ export default class SortedTable extends Component {
       urlState !== undefined &&
       (matches = URL_STATE_RE.exec(urlState)) !== null
     ) {
-      const page = matches[1]
-      if (page !== undefined) {
-        state.page = +page
-      }
       let selectedColumn = matches[2]
       if (
         selectedColumn !== undefined &&
@@ -413,7 +408,7 @@ export default class SortedTable extends Component {
 
     this._getVisibleItems = createPager(
       this._getItems,
-      () => this.state.page,
+      this.getPage,
       () => this.props.itemsPerPage
     )
 
@@ -726,6 +721,11 @@ export default class SortedTable extends Component {
     () => this.props.defaultFilter,
     (filter, filters, defaultFilter) =>
       defined(filter, () => filters[defaultFilter], '')
+  )
+
+  getPage = createSelector(
+    () => this._getParsedQueryString().page,
+    page => (page !== undefined ? +page : 1)
   )
 
   _getGroupedActions = createSelector(

--- a/packages/xo-web/src/common/sorted-table/index.js
+++ b/packages/xo-web/src/common/sorted-table/index.js
@@ -634,12 +634,8 @@ class SortedTable extends Component {
   _getParsedQueryString = createSelector(
     () => this.props.router.location.query[this.props.stateUrlParam],
     urlState => {
-      let matches
       const [, page, selectedColumnId, sortOrder, filter] =
-        urlState !== undefined &&
-        (matches = URL_STATE_RE.exec(urlState)) !== null
-          ? matches
-          : []
+        URL_STATE_RE.exec(urlState) || []
       return {
         filter,
         page,
@@ -673,12 +669,12 @@ class SortedTable extends Component {
     () => this._getParsedQueryString().selectedColumnId,
     () => this.props.columns,
     () => this.props.defaultColumn,
-    (index, columns, defaultColumnIndex) =>
-      index !== undefined && (index = +index) < columns.length
-        ? index
+    (columnId, columns, defaultColumnId) =>
+      columnId !== undefined && (columnId = +columnId) < columns.length
+        ? columnId
         : defined(
-            defaultColumnIndex,
-            (index = findIndex(columns, 'default')) !== -1 ? index : 0
+            defaultColumnId,
+            (columnId = findIndex(columns, 'default')) !== -1 ? columnId : 0
           )
   )
 

--- a/packages/xo-web/src/common/sorted-table/index.js
+++ b/packages/xo-web/src/common/sorted-table/index.js
@@ -633,13 +633,9 @@ class SortedTable extends Component {
 
   _getParsedQueryString = createSelector(
     () => this.props.router.location.query[this.props.stateUrlParam],
-    urlState => {
-      let matches
+    (urlState = '') => {
       const [, page, selectedColumnId, sortOrder, filter] =
-        urlState !== undefined &&
-        (matches = URL_STATE_RE.exec(urlState)) !== null
-          ? matches
-          : []
+        URL_STATE_RE.exec(urlState) || []
       return {
         filter,
         page,
@@ -673,12 +669,14 @@ class SortedTable extends Component {
     () => this._getParsedQueryString().selectedColumnId,
     () => this.props.columns,
     () => this.props.defaultColumn,
-    (columnId, columns, defaultColumnId) =>
-      columnId !== undefined && (columnId = +columnId) < columns.length
-        ? columnId
+    (columnIndex, columns, defaultColumnIndex) =>
+      columnIndex !== undefined && (columnIndex = +columnIndex) < columns.length
+        ? columnIndex
         : defined(
-            defaultColumnId,
-            (columnId = findIndex(columns, 'default')) !== -1 ? columnId : 0
+            defaultColumnIndex,
+            (columnIndex = findIndex(columns, 'default')) !== -1
+              ? columnIndex
+              : 0
           )
   )
 

--- a/packages/xo-web/src/common/sorted-table/index.js
+++ b/packages/xo-web/src/common/sorted-table/index.js
@@ -509,9 +509,8 @@ class SortedTable extends Component {
       ...location,
       query: {
         ...location.query,
-        [this.props.stateUrlParam]: `${page}_${selectedColumn}${
-          sortOrder === 'desc' ? '_desc' : '_asc'
-        }-${filter}`,
+        [this.props
+          .stateUrlParam]: `${page}_${selectedColumn}_${sortOrder}-${filter}`,
       },
     })
   }


### PR DESCRIPTION
See #4564

This PR can be merged after resolving this issue #4542.

This PR update the `SortedTable` implementation to :
  - let it totally controlled by only using the values provided by the URL in case of getting/updating filter, page, sort order and selected column
  - make url state dynamic

### Check list

> Check if done.
>
> Strikethrough if not relevant: ~~example~~ ([doc](https://help.github.com/en/articles/basic-writing-and-formatting-syntax)).

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] ~if UI changes, a screenshot has been added to the PR~
- [ ] ~documentation updated~
- ~`CHANGELOG.unreleased.md`~:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] ~unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))~
  - [ ] ~if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)~
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
