### PR TITLE
fix(xo-server): set VIF locking mode to 'locked' when adding allowed IPs

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [VM/network] Change VIF's locking mode automatically to 'locked' when adding allowed IPs (PR [#5472](https://github.com/vatesfr/xen-orchestra/pull/5472))
+- [VM/network] Change VIF's locking mode automatically to `locked` when adding allowed IPs (PR [#5472](https://github.com/vatesfr/xen-orchestra/pull/5472))
 
 
 ### Packages to release

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,9 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [VM/network] Change VIF's locking mode automatically to 'locked' when adding allowed IPs (PR [#5472](https://github.com/vatesfr/xen-orchestra/pull/5472))
+
+
 ### Packages to release
 
 > Packages will be released in the order they are here, therefore, they should
@@ -27,3 +30,5 @@
 > - major: if the change breaks compatibility
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
+
+- xo-server patch

--- a/packages/xo-server/src/xapi/mixins/networking.js
+++ b/packages/xo-server/src/xapi/mixins/networking.js
@@ -41,7 +41,7 @@ export default {
       set: [
         'ipv6Allowed',
         function (value, vif) {
-          if (!isEmpty(value) && vif.locking_mode !== 'locked') {
+          if (value.length !== 0 && vif.locking_mode !== 'locked') {
             return vif.set_locking_mode('locked')
           }
         },

--- a/packages/xo-server/src/xapi/mixins/networking.js
+++ b/packages/xo-server/src/xapi/mixins/networking.js
@@ -1,3 +1,4 @@
+import { isEmpty } from 'lodash'
 import { makeEditObject } from '../utils'
 
 export default {
@@ -24,8 +25,36 @@ export default {
     await this._disconnectVif(this.getObject(vifId))
   },
   editVif: makeEditObject({
-    ipv4Allowed: true,
-    ipv6Allowed: true,
+    ipv4Allowed: {
+      get: true,
+      set: [
+        'ipv4Allowed',
+        function (value, vif) {
+          if (isEmpty(value) && isEmpty(vif.ipv6_allowed)) {
+            return
+          }
+
+          if (vif.locking_mode !== 'locked') {
+            return vif.set_locking_mode('locked')
+          }
+        },
+      ],
+    },
+    ipv6Allowed: {
+      get: true,
+      set: [
+        'ipv6Allowed',
+        function (value, vif) {
+          if (isEmpty(value) && isEmpty(vif.ipv6_allowed)) {
+            return
+          }
+
+          if (vif.locking_mode !== 'locked') {
+            return vif.set_locking_mode('locked')
+          }
+        },
+      ],
+    },
     lockingMode: {
       set: (value, vif) => vif.set_locking_mode(value),
     },

--- a/packages/xo-server/src/xapi/mixins/networking.js
+++ b/packages/xo-server/src/xapi/mixins/networking.js
@@ -1,4 +1,3 @@
-import { isEmpty } from 'lodash'
 import { makeEditObject } from '../utils'
 
 export default {

--- a/packages/xo-server/src/xapi/mixins/networking.js
+++ b/packages/xo-server/src/xapi/mixins/networking.js
@@ -30,11 +30,7 @@ export default {
       set: [
         'ipv4Allowed',
         function (value, vif) {
-          if (isEmpty(value) && isEmpty(vif.ipv6_allowed)) {
-            return
-          }
-
-          if (vif.locking_mode !== 'locked') {
+          if (!isEmpty(value) && vif.locking_mode !== 'locked') {
             return vif.set_locking_mode('locked')
           }
         },
@@ -45,11 +41,7 @@ export default {
       set: [
         'ipv6Allowed',
         function (value, vif) {
-          if (isEmpty(value) && isEmpty(vif.ipv6_allowed)) {
-            return
-          }
-
-          if (vif.locking_mode !== 'locked') {
+          if (!isEmpty(value) && vif.locking_mode !== 'locked') {
             return vif.set_locking_mode('locked')
           }
         },

--- a/packages/xo-server/src/xapi/mixins/networking.js
+++ b/packages/xo-server/src/xapi/mixins/networking.js
@@ -30,7 +30,7 @@ export default {
       set: [
         'ipv4Allowed',
         function (value, vif) {
-          if (!isEmpty(value) && vif.locking_mode !== 'locked') {
+          if (value.length !== 0 && vif.locking_mode !== 'locked') {
             return vif.set_locking_mode('locked')
           }
         },


### PR DESCRIPTION
Introduced by https://github.com/vatesfr/xen-orchestra/pull/5357
See xoa-support#2929 (last comment)

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
