### PR TITLE
fix(xo-server/metadata-backups): ensure cache reset at the end

### DIFF
--- a/packages/xo-server/src/xo-mixins/metadata-backups.js
+++ b/packages/xo-server/src/xo-mixins/metadata-backups.js
@@ -515,6 +515,7 @@ export default class metadataBackup {
             }
           }
         }
+        return
       } finally {
         remoteIds.forEach(id => {
           this._listPoolMetadataBackups(REMOVE_CACHE_ENTRY, id)

--- a/packages/xo-server/src/xo-mixins/metadata-backups.js
+++ b/packages/xo-server/src/xo-mixins/metadata-backups.js
@@ -476,10 +476,11 @@ export default class metadataBackup {
         params.job.xoMetadata = await app.exportConfig()
       }
 
-      const logsStream = await app.callProxyMethod(proxyId, 'backup.run', params, {
-        assertType: 'iterator',
-      })
       try {
+        const logsStream = await app.callProxyMethod(proxyId, 'backup.run', params, {
+          assertType: 'iterator',
+        })
+
         const localTaskIds = { __proto__: null }
         for await (const log of logsStream) {
           const { event, message, taskId } = log

--- a/packages/xo-server/src/xo-mixins/metadata-backups.js
+++ b/packages/xo-server/src/xo-mixins/metadata-backups.js
@@ -479,47 +479,48 @@ export default class metadataBackup {
       const logsStream = await app.callProxyMethod(proxyId, 'backup.run', params, {
         assertType: 'iterator',
       })
+      try {
+        const localTaskIds = { __proto__: null }
+        for await (const log of logsStream) {
+          const { event, message, taskId } = log
 
-      const localTaskIds = { __proto__: null }
-      for await (const log of logsStream) {
-        const { event, message, taskId } = log
-
-        const common = {
-          data: log.data,
-          event: 'task.' + event,
-          result: log.result,
-          status: log.status,
-        }
-
-        if (event === 'start') {
-          const { parentId } = log
-          if (parentId === undefined) {
-            // ignore root task (already handled by runJob)
-            localTaskIds[taskId] = runJobId
-          } else {
-            common.parentId = localTaskIds[parentId]
-            localTaskIds[taskId] = logger.notice(message, common)
+          const common = {
+            data: log.data,
+            event: 'task.' + event,
+            result: log.result,
+            status: log.status,
           }
-        } else {
-          const localTaskId = localTaskIds[taskId]
-          if (localTaskId === runJobId) {
-            if (event === 'end') {
-              if (log.status === 'failure') {
-                throw log.result
-              }
-              return log.result
+
+          if (event === 'start') {
+            const { parentId } = log
+            if (parentId === undefined) {
+              // ignore root task (already handled by runJob)
+              localTaskIds[taskId] = runJobId
+            } else {
+              common.parentId = localTaskIds[parentId]
+              localTaskIds[taskId] = logger.notice(message, common)
             }
           } else {
-            common.taskId = localTaskId
-            logger.notice(message, common)
+            const localTaskId = localTaskIds[taskId]
+            if (localTaskId === runJobId) {
+              if (event === 'end') {
+                if (log.status === 'failure') {
+                  throw log.result
+                }
+                return log.result
+              }
+            } else {
+              common.taskId = localTaskId
+              logger.notice(message, common)
+            }
           }
         }
+      } finally {
+        remoteIds.forEach(id => {
+          this._listPoolMetadataBackups(REMOVE_CACHE_ENTRY, id)
+          this._listXoMetadataBackups(REMOVE_CACHE_ENTRY, id)
+        })
       }
-      remoteIds.forEach(id => {
-        this._listPoolMetadataBackups(REMOVE_CACHE_ENTRY, id)
-        this._listXoMetadataBackups(REMOVE_CACHE_ENTRY, id)
-      })
-      return
     }
 
     cancelToken.throwIfRequested()


### PR DESCRIPTION
Introduced by 61c3057060611f8df9df6bf51c4e7d850276b59a

cause: https://github.com/vatesfr/xen-orchestra/blob/04024101c6a2ae30dafc46060372198ad5b0a5af/packages/xo-server/src/xo-mixins/metadata-backups.js#L507-L510

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
