### PR TITLE
fix(@xen-orchestra/proxy#readDeltaVmBackup): use path.join

### DIFF
--- a/@xen-orchestra/proxy/src/app/mixins/backups/_RemoteAdapter.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/_RemoteAdapter.js
@@ -2,7 +2,7 @@ import asyncMap from '@xen-orchestra/async-map'
 import fromCallback from 'promise-toolbox/fromCallback'
 import pump from 'pump'
 import Vhd, { createSyntheticStream, mergeVhd } from 'vhd-lib'
-import { basename, dirname, resolve } from 'path'
+import { basename, dirname, join, resolve } from 'path'
 import { createLogger } from '@xen-orchestra/log'
 
 import { BACKUP_DIR } from './_getVmBackupDir'
@@ -174,7 +174,7 @@ export class RemoteAdapter {
     await asyncMap(vdis, async (vdi, id) => {
       streams[`${id}.vhd`] = await createSyntheticStream(
         handler,
-        resolve(dir, vhds[id])
+        join(dir, vhds[id])
       )
     })
 


### PR DESCRIPTION
This PR fixes the issue with the delta backup restoration.

**Fixed error**:

```
2020-10-21T13:07:29.502Z xo:proxy:api WARN call error {
  method: 'backup.importVmBackup',
  params: {
    backupId: 'xo-vm-backups/933706c5-ae47-8784-ab34-85e669f2f111/20201021T080131Z.json',
    remote: { url: 'file:///home/badrazizbi/Documents/proxyRemote' },
    srUuid: '86a9757d-9c05-9fe0-e79a-8243cb1f37f3',
    xapi: {
      allowUnauthorized: true,
      credentials: [Object],
      url: '172.16.210.11'
    }
  },
  error: [Error: ENOENT: no such file or directory, open '/home/badrazizbi/Documents/proxyRemote/home/badrazizbi/Documents/tmpXo/xen-orchestra/@xen-orchestra/proxy/xo-vm-backups/933706c5-ae47-8784-ab34-85e669f2f111/vdis/e7225b46-0b19-477f-912b-b2b6ce9950d9/7d2c1146-ebc9-485c-b2e8-7abfece98bc6/20201021T080131Z.vhd'] {
    errno: -2,
    code: 'ENOENT',
    syscall: 'open',
    path: '/home/badrazizbi/Documents/proxyRemote/home/badrazizbi/Documents/tmpXo/xen-orchestra/@xen-orchestra/proxy/xo-vm-backups/933706c5-ae47-8784-ab34-85e669f2f111/vdis/e7225b46-0b19-477f-912b-b2b6ce9950d9/7d2c1146-ebc9-485c-b2e8-7abfece98bc6/20201021T080131Z.vhd'
  }
}
```
 The cause of this issue is that `path.resolve` creates an absolute path of the current working directory if no segment path is passed


### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
