### PR TITLE
fix(xo-server/self): always de-allocate resources in case of failure

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Self] When a Self Service related operation fails, always revert the quotas to what they were before the operation (PR [#4861](https://github.com/vatesfr/xen-orchestra/pull/4861))
+
 ### Released packages
 
 > Packages will be released in the order they are here, therefore, they should

--- a/packages/xo-server/src/api/disk.js
+++ b/packages/xo-server/src/api/disk.js
@@ -1,6 +1,7 @@
-import createLogger from '@xen-orchestra/log'
-import pump from 'pump'
 import convertVmdkToVhdStream from 'xo-vmdk-to-vhd'
+import createLogger from '@xen-orchestra/log'
+import defer from 'golike-defer'
+import pump from 'pump'
 import { format, JsonRpcError } from 'json-rpc-peer'
 import { noSuchObject } from 'xo-common/api-errors'
 import { peekFooterFromVhdStream } from 'vhd-lib'
@@ -11,7 +12,10 @@ const log = createLogger('xo:disk')
 
 // ===================================================================
 
-export async function create({ name, size, sr, vm, bootable, position, mode }) {
+export const create = defer(async function(
+  $defer,
+  { name, size, sr, vm, bootable, position, mode }
+) {
   const attach = vm !== undefined
 
   do {
@@ -22,6 +26,9 @@ export async function create({ name, size, sr, vm, bootable, position, mode }) {
           sr.id,
         ])
         await this.allocateLimitsInResourceSet({ disk: size }, resourceSet)
+        $defer.onFailure(() =>
+          this.releaseLimitsInResourceSet({ disk: size }, resourceSet)
+        )
 
         break
       } catch (error) {
@@ -54,7 +61,7 @@ export async function create({ name, size, sr, vm, bootable, position, mode }) {
   }
 
   return vdi.$id
-}
+})
 
 create.description = 'create a new disk on a SR'
 

--- a/packages/xo-server/src/api/disk.js
+++ b/packages/xo-server/src/api/disk.js
@@ -49,6 +49,7 @@ export const create = defer(async function(
     size,
     sr: sr._xapiId,
   })
+  $defer.onFailure(() => xapi.deleteVdi(vdi.$id))
 
   if (attach) {
     await xapi.createVbd({

--- a/packages/xo-server/src/api/vdi.js
+++ b/packages/xo-server/src/api/vdi.js
@@ -8,7 +8,7 @@ import { parseSize } from '../utils'
 
 // ====================================================================
 
-export const delete_ = defer(async function($defer, { vdi }) {
+export const delete_ = async function({ vdi }) {
   const resourceSet = reduce(
     vdi.$VBDs,
     (resourceSet, vbd) =>
@@ -16,15 +16,12 @@ export const delete_ = defer(async function($defer, { vdi }) {
     undefined
   )
 
+  await this.getXapi(vdi).deleteVdi(vdi._xapiId)
+
   if (resourceSet !== undefined) {
     await this.releaseLimitsInResourceSet({ disk: vdi.size }, resourceSet)
-    $defer.onFailure(() =>
-      this.allocateLimitsInResourceSet({ disl: vdi.size }, resourceSet)
-    )
   }
-
-  await this.getXapi(vdi).deleteVdi(vdi._xapiId)
-})
+}
 
 delete_.params = {
   id: { type: 'string' },

--- a/packages/xo-server/src/api/vdi.js
+++ b/packages/xo-server/src/api/vdi.js
@@ -8,7 +8,7 @@ import { parseSize } from '../utils'
 
 // ====================================================================
 
-export const delete_ = async function({ vdi }) {
+export async function delete_({ vdi }) {
   const resourceSet = reduce(
     vdi.$VBDs,
     (resourceSet, vbd) =>

--- a/packages/xo-server/src/api/vm.js
+++ b/packages/xo-server/src/api/vm.js
@@ -152,6 +152,8 @@ export const create = defer(async function($defer, params) {
   }
 
   const xapiVm = await xapi.createVm(template._xapiId, params, checkLimits)
+  $defer.onFailure(() => xapi.deleteVm(xapiVm.$id, true, true))
+
   const vm = xapi.xo.addObject(xapiVm)
 
   if (resourceSet) {

--- a/packages/xo-server/src/api/vm.js
+++ b/packages/xo-server/src/api/vm.js
@@ -696,9 +696,8 @@ export const clone = defer(async function(
   }
 
   if (vm.resourceSet !== undefined) {
-    const vmResourcesUsage = await this.computeVmResourcesUsage(vm)
     await this.allocateLimitsInResourceSet(
-      vmResourcesUsage,
+      await this.computeVmResourcesUsage(vm),
       vm.resourceSet,
       isAdmin
     )

--- a/packages/xo-server/src/xo-mixins/resource-sets.js
+++ b/packages/xo-server/src/xo-mixins/resource-sets.js
@@ -386,6 +386,9 @@ export default class {
         resourcesUsage,
         previousResourceSetId
       )
+      $defer.onFailure(() =>
+        this.allocateLimitsInResourceSet(resourcesUsage, previousResourceSetId)
+      )
     }
 
     await xapi.xo.setData(

--- a/packages/xo-server/src/xo-mixins/resource-sets.js
+++ b/packages/xo-server/src/xo-mixins/resource-sets.js
@@ -396,6 +396,13 @@ export default class {
       'resourceSet',
       resourceSetId === undefined ? null : resourceSetId
     )
+    $defer.onFailure(() =>
+      xapi.xo.setData(
+        vmId,
+        'resourceSet',
+        previousResourceSetId === undefined ? null : previousResourceSetId
+      )
+    )
 
     if (previousResourceSetId !== undefined) {
       await this._xo.removeAclsForObject(vmId)

--- a/packages/xo-server/src/xo-mixins/resource-sets.js
+++ b/packages/xo-server/src/xo-mixins/resource-sets.js
@@ -1,4 +1,5 @@
 import asyncMap from '@xen-orchestra/async-map'
+import deferrable from 'golike-defer'
 import synchronized from 'decorator-synchronized'
 import {
   every,
@@ -354,7 +355,8 @@ export default class {
     await Promise.all(mapToArray(sets, set => this._save(set)))
   }
 
-  async setVmResourceSet(vmId, resourceSetId) {
+  @deferrable
+  async setVmResourceSet($defer, vmId, resourceSetId) {
     const xapi = this._xo.getXapi(vmId)
     const previousResourceSetId = xapi.xo.getData(vmId, 'resourceSet')
 
@@ -371,6 +373,9 @@ export default class {
 
     if (resourceSetId != null) {
       await this.allocateLimitsInResourceSet(resourcesUsage, resourceSetId)
+      $defer.onFailure(() =>
+        this.releaseLimitsInResourceSet(resourcesUsage, resourceSetId)
+      )
     }
 
     if (


### PR DESCRIPTION
See xoa-support#2240

Whenever an operation allocates (resp. deallocates) some resources in a resource set, we need to make sure to deallocate (resp. re-allocate) them if the operation fails.

Concerned operations:
- `disk.create`
- `vdi.delete`
- `vdi.set({ size })`
- `vm.create`
- `vm.set`
- ~`vm.clone`~
- `setVmResourceSet`

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
