### PR TITLE
fix(xo-web/remotes): fix S3 secret key edit UI

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Backup/S3] Fix secret key edit form [#5233](https://github.com/vatesfr/xen-orchestra/issues/5233) (PR[#5305](https://github.com/vatesfr/xen-orchestra/pull/5305))
+
 ### Packages to release
 
 > Packages will be released in the order they are here, therefore, they should

--- a/packages/xo-web/src/xo-app/settings/remotes/remote.js
+++ b/packages/xo-web/src/xo-app/settings/remotes/remote.js
@@ -419,6 +419,7 @@ export default decorate([
                   name='password'
                   onChange={effects.setSecretKey}
                   placeholder='Paste secret here to change it'
+                  autoComplete='off'
                   required
                   type='text'
                 />

--- a/packages/xo-web/src/xo-app/settings/remotes/remote.js
+++ b/packages/xo-web/src/xo-app/settings/remotes/remote.js
@@ -139,6 +139,9 @@ export default decorate([
           .then(reset)
           .catch(err => error('Create Remote', err.message || String(err)))
       },
+      setSecretKey(_, { target: { value } }) {
+        this.state.password = value
+      },
     },
     computed: {
       formId: generateId,
@@ -414,11 +417,10 @@ export default decorate([
                 <input
                   className='form-control'
                   name='password'
-                  onChange={effects.linkState}
-                  placeholder='Secret access key'
+                  onChange={effects.setSecretKey}
+                  placeholder='Paste secret here to change it'
                   required
                   type='text'
-                  value={password}
                 />
               </div>
             </fieldset>


### PR DESCRIPTION
Bug #5233

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
