### PR TITLE
fix(xo-server/disk): remove `disk.resize` method

### DIFF
--- a/packages/xo-server/src/api/disk.js
+++ b/packages/xo-server/src/api/disk.js
@@ -5,7 +5,6 @@ import { format, JsonRpcError } from 'json-rpc-peer'
 import { noSuchObject } from 'xo-common/api-errors'
 import { peekFooterFromVhdStream } from 'vhd-lib'
 
-import { parseSize } from '../utils'
 import { VDI_FORMAT_VHD } from '../xapi'
 
 const log = createLogger('xo:disk')
@@ -153,21 +152,6 @@ importContent.resolve = {
 }
 
 // -------------------------------------------------------------------
-
-export async function resize({ vdi, size }) {
-  await this.getXapi(vdi).resizeVdi(vdi._xapiId, parseSize(size))
-}
-
-resize.description = 'resize an existing VDI'
-
-resize.params = {
-  id: { type: 'string' },
-  size: { type: ['integer', 'string'] },
-}
-
-resize.resolve = {
-  vdi: ['id', ['VDI', 'VDI-snapshot'], 'administrate'],
-}
 
 async function handleImport(
   req,


### PR DESCRIPTION
- resizing a VDI can be done with `VDI.set`
- disk.resize doesn't check Self Service constraints

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
