### PR TITLE
feat(xo-server/backups-ng): limit number of gc-ed deltas

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 
 - [Metadata backup] Add 10 minutes timeout to avoid stuck jobs [#4657](https://github.com/vatesfr/xen-orchestra/issues/4657) (PR [#4666](https://github.com/vatesfr/xen-orchestra/pull/4666))
 - [Metadata backups] Fix out-of-date listing for 1 minute due to cache (PR [#4672](https://github.com/vatesfr/xen-orchestra/pull/4672))
+- [Delta backup] Limit the number of merged deltas per run to avoid interrupted jobs (PR [#4674](https://github.com/vatesfr/xen-orchestra/pull/4674))
 
 ### Released packages
 

--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -67,6 +67,11 @@ poolMetadataTimeout = '10 minutes'
 #[http.helmet.hsts]
 #includeSubDomains = false
 
+# This is a work-around.
+#
+# See https://github.com/vatesfr/xen-orchestra/pull/4674
+maxMergedDeltasPerRun = 2
+
 [[http.listen]]
 port = 80
 

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -1594,6 +1594,17 @@ export default class BackupNg {
                   _ => _.mode === 'delta' && _.scheduleId === scheduleId
                 )
               ): any)
+
+              // FIXME: implement optimized multiple VHDs merging with synthetic
+              // delta
+              //
+              // For the time being, limit the number of deleted backups to 2
+              // because it can take a very long time and can lead to
+              // interrupted backup with broken VHD chain.
+              if (oldBackups.length > 2) {
+                oldBackups.length = 2
+              }
+
               const deleteOldBackups = () =>
                 wrapTask(
                   {

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -1598,14 +1598,15 @@ export default class BackupNg {
               // FIXME: implement optimized multiple VHDs merging with synthetic
               // delta
               //
-              // For the time being, limit the number of deleted backups to 2 by
-              // run because it can take a very long time and can lead to
+              // For the time being, limit the number of deleted backups by run
+              // because it can take a very long time and can lead to
               // interrupted backup with broken VHD chain.
               //
               // The old backups will be eventually merged in future runs of the
               // job.
-              if (oldBackups.length > 2) {
-                oldBackups.length = 2
+              const { maxMergedDeltasPerRun } = this._backupOptions
+              if (oldBackups.length > maxMergedDeltasPerRun) {
+                oldBackups.length = maxMergedDeltasPerRun
               }
 
               const deleteOldBackups = () =>

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -1598,9 +1598,12 @@ export default class BackupNg {
               // FIXME: implement optimized multiple VHDs merging with synthetic
               // delta
               //
-              // For the time being, limit the number of deleted backups to 2
-              // because it can take a very long time and can lead to
+              // For the time being, limit the number of deleted backups to 2 by
+              // run because it can take a very long time and can lead to
               // interrupted backup with broken VHD chain.
+              //
+              // The old backups will be eventually merged in future runs of the
+              // job.
               if (oldBackups.length > 2) {
                 oldBackups.length = 2
               }


### PR DESCRIPTION
Merging multiple VHDs is currently a slow process which could be optimized by doing a single merge of a synthetic delta.

Until this is implement, the number of garbage collected deltas should be limited to avoid taking too much time (and possibly interrupted jobs) in case of an important retention change.

### Check list

> Check if done.
>
> Strikethrough if not relevant: ~~example~~ ([doc](https://help.github.com/en/articles/basic-writing-and-formatting-syntax)).

- [ ] ~~PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)~~
- [ ] ~~if UI changes, a screenshot has been added to the PR~~
- [ ] ~~documentation updated~~
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] ~~list of packages to release updated (`${name} v${new version}`)~~
- **I have tested added/updated features** (and impacted code)
  - [ ] ~~unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))~~
  - [ ] ~~if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)~~
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
