### PR TITLE
fix(xo-web/vm/disks): correctly handle VDIs with size `0`

### DIFF
--- a/packages/xo-web/src/common/editable/index.js
+++ b/packages/xo-web/src/common/editable/index.js
@@ -490,10 +490,8 @@ export class XoSelect extends Editable {
 
 export class Size extends Editable {
   static propTypes = {
-    value: PropTypes.oneOfType([
-      PropTypes.number.isRequired,
-      PropTypes.oneOf([null]),
-    ]).isRequired,
+    value: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([null])])
+      .isRequired,
   }
 
   get value() {

--- a/packages/xo-web/src/common/editable/index.js
+++ b/packages/xo-web/src/common/editable/index.js
@@ -490,7 +490,10 @@ export class XoSelect extends Editable {
 
 export class Size extends Editable {
   static propTypes = {
-    value: PropTypes.number.isRequired,
+    value: PropTypes.oneOfType([
+      PropTypes.number.isRequired,
+      PropTypes.oneOf([null]),
+    ]).isRequired,
   }
 
   get value() {
@@ -498,7 +501,15 @@ export class Size extends Editable {
   }
 
   _renderDisplay() {
-    return this.props.children || formatSize(this.props.value)
+    if (this.props.children !== undefined) {
+      return this.props.children
+    }
+
+    if (this.props.value != null) {
+      return formatSize(this.props.value)
+    }
+
+    return null
   }
 
   _saveIfUnfocused = () => {

--- a/packages/xo-web/src/xo-app/vm/tab-disks.js
+++ b/packages/xo-web/src/xo-app/vm/tab-disks.js
@@ -2,6 +2,7 @@ import _, { messages } from 'intl'
 import ActionButton from 'action-button'
 import Component from 'base-component'
 import copy from 'copy-to-clipboard'
+import defined from '@xen-orchestra/defined'
 import HTML5Backend from 'react-dnd-html5-backend'
 import Icon from 'icon'
 import IsoDevice from 'iso-device'
@@ -131,7 +132,7 @@ const COLUMNS_VM_PV = [
   {
     itemRenderer: ({ vdi }) => (
       <Size
-        value={vdi.size || null}
+        value={defined(vdi.size, null)}
         onChange={size => editVdi(vdi, { size })}
       />
     ),


### PR DESCRIPTION
Fixes support#2181

- Don't pass `null` to `Size` when `vdi.size` is `0`
- Handle `null` `value` in `Size`

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
