### PR TITLE
fix(xo-server/backup): remove enumerable `xapi` on SR records

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,7 +18,7 @@
 - [Host/Load-balancer] Fix VM migration condition: free memory in the destination host must be greater or equal to used VM memory (PR [#5054](https://github.com/vatesfr/xen-orchestra/pull/5054))
 - [Home] Broken "Import VM" link [#5055](https://github.com/vatesfr/xen-orchestra/issues/5055) (PR [#5056](https://github.com/vatesfr/xen-orchestra/pull/5056))
 - [Home/SR] Fix inability to edit SRs' name [#5057](https://github.com/vatesfr/xen-orchestra/issues/5057) (PR [#5058](https://github.com/vatesfr/xen-orchestra/pull/5058))
-- [Backup] Fix huge logs in case of Continuous Replication or Disaster Recovery errors
+- [Backup] Fix huge logs in case of Continuous Replication or Disaster Recovery errors (PR [#5069](https://github.com/vatesfr/xen-orchestra/pull/5069))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@
 - [Host/Load-balancer] Fix VM migration condition: free memory in the destination host must be greater or equal to used VM memory (PR [#5054](https://github.com/vatesfr/xen-orchestra/pull/5054))
 - [Home] Broken "Import VM" link [#5055](https://github.com/vatesfr/xen-orchestra/issues/5055) (PR [#5056](https://github.com/vatesfr/xen-orchestra/pull/5056))
 - [Home/SR] Fix inability to edit SRs' name [#5057](https://github.com/vatesfr/xen-orchestra/issues/5057) (PR [#5058](https://github.com/vatesfr/xen-orchestra/pull/5058))
+- [Backup] Fix huge logs in case of Continuous Replication or Disaster Recovery errors
 
 ### Packages to release
 

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -1586,7 +1586,7 @@ export default class BackupNg {
           }
         })
 
-        for (const { uuid: srUuid, xapi } of srs) {
+        for (const { uuid: srUuid, $xapi: xapi } of srs) {
           const replicatedVm = listReplicatedVms(
             xapi,
             jobId,

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -681,13 +681,7 @@ export default class BackupNg {
           })
         }
 
-        const srs = srIds.map(id => {
-          const xapi = app.getXapi(id)
-          return {
-            __proto__: xapi.getObject(id),
-            xapi,
-          }
-        })
+        const srs = srIds.map(id => app.getXapiObject(id, 'SR'))
         const remotes = await Promise.all(
           remoteIds.map(async id => {
             const remote = await app.getRemote(id)
@@ -1482,7 +1476,7 @@ export default class BackupNg {
             async (taskId, sr) => {
               const fork = forkExport()
 
-              const { uuid: srUuid, xapi } = sr
+              const { uuid: srUuid, $xapi: xapi } = sr
 
               // delete previous interrupted copies
               ignoreErrors.call(
@@ -1871,7 +1865,7 @@ export default class BackupNg {
             async (taskId, sr) => {
               const fork = forkExport()
 
-              const { uuid: srUuid, xapi } = sr
+              const { uuid: srUuid, $xapi: xapi } = sr
 
               // delete previous interrupted copies
               ignoreErrors.call(


### PR DESCRIPTION
Fixes xoa-support#2527

This was causing huge logs in case of CR/DR errors because this property was included and pulled in all XAPI records.

Instead of making it non-enumerable, I was able to remove entirely because records now already include a non-enumerable `$xapi` property.

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
