### PR TITLE
feat(xo-web/proxies): better upgrade feedback

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 - [Pool/advanced] Ability to define default migration network [#3788](https://github.com/vatesfr/xen-orchestra/issues/3788#issuecomment-743207834) (PR [#5465](https://github.com/vatesfr/xen-orchestra/pull/5465))
 - [Proxy] Ability to run metadata backups (PR [#5499](https://github.com/vatesfr/xen-orchestra/pull/5499))
 - [Metadata backups] Ability to link a backup to a proxy (PR [#4206](https://github.com/vatesfr/xen-orchestra/pull/4206))
+- [Proxy] Improve upgrade feedback (PR [#5525](https://github.com/vatesfr/xen-orchestra/pull/5525))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -87,6 +87,7 @@ const messages = {
   unknown: 'Unknown',
   upgradesAvailable: 'Upgrades available',
   advancedSettings: 'Advanced settings',
+  forceUpgrade: 'Force upgrade',
   txChecksumming: 'TX checksumming',
   unknownSize: 'Unknown size',
   installedCertificates: 'Installed certificates',
@@ -2362,6 +2363,7 @@ const messages = {
   httpProxyPlaceholder: 'protocol://username:password@address:port',
   proxyUpgradesError: 'Unable to check upgrades availability',
   proxyApplianceSettingsInfo: 'Leave the field empty and click on OK to remove the existing configuration',
+  proxyUpToDate: 'Your proxy is up-to-date',
 
   // ----- Utils -----
   secondsFormat: '{seconds, plural, one {# second} other {# seconds}}',

--- a/packages/xo-web/src/xo-app/proxies/index.js
+++ b/packages/xo-web/src/xo-app/proxies/index.js
@@ -74,6 +74,14 @@ const INDIVIDUAL_ACTIONS = [
     level: 'primary',
   },
   {
+    collapsed: true,
+    disabled: ({ vmUuid }) => vmUuid === undefined,
+    handler: (proxy, { upgradeAppliance }) => upgradeAppliance(proxy.id),
+    icon: 'upgrade',
+    label: _('forceUpgrade'),
+    level: 'primary',
+  },
+  {
     handler: ({ id }, { router }) =>
       router.push({
         pathname: '/settings/remotes',
@@ -144,16 +152,7 @@ const COLUMNS = [
         state === 'updater-upgraded' ||
         state === 'installer-upgraded'
       ) {
-        return (
-          <ActionButton
-            disabled={proxy.vmUuid === undefined}
-            handler={upgradeAppliance}
-            handlerParam={proxy.id}
-            icon='upgrade'
-          >
-            {_('upgrade')}
-          </ActionButton>
-        )
+        return <p className='text-success'>{_('proxyUpToDate')}</p>
       }
 
       return (


### PR DESCRIPTION
- display up-to-date message instead of upgrade button
- add force upgrade button to the advanced settings

![image](https://user-images.githubusercontent.com/21563339/105510478-f813d600-5cce-11eb-8224-edc36143b579.png)

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
