### PR TITLE
fix(xo-web/Number): fix inability to set advanced expressions

### DIFF
--- a/packages/xo-web/src/common/form/number.js
+++ b/packages/xo-web/src/common/form/number.js
@@ -37,17 +37,14 @@ const Number_ = decorate([
       },
     },
     computed: {
-      value: ({ displayedValue }, { value }) => {
-        if (
-          displayedValue !== '' &&
-          (Number.isNaN((displayedValue = +displayedValue)) ||
-            displayedValue === value)
-        ) {
-          return displayedValue
-        }
-
-        return value === undefined ? '' : String(value)
-      },
+      value: ({ displayedValue }, { value }) =>
+        displayedValue !== '' &&
+        (Number.isNaN((displayedValue = +displayedValue)) ||
+          displayedValue === value)
+          ? displayedValue
+          : value === undefined
+          ? ''
+          : String(value),
     },
   }),
   injectState,

--- a/packages/xo-web/src/common/form/number.js
+++ b/packages/xo-web/src/common/form/number.js
@@ -7,9 +7,14 @@ import decorate from '../apply-decorators'
 // it provide `data-*` to add params to the `onChange`
 const Number_ = decorate([
   provideState({
+    initialState: () => ({
+      displayedValue: '',
+    }),
     effects: {
-      onChange: (_, { target: { value } }) => (state, props) => {
-        value = value.trim()
+      onChange(_, { target: { value } }) {
+        const { state, props } = this
+        state.displayedValue = value = value.trim()
+
         if (value === '') {
           value = undefined
         } else {
@@ -31,6 +36,19 @@ const Number_ = decorate([
         props.onChange(value, empty ? undefined : params)
       },
     },
+    computed: {
+      value: ({ displayedValue }, { value }) => {
+        if (
+          displayedValue !== '' &&
+          (Number.isNaN((displayedValue = +displayedValue)) ||
+            displayedValue === value)
+        ) {
+          return displayedValue
+        }
+
+        return value === undefined ? '' : String(value)
+      },
+    },
   }),
   injectState,
   ({ state, effects, value, className = 'form-control', ...props }) => (
@@ -39,7 +57,7 @@ const Number_ = decorate([
       className={className}
       onChange={effects.onChange}
       type='number'
-      value={value === undefined ? '' : String(value)}
+      value={state.value}
     />
   ),
 ])

--- a/packages/xo-web/src/common/form/number.js
+++ b/packages/xo-web/src/common/form/number.js
@@ -64,7 +64,7 @@ const Number_ = decorate([
 
 Number_.propTypes = {
   onChange: PropTypes.func.isRequired,
-  value: PropTypes.number.isRequired,
+  value: PropTypes.number,
 }
 
 export default Number_

--- a/packages/xo-web/src/common/form/number.js
+++ b/packages/xo-web/src/common/form/number.js
@@ -37,14 +37,16 @@ const Number_ = decorate([
       },
     },
     computed: {
-      value: ({ displayedValue }, { value }) =>
-        displayedValue !== '' &&
-        (Number.isNaN((displayedValue = +displayedValue)) ||
-          displayedValue === value)
-          ? displayedValue
-          : value === undefined
-          ? ''
-          : String(value),
+      value: ({ displayedValue }, { value }) => {
+        const numericValue = +displayedValue
+        if (
+          displayedValue === '' ||
+          (!Number.isNaN(numericValue) && numericValue !== value)
+        ) {
+          return value === undefined ? '' : String(value)
+        }
+        return displayedValue
+      },
     },
   }),
   injectState,


### PR DESCRIPTION
Fixes #4566

This PR separate displayed value with the current correct value to let user set an advanced expression.

### Check list

> Check if done.
>
> Strikethrough if not relevant: ~~example~~ ([doc](https://help.github.com/en/articles/basic-writing-and-formatting-syntax)).

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] ~if UI changes, a screenshot has been added to the PR~
- [ ] ~documentation updated~
- ~`CHANGELOG.unreleased.md`~:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] ~unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))~
  - [ ] ~if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)~
  - [X] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
