### PR TITLE
fix(xo-server/users): serialize properties on user `create` as well

### DIFF
--- a/packages/xo-server/src/models/user.js
+++ b/packages/xo-server/src/models/user.js
@@ -2,7 +2,6 @@ import isEmpty from 'lodash/isEmpty'
 
 import Collection from '../collection/redis'
 import Model from '../model'
-import { forEach } from '../utils'
 
 import { parseProp } from './utils'
 
@@ -15,6 +14,23 @@ User.prototype.default = {
 }
 
 // -------------------------------------------------------------------
+
+const serialize = user => {
+  let tmp
+  return {
+    ...user,
+    groups: isEmpty((tmp = user.groups)) ? undefined : JSON.stringify(tmp),
+    preferences: isEmpty((tmp = user.preferences))
+      ? undefined
+      : JSON.stringify(tmp),
+  }
+}
+
+const deserialize = user => ({
+  ...user,
+  groups: parseProp('user', user, 'groups', []),
+  preferences: parseProp('user', user, 'preferences', {}),
+})
 
 export class Users extends Collection {
   get Model() {
@@ -30,32 +46,17 @@ export class Users extends Collection {
     }
 
     // Create the user object.
-    const user = new User(properties)
+    const user = new User(serialize(properties))
 
     // Adds the user to the collection.
     return /* await */ this.add(user)
   }
 
   async save(user) {
-    // Serializes.
-    let tmp
-    user.groups = isEmpty((tmp = user.groups)) ? undefined : JSON.stringify(tmp)
-    user.preferences = isEmpty((tmp = user.preferences))
-      ? undefined
-      : JSON.stringify(tmp)
-
-    return /* await */ this.update(user)
+    return /* await */ this.update(serialize(user))
   }
 
   async get(properties) {
-    const users = await super.get(properties)
-
-    // Deserializes
-    forEach(users, user => {
-      user.groups = parseProp('user', user, 'groups', [])
-      user.preferences = parseProp('user', user, 'preferences', {})
-    })
-
-    return users
+    return (await super.get(properties)).map(deserialize)
   }
 }


### PR DESCRIPTION
This didn't break anything because we usually don't assign `groups` and/or
`preferences` (which are the only 2 properties that need serialization) on user
creation.

This also prepares a minimal change to add a `authProviders` object property on
users.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
