### PR TITLE
fix(@xen-orchestra/openflow): readChunk import, msg iteration, supports reading header-only messages

### DIFF
--- a/@xen-orchestra/openflow/README.md
+++ b/@xen-orchestra/openflow/README.md
@@ -24,7 +24,7 @@ const version = openflow.versions.openFlow11
 const ofProtocol = openflow.protocols[version]
 
 function parseOpenFlowMessages(socket) {
-  for await (const msg from parse(socket)) {
+  for await (const msg of parse(socket)) {
     if (msg.header !== undefined) {
       const ofType = msg.header.type
       switch (ofType) {

--- a/@xen-orchestra/openflow/src/parse-socket.js
+++ b/@xen-orchestra/openflow/src/parse-socket.js
@@ -1,8 +1,8 @@
 import assert from 'assert'
 
 import of from './index'
-import readChunk from './util/read-stream-chunk'
 import scheme from './default-header-scheme'
+import { readChunk } from '@vates/read-chunk'
 
 // =============================================================================
 
@@ -21,9 +21,11 @@ export default async function* parse(socket) {
     }
 
     // Read the rest of the openflow message
-    data = await readChunk(socket, msgSize - scheme.size)
-    assert.notStrictEqual(data, null)
-    data.copy(buffer, scheme.size, 0, msgSize - scheme.size)
+    if (msgSize > scheme.size) {
+      data = await readChunk(socket, msgSize - scheme.size)
+      assert.notStrictEqual(data, null)
+      data.copy(buffer, scheme.size, 0, msgSize - scheme.size)
+    }
 
     yield of.unpack(buffer)
   }


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
