### PR TITLE
fix(auth-ldap/authenticate): dont use second param as logger

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [auth-ldap] This plugin has been broken in XO 5.47.0 (PR [#5039](https://github.com/vatesfr/xen-orchestra/pull/5039))
+- [auth-ldap] Sign in was broken in XO 5.47.0 (PR [#5039](https://github.com/vatesfr/xen-orchestra/pull/5039))
 
 ### Released packages
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [auth-ldap] This plugin has been broken in XO 5.47.0 (PR [#5039](https://github.com/vatesfr/xen-orchestra/pull/5039))
+
 ### Released packages
 
 > Packages will be released in the order they are here, therefore, they should
@@ -27,3 +29,5 @@
 > - major: if the change breaks compatibility
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
+
+- xo-server-auth-ldap minor

--- a/packages/xo-server-auth-ldap/src/index.js
+++ b/packages/xo-server-auth-ldap/src/index.js
@@ -128,7 +128,8 @@ export const testSchema = {
 // ===================================================================
 
 class AuthLdap {
-  constructor(xo) {
+  constructor({ logger = noop, xo }) {
+    this._logger = logger
     this._xo = xo
 
     this._authenticate = this._authenticate.bind(this)
@@ -192,7 +193,9 @@ class AuthLdap {
     })
   }
 
-  async _authenticate({ username, password }, logger = noop) {
+  async _authenticate({ username, password }) {
+    const logger = this._logger
+
     if (username === undefined || password === undefined) {
       logger('require `username` and `password` to authenticate!')
 
@@ -251,4 +254,4 @@ class AuthLdap {
 
 // ===================================================================
 
-export default ({ xo }) => new AuthLdap(xo)
+export default opts => new AuthLdap(opts)

--- a/packages/xo-server-auth-ldap/src/test-cli.js
+++ b/packages/xo-server-auth-ldap/src/test-cli.js
@@ -33,16 +33,15 @@ execPromise(async args => {
     }
   )
 
-  const plugin = createPlugin({})
+  const plugin = createPlugin({
+    logger: console.log.bind(console),
+  })
   await plugin.configure(config)
 
-  await plugin._authenticate(
-    {
-      username: await input('Username', {
-        validate: input => !!input.length,
-      }),
-      password: await password('Password'),
-    },
-    console.log.bind(console)
-  )
+  await plugin._authenticate({
+    username: await input('Username', {
+      validate: input => !!input.length,
+    }),
+    password: await password('Password'),
+  })
 })


### PR DESCRIPTION
Since 9adaf3e, the second parameter is used by xo-server to pass user data, thus breaking this plugin.

Fixes xoa-support#2549

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
