### PR TITLE
fix(xo-server/store): store.get returns a promise

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Self,IP pools] Fixed the creation being stuck and freezing XO (PR [#4776](https://github.com/vatesfr/xen-orchestra/pull/4776))
+
 ### Released packages
 
 > Packages will be released in the order they are here, therefore, they should

--- a/packages/xo-server/src/xo-mixins/store.js
+++ b/packages/xo-server/src/xo-mixins/store.js
@@ -4,7 +4,7 @@ import { ensureDir } from 'fs-extra'
 
 // ===================================================================
 
-const _levelHas = function has(key, cb) {
+const _levelHas = async function has(key, cb) {
   if (cb) {
     return this.get(key, (error, value) =>
       error ? (error.notFound ? cb(null, false) : cb(error)) : cb(null, true)
@@ -12,7 +12,7 @@ const _levelHas = function has(key, cb) {
   }
 
   try {
-    this.get(key)
+    await this.get(key)
     return true
   } catch (error) {
     if (!error.notFound) {


### PR DESCRIPTION
Fixes xoa-support#2137

Not `await`ing the promise caused `store.has` to always answer `true` which caused such a loop to never finish:
https://github.com/vatesfr/xen-orchestra/blob/ef784c5a2597360468bd779d41ddbefecf2f99e2/packages/xo-server/src/xo-mixins/resource-sets.js#L95-L101

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
