### PR TITLE
feat(xo-server/api): user must be signed in by default

### DIFF
--- a/packages/xo-server/src/api/acl.js
+++ b/packages/xo-server/src/api/acl.js
@@ -12,8 +12,6 @@ export async function getCurrentPermissions() {
   return /* await */ this.getPermissionsForUser(this.session.get('user_id'))
 }
 
-getCurrentPermissions.permission = ''
-
 getCurrentPermissions.description =
   'get (explicit) permissions by object for the current user'
 

--- a/packages/xo-server/src/api/ip-pool.js
+++ b/packages/xo-server/src/api/ip-pool.js
@@ -25,7 +25,6 @@ export function getAll(params) {
   )
 }
 
-getAll.permission = ''
 getAll.description = 'List all ipPools'
 
 // -------------------------------------------------------------------

--- a/packages/xo-server/src/api/pool.js
+++ b/packages/xo-server/src/api/pool.js
@@ -42,8 +42,6 @@ export async function setDefaultSr({ sr }) {
   await this.getXapi(sr).setDefaultSr(sr._xapiId)
 }
 
-setDefaultSr.permission = '' // signed in
-
 setDefaultSr.params = {
   sr: {
     type: 'string',

--- a/packages/xo-server/src/api/resource-set.js
+++ b/packages/xo-server/src/api/resource-set.js
@@ -98,7 +98,6 @@ export function get({ id }) {
   return this.getResourceSet(id)
 }
 
-get.permission = ''
 get.params = {
   id: {
     type: 'string',
@@ -111,7 +110,6 @@ export async function getAll() {
   return this.getAllResourceSets(this.user.id)
 }
 
-getAll.permission = ''
 getAll.description = 'Get the list of all existing resource set'
 
 // -------------------------------------------------------------------

--- a/packages/xo-server/src/api/session.js
+++ b/packages/xo-server/src/api/session.js
@@ -23,6 +23,7 @@ export async function signIn(credentials) {
 }
 
 signIn.description = 'sign in'
+signIn.permission = null // user does not need to be authenticated
 
 // -------------------------------------------------------------------
 
@@ -35,6 +36,7 @@ signInWithPassword.params = {
   email: { type: 'string' },
   password: { type: 'string' },
 }
+signInWithPassword.permission = null // user does not need to be authenticated
 
 // -------------------------------------------------------------------
 
@@ -43,6 +45,7 @@ export const signInWithToken = deprecate(signIn, 'use session.signIn() instead')
 signInWithToken.params = {
   token: { type: 'string' },
 }
+signInWithToken.permission = null // user does not need to be authenticated
 
 // -------------------------------------------------------------------
 
@@ -51,9 +54,6 @@ export function signOut() {
 }
 
 signOut.description = 'sign out the user from the current session'
-
-// This method requires the user to be signed in.
-signOut.permission = ''
 
 // -------------------------------------------------------------------
 
@@ -66,3 +66,4 @@ export async function getUser() {
 }
 
 getUser.description = 'return the currently connected user'
+getUser.permission = null // user does not need to be authenticated

--- a/packages/xo-server/src/api/system.js
+++ b/packages/xo-server/src/api/system.js
@@ -22,6 +22,7 @@ export function getMethodsInfo() {
 }
 getMethodsInfo.description =
   'returns the signatures of all available API methods'
+getMethodsInfo.permission = null // user does not need to be authenticated
 
 // -------------------------------------------------------------------
 
@@ -32,11 +33,13 @@ getServerTimezone.description = 'return the timezone server'
 
 export const getServerVersion = () => xoServerVersion
 getServerVersion.description = 'return the version of xo-server'
+getServerVersion.permission = null // user does not need to be authenticated
 
 // -------------------------------------------------------------------
 
 export const getVersion = () => '0.1'
 getVersion.description = 'API version (unstable)'
+getVersion.permission = null // user does not need to be authenticated
 
 // -------------------------------------------------------------------
 
@@ -44,6 +47,7 @@ export function listMethods() {
   return getKeys(this.apiMethods)
 }
 listMethods.description = 'returns the name of all available API methods'
+listMethods.permission = null // user does not need to be authenticated
 
 // -------------------------------------------------------------------
 
@@ -66,3 +70,4 @@ export function methodSignature({ method: name }) {
   ]
 }
 methodSignature.description = 'returns the signature of an API method'
+methodSignature.permission = null // user does not need to be authenticated

--- a/packages/xo-server/src/api/token.js
+++ b/packages/xo-server/src/api/token.js
@@ -18,8 +18,6 @@ create.params = {
   },
 }
 
-create.permission = '' // sign in
-
 // -------------------------------------------------------------------
 
 // TODO: an user should be able to delete its own tokens.
@@ -52,8 +50,6 @@ export async function deleteAll({ except }) {
 
 deleteAll.description =
   'delete all tokens of the current user except the current one'
-
-deleteAll.permission = ''
 
 deleteAll.params = {
   except: { type: 'string', optional: true },

--- a/packages/xo-server/src/api/user.js
+++ b/packages/xo-server/src/api/user.js
@@ -74,8 +74,6 @@ export async function set({ id, email, password, permission, preferences }) {
 
 set.description = 'changes the properties of an existing user'
 
-set.permission = ''
-
 set.params = {
   id: { type: 'string' },
   email: { type: 'string', optional: true },
@@ -93,8 +91,6 @@ export async function changePassword({ oldPassword, newPassword }) {
 
 changePassword.description =
   'change password after checking old password (user function)'
-
-changePassword.permission = ''
 
 changePassword.params = {
   oldPassword: { type: 'string' },

--- a/packages/xo-server/src/api/xo.js
+++ b/packages/xo-server/src/api/xo.js
@@ -60,7 +60,6 @@ export function getAllObjects({ filter, limit, ndjson = false }) {
     : this.getObjects({ filter, limit })
 }
 
-getAllObjects.permission = ''
 getAllObjects.description = 'Returns all XO objects'
 
 getAllObjects.params = {

--- a/packages/xo-server/src/xo-mixins/api.js
+++ b/packages/xo-server/src/xo-mixins/api.js
@@ -78,8 +78,8 @@ function checkPermission(method) {
 
   const { permission } = method
 
-  // No requirement.
-  if (permission === undefined) {
+  // User does not need to be authenticated.
+  if (permission === null) {
     return
   }
 
@@ -88,8 +88,7 @@ function checkPermission(method) {
     throw errors.unauthorized(permission)
   }
 
-  // The only requirement is login.
-  if (!permission) {
+  if (permission === undefined) {
     return
   }
 


### PR DESCRIPTION
It's a lot more secure than previous default value.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
