### PR TITLE
fix(xo-web/migrate-vdi-modal): remove inter-pool migration possibility

### DIFF
--- a/packages/xo-web/src/common/xo/migrate-vdi-modal/index.js
+++ b/packages/xo-web/src/common/xo/migrate-vdi-modal/index.js
@@ -46,10 +46,10 @@ export default class MigrateVdiModalBody extends Component {
           <Col size={6}>{_('vdiMigrateSelectSr')}</Col>
           <Col size={6}>
             <SelectSr
-              predicate={this._getSrPredicate()}
               compareContainers={this._getCompareContainers()}
               compareOptions={compareSrs}
               onChange={this.linkState('sr')}
+              predicate={this._getSrPredicate()}
               required
             />
           </Col>

--- a/packages/xo-web/src/common/xo/migrate-vdi-modal/index.js
+++ b/packages/xo-web/src/common/xo/migrate-vdi-modal/index.js
@@ -8,7 +8,7 @@ import { createCompare, createCompareContainers } from 'utils'
 import { createSelector } from 'selectors'
 import { SelectSr } from 'select-objects'
 
-import { isSrShared } from '../'
+import { isSrShared, isSrWritable } from '../'
 
 const compareSrs = createCompare([isSrShared])
 
@@ -33,6 +33,11 @@ export default class MigrateVdiModalBody extends Component {
     (warningBeforeMigrate, sr) => warningBeforeMigrate(sr)
   )
 
+  _getSrPredicate = createSelector(
+    () => this.props.pool,
+    pool => sr => isSrWritable(sr) && sr.$pool === pool
+  )
+
   render() {
     const warningBeforeMigrate = this._getWarningBeforeMigrate()
     return (
@@ -41,6 +46,7 @@ export default class MigrateVdiModalBody extends Component {
           <Col size={6}>{_('vdiMigrateSelectSr')}</Col>
           <Col size={6}>
             <SelectSr
+              predicate={this._getSrPredicate()}
               compareContainers={this._getCompareContainers()}
               compareOptions={compareSrs}
               onChange={this.linkState('sr')}


### PR DESCRIPTION
Inter-pool migration isn't supported by the API

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
