### PR TITLE
fix(xo-server/patching): filter out CH8x patches

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Backup] Fix TLS error (`unsupported protocol`) when XenServer <= 6.5 is used as target
+- [Patches] Hide patch `CH81` (upgrade patch) from the pool patches (PR [#4942](https://github.com/vatesfr/xen-orchestra/pull/4942))
 
 ### Released packages
 

--- a/packages/xo-server/src/xapi/mixins/patching.js
+++ b/packages/xo-server/src/xapi/mixins/patching.js
@@ -88,7 +88,7 @@ export default {
           patch => patch.requiredpatch.uuid
         ),
         paid: patch['update-stream'] === 'premium',
-        upgrade: /^XS\d{2,}$/.test(patch['name-label']),
+        upgrade: /^(XS|CH)\d{2,}$/.test(patch['name-label']),
         // TODO: what does it mean, should we handle it?
         // version: patch.version,
       }


### PR DESCRIPTION
We already filter out XSxx patches from normal patches (XSxxExxx) since they're
special patches that are meant to upgrade the host to the next version.
Since XenServer has been renamed Citrix Hypervisor, patches names now start
with the letters "CH" so we also need to filter out CHxx patches.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
