### PR TITLE
fix(docs/from sources): require Node 12

### DIFF
--- a/docs/from_the_sources.md
+++ b/docs/from_the_sources.md
@@ -14,13 +14,13 @@ As you may have seen in other parts of the documentation, XO is composed of two 
 
 ### NodeJS
 
-XO needs Node.js. **Please use Node LTS**.
+XO needs Node.js. **Please use Node LTS version 12**.
 
 We'll consider at this point that you've got a working node on your box. E.g:
 
 ```
 $ node -v
-v12.16.1
+v12.16.3
 ```
 
 If not, see [this page](https://nodejs.org/en/download/package-manager/) for instructions on how to install Node.


### PR DESCRIPTION
According to my testing (#4964) it appears that running Node.js version 10 isn't a good idea.

So update the docs to specify which LTS version should be used, since at this time, Node.js 10 can still be described as an LTS version (according to https://nodejs.org/en/about/releases/)

(redux of #4966)