### PR TITLE
feat(proxy/backups): move getTmpDir to its own module

### DIFF
--- a/@xen-orchestra/proxy/src/app/mixins/backups/_RemoteAdapter.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/_RemoteAdapter.js
@@ -17,6 +17,7 @@ import { deduped } from '../../_deduped'
 import { asyncMap } from '../../../_asyncMap'
 
 import { BACKUP_DIR } from './_getVmBackupDir'
+import { getTempMountDir } from './_getTempMountDir'
 import { listPartitions, LVM_PARTITION_TYPE } from './_listPartitions'
 import { lvs, pvs } from './_lvm'
 
@@ -177,7 +178,7 @@ export class RemoteAdapter {
       }
     }
 
-    const path = yield this._app.remotes.getTempMountDir()
+    const path = yield getTempMountDir()
     const mount = options => {
       return fromCallback(execFile, 'mount', [
         `--options=${options.join(',')}`,
@@ -291,7 +292,7 @@ export class RemoteAdapter {
     const handler = this._handler
 
     const diskPath = handler._getFilePath('/' + diskId)
-    const mountDir = yield this._app.remotes.getTempMountDir()
+    const mountDir = yield getTempMountDir()
     await fromCallback(execFile, 'vhdimount', [diskPath, mountDir])
     try {
       let max = 0

--- a/@xen-orchestra/proxy/src/app/mixins/backups/_RemoteAdapter.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/_RemoteAdapter.js
@@ -17,7 +17,7 @@ import { deduped } from '../../_deduped'
 import { asyncMap } from '../../../_asyncMap'
 
 import { BACKUP_DIR } from './_getVmBackupDir'
-import { getTempMountDir } from './_getTempMountDir'
+import { getTmpDir } from './_getTmpDir'
 import { listPartitions, LVM_PARTITION_TYPE } from './_listPartitions'
 import { lvs, pvs } from './_lvm'
 
@@ -178,7 +178,7 @@ export class RemoteAdapter {
       }
     }
 
-    const path = yield getTempMountDir()
+    const path = yield getTmpDir()
     const mount = options => {
       return fromCallback(execFile, 'mount', [
         `--options=${options.join(',')}`,
@@ -292,7 +292,7 @@ export class RemoteAdapter {
     const handler = this._handler
 
     const diskPath = handler._getFilePath('/' + diskId)
-    const mountDir = yield getTempMountDir()
+    const mountDir = yield getTmpDir()
     await fromCallback(execFile, 'vhdimount', [diskPath, mountDir])
     try {
       let max = 0

--- a/@xen-orchestra/proxy/src/app/mixins/backups/_getTempMountDir.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/_getTempMountDir.js
@@ -1,0 +1,9 @@
+import Disposable from 'promise-toolbox/Disposable'
+import fromCallback from 'promise-toolbox/fromCallback'
+import tmp from 'tmp'
+import { rmdir } from 'fs-extra'
+
+export const getTempMountDir = async () => {
+  const mountDir = await fromCallback(tmp.dir)
+  return new Disposable(mountDir, () => rmdir(mountDir))
+}

--- a/@xen-orchestra/proxy/src/app/mixins/backups/_getTmpDir.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/_getTmpDir.js
@@ -4,6 +4,6 @@ import tmp from 'tmp'
 import { rmdir } from 'fs-extra'
 
 export const getTmpDir = async () => {
-  const mountDir = await fromCallback(tmp.dir)
-  return new Disposable(mountDir, () => rmdir(mountDir))
+  const tmpDir = await fromCallback(tmp.dir)
+  return new Disposable(tmpDir, () => rmdir(tmpDir))
 }

--- a/@xen-orchestra/proxy/src/app/mixins/backups/_getTmpDir.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/_getTmpDir.js
@@ -3,7 +3,7 @@ import fromCallback from 'promise-toolbox/fromCallback'
 import tmp from 'tmp'
 import { rmdir } from 'fs-extra'
 
-export const getTempMountDir = async () => {
+export const getTmpDir = async () => {
   const mountDir = await fromCallback(tmp.dir)
   return new Disposable(mountDir, () => rmdir(mountDir))
 }

--- a/@xen-orchestra/proxy/src/app/mixins/remotes.js
+++ b/@xen-orchestra/proxy/src/app/mixins/remotes.js
@@ -1,10 +1,7 @@
 import Disposable from 'promise-toolbox/Disposable'
-import fromCallback from 'promise-toolbox/fromCallback'
-import tmp from 'tmp'
 import using from 'promise-toolbox/using'
 import { decorateWith } from '@vates/decorate-with'
 import { getHandler } from '@xen-orchestra/fs'
-import { rmdir } from 'fs-extra'
 
 import { debounceResource } from '../_debounceResource'
 import { decorateResult } from '../_decorateResult'
@@ -67,10 +64,5 @@ export default class Remotes {
   @decorateWith(Disposable.factory)
   *getAdapter(remote) {
     return new RemoteAdapter(yield this.getHandler(remote), { app: this._app })
-  }
-
-  async getTempMountDir() {
-    const mountDir = await fromCallback(tmp.dir)
-    return new Disposable(mountDir, () => rmdir(mountDir))
   }
 }


### PR DESCRIPTION
This makes `RemoteAdapter` independent of `Remotes`.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
