### PR TITLE
fix(xo-server/sensitive-values): obfuscate params containing "password"

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
 
 - [Proxy/deploy] Fix `no such proxy ok` error on a failure trial start (PR [#5196](https://github.com/vatesfr/xen-orchestra/pull/5196))
 - [VM/snapshots] Fix redirection when creating a VM from a snapshot (PR [#5213](https://github.com/vatesfr/xen-orchestra/pull/5213))
-- [Audit] Obfuscate `user.changePassword` sensitive data [#5219](https://github.com/vatesfr/xen-orchestra/issues/5219) (PR [#5220](https://github.com/vatesfr/xen-orchestra/pull/5220))
+- [Audit] Obfuscate sensitive data in `user.changePassword` action's records [#5219](https://github.com/vatesfr/xen-orchestra/issues/5219) (PR [#5220](https://github.com/vatesfr/xen-orchestra/pull/5220))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -35,4 +35,5 @@
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
 - xo-server-sdn-controller patch
+- xo-server patch
 - xo-web minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,6 +34,6 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
-- xo-server-sdn-controller patch
 - xo-server patch
+- xo-server-sdn-controller patch
 - xo-web minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 
 - [Proxy/deploy] Fix `no such proxy ok` error on a failure trial start (PR [#5196](https://github.com/vatesfr/xen-orchestra/pull/5196))
 - [VM/snapshots] Fix redirection when creating a VM from a snapshot (PR [#5213](https://github.com/vatesfr/xen-orchestra/pull/5213))
+- [Audit] Obfuscate `user.changePassword` sensitive data [#5219](https://github.com/vatesfr/xen-orchestra/issues/5219) (PR [#5219](https://github.com/vatesfr/xen-orchestra/pull/5219))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
 
 - [Proxy/deploy] Fix `no such proxy ok` error on a failure trial start (PR [#5196](https://github.com/vatesfr/xen-orchestra/pull/5196))
 - [VM/snapshots] Fix redirection when creating a VM from a snapshot (PR [#5213](https://github.com/vatesfr/xen-orchestra/pull/5213))
-- [Audit] Obfuscate `user.changePassword` sensitive data [#5219](https://github.com/vatesfr/xen-orchestra/issues/5219) (PR [#5219](https://github.com/vatesfr/xen-orchestra/pull/5219))
+- [Audit] Obfuscate `user.changePassword` sensitive data [#5219](https://github.com/vatesfr/xen-orchestra/issues/5219) (PR [#5220](https://github.com/vatesfr/xen-orchestra/pull/5220))
 
 ### Packages to release
 

--- a/packages/xo-server/src/sensitive-values.js
+++ b/packages/xo-server/src/sensitive-values.js
@@ -28,6 +28,7 @@ export const obfuscate = value => replace(value, OBFUSCATED_VALUE)
 
 const SENSITIVE_PARAMS = {
   __proto__: null,
+  chapPassword: true,
   cifspassword: true,
   newPassword: true,
   oldPassword: true,

--- a/packages/xo-server/src/sensitive-values.js
+++ b/packages/xo-server/src/sensitive-values.js
@@ -29,6 +29,8 @@ export const obfuscate = value => replace(value, OBFUSCATED_VALUE)
 const SENSITIVE_PARAMS = {
   __proto__: null,
   cifspassword: true,
+  newPassword: true,
+  oldPassword: true,
   password: true,
   token: true,
 }

--- a/packages/xo-server/src/sensitive-values.js
+++ b/packages/xo-server/src/sensitive-values.js
@@ -1,5 +1,7 @@
 import mapValues from 'lodash/mapValues'
 
+import globMatcher from './glob-matcher'
+
 // this random value is used to obfuscate real data
 const OBFUSCATED_VALUE = 'q3oi6d9X8uenGvdLnHk2'
 
@@ -26,19 +28,13 @@ export const merge = (newValue, oldValue) => {
 
 export const obfuscate = value => replace(value, OBFUSCATED_VALUE)
 
-const SENSITIVE_PARAMS = {
-  __proto__: null,
-  chapPassword: true,
-  cifspassword: true,
-  newPassword: true,
-  oldPassword: true,
-  password: true,
-  token: true,
-}
+const sensitiveParamsMatcher = globMatcher(['token', '*password*'], {
+  nocase: true,
+})
 
 export function replace(value, replacement) {
   function helper(value, name) {
-    if (typeof value === 'string' && name in SENSITIVE_PARAMS) {
+    if (typeof value === 'string' && sensitiveParamsMatcher(name)) {
       return replacement
     }
 

--- a/packages/xo-server/src/sensitive-values.js
+++ b/packages/xo-server/src/sensitive-values.js
@@ -27,14 +27,14 @@ export const merge = (newValue, oldValue) => {
 export const obfuscate = value => replace(value, OBFUSCATED_VALUE)
 
 const SENSITIVE_PARAMS = ['token', /password/i]
-const sensitiveParamsMatcher = name =>
+const isSensitiveParam = name =>
   SENSITIVE_PARAMS.some(pattern =>
     typeof pattern === 'string' ? pattern === name : pattern.test(name)
   )
 
 export function replace(value, replacement) {
   function helper(value, name) {
-    if (typeof value === 'string' && sensitiveParamsMatcher(name)) {
+    if (typeof value === 'string' && isSensitiveParam(name)) {
       return replacement
     }
 

--- a/packages/xo-server/src/sensitive-values.js
+++ b/packages/xo-server/src/sensitive-values.js
@@ -1,7 +1,5 @@
 import mapValues from 'lodash/mapValues'
 
-import globMatcher from './glob-matcher'
-
 // this random value is used to obfuscate real data
 const OBFUSCATED_VALUE = 'q3oi6d9X8uenGvdLnHk2'
 
@@ -28,9 +26,11 @@ export const merge = (newValue, oldValue) => {
 
 export const obfuscate = value => replace(value, OBFUSCATED_VALUE)
 
-const sensitiveParamsMatcher = globMatcher(['token', '*password*'], {
-  nocase: true,
-})
+const SENSITIVE_PARAMS = ['token', /password/i]
+const sensitiveParamsMatcher = name =>
+  SENSITIVE_PARAMS.some(pattern =>
+    typeof pattern === 'string' ? pattern === name : pattern.test(name)
+  )
 
 export function replace(value, replacement) {
   function helper(value, name) {


### PR DESCRIPTION
Fixes #5219

To understand this PR see:
- [oldPassword/newPassword usage](https://github.com/vatesfr/xen-orchestra/blob/af2710135b3d271cf024b63f175ec82ba2c36799/packages/xo-server/src/api/user.js#L96-L97)
- [chapPassword usage](https://github.com/vatesfr/xen-orchestra/blob/master/packages/xo-server/src/api/sr.js#L595)
- [sensitiveValues.replace usage on the API call with its log](https://github.com/vatesfr/xen-orchestra/blob/master/packages/xo-server/src/xo-mixins/api.js#L262-L272)

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
