### PR TITLE
fix(xo-server/remotes): update remote error on test

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@
 - [Backup/S3] Fix `TimeoutError: Connection timed out after 120000ms` (PR [#5456](https://github.com/vatesfr/xen-orchestra/pull/5456))
 - [New SR/reattach SR] Fix SR not being properly reattached to hosts [#4546](https://github.com/vatesfr/xen-orchestra/issues/4546) (PR [#5488](https://github.com/vatesfr/xen-orchestra/pull/5488))
 - [Home/pool] Missing patches warning: fix 1 patch showing as missing in case of error [#4922](https://github.com/vatesfr/xen-orchestra/issues/4922)
+- [Proxy/remote] Fix error not cleared on successful remote test (PR [#5514](https://github.com/vatesfr/xen-orchestra/pull/5514))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,7 +25,7 @@
 - [Backup/S3] Fix `TimeoutError: Connection timed out after 120000ms` (PR [#5456](https://github.com/vatesfr/xen-orchestra/pull/5456))
 - [New SR/reattach SR] Fix SR not being properly reattached to hosts [#4546](https://github.com/vatesfr/xen-orchestra/issues/4546) (PR [#5488](https://github.com/vatesfr/xen-orchestra/pull/5488))
 - [Home/pool] Missing patches warning: fix 1 patch showing as missing in case of error [#4922](https://github.com/vatesfr/xen-orchestra/issues/4922)
-- [Proxy/remote] Fix error not cleared on successful remote test (PR [#5514](https://github.com/vatesfr/xen-orchestra/pull/5514))
+- [Proxy/remote] Fix error not updated on remote test (PR [#5514](https://github.com/vatesfr/xen-orchestra/pull/5514))
 
 ### Packages to release
 

--- a/packages/xo-server/src/xo-mixins/remotes.js
+++ b/packages/xo-server/src/xo-mixins/remotes.js
@@ -103,6 +103,7 @@ export default class {
         writeRate,
       }
       await this._updateRemote(remoteId, {
+        error: '',
         benchmarks:
           remote.benchmarks !== undefined
             ? [...remote.benchmarks.slice(-49), benchmark] // store 50 benchmarks

--- a/packages/xo-server/src/xo-mixins/remotes.js
+++ b/packages/xo-server/src/xo-mixins/remotes.js
@@ -109,6 +109,10 @@ export default class {
             ? [...remote.benchmarks.slice(-49), benchmark] // store 50 benchmarks
             : [benchmark],
       })
+    } else {
+      await this._updateRemote(remoteId, {
+        error: answer.error,
+      })
     }
 
     return answer


### PR DESCRIPTION
See xoa-support#3255

**The issue:**

All operations on remotes will call `getRemoteHandler` which will clean remote's error on success or update it on fail.

But, this method will not be called in case of a proxy remote, then, the remote's error will not be cleaned if an error happened before its bound to a proxy.

**Discussed solution:**

Clear remote error on test

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
