### PR TITLE
fix(xo-server#createVm): move VDIs before resize them

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [VM/Creation] Fix `SR_BACKEND_FAILURE_44` error in case of changing the existing VDIs' SRs (PR [#5044](https://github.com/vatesfr/xen-orchestra/pull/5044))
+
 ### Released packages
 
 > Packages will be released in the order they are here, therefore, they should

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [VM/Creation] Fix `SR_BACKEND_FAILURE_44` error in case of changing the existing VDIs' SRs (PR [#5044](https://github.com/vatesfr/xen-orchestra/pull/5044))
+- [VM/Creation] Fix `insufficient space` which could happened when moving and resizing disks (PR [#5044](https://github.com/vatesfr/xen-orchestra/pull/5044))
 
 ### Released packages
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,3 +31,5 @@
 > - major: if the change breaks compatibility
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
+
+- xo-server patch

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1847,6 +1847,7 @@ export default class Xapi extends XapiBase {
           when: { code: 'TOO_MANY_STORAGE_MIGRATES' },
         }
       ).then(extractOpaqueRef)
+
       return sr.$xapi._getOrWaitObject(ref)
     } catch (error) {
       const { code } = error

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1841,7 +1841,7 @@ export default class Xapi extends XapiBase {
       `Moving VDI ${vdi.name_label} from ${vdi.$SR.name_label} to ${sr.name_label}`
     )
     try {
-      return sr.$xapi.barrier(
+      return this.barrier(
         await pRetry(
           () => this.callAsync('VDI.pool_migrate', vdi.$ref, sr.$ref, {}),
           {

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1841,14 +1841,14 @@ export default class Xapi extends XapiBase {
       `Moving VDI ${vdi.name_label} from ${vdi.$SR.name_label} to ${sr.name_label}`
     )
     try {
-      const ref = await pRetry(
-        () => this.callAsync('VDI.pool_migrate', vdi.$ref, sr.$ref, {}),
-        {
-          when: { code: 'TOO_MANY_STORAGE_MIGRATES' },
-        }
-      ).then(extractOpaqueRef)
-
-      return sr.$xapi._getOrWaitObject(ref)
+      return sr.$xapi.barrier(
+        await pRetry(
+          () => this.callAsync('VDI.pool_migrate', vdi.$ref, sr.$ref, {}),
+          {
+            when: { code: 'TOO_MANY_STORAGE_MIGRATES' },
+          }
+        ).then(extractOpaqueRef)
+      )
     } catch (error) {
       const { code } = error
       if (

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1841,12 +1841,13 @@ export default class Xapi extends XapiBase {
       `Moving VDI ${vdi.name_label} from ${vdi.$SR.name_label} to ${sr.name_label}`
     )
     try {
-      await pRetry(
+      const ref = await pRetry(
         () => this.callAsync('VDI.pool_migrate', vdi.$ref, sr.$ref, {}),
         {
           when: { code: 'TOO_MANY_STORAGE_MIGRATES' },
         }
-      )
+      ).then(extractOpaqueRef)
+      return sr.$xapi._getOrWaitObject(ref)
     } catch (error) {
       const { code } = error
       if (
@@ -1869,6 +1870,8 @@ export default class Xapi extends XapiBase {
         })
       })
       await this._deleteVdi(vdi.$ref)
+
+      return newVdi
     }
   }
 

--- a/packages/xo-server/src/xapi/mixins/vm.js
+++ b/packages/xo-server/src/xapi/mixins/vm.js
@@ -175,13 +175,14 @@ export default {
             const vdi = vbd.$VDI
             await this._setObjectProperties(vdi, properties)
 
-            // if the disk is bigger
-            if (size != null && size > vdi.virtual_size) {
-              await this.resizeVdi(vdi.$id, size)
-            }
             // if another SR is set, move it there
             if (srId) {
               await this.moveVdi(vdi.$id, srId)
+            }
+
+            // if the disk is bigger
+            if (size != null && size > vdi.virtual_size) {
+              await this.resizeVdi(vdi.$id, size)
             }
           }
         )

--- a/packages/xo-server/src/xapi/mixins/vm.js
+++ b/packages/xo-server/src/xapi/mixins/vm.js
@@ -172,12 +172,12 @@ export default {
             if (!vbd) {
               return
             }
-            const vdi = vbd.$VDI
+            let vdi = vbd.$VDI
             await this._setObjectProperties(vdi, properties)
 
             // if another SR is set, move it there
             if (srId) {
-              await this.moveVdi(vdi.$id, srId)
+              vdi = await this.moveVdi(vdi.$id, srId)
             }
 
             // if the disk is bigger


### PR DESCRIPTION
See xoa-support#2535

Resizing a VDI before moving it can reach the source SR size limitation which will lead to a failed VM creation.

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
