### PR TITLE
fix(xo-web/utils/format*): never throw

### DIFF
--- a/packages/xo-web/src/common/utils.js
+++ b/packages/xo-web/src/common/utils.js
@@ -211,17 +211,29 @@ export const osFamily = invoke(
 
 // -------------------------------------------------------------------
 
+function safeHumanFormat(value, opts) {
+  try {
+    return humanFormat(value, opts)
+  } catch (error) {
+    console.error('humanFormat', value, opts, error)
+    return 'N/D'
+  }
+}
+
 export const formatSize = bytes =>
-  humanFormat(bytes, { scale: 'binary', unit: 'B' })
+  safeHumanFormat(bytes, { scale: 'binary', unit: 'B' })
 
 export const formatSizeShort = bytes =>
-  humanFormat(bytes, { scale: 'binary', unit: 'B', decimals: 0 })
+  safeHumanFormat(bytes, { scale: 'binary', unit: 'B', decimals: 0 })
 
 export const formatSizeRaw = bytes =>
   humanFormat.raw(bytes, { scale: 'binary', unit: 'B' })
 
 export const formatSpeed = (bytes, milliseconds) =>
-  humanFormat((bytes * 1e3) / milliseconds, { scale: 'binary', unit: 'B/s' })
+  safeHumanFormat((bytes * 1e3) / milliseconds, {
+    scale: 'binary',
+    unit: 'B/s',
+  })
 
 const timeScale = new humanFormat.Scale({
   ns: 1e-6,
@@ -234,7 +246,7 @@ const timeScale = new humanFormat.Scale({
   y: 2592000 * 1e3,
 })
 export const formatTime = milliseconds =>
-  humanFormat(milliseconds, { scale: timeScale, decimals: 0 })
+  safeHumanFormat(milliseconds, { scale: timeScale, decimals: 0 })
 
 export const parseSize = size => {
   let bytes = humanFormat.parse.raw(size, { scale: 'binary' })


### PR DESCRIPTION
These functions previously thew if the param was not a number.

This can breaks the UI, as a work-around, this change logs the error and returns a default value.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
