### PR TITLE
feat(xo-server#_listVmBackupsOnRemote): only send used properties

### DIFF
--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -993,25 +993,30 @@ export default class BackupNg {
             return
           }
 
-          // inject an id usable by importVmBackupNg()
-          backups.forEach(backup => {
-            backup.id = `${remoteId}/${backup._filename}`
-
-            const { vdis, vhds } = backup
-            backup.disks =
-              vhds === undefined
+          backupsByVm[vmUuid] = backups.map(backup => ({
+            disks:
+              backup.vhds === undefined
                 ? []
-                : Object.keys(vhds).map(vdiId => {
-                    const vdi = vdis[vdiId]
+                : Object.keys(backup.vhds).map(vdiId => {
+                    const vdi = backup.vdis[vdiId]
                     return {
-                      id: `${dirname(backup._filename)}/${vhds[vdiId]}`,
+                      id: `${dirname(backup._filename)}/${backup.vhds[vdiId]}`,
                       name: vdi.name_label,
                       uuid: vdi.uuid,
                     }
-                  })
-          })
+                  }),
 
-          backupsByVm[vmUuid] = backups
+            // inject an id usable by importVmBackupNg()
+            id: `${remoteId}/${backup._filename}`,
+            jobId: backup.jobId,
+            mode: backup.mode,
+            size: backup.size,
+            timestamp: backup.timestamp,
+            vm: {
+              name_description: backup.vm.name_description,
+              name_label: backup.vm.name_label,
+            },
+          }))
         })
       )
     } catch (error) {


### PR DESCRIPTION
This PR removes unused properties from the backups in order to improve backup listing performance.

**Used properties:**
- disks
- id
- jobId
- mode
- size
- timestamp
- vm.name_description
- vm.name_label

**Unused properties**:
- scheduleId
- vbds
- vdis
- version
- vifs
- vhds
- other vm properties
- vmSnapshot

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
