### PR TITLE
feat(xo-web/restore): allow all licenses to restore backups

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,7 +7,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [Backup/restore] Allow backup restore to any licence even if xoa isn't registered
+- [Backup/restore] Allow backup restore to any licence even if xoa isn't registered (PR [#5547](https://github.com/vatesfr/xen-orchestra/pull/5547))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Backup/restore] Allow backup restore to any licence even if xoa isn't registered
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -27,3 +29,5 @@
 > - major: if the change breaks compatibility
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
+
+- xo-web minor

--- a/packages/xo-web/src/xo-app/backup/restore/index.js
+++ b/packages/xo-web/src/xo-app/backup/restore/index.js
@@ -5,7 +5,6 @@ import Component from 'base-component'
 import Icon from 'icon'
 import React from 'react'
 import SortedTable from 'sorted-table'
-import Upgrade from 'xoa-upgrade'
 import { addSubscriptions, formatSize, noop } from 'utils'
 import { confirm } from 'modal'
 import { error } from 'notification'
@@ -259,28 +258,26 @@ export default class Restore extends Component {
 
   render() {
     return (
-      <Upgrade place='restoreBackup' available={2}>
-        <div>
-          <RestoreLegacy />
-          <div className='mt-1 mb-1'>
-            <h3>{_('restore')}</h3>
-            <ActionButton btnStyle='primary' handler={this._refreshBackupList} icon='refresh'>
-              {_('refreshBackupList')}
-            </ActionButton>{' '}
-            <ButtonLink to='backup/restore/metadata'>
-              <Icon icon='database' /> {_('metadata')}
-            </ButtonLink>
-          </div>
-          <SortedTable
-            actions={this._actions}
-            collection={this.state.backupDataByVm}
-            columns={BACKUPS_COLUMNS}
-            stateUrlParam='s'
-          />
-          <br />
-          <Logs />
+      <div>
+        <RestoreLegacy />
+        <div className='mt-1 mb-1'>
+          <h3>{_('restore')}</h3>
+          <ActionButton btnStyle='primary' handler={this._refreshBackupList} icon='refresh'>
+            {_('refreshBackupList')}
+          </ActionButton>{' '}
+          <ButtonLink to='backup/restore/metadata'>
+            <Icon icon='database' /> {_('metadata')}
+          </ButtonLink>
         </div>
-      </Upgrade>
+        <SortedTable
+          actions={this._actions}
+          collection={this.state.backupDataByVm}
+          columns={BACKUPS_COLUMNS}
+          stateUrlParam='s'
+        />
+        <br />
+        <Logs />
+      </div>
     )
   }
 }

--- a/packages/xo-web/src/xo-app/index.js
+++ b/packages/xo-web/src/xo-app/index.js
@@ -227,8 +227,10 @@ export default class XoApp extends Component {
 
   render() {
     const { signedUp, trial, registerNeeded } = this.props
+    const { pathname } = this.context.router.location
     // If we are under expired or unstable trial (signed up only)
-    const blocked = signedUp && blockXoaAccess(trial) && !this.context.router.location.pathname.startsWith('/xoa/')
+    const blocked =
+      signedUp && blockXoaAccess(trial) && !(pathname.startsWith('/xoa/') || pathname === '/backup/restore')
     const plan = getXoaPlan()
 
     return (


### PR DESCRIPTION
See https://xcp-ng.org/forum/topic/4165/crashed-xoa-can-t-boot-a-clean-xoa-and-use-restore-because-of-registration/7

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
