### PR TITLE
fix(xo-web/vm/snapshots): no redirection if the VM creation failed or canceled

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [VM/snapshots] No redirection if the VM creation failed or canceled
+
 ### Packages to release
 
 > Packages will be released in the order they are here, therefore, they should

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [VM/snapshots] No redirection if the VM creation failed or canceled
+- [VM/snapshots] No redirection if the VM creation from a snapshot failed or canceled [#5215](https://github.com/vatesfr/xen-orchestra/pull/5215)
 
 ### Packages to release
 

--- a/packages/xo-web/src/xo-app/vm/tab-snapshots.js
+++ b/packages/xo-web/src/xo-app/vm/tab-snapshots.js
@@ -89,7 +89,8 @@ const INDIVIDUAL_ACTIONS = [
     handler: snapshot => copyVm(snapshot),
     icon: 'vm-copy',
     label: _('copySnapshot'),
-    redirectOnSuccess: vm => vm && `/vms/${vm}/general`,
+    redirectOnSuccess: vm =>
+      vm !== undefined ? `/vms/${vm}/general` : undefined,
   },
   {
     handler: exportVm,


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
