### PR TITLE
fix(xo-web): SR_NOT_ATTACHED when migration network is selected

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@
 - [New SR/reattach SR] Fix SR not being properly reattached to hosts [#4546](https://github.com/vatesfr/xen-orchestra/issues/4546) (PR [#5488](https://github.com/vatesfr/xen-orchestra/pull/5488))
 - [Home/pool] Missing patches warning: fix 1 patch showing as missing in case of error [#4922](https://github.com/vatesfr/xen-orchestra/issues/4922)
 - [Proxy/remote] Fix error not updated on remote test (PR [#5514](https://github.com/vatesfr/xen-orchestra/pull/5514))
+- [VM migration] Fix `SR_NOT_ATTACHED` error when migration network is selected (PR [#5516](https://github.com/vatesfr/xen-orchestra/pull/5516))
 
 ### Packages to release
 

--- a/packages/xo-web/src/common/xo/migrate-vm-modal/index.js
+++ b/packages/xo-web/src/common/xo/migrate-vm-modal/index.js
@@ -12,7 +12,7 @@ import invoke from '../../invoke'
 import SingleLineRow from '../../single-line-row'
 import { Col } from '../../grid'
 import { connectStore, mapPlus, resolveId, resolveIds } from '../../utils'
-import { getDefaultNetworkForVif, getDefaultMigrationNetwork } from '../utils'
+import { getDefaultNetworkForVif } from '../utils'
 import { SelectHost, SelectNetwork } from '../../select-objects'
 import { createGetObjectsOfType, createPicker, createSelector, getObject } from '../../selectors'
 
@@ -141,8 +141,9 @@ export default class MigrateVmModalBody extends BaseComponent {
       return
     }
 
-    const { pifs, pools, vbds, vm } = this.props
+    const { pools, vbds, vm } = this.props
     const intraPool = vm.$pool === host.$pool
+
     // Intra-pool
     if (intraPool) {
       let doNotMigrateVdis
@@ -163,14 +164,15 @@ export default class MigrateVmModalBody extends BaseComponent {
         host,
         intraPool,
         mapVifsNetworks: undefined,
-        migrationNetworkId: getDefaultMigrationNetwork(host, pools, pifs),
+        migrationNetworkId: undefined,
         targetSrs: {},
       })
       return
     }
 
     // Inter-pool
-    const { networks, vifs } = this.props
+    const { networks, pifs, vifs } = this.props
+    const defaultMigrationNetworkId = find(pifs, pif => pif.$host === host.id && pif.management).$network
 
     const defaultNetwork = invoke(() => {
       // First PIF with an IP.
@@ -190,7 +192,7 @@ export default class MigrateVmModalBody extends BaseComponent {
       host,
       intraPool,
       mapVifsNetworks: defaultNetworksForVif,
-      migrationNetworkId: getDefaultMigrationNetwork(host, pools, pifs),
+      migrationNetworkId: defaultMigrationNetworkId,
       targetSrs: { mainSr: pools[host.$pool].default_SR },
     })
   }

--- a/packages/xo-web/src/common/xo/migrate-vms-modal/index.js
+++ b/packages/xo-web/src/common/xo/migrate-vms-modal/index.js
@@ -275,7 +275,7 @@ export default class MigrateVmsModalBody extends BaseComponent {
             {intraPool && <i>{_('optionalEntry')}</i>}
           </div>
         )}
-        {host && (!intraPool || !noVdisMigration) && (
+        {host && (!noVdisMigration || migrationNetworkId != null) && (
           <div key='sr' style={LINE_STYLE}>
             <SingleLineRow>
               <Col size={6}>
@@ -297,7 +297,7 @@ export default class MigrateVmsModalBody extends BaseComponent {
                 )}
               </Col>
               <Col size={6}>
-                <SelectSr onChange={this._selectSr} predicate={this._getSrPredicate()} value={srId} />
+                <SelectSr onChange={this._selectSr} predicate={this._getSrPredicate()} required value={srId} />
               </Col>
             </SingleLineRow>
           </div>


### PR DESCRIPTION
See xoa-support#3248
Introduced by https://github.com/vatesfr/xen-orchestra/commit/062fb3ba3074b47734220abdf35d55c65c8867b4 and https://github.com/vatesfr/xen-orchestra/commit/4dd7d86ea8a71cfbc275ce10ea30c33b1e100034

- Issue:  
  When choosing a network for VM migration within a pool: 
    - default SR is shared: the VMs' VDIs will be migrated to this SR
    - if not: `SR_NOT_ATTACHED` error will be thrown.

https://github.com/vatesfr/xen-orchestra/blob/0e0211050b7601ffd33e20c3fb13f612601fb23b/packages/xo-server/src/xapi/index.js#L1391-L1425

https://github.com/vatesfr/xen-orchestra/blob/0e0211050b7601ffd33e20c3fb13f612601fb23b/packages/xo-server/src/xapi/index.js#L1101-L1166



- Fix:  when the migration network is defined, the SR will be required.

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
