### PR TITLE
fix(xo-web/remotes): fix editing bucket and directory for S3

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Import VMDK] Fix `No position specified for vmdisk1` error (PR [#5255](https://github.com/vatesfr/xen-orchestra/pull/5255))
+- [Backup/S3] Fix S3 remote edit UI [#5233](https://github.com/vatesfr/xen-orchestra/issues/5233) (PR [5276](https://github.com/vatesfr/xen-orchestra/pull/5276))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Import VMDK] Fix `No position specified for vmdisk1` error (PR [#5255](https://github.com/vatesfr/xen-orchestra/pull/5255))
-- [Backup/S3] Fix S3 remote edit UI [#5233](https://github.com/vatesfr/xen-orchestra/issues/5233) (PR [5276](https://github.com/vatesfr/xen-orchestra/pull/5276))
+- [Remotes] Fix editing bucket and directory for S3 remotes [#5233](https://github.com/vatesfr/xen-orchestra/issues/5233) (PR [5276](https://github.com/vatesfr/xen-orchestra/pull/5276))
 
 ### Packages to release
 

--- a/packages/xo-web/src/xo-app/settings/remotes/remote.js
+++ b/packages/xo-web/src/xo-app/settings/remotes/remote.js
@@ -56,12 +56,18 @@ export default decorate([
           name,
           options = remote.options || '',
           password = remote.password,
-          path = remote.path,
           port = remote.port,
           proxyId = remote.proxy,
           type = remote.type,
           username = remote.username,
+          parsedPath,
+          bucket = parsedPath && parsedPath.split('/')[0],
+          directory = parsedPath && parsedPath.split('/')[1],
         } = state
+        let { path = remote.path } = state
+        if (type === 's3') {
+          path = bucket + '/' + directory
+        }
         return editRemote(remote, {
           name,
           url: format({
@@ -152,7 +158,7 @@ export default decorate([
       path = parsedPath || '',
       parsedBucket = parsedPath && parsedPath.split('/')[0],
       bucket = parsedBucket || '',
-      parsedDirectory,
+      parsedDirectory = parsedPath && parsedPath.split('/')[1],
       directory = parsedDirectory || '',
       port = remote.port,
       proxyId = remote.proxy,

--- a/packages/xo-web/src/xo-app/settings/remotes/remote.js
+++ b/packages/xo-web/src/xo-app/settings/remotes/remote.js
@@ -61,8 +61,8 @@ export default decorate([
           type = remote.type,
           username = remote.username,
           parsedPath,
-          bucket = parsedPath && parsedPath.split('/')[0],
-          directory = parsedPath && parsedPath.split('/')[1],
+          bucket = parsedPath != null && parsedPath.split('/')[0],
+          directory = parsedPath != null && parsedPath.split('/')[1],
         } = state
         let { path = remote.path } = state
         if (type === 's3') {
@@ -156,9 +156,9 @@ export default decorate([
       password = remote.password || '',
       parsedPath,
       path = parsedPath || '',
-      parsedBucket = parsedPath && parsedPath.split('/')[0],
+      parsedBucket = parsedPath != null && parsedPath.split('/')[0],
       bucket = parsedBucket || '',
-      parsedDirectory = parsedPath && parsedPath.split('/')[1],
+      parsedDirectory = parsedPath != null && parsedPath.split('/')[1],
       directory = parsedDirectory || '',
       port = remote.port,
       proxyId = remote.proxy,

--- a/packages/xo-web/src/xo-app/settings/remotes/remote.js
+++ b/packages/xo-web/src/xo-app/settings/remotes/remote.js
@@ -60,12 +60,14 @@ export default decorate([
           proxyId = remote.proxy,
           type = remote.type,
           username = remote.username,
-          parsedPath,
-          bucket = parsedPath != null && parsedPath.split('/')[0],
-          directory = parsedPath != null && parsedPath.split('/')[1],
         } = state
         let { path = remote.path } = state
         if (type === 's3') {
+          const {
+            parsedPath,
+            bucket = parsedPath != null && parsedPath.split('/')[0],
+            directory = parsedPath != null && parsedPath.split('/')[1],
+          } = state
           path = bucket + '/' + directory
         }
         return editRemote(remote, {
@@ -102,8 +104,6 @@ export default decorate([
           path,
           port,
           proxyId,
-          bucket,
-          directory,
           type = 'nfs',
           username,
         } = state
@@ -115,6 +115,7 @@ export default decorate([
           type,
         }
         if (type === 's3') {
+          const { bucket, directory } = state
           urlParams.path = bucket + '/' + directory
         }
         username && (urlParams.username = username)

--- a/packages/xo-web/src/xo-app/settings/remotes/remote.js
+++ b/packages/xo-web/src/xo-app/settings/remotes/remote.js
@@ -65,8 +65,8 @@ export default decorate([
         if (type === 's3') {
           const {
             parsedPath,
-            bucket = parsedPath != null && parsedPath.split('/')[0],
-            directory = parsedPath != null && parsedPath.split('/')[1],
+            bucket = parsedPath.split('/')[0],
+            directory = parsedPath.split('/')[1],
           } = state
           path = bucket + '/' + directory
         }


### PR DESCRIPTION
Reported at #5233
This is a purely behavioral fix that do not change the UI appearance.

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
