### PR TITLE
chore(xo-web,xo-server): move "snapshot before" feature to the client

### DIFF
--- a/packages/xo-server/src/api/vm.js
+++ b/packages/xo-server/src/api/vm.js
@@ -1159,21 +1159,15 @@ resume.resolve = {
 
 // -------------------------------------------------------------------
 
-export async function revert({ snapshot, snapshotBefore }) {
-  const { id: userId, permission } = this.user
-  await this.checkPermissions(userId, [[snapshot.$snapshot_of, 'operate']])
-  const newSnapshot = await this.getXapi(snapshot).revertVm(
-    snapshot._xapiId,
-    snapshotBefore
-  )
-  if (snapshotBefore && permission !== 'admin') {
-    await this.addAcl(userId, newSnapshot.$id, 'admin')
-  }
+export async function revert({ snapshot }) {
+  await this.checkPermissions(this.user.id, [
+    [snapshot.$snapshot_of, 'operate'],
+  ])
+  await this.getXapi(snapshot).revertVm(snapshot._xapiId)
 }
 
 revert.params = {
   snapshot: { type: 'string' },
-  snapshotBefore: { type: 'boolean', optional: true },
 }
 
 revert.resolve = {

--- a/packages/xo-server/src/xapi/mixins/vm.js
+++ b/packages/xo-server/src/xapi/mixins/vm.js
@@ -480,12 +480,8 @@ export default {
     return /* await */ this._editVm(this.getObject(id), props, checkLimits)
   },
 
-  async revertVm(snapshotId, snapshotBefore = true) {
+  async revertVm(snapshotId) {
     const snapshot = this.getObject(snapshotId)
-    let newSnapshot
-    if (snapshotBefore) {
-      newSnapshot = await this._snapshotVm(snapshot.$snapshot_of)
-    }
     await this.callAsync('VM.revert', snapshot.$ref)
     if (snapshot.snapshot_info['power-state-at-snapshot'] === 'Running') {
       const vm = await this.barrier(snapshot.snapshot_of)
@@ -495,7 +491,6 @@ export default {
         this.resumeVm(vm.$id)::ignoreErrors()
       }
     }
-    return newSnapshot
   },
 
   async resumeVm(vmId) {

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -1439,16 +1439,13 @@ export const revertSnapshot = snapshot =>
   confirm({
     title: _('revertVmModalTitle'),
     body: <RevertSnapshotModalBody />,
-  }).then(
-    snapshotBefore =>
-      _call('vm.revert', {
-        snapshotBefore,
-        snapshot: resolveId(snapshot),
-      }).then(() =>
-        success(_('vmRevertSuccessfulTitle'), _('vmRevertSuccessfulMessage'))
-      ),
-    noop
-  )
+  }).then(async snapshotBefore => {
+    if (snapshotBefore) {
+      await _call('vm.snapshot', { id: snapshot.$snapshot_of })
+    }
+    await _call('vm.revert', { snapshot: snapshot.id })
+    success(_('vmRevertSuccessfulTitle'), _('vmRevertSuccessfulMessage'))
+  }, noop)
 
 export const editVm = (vm, props) =>
   _call('vm.set', { ...props, id: resolveId(vm) }).catch(err => {


### PR DESCRIPTION
From xo-server's API's point of view, it makes more sense for the "snapshot before" feature to be implemented in xo-web since snapshotting a VM is a whole independent process on its own that requires its own API permissions.

Making this change will be especially useful to not over-complicate the permissions checks for the incoming "Self Service snapshots" feature.

See #3693

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
