### PR TITLE
fix(xo-server/proxies): use configured address only when no associated VM

### DIFF
--- a/packages/xo-server/src/xo-mixins/proxies.js
+++ b/packages/xo-server/src/xo-mixins/proxies.js
@@ -352,7 +352,7 @@ export default class Proxy {
           proxy.authenticationToken
         ),
       },
-      hostname: ipAddress,
+      host: ipAddress,
       method: 'POST',
       pathname: '/api/v1',
       protocol: 'https:',

--- a/packages/xo-server/src/xo-mixins/proxies.js
+++ b/packages/xo-server/src/xo-mixins/proxies.js
@@ -337,9 +337,8 @@ export default class Proxy {
     }
 
     if (ipAddress === undefined) {
-      const error = new Error('cannot get the proxy VM IP')
-      error.vmUuid = proxy.vmUuid
-      error.address = proxy.address
+      const error = new Error('cannot get the proxy IP')
+      error.proxy = omit(proxy, 'authenticationToken')
       throw error
     }
 

--- a/packages/xo-server/src/xo-mixins/proxies.js
+++ b/packages/xo-server/src/xo-mixins/proxies.js
@@ -329,19 +329,15 @@ export default class Proxy {
 
   async callProxyMethod(id, method, params, expectStream = false) {
     const proxy = await this._getProxy(id)
-    if (proxy.address === undefined) {
-      if (proxy.vmUuid === undefined) {
-        throw new Error(
-          'proxy VM and proxy address should not be both undefined'
-        )
-      }
+    if (proxy.address === undefined && proxy.vmUuid === undefined) {
+      throw new Error('proxy VM and proxy address should not be both undefined')
+    }
 
+    if (proxy.vmUuid !== undefined) {
       const vm = this._app.getXapi(proxy.vmUuid).getObjectByUuid(proxy.vmUuid)
-      if (
-        (proxy.address = extractIpFromVmNetworks(
-          vm.$guest_metrics?.networks
-        )) === undefined
-      ) {
+      proxy.address =
+        extractIpFromVmNetworks(vm.$guest_metrics?.networks) ?? proxy.address
+      if (proxy.address === undefined) {
         throw new Error(`cannot get the proxy VM IP (${proxy.vmUuid})`)
       }
     }

--- a/packages/xo-server/src/xo-mixins/proxies.js
+++ b/packages/xo-server/src/xo-mixins/proxies.js
@@ -330,10 +330,12 @@ export default class Proxy {
   async callProxyMethod(id, method, params, expectStream = false) {
     const proxy = await this._getProxy(id)
 
-    let ipAddress = proxy.address
+    let ipAddress
     if (proxy.vmUuid !== undefined) {
       const vm = this._app.getXapi(proxy.vmUuid).getObjectByUuid(proxy.vmUuid)
       ipAddress = extractIpFromVmNetworks(vm.$guest_metrics?.networks)
+    } else {
+      ipAddress = proxy.address
     }
 
     if (ipAddress === undefined) {


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
