### PR TITLE
fix(fs/Local#getInfo): remove `NaN` values

### DIFF
--- a/@xen-orchestra/fs/src/local.js
+++ b/@xen-orchestra/fs/src/local.js
@@ -48,6 +48,10 @@ export default class LocalHandler extends RemoteHandlerAbstract {
   }
 
   async _getInfo() {
+    // df.file() resolves with an object with the following properties:
+    // filesystem, type, size, used, available, capacity and mountpoint.
+    // size, used, available and capacity may be `NaN` so we remove any `NaN`
+    // value from the object.
     const info = await df.file(this._getFilePath('/'))
     Object.keys(info).forEach(key => {
       if (Number.isNaN(info[key])) {

--- a/@xen-orchestra/fs/src/local.js
+++ b/@xen-orchestra/fs/src/local.js
@@ -48,6 +48,9 @@ export default class LocalHandler extends RemoteHandlerAbstract {
   }
 
   _getInfo() {
+    // Resolves with an object with the following properties:
+    // filesystem, type, size, used, available, capacity and mountpoint.
+    // size, used, available and capacity may be `NaN`
     return df.file(this._getFilePath('/'))
   }
 

--- a/@xen-orchestra/fs/src/local.js
+++ b/@xen-orchestra/fs/src/local.js
@@ -47,11 +47,15 @@ export default class LocalHandler extends RemoteHandlerAbstract {
     })
   }
 
-  _getInfo() {
-    // Resolves with an object with the following properties:
-    // filesystem, type, size, used, available, capacity and mountpoint.
-    // size, used, available and capacity may be `NaN`
-    return df.file(this._getFilePath('/'))
+  async _getInfo() {
+    const info = await df.file(this._getFilePath('/'))
+    Object.keys(info).forEach(key => {
+      if (Number.isNaN(info[key])) {
+        delete info[key]
+      }
+    })
+
+    return info
   }
 
   async _getSize(file) {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,5 +18,6 @@
 >
 > Rule of thumb: add packages on top.
 
+- @xen-orchestra/fs v0.10.2
 - xo-server v5.53.0
 - xo-web v5.53.0

--- a/packages/xo-web/src/xo-app/settings/remotes/index.js
+++ b/packages/xo-web/src/xo-app/settings/remotes/index.js
@@ -86,8 +86,8 @@ const COLUMN_STATE = {
 const COLUMN_DISK = {
   itemRenderer: remote =>
     remote.info !== undefined &&
-    remote.info.used != null &&
-    remote.info.size != null && (
+    remote.info.used !== undefined &&
+    remote.info.size !== undefined && (
       <span>
         {`${formatSize(remote.info.used)} / ${formatSize(remote.info.size)}`}
       </span>

--- a/packages/xo-web/src/xo-app/settings/remotes/index.js
+++ b/packages/xo-web/src/xo-app/settings/remotes/index.js
@@ -86,8 +86,8 @@ const COLUMN_STATE = {
 const COLUMN_DISK = {
   itemRenderer: remote =>
     remote.info !== undefined &&
-    remote.info.used !== undefined &&
-    remote.info.size !== undefined && (
+    remote.info.used != null &&
+    remote.info.size != null && (
       <span>
         {`${formatSize(remote.info.used)} / ${formatSize(remote.info.size)}`}
       </span>


### PR DESCRIPTION
Introduced by e34a0a6e33b87466fb43bcad7a0ba70c9d96ebc8

`NaN`s were turned into `null`s when sent to the client which was making
`human-format` throw a `value must be a number` error.

### Check list

> Check if done.
>
> Strikethrough if not relevant: ~~example~~ ([doc](https://help.github.com/en/articles/basic-writing-and-formatting-syntax)).

- [ ] ~~PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)~~
- [ ] ~~if UI changes, a screenshot has been added to the PR~~
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] ~~enhancement/bug fix entry added~~
  - [ ] ~~list of packages to release updated (`${name} v${new version}`)~~
- **I have tested added/updated features** (and impacted code)
  - [ ] ~~unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))~~
  - [ ] ~~if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)~~
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
