### PR TITLE
fix(xo-server-backup-reports): fix `No recipients defined` error

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@
 - Fix default filters not being set in all tables (PR [#4994](https://github.com/vatesfr/xen-orchestra/pull/4994))
 - [SDN Controller] Broken encrypted tunnels after host reboot [#4996](https://github.com/vatesfr/xen-orchestra/pull/4996)
 - Don't log server's credentials in case of `SESSION_AUTHENTICATION_FAILED` error (PR [#4995](https://github.com/vatesfr/xen-orchestra/pull/4995))
+- [Plugin/backup-reports] Fix `No recipients defined` error (PR [#4998](https://github.com/vatesfr/xen-orchestra/pull/4998))
 
 ### Released packages
 
@@ -41,6 +42,7 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
+- xo-server-backup-reports patch
 - xen-api patch
 - xo-server-auth-ldap minor
 - xo-server-sdn-controller patch

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,7 +23,7 @@
 - Fix default filters not being set in all tables (PR [#4994](https://github.com/vatesfr/xen-orchestra/pull/4994))
 - [SDN Controller] Broken encrypted tunnels after host reboot [#4996](https://github.com/vatesfr/xen-orchestra/pull/4996)
 - Don't log server's credentials in case of `SESSION_AUTHENTICATION_FAILED` error (PR [#4995](https://github.com/vatesfr/xen-orchestra/pull/4995))
-- [Plugin/backup-reports] Fix `No recipients defined` error (PR [#4998](https://github.com/vatesfr/xen-orchestra/pull/4998))
+- [Plugin/backup-reports] Fix `No recipients defined` error when recipients defined at plugin level (PR [#4998](https://github.com/vatesfr/xen-orchestra/pull/4998))
 
 ### Released packages
 

--- a/packages/xo-server-backup-reports/src/index.js
+++ b/packages/xo-server-backup-reports/src/index.js
@@ -668,12 +668,16 @@ class BackupReportsXoPlugin {
   }
 
   _sendReport({
-    mailReceivers = this._mailsReceivers,
+    mailReceivers = [],
     markdown,
     nagiosMarkdown,
     subject,
     success,
   }) {
+    if (mailReceivers.length === 0) {
+      mailReceivers = this._mailsReceivers
+    }
+
     const xo = this._xo
     return Promise.all([
       xo.sendEmail !== undefined &&

--- a/packages/xo-server-backup-reports/src/index.js
+++ b/packages/xo-server-backup-reports/src/index.js
@@ -667,14 +667,8 @@ class BackupReportsXoPlugin {
     })
   }
 
-  _sendReport({
-    mailReceivers = [],
-    markdown,
-    nagiosMarkdown,
-    subject,
-    success,
-  }) {
-    if (mailReceivers.length === 0) {
+  _sendReport({ mailReceivers, markdown, nagiosMarkdown, subject, success }) {
+    if (mailReceivers === undefined || mailReceivers.length === 0) {
       mailReceivers = this._mailsReceivers
     }
 


### PR DESCRIPTION
Report not sent when the backup's settings have an empty report recipient 

See xoa-support#2465

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
