### PR TITLE
fix(xo-web/tooltip): use pointer events instead of mouse events

### DIFF
--- a/packages/xo-web/src/common/tooltip/index.js
+++ b/packages/xo-web/src/common/tooltip/index.js
@@ -57,12 +57,6 @@ export class TooltipViewer extends Component {
 
 // ===================================================================
 
-// Wrap disabled HTML element before wrapping it with Tooltip
-// <Tooltip>
-//   <div>
-//     <MyComponent disabled />
-//   </div>
-// </Tooltip>
 export default class Tooltip extends Component {
   static propTypes = {
     children: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
@@ -95,9 +89,15 @@ export default class Tooltip extends Component {
   _addListeners() {
     const node = (this._node = ReactDOM.findDOMNode(this))
 
-    node.addEventListener('mouseenter', this._showTooltip)
-    node.addEventListener('mouseleave', this._hideTooltip)
-    node.addEventListener('mousemove', this._updateTooltip)
+    // 2020-06-15: Use pointer events instead of mouse events to workaround
+    // Chrome not firing any mouse event on disabled inputs. Pointer events
+    // should be correctly fired on most browsers and are similar to mouse
+    // events on mouse-controlled devices.
+    // https://github.com/reach/reach-ui/issues/564#issuecomment-620502842
+    // https://caniuse.com/#feat=mdn-api_pointerevent
+    node.addEventListener('pointerenter', this._showTooltip)
+    node.addEventListener('pointerleave', this._hideTooltip)
+    node.addEventListener('pointermove', this._updateTooltip)
   }
 
   _removeListeners() {
@@ -108,9 +108,9 @@ export default class Tooltip extends Component {
       return
     }
 
-    node.removeEventListener('mouseenter', this._showTooltip)
-    node.removeEventListener('mouseleave', this._hideTooltip)
-    node.removeEventListener('mousemove', this._updateTooltip)
+    node.removeEventListener('pointerenter', this._showTooltip)
+    node.removeEventListener('pointerleave', this._hideTooltip)
+    node.removeEventListener('pointermove', this._updateTooltip)
 
     this._node = null
   }

--- a/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
+++ b/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
@@ -160,20 +160,18 @@ const SchedulePreviewBody = decorate([
         />
         {job.runId !== undefined ? (
           <Tooltip content={_('temporarilyDisabled')}>
-            <span>
-              <ActionButton
-                btnStyle='danger'
-                // 2020-01-29 Job cancellation will be disabled until we find a way to make it work.
-                // See https://github.com/vatesfr/xen-orchestra/issues/4657
-                disabled
-                handler={cancelJob}
-                handlerParam={job}
-                icon='cancel'
-                key='cancel'
-                size='small'
-                tooltip={_('formCancel')}
-              />
-            </span>
+            <ActionButton
+              btnStyle='danger'
+              // 2020-01-29 Job cancellation will be disabled until we find a way to make it work.
+              // See https://github.com/vatesfr/xen-orchestra/issues/4657
+              disabled
+              handler={cancelJob}
+              handlerParam={job}
+              icon='cancel'
+              key='cancel'
+              size='small'
+              tooltip={_('formCancel')}
+            />
           </Tooltip>
         ) : (
           <ActionButton

--- a/packages/xo-web/src/xo-app/host/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/host/tab-advanced.js
@@ -199,12 +199,10 @@ export default class extends Component {
           <Col className='text-xs-right'>
             {!isNetDataPluginCorrectlySet ? (
               <Tooltip content={_('pluginNetDataIsNecessary')}>
-                <span>{telemetryButton}</span>
+                {telemetryButton}
               </Tooltip>
             ) : !_isXcpNgHost ? (
-              <Tooltip content={_('xcpOnlyFeature')}>
-                <span>{telemetryButton}</span>
-              </Tooltip>
+              <Tooltip content={_('xcpOnlyFeature')}>{telemetryButton}</Tooltip>
             ) : (
               telemetryButton
             )}


### PR DESCRIPTION
Chromium-based browsers don't fire mouse events on disabled inputs, which
prevented tooltips from appearing/disappearing. However, they correctly fire
pointer events, which are very similar to mouse events on mouse controlled
devices.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
