### PR TITLE
fix(xo-server/docs/file-restoration): use sizelimit options

### DIFF
--- a/packages/xo-server/docs/file-restoration.md
+++ b/packages/xo-server/docs/file-restoration.md
@@ -31,7 +31,7 @@ NR="5" START="501760" SIZE="8331984896" NAME="" UUID="c8d70417-05" TYPE="0x8e"
 ## Mount LVM physical volume (partition type equals to `0x8e`)
 
 ```
-> losetup -o $(($START * 512)) --show -f /tmp/vhd-mount/vhdi2
+> losetup -o $(($START * 512)) --sizelimit $(($SIZE)) --show -f /tmp/vhd-mount/vhdi2
 /dev/loop0
 > pvscan --cache /dev/loop0
 ```
@@ -72,7 +72,7 @@ When logical volume no longer necessary:
 
 ```
 > mkdir /tmp/block-mount
-> mount --options=loop,ro,$((START * 512)) --source=/tmp/vhd-mount/vhdi2 --target=/tmp/block-mount
+> mount --options=loop,ro,offset=$(($START * 512)),sizelimit=$(($SIZE)) --source=/tmp/vhd-mount/vhdi2 --target=/tmp/block-mount
 > ls /tmp/block-mount
 bin  boot  dev	etc  home  lib	lib64  lost+found  media  mnt  opt  proc  root	run  sbin  srv	sys  @System.solv  tmp	usr  var
 ```


### PR DESCRIPTION
When creating a loop device, the `sizelimit` options is necessary to indicate the end of the data to mount, otherwise the following error is thrown when trying to mount multiple parts of the disk:

```
overlapping loop device exists for /tmp/proxy1/vhdi1.
```

As an example, let's take this disk:

```
[ partition 0 | partition 1 | partition 2 ]
```

Mounting *partition 1* without `sizelimit` will mount the whole space starting from *partition 1* up to the end, which prevents *partition 2* from being mounted.

`man losetup`: https://manpages.ubuntu.com/manpages/precise/en/man8/losetup.8.html

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
