### PR TITLE
feat(xo-server): allow creating plugged VIF and VBD for suspended VMs

### DIFF
--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1705,7 +1705,8 @@ export default class Xapi extends XapiBase {
 
   async createVbd({
     bootable = false,
-    device = undefined,
+    currently_attached = false,
+    device = '',
     other_config = {},
     qos_algorithm_params = {},
     qos_algorithm_type = '',
@@ -1751,6 +1752,8 @@ export default class Xapi extends XapiBase {
       'VBD.create',
       filterUndefineds({
         bootable: Boolean(bootable),
+        currently_attached:
+          vm.power_state === 'Suspended' ? currently_attached : undefined,
         device: vm.power_state === 'Suspended' ? device : undefined,
         empty: Boolean(empty),
         mode,
@@ -2102,6 +2105,8 @@ export default class Xapi extends XapiBase {
     const vifRef = await this.call(
       'VIF.create',
       filterUndefineds({
+        currently_attached:
+          vm.power_state === 'Suspended' ? currently_attached : undefined,
         device,
         ipv4_allowed,
         ipv6_allowed,

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1088,7 +1088,6 @@ export default class Xapi extends XapiBase {
         })
         $defer.onFailure(() => this._deleteVdi(newVdi.$ref))
       }
-
       await asyncMap(vbds[vdiRef], vbd =>
         this.createVbd({
           ...vbd,
@@ -1096,7 +1095,6 @@ export default class Xapi extends XapiBase {
           vm,
         })
       )
-
       return newVdi
     })::pAll()
 
@@ -1765,8 +1763,6 @@ export default class Xapi extends XapiBase {
     if (isVmRunning(vm)) {
       await this.callAsync('VBD.plug', vbdRef)
     }
-
-    return this.getRecord('VBD', vbdRef)
   }
 
   _cloneVdi(vdi) {

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1765,6 +1765,8 @@ export default class Xapi extends XapiBase {
     if (isVmRunning(vm)) {
       await this.callAsync('VBD.plug', vbdRef)
     }
+
+    return this.getObject(vbdRef)
   }
 
   _cloneVdi(vdi) {

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1088,6 +1088,7 @@ export default class Xapi extends XapiBase {
         })
         $defer.onFailure(() => this._deleteVdi(newVdi.$ref))
       }
+
       await asyncMap(vbds[vdiRef], vbd =>
         this.createVbd({
           ...vbd,
@@ -1095,6 +1096,7 @@ export default class Xapi extends XapiBase {
           vm,
         })
       )
+
       return newVdi
     })::pAll()
 

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1750,25 +1750,22 @@ export default class Xapi extends XapiBase {
     }
 
     // By default a VBD is unpluggable.
-    const vbdRef = await this.call(
-      'VBD.create',
-      filterUndefineds({
-        bootable: Boolean(bootable),
-        currently_attached:
-          vm.power_state === 'Suspended' ? currently_attached : undefined,
-        device: vm.power_state === 'Suspended' ? device : undefined,
-        empty: Boolean(empty),
-        mode,
-        other_config,
-        qos_algorithm_params,
-        qos_algorithm_type,
-        type,
-        unpluggable: Boolean(unpluggable),
-        userdevice,
-        VDI: vdi && vdi.$ref,
-        VM: vm.$ref,
-      })
-    )
+    const vbdRef = await this.call('VBD.create', {
+      bootable: Boolean(bootable),
+      currently_attached:
+        vm.power_state === 'Suspended' ? currently_attached : undefined,
+      device: vm.power_state === 'Suspended' ? device : undefined,
+      empty: Boolean(empty),
+      mode,
+      other_config,
+      qos_algorithm_params,
+      qos_algorithm_type,
+      type,
+      unpluggable: Boolean(unpluggable),
+      userdevice,
+      VDI: vdi && vdi.$ref,
+      VM: vm.$ref,
+    })
 
     if (isVmRunning(vm)) {
       await this.callAsync('VBD.plug', vbdRef)

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -28,6 +28,7 @@ import {
   flatMap,
   flatten,
   groupBy,
+  identity,
   includes,
   isEmpty,
   noop,
@@ -1749,12 +1750,13 @@ export default class Xapi extends XapiBase {
       }
     }
 
+    const ifVmSuspended = vm.power_state === 'Suspended' ? identity : noop
+
     // By default a VBD is unpluggable.
     const vbdRef = await this.call('VBD.create', {
       bootable: Boolean(bootable),
-      currently_attached:
-        vm.power_state === 'Suspended' ? currently_attached : undefined,
-      device: vm.power_state === 'Suspended' ? device : undefined,
+      currently_attached: ifVmSuspended(currently_attached),
+      device: ifVmSuspended(device),
       empty: Boolean(empty),
       mode,
       other_config,

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1766,7 +1766,7 @@ export default class Xapi extends XapiBase {
       await this.callAsync('VBD.plug', vbdRef)
     }
 
-    return this.getObject(vbdRef)
+    return this.getRecord('VBD', vbdRef)
   }
 
   _cloneVdi(vdi) {

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1705,6 +1705,7 @@ export default class Xapi extends XapiBase {
 
   async createVbd({
     bootable = false,
+    device = undefined,
     other_config = {},
     qos_algorithm_params = {},
     qos_algorithm_type = '',
@@ -1746,19 +1747,23 @@ export default class Xapi extends XapiBase {
     }
 
     // By default a VBD is unpluggable.
-    const vbdRef = await this.call('VBD.create', {
-      bootable: Boolean(bootable),
-      empty: Boolean(empty),
-      mode,
-      other_config,
-      qos_algorithm_params,
-      qos_algorithm_type,
-      type,
-      unpluggable: Boolean(unpluggable),
-      userdevice,
-      VDI: vdi && vdi.$ref,
-      VM: vm.$ref,
-    })
+    const vbdRef = await this.call(
+      'VBD.create',
+      filterUndefineds({
+        bootable: Boolean(bootable),
+        device: vm.power_state === 'Suspended' ? device : undefined,
+        empty: Boolean(empty),
+        mode,
+        other_config,
+        qos_algorithm_params,
+        qos_algorithm_type,
+        type,
+        unpluggable: Boolean(unpluggable),
+        userdevice,
+        VDI: vdi && vdi.$ref,
+        VM: vm.$ref,
+      })
+    )
 
     if (isVmRunning(vm)) {
       await this.callAsync('VBD.plug', vbdRef)

--- a/packages/xo-server/src/xapi/mixins/vm.js
+++ b/packages/xo-server/src/xapi/mixins/vm.js
@@ -502,7 +502,11 @@ export default {
 
   async resumeVm(vmId) {
     // the force parameter is always true
-    await this.callAsync('VM.resume', this.getObject(vmId).$ref, false, true)
+    const vm = this.getObject(vmId)
+    await this.call('VM.resume', vm.$ref, false, true)
+
+    vm.$VBDs.forEach(vbd => vbd.$call('plug'))
+    vm.$VIFs.forEach(vif => vif.$call('plug'))
   },
 
   async unpauseVm(vmId) {

--- a/packages/xo-server/src/xapi/mixins/vm.js
+++ b/packages/xo-server/src/xapi/mixins/vm.js
@@ -502,7 +502,7 @@ export default {
 
   async resumeVm(vmId) {
     // the force parameter is always true
-    await this.call('VM.resume', this.getObject(vmId).$ref, false, true)
+    await this.callAsync('VM.resume', this.getObject(vmId).$ref, false, true)
   },
 
   async unpauseVm(vmId) {

--- a/packages/xo-server/src/xapi/mixins/vm.js
+++ b/packages/xo-server/src/xapi/mixins/vm.js
@@ -502,11 +502,7 @@ export default {
 
   async resumeVm(vmId) {
     // the force parameter is always true
-    const vm = this.getObject(vmId)
-    await this.call('VM.resume', vm.$ref, false, true)
-
-    vm.$VBDs.forEach(vbd => vbd.$call('plug'))
-    vm.$VIFs.forEach(vif => vif.$call('plug'))
+    await this.call('VM.resume', this.getObject(vmId).$ref, false, true)
   },
 
   async unpauseVm(vmId) {


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] ~~PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)~~
- [ ] ~~if UI changes, a screenshot has been added to the PR~~
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] ~~unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))~~
  - [ ] ~~if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)~~
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
