### PR TITLE
feat(test): Remove need for prepare script

### DIFF
--- a/@xen-orchestra/async-map/package.json
+++ b/@xen-orchestra/async-map/package.json
@@ -46,7 +46,6 @@
     "dev": "cross-env NODE_ENV=development babel --watch --source-maps --out-dir=dist/ src/",
     "prebuild": "yarn run clean",
     "predev": "yarn run prebuild",
-    "prepare": "yarn run build",
     "prepublishOnly": "yarn run build",
     "postversion": "npm publish"
   }

--- a/@xen-orchestra/fs/package.json
+++ b/@xen-orchestra/fs/package.json
@@ -58,7 +58,6 @@
     "dev": "cross-env NODE_ENV=development babel --watch --source-maps --out-dir=dist/ src/",
     "prebuild": "yarn run clean",
     "predev": "yarn run clean",
-    "prepare": "yarn run build",
     "postversion": "npm publish"
   },
   "author": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,15 @@
   },
   "jest": {
     "collectCoverage": true,
+    "moduleNameMapper": {
+      "^@xen-orchestra/async-map": "@xen-orchestra/async-map/src",
+      "^@xen-orchestra/fs": "@xen-orchestra/fs/src",
+      "^xo-remote-parser": "xo-remote-parser/src",
+      "^vhd-lib": "vhd-lib/src",
+      "^vhd-cli": "vhd-cli/src",
+      "^xo-vmdk-to-vhd": "xo-vmdk-to-vhd/src",
+      "^value-matcher": "value-matcher/src"
+    },
     "projects": [
       "<rootDir>"
     ],
@@ -66,7 +75,6 @@
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs",
     "posttest": "scripts/run-script test",
-    "prepare": "scripts/run-script prepare",
     "pretest": "eslint --ignore-path .gitignore .",
     "prettify": "prettier --ignore-path .gitignore --write '**/*.{js,jsx,md,mjs,ts,tsx}'",
     "test": "jest \"^(?!.*\\.integ\\.spec\\.js$)\"",

--- a/packages/value-matcher/package.json
+++ b/packages/value-matcher/package.json
@@ -43,7 +43,6 @@
     "dev": "cross-env NODE_ENV=development babel --watch --source-maps --out-dir=dist/ src/",
     "prebuild": "yarn run clean",
     "predev": "yarn run prebuild",
-    "prepare": "yarn run build",
     "prepublishOnly": "yarn run build",
     "postversion": "npm publish"
   }

--- a/packages/vhd-cli/package.json
+++ b/packages/vhd-cli/package.json
@@ -52,7 +52,6 @@
     "dev": "cross-env NODE_ENV=development babel --watch --source-maps --out-dir=dist/ src/",
     "prebuild": "rimraf dist/ && index-modules --cjs-lazy src/commands",
     "predev": "yarn run prebuild",
-    "prepare": "yarn run build",
     "postversion": "npm publish"
   }
 }

--- a/packages/vhd-lib/package.json
+++ b/packages/vhd-lib/package.json
@@ -53,7 +53,6 @@
     "dev": "cross-env NODE_ENV=development babel --watch --source-maps --out-dir=dist/ src/",
     "prebuild": "yarn run clean",
     "predev": "yarn run clean",
-    "prepare": "yarn run build",
     "postversion": "npm publish"
   },
   "author": {

--- a/packages/xo-remote-parser/package.json
+++ b/packages/xo-remote-parser/package.json
@@ -42,7 +42,6 @@
     "dev": "cross-env NODE_ENV=development babel --watch --source-maps --out-dir=dist/ src/",
     "prebuild": "rimraf dist/",
     "predev": "yarn run prebuild",
-    "prepare": "yarn run build",
     "postversion": "npm publish"
   }
 }

--- a/packages/xo-vmdk-to-vhd/package.json
+++ b/packages/xo-vmdk-to-vhd/package.json
@@ -53,7 +53,6 @@
     "dev": "cross-env NODE_ENV=development babel --watch --source-maps --out-dir=dist/ src/",
     "prebuild": "yarn run clean",
     "predev": "yarn run clean",
-    "prepare": "yarn run build",
     "postversion": "npm publish"
   },
   "author": {


### PR DESCRIPTION
As you may know I'm trying to setup xen-orchestra development on Mac. The prepare script is quite painful to use (it automatically runs on first yarn, and then you need to run it each time the dependency is updated).

This PR replaces prepare script with appropriately configured Jest. This way all scripts are automatically compiled with babel configured in test environment, and scripts that require compilation to dist also work.