### PR TITLE
fix(proxy/remote.test): always return a result object

### DIFF
--- a/@xen-orchestra/proxy/src/app/mixins/api.js
+++ b/@xen-orchestra/proxy/src/app/mixins/api.js
@@ -1,4 +1,4 @@
-import { format, JsonRpcError, parse, MethodNotFound } from 'json-rpc-protocol'
+import { format, parse, MethodNotFound } from 'json-rpc-protocol'
 import * as errors from 'xo-common/api-errors'
 import Ajv from 'ajv'
 import asyncIteratorToStream from 'async-iterator-to-stream'
@@ -53,8 +53,7 @@ export default class Api {
       try {
         body = parse(body)
       } catch (error) {
-        warn('error on parsing request body', { error })
-        ctx.body = format.error(null, new JsonRpcError(error.message, error.code))
+        ctx.body = format.error(null, error)
         return
       }
 
@@ -68,7 +67,7 @@ export default class Api {
         const { method, params } = body
         warn('call error', { method, params, error })
         ctx.set('Content-Type', 'application/json')
-        ctx.body = format.error(body.id, new JsonRpcError(error.message, error.code))
+        ctx.body = format.error(body.id, error)
         return
       }
 

--- a/@xen-orchestra/proxy/src/app/mixins/api.js
+++ b/@xen-orchestra/proxy/src/app/mixins/api.js
@@ -53,6 +53,7 @@ export default class Api {
       try {
         body = parse(body)
       } catch (error) {
+        warn('body parse error', { error })
         ctx.body = format.error(null, new JsonRpcError(error.message, error.code))
         return
       }

--- a/@xen-orchestra/proxy/src/app/mixins/api.js
+++ b/@xen-orchestra/proxy/src/app/mixins/api.js
@@ -53,7 +53,7 @@ export default class Api {
       try {
         body = parse(body)
       } catch (error) {
-        warn('body parse error', { error })
+        warn('error on parsing request body', { error })
         ctx.body = format.error(null, new JsonRpcError(error.message, error.code))
         return
       }

--- a/@xen-orchestra/proxy/src/app/mixins/api.js
+++ b/@xen-orchestra/proxy/src/app/mixins/api.js
@@ -1,4 +1,4 @@
-import { format, parse, MethodNotFound } from 'json-rpc-protocol'
+import { format, JsonRpcError, parse, MethodNotFound } from 'json-rpc-protocol'
 import * as errors from 'xo-common/api-errors'
 import Ajv from 'ajv'
 import asyncIteratorToStream from 'async-iterator-to-stream'
@@ -53,7 +53,7 @@ export default class Api {
       try {
         body = parse(body)
       } catch (error) {
-        ctx.body = format.error(null, error)
+        ctx.body = format.error(null, new JsonRpcError(error.message, error.code))
         return
       }
 
@@ -67,7 +67,7 @@ export default class Api {
         const { method, params } = body
         warn('call error', { method, params, error })
         ctx.set('Content-Type', 'application/json')
-        ctx.body = format.error(body.id, error)
+        ctx.body = format.error(body.id, new JsonRpcError(error.message, error.code))
         return
       }
 

--- a/@xen-orchestra/proxy/src/app/mixins/remotes.js
+++ b/@xen-orchestra/proxy/src/app/mixins/remotes.js
@@ -4,6 +4,7 @@ import tmp from 'tmp'
 import using from 'promise-toolbox/using'
 import { decorateWith } from '@vates/decorate-with'
 import { getHandler } from '@xen-orchestra/fs'
+import { JsonRpcError } from 'json-rpc-protocol'
 import { parseDuration } from '@vates/parse-duration'
 import { rmdir } from 'fs-extra'
 
@@ -34,7 +35,10 @@ export default class Remotes {
         ],
 
         test: [
-          ({ remote }) => using(this.getHandler(remote), handler => handler.test()),
+          ({ remote }) =>
+            using(this.getHandler(remote), handler => handler.test()).catch(error => {
+              throw new JsonRpcError(error.message, error.code)
+            }),
           {
             params: {
               remote: { type: 'object' },

--- a/@xen-orchestra/proxy/src/app/mixins/remotes.js
+++ b/@xen-orchestra/proxy/src/app/mixins/remotes.js
@@ -4,7 +4,6 @@ import tmp from 'tmp'
 import using from 'promise-toolbox/using'
 import { decorateWith } from '@vates/decorate-with'
 import { getHandler } from '@xen-orchestra/fs'
-import { JsonRpcError } from 'json-rpc-protocol'
 import { parseDuration } from '@vates/parse-duration'
 import { rmdir } from 'fs-extra'
 
@@ -36,9 +35,10 @@ export default class Remotes {
 
         test: [
           ({ remote }) =>
-            using(this.getHandler(remote), handler => handler.test()).catch(error => {
-              throw new JsonRpcError(error.message, error.code)
-            }),
+            using(this.getHandler(remote), handler => handler.test()).catch(error => ({
+              success: false,
+              error: error.message ?? String(error),
+            })),
           {
             params: {
               remote: { type: 'object' },


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
