### PR TITLE
feat(xen-api): optional sync traces

### DIFF
--- a/packages/xen-api/src/cli.js
+++ b/packages/xen-api/src/cli.js
@@ -87,6 +87,7 @@ const main = async args => {
     auth,
     debounce: opts.debounce != null ? +opts.debounce : null,
     readOnly: opts.ro,
+    syncStackTraces: true,
   })
   await xapi.connect()
 

--- a/packages/xen-api/src/index.js
+++ b/packages/xen-api/src/index.js
@@ -67,7 +67,7 @@ const identity = value => value
 
 // save current stack trace and add it to any rejected error
 //
-// This is especially useful when the resolution is separate of the initial
+// This is especially useful when the resolution is separate from the initial
 // call, which is often the case with RPC libs.
 //
 // There is a perf impact and it should be avoided in production.


### PR DESCRIPTION
Initial actions call stacks are often missing from the resulting error for the following reasons:

- low level Node functions don't have proper stack traces
- replies handling maybe separate from requests (eg watchers)

This PR adds the option `syncStackTraces` that works around this, it has a performance impact but is useful for debugging.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
