### PR TITLE
feat(xo-web/licenses): rebind license to this XOA

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 - [Home/VM] Homogenize the list of backed up VMs with the normal list (PR [#5046](https://github.com/vatesfr/xen-orchestra/pull/5046)
 - [SR/Disks] Add tooltip for disabled migration (PR [#4884](https://github.com/vatesfr/xen-orchestra/pull/4884))
 - [SR/Advanced, SR selector] Show thin/thick provisioning [#2208](https://github.com/vatesfr/xen-orchestra/issues/2208) (PR [#5081](https://github.com/vatesfr/xen-orchestra/pull/5081))
+- [Licenses] Ability to move a license from another XOA to the current XOA (PR [#5110](https://github.com/vatesfr/xen-orchestra/pull/5110))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2334,6 +2334,7 @@ const messages = {
   xosanInstallXoaPlugin: 'Install XOA plugin first',
   xosanLoadXoaPlugin: 'Load XOA plugin first',
   bindXoaLicense: 'Activate license',
+  rebindXoaLicense: 'Move license to this XOA',
   bindXoaLicenseConfirm:
     'Are you sure you want to activate this license on your XOA? This action is not reversible!',
   bindXoaLicenseConfirmText: 'activate {licenseType} license',

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -3072,7 +3072,7 @@ export const getLicense = (productId, boundObjectId) =>
 export const unlockXosan = (licenseId, srId) =>
   _call('xosan.unlock', { licenseId, sr: srId })
 
-export const selfBindLicense = ({ id, plan }) =>
+export const selfBindLicense = ({ id, plan, oldXoaId }) =>
   confirm({
     title: _('bindXoaLicense'),
     body: _('bindXoaLicenseConfirm'),
@@ -3082,7 +3082,10 @@ export const selfBindLicense = ({ id, plan }) =>
     },
     icon: 'unlock',
   })
-    .then(() => _call('xoa.licenses.bindToSelf', { licenseId: id }), noop)
+    .then(
+      () => _call('xoa.licenses.bindToSelf', { licenseId: id, oldXoaId }),
+      noop
+    )
     ::tap(subscribeSelfLicenses.forceRefresh)
 
 export const subscribeSelfLicenses = createSubscription(() =>

--- a/packages/xo-web/src/xo-app/xoa/licenses/index.js
+++ b/packages/xo-web/src/xo-app/xoa/licenses/index.js
@@ -93,7 +93,22 @@ const LicenseManager = ({ item, userData }) => {
       )
     }
 
-    return <span>{_('licenseBoundToOtherXoa')}</span>
+    return (
+      <span>
+        {_('licenseBoundToOtherXoa')}
+        <br />
+        <ActionButton
+          btnStyle='danger'
+          data-id={item.id}
+          data-plan={item.product}
+          data-oldXoaId={item.xoaId}
+          handler={selfBindLicense}
+          icon='unlock'
+        >
+          {_('rebindXoaLicense')}
+        </ActionButton>
+      </span>
+    )
   }
 
   if (type === 'proxy') {


### PR DESCRIPTION
See xoa#55
Requires xoa#58

When an XOA license is bound to another XOA, allow the user to move it to the
current XOA (thus unbinding it from the other one).

### Screenshots

![Capture_2020-06-25_10:44:41](https://user-images.githubusercontent.com/10992860/85689188-b5573480-b6d2-11ea-88d8-fa93a849a7b2.png)
![Capture_2020-06-25_10:44:58](https://user-images.githubusercontent.com/10992860/85689195-b5efcb00-b6d2-11ea-8b7d-7fc915c7b7b7.png)

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
