### PR TITLE
fix(sdn-controller): Recreate both sides of tunnels when host updated…

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@
 
 - Fix mounting of NFS remote in FreeBSD (PR [#4988](https://github.com/vatesfr/xen-orchestra/issues/4988))
 - [Remotes] Fix "remote is disabled" error on getting the remotes info (commit [eb2f429964d7adc264bf678c37e49a856454388e](https://github.com/vatesfr/xen-orchestra/commit/eb2f429964d7adc264bf678c37e49a856454388e))
-- [SDN Controller] Fix encrypted tunnels recreation [#4996](https://github.com/vatesfr/xen-orchestra/pull/4996)
+- [SDN Controller] Broken encrypted tunnels after host reboot [#4996](https://github.com/vatesfr/xen-orchestra/pull/4996)
 
 ### Released packages
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 
 - Fix mounting of NFS remote in FreeBSD (PR [#4988](https://github.com/vatesfr/xen-orchestra/issues/4988))
 - [Remotes] Fix "remote is disabled" error on getting the remotes info (commit [eb2f429964d7adc264bf678c37e49a856454388e](https://github.com/vatesfr/xen-orchestra/commit/eb2f429964d7adc264bf678c37e49a856454388e))
+- [SDN Controller] Fix encrypted tunnels recreation [#4996](https://github.com/vatesfr/xen-orchestra/pull/4996)
 
 ### Released packages
 
@@ -35,6 +36,7 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
+- xo-server-sdn-controller patch
 - @xen-orchestra/fs patch
 - xo-server patch
 - xo-web minor

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -312,7 +312,7 @@ class SDNController extends EventEmitter {
     this._getDataDir = getDataDir
 
     this._newHosts = []
-    this._privateNetworks = {}
+    this.privateNetworks = {}
 
     this._networks = new Map()
     this._starCenters = new Map()
@@ -366,7 +366,7 @@ class SDNController extends EventEmitter {
     })
     const updatedPools = []
     await Promise.all(
-      map(this._privateNetworks, async privateNetworks => {
+      map(this.privateNetworks, async privateNetworks => {
         await Promise.all(
           privateNetworks.getPools().map(async pool => {
             if (!updatedPools.includes(pool)) {
@@ -436,7 +436,7 @@ class SDNController extends EventEmitter {
   }
 
   async unload() {
-    this._privateNetworks = {}
+    this.privateNetworks = {}
     this._newHosts = []
 
     this._networks.clear()
@@ -491,11 +491,10 @@ class SDNController extends EventEmitter {
             return
           }
 
-          let privateNetwork = this._privateNetworks[uuid]
-          if (privateNetwork === undefined) {
-            privateNetwork = new PrivateNetwork(this, uuid)
-            this._privateNetworks[uuid] = privateNetwork
-          }
+          const privateNetwork =
+            this.privateNetworks[uuid] !== undefined
+              ? this.privateNetworks[uuid]
+              : new PrivateNetwork(this, uuid)
 
           const vni = otherConfig['xo:sdn-controller:vni']
           if (vni === undefined) {
@@ -563,7 +562,7 @@ class SDNController extends EventEmitter {
           )
 
           // Re-elect a center to apply the VNI
-          const privateNetwork = this._privateNetworks[
+          const privateNetwork = this.privateNetworks[
             network.other_config['xo:sdn-controller:private-network-uuid']
           ]
           await this._electNewCenter(privateNetwork)
@@ -580,7 +579,7 @@ class SDNController extends EventEmitter {
   _handleDisconnectedXapi(xapi) {
     log.debug('xapi disconnected', { id: xapi.pool.uuid })
     try {
-      forOwn(this._privateNetworks, privateNetwork => {
+      forOwn(this.privateNetworks, privateNetwork => {
         privateNetwork.networks = omitBy(
           privateNetwork.networks,
           network => network.$pool.uuid === xapi.pool.uuid
@@ -591,8 +590,8 @@ class SDNController extends EventEmitter {
         }
       })
 
-      this._privateNetworks = filter(
-        this._privateNetworks,
+      this.privateNetworks = filter(
+        this.privateNetworks,
         privateNetwork => Object.keys(privateNetwork.networks).length !== 0
       )
     } catch (error) {
@@ -745,7 +744,7 @@ class SDNController extends EventEmitter {
         if (starCenterRef !== undefined) {
           this._starCenters.delete(id)
           const privateNetworks = filter(
-            this._privateNetworks,
+            this.privateNetworks,
             privateNetwork => privateNetwork.center?.$ref === starCenterRef
           )
           for (const privateNetwork of privateNetworks) {
@@ -754,19 +753,19 @@ class SDNController extends EventEmitter {
           return
         }
 
-        // If a network is removed, clean this._privateNetworks from it
+        // If a network is removed, clean this.privateNetworks from it
         const networkRef = this._networks.get(id)
         if (networkRef !== undefined) {
           this._networks.delete(id)
-          forOwn(this._privateNetworks, privateNetwork => {
+          forOwn(this.privateNetworks, privateNetwork => {
             privateNetwork.networks = omitBy(
               privateNetwork.networks,
               network => network.$ref === networkRef
             )
           })
 
-          this._privateNetworks = filter(
-            this._privateNetworks,
+          this.privateNetworks = filter(
+            this.privateNetworks,
             privateNetwork => Object.keys(privateNetwork.networks).length !== 0
           )
         }
@@ -782,7 +781,7 @@ class SDNController extends EventEmitter {
   async _pifUpdated(pif) {
     // Only if PIF is in a private network
     const privateNetwork = find(
-      this._privateNetworks,
+      this.privateNetworks,
       privateNetwork =>
         privateNetwork.networks[pif.$pool.uuid]?.$ref === pif.network
     )
@@ -856,7 +855,7 @@ class SDNController extends EventEmitter {
     }
 
     const privateNetworks = filter(
-      this._privateNetworks,
+      this.privateNetworks,
       privateNetwork => privateNetwork[host.$pool.uuid] !== undefined
     )
     for (const privateNetwork of privateNetworks) {
@@ -888,23 +887,23 @@ class SDNController extends EventEmitter {
   // ---------------------------------------------------------------------------
 
   async _setPoolControllerIfNeeded(pool) {
-    if (!isControllerNeeded(pool.$xapi)) {
-      // Nothing to do
-      return
-    }
+    if (isControllerNeeded(pool.$xapi)) {
+      const controller = find(pool.$xapi.objects.all, {
+        $type: 'SDN_controller',
+      })
+      if (controller !== undefined) {
+        await pool.$xapi.call('SDN_controller.forget', controller.$ref)
+        log.debug('Old SDN controller removed', {
+          pool: pool.name_label,
+        })
+      }
 
-    const controller = find(pool.$xapi.objects.all, { $type: 'SDN_controller' })
-    if (controller !== undefined) {
-      await pool.$xapi.call('SDN_controller.forget', controller.$ref)
-      log.debug('Old SDN controller removed', {
+      await pool.$xapi.call('SDN_controller.introduce', PROTOCOL)
+      log.debug('SDN controller has been set', {
         pool: pool.name_label,
       })
     }
 
-    await pool.$xapi.call('SDN_controller.introduce', PROTOCOL)
-    log.debug('SDN controller has been set', {
-      pool: pool.name_label,
-    })
     this._cleaners.push(await this._manageXapi(pool.$xapi))
   }
 
@@ -965,7 +964,7 @@ class SDNController extends EventEmitter {
     }
 
     const privateNetwork = find(
-      this._privateNetworks,
+      this.privateNetworks,
       privateNetwork =>
         privateNetwork.networks[host.$pool.uuid]?.$ref === network.$ref
     )
@@ -1041,7 +1040,7 @@ class SDNController extends EventEmitter {
   }
 
   async _hostUnreachable(host) {
-    let privateNetworks = filter(this._privateNetworks, privateNetwork => {
+    let privateNetworks = filter(this.privateNetworks, privateNetwork => {
       return privateNetwork.center.$ref === host.$ref
     })
     for (const privateNetwork of privateNetworks) {
@@ -1055,7 +1054,7 @@ class SDNController extends EventEmitter {
     }
 
     privateNetworks = filter(
-      this._privateNetworks,
+      this.privateNetworks,
       privateNetwork => privateNetwork[host.$pool.uuid] !== undefined
     )
     await Promise.all(

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -450,6 +450,15 @@ class SDNController extends EventEmitter {
     this._unsetApiMethods()
   }
 
+  // ---------------------------------------------------------------------------
+
+  registerPrivateNetwork(privateNetwork) {
+    this.privateNetworks[privateNetwork.uuid] = privateNetwork
+    log.info('Private network registered', {
+      privateNetwork: privateNetwork.uuid,
+    })
+  }
+
   // ===========================================================================
 
   async _handleConnectedXapi(xapi) {

--- a/packages/xo-server-sdn-controller/src/private-network/private-network.js
+++ b/packages/xo-server-sdn-controller/src/private-network/private-network.js
@@ -19,7 +19,7 @@ export class PrivateNetwork {
     this.uuid = uuid
     this.networks = {}
 
-    this.controller.privateNetworks[this.uuid] = this
+    this.controller.registerPrivateNetwork(this)
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/xo-server-sdn-controller/src/private-network/private-network.js
+++ b/packages/xo-server-sdn-controller/src/private-network/private-network.js
@@ -18,6 +18,8 @@ export class PrivateNetwork {
     this.controller = controller
     this.uuid = uuid
     this.networks = {}
+
+    this.controller.privateNetworks[this.uuid] = this
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
… to keep password synced

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [x] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
