### PR TITLE
fix(xo-web): use window.open instead of window.location

### DIFF
--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -523,7 +523,7 @@ export const importConfig = config =>
 
 export const exportConfig = () =>
   _call('xo.exportConfig').then(({ $getFrom: url }) => {
-    window.location = `.${url}`
+    window.open(`.${url}`)
   })
 
 // Server ------------------------------------------------------------
@@ -1568,7 +1568,7 @@ export const exportVm = vm =>
     info(_('startVmExport'), id)
     return _call('vm.export', { vm: id, compress }).then(
       ({ $getFrom: url }) => {
-        window.location = `.${url}`
+        window.open(`.${url}`)
       }
     )
   })
@@ -1577,7 +1577,7 @@ export const exportVdi = vdi => {
   info(_('startVdiExport'), vdi.id)
   return _call('disk.exportContent', { id: resolveId(vdi) }).then(
     ({ $getFrom: url }) => {
-      window.location = `.${url}`
+      window.open(`.${url}`)
     }
   )
 }
@@ -2361,7 +2361,7 @@ export const fetchFiles = (remote, disk, partition, paths, format) =>
     'backup.fetchFiles',
     resolveIds({ remote, disk, partition, paths, format })
   ).then(({ $getFrom: url }) => {
-    window.location = `.${url}`
+    window.open(`.${url}`)
   })
 
 // File restore NG  ----------------------------------------------------
@@ -2377,7 +2377,7 @@ export const fetchFilesNg = (remote, disk, partition, paths) =>
     'backupNg.fetchFiles',
     resolveIds({ remote, disk, partition, paths })
   ).then(({ $getFrom: url }) => {
-    window.location = `.${url}`
+    window.open(`.${url}`)
   })
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
Fixes #4709

Changing the location closes the WebSocket connection

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
