### PR TITLE
feat(xo-server/metadata-backups): clear backup listing cache on change

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Metadata backup] Add 10 minutes timeout to avoid stuck jobs [#4657](https://github.com/vatesfr/xen-orchestra/issues/4657) (PR [#4666](https://github.com/vatesfr/xen-orchestra/pull/4666))
+- [Metadata backups] Fix backup list takes 1 min to be updated after a backup or a deletion of a backup (PR [#4672](https://github.com/vatesfr/xen-orchestra/pull/4672))
 
 ### Released packages
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Metadata backup] Add 10 minutes timeout to avoid stuck jobs [#4657](https://github.com/vatesfr/xen-orchestra/issues/4657) (PR [#4666](https://github.com/vatesfr/xen-orchestra/pull/4666))
-- [Metadata backups] Fix backup list takes 1 min to be updated after a backup or a deletion of a backup (PR [#4672](https://github.com/vatesfr/xen-orchestra/pull/4672))
+- [Metadata backups] Fix out-of-date listing for 1 minute due to cache (PR [#4672](https://github.com/vatesfr/xen-orchestra/pull/4672))
 
 ### Released packages
 

--- a/packages/xo-server/src/xo-mixins/metadata-backups.js
+++ b/packages/xo-server/src/xo-mixins/metadata-backups.js
@@ -3,7 +3,7 @@ import asyncMap from '@xen-orchestra/async-map'
 import createLogger from '@xen-orchestra/log'
 import { fromEvent, ignoreErrors, timeout } from 'promise-toolbox'
 
-import { debounceWithKey } from '../_pDebounceWithKey'
+import { debounceWithKey, REMOVE_CACHE_ENTRY } from '../_pDebounceWithKey'
 import { waitAll } from '../_waitAll'
 import parseDuration from '../_parseDuration'
 import { type Xapi } from '../xapi'
@@ -251,6 +251,8 @@ export default class metadataBackup {
               taskId: subTaskId,
             }
           )
+
+          this._listXoMetadataBackups(REMOVE_CACHE_ENTRY, remoteId)
         } catch (error) {
           await handler.rmtree(dir).catch(error => {
             logger.warning(`unable to delete the folder ${dir}`, {
@@ -396,6 +398,8 @@ export default class metadataBackup {
               taskId: subTaskId,
             }
           )
+
+          this._listPoolMetadataBackups(REMOVE_CACHE_ENTRY, remoteId)
         } catch (error) {
           if (outputStream !== undefined) {
             outputStream.destroy()
@@ -812,6 +816,12 @@ export default class metadataBackup {
     const [remoteId, ...path] = id.split('/')
 
     const handler = await app.getRemoteHandler(remoteId)
-    return handler.rmtree(path.join('/'))
+    await handler.rmtree(path.join('/'))
+
+    if (path[0] === 'xo-config-backups') {
+      this._listXoMetadataBackups(REMOVE_CACHE_ENTRY, remoteId)
+    } else {
+      this._listPoolMetadataBackups(REMOVE_CACHE_ENTRY, remoteId)
+    }
   }
 }


### PR DESCRIPTION
See 471f3974184085513cddff6bd0b4d628139c1540

### Check list

> Check if done.
>
> Strikethrough if not relevant: ~~example~~ ([doc](https://help.github.com/en/articles/basic-writing-and-formatting-syntax)).

- [ ] ~PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)~
- [ ] ~if UI changes, a screenshot has been added to the PR~
- [ ] ~documentation updated~
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] ~list of packages to release updated (`${name} v${new version}`)~
- **I have tested added/updated features** (and impacted code)
  - [ ] ~unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))~
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
