### PR TITLE
fix(xo-web/proxies): remove upgrade button style

### DIFF
--- a/packages/xo-web/src/xo-app/proxies/index.js
+++ b/packages/xo-web/src/xo-app/proxies/index.js
@@ -145,7 +145,6 @@ const COLUMNS = [
       ) {
         return (
           <ActionButton
-            btnStyle='primary'
             disabled={proxy.vmUuid === undefined}
             handler={upgradeAppliance}
             handlerParam={proxy.id}


### PR DESCRIPTION
See https://github.com/vatesfr/xen-orchestra/pull/5167/files?file-filters%5B%5D=.md#r469763760

**Case:** When there is no upgrades available.

**Before**

![image](https://user-images.githubusercontent.com/21563339/90115111-f1625980-dd53-11ea-96a3-f1fe3603fd70.png)

**After**

![image](https://user-images.githubusercontent.com/21563339/90115002-cb3cb980-dd53-11ea-9a2b-8dcc30c434a3.png)

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
