### PR TITLE
fix(xo-vmdk-to-vhd/grabTables): read each entry independently

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [New SR] Fix `Cannot read property 'trim' of undefined` error (PR [#5212](https://github.com/vatesfr/xen-orchestra/pull/5212))
+- [Import VMDK] Fix `No position specified for vmdisk1` error (PR [#5255](https://github.com/vatesfr/xen-orchestra/pull/5255))
 
 ### Packages to release
 
@@ -32,5 +33,6 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
+- xo-vmdk-to-vhd patch
 - xo-web minor
 - xo-server patch

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "moduleNameMapper": {
       "^@xen-orchestra/async-map": "@xen-orchestra/async-map/src",
       "^@xen-orchestra/fs": "@xen-orchestra/fs/src",
+      "^@xen-orchestra/log": "@xen-orchestra/log/src",
       "^xo-remote-parser": "xo-remote-parser/src",
       "^vhd-lib": "vhd-lib/src",
       "^vhd-cli": "vhd-cli/src",

--- a/packages/xo-vmdk-to-vhd/src/vmdk-read-table.js
+++ b/packages/xo-vmdk-to-vhd/src/vmdk-read-table.js
@@ -50,28 +50,14 @@ async function grabTables(
   fileAccessor
 ) {
   const cachedGrainTables = []
-  let grainTableAddresMin = Infinity
-  let grainTableAddressMax = -Infinity
   for (let i = 0; i < grainDirectoryEntries; i++) {
     const grainTableAddr = grainDir[i] * SECTOR_SIZE
     if (grainTableAddr !== 0) {
-      grainTableAddresMin = Math.min(grainTableAddresMin, grainTableAddr)
-      grainTableAddressMax = Math.max(
-        grainTableAddressMax,
-        grainTableAddr + grainTablePhysicalSize
-      )
-    }
-  }
-  const grainTableBuffer = await fileAccessor(
-    grainTableAddresMin,
-    grainTableAddressMax
-  )
-  for (let i = 0; i < grainDirectoryEntries; i++) {
-    const grainTableAddr = grainDir[i] * SECTOR_SIZE
-    if (grainTableAddr !== 0) {
-      const addr = grainTableAddr - grainTableAddresMin
       cachedGrainTables[i] = new Uint32Array(
-        grainTableBuffer.slice(addr, addr + grainTablePhysicalSize)
+        await fileAccessor(
+          grainTableAddr,
+          grainTableAddr + grainTablePhysicalSize
+        )
       )
     }
   }


### PR DESCRIPTION
Reading all entries at once cause problems on some VMDKs (those generated by VirtualBox) because they appear to be distributed throughout the VMDK thus making the buffer not fit in memory.

See https://xcp-ng.org/forum/topic/3374/cannot-import-ova-from-virtualbox/14?_=1599689219209

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
