### PR TITLE
chore(xo-web/xosan): prevent installing XOSAN on XCP-ng pools

### DIFF
--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2173,6 +2173,8 @@ const messages = {
   xosanState_configuringGluster: 'Configuring gluster…',
   xosanState_creatingSr: 'Creating SR…',
   xosanState_scanningSr: 'Scanning SR…',
+  xosanXcpngWarning:
+    'XOSAN cannot be installed on XCP-ng yet. Incoming XOSANv2 will be compatible with XCP-ng: {link}.',
   // Pack download modal
   xosanInstallCloudPlugin: 'Install XOA plugin first',
   xosanLoadCloudPlugin: 'Load XOA plugin first',

--- a/packages/xo-web/src/xo-app/xosan/index.js
+++ b/packages/xo-web/src/xo-app/xosan/index.js
@@ -279,8 +279,8 @@ const XOSAN_INDIVIDUAL_ACTIONS = [
     getXosanSrs,
     getHosts,
     (srs, hosts) => pool =>
-      every(srs, sr => sr.$pool !== pool.id) &&
-      hosts[pool.master].productBrand !== 'XCP-ng'
+      hosts[pool.master].productBrand !== 'XCP-ng' &&
+      every(srs, sr => sr.$pool !== pool.id)
   )
 
   return {

--- a/packages/xo-web/src/xo-app/xosan/index.js
+++ b/packages/xo-web/src/xo-app/xosan/index.js
@@ -275,8 +275,12 @@ const XOSAN_INDIVIDUAL_ACTIONS = [
     }
   )
 
-  const getPoolPredicate = createSelector(getXosanSrs, srs => pool =>
-    every(srs, sr => sr.$pool !== pool.id)
+  const getPoolPredicate = createSelector(
+    getXosanSrs,
+    getHosts,
+    (srs, hosts) => pool =>
+      every(srs, sr => sr.$pool !== pool.id) &&
+      hosts[pool.master].productBrand !== 'XCP-ng'
   )
 
   return {

--- a/packages/xo-web/src/xo-app/xosan/new-xosan.js
+++ b/packages/xo-web/src/xo-app/xosan/new-xosan.js
@@ -111,6 +111,11 @@ export default class NewXosan extends Component {
     suggestion: 0,
   }
 
+  _hasXcpng = createSelector(
+    () => this.props.hosts,
+    hosts => Object.values(hosts).some(host => host.productBrand === 'XCP-ng')
+  )
+
   _checkPacks = pool =>
     getResourceCatalog().then(
       catalog => {
@@ -347,6 +352,24 @@ export default class NewXosan extends Component {
 
     return (
       <Container>
+        {this._hasXcpng() && (
+          <Row className='mb-1'>
+            <span className='text-muted'>
+              <Icon icon='info' />{' '}
+              {_('xosanXcpngWarning', {
+                link: (
+                  <a
+                    href='https://xcp-ng.org/docs/storage.html#xosanv2'
+                    rel='noopener noreferrer'
+                    target='_blank'
+                  >
+                    https://xcp-ng.org/docs/storage.html
+                  </a>
+                ),
+              })}
+            </span>
+          </Row>
+        )}
         <Row className='mb-1'>
           <Col size={4}>
             <SelectPool


### PR DESCRIPTION
Due to conflicts between XOSAN pack RPMs and XCP-ng updates RPMs (yum update),
installing XOSAN on XCP-ng is temporarily disabled

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
