### PR TITLE
fix(xo-web/vm/tab-network): add default value to plugins

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,4 +30,5 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
+xo-web patch
 xo-server-sdn-controller patch

--- a/packages/xo-web/src/xo-app/vm/tab-network.js
+++ b/packages/xo-web/src/xo-app/vm/tab-network.js
@@ -534,7 +534,7 @@ class AclRulesRows extends BaseComponent {
   )
 
   render() {
-    const { vif, plugins } = this.props
+    const { vif, plugins = [] } = this.props
     const { showRules } = this.state
     const sdnControllerLoaded = plugins.some(
       plugin => plugin.name === 'sdn-controller' && plugin.loaded


### PR DESCRIPTION
Introduced by 2a74a499955489d58fbf80e98fdf39e0c293014b

`plugins` can be `undefined` on fetching which triggers the error `Cannot read property "some" of undefined`

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
