### PR TITLE
chore(sdn-controller/ovsdb-client): dont use set when not necessary

### DIFF
--- a/packages/xo-server-sdn-controller/src/protocol/ovsdb-client.js
+++ b/packages/xo-server-sdn-controller/src/protocol/ovsdb-client.js
@@ -131,7 +131,7 @@ export class OvsdbClient {
       table: 'Port',
       row: {
         name: portName,
-        interfaces: ['set', [['named-uuid', 'new_iface']]],
+        interfaces: ['named-uuid', 'new_iface'],
         other_config: toMap({
           'xo:sdn-controller:private-network-uuid': privateNetworkUuid,
         }),
@@ -143,7 +143,7 @@ export class OvsdbClient {
       op: 'mutate',
       table: 'Bridge',
       where: [['_uuid', '==', ['uuid', bridge.uuid]]],
-      mutations: [['ports', 'insert', ['set', [['named-uuid', 'new_port']]]]],
+      mutations: [['ports', 'insert', ['named-uuid', 'new_port']]],
     }
     const params = [
       'Open_vSwitch',


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] ~~PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)~~
- [ ] ~~if UI changes, a screenshot has been added to the PR~~
- [ ] ~~documentation updated~~
- `CHANGELOG.unreleased.md`:
  - [ ] ~~enhancement/bug fix entry added~~
  - [ ] ~~list of packages to release updated (`${name} v${new version}`)~~
- **I have tested added/updated features** (and impacted code)
  - [ ] ~~unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))~~
  - [ ] ~~if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)~~
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
