### PR TITLE
fix(xo-server-auth-ldap/synchronizeGroups): fix adding users to groups

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [LDAP] Group synchronization: fix users not added to groups in some cases
+- [LDAP] Group synchronization: fix users not added to groups in some cases (PR [#5545](https://github.com/vatesfr/xen-orchestra/pull/5545))
 
 ### Packages to release
 
@@ -29,3 +29,5 @@
 > - major: if the change breaks compatibility
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
+
+- xo-server-auth-ldap patch

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [LDAP] Group synchronization: fix users not added to groups in some cases
+
 ### Packages to release
 
 > Packages will be released in the order they are here, therefore, they should

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [LDAP] Group synchronization: fix users not added to groups in some cases (PR [#5545](https://github.com/vatesfr/xen-orchestra/pull/5545))
+- [LDAP] "Synchronize LDAP groups" button: fix imported LDAP users not being correctly added or removed from groups in some cases (PR [#5545](https://github.com/vatesfr/xen-orchestra/pull/5545))
 
 ### Packages to release
 

--- a/packages/xo-server-auth-ldap/src/index.js
+++ b/packages/xo-server-auth-ldap/src/index.js
@@ -418,11 +418,22 @@ class AuthLdap {
 
         const xoGroupMembers = xoGroup.users === undefined ? [] : xoGroup.users.slice(0)
 
-        for (const ldapId of ldapGroupMembers) {
-          const xoUser = xoUsers.find(user => user.authProviders.ldap.id === ldapId)
+        for (const memberId of ldapGroupMembers) {
+          const {
+            searchEntries: [ldapUser],
+          } = await client.search(this._searchBase, {
+            scope: 'sub',
+            filter: `(${escape(membersMapping.userAttribute)}=${escape(memberId)})`,
+          })
+          if (ldapUser === undefined) {
+            continue
+          }
+
+          const xoUser = xoUsers.find(user => user.authProviders.ldap.id === ldapUser[this._userIdAttribute])
           if (xoUser === undefined) {
             continue
           }
+
           // If the user exists in XO, should be a member of the LDAP-provided
           // group but isn't: add it
           const userIdIndex = xoGroupMembers.findIndex(id => id === xoUser.id)

--- a/packages/xo-server-auth-ldap/src/index.js
+++ b/packages/xo-server-auth-ldap/src/index.js
@@ -424,6 +424,7 @@ class AuthLdap {
           } = await client.search(this._searchBase, {
             scope: 'sub',
             filter: `(${escape(membersMapping.userAttribute)}=${escape(memberId)})`,
+            sizeLimit: 1,
           })
           if (ldapUser === undefined) {
             continue

--- a/packages/xo-server-auth-ldap/src/index.js
+++ b/packages/xo-server-auth-ldap/src/index.js
@@ -433,7 +433,6 @@ class AuthLdap {
           if (xoUser === undefined) {
             continue
           }
-
           // If the user exists in XO, should be a member of the LDAP-provided
           // group but isn't: add it
           const userIdIndex = xoGroupMembers.findIndex(id => id === xoUser.id)


### PR DESCRIPTION
Fixes xoa-support#3333
Introduced by 8cfaabedeb1b4d850043ca34bc65f6034217ba48

`synchronizeGroups` (called without a user) tries to find XO users that belong
to LDAP groups and add them to those groups. In order to find those users, it
was using the `userIdAttribute` attribute instead of the
`membersMapping.userAttribute` attribute from the configuration.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
