### PR TITLE
fix(xo-server-audit): handle non-existent XOA plugin

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,4 +30,5 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
+- xo-server-audit patch
 - xo-server patch

--- a/packages/xo-server-audit/src/index.js
+++ b/packages/xo-server-audit/src/index.js
@@ -312,6 +312,12 @@ class AuditXoPlugin {
   // See www-xo#344
   async _uploadLastHash() {
     const xo = this._xo
+
+    // In case of non-existent XOA plugin
+    if (xo.audit === undefined) {
+      return
+    }
+
     const chain = await xo.audit.getLastChain()
 
     let lastHash, integrityCheckSuccess


### PR DESCRIPTION
See https://github.com/vatesfr/xen-orchestra/commit/38de5048bc2f867944546337d4a464ed19eb51a4#commitcomment-41875481

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
