### PR TITLE
fix(import/ova): speedup the import of gziped vmdk disks nested in .ova

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,7 +22,7 @@
 - [API] Fix `this.removeSubjectFromResourceSet is not a function` error on calling `resourceSet.removeSubject` via `xo-cli` [#5265](https://github.com/vatesfr/xen-orchestra/issues/5265) (PR [#5266](https://github.com/vatesfr/xen-orchestra/pull/5266))
 - [Import OVA] Fix frozen UI when dropping a big OVA on the page (PR [#5274](https://github.com/vatesfr/xen-orchestra/pull/5274))
 - [Remotes/S3] Fix S3 backup of 50GB+ files [#5197](https://github.com/vatesfr/xen-orchestra/issues/5197) (PR[ #5242](https://github.com/vatesfr/xen-orchestra/pull/5242) )
-- [Import OVA] Improve import speed of embedded gzipped vmdk disks (PR [#5275](https://github.com/vatesfr/xen-orchestra/pull/5275))
+- [Import OVA] Improve import speed of embedded gzipped VMDK disks (PR [#5275](https://github.com/vatesfr/xen-orchestra/pull/5275))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@
 
 - [Import VMDK] Fix `No position specified for vmdisk1` error (PR [#5255](https://github.com/vatesfr/xen-orchestra/pull/5255))
 - [API] Fix `this.removeSubjectFromResourceSet is not a function` error on calling `resourceSet.removeSubject` via `xo-cli` [#5265](https://github.com/vatesfr/xen-orchestra/issues/5265) (PR [#5266](https://github.com/vatesfr/xen-orchestra/pull/5266))
+- [Import OVA] Improve import speed of embedded gzipped vmdk disks (PR [#5275](https://github.com/vatesfr/xen-orchestra/pull/5275))
 
 ### Packages to release
 

--- a/packages/xo-vmdk-to-vhd/src/ova.js
+++ b/packages/xo-vmdk-to-vhd/src/ova.js
@@ -305,22 +305,18 @@ export async function parseOVAFile(
         // if next read is further down the stream than previous read, re-uses the previous zstream
         async function parseGzipFromStart(start, end, fileSlice) {
           const chunks = []
-          if (
-            forwardsInflater.result != null &&
-            start <
-              forwardsInflater.strm.total_out - forwardsInflater.result.length
-          ) {
+          const resultStart = () =>
+            forwardsInflater.strm.total_out - forwardsInflater.result.length
+          if (forwardsInflater.result != null && start < resultStart()) {
             // the block we are reading starts before the last decompressed chunk, reset stream
             forwardsInflater = new pako.Inflate()
           }
           let isLast = false
           while (true) {
             if (forwardsInflater.strm.total_out > start) {
-              const inflatedChunkStart =
-                forwardsInflater.strm.total_out - forwardsInflater.result.length
               let chunk = forwardsInflater.result
-              if (inflatedChunkStart < start) {
-                chunk = chunk.slice(start - inflatedChunkStart)
+              if (resultStart() < start) {
+                chunk = chunk.slice(start - resultStart())
               }
               if (forwardsInflater.strm.total_out > end) {
                 chunk = chunk.slice(0, -(forwardsInflater.strm.total_out - end))


### PR DESCRIPTION
This the followup to #5085

Avoid unzipping the entire file from the beginning before each read.
The test case when from 10min down to 26 seconds.

When reading a block from the gzipped file, we keep the current state in memory, if the next read happens at an offset greater than the previous read, we just carry one decompressing the file until the desired position.

The previous code would decompress from the start of the file for every read operation.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
