### PR TITLE
fix(xo-web/VM resource set): handle unknown resource set

### DIFF
--- a/packages/xo-web/src/xo-app/vm/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/vm/tab-advanced.js
@@ -160,19 +160,13 @@ class AffinityHost extends Component {
 @connectStore({
   isAdmin,
 })
-class ResourceSetItem extends Component {
+class ResourceSet extends Component {
   _getResourceSet = createSelector(
     () => this.props.resourceSets,
     () => this.props.vm.resourceSet,
     (resourceSets, resourceSetId) => {
-      let resourceSet
-      if (
-        (resourceSet = find(resourceSets, { id: resourceSetId })) === undefined
-      ) {
-        return
-      }
-
-      return Object.assign(resourceSet, { type: 'resourceSet' })
+      const resourceSet = find(resourceSets, { id: resourceSetId })
+      return resourceSet && Object.assign(resourceSet, { type: 'resourceSet' })
     }
   )
 
@@ -959,7 +953,7 @@ export default class TabAdvanced extends Component {
                 <tr>
                   <th>{_('resourceSet')}</th>
                   <td>
-                    <ResourceSetItem vm={vm} />
+                    <ResourceSet vm={vm} />
                   </td>
                 </tr>
                 {isAdmin && (

--- a/packages/xo-web/src/xo-app/vm/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/vm/tab-advanced.js
@@ -157,18 +157,69 @@ class AffinityHost extends Component {
 @addSubscriptions({
   resourceSets: subscribeResourceSets,
 })
+@connectStore({
+  isAdmin,
+})
 class ResourceSetItem extends Component {
   _getResourceSet = createSelector(
     () => this.props.resourceSets,
-    () => this.props.id,
-    (resourceSets, id) =>
-      Object.assign(find(resourceSets, { id }), { type: 'resourceSet' })
+    () => this.props.vm.resourceSet,
+    (resourceSets, resourceSetId) => {
+      let resourceSet
+      if (
+        (resourceSet = find(resourceSets, { id: resourceSetId })) === undefined
+      ) {
+        return
+      }
+
+      return Object.assign(resourceSet, { type: 'resourceSet' })
+    }
   )
 
   render() {
-    return this.props.resourceSets === undefined
-      ? null
-      : renderXoItem(this._getResourceSet())
+    const resourceSet = this._getResourceSet()
+    const { vm, isAdmin } = this.props
+
+    return isAdmin ? (
+      <div className='input-group'>
+        <SelectResourceSet
+          onChange={resourceSet =>
+            editVm(vm, {
+              resourceSet: resourceSet != null ? resourceSet.id : resourceSet,
+            })
+          }
+          value={vm.resourceSet}
+        />
+        {resourceSet !== undefined && (
+          <span className='input-group-btn'>
+            <ActionButton
+              btnStyle='primary'
+              handler={shareVmProxy}
+              handlerParam={vm}
+              icon='vm-share'
+              style={SHARE_BUTTON_STYLE}
+              tooltip={_('vmShareButton')}
+            />
+          </span>
+        )}
+      </div>
+    ) : vm.resourceSet === undefined ? (
+      _('resourceSetNone')
+    ) : resourceSet === undefined ? (
+      _('errorUnknownItem', { type: 'resource set' })
+    ) : (
+      <span>
+        {renderXoItem(resourceSet)}{' '}
+        <ActionButton
+          btnStyle='primary'
+          handler={shareVmProxy}
+          handlerParam={vm}
+          icon='vm-share'
+          size='small'
+          tooltip={_('vmShareButton')}
+        />
+      </span>
+    )
   }
 }
 
@@ -908,47 +959,7 @@ export default class TabAdvanced extends Component {
                 <tr>
                   <th>{_('resourceSet')}</th>
                   <td>
-                    {isAdmin ? (
-                      <div className='input-group'>
-                        <SelectResourceSet
-                          onChange={resourceSet =>
-                            editVm(vm, {
-                              resourceSet:
-                                resourceSet != null
-                                  ? resourceSet.id
-                                  : resourceSet,
-                            })
-                          }
-                          value={vm.resourceSet}
-                        />
-                        {vm.resourceSet !== undefined && (
-                          <span className='input-group-btn'>
-                            <ActionButton
-                              btnStyle='primary'
-                              handler={shareVmProxy}
-                              handlerParam={vm}
-                              icon='vm-share'
-                              style={SHARE_BUTTON_STYLE}
-                              tooltip={_('vmShareButton')}
-                            />
-                          </span>
-                        )}
-                      </div>
-                    ) : vm.resourceSet !== undefined ? (
-                      <span>
-                        <ResourceSetItem id={vm.resourceSet} />{' '}
-                        <ActionButton
-                          btnStyle='primary'
-                          handler={shareVmProxy}
-                          handlerParam={vm}
-                          icon='vm-share'
-                          size='small'
-                          tooltip={_('vmShareButton')}
-                        />
-                      </span>
-                    ) : (
-                      _('resourceSetNone')
-                    )}
+                    <ResourceSetItem vm={vm} />
                   </td>
                 </tr>
                 {isAdmin && (


### PR DESCRIPTION
In the VM's advanced tab, there was an "an error has occurred" whenever the user couldn't access the VM's resource set.

This should now properly handle the display/select/share button of the resource set for:
- an admin
- a normal user with ACLs
- a self user

when:
- the VM isn't bound to any resource set
- the VM is bound to a resource set but the user can't access it
- the VM is bound to a resource set and the user can access it

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
