### PR TITLE
fix(xo-web/proxies): proxy VM should be in RO

### DIFF
--- a/packages/xo-web/src/xo-app/proxies/index.js
+++ b/packages/xo-web/src/xo-app/proxies/index.js
@@ -138,7 +138,7 @@ const COLUMNS = [
   {
     itemRenderer: proxy => <Vm id={proxy.vmUuid} link newTab />,
     name: _('vm'),
-    sortCriteria: 'vm',
+    sortCriteria: 'vmUuid',
   },
 ]
 

--- a/packages/xo-web/src/xo-app/proxies/index.js
+++ b/packages/xo-web/src/xo-app/proxies/index.js
@@ -9,7 +9,7 @@ import React from 'react'
 import SortedTable from 'sorted-table'
 import { adminOnly } from 'utils'
 import { provideState, injectState } from 'reaclette'
-import { Text, XoSelect } from 'editable'
+import { Text } from 'editable'
 import { Vm } from 'render-xo-item'
 import { withRouter } from 'react-router'
 import {
@@ -136,27 +136,7 @@ const COLUMNS = [
     sortCriteria: 'address',
   },
   {
-    itemRenderer: proxy => (
-      <XoSelect
-        onChange={value => _editProxy(value, { name: 'vm', proxy })}
-        value={proxy.vmUuid}
-        xoType='VM'
-      >
-        {proxy.vmUuid !== undefined ? (
-          <div>
-            <Vm id={proxy.vmUuid} />{' '}
-            <a
-              role='button'
-              onClick={() => _editProxy(null, { name: 'vm', proxy })}
-            >
-              <Icon icon='remove' />
-            </a>
-          </div>
-        ) : (
-          _('noValue')
-        )}
-      </XoSelect>
-    ),
+    itemRenderer: proxy => <Vm id={proxy.vmUuid} link newTab />,
     name: _('vm'),
     sortCriteria: 'vm',
   },

--- a/packages/xo-web/src/xo-app/proxies/index.js
+++ b/packages/xo-web/src/xo-app/proxies/index.js
@@ -138,7 +138,6 @@ const COLUMNS = [
   {
     itemRenderer: proxy => <Vm id={proxy.vmUuid} link newTab />,
     name: _('vm'),
-    sortCriteria: 'vmUuid',
   },
 ]
 


### PR DESCRIPTION
It doesn't make sense to let users link/unlink a `VM` to a proxy because it's out of the proxy workflow and each proxy needs the `XOA` token and a license which cannot be provided by the user.

This PR also prevents proxies to be without an `XOA` which is an incoherent state.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
