### PR TITLE
feat(xo-server/Xapi): make built-in concurrency limits configurable

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -10,6 +10,11 @@
 - [Snapshot] Fallback to normal snapshot if quiesce is not available [#4735](https://github.com/vatesfr/xen-orchestra/issues/4735) (PR [#4736](https://github.com/vatesfr/xen-orchestra/pull/4736)) \
   Fixes compatibility with **Citrix Hypervisor 8.1**.
 - [Uncompressed full backup] Quick healthcheck of downloaded XVAs in case there was an undetected issue (PR [#4741](https://github.com/vatesfr/xen-orchestra/pull/4741))
+- [Backup] Make built-in concurrency limits configurable (PR [#4743](https://github.com/vatesfr/xen-orchestra/pull/4743)) \
+  Via the following entries in `xo-server`'s configuration file:
+  - `xapiOptions.vdiExportConcurrency`
+  - `xapiOptions.vmExportConcurrency`
+  - `xapiOptions.vmSnapshotConcurrency`
 
 ### Bug fixes
 

--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -120,4 +120,7 @@ timeout = 600e3
 #numWorkers = 2
 
 [xapiOptions]
+exportVdiConcurrency = 12
+exportVmConcurrency = 2
+snapshotVmConcurrency = 2
 maxUncoalescedVdis = 1

--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -120,7 +120,7 @@ timeout = 600e3
 #numWorkers = 2
 
 [xapiOptions]
-exportVdiConcurrency = 12
-exportVmConcurrency = 2
-snapshotVmConcurrency = 2
 maxUncoalescedVdis = 1
+vdiExportConcurrency = 12
+vmExportConcurrency = 2
+vmSnapshotConcurrency = 2

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -95,11 +95,11 @@ export const IPV6_CONFIG_MODES = ['None', 'DHCP', 'Static', 'Autoconf']
 @mixin(mapToArray(mixins))
 export default class Xapi extends XapiBase {
   constructor({
-    exportVdiConcurrency,
-    exportVmConcurrency,
-    snapshotVmConcurrency,
     guessVhdSizeOnImport,
     maxUncoalescedVdis,
+    vdiExportConcurrency,
+    vmExportConcurrency,
+    vmSnapshotConcurrency,
     ...opts
   }) {
     super(opts)
@@ -109,15 +109,15 @@ export default class Xapi extends XapiBase {
 
     const waitStreamEnd = async stream => fromEvent(await stream, 'end')
     this._exportVdi = concurrency(
-      exportVdiConcurrency,
+      vdiExportConcurrency,
       waitStreamEnd
     )(this._exportVdi)
     this.exportVm = concurrency(
-      exportVmConcurrency,
+      vmExportConcurrency,
       waitStreamEnd
     )(this.exportVm)
 
-    this._snapshotVm = concurrency(snapshotVmConcurrency)(this._snapshotVm)
+    this._snapshotVm = concurrency(vmSnapshotConcurrency)(this._snapshotVm)
 
     // Patch getObject to resolve _xapiId property.
     this.getObject = (getObject => (...args) => {


### PR DESCRIPTION
See xoa-support#2075

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
