### PR TITLE
chore(xo-web/home): remove 'tags' filter from the filter selector

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Home] Remove 'tags' filter from the filter selector (PR [#5121](https://github.com/vatesfr/xen-orchestra/pull/5121))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -27,3 +29,5 @@
 > - major: if the change breaks compatibility
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
+
+- xo-web minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,7 +7,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [Home] Remove 'tags' filter from the filter selector (PR [#5121](https://github.com/vatesfr/xen-orchestra/pull/5121))
+- [Home] Remove 'tags' filter from the filter selector since tags have their own selector (PR [#5121](https://github.com/vatesfr/xen-orchestra/pull/5121))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/home-filters.js
+++ b/packages/xo-web/src/common/home-filters.js
@@ -8,26 +8,21 @@ export const VM = {
   homeFilterNonRunningVms: '!power_state:running ',
   homeFilterHvmGuests: 'virtualizationMode:hvm ',
   homeFilterRunningVms: 'power_state:running ',
-  homeFilterTags: 'tags:',
 }
 
 export const host = {
   ...common,
   homeFilterRunningHosts: 'power_state:running ',
-  homeFilterTags: 'tags:',
 }
 
 export const pool = {
   ...common,
-  homeFilterTags: 'tags:',
 }
 
 export const vmTemplate = {
   ...common,
-  homeFilterTags: 'tags:',
 }
 
 export const SR = {
   ...common,
-  homeFilterTags: 'tags:',
 }

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -236,7 +236,6 @@ const messages = {
   homeFilterNonRunningVms: 'Non running VMs',
   homeFilterPendingVms: 'Pending VMs',
   homeFilterHvmGuests: 'HVM guests',
-  homeFilterTags: 'Tags',
   homeSortBy: 'Sort by',
   homeSortByCpus: 'CPUs',
   homeSortByStartTime: 'Start time',


### PR DESCRIPTION
See https://github.com/vatesfr/xen-orchestra/pull/5118#discussion_r447586676

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
