### PR TITLE
fix(xo-server/plugins): try empty config if none provided

### DIFF
--- a/packages/xo-server/src/xo-mixins/plugins.js
+++ b/packages/xo-server/src/xo-mixins/plugins.js
@@ -60,9 +60,7 @@ export default class {
     const plugin = (this._plugins[id] = {
       configurationPresets,
       configurationSchema,
-      configured:
-        configurationSchema === undefined ||
-        configurationSchema.required === undefined,
+      configured: !configurationSchema,
       description,
       id,
       instance,
@@ -87,7 +85,11 @@ export default class {
     }
 
     if (configurationSchema !== undefined) {
-      if (configuration === undefined) {
+      if (
+        configuration === undefined &&
+        (typeof configurationSchema !== 'object' ||
+          configurationSchema.required !== undefined)
+      ) {
         return
       }
 
@@ -137,7 +139,7 @@ export default class {
   }
 
   // Validate the configuration and configure the plugin instance.
-  async _configurePlugin(plugin, configuration) {
+  async _configurePlugin(plugin, configuration = {}) {
     const { configurationSchema } = plugin
 
     if (!configurationSchema) {

--- a/packages/xo-server/src/xo-mixins/plugins.js
+++ b/packages/xo-server/src/xo-mixins/plugins.js
@@ -60,7 +60,9 @@ export default class {
     const plugin = (this._plugins[id] = {
       configurationPresets,
       configurationSchema,
-      configured: !configurationSchema,
+      configured:
+        configurationSchema === undefined ||
+        configurationSchema.required === undefined,
       description,
       id,
       instance,


### PR DESCRIPTION
See #4581

Plugins with optional configuration should not require explicit configuration.

### Check list

> Check if done.
>
> Strikethrough if not relevant: ~~example~~ ([doc](https://help.github.com/en/articles/basic-writing-and-formatting-syntax)).

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] ~if UI changes, a screenshot has been added to the PR~
- [ ] ~documentation updated~
- ~`CHANGELOG.unreleased.md`~:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] ~unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))~
  - [ ] ~if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)~
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
