### PR TITLE
fix(xo-server/vif.set): don't change a VIF locking mode automatically

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Remotes/NFS] Only mount with `vers=3` when no other options [#4940](https://github.com/vatesfr/xen-orchestra/issues/4940) (PR [#5354](https://github.com/vatesfr/xen-orchestra/pull/5354))
-- [VM/network, New VM] Don't change VIF's locking mode automatically (PR [#5357](https://github.com/vatesfr/xen-orchestra/pull/5357))
+- [VM/network] Don't change VIF's locking mode automatically (PR [#5357](https://github.com/vatesfr/xen-orchestra/pull/5357))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Remotes/NFS] Only mount with `vers=3` when no other options [#4940](https://github.com/vatesfr/xen-orchestra/issues/4940) (PR [#5354](https://github.com/vatesfr/xen-orchestra/pull/5354))
-- [VM/network] Don't change a VIF's locking mode automatically (PR [#5357](https://github.com/vatesfr/xen-orchestra/pull/5357))
+- [VM/network, New VM] Don't change a VIF's locking mode automatically (PR [#5357](https://github.com/vatesfr/xen-orchestra/pull/5357))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Remotes/NFS] Only mount with `vers=3` when no other options [#4940](https://github.com/vatesfr/xen-orchestra/issues/4940) (PR [#5354](https://github.com/vatesfr/xen-orchestra/pull/5354))
-- [VM/network, New VM] Don't change a VIF's locking mode automatically (PR [#5357](https://github.com/vatesfr/xen-orchestra/pull/5357))
+- [VM/network, New VM] Don't change VIF's locking mode automatically (PR [#5357](https://github.com/vatesfr/xen-orchestra/pull/5357))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Remotes/NFS] Only mount with `vers=3` when no other options [#4940](https://github.com/vatesfr/xen-orchestra/issues/4940) (PR [#5354](https://github.com/vatesfr/xen-orchestra/pull/5354))
+- [VM/network] Don't change a VIF's locking mode automatically (PR [#5357](https://github.com/vatesfr/xen-orchestra/pull/5357))
 
 ### Packages to release
 

--- a/packages/xo-server/src/api/vif.js
+++ b/packages/xo-server/src/api/vif.js
@@ -119,7 +119,7 @@ export async function set({
       mac,
       currently_attached: attached,
       ipv4_allowed: newIpAddresses,
-      locking_mode: lockingMode,
+      locking_mode: lockingMode ?? vif.lockingMode,
       qos_algorithm_type: rateLimit != null ? 'ratelimit' : undefined,
       qos_algorithm_params:
         rateLimit != null ? { kbps: String(rateLimit) } : undefined,

--- a/packages/xo-server/src/xapi/mixins/networking.js
+++ b/packages/xo-server/src/xapi/mixins/networking.js
@@ -1,5 +1,3 @@
-import { isEmpty } from '../../utils'
-
 import { makeEditObject } from '../utils'
 
 export default {
@@ -27,36 +25,10 @@ export default {
   },
   editVif: makeEditObject({
     ipv4Allowed: {
-      get: true,
-      set: [
-        'ipv4Allowed',
-        function (value, vif) {
-          const lockingMode =
-            isEmpty(value) && isEmpty(vif.ipv6_allowed)
-              ? 'network_default'
-              : 'locked'
-
-          if (lockingMode !== vif.locking_mode) {
-            return vif.set_locking_mode(lockingMode)
-          }
-        },
-      ],
+      set: (value, vif) => vif.set_ipv4_allowed(value),
     },
     ipv6Allowed: {
-      get: true,
-      set: [
-        'ipv6Allowed',
-        function (value, vif) {
-          const lockingMode =
-            isEmpty(value) && isEmpty(vif.ipv4_allowed)
-              ? 'network_default'
-              : 'locked'
-
-          if (lockingMode !== vif.locking_mode) {
-            return vif.set_locking_mode(lockingMode)
-          }
-        },
-      ],
+      set: (value, vif) => vif.set_ipv6_allowed(value),
     },
     lockingMode: {
       set: (value, vif) => vif.set_locking_mode(value),

--- a/packages/xo-server/src/xapi/mixins/networking.js
+++ b/packages/xo-server/src/xapi/mixins/networking.js
@@ -24,12 +24,8 @@ export default {
     await this._disconnectVif(this.getObject(vifId))
   },
   editVif: makeEditObject({
-    ipv4Allowed: {
-      set: (value, vif) => vif.set_ipv4_allowed(value),
-    },
-    ipv6Allowed: {
-      set: (value, vif) => vif.set_ipv6_allowed(value),
-    },
+    ipv4Allowed: true,
+    ipv6Allowed: true,
     lockingMode: {
       set: (value, vif) => vif.set_locking_mode(value),
     },

--- a/packages/xo-server/src/xapi/mixins/vm.js
+++ b/packages/xo-server/src/xapi/mixins/vm.js
@@ -229,10 +229,7 @@ export default {
             ipv4_allowed: vif.ipv4_allowed,
             ipv6_allowed: vif.ipv6_allowed,
             device: devices[index],
-            locking_mode:
-              isEmpty(vif.ipv4_allowed) && isEmpty(vif.ipv6_allowed)
-                ? 'network_default'
-                : 'locked',
+            locking_mode: vif.lockingMode,
             mac: vif.mac,
             mtu: vif.mtu,
           })

--- a/packages/xo-server/src/xapi/mixins/vm.js
+++ b/packages/xo-server/src/xapi/mixins/vm.js
@@ -229,7 +229,10 @@ export default {
             ipv4_allowed: vif.ipv4_allowed,
             ipv6_allowed: vif.ipv6_allowed,
             device: devices[index],
-            locking_mode: vif.lockingMode,
+            locking_mode:
+              isEmpty(vif.ipv4_allowed) && isEmpty(vif.ipv6_allowed)
+                ? 'network_default'
+                : 'locked',
             mac: vif.mac,
             mtu: vif.mtu,
           })


### PR DESCRIPTION
See xoa-support#2929

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
