### PR TITLE
feat(xo-server-audit): should not use "app-conf"

### DIFF
--- a/packages/xo-server-audit/package.json
+++ b/packages/xo-server-audit/package.json
@@ -52,8 +52,8 @@
     "@iarna/toml": "^2.2.3",
     "@xen-orchestra/audit-core": "^0.1.0",
     "@xen-orchestra/log": "^0.2.0",
-    "app-conf": "^0.7.1",
     "async-iterator-to-stream": "^1.1.0",
+    "fs-extra": "^8.1.0",
     "promise-toolbox": "^0.15.0",
     "readable-stream": "^3.5.0",
     "xo-common": "^0.4.0"

--- a/packages/xo-server-audit/src/index.js
+++ b/packages/xo-server-audit/src/index.js
@@ -1,10 +1,11 @@
-import appConf from 'app-conf'
 import asyncIteratorToStream from 'async-iterator-to-stream'
 import createLogger from '@xen-orchestra/log'
 import path from 'path'
+import TOML from '@iarna/toml'
 import { alteredAuditRecord, missingAuditRecord } from 'xo-common/api-errors'
 import { fromCallback } from 'promise-toolbox'
 import { pipeline } from 'readable-stream'
+import { readFile } from 'fs-extra'
 import {
   AlteredRecordError,
   AuditCore,
@@ -66,10 +67,8 @@ class AuditXoPlugin {
         await this._xo.getStore(NAMESPACE)
       ))
       this._auditCore = new AuditCore(storage)
-      this._blockedList = (
-        await appConf.load('xo-server-audit', {
-          appDir: path.join(__dirname, '..'),
-        })
+      this._blockedList = TOML.parse(
+        await readFile(path.join(__dirname, '..', 'config.toml'), 'utf8')
       ).blockedList
 
       cleaners.push(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2361,7 +2361,7 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-app-conf@^0.7.0, app-conf@^0.7.1:
+app-conf@^0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/app-conf/-/app-conf-0.7.1.tgz#59bf3605e6d8fa19107408ae9f94c1c9984764b4"
   integrity sha512-arusY8qGB4EmPFUweuLVQde4cj0zQfMBo+D7wRk285SQPfetX9Jk+4VRL+20n5dsJr4Rm4uj2y6exm78wsgCFg==


### PR DESCRIPTION
See #4798

This change is related to this [comment](https://github.com/vatesfr/xen-orchestra/pull/4740#discussion_r384556971).

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
