### PR TITLE
fix(@xen-orchestra/fs): fix deadlock between "outputFile" and "mkdir"

### DIFF
--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -282,7 +282,8 @@ export default class RemoteHandlerAbstract {
     return entries
   }
 
-  async mkdir(dir: string): Promise<void> {
+  // mutualized to avoid the parallel execution restriction on `mkdir`
+  async _createDir(dir: string): Promise<void> {
     dir = normalizePath(dir)
     try {
       await this._mkdir(dir)
@@ -294,6 +295,10 @@ export default class RemoteHandlerAbstract {
       // this operation will throw if it's not already a directory
       await this._list(dir)
     }
+  }
+
+  mkdir(dir: string): Promise<void> {
+    return this._createDir(dir)
   }
 
   async mktree(dir: string): Promise<void> {
@@ -513,7 +518,7 @@ export default class RemoteHandlerAbstract {
 
   async _mktree(dir: string): Promise<void> {
     try {
-      return await this.mkdir(dir)
+      return await this._createDir(dir)
     } catch (error) {
       if (error.code !== 'ENOENT') {
         throw error

--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -95,7 +95,6 @@ export default class RemoteHandlerAbstract {
     this.list = sharedLimit(this.list)
     this.mkdir = sharedLimit(this.mkdir)
     this.openFile = sharedLimit(this.openFile)
-    this.outputFile = sharedLimit(this.outputFile)
     this.read = sharedLimit(this.read)
     this.readFile = sharedLimit(this.readFile)
     this.rename = sharedLimit(this.rename)
@@ -282,8 +281,7 @@ export default class RemoteHandlerAbstract {
     return entries
   }
 
-  // mutualized to avoid the parallel execution restriction on `mkdir`
-  async _createDir(dir: string): Promise<void> {
+  async mkdir(dir: string): Promise<void> {
     dir = normalizePath(dir)
     try {
       await this._mkdir(dir)
@@ -295,10 +293,6 @@ export default class RemoteHandlerAbstract {
       // this operation will throw if it's not already a directory
       await this._list(dir)
     }
-  }
-
-  mkdir(dir: string): Promise<void> {
-    return this._createDir(dir)
   }
 
   async mktree(dir: string): Promise<void> {
@@ -518,7 +512,7 @@ export default class RemoteHandlerAbstract {
 
   async _mktree(dir: string): Promise<void> {
     try {
-      return await this._createDir(dir)
+      return await this.mkdir(dir)
     } catch (error) {
       if (error.code !== 'ENOENT') {
         throw error
@@ -539,14 +533,14 @@ export default class RemoteHandlerAbstract {
     options: { flags?: string }
   ): Promise<void> {
     try {
-      return await this._writeFile(file, data, options)
+      return await this.writeFile(file, data, options)
     } catch (error) {
       if (error.code !== 'ENOENT') {
         throw error
       }
     }
 
-    await this._mktree(dirname(file))
+    await this.mktree(dirname(file))
     return this._outputFile(file, data, options)
   }
 

--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -283,7 +283,7 @@ export default class RemoteHandlerAbstract {
   }
 
   async mkdir(dir: string): Promise<void> {
-    await this.__mkdir(dir)
+    await this.__mkdir(normalizePath(dir))
   }
 
   async mktree(dir: string): Promise<void> {
@@ -447,7 +447,6 @@ export default class RemoteHandlerAbstract {
   }
 
   async __mkdir(dir: string): Promise<void> {
-    dir = normalizePath(dir)
     try {
       await this._mkdir(dir)
     } catch (error) {

--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -282,8 +282,8 @@ export default class RemoteHandlerAbstract {
     return entries
   }
 
-  mkdir(dir: string): Promise<void> {
-    return this.__mkdir(dir)
+  async mkdir(dir: string): Promise<void> {
+    await this.__mkdir(dir)
   }
 
   async mktree(dir: string): Promise<void> {

--- a/@xen-orchestra/fs/src/fs.spec.js
+++ b/@xen-orchestra/fs/src/fs.spec.js
@@ -219,6 +219,12 @@ handlers.forEach(url => {
         const error = await rejectionOf(handler.outputFile('file', ''))
         expect(error.code).toBe('EEXIST')
       })
+
+      it('should`t timeout in case of the respect of the parallel execution restriction', async () => {
+        const handler = getHandler({ url }, { maxParallelOperations: 1 })
+        await handler.sync()
+        await handler.outputFile(`xo-fs-tests-${Date.now()}/test`, '')
+      }, 40)
     })
 
     describe('#read()', () => {

--- a/@xen-orchestra/fs/src/fs.spec.js
+++ b/@xen-orchestra/fs/src/fs.spec.js
@@ -220,7 +220,7 @@ handlers.forEach(url => {
         expect(error.code).toBe('EEXIST')
       })
 
-      it('should`t timeout in case of the respect of the parallel execution restriction', async () => {
+      it('shouldn`t timeout in case of the respect of the parallel execution restriction', async () => {
         const handler = getHandler({ url }, { maxParallelOperations: 1 })
         await handler.sync()
         await handler.outputFile(`xo-fs-tests-${Date.now()}/test`, '')

--- a/@xen-orchestra/fs/src/fs.spec.js
+++ b/@xen-orchestra/fs/src/fs.spec.js
@@ -220,7 +220,7 @@ handlers.forEach(url => {
         expect(error.code).toBe('EEXIST')
       })
 
-      it('shouldn`t timeout in case of the respect of the parallel execution restriction', async () => {
+      it("shouldn't timeout in case of the respect of the parallel execution restriction", async () => {
         const handler = getHandler({ url }, { maxParallelOperations: 1 })
         await handler.sync()
         await handler.outputFile(`xo-fs-tests-${Date.now()}/test`, '')

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 
 - [Backup reports] Fix backup report not sent in case of interrupted backup job (PR [#4772](https://github.com/vatesfr/xen-orchestra/pull/4772))
 - Fix TLS error (`unsupported protocol`) with XenServer <= 6.5 and Node >= 12 (PR [#8437](https://github.com/vatesfr/xen-orchestra/pull/8437))
-- [Metadata backup] fix the metadata backup timeout (PR [#4831](https://github.com/vatesfr/xen-orchestra/pull/4831))
+- [Metadata backup] fix metadata backup timeout (PR [#4831](https://github.com/vatesfr/xen-orchestra/pull/4831))
 
 ### Released packages
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 
 - [Backup reports] Fix backup report not sent in case of interrupted backup job (PR [#4772](https://github.com/vatesfr/xen-orchestra/pull/4772))
 - Fix TLS error (`unsupported protocol`) with XenServer <= 6.5 and Node >= 12 (PR [#8437](https://github.com/vatesfr/xen-orchestra/pull/8437))
-- [Metadata backup] fix metadata backup timeout [#4819](https://github.com/vatesfr/xen-orchestra/issues/4819) (PR [#4831](https://github.com/vatesfr/xen-orchestra/pull/4831))
+- [Metadata backup] Fix timeout when lots of pools are backed up [#4819](https://github.com/vatesfr/xen-orchestra/issues/4819) (PR [#4831](https://github.com/vatesfr/xen-orchestra/pull/4831))
 
 ### Released packages
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,7 @@
 
 - [Backup reports] Fix backup report not sent in case of interrupted backup job (PR [#4772](https://github.com/vatesfr/xen-orchestra/pull/4772))
 - Fix TLS error (`unsupported protocol`) with XenServer <= 6.5 and Node >= 12 (PR [#8437](https://github.com/vatesfr/xen-orchestra/pull/8437))
+- [Metadata backup] fix the metadata backup timeout (PR [#4831](https://github.com/vatesfr/xen-orchestra/pull/4831))
 
 ### Released packages
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 
 - [Backup reports] Fix backup report not sent in case of interrupted backup job (PR [#4772](https://github.com/vatesfr/xen-orchestra/pull/4772))
 - Fix TLS error (`unsupported protocol`) with XenServer <= 6.5 and Node >= 12 (PR [#8437](https://github.com/vatesfr/xen-orchestra/pull/8437))
-- [Metadata backup] fix metadata backup timeout (PR [#4831](https://github.com/vatesfr/xen-orchestra/pull/4831))
+- [Metadata backup] fix metadata backup timeout [#4819](https://github.com/vatesfr/xen-orchestra/issues/4819) (PR [#4831](https://github.com/vatesfr/xen-orchestra/pull/4831))
 
 ### Released packages
 
@@ -22,6 +22,7 @@
 >
 > Rule of thumb: add packages on top.
 
+- @xen-orchestra/fs v0.10.3
 - xo-server-backup-reports v0.16.5
 - xo-server v5.58.0
 - xo-web v5.58.0


### PR DESCRIPTION
Fixes #4819 

See xoa-support#2190

There is a [parallel executions](https://github.com/vatesfr/xen-orchestra/compare/fixFs?expand=1#diff-214b21d168ffee0dd56ff8162e12893fR89) restriction between public methods. A deadlock can be triggered when a public method was called in a call chain which reach the restriction.

This PR will resolve the issue with the timeout of the metadata backups which use `fs.outputFile`.

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
