### PR TITLE
fix(xo-server-sdn-controller): correctly find preferred center's pool

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -39,6 +39,7 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
+- xo-server-sdn-controller patch
 - xo-server-load-balancer patch
 - xo-server patch
 - xo-web minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,7 +20,7 @@
 - [Home/SR] Fix inability to edit SRs' name [#5057](https://github.com/vatesfr/xen-orchestra/issues/5057) (PR [#5058](https://github.com/vatesfr/xen-orchestra/pull/5058))
 - [Backup] Fix huge logs in case of Continuous Replication or Disaster Recovery errors (PR [#5069](https://github.com/vatesfr/xen-orchestra/pull/5069))
 - [Notification] Fix same notification showing again as unread (PR [#5067](https://github.com/vatesfr/xen-orchestra/pull/5067))
-- [SDN Controller] Fix broken private network creation when specifiyng a preferred center [#5076](https://github.com/vatesfr/xen-orchestra/issues/5076) (PR [#5079](https://github.com/vatesfr/xen-orchestra/pull/5079))
+- [SDN Controller] Fix broken private network creation when specifiyng a preferred center [#5076](https://github.com/vatesfr/xen-orchestra/issues/5076) (PR [#5079](https://github.com/vatesfr/xen-orchestra/pull/5079)) (PR [#5080](https://github.com/vatesfr/xen-orchestra/pull/5080))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,7 +20,7 @@
 - [Home/SR] Fix inability to edit SRs' name [#5057](https://github.com/vatesfr/xen-orchestra/issues/5057) (PR [#5058](https://github.com/vatesfr/xen-orchestra/pull/5058))
 - [Backup] Fix huge logs in case of Continuous Replication or Disaster Recovery errors (PR [#5069](https://github.com/vatesfr/xen-orchestra/pull/5069))
 - [Notification] Fix same notification showing again as unread (PR [#5067](https://github.com/vatesfr/xen-orchestra/pull/5067))
-- [SDN Controller] Fix broken private network creation when specifiyng a preferred center [#5076](https://github.com/vatesfr/xen-orchestra/issues/5076) (PR [#5079](https://github.com/vatesfr/xen-orchestra/pull/5079)) (PR [#5080](https://github.com/vatesfr/xen-orchestra/pull/5080))
+- [SDN Controller] Fix broken private network creation when specifiyng a preferred center [#5076](https://github.com/vatesfr/xen-orchestra/issues/5076) (PRs [#5079](https://github.com/vatesfr/xen-orchestra/pull/5079) & [#5080](https://github.com/vatesfr/xen-orchestra/pull/5080))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -39,7 +39,6 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
-- xo-server-sdn-controller patch
 - xo-server-load-balancer patch
 - xo-server patch
 - xo-web minor

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -650,10 +650,11 @@ class SDNController extends EventEmitter {
       )
 
       // Put pool of preferred center first
-      const i = poolIds.indexOf(preferredCenterId)
+      const preferredCenterPoolId = preferredCenter.$pool.uuid
+      const i = poolIds.indexOf(preferredCenterPoolId)
       assert.notStrictEqual(i, -1)
       poolIds[i] = poolIds[0]
-      poolIds[0] = preferredCenterId
+      poolIds[0] = preferredCenterPoolId
     }
 
     const privateNetwork = new PrivateNetwork(this, uuidv4(), preferredCenter)

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -643,6 +643,8 @@ class SDNController extends EventEmitter {
     mtu,
     preferredCenterId,
   }) {
+    const pools = poolIds.map(id => this._xo.getXapiObject(id, 'pool'))
+
     let preferredCenter
     if (preferredCenterId !== undefined) {
       preferredCenter = this._xo.getXapiObject(
@@ -651,7 +653,6 @@ class SDNController extends EventEmitter {
 
       // Put pool of preferred center first
       const preferredCenterPoolUuid = preferredCenter.$pool.uuid
-      const pools = poolIds.map(id => this._xo.getXapiObject(id, 'pool'))
       const i = pools.findIndex(pool => pool.uuid === preferredCenterPoolUuid)
       assert.notStrictEqual(i, -1)
       poolIds[i] = poolIds[0]
@@ -659,9 +660,7 @@ class SDNController extends EventEmitter {
     }
 
     const privateNetwork = new PrivateNetwork(this, uuidv4(), preferredCenter)
-    for (const poolId of poolIds) {
-      const pool = this._xo.getXapiObject(this._xo.getObject(poolId, 'pool'))
-
+    for (const pool of pools) {
       await this._setPoolControllerIfNeeded(pool)
 
       const pifId = pifIds.find(id => {

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -650,11 +650,14 @@ class SDNController extends EventEmitter {
       )
 
       // Put pool of preferred center first
-      const preferredCenterPoolId = preferredCenter.$pool.uuid
-      const i = poolIds.indexOf(preferredCenterPoolId)
+      const preferredCenterPoolUuid = preferredCenter.$pool.uuid
+      const i = poolIds.findIndex(id => {
+        const pool = this._xo.getXapiObject(this._xo.getObject(id, 'pool'))
+        return pool.uuid === preferredCenterPoolUuid
+      })
       assert.notStrictEqual(i, -1)
       poolIds[i] = poolIds[0]
-      poolIds[0] = preferredCenterPoolId
+      poolIds[0] = preferredCenterPoolUuid
     }
 
     const privateNetwork = new PrivateNetwork(this, uuidv4(), preferredCenter)

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -651,10 +651,8 @@ class SDNController extends EventEmitter {
 
       // Put pool of preferred center first
       const preferredCenterPoolUuid = preferredCenter.$pool.uuid
-      const i = poolIds.findIndex(id => {
-        const pool = this._xo.getXapiObject(this._xo.getObject(id, 'pool'))
-        return pool.uuid === preferredCenterPoolUuid
-      })
+      const pools = poolIds.map(id => this._xo.getXapiObject(id, 'pool'))
+      const i = pools.findIndex(pool => pool.uuid === preferredCenterPoolUuid)
       assert.notStrictEqual(i, -1)
       poolIds[i] = poolIds[0]
       poolIds[0] = preferredCenterPoolUuid


### PR DESCRIPTION
https://github.com/vatesfr/xen-orchestra/issues/5076

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [x] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
