### PR TITLE
fix(fs/nfs): only use vers=3 if no other options

### DIFF
--- a/@xen-orchestra/fs/src/_mount.js
+++ b/@xen-orchestra/fs/src/_mount.js
@@ -25,7 +25,7 @@ export default class MountHandler extends LocalHandler {
     this._keeper = undefined
     this._params = {
       ...params,
-      options: [params.options, remote.options]
+      options: [params.options, remote.options ?? params.defaultOptions]
         .filter(_ => _ !== undefined)
         .join(','),
     }

--- a/@xen-orchestra/fs/src/nfs.js
+++ b/@xen-orchestra/fs/src/nfs.js
@@ -2,15 +2,13 @@ import { parse } from 'xo-remote-parser'
 
 import MountHandler from './_mount'
 
-const DEFAULT_NFS_OPTIONS = 'vers=3'
-
 export default class NfsHandler extends MountHandler {
   constructor(remote, opts) {
     const { host, port, path } = parse(remote.url)
     super(remote, opts, {
       type: 'nfs',
       device: `${host}${port !== undefined ? ':' + port : ''}:${path}`,
-      options: DEFAULT_NFS_OPTIONS,
+      defaultOptions: 'vers=3',
     })
   }
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Remotes/NFS] Only mount with `vers=3` when no other options [#4940](https://github.com/vatesfr/xen-orchestra/issues/4940) (PR [#5354](https://github.com/vatesfr/xen-orchestra/pull/5354))
+
 ### Packages to release
 
 > Packages will be released in the order they are here, therefore, they should
@@ -27,3 +29,6 @@
 > - major: if the change breaks compatibility
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
+
+- @xen-orchestra/fs patch
+- xo-server patch


### PR DESCRIPTION
Fixes #4940

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
