### PR TITLE
fix(xen-api): Node warning promise rejected with non-error

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 - [SDN controller] Prevent private network creation on bond slave PIF (Fixes https://github.com/xcp-ng/xcp/issues/300) (PR [4633](https://github.com/vatesfr/xen-orchestra/pull/4633))
 
 - [Metadata backup] Fix failed backup reported as successful [#4596](https://github.com/vatesfr/xen-orchestra/issues/4596) (PR [#4598](https://github.com/vatesfr/xen-orchestra/pull/4598))
+- Fix `promise rejected with non-error` warnings in logs (PR [#4659](https://github.com/vatesfr/xen-orchestra/pull/4659))
 
 ### Released packages
 
@@ -24,6 +25,7 @@
 >
 > Rule of thumb: add packages on top.
 
+- xen-api v0.27.3
 - xo-server-backup-reports v0.16.3
 - vhd-lib v0.7.1
 - xo-server v5.52.0

--- a/packages/xen-api/src/index.js
+++ b/packages/xen-api/src/index.js
@@ -25,7 +25,6 @@ import isReadOnlyCall from './_isReadOnlyCall'
 import makeCallSetting from './_makeCallSetting'
 import parseUrl from './_parseUrl'
 import replaceSensitiveValues from './_replaceSensitiveValues'
-import XapiError from './_XapiError'
 
 // ===================================================================
 
@@ -626,9 +625,7 @@ export class Xapi extends EventEmitter {
         kindOf(result)
       )
       return result
-    } catch (e) {
-      const error = e instanceof Error ? e : XapiError.wrap(e)
-
+    } catch (error) {
       // do not log the session ID
       //
       // TODO: should log at the session level to avoid logging sensitive

--- a/packages/xen-api/src/transports/json-rpc.js
+++ b/packages/xen-api/src/transports/json-rpc.js
@@ -1,6 +1,8 @@
 import httpRequestPlus from 'http-request-plus'
 import { format, parse } from 'json-rpc-protocol'
 
+import XapiError from '../_XapiError'
+
 import UnsupportedTransport from './_UnsupportedTransport'
 
 // https://github.com/xenserver/xenadmin/blob/0df39a9d83cd82713f32d24704852a0fd57b8a64/XenModel/XenAPI/Session.cs#L403-L433
@@ -30,7 +32,7 @@ export default ({ allowUnauthorized, url }) => {
             return response.result
           }
 
-          throw response.error
+          throw XapiError.wrap(response.error)
         },
         error => {
           if (error.response !== undefined) {

--- a/packages/xen-api/src/transports/xml-rpc-json.js
+++ b/packages/xen-api/src/transports/xml-rpc-json.js
@@ -1,6 +1,8 @@
 import { createClient, createSecureClient } from 'xmlrpc'
 import { promisify } from 'promise-toolbox'
 
+import XapiError from '../_XapiError'
+
 import prepareXmlRpcParams from './_prepareXmlRpcParams'
 import UnsupportedTransport from './_UnsupportedTransport'
 
@@ -33,7 +35,7 @@ const parseResult = result => {
   }
 
   if (status !== 'Success') {
-    throw result.ErrorDescription
+    throw XapiError.wrap(result.ErrorDescription)
   }
 
   const value = result.Value

--- a/packages/xen-api/src/transports/xml-rpc.js
+++ b/packages/xen-api/src/transports/xml-rpc.js
@@ -1,6 +1,8 @@
 import { createClient, createSecureClient } from 'xmlrpc'
 import { promisify } from 'promise-toolbox'
 
+import XapiError from '../_XapiError'
+
 import prepareXmlRpcParams from './_prepareXmlRpcParams'
 
 const logError = error => {
@@ -26,7 +28,7 @@ const parseResult = result => {
   }
 
   if (status !== 'Success') {
-    throw result.ErrorDescription
+    throw XapiError.wrap(result.ErrorDescription)
   }
 
   return result.Value


### PR DESCRIPTION
Not a real problems but triggered a lot of warnings which could be very verbose in application logs.

### Check list

> Check if done.
>
> Strikethrough if not relevant: ~~example~~ ([doc](https://help.github.com/en/articles/basic-writing-and-formatting-syntax)).

- [ ] ~~PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)~~
- [ ] ~~if UI changes, a screenshot has been added to the PR~~
- [ ] ~~documentation updated~~
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] ~~unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))~~
  - [ ] ~~if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)~~
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
