### PR TITLE
fix(xo-server): rm xenStore entries after use

### DIFF
--- a/packages/xo-server/src/_XenStore.js
+++ b/packages/xo-server/src/_XenStore.js
@@ -2,3 +2,4 @@ import fromCallback from 'promise-toolbox/fromCallback'
 import { execFile } from 'child_process'
 
 export const read = key => fromCallback(execFile, 'xenstore-read', [key])
+export const rm = key => fromCallback(execFile, 'xenstore-rm', [key])

--- a/packages/xo-server/src/xo-mixins/subjects.js
+++ b/packages/xo-server/src/xo-mixins/subjects.js
@@ -59,12 +59,14 @@ export default class {
       )
 
       if (!(await usersDb.exists())) {
-        const { email = 'admin@admin.net', password = 'admin' } = await XenStore.read('vm-data/admin-account')
+        const key = 'vm-data/admin-account'
+        const { email = 'admin@admin.net', password = 'admin' } = await XenStore.read(key)
           .then(JSON.parse)
           .catch(() => ({}))
 
         await this.createUser({ email, password, permission: 'admin' })
         log.info(`Default user created: ${email} with password ${password}`)
+        ignoreErrors.call(XenStore.rm(key))
       }
     })
   }

--- a/packages/xo-server/src/xo-mixins/xen-servers.js
+++ b/packages/xo-server/src/xo-mixins/xen-servers.js
@@ -65,12 +65,14 @@ export default class {
 
       // Add servers in XenStore
       if (servers.length === 0) {
-        const xenStoreServers = await XenStore.read('vm-data/xen-servers')
+        const key = 'vm-data/xen-servers'
+        const xenStoreServers = await XenStore.read(key)
           .then(JSON.parse)
           .catch(() => [])
         for (const server of xenStoreServers) {
           servers.push(await this.registerXenServer(server))
         }
+        ignoreErrors.call(XenStore.rm(key))
       }
 
       // Connects to existing servers.


### PR DESCRIPTION
This should already be done by the deploy scripts but in case it's not, xo-server should do it.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
