### PR TITLE
feat(xo-server): passport strategies can be unregistered

### DIFF
--- a/packages/xo-server-auth-github/src/index.js
+++ b/packages/xo-server-auth-github/src/index.js
@@ -19,6 +19,7 @@ export const configurationSchema = {
 
 class AuthGitHubXoPlugin {
   constructor(xo) {
+    this._unregisterPassportStrategy = undefined
     this._xo = xo
   }
 
@@ -29,7 +30,7 @@ class AuthGitHubXoPlugin {
   load() {
     const { _xo: xo } = this
 
-    xo.registerPassportStrategy(
+    this._unregisterPassportStrategy = xo.registerPassportStrategy(
       new Strategy(
         this._conf,
         async (accessToken, refreshToken, profile, done) => {
@@ -41,6 +42,10 @@ class AuthGitHubXoPlugin {
         }
       )
     )
+  }
+
+  unload() {
+    this._unregisterPassportStrategy()
   }
 }
 

--- a/packages/xo-server-auth-google/src/index.js
+++ b/packages/xo-server-auth-google/src/index.js
@@ -31,6 +31,7 @@ export const configurationSchema = {
 class AuthGoogleXoPlugin {
   constructor({ xo }) {
     this._conf = null
+    this._unregisterPassportStrategy = undefined
     this._xo = xo
   }
 
@@ -42,7 +43,7 @@ class AuthGoogleXoPlugin {
     const conf = this._conf
     const xo = this._xo
 
-    xo.registerPassportStrategy(
+    this._unregisterPassportStrategy = xo.registerPassportStrategy(
       new Strategy(conf, async (accessToken, refreshToken, profile, done) => {
         try {
           done(
@@ -59,6 +60,10 @@ class AuthGoogleXoPlugin {
         }
       })
     )
+  }
+
+  unload() {
+    this._unregisterPassportStrategy()
   }
 }
 

--- a/packages/xo-server-auth-saml/src/index.js
+++ b/packages/xo-server-auth-saml/src/index.js
@@ -48,6 +48,7 @@ You should try \`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddr
 class AuthSamlXoPlugin {
   constructor({ xo }) {
     this._conf = null
+    this._unregisterPassportStrategy = undefined
     this._usernameField = null
     this._xo = xo
   }
@@ -66,7 +67,7 @@ class AuthSamlXoPlugin {
   load() {
     const xo = this._xo
 
-    xo.registerPassportStrategy(
+    this._unregisterPassportStrategy = xo.registerPassportStrategy(
       new Strategy(this._conf, async (profile, done) => {
         const name = profile[this._usernameField]
         if (!name) {
@@ -82,6 +83,10 @@ class AuthSamlXoPlugin {
         }
       })
     )
+  }
+
+  unload() {
+    this._unregisterPassportStrategy()
   }
 }
 

--- a/packages/xo-server/src/index.js
+++ b/packages/xo-server/src/index.js
@@ -15,7 +15,7 @@ import serveStatic from 'serve-static'
 import stoppable from 'stoppable'
 import WebServer from 'http-server-plus'
 import WebSocket from 'ws'
-import { forOwn, map } from 'lodash'
+import { forOwn, map, once } from 'lodash'
 import { URL } from 'url'
 
 import { compile as compilePug } from 'pug'
@@ -125,10 +125,14 @@ async function setUpPassport(express, xo, { authentication: authCfg }) {
     { label = strategy.label, name = strategy.name } = {}
   ) => {
     passport.use(name, strategy)
-
     if (name !== 'local') {
       strategies[name] = label ?? name
     }
+
+    return once(() => {
+      passport.unuse(name)
+      delete strategies[name]
+    })
   }
 
   // Registers the sign in form.


### PR DESCRIPTION
Now all authentication plugins can be unloaded.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
