### PR TITLE
feat(xo-server/proxies): unbind license on forgetting a proxy

### DIFF
--- a/packages/xo-server/src/xo-mixins/proxies.js
+++ b/packages/xo-server/src/xo-mixins/proxies.js
@@ -84,6 +84,8 @@ export default class Proxy {
   }
 
   async unregisterProxy(id) {
+    await this._db.remove(id)
+
     const { vmUuid } = await this._getProxy(id)
     if (vmUuid !== undefined) {
       this._app
@@ -93,8 +95,6 @@ export default class Proxy {
         })
         .catch(log.warn)
     }
-
-    return this._db.remove(id)
   }
 
   async destroyProxy(id) {

--- a/packages/xo-server/src/xo-mixins/proxies.js
+++ b/packages/xo-server/src/xo-mixins/proxies.js
@@ -83,7 +83,17 @@ export default class Proxy {
     return id
   }
 
-  unregisterProxy(id) {
+  async unregisterProxy(id) {
+    const { vmUuid } = await this._getProxy(id)
+    if (vmUuid !== undefined) {
+      this._app
+        .unbindLicense({
+          boundObjectId: vmUuid,
+          productId: this._xoProxyConf.licenseProductId,
+        })
+        .catch(log.warn)
+    }
+
     return this._db.remove(id)
   }
 

--- a/packages/xo-server/src/xo-mixins/proxies.js
+++ b/packages/xo-server/src/xo-mixins/proxies.js
@@ -89,6 +89,7 @@ export default class Proxy {
     await this._db.remove(id)
 
     if (vmUuid !== undefined) {
+      // waiting the unbind of the license in order to be available at the end of the method call
       await this._app
         .unbindLicense({
           boundObjectId: vmUuid,

--- a/packages/xo-server/src/xo-mixins/proxies.js
+++ b/packages/xo-server/src/xo-mixins/proxies.js
@@ -89,7 +89,7 @@ export default class Proxy {
     await this._db.remove(id)
 
     if (vmUuid !== undefined) {
-      this._app
+      await this._app
         .unbindLicense({
           boundObjectId: vmUuid,
           productId: this._xoProxyConf.licenseProductId,

--- a/packages/xo-server/src/xo-mixins/proxies.js
+++ b/packages/xo-server/src/xo-mixins/proxies.js
@@ -84,9 +84,10 @@ export default class Proxy {
   }
 
   async unregisterProxy(id) {
+    const { vmUuid } = await this._getProxy(id)
+
     await this._db.remove(id)
 
-    const { vmUuid } = await this._getProxy(id)
     if (vmUuid !== undefined) {
       this._app
         .unbindLicense({


### PR DESCRIPTION
See xoa#52

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
