### PR TITLE
WiP: fix(backup/s3): maybe fix S3 timeout

### DIFF
--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -55,7 +55,7 @@ export default class S3Handler extends RemoteHandlerAbstract {
         ...this._createParams(path),
         Body: inputStream,
       },
-      { partSize: IDEAL_FRAGMENT_SIZE }
+      { partSize: IDEAL_FRAGMENT_SIZE, queueSize: 1 }
     )
     await upload.promise()
     if (checksum) {
@@ -174,7 +174,6 @@ export default class S3Handler extends RemoteHandlerAbstract {
         } else {
           const fragmentsCount = Math.ceil(prefixSize / MAX_PART_SIZE)
           const prefixFragmentSize = Math.ceil(prefixSize / fragmentsCount)
-          const lastFragmentSize = prefixFragmentSize * fragmentsCount - prefixSize
           let prefixPosition = 0
           for (let i = 0; i < fragmentsCount; i++) {
             const copyPrefixParams = {
@@ -189,8 +188,6 @@ export default class S3Handler extends RemoteHandlerAbstract {
               PartNumber: copyPrefixParams.PartNumber,
             })
             prefixPosition += prefixFragmentSize
-          }
-          if (lastFragmentSize) {
           }
         }
         if (hasSuffix && editBuffer.length < MIN_PART_SIZE) {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@
 
 - [Host] Fix `an error has occurred` on accessing a host's page (PR [#5417](https://github.com/vatesfr/xen-orchestra/pull/5417))
 - [Dashboard/Overview] Filter out `udev` SRs [#5423](https://github.com/vatesfr/xen-orchestra/issues/5423) (PR [#5453](https://github.com/vatesfr/xen-orchestra/pull/5453))
+- [Backup/S3] Fix `TimeoutError: Connection timed out after 120000ms` (PR [#5456](https://github.com/vatesfr/xen-orchestra/pull/5456))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -42,5 +42,6 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
+- @xen-orchestra/fs minor
 - xo-web minor
 - xo-server minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -42,6 +42,6 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
-- @xen-orchestra/fs minor
+- @xen-orchestra/fs patch
 - xo-web minor
 - xo-server minor


### PR DESCRIPTION
Reported here:
https://xcp-ng.org/forum/topic/3848/backblaze-b2-amazon-s3-as-remote-in-xoa/5?_=1607961862789
customer noticed that increasing memory got rid of the issue.

the S3 managed upload is a concurrent system, we chose 512Mo fragment size, and the default concurrency was 4 -> 2GB of memory. Might be enough to explain the issue, but it's not sure.

This PR reduces the concurrency to 1 fragment at a time. Changing fragment size is a bit of an issue since their total number has to be less than 10000 and we don't know the file size.


### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
