### PR TITLE
fix(xo-server/backup-ng): throw error if remote's proxy is different than backup's proxy

### DIFF
--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -619,20 +619,6 @@ export default class BackupNg {
         const jobId = job.id
 
         const remoteIds = unboxIdsFromPattern(job.remotes)
-
-        await Promise.all(
-          remoteIds.map(async id => {
-            const remote = await app.getRemote(id)
-            if (remote.proxy !== job.proxy) {
-              throw new Error(
-                job.proxy !== undefined
-                  ? `The remote ${remote.name} must be linked to the proxy ${job.proxy}`
-                  : `The remote ${remote.name} must not be linked to a proxy`
-              )
-            }
-          })
-        )
-
         const srIds = unboxIdsFromPattern(job.srs)
 
         if (job.proxy !== undefined) {
@@ -652,7 +638,14 @@ export default class BackupNg {
           const xapis = {}
           await waitAll([
             asyncMap(remoteIds, async id => {
-              remotes[id] = await app.getRemoteWithCredentials(id)
+              const remote = await app.getRemoteWithCredentials(id)
+              if (remote.proxy !== job.proxy) {
+                throw new Error(
+                  `The remote ${remote.name} must be linked to the proxy ${job.proxy}`
+                )
+              }
+
+              remotes[id] = remote
             }),
             asyncMap([...servers], async id => {
               const {
@@ -695,10 +688,19 @@ export default class BackupNg {
           }
         })
         const remotes = await Promise.all(
-          remoteIds.map(async id => ({
-            id,
-            handler: await app.getRemoteHandler(id),
-          }))
+          remoteIds.map(async id => {
+            const remote = await app.getRemote(id)
+            if (remote.proxy !== undefined) {
+              throw new Error(
+                `The remote ${remote.name} must not be linked to a proxy`
+              )
+            }
+
+            return {
+              id,
+              handler: await app.getRemoteHandler(id),
+            }
+          })
         )
 
         const settings = merge(job.settings, data?.settings)

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -619,6 +619,17 @@ export default class BackupNg {
         const jobId = job.id
 
         const remoteIds = unboxIdsFromPattern(job.remotes)
+        for (const id of remoteIds) {
+          const remote = await app.getRemote(id)
+          if (remote.proxy !== job.proxy) {
+            throw new Error(
+              job.proxy !== undefined
+                ? `The remote ${remote.name} should be linked to the proxy ${job.proxy}`
+                : `The remote ${remote.name} should not be linked to a proxy`
+            )
+          }
+        }
+
         const srIds = unboxIdsFromPattern(job.srs)
 
         if (job.proxy !== undefined) {

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -698,7 +698,7 @@ export default class BackupNg {
 
             return {
               id,
-              handler: await app.getRemoteHandler(id),
+              handler: await app.getRemoteHandler(remote),
             }
           })
         )

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -619,16 +619,19 @@ export default class BackupNg {
         const jobId = job.id
 
         const remoteIds = unboxIdsFromPattern(job.remotes)
-        for (const id of remoteIds) {
-          const remote = await app.getRemote(id)
-          if (remote.proxy !== job.proxy) {
-            throw new Error(
-              job.proxy !== undefined
-                ? `The remote ${remote.name} should be linked to the proxy ${job.proxy}`
-                : `The remote ${remote.name} should not be linked to a proxy`
-            )
-          }
-        }
+
+        await Promise.all(
+          remoteIds.map(async id => {
+            const remote = await app.getRemote(id)
+            if (remote.proxy !== job.proxy) {
+              throw new Error(
+                job.proxy !== undefined
+                  ? `The remote ${remote.name} must be linked to the proxy ${job.proxy}`
+                  : `The remote ${remote.name} must not be linked to a proxy`
+              )
+            }
+          })
+        )
 
         const srIds = unboxIdsFromPattern(job.srs)
 


### PR DESCRIPTION
See #4905

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
