### PR TITLE
Various fixes/update in xo-web/xoa-updater state handling

### DIFF
--- a/packages/xo-web/src/common/xoa-updater.js
+++ b/packages/xo-web/src/common/xoa-updater.js
@@ -126,23 +126,23 @@ class XoaUpdater extends EventEmitter {
       })
       middle.on('end', end => {
         this._lowState = end
-        switch (this._lowState.state) {
-          case 'xoa-up-to-date':
-          case 'xoa-upgraded':
-          case 'updater-upgraded':
-          case 'installer-upgraded':
-            this.state('upToDate')
-            break
-          case 'xoa-upgrade-needed':
-          case 'updater-upgrade-needed':
-          case 'installer-upgrade-needed':
-            this.state('upgradeNeeded')
-            break
-          case 'register-needed':
-            this.state('registerNeeded')
-            break
-          default:
-            this.state('error')
+        const { state } = end
+        if (state.endsWith('-upgrade-needed')) {
+          this.state('upgradeNeeded')
+        } else {
+          switch (this._lowState.state) {
+            case 'xoa-up-to-date':
+            case 'xoa-upgraded':
+            case 'updater-upgraded':
+            case 'installer-upgraded':
+              this.state('upToDate')
+              break
+            case 'register-needed':
+              this.state('registerNeeded')
+              break
+            default:
+              this.state('error')
+          }
         }
         this.log(end.level, end.message)
         this._lastRun = Date.now()

--- a/packages/xo-web/src/common/xoa-updater.js
+++ b/packages/xo-web/src/common/xoa-updater.js
@@ -130,7 +130,7 @@ class XoaUpdater extends EventEmitter {
         if (state.endsWith('-upgrade-needed')) {
           this.state('upgradeNeeded')
         } else {
-          switch (this._lowState.state) {
+          switch (state) {
             case 'xoa-up-to-date':
             case 'xoa-upgraded':
             case 'updater-upgraded':
@@ -148,14 +148,14 @@ class XoaUpdater extends EventEmitter {
         this._lastRun = Date.now()
         this._waiting = false
         this.emit('end', end)
-        if (this._lowState.state === 'register-needed') {
+        if (state === 'register-needed') {
           this.isRegistered()
         } else if (
-          this._lowState.state === 'updater-upgraded' ||
-          this._lowState.state === 'installer-upgraded'
+          state === 'updater-upgraded' ||
+          state === 'installer-upgraded'
         ) {
           this.update()
-        } else if (this._lowState.state === 'xoa-upgraded') {
+        } else if (state === 'xoa-upgraded') {
           this._upgradeSuccessful()
         }
         this.xoaState()

--- a/packages/xo-web/src/common/xoa-updater.js
+++ b/packages/xo-web/src/common/xoa-updater.js
@@ -148,10 +148,9 @@ class XoaUpdater extends EventEmitter {
         this._lastRun = Date.now()
         this._waiting = false
         this.emit('end', end)
-        if (this._lowState === 'register-needed') {
+        if (this._lowState.state === 'register-needed') {
           this.isRegistered()
-        }
-        if (
+        } else if (
           this._lowState.state === 'updater-upgraded' ||
           this._lowState.state === 'installer-upgraded'
         ) {


### PR DESCRIPTION
Please review [commit by commit](https://github.com/vatesfr/xen-orchestra/pull/4808/commits/7670562cd45be9856834f9fde1a33674aeda47f0?w=1)

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
