### PR TITLE
feat(xo-web/new-vm): ability to set VM max vCPUS

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [New VM] Ability to set VM max vCPUS [#4703](https://github.com/vatesfr/xen-orchestra/issues/4703) (PR [#4729](https://github.com/vatesfr/xen-orchestra/pull/4729))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -45,6 +45,7 @@ const messages = {
   restore: 'Restore',
   delete: 'Delete',
   vms: 'VMs',
+  cpusMax: 'Max vCPUs',
   metadata: 'Metadata',
   chooseBackup: 'Choose a backup',
   clickToShowError: 'Click to show error',

--- a/packages/xo-web/src/xo-app/new-vm/index.js
+++ b/packages/xo-web/src/xo-app/new-vm/index.js
@@ -1085,7 +1085,7 @@ export default class NewVm extends BaseComponent {
     const memoryThreshold = get(() => template.memory.static[0])
     const selectCoresPerSocket = (
       <SelectCoresPerSocket
-        disabled={pool === undefined}
+        disabled={pool === undefined || template === undefined}
         maxCores={get(() => pool.cpus.cores)}
         maxVcpus={cpusMax}
         onChange={this._linkState('coresPerSocket')}

--- a/packages/xo-web/src/xo-app/new-vm/index.js
+++ b/packages/xo-web/src/xo-app/new-vm/index.js
@@ -1644,7 +1644,6 @@ export default class NewVm extends BaseComponent {
       autoPoweron,
       bootAfterCreate,
       cpuCap,
-      CPUs,
       cpusMax,
       cpuWeight,
       hvmBootFirmware,
@@ -1742,7 +1741,6 @@ export default class NewVm extends BaseComponent {
             <Item label={_('cpusMax')}>
               <DebounceInput
                 className='form-control'
-                min={CPUs}
                 onChange={this._linkState('cpusMax')}
                 type='number'
                 value={cpusMax}

--- a/packages/xo-web/src/xo-app/new-vm/index.js
+++ b/packages/xo-web/src/xo-app/new-vm/index.js
@@ -1071,7 +1071,7 @@ export default class NewVm extends BaseComponent {
   _getCpusMax = createSelector(
     () => this.state.state.CPUs,
     () => this.state.state.cpusMax,
-    (cpus, cpusMax) => Math.max(cpus, cpusMax)
+    Math.max
   )
 
   _renderPerformances = () => {
@@ -1645,6 +1645,7 @@ export default class NewVm extends BaseComponent {
       bootAfterCreate,
       cpuCap,
       CPUs,
+      cpusMax,
       cpuWeight,
       hvmBootFirmware,
       memoryDynamicMin,
@@ -1741,11 +1742,10 @@ export default class NewVm extends BaseComponent {
             <Item label={_('cpusMax')}>
               <DebounceInput
                 className='form-control'
-                debounceTimeout={3e3}
                 min={CPUs}
                 onChange={this._linkState('cpusMax')}
                 type='number'
-                value={this._getCpusMax()}
+                value={cpusMax}
               />
             </Item>
           </SectionContent>,


### PR DESCRIPTION
Fixes #4703

![image](https://user-images.githubusercontent.com/21563339/71978327-5896b900-321b-11ea-9ea4-cd05f435c4ad.png)

**The use case**

The "cores per socket" possibilities are calculated from the VM's max vCPUs
`maxVcpus = nCoresPerSockets * nSockets` 

Currently, if a user wants to choose a large number of cores per sockets, they either need to create a VM and make the modification in the VM's advanced tab or to modify the template's max vCPUs.

A solution - and to respond to a customer's need - is to implement the same behavior as XCP-ng Center. I chose to let the users set the VM's max vCPUs in the VM creation form.

![image](https://user-images.githubusercontent.com/21563339/71979747-c2649200-321e-11ea-9d49-ad3b1c3df211.png)

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
