### PR TITLE
fix(xo-server/_authenticateUser): remove broken/unused provider API

### DIFF
--- a/packages/xo-server/src/xo-mixins/authentication.js
+++ b/packages/xo-server/src/xo-mixins/authentication.js
@@ -113,7 +113,7 @@ export default class {
 
         if (typeof result === 'string') {
           return {
-            user: await this._getUser(result),
+            user: await this._xo.getUser(result),
           }
         }
 

--- a/packages/xo-server/src/xo-mixins/authentication.js
+++ b/packages/xo-server/src/xo-mixins/authentication.js
@@ -97,7 +97,6 @@ export default class {
       try {
         // A provider can return:
         // - `undefined`/`null` if the user could not be authenticated
-        // - the identifier of the authenticated user
         // - an object containing:
         //   - `userId`
         //   - optionally `expiration` to indicate when the session is no longer
@@ -109,12 +108,6 @@ export default class {
         // No match.
         if (result == null) {
           continue
-        }
-
-        if (typeof result === 'string') {
-          return {
-            user: await this._xo.getUser(result),
-          }
         }
 
         const { userId, username, expiration } = result


### PR DESCRIPTION
Broken and not used by any auth provider

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
