### PR TITLE
feat(test): Allow for developing in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+node_modules
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM centos:7 as base
+
+RUN curl -sL https://rpm.nodesource.com/setup_12.x | bash - && \
+    curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
+    yum -y install libpng-devel git libvhdi-utils lvm2 cifs-utils \
+      make automake gcc gcc-c++ nodejs yarn
+
+WORKDIR /xen-orchestra
+
+EXPOSE 80 443
+
+FROM base as runtime
+
+ADD . /xen-orchestra
+
+RUN yarn && yarn build && yarn --production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3.4'
+services:
+  yarn:
+    build:
+      context: .
+      target: base
+    tty: true
+    container_name: xo-server
+    ports:
+    - "80:80"
+    - "443:443"
+    cap_add:
+      - SYS_ADMIN
+    volumes:
+    - .:/xen-orchestra:cached
+    - xo-node-modules:/xen-orchestra/node_modules/
+    - xo-data:/var/lib/xo-server
+    - xo-log:/var/log
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1M"
+        max-file: "2"
+    depends_on:
+    - redis
+    entrypoint: yarn
+  redis:
+    image: redis:alpine
+    restart: unless-stopped
+    container_name: xo-redis
+    command: redis-server --appendonly yes
+    volumes:
+      - xo-redis-data:/data
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1M"
+        max-file: "2"
+volumes:
+  xo-redis-data: {}
+  xo-data: {}
+  xo-log: {}
+  xo-node-modules: {}

--- a/docs/from_the_sources.md
+++ b/docs/from_the_sources.md
@@ -140,6 +140,15 @@ If you need to delete the service:
 forever-service delete orchestra
 ```
 
+## Running in docker
+
+You can user [docker](https://www.docker.com/) and [docker-compose](https://docs.docker.com/compose/install/) to easily develop xen-orchestra. Just use `docker-compose run yarn` instead of `yarn`, for example:
+
+```
+docker-compose run yarn
+docker-compose run yarn dev-test
+```
+
 ## Troubleshooting
 
 If you have problems during the building phase, follow these steps in your `xen-orchestra` directory:


### PR DESCRIPTION
After long hours of optimizing setup of Docker on Mac, I've finally managed to create something fast and useful. I think it's good idea to include it here so people like me can quickly start developing xen-orchestra.

Setup uses docker-compose to easily manage containers with xen-orchestra environment (with node_modules attached as volume, so Macs have their own native modules compiled, and containers their own, plus it's [a lot faster this way](https://github.com/facebook/jest/issues/1395#issuecomment-610472323)). I know it isn't perfect, but good starting point, we can iterate on it.