### PR TITLE
fix(xo-web/restore/metadata): ignore disabled remotes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 - [VM/network] Change VIF's locking mode automatically to `locked` when adding allowed IPs (PR [#5472](https://github.com/vatesfr/xen-orchestra/pull/5472))
 - [Backup Reports] Don't hide errors during plugin test [#5486](https://github.com/vatesfr/xen-orchestra/issues/5486) (PR [#5491](https://github.com/vatesfr/xen-orchestra/pull/5491))
 - [Backup reports] Fix malformed sent email in case of multiple VMs (PR [#5479](https://github.com/vatesfr/xen-orchestra/pull/5479))
+- [Restore/metadata] Ignore disabled remotes on listing backups (PR [#5504](https://github.com/vatesfr/xen-orchestra/pull/5504))
 
 ### Packages to release
 

--- a/packages/xo-web/src/xo-app/backup/restore/metadata.js
+++ b/packages/xo-web/src/xo-app/backup/restore/metadata.js
@@ -10,7 +10,7 @@ import SortedTable from 'sorted-table'
 import Upgrade from 'xoa-upgrade'
 import { confirm } from 'modal'
 import { error } from 'notification'
-import { flatMap, forOwn, reduce, toArray } from 'lodash'
+import { filter, flatMap, forOwn, reduce } from 'lodash'
 import { FormattedDate } from 'react-intl'
 import { injectState, provideState } from 'reaclette'
 import { noop } from 'utils'
@@ -150,7 +150,7 @@ export default decorate([
   addSubscriptions({
     remotes: cb =>
       subscribeRemotes(remotes => {
-        cb(toArray(remotes))
+        cb(filter(remotes, { enabled: true }))
       }),
   }),
   provideState({
@@ -169,7 +169,8 @@ export default decorate([
       // }
       async backups(_, { remotes = [] }) {
         if (remotes.length === 0) {
-          return
+          // NoObjects displays a spinner when collection is undefined
+          return {}
         }
 
         const { xo: xoType, pool: poolType } = await listMetadataBackups(remotes)


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
