### PR TITLE
feat(xo-server/audit): add more data about open/close console event 

### DIFF
--- a/packages/xo-server/src/index.js
+++ b/packages/xo-server/src/index.js
@@ -619,7 +619,7 @@ const setUpConsoleProxy = (webServer, xo) => {
 
         const vm = xapi.getObject(id)
         if (vm.is_control_domain) {
-          const host = xapi.getObject(vm.resident_on)
+          const host = vm.$resident_on
           data.hostDescription = host.name_description
           data.hostName = host.name_label
           data.hostUuid = host.uuid

--- a/packages/xo-server/src/index.js
+++ b/packages/xo-server/src/index.js
@@ -596,6 +596,8 @@ const setUpConsoleProxy = (webServer, xo) => {
 
     const [, id] = matches
     try {
+      const vm = xo.getXapiObject(id, ['VM', 'VM-controller'])
+
       // TODO: factorize permissions checking in an Express middleware.
       {
         const { token } = parseCookies(req.headers.cookie)
@@ -615,7 +617,6 @@ const setUpConsoleProxy = (webServer, xo) => {
           userName: user.name,
         }
 
-        const vm = xo.getXapiObject(id, ['VM', 'VM-controller'])
         if (vm.is_control_domain) {
           const host = vm.$resident_on
           data.hostDescription = host.name_description
@@ -638,7 +639,7 @@ const setUpConsoleProxy = (webServer, xo) => {
         })
       }
 
-      const xapi = xo.getXapi(id, ['VM', 'VM-controller'])
+      const xapi = vm.$xapi
       const vmConsole = xapi.getVmConsole(id)
 
       // FIXME: lost connection due to VM restart is not detected.

--- a/packages/xo-server/src/index.js
+++ b/packages/xo-server/src/index.js
@@ -596,8 +596,6 @@ const setUpConsoleProxy = (webServer, xo) => {
 
     const [, id] = matches
     try {
-      const xapi = xo.getXapi(id, ['VM', 'VM-controller'])
-
       // TODO: factorize permissions checking in an Express middleware.
       {
         const { token } = parseCookies(req.headers.cookie)
@@ -617,7 +615,7 @@ const setUpConsoleProxy = (webServer, xo) => {
           userName: user.name,
         }
 
-        const vm = xapi.getObject(id)
+        const vm = xo.getXapiObject(id, ['VM', 'VM-controller'])
         if (vm.is_control_domain) {
           const host = vm.$resident_on
           data.hostDescription = host.name_description
@@ -640,6 +638,7 @@ const setUpConsoleProxy = (webServer, xo) => {
         })
       }
 
+      const xapi = xo.getXapi(id, ['VM', 'VM-controller'])
       const vmConsole = xapi.getVmConsole(id)
 
       // FIXME: lost connection due to VM restart is not detected.

--- a/packages/xo-server/src/xo-mixins/xen-servers.js
+++ b/packages/xo-server/src/xo-mixins/xen-servers.js
@@ -479,10 +479,8 @@ export default class {
 
   // returns the XAPI object corresponding to an XO object/ID
   getXapiObject(xoObjectOrId, type) {
-    if (typeof xoObjectOrId === 'string') {
-      xoObjectOrId = this._xo.getObject(xoObjectOrId, type)
-    }
-    return this.getXapi(xoObjectOrId).getObjectByRef(xoObjectOrId._xapiRef)
+    const xoObject = typeof xoObjectOrId === 'string' ? this._xo.getObject(xoObjectOrId, type) : xoObjectOrId
+    return this.getXapi(xoObject).getObjectByRef(xoObject._xapiRef)
   }
 
   _getXenServerStatus(id) {

--- a/packages/xo-server/src/xo-mixins/xen-servers.js
+++ b/packages/xo-server/src/xo-mixins/xen-servers.js
@@ -477,12 +477,14 @@ export default class {
     return this._xapis[this.getXenServerIdByObject(object)]
   }
 
-  // returns the XAPI object corresponding to an XO object
-  getXapiObject(xoObject, type) {
-    if (typeof xoObject === 'string') {
-      xoObject = this._xo.getObject(xoObject, type)
+  // returns the XAPI object corresponding to an XO object/ID
+  getXapiObject(xoObjectOrId, type) {
+    if (typeof xoObjectOrId === 'string') {
+      xoObjectOrId = this._xo.getObject(xoObjectOrId, type)
     }
-    return this.getXapi(xoObject, type).getObjectByRef(xoObject._xapiRef)
+    return this.getXapi(xoObjectOrId, type).getObjectByRef(
+      xoObjectOrId._xapiRef
+    )
   }
 
   _getXenServerStatus(id) {

--- a/packages/xo-server/src/xo-mixins/xen-servers.js
+++ b/packages/xo-server/src/xo-mixins/xen-servers.js
@@ -478,8 +478,11 @@ export default class {
   }
 
   // returns the XAPI object corresponding to an XO object
-  getXapiObject(xoObject) {
-    return this.getXapi(xoObject).getObjectByRef(xoObject._xapiRef)
+  getXapiObject(xoObject, type) {
+    if (typeof xoObject === 'string') {
+      xoObject = this._xo.getObject(xoObject, type)
+    }
+    return this.getXapi(xoObject, type).getObjectByRef(xoObject._xapiRef)
   }
 
   _getXenServerStatus(id) {

--- a/packages/xo-server/src/xo-mixins/xen-servers.js
+++ b/packages/xo-server/src/xo-mixins/xen-servers.js
@@ -482,9 +482,7 @@ export default class {
     if (typeof xoObjectOrId === 'string') {
       xoObjectOrId = this._xo.getObject(xoObjectOrId, type)
     }
-    return this.getXapi(xoObjectOrId, type).getObjectByRef(
-      xoObjectOrId._xapiRef
-    )
+    return this.getXapi(xoObjectOrId).getObjectByRef(xoObjectOrId._xapiRef)
   }
 
   _getXenServerStatus(id) {

--- a/packages/xo-server/src/xo-mixins/xen-servers.js
+++ b/packages/xo-server/src/xo-mixins/xen-servers.js
@@ -479,7 +479,10 @@ export default class {
 
   // returns the XAPI object corresponding to an XO object/ID
   getXapiObject(xoObjectOrId, type) {
-    const xoObject = typeof xoObjectOrId === 'string' ? this._xo.getObject(xoObjectOrId, type) : xoObjectOrId
+    const xoObject =
+      typeof xoObjectOrId === 'string'
+        ? this._xo.getObject(xoObjectOrId, type)
+        : xoObjectOrId
     return this.getXapi(xoObject).getObjectByRef(xoObject._xapiRef)
   }
 


### PR DESCRIPTION
See #4798

This PR add more information about the open/close of the VM/host console event. This information will help the user to identify which VM/host is linked to the event in case of their deletion.

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
