### PR TITLE
fix(xo-server-usage-report): dynamic date

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [Usage Report] Fix not updated report date [#4779](https://github.com/vatesfr/xen-orchestra/issues/4779) (PR [#4799](https://github.com/vatesfr/xen-orchestra/pull/4799))
+- [Usage Report] Fix wrong report date [#4779](https://github.com/vatesfr/xen-orchestra/issues/4779) (PR [#4799](https://github.com/vatesfr/xen-orchestra/pull/4799))
 
 ### Released packages
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Usage Report] Fix not updated report date [#4779](https://github.com/vatesfr/xen-orchestra/issues/4779) (PR [#4799](https://github.com/vatesfr/xen-orchestra/pull/4799))
+
 ### Released packages
 
 > Packages will be released in the order they are here, therefore, they should
@@ -18,5 +20,6 @@
 >
 > Rule of thumb: add packages on top.
 
+- xo-server-usage-report v0.7.4
 - xo-server v5.57.0
 - xo-web v5.57.0

--- a/packages/xo-server-usage-report/src/index.js
+++ b/packages/xo-server-usage-report/src/index.js
@@ -30,8 +30,6 @@ const GRANULARITY = 'days'
 const pReadFile = promisify(readFile)
 const pWriteFile = promisify(writeFile)
 
-const currDate = new Date().toISOString().slice(0, 10)
-
 const compareOperators = {
   '>': (l, r) => l > r,
 }
@@ -615,7 +613,7 @@ async function computeEvolution({ storedStatsPath, ...newStats }) {
   }
 }
 
-async function dataBuilder({ xo, storedStatsPath, all }) {
+async function dataBuilder({ currDate, xo, storedStatsPath, all }) {
   const xoObjects = values(xo.getObjects())
   const runningVms = filter(xoObjects, { type: 'VM', power_state: 'Running' })
   const haltedVms = filter(xoObjects, { type: 'VM', power_state: 'Halted' })
@@ -766,7 +764,9 @@ class UsageReportPlugin {
       )
     }
 
+    const currDate = new Date().toISOString().slice(0, 10)
     const data = await dataBuilder({
+      currDate,
       xo,
       storedStatsPath: this._storedStatsPath,
       all: this._conf.all,


### PR DESCRIPTION
Fixes #4779

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
