### PR TITLE
feat(xo-web/audit): remove useless step in the integrity check

### DIFF
--- a/packages/xo-web/src/xo-app/settings/audit/index.js
+++ b/packages/xo-web/src/xo-app/settings/audit/index.js
@@ -113,7 +113,6 @@ const FingerPrintModalBody = injectIntl(
   )
 )
 
-const DEFAULT_HASH = 'nullId|nullId'
 const openFingerprintPromptModal = () =>
   form({
     render: ({ onChange, value }) => (
@@ -124,15 +123,16 @@ const openFingerprintPromptModal = () =>
         <Icon icon='diagnosis' /> {_('auditCheckIntegrity')}
       </span>
     ),
-  }).then((value = '') => {
-    value = value.trim()
-    return value !== '' ? value : DEFAULT_HASH
-  }, noop)
+  }).then((value = '') => value.trim(), noop)
 
 const checkIntegrity = async () => {
   const fingerprint = await openFingerprintPromptModal()
   if (fingerprint === undefined) {
     return
+  }
+
+  if (fingerprint === '') {
+    return openGeneratedFingerprintModal(await generateAuditFingerprint())
   }
 
   const [oldest, newest] = fingerprint.split('|')

--- a/packages/xo-web/src/xo-app/settings/audit/index.js
+++ b/packages/xo-web/src/xo-app/settings/audit/index.js
@@ -131,30 +131,33 @@ const checkIntegrity = async () => {
     return
   }
 
-  if (fingerprint === '') {
-    return openGeneratedFingerprintModal(await generateAuditFingerprint())
-  }
+  let recentRecord
+  if (fingerprint !== '') {
+    const [oldest, newest] = fingerprint.split('|')
+    recentRecord = newest
 
-  const [oldest, newest] = fingerprint.split('|')
-  const error = await checkAuditRecordsIntegrity(oldest, newest).then(
-    noop,
-    error => {
-      if (missingAuditRecord.is(error) || alteredAuditRecord.is(error)) {
-        return {
-          nValid: error.data.nValid,
-          error,
+    const error = await checkAuditRecordsIntegrity(oldest, newest).then(
+      noop,
+      error => {
+        if (missingAuditRecord.is(error) || alteredAuditRecord.is(error)) {
+          return {
+            nValid: error.data.nValid,
+            error,
+          }
         }
+        throw error
       }
-      throw error
-    }
-  )
+    )
 
-  const shouldGenerateFingerprint = await openIntegrityFeedbackModal(error)
-  if (!shouldGenerateFingerprint) {
-    return
+    const shouldGenerateFingerprint = await openIntegrityFeedbackModal(error)
+    if (!shouldGenerateFingerprint) {
+      return
+    }
   }
 
-  await openGeneratedFingerprintModal(await generateAuditFingerprint(newest))
+  await openGeneratedFingerprintModal(
+    await generateAuditFingerprint(recentRecord)
+  )
 }
 
 const displayRecord = record =>


### PR DESCRIPTION
See #4798

**Integrity check process**:

Currently, if a user don't insert a fingerprint, a useless integrity check will be done and it will never fails.

This PR skip the useless step, if a user don't insert the fingerprint, he will be automatically redirected to the fingerprint generation modal.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
