### PR TITLE
fix(import/OVA): fix big size parsing in OVA files

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Restore legacy, File restore legacy] Fix mount error in case of existing proxy remotes (PR [#5124](https://github.com/vatesfr/xen-orchestra/pull/5124))
+- [Import/OVA] Fix import of bigger OVA files (>8GB .vmdk disk) (PR [#5129](https://github.com/vatesfr/xen-orchestra/pull/5129))
 
 ### Packages to release
 
@@ -33,5 +34,6 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
+- xo-vmdk-to-vhd patch
 - xo-server minor
 - xo-web minor

--- a/packages/xo-vmdk-to-vhd/src/ova.js
+++ b/packages/xo-vmdk-to-vhd/src/ova.js
@@ -70,6 +70,9 @@ function parseTarHeader(header, stringDeserializer) {
   const sizeBuffer = header.slice(124, 124 + 12)
   // size encoding: https://codeistry.wordpress.com/2014/08/14/how-to-parse-a-tar-file/
   let fileSize = 0
+  // If the leading byte is 0x80 (128), the non-leading bytes of the field are concatenated in big-endian order, with the result being a positive number expressed in binary form.
+  //
+  // Source: https://www.gnu.org/software/tar/manual/html_node/Extensions.html
   if (new Uint8Array(sizeBuffer)[0] === 128) {
     for (const byte of new Uint8Array(sizeBuffer.slice(1))) {
       fileSize *= 256

--- a/packages/xo-vmdk-to-vhd/src/ova.js
+++ b/packages/xo-vmdk-to-vhd/src/ova.js
@@ -67,10 +67,18 @@ function parseTarHeader(header, stringDeserializer) {
   if (fileName.length === 0) {
     return null
   }
-  const fileSize = parseInt(
-    stringDeserializer(header.slice(124, 124 + 11), 'ascii'),
-    8
-  )
+  const sizeBuffer = header.slice(124, 124 + 12)
+  // size encoding: https://codeistry.wordpress.com/2014/08/14/how-to-parse-a-tar-file/
+  let fileSize = 0
+  if (new Uint8Array(sizeBuffer)[0] === 128) {
+    for (const byte of new Uint8Array(sizeBuffer.slice(1))) {
+      fileSize *= 256
+      fileSize += byte
+    }
+  } else {
+    fileSize = parseInt(stringDeserializer(sizeBuffer.slice(0, 11), 'ascii'), 8)
+  }
+
   return { fileName, fileSize }
 }
 


### PR DESCRIPTION
detected on the forum: https://xcp-ng.org/forum/topic/3142/ova-import-failing/31?_=1593721131514

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
