### PR TITLE
fix(xo-server/subjects/addToArraySet): dont erase previous values

### DIFF
--- a/packages/xo-server/src/xo-mixins/subjects.js
+++ b/packages/xo-server/src/xo-mixins/subjects.js
@@ -1,5 +1,5 @@
 import createLogger from '@xen-orchestra/log'
-import { filter, includes } from 'lodash'
+import { filter } from 'lodash'
 import { ignoreErrors } from 'promise-toolbox'
 import { hash, needsRehash, verify } from 'hashy'
 import { invalidCredentials, noSuchObject } from 'xo-common/api-errors'
@@ -14,7 +14,7 @@ import { forEach, isEmpty, lightSet, mapToArray } from '../utils'
 const log = createLogger('xo:xo-mixins:subjects')
 
 const addToArraySet = (set, value) =>
-  set ? (includes(set, value) ? set : set.concat(value)) : [value]
+  set !== undefined ? (set.includes(value) ? set : set.concat(value)) : [value]
 const removeFromArraySet = (set, value) =>
   set && filter(set, current => current !== value)
 

--- a/packages/xo-server/src/xo-mixins/subjects.js
+++ b/packages/xo-server/src/xo-mixins/subjects.js
@@ -14,7 +14,7 @@ import { forEach, isEmpty, lightSet, mapToArray } from '../utils'
 const log = createLogger('xo:xo-mixins:subjects')
 
 const addToArraySet = (set, value) =>
-  set && !includes(set, value) ? set.concat(value) : [value]
+  set ? (includes(set, value) ? set : set.concat(value)) : [value]
 const removeFromArraySet = (set, value) =>
   set && filter(set, current => current !== value)
 


### PR DESCRIPTION
Prior to this change, adding a value to an existing set that already contains
that value would replace the whole set with a new one containing only that
value.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
