### PR TITLE
fix(xo-web/vm/disks): VDI disappears after migration

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [Self/ VDI migration] Fix hidden VDI after migration (PR [#5296](https://github.com/vatesfr/xen-orchestra/pull/5296))
+- [Self/VDI migration] Fix hidden VDI after migration (PR [#5296](https://github.com/vatesfr/xen-orchestra/pull/5296))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Self/ VDI migration] Fix hidden VDI after migration (PR [#5296](https://github.com/vatesfr/xen-orchestra/pull/5296))
+
 ### Packages to release
 
 > Packages will be released in the order they are here, therefore, they should
@@ -27,3 +29,5 @@
 > - major: if the change breaks compatibility
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
+
+- xo-web patch

--- a/packages/xo-web/src/xo-app/vm/index.js
+++ b/packages/xo-web/src/xo-app/vm/index.js
@@ -81,8 +81,11 @@ import VmActionBar from './action-bar'
       pool: getPool(state, props),
       srs: getSrs(state, props),
       vbds: getVbds(state, props),
-      // Workaround to get VDIs as a self user
-      vdis: getVdis(state, props, vm.resourceSet !== undefined),
+      // Workaround to get the VDI object when the permissions cache isn't up to date:
+      // when a VDI is created on a VM, the user permissions might be checked on the
+      // VBD *before* it's attached to the VM so the permissions cache will store that
+      // the user doesn't have permissions on the VDI even after it's been attached
+      vdis: getVdis(state, props, true),
       vm,
       vmTotalDiskSpace: getVmTotalDiskSpace(state, props),
     }

--- a/packages/xo-web/src/xo-app/vm/index.js
+++ b/packages/xo-web/src/xo-app/vm/index.js
@@ -81,7 +81,8 @@ import VmActionBar from './action-bar'
       pool: getPool(state, props),
       srs: getSrs(state, props),
       vbds: getVbds(state, props),
-      vdis: getVdis(state, props),
+      // Workaround to get VDIs as a self user
+      vdis: getVdis(state, props, vm.resourceSet !== undefined),
       vm,
       vmTotalDiskSpace: getVmTotalDiskSpace(state, props),
     }


### PR DESCRIPTION
Introduced after adding the possibility to migrate VDIs as a self user  https://github.com/vatesfr/xen-orchestra/commit/1116530a6be539e644516f9e685bac57b72e78cb

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
