### PR TITLE
fix(xo-web): fix selectors

### DIFF
--- a/packages/xo-web/src/xo-app/dashboard/overview/index.js
+++ b/packages/xo-web/src/xo-app/dashboard/overview/index.js
@@ -89,22 +89,17 @@ class PatchesCard extends Component {
 @injectIntl
 class DefaultCard extends Component {
   _getPoolWisePredicate = createSelector(
-    () => this.state.pools,
-    pools => item => {
-      const poolsIds = map(pools, 'id')
-      return isEmpty(poolsIds) || includes(poolsIds, item.$pool)
-    }
+    createCollectionWrapper(() => map(this.state.pools, 'id')),
+    poolsIds => item => isEmpty(poolsIds) || includes(poolsIds, item.$pool)
   )
 
   _getPredicate = createSelector(
     this._getPoolWisePredicate,
-    () => this.state.hosts,
-    (poolWisePredicate, hosts) => item => {
-      const hostsIds = map(hosts, 'id')
-      return isEmpty(hostsIds)
+    createCollectionWrapper(() => map(this.state.hosts, 'id')),
+    (poolWisePredicate, hostsIds) => item =>
+      isEmpty(hostsIds)
         ? poolWisePredicate(item)
         : includes(hostsIds, item.$container || item.$host)
-    }
   )
 
   _onPoolsChange = pools => {

--- a/packages/xo-web/src/xo-app/dashboard/overview/index.js
+++ b/packages/xo-web/src/xo-app/dashboard/overview/index.js
@@ -89,17 +89,22 @@ class PatchesCard extends Component {
 @injectIntl
 class DefaultCard extends Component {
   _getPoolWisePredicate = createSelector(
-    () => map(this.state.pools, 'id'),
-    poolsIds => item => isEmpty(poolsIds) || includes(poolsIds, item.$pool)
+    () => this.state.pools,
+    pools => item => {
+      const poolsIds = map(pools, 'id')
+      return isEmpty(poolsIds) || includes(poolsIds, item.$pool)
+    }
   )
 
   _getPredicate = createSelector(
     this._getPoolWisePredicate,
-    () => map(this.state.hosts, 'id'),
-    (poolWisePredicate, hostsIds) => item =>
-      isEmpty(hostsIds)
+    () => this.state.hosts,
+    (poolWisePredicate, hosts) => item => {
+      const hostsIds = map(hosts, 'id')
+      return isEmpty(hostsIds)
         ? poolWisePredicate(item)
         : includes(hostsIds, item.$container || item.$host)
+    }
   )
 
   _onPoolsChange = pools => {

--- a/packages/xo-web/src/xo-app/sr/tab-disks.js
+++ b/packages/xo-web/src/xo-app/sr/tab-disks.js
@@ -18,6 +18,7 @@ import { Container, Row, Col } from 'grid'
 import { connectStore, formatSize, noop } from 'utils'
 import { concat, groupBy, isEmpty, map, mapValues, pick, some } from 'lodash'
 import {
+  createCollectionWrapper,
   createGetObjectsOfType,
   createSelector,
   getCheckPermissions,
@@ -313,8 +314,8 @@ export default class SrDisks extends Component {
   _getIsVdiAttached = createSelector(
     createSelector(
       () => this.props.vbds,
-      () => this.props.vdis,
-      (vbds, vdis) => pick(groupBy(vbds, 'VDI'), map(vdis, 'id'))
+      createCollectionWrapper(() => map(this.props.vdis, 'id')),
+      (vbds, vdis) => pick(groupBy(vbds, 'VDI'), vdis)
     ),
     vbdsByVdi => mapValues(vbdsByVdi, vbds => some(vbds, 'attached'))
   )

--- a/packages/xo-web/src/xo-app/sr/tab-disks.js
+++ b/packages/xo-web/src/xo-app/sr/tab-disks.js
@@ -313,8 +313,8 @@ export default class SrDisks extends Component {
   _getIsVdiAttached = createSelector(
     createSelector(
       () => this.props.vbds,
-      () => map(this.props.vdis, 'id'),
-      (vbds, vdis) => pick(groupBy(vbds, 'VDI'), vdis)
+      () => this.props.vdis,
+      (vbds, vdis) => pick(groupBy(vbds, 'VDI'), map(vdis, 'id'))
     ),
     vbdsByVdi => mapValues(vbdsByVdi, vbds => some(vbds, 'attached'))
   )


### PR DESCRIPTION
- Each time, the selector will be recomputed because we use the `_.map` in its entry.
- Fix: remove `_.map` from the input selector. 

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
