### PR TITLE
fix(xo-web/modal/form): pass `onChange` and `value` to form's body component

### DIFF
--- a/packages/xo-web/src/common/modal.js
+++ b/packages/xo-web/src/common/modal.js
@@ -324,42 +324,49 @@ export const FormModal = decorate([
     },
   }),
   injectState,
-  ({ state, effects }) => (
-    <ReactModal
-      backdrop='static'
-      bsSize={state.size}
-      keyboard={false}
-      onExited={effects.reset}
-      onHide={effects.onCancel}
-      show={state.opened}
-    >
-      <ReactModal.Header closeButton>
-        <ReactModal.Title>{state.header}</ReactModal.Title>
-      </ReactModal.Header>
+  ({ state, effects }) => {
+    const Component = state.component
 
-      <ReactModal.Body>
-        <form id={state.formId}>
-          {/* It should be better to use a computed to avoid calling the render function on each render,
+    return (
+      <ReactModal
+        backdrop='static'
+        bsSize={state.size}
+        keyboard={false}
+        onExited={effects.reset}
+        onHide={effects.onCancel}
+        show={state.opened}
+      >
+        <ReactModal.Header closeButton>
+          <ReactModal.Title>{state.header}</ReactModal.Title>
+        </ReactModal.Header>
+
+        <ReactModal.Body>
+          <form id={state.formId}>
+            {/* It should be better to use a computed to avoid calling the render function on each render,
             but reaclette(v0.4.0) not allow us to access to the effects from a computed */}
-          {state.component ||
-            (state.render !== undefined &&
+            {Component !== undefined ? (
+              <Component onChange={effects.onChange} value={state.value} />
+            ) : (
+              state.render !== undefined &&
               state.render({
                 onChange: effects.onChange,
                 value: state.value,
-              }))}
-        </form>
-      </ReactModal.Body>
+              })
+            )}
+          </form>
+        </ReactModal.Body>
 
-      <ReactModal.Footer>
-        <ActionButton btnStyle='primary' form={state.formId} handler={effects.onSubmit} icon='save' size='large'>
-          {_('formOk')}
-        </ActionButton>{' '}
-        <ActionButton handler={effects.onCancel} icon='cancel' size='large'>
-          {_('formCancel')}
-        </ActionButton>
-      </ReactModal.Footer>
-    </ReactModal>
-  ),
+        <ReactModal.Footer>
+          <ActionButton btnStyle='primary' form={state.formId} handler={effects.onSubmit} icon='save' size='large'>
+            {_('formOk')}
+          </ActionButton>{' '}
+          <ActionButton handler={effects.onCancel} icon='cancel' size='large'>
+            {_('formCancel')}
+          </ActionButton>
+        </ReactModal.Footer>
+      </ReactModal>
+    )
+  },
 ])
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #4705

Easier to review [without whitespaces](https://github.com/vatesfr/xen-orchestra/pull/5434/files?w=1).

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
