### PR TITLE
fix(xo-web/select-objects): clearer placeholder for SelectProxy

### DIFF
--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -301,6 +301,7 @@ const messages = {
   selectPools: 'Select pool(s)…',
   selectRemotes: 'Select remote(s)…',
   selectProxies: 'Select proxy(ies)…',
+  selectProxy: 'Select proxy…',
   selectResourceSets: 'Select resource set(s)…',
   selectResourceSetsVmTemplate: 'Select template(s)…',
   selectResourceSetsSr: 'Select SR(s)…',

--- a/packages/xo-web/src/common/select-objects.js
+++ b/packages/xo-web/src/common/select-objects.js
@@ -326,7 +326,10 @@ const makeStoreSelect = (createSelectors, defaultProps) =>
     ))
   )
 
-const makeSubscriptionSelect = (subscribe, props) =>
+const makeSubscriptionSelect = (
+  subscribe,
+  { placeholder, placeholderMulti = placeholder, ...props } = {}
+) =>
   uncontrollableInput(options)(
     class extends React.PureComponent {
       state = {}
@@ -366,6 +369,7 @@ const makeSubscriptionSelect = (subscribe, props) =>
           <GenericSelect
             {...props}
             {...this.props}
+            placeholder={this.props.multi ? placeholderMulti : placeholder}
             xoObjects={this._getFilteredXoObjects()}
             xoContainers={
               this.state.xoContainers && this._getFilteredXoContainers()
@@ -854,7 +858,7 @@ export const SelectProxy = makeSubscriptionSelect(
         })),
       })
     }),
-  { placeholder: _('selectProxies') }
+  { placeholderMulti: _('selectProxies'), placeholder: _('selectProxy') }
 )
 
 // ===================================================================


### PR DESCRIPTION
The placeholder `Select proxy(ies)` is a little confusing in case of a simple select. Some users will feel that they can select multiple proxies.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
