### PR TITLE
feat(xo-server,xo-web/smart backup): exclude XO Proxy VMs by default

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Backup/New] Add "XOA Proxy" to the excluded tags by default
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -27,3 +29,6 @@
 > - major: if the change breaks compatibility
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
+
+- xo-server minor
+- xo-web minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,7 +7,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [Backup/New] Add "XOA Proxy" to the excluded tags by default
+- [Backup/New] Add "XOA Proxy" to the excluded tags by default (PR [#5128](https://github.com/vatesfr/xen-orchestra/pull/5128))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/api/backup-ng.js
+++ b/packages/xo-server/src/api/backup-ng.js
@@ -48,6 +48,15 @@ createJob.params = {
   },
 }
 
+export function getSuggestedExcludedTags() {
+  return [
+    'Continuous Replication',
+    'Disaster Recovery',
+    'XOSAN',
+    this._config['xo-proxy'].vmTag,
+  ]
+}
+
 export function migrateLegacyJob({ id }) {
   return this.migrateLegacyBackupJob(id)
 }

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -2101,6 +2101,9 @@ export const subscribeMetadataBackupJobs = createSubscription(() =>
 export const createBackupNgJob = props =>
   _call('backupNg.createJob', props)::tap(subscribeBackupNgJobs.forceRefresh)
 
+export const getSuggestedExcludedTags = () =>
+  _call('backupNg.getSuggestedExcludedTags')
+
 export const deleteBackupJobs = async ({
   backupIds = [],
   metadataBackupIds = [],

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -36,6 +36,7 @@ import {
   deleteSchedule,
   editBackupNgJob,
   editSchedule,
+  getSuggestedExcludedTags,
   isSrWritable,
   subscribeRemotes,
 } from 'xo'
@@ -235,9 +236,7 @@ const getInitialState = ({ preSelectedVmIds, setHomeVmIdsSelection }) => {
     smartMode: false,
     snapshotMode: false,
     srs: [],
-    tags: {
-      notValues: ['Continuous Replication', 'Disaster Recovery', 'XOSAN'],
-    },
+    tags: {},
     vms: preSelectedVmIds,
   }
 }
@@ -301,6 +300,9 @@ export default decorate([
   provideState({
     initialState: getInitialState,
     effects: {
+      initialize: async function () {
+        this.state.tags.notValues = await getSuggestedExcludedTags()
+      },
       createJob: () => async state => {
         if (state.isJobInvalid) {
           return {

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -301,7 +301,7 @@ export default decorate([
     initialState: getInitialState,
     effects: {
       initialize: async function () {
-        this.state.tags.notValues = await getSuggestedExcludedTags()
+        this.state.tags = { notValues: await getSuggestedExcludedTags() }
       },
       createJob: () => async state => {
         if (state.isJobInvalid) {


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
