### PR TITLE
fix(xo-web/backup/edit): excluded tags being overwritten by the default ones

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Smart backup/edit] Fix "Excluded VMs tags" being reset to the default ones (PR [#5136](https://github.com/vatesfr/xen-orchestra/pull/5136))
+
 ### Packages to release
 
 > Packages will be released in the order they are here, therefore, they should
@@ -27,3 +29,5 @@
 > - major: if the change breaks compatibility
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
+
+- xo-web patch

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -539,6 +539,7 @@ const messages = {
   deleteOldBackupsFirstMessage:
     'Delete old backups before backing up the VMs. If the new backup fails, you will lose your old backups.',
   customTag: 'Custom tag',
+  editJobNotFound: "The job you're trying to edit wasn't found",
 
   // ------ New Remote -----
   newRemote: 'New file system remote',

--- a/packages/xo-web/src/xo-app/backup/edit.js
+++ b/packages/xo-web/src/xo-app/backup/edit.js
@@ -1,6 +1,8 @@
+import _ from 'intl'
 import addSubscriptions from 'add-subscriptions'
 import decorate from 'apply-decorators'
 import defined from '@xen-orchestra/defined'
+import Icon from 'icon'
 import React from 'react'
 import { injectState, provideState } from 'reaclette'
 import { find, groupBy, keyBy } from 'lodash'
@@ -28,11 +30,21 @@ export default decorate([
         defined(find(jobs, { id }), find(metadataJobs, { id })),
       schedules: (_, { schedulesByJob, routeParams: { id } }) =>
         schedulesByJob && keyBy(schedulesByJob[id], 'id'),
+      loading: (_, props) =>
+        props.jobs === undefined ||
+        props.metadataJobs === undefined ||
+        props.schedulesByJob === undefined,
     },
   }),
   injectState,
-  ({ state: { job = {}, schedules } }) =>
-    job.type === 'backup' ? (
+  ({ state: { job, loading, schedules } }) =>
+    loading ? (
+      _('statusLoading')
+    ) : job === undefined ? (
+      <span className='text-danger'>
+        <Icon icon='error' /> {_('editJobNotFound')}
+      </span>
+    ) : job.type === 'backup' ? (
       <New job={job} schedules={schedules} />
     ) : (
       <Metadata job={job} schedules={schedules} />

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -216,7 +216,11 @@ const createDoesRetentionExist = name => {
   return ({ propSettings, settings = propSettings }) => settings.some(predicate)
 }
 
-const getInitialState = ({ preSelectedVmIds, setHomeVmIdsSelection }) => {
+const getInitialState = ({
+  preSelectedVmIds,
+  setHomeVmIdsSelection,
+  suggestedExcludedTags,
+}) => {
   setHomeVmIdsSelection([]) // Clear preselected vmIds
   return {
     _displayAdvancedSettings: undefined,
@@ -228,7 +232,6 @@ const getInitialState = ({ preSelectedVmIds, setHomeVmIdsSelection }) => {
     deltaMode: false,
     drMode: false,
     name: '',
-    paramsUpdated: false,
     remotes: [],
     schedules: {},
     settings: undefined,
@@ -236,7 +239,7 @@ const getInitialState = ({ preSelectedVmIds, setHomeVmIdsSelection }) => {
     smartMode: false,
     snapshotMode: false,
     srs: [],
-    tags: {},
+    tags: { notValues: suggestedExcludedTags },
     vms: preSelectedVmIds,
   }
 }
@@ -281,15 +284,12 @@ const DeleteOldBackupsFirst = ({ handler, handlerParam, value }) => (
   </ActionButton>
 )
 
-export default decorate([
+const New = decorate([
   New => props => (
     <Upgrade place='newBackup' required={2}>
       <New {...props} />
     </Upgrade>
   ),
-  addSubscriptions({
-    remotes: subscribeRemotes,
-  }),
   connectStore(() => ({
     hostsById: createGetObjectsOfType('host'),
     poolsById: createGetObjectsOfType('pool'),
@@ -300,8 +300,10 @@ export default decorate([
   provideState({
     initialState: getInitialState,
     effects: {
-      initialize: async function () {
-        this.state.tags = { notValues: await getSuggestedExcludedTags() }
+      initialize: function ({ updateParams }) {
+        if (this.state.edition) {
+          updateParams()
+        }
       },
       createJob: () => async state => {
         if (state.isJobInvalid) {
@@ -506,7 +508,6 @@ export default decorate([
 
         return {
           name: job.name,
-          paramsUpdated: true,
           smartMode: job.vms.id === undefined,
           snapshotMode: some(
             job.settings,
@@ -710,8 +711,7 @@ export default decorate([
             type: 'VM',
           }
         ),
-      needUpdateParams: (state, { job, schedules }) =>
-        job !== undefined && schedules !== undefined && !state.paramsUpdated,
+      edition: (_, { job }) => job !== undefined,
       isJobInvalid: state =>
         state.missingName ||
         state.missingVms ||
@@ -819,10 +819,6 @@ export default decorate([
       reportWhen = 'failure',
       timeout,
     } = settings.get('') || {}
-
-    if (state.needUpdateParams) {
-      effects.updateParams()
-    }
 
     return (
       <form id={state.formId}>
@@ -1227,7 +1223,7 @@ export default decorate([
           <Row>
             <Card>
               <CardBlock>
-                {state.paramsUpdated ? (
+                {state.edition ? (
                   <ActionButton
                     btnStyle='primary'
                     form={state.formId}
@@ -1269,4 +1265,27 @@ export default decorate([
       </form>
     )
   },
+])
+
+export default decorate([
+  addSubscriptions({
+    remotes: subscribeRemotes,
+  }),
+  provideState({
+    initialState: () => ({ suggestedExcludedTags: undefined }),
+    effects: {
+      initialize: async function () {
+        this.state.suggestedExcludedTags = await getSuggestedExcludedTags()
+      },
+    },
+  }),
+  injectState,
+  ({ state, ...props }) =>
+    state.suggestedExcludedTags === undefined ||
+    props.remotes === undefined ||
+    (props.job !== undefined && props.schedules === undefined) ? (
+      _('statusLoading')
+    ) : (
+      <New suggestedExcludedTags={state.suggestedExcludedTags} {...props} />
+    ),
 ])

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -1278,14 +1278,17 @@ export default decorate([
         this.state.suggestedExcludedTags = await getSuggestedExcludedTags()
       },
     },
+    computed: {
+      loading: (state, props) =>
+        state.suggestedExcludedTags === undefined ||
+        props.remotes === undefined,
+    },
   }),
   injectState,
-  ({ state, ...props }) =>
-    state.suggestedExcludedTags === undefined ||
-    props.remotes === undefined ||
-    (props.job !== undefined && props.schedules === undefined) ? (
+  ({ state: { loading, suggestedExcludedTags }, ...props }) =>
+    loading ? (
       _('statusLoading')
     ) : (
-      <New suggestedExcludedTags={state.suggestedExcludedTags} {...props} />
+      <New suggestedExcludedTags={suggestedExcludedTags} {...props} />
     ),
 ])

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -1272,16 +1272,11 @@ export default decorate([
     remotes: subscribeRemotes,
   }),
   provideState({
-    initialState: () => ({ suggestedExcludedTags: undefined }),
-    effects: {
-      initialize: async function () {
-        this.state.suggestedExcludedTags = await getSuggestedExcludedTags()
-      },
-    },
     computed: {
       loading: (state, props) =>
         state.suggestedExcludedTags === undefined ||
         props.remotes === undefined,
+      suggestedExcludedTags: () => getSuggestedExcludedTags(),
     },
   }),
   injectState,


### PR DESCRIPTION
Introduced by 1c042778b6191eb5f718e8d2545600ab25f01a4f
See xoa-support#2663

- `Edit` waits for the `job` and the `schedules` before rendering its child
- `New`'s wrapper waits for the `remotes` and the `suggestedExcludedTags` before rendering its child
- `updateParams` is now called in `initialize` because we don't need to wait for the job and the schedules any more to be able to populate the form

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
