### PR TITLE
fix(xo-server#removeSubjectToResourceSet): rename to removeSubjectFromResourceSet

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,8 @@
 
 ### Bug fixes
 
+> Users must be able to say: “I had this issue, happy to know it's fixed”
+
 - [Resource Set] Fix `this.removeSubjectFromResourceSet is not a function` error on calling `resourceSet.removeSubject` via `xo-cli` [#5265](https://github.com/vatesfr/xen-orchestra/issues/5265) (PR [#5266](https://github.com/vatesfr/xen-orchestra/pull/5266))
 
 ### Packages to release

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 
 ### Bug fixes
 
-- [Resource Set] Fix issue that caused the `resourceSet.removeSubject` rpc call to fail
+- [Resource Set] Fix `this.removeSubjectFromResourceSet is not a function` error on calling `resourceSet.removeSubject` via `xo-cli` [#5265](https://github.com/vatesfr/xen-orchestra/issues/5265) (PR [#5266](https://github.com/vatesfr/xen-orchestra/pull/5266))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 
 ### Bug fixes
 
-> Users must be able to say: “I had this issue, happy to know it's fixed”
+- [Resource Set] Fix issue that caused the `resourceSet.removeSubject` rpc call to fail
 
 ### Packages to release
 
@@ -33,3 +33,4 @@
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
 - xo-web minor
+- xo-server patch

--- a/packages/xo-server-test/src/_xoConnection.js
+++ b/packages/xo-server-test/src/_xoConnection.js
@@ -109,6 +109,12 @@ class XoConnection extends Xo {
     return id
   }
 
+  async createTempResourceSet(params) {
+    const { id } = await xo.call('resourceSet.create', params)
+    this._tempResourceDisposers.push('resourceSet.delete', { id })
+    return id
+  }
+
   async getUser(id) {
     return find(await super.call('user.getAll'), { id })
   }

--- a/packages/xo-server-test/src/issues/index.spec.js
+++ b/packages/xo-server-test/src/issues/index.spec.js
@@ -124,18 +124,14 @@ describe('issue', () => {
           'three',
     ]
     test('resourceSet.removeSubject call', async () => {
-      const rs = await xo.call('resourceSet.create', {
+      const id = await xo.createTempResourceSet({
         name: rsName,
         subjects: subjects,
       })
 
       await xo.call('resourceSet.removeSubject', {
-        id: rs.id,
+        id,
         subject: subjects[0]
-      })
-
-      await xo.call('resourceSet.delete', {
-        id: rs.id,
       })
     })
   })

--- a/packages/xo-server-test/src/issues/index.spec.js
+++ b/packages/xo-server-test/src/issues/index.spec.js
@@ -115,4 +115,28 @@ describe('issue', () => {
       expect(vm.boot.order).toBe('n' + bootOrder)
     })
   })
+
+  describe('5265',  () => {
+    const rsName = "xo-server-test resource set"
+    const subjects = [
+          'one',
+          'two',
+          'three',
+    ]
+    test('resourceSet.removeSubject call', async () => {
+      const rs = await xo.call('resourceSet.create', {
+        name: rsName,
+        subjects: subjects,
+      })
+
+      await xo.call('resourceSet.removeSubject', {
+        id: rs.id,
+        subject: subjects[0]
+      })
+
+      await xo.call('resourceSet.delete', {
+        id: rs.id,
+      })
+    })
+  })
 })

--- a/packages/xo-server/src/xo-mixins/resource-sets.js
+++ b/packages/xo-server/src/xo-mixins/resource-sets.js
@@ -307,7 +307,7 @@ export default class {
     await this._save(set)
   }
 
-  async removeSubjectToResourceSet(subjectId, setId) {
+  async removeSubjectFromResourceSet(subjectId, setId) {
     const set = await this.getResourceSet(setId)
     remove(set.subjects, id => id === subjectId)
     await this._save(set)


### PR DESCRIPTION
Fixes #5265

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [x] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.