### PR TITLE
fix(xo-web/modal#form): deffer rendering until all props are set

### DIFF
--- a/packages/xo-web/src/common/modal.js
+++ b/packages/xo-web/src/common/modal.js
@@ -299,13 +299,15 @@ export const form = ({
     formModalState.component = component
     formModalState.handler = handler
     formModalState.header = header
-    formModalState.opened = true
     formModalState.reject = reject
     formModalState.render = render
     formModalState.resolve = resolve
     formModalState.size = size
     formModalState.value = defaultValue
     disableShortcuts()
+
+    // the modal should be opened after the set of its props to avoid race conditions
+    formModalState.opened = true
   })
 
 const getInitialState = () => ({

--- a/packages/xo-web/src/common/modal.js
+++ b/packages/xo-web/src/common/modal.js
@@ -306,7 +306,7 @@ export const form = ({
     formModalState.value = defaultValue
     disableShortcuts()
 
-    // the modal should be opened after the set of its props to avoid race conditions
+    // the modal should be opened after its props have been set to avoid race conditions
     formModalState.opened = true
   })
 


### PR DESCRIPTION
The set default value is not used in the first render due to a race condition between the modal render and the modal value. 

To avoid this race condition and multiple renders, the modal should open at the end of the set of its properties.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
