### PR TITLE
fix(xo-server/jobs): don't throw when the job owner doesn't exist

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,3 +27,5 @@
 > - major: if the change breaks compatibility
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
+
+- xo-server patch

--- a/packages/xo-server/src/xo-mixins/jobs/index.js
+++ b/packages/xo-server/src/xo-mixins/jobs/index.js
@@ -263,7 +263,11 @@ export default class Jobs {
     })
 
     const app = this._app
-    const user = await app.getUser(job.userId)
+    const user = await app.getUser(job.userId).catch(error => {
+      if (!noSuchObject.is(error)) {
+        throw error
+      }
+    })
     const data = {
       callId: Math.random().toString(36).slice(2),
       method: 'backupNg.runJob',


### PR DESCRIPTION
Introduced by 31b19725b75808af687e4db4334ff6dd222d8f16

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
