### PR TITLE
feat(xo-web/log): add XOA info to bug report

### DIFF
--- a/packages/xo-web/src/common/report-bug-button.js
+++ b/packages/xo-web/src/common/report-bug-button.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import stripAnsi from 'strip-ansi'
 import xoaUpdater from 'xoa-updater'
-import { checkXoa } from 'xo'
+import { checkXoa, getXoaInfo } from 'xo'
 import { createBlobFromString } from 'utils'
 import { createLogger } from '@xen-orchestra/log'
 import { identity, omit } from 'lodash'
@@ -71,6 +71,15 @@ const reportOnSupportPanel = async ({
           'xoaCheck.txt'
         ),
       error => logger.warn('cannot get the xoa check', { error })
+    ),
+    timeout.call(getXoaInfo(), 5e3).then(
+      xoaInfo =>
+        formData.append(
+          'attachments',
+          createBlobFromString(JSON.stringify(xoaInfo, null, 2)),
+          'xoaInfo.json'
+        ),
+      error => logger.warn('cannot get xoa info', { error })
     ),
   ])
 

--- a/packages/xo-web/src/common/report-bug-button.js
+++ b/packages/xo-web/src/common/report-bug-button.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import stripAnsi from 'strip-ansi'
 import xoaUpdater from 'xoa-updater'
-import { checkXoa, getXoaInfo } from 'xo'
+import { checkXoa, getApplianceInfo } from 'xo'
 import { createBlobFromString } from 'utils'
 import { createLogger } from '@xen-orchestra/log'
 import { identity, omit } from 'lodash'
@@ -32,11 +32,11 @@ const ADDITIONAL_FILES = [
     name: 'manifest.json',
   },
   {
-    fetch: () => checkXoa().then(xoaCheck => stripAnsi(xoaCheck)),
+    fetch: () => checkXoa().then(stripAnsi),
     name: 'xoaCheck.txt',
   },
   {
-    fetch: () => getXoaInfo().then(jsonStringify),
+    fetch: () => getApplianceInfo().then(jsonStringify),
     name: 'xoaInfo.json',
   },
 ]

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -3003,6 +3003,8 @@ export const unlockXosan = (licenseId, srId) =>
 
 export const checkXoa = () => _call('xoa.check')
 
+export const getXoaInfo = () => _call('xoa.getApplianceInfo')
+
 export const closeTunnel = () =>
   _call('xoa.supportTunnel.close')::tap(subscribeTunnelState.forceRefresh)
 

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -3003,8 +3003,6 @@ export const unlockXosan = (licenseId, srId) =>
 
 export const checkXoa = () => _call('xoa.check')
 
-export const getXoaInfo = () => _call('xoa.getApplianceInfo')
-
 export const closeTunnel = () =>
   _call('xoa.supportTunnel.close')::tap(subscribeTunnelState.forceRefresh)
 


### PR DESCRIPTION
### Check list

> Check if done.
>
> Strikethrough if not relevant: ~~example~~ ([doc](https://help.github.com/en/articles/basic-writing-and-formatting-syntax)).

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
