### PR TITLE
fix(xo-web/xoa): always allow users to manage the XOA

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Backup] Fix TLS error (`unsupported protocol`) when XenServer <= 6.5 is used as target
+- [XOA] Allow to access the license page when a XOA trial has ended
 
 ### Released packages
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Backup] Fix TLS error (`unsupported protocol`) when XenServer <= 6.5 is used as target
-- [XOA] Allow to access the license page when a XOA trial has ended
+- [XOA] Allow to access the license page when a XOA trial has ended (PR [#4941](https://github.com/vatesfr/xen-orchestra/pull/4941))
 
 ### Released packages
 

--- a/packages/xo-web/src/xo-app/index.js
+++ b/packages/xo-web/src/xo-app/index.js
@@ -217,10 +217,11 @@ export default class XoApp extends Component {
 
   render() {
     const { signedUp, trial, registerNeeded } = this.props
+    // If we are under expired or unstable trial (signed up only)
     const blocked =
       signedUp &&
       blockXoaAccess(trial) &&
-      !this.context.router.location.pathname.startsWith('/xoa/') // If we are under expired or unstable trial (signed up only)
+      !this.context.router.location.pathname.startsWith('/xoa/')
     const plan = getXoaPlan()
 
     return (

--- a/packages/xo-web/src/xo-app/index.js
+++ b/packages/xo-web/src/xo-app/index.js
@@ -217,7 +217,10 @@ export default class XoApp extends Component {
 
   render() {
     const { signedUp, trial, registerNeeded } = this.props
-    const blocked = signedUp && blockXoaAccess(trial) // If we are under expired or unstable trial (signed up only)
+    const blocked =
+      signedUp &&
+      blockXoaAccess(trial) &&
+      !this.context.router.location.pathname.startsWith('/xoa/') // If we are under expired or unstable trial (signed up only)
     const plan = getXoaPlan()
 
     return (


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
