### PR TITLE
fix(xo-server-perf-alert): make message compatible with XenCenter

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@
 - [Remotes] Fix "remote is disabled" error on getting the remotes info (commit [eb2f429964d7adc264bf678c37e49a856454388e](https://github.com/vatesfr/xen-orchestra/commit/eb2f429964d7adc264bf678c37e49a856454388e))
 - Fix default filters not being set in all tables (PR [#4994](https://github.com/vatesfr/xen-orchestra/pull/4994))
 - [SDN Controller] Broken encrypted tunnels after host reboot [#4996](https://github.com/vatesfr/xen-orchestra/pull/4996)
+- [Plugin/perf-alert] Fix compatibility of the alert messages with XenCenter (PR [#5004](https://github.com/vatesfr/xen-orchestra/pull/5004))
 
 ### Released packages
 
@@ -40,6 +41,7 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
+- xo-server-perf-alert patch
 - xo-server-auth-ldap minor
 - xo-server-sdn-controller patch
 - xo-server-usage-report minor

--- a/packages/xo-server-perf-alert/src/index.js
+++ b/packages/xo-server-perf-alert/src/index.js
@@ -3,6 +3,12 @@ import { createSchedule } from '@xen-orchestra/cron'
 import { forOwn, map, mean } from 'lodash'
 import { utcParse } from 'd3-time-format'
 
+const XAPI_TO_XENCENTER = {
+  cpuUsage: 'cpu_usage',
+  memoryUsage: 'mem_usage',
+  storageUsage: 'physical_utilisation',
+}
+
 const COMPARATOR_FN = {
   '>': (a, b) => a > b,
   '<': (a, b) => a < b,
@@ -33,6 +39,7 @@ const VM_FUNCTIONS = {
         getDisplayableValue,
         shouldAlarm: () =>
           COMPARATOR_FN[comparator](getDisplayableValue(), threshold),
+        threshold,
       }
     },
   },
@@ -58,6 +65,7 @@ const VM_FUNCTIONS = {
         getDisplayableValue,
         shouldAlarm: () =>
           COMPARATOR_FN[comparator](getDisplayableValue(), threshold),
+        threshold,
       }
     },
   },
@@ -88,6 +96,7 @@ const HOST_FUNCTIONS = {
         getDisplayableValue,
         shouldAlarm: () =>
           COMPARATOR_FN[comparator](getDisplayableValue(), threshold),
+        threshold,
       }
     },
   },
@@ -113,6 +122,7 @@ const HOST_FUNCTIONS = {
         getDisplayableValue,
         shouldAlarm: () =>
           COMPARATOR_FN[comparator](getDisplayableValue(), threshold),
+        threshold,
       }
     },
   },
@@ -131,6 +141,7 @@ const SR_FUNCTIONS = {
         getDisplayableValue,
         shouldAlarm: () =>
           COMPARATOR_FN[comparator](getDisplayableValue(), threshold),
+        threshold,
       }
     },
   },
@@ -487,6 +498,8 @@ ${monitorBodies.join('\n')}`
                     data,
                     value: data.getDisplayableValue(),
                     shouldAlarm: data.shouldAlarm(),
+                    threshold: data.threshold,
+                    observationPeriod,
                   })
                 }
               } else {
@@ -499,6 +512,8 @@ ${monitorBodies.join('\n')}`
                 Object.assign(result, {
                   value: data.getDisplayableValue(),
                   shouldAlarm: data.shouldAlarm(),
+                  threshold: data.threshold,
+                  observationPeriod,
                 })
               }
 
@@ -596,23 +611,23 @@ ${entry.listItem}`
           continue
         }
 
-        const raiseAlarm = alarmId => {
-          // sample XenCenter message:
-          // value: 1.242087 config: <variable> <name value="mem_usage"/> </variable>
-          this._xo
-            .getXapi(entry.object.uuid)
-            .call(
-              'message.create',
-              'ALARM',
-              3,
-              entry.object.$type,
-              entry.object.uuid,
-              `value: ${entry.value.toFixed(
-                1
-              )} config: <variable> <name value="${
-                monitor.variableName
-              }"/> </variable>`
-            )
+        const raiseAlarm = _alarmId => {
+          // sample XenCenter message (linebreaks are meaningful):
+          // value: 1.242087\n config: <variable>\n <name value="mem_usage"/>\n<alarm_trigger_level value="0.5"/>\n <alarm_trigger_period value ="60"/>\n</variable>
+          this._xo.getXapi(entry.object.uuid).call(
+            'message.create',
+            'ALARM',
+            3,
+            entry.object.$type,
+            entry.object.uuid,
+            `value: ${(entry.value / 100).toFixed(1)}
+config:
+<variable>
+<name value="${XAPI_TO_XENCENTER[monitor.variableName]}"/>
+<alarm_trigger_level value="${entry.threshold / 100}"/>
+<alarm_trigger_period value ="${entry.observationPeriod}"/>
+</variable>`
+          )
           this._sendAlertEmail(
             '',
             `
@@ -623,7 +638,7 @@ ${entry.listItem}
           )
         }
 
-        const lowerAlarm = alarmId => {
+        const lowerAlarm = _alarmId => {
           this._sendAlertEmail(
             'END OF ALERT',
             `


### PR DESCRIPTION
See xoa-support#2440

The messages generated by the plugin where not even close to being compatible with XenCenter. This is fixed now.
![fixed messages](https://user-images.githubusercontent.com/46941/82157764-b7340980-9883-11ea-8c04-2d775b0213ed.png)



### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
