### PR TITLE
fix(xo-server/pool.listMissingPatches): don't log errors

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@
 - [Proxy] Don't use configured HTTP proxy to connect to XO proxy
 - [Backup with proxy] Correctly log job-level errors
 - [XO] Fix a few broken documentation links (PR [#5146](https://github.com/vatesfr/xen-orchestra/pull/5146))
+- [Patches] Don't log errors related to missing patches listing (PR [#5149](https://github.com/vatesfr/xen-orchestra/pull/5149))
 
 ### Packages to release
 

--- a/packages/xo-server/src/xo-mixins/api.js
+++ b/packages/xo-server/src/xo-mixins/api.js
@@ -333,11 +333,16 @@ export default class Api {
         data.params
       )}) [${ms(Date.now() - startTime)}] =!> ${error}`
 
-      this._logger.error(message, {
-        ...data,
-        duration: Date.now() - startTime,
-        error: serializedError,
-      })
+      // 2020-07-10: Work-around: many kinds of error can be triggered by this
+      // method, which can generates a lot of logs due to the fact that xo-web
+      // uses 5s active subscriptions to call it
+      if (method !== 'pool.listMissingPatches') {
+        this._logger.error(message, {
+          ...data,
+          duration: Date.now() - startTime,
+          error: serializedError,
+        })
+      }
 
       if (xo._config.verboseLogsOnErrors) {
         log.warn(message, { error })


### PR DESCRIPTION
Work-around to avoid generating too many logs

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
