### PR TITLE
fix(xo-web/home/sr): sort SR usage in %

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@
 - [Backup/S3] Fix `TimeoutError: Connection timed out after 120000ms` (PR [#5456](https://github.com/vatesfr/xen-orchestra/pull/5456))
 - [New SR/reattach SR] Fix SR not being properly reattached to hosts [#4546](https://github.com/vatesfr/xen-orchestra/issues/4546) (PR [#5488](https://github.com/vatesfr/xen-orchestra/pull/5488))
 - [Home/pool] Missing patches warning: fix 1 patch showing as missing in case of error [#4922](https://github.com/vatesfr/xen-orchestra/issues/4922)
+- [Home/SR] Sort SR usage in % instead of bytes [#5463](https://github.com/vatesfr/xen-orchestra/issues/5463) (PR [#5513](https://github.com/vatesfr/xen-orchestra/pull/5513))
 
 ### Packages to release
 

--- a/packages/xo-web/src/xo-app/home/index.js
+++ b/packages/xo-web/src/xo-app/home/index.js
@@ -456,7 +456,7 @@ const NoObjects = props =>
     mapValues(items, item => ({
       ...item,
       container: containers[item.$container || item.$pool],
-      usage: item.size > 0 ? item.physical_usage / item.size : item.physical_usage,
+      usage: item.size > 0 ? item.physical_usage / item.size : 0,
     }))
   )
   // VMs are handled separately because we need to inject their 'vdisUsage'

--- a/packages/xo-web/src/xo-app/home/index.js
+++ b/packages/xo-web/src/xo-app/home/index.js
@@ -456,7 +456,7 @@ const NoObjects = props =>
     mapValues(items, item => ({
       ...item,
       container: containers[item.$container || item.$pool],
-      usage: item.size > 0 ? (item.physical_usage / item.size) * 100 : item.physical_usage,
+      usage: item.size > 0 ? item.physical_usage / item.size : item.physical_usage,
     }))
   )
   // VMs are handled separately because we need to inject their 'vdisUsage'

--- a/packages/xo-web/src/xo-app/home/index.js
+++ b/packages/xo-web/src/xo-app/home/index.js
@@ -292,7 +292,7 @@ const OPTIONS = {
       { labelId: 'homeSortByShared', sortBy: isSrShared, sortOrder: 'desc' },
       {
         labelId: 'homeSortByUsage',
-        sortBy: 'usage',
+        sortBy: 'physicalUsageBySize',
         sortOrder: 'desc',
       },
       { labelId: 'homeSortByType', sortBy: 'SR_type', sortOrder: 'asc' },
@@ -456,7 +456,7 @@ const NoObjects = props =>
     mapValues(items, item => ({
       ...item,
       container: containers[item.$container || item.$pool],
-      usage: item.size > 0 ? item.physical_usage / item.size : 0,
+      physicalUsageBySize: item.type === 'SR' ? (item.size > 0 ? item.physical_usage / item.size : 0) : undefined,
     }))
   )
   // VMs are handled separately because we need to inject their 'vdisUsage'

--- a/packages/xo-web/src/xo-app/home/index.js
+++ b/packages/xo-web/src/xo-app/home/index.js
@@ -292,7 +292,7 @@ const OPTIONS = {
       { labelId: 'homeSortByShared', sortBy: isSrShared, sortOrder: 'desc' },
       {
         labelId: 'homeSortByUsage',
-        sortBy: 'physical_usage',
+        sortBy: 'usage',
         sortOrder: 'desc',
       },
       { labelId: 'homeSortByType', sortBy: 'SR_type', sortOrder: 'asc' },
@@ -456,6 +456,7 @@ const NoObjects = props =>
     mapValues(items, item => ({
       ...item,
       container: containers[item.$container || item.$pool],
+      usage: item.size > 0 ? (item.physical_usage / item.size) * 100 : item.physical_usage,
     }))
   )
   // VMs are handled separately because we need to inject their 'vdisUsage'


### PR DESCRIPTION
 Fixes #5463

### Screenshots

![Capture d’écran de 2021-01-19 09-57-20](https://user-images.githubusercontent.com/7724491/105011195-f0d59980-5a3c-11eb-8ce7-885c385ac378.png)

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
