### PR TITLE
feat(xo-server/patches): debounce listMissingPatches for XS

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@
 
 - Fix TLS error (`unsupported protocol`) with XenServer <= 6.5 and Node >= 12 for backups, consoles, and statistics [#4906](https://github.com/vatesfr/xen-orchestra/issues/4906)
 - [Audit] Fix "EACCES" error in case of changing the user that run "xo-server" [#4854](https://github.com/vatesfr/xen-orchestra/issues/4854) (PR [#4897](https://github.com/vatesfr/xen-orchestra/pull/4897))
+- [Patches] Reduce the amount of error logs related to missing patches (PR [#4911](https://github.com/vatesfr/xen-orchestra/pull/4911))
 
 ### Released packages
 

--- a/packages/xo-server/src/xapi/mixins/patching.js
+++ b/packages/xo-server/src/xapi/mixins/patching.js
@@ -35,26 +35,20 @@ const log = createLogger('xo:xapi')
 
 const _isXcp = host => host.software_version.product_brand === 'XCP-ng'
 
-const XCP_NG_DEBOUNCE_TIME_MS = 60000
+const LISTING_DEBOUNCE_TIME_MS = 60000
 
-// list all yum updates available for a XCP-ng host
-// (hostObject) → { uuid: patchObject }
-async function _listXcpUpdates(host) {
-  return JSON.parse(
-    await this.call(
-      'host.call_plugin',
-      host.$ref,
-      'updater.py',
-      'check_update',
-      {}
-    )
-  )
+async function _listMissingPatches(hostId) {
+  const host = this.getObject(hostId)
+  return _isXcp(host)
+    ? this._listXcpUpdates(host)
+    : // TODO: list paid patches of free hosts as well so the UI can show them
+      this._listInstallablePatches(host)
 }
 
-const _listXcpUpdateDebounced = debounceWithKey(
-  _listXcpUpdates,
-  XCP_NG_DEBOUNCE_TIME_MS,
-  host => host.$ref
+const listMissingPatches = debounceWithKey(
+  _listMissingPatches,
+  LISTING_DEBOUNCE_TIME_MS,
+  hostId => hostId
 )
 
 // =============================================================================
@@ -163,8 +157,19 @@ export default {
 
   // LIST ----------------------------------------------------------------------
 
-  _listXcpUpdates,
-  _listXcpUpdateDebounced,
+  // list all yum updates available for a XCP-ng host
+  // (hostObject) → { uuid: patchObject }
+  async _listXcpUpdates(host) {
+    return JSON.parse(
+      await this.call(
+        'host.call_plugin',
+        host.$ref,
+        'updater.py',
+        'check_update',
+        {}
+      )
+    )
+  },
 
   // list all patches provided by Citrix for this host version regardless
   // of if they're installed or not
@@ -314,13 +319,7 @@ export default {
   },
 
   // high level
-  listMissingPatches(hostId) {
-    const host = this.getObject(hostId)
-    return _isXcp(host)
-      ? this._listXcpUpdateDebounced(host)
-      : // TODO: list paid patches of free hosts as well so the UI can show them
-        this._listInstallablePatches(host)
-  },
+  listMissingPatches,
 
   // convenient method to find which patches should be installed from a
   // list of patch names


### PR DESCRIPTION
Debounce the missing patches requests for XenServer hosts so that there aren't more than 1 request/min/host.

It was already done for XCP-ng (see #4477).

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
