### PR TITLE
fix(xo-server/{CR,DR}): add tags at VM creation

### DIFF
--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -1549,17 +1549,19 @@ export default class BackupNg {
                     result: () => ({ size: xva.size }),
                   },
                   xapi._importVm($cancelToken, fork, sr, vm =>
-                    vm.set_name_label(
-                      `${metadata.vm.name_label} - ${
-                        job.name
-                      } - (${safeDateFormat(metadata.timestamp)})`
-                    )
+                    Promise.all([
+                      vm.add_tags('Disaster Recovery'),
+                      vm.set_name_label(
+                        `${metadata.vm.name_label} - ${
+                          job.name
+                        } - (${safeDateFormat(metadata.timestamp)})`
+                      ),
+                    ])
                   )
                 )
               )
 
               await Promise.all([
-                vm.add_tags('Disaster Recovery'),
                 disableVmHighAvailability(xapi, vm),
                 vm.update_blocked_operations(
                   'start',
@@ -1936,17 +1938,25 @@ export default class BackupNg {
                   parentId: taskId,
                   result: ({ transferSize }) => ({ size: transferSize }),
                 },
-                xapi.importDeltaVm(fork, {
-                  disableStartAfterImport: false, // we'll take care of that
-                  name_label: `${metadata.vm.name_label} - ${
-                    job.name
-                  } - (${safeDateFormat(metadata.timestamp)})`,
-                  srId: sr.$id,
-                })
+                xapi.importDeltaVm(
+                  {
+                    __proto__: fork,
+                    vm: {
+                      __proto__: fork.vm,
+                      tags: [...fork.vm.tags, 'Continuous Replication'],
+                    },
+                  },
+                  {
+                    disableStartAfterImport: false, // we'll take care of that
+                    name_label: `${metadata.vm.name_label} - ${
+                      job.name
+                    } - (${safeDateFormat(metadata.timestamp)})`,
+                    srId: sr.$id,
+                  }
+                )
               )
 
               await Promise.all([
-                vm.add_tags('Continuous Replication'),
                 disableVmHighAvailability(xapi, vm),
                 vm.update_blocked_operations(
                   'start',

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -1942,7 +1942,7 @@ export default class BackupNg {
                   {
                     __proto__: fork,
                     vm: {
-                      __proto__: fork.vm,
+                      ...fork.vm,
                       tags: [...fork.vm.tags, 'Continuous Replication'],
                     },
                   },


### PR DESCRIPTION
Fixes https://xcp-ng.org/forum/topic/3285/cr-tag-ignored-kind-of-in-smart-backup

Necessary to avoid smart mode from matching the replicated VMs

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
