### PR TITLE
fix(xo-server/backup-ng): handle existant snapshots per schedule

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Backup NG] Fix snapshots deleted by a not linked schedule in case of a job with multiple schedules (PR [#4803](https://github.com/vatesfr/xen-orchestra/pull/4803))
+
 ### Released packages
 
 > Packages will be released in the order they are here, therefore, they should

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -1175,7 +1175,7 @@ export default class BackupNg {
       }
     } else {
       const snapshots = vm.$snapshots
-        .filter(_ => _.other_config['xo:backup:job'] === jobId)
+        .filter(_ => _.other_config['xo:backup:schedule'] === scheduleId)
         .sort(compareSnapshotTime)
 
       const bypassVdiChainsCheck: boolean = getSetting(


### PR DESCRIPTION
See https://xcp-ng.org/forum/topic/2613/continuous-replication-and-snapshots-together/4

**Current issue**:

On creating a job with multiple schedules, a schedule will delete snapshots created  by other schedules

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
