### PR TITLE
 feat(proxy/backups): make RemoteAdapter not depend on app hooks

### DIFF
--- a/@xen-orchestra/proxy/config.toml
+++ b/@xen-orchestra/proxy/config.toml
@@ -8,7 +8,6 @@
 authenticationToken = ''
 
 datadir = '/var/lib/xo-proxy/data'
-maxHooksListeners = 0
 resourceDebounce = '5m'
 
 [api]

--- a/@xen-orchestra/proxy/src/app/_debounceResource.js
+++ b/@xen-orchestra/proxy/src/app/_debounceResource.js
@@ -1,6 +1,6 @@
 import Disposable from 'promise-toolbox/Disposable'
 
-export async function debounceResource(pDisposable, hooks, delay = 0) {
+export async function debounceResource(pDisposable, addDisposeListener = dispose => Function.prototype, delay = 0) {
   if (delay === 0) {
     return pDisposable
   }
@@ -12,13 +12,13 @@ export async function debounceResource(pDisposable, hooks, delay = 0) {
     if (timeoutId !== undefined) {
       clearTimeout(timeoutId)
       timeoutId = undefined
-      hooks.removeListener('stop', onStop)
+      removeDisposeListener()
 
       return disposable.dispose()
     }
   }
 
-  const onStop = () => {
+  const removeDisposeListener = addDisposeListener(() => {
     const shouldDisposeNow = timeoutId !== undefined
     if (shouldDisposeNow) {
       return disposeWrapper()
@@ -26,8 +26,7 @@ export async function debounceResource(pDisposable, hooks, delay = 0) {
       // will dispose ASAP
       delay = 0
     }
-  }
-  hooks.on('stop', onStop)
+  })
 
   return new Disposable(disposable.value, () => {
     timeoutId = setTimeout(disposeWrapper, delay)

--- a/@xen-orchestra/proxy/src/app/_debounceResource.js
+++ b/@xen-orchestra/proxy/src/app/_debounceResource.js
@@ -45,9 +45,10 @@ export const createDebounceResource = defaultDelay => {
     })
   }
   debounceResource.flushAll = () => {
-    const currentFlushers = [...flushers]
+    // iterate on a sync way in order to not remove a flusher added on processing flushers
+    const promise = asyncMap(flushers)
     flushers.clear()
-    return asyncMap(currentFlushers, flush => flush())
+    return promise
   }
 
   return debounceResource

--- a/@xen-orchestra/proxy/src/app/_debounceResource.js
+++ b/@xen-orchestra/proxy/src/app/_debounceResource.js
@@ -1,7 +1,7 @@
 import asyncMap from '@xen-orchestra/async-map'
 import Disposable from 'promise-toolbox/Disposable'
 
-const disposers = []
+const disposers = new Set()
 export async function debounceResource(pDisposable, delay) {
   if (delay === 0) {
     return pDisposable
@@ -19,7 +19,7 @@ export async function debounceResource(pDisposable, delay) {
     }
   }
 
-  disposers.push(() => {
+  disposers.add(() => {
     const shouldDisposeNow = timeoutId !== undefined
     if (shouldDisposeNow) {
       return disposeWrapper()
@@ -33,4 +33,8 @@ export async function debounceResource(pDisposable, delay) {
     timeoutId = setTimeout(disposeWrapper, delay)
   })
 }
-debounceResource.flushAll = () => asyncMap(disposers, dispose => dispose())
+debounceResource.flushAll = () =>
+  asyncMap(disposers, dispose => {
+    disposers.delete(dispose)
+    return dispose()
+  })

--- a/@xen-orchestra/proxy/src/app/_debounceResource.js
+++ b/@xen-orchestra/proxy/src/app/_debounceResource.js
@@ -46,7 +46,7 @@ export const createDebounceResource = defaultDelay => {
   debounceResource.flushAll = () => {
     const currentFlushers = [...flushers]
     flushers.clear()
-    return asyncMapSettled(currentFlushers, dispose => dispose())
+    return asyncMapSettled(currentFlushers, flush => flush())
   }
 
   return debounceResource

--- a/@xen-orchestra/proxy/src/app/_debounceResource.js
+++ b/@xen-orchestra/proxy/src/app/_debounceResource.js
@@ -46,7 +46,7 @@ export const createDebounceResource = defaultDelay => {
   }
   debounceResource.flushAll = () => {
     // iterate on a sync way in order to not remove a flusher added on processing flushers
-    const promise = asyncMap(flushers)
+    const promise = asyncMap(flushers, flush => flush())
     flushers.clear()
     return promise
   }

--- a/@xen-orchestra/proxy/src/app/_debounceResource.js
+++ b/@xen-orchestra/proxy/src/app/_debounceResource.js
@@ -18,7 +18,7 @@ export const createDebounceResource = defaultDelay => {
       if (timeoutId !== undefined) {
         clearTimeout(timeoutId)
         timeoutId = undefined
-        flushers.delete(disposer)
+        flushers.delete(flusher)
 
         try {
           await disposable.dispose()
@@ -28,7 +28,7 @@ export const createDebounceResource = defaultDelay => {
       }
     }
 
-    const disposer = () => {
+    const flusher = () => {
       const shouldDisposeNow = timeoutId !== undefined
       if (shouldDisposeNow) {
         return disposeWrapper()
@@ -37,7 +37,7 @@ export const createDebounceResource = defaultDelay => {
         delay = 0
       }
     }
-    flushers.add(disposer)
+    flushers.add(flusher)
 
     return new Disposable(disposable.value, () => {
       timeoutId = setTimeout(disposeWrapper, delay)

--- a/@xen-orchestra/proxy/src/app/_debounceResource.js
+++ b/@xen-orchestra/proxy/src/app/_debounceResource.js
@@ -4,9 +4,9 @@ import { createLogger } from '@xen-orchestra/log/dist'
 
 const { warn } = createLogger('xo:proxy:debounceResource')
 
-export const createDebounceResource = delay => {
+export const createDebounceResource = defaultDelay => {
   const flushers = new Set()
-  async function debounceResource(pDisposable) {
+  async function debounceResource(pDisposable, delay = defaultDelay) {
     if (delay === 0) {
       return pDisposable
     }

--- a/@xen-orchestra/proxy/src/app/_debounceResource.js
+++ b/@xen-orchestra/proxy/src/app/_debounceResource.js
@@ -36,7 +36,7 @@ export async function debounceResource(pDisposable, delay) {
   })
 }
 debounceResource.flushAll = () =>
-  asyncMapSettled(disposers, dispose => {
+  asyncMapSettled([...disposers], dispose => {
     disposers.delete(dispose)
     return dispose()
   })

--- a/@xen-orchestra/proxy/src/app/_debounceResource.js
+++ b/@xen-orchestra/proxy/src/app/_debounceResource.js
@@ -1,6 +1,7 @@
-import asyncMapSettled from '@xen-orchestra/async-map'
 import Disposable from 'promise-toolbox/Disposable'
 import { createLogger } from '@xen-orchestra/log/dist'
+
+import { asyncMap } from '../_asyncMap'
 
 const { warn } = createLogger('xo:proxy:debounceResource')
 
@@ -46,7 +47,7 @@ export const createDebounceResource = defaultDelay => {
   debounceResource.flushAll = () => {
     const currentFlushers = [...flushers]
     flushers.clear()
-    return asyncMapSettled(currentFlushers, flush => flush())
+    return asyncMap(currentFlushers, flush => flush())
   }
 
   return debounceResource

--- a/@xen-orchestra/proxy/src/app/_debounceResource.js
+++ b/@xen-orchestra/proxy/src/app/_debounceResource.js
@@ -1,6 +1,8 @@
+import asyncMap from '@xen-orchestra/async-map'
 import Disposable from 'promise-toolbox/Disposable'
 
-export async function debounceResource(pDisposable, addDisposeListener = dispose => Function.prototype, delay = 0) {
+const disposers = []
+export async function debounceResource(pDisposable, delay) {
   if (delay === 0) {
     return pDisposable
   }
@@ -12,13 +14,12 @@ export async function debounceResource(pDisposable, addDisposeListener = dispose
     if (timeoutId !== undefined) {
       clearTimeout(timeoutId)
       timeoutId = undefined
-      removeDisposeListener()
 
       return disposable.dispose()
     }
   }
 
-  const removeDisposeListener = addDisposeListener(() => {
+  disposers.push(() => {
     const shouldDisposeNow = timeoutId !== undefined
     if (shouldDisposeNow) {
       return disposeWrapper()
@@ -32,3 +33,4 @@ export async function debounceResource(pDisposable, addDisposeListener = dispose
     timeoutId = setTimeout(disposeWrapper, delay)
   })
 }
+debounceResource.flushAll = () => asyncMap(disposers, dispose => dispose())

--- a/@xen-orchestra/proxy/src/app/index.js
+++ b/@xen-orchestra/proxy/src/app/index.js
@@ -1,6 +1,7 @@
 import camelCase from 'lodash/camelCase'
 
 import mixins from './mixins'
+import { debounceResource } from './_debounceResource'
 
 const { defineProperties, defineProperty, keys } = Object
 const noop = Function.prototype
@@ -39,5 +40,14 @@ export default class App {
     keys(descriptors).forEach(name => {
       noop(this[name])
     })
+
+    // dispose all created resources on stop
+    this.hooks.once('stop', () => {
+      debounceResource.flushAll().catch(() => {})
+    })
+  }
+
+  debounceResource(pDisposable) {
+    return debounceResource(pDisposable, this.config.getDuration('resourceDebounce') ?? 0)
   }
 }

--- a/@xen-orchestra/proxy/src/app/index.js
+++ b/@xen-orchestra/proxy/src/app/index.js
@@ -1,7 +1,7 @@
 import camelCase from 'lodash/camelCase'
 
 import mixins from './mixins'
-import { debounceResource } from './_debounceResource'
+import { createDebounceResource } from './_debounceResource'
 
 const { defineProperties, defineProperty, keys } = Object
 const noop = Function.prototype
@@ -41,11 +41,11 @@ export default class App {
       noop(this[name])
     })
 
-    // dispose all created resources on stop
-    this.hooks.once('stop', () => debounceResource.flushAll().catch(() => {}))
-  }
+    const debounceResource = (this.debounceResource = createDebounceResource(
+      this.config.getDuration('resourceDebounce')
+    ))
 
-  debounceResource(pDisposable) {
-    return debounceResource(pDisposable, this.config.getDuration('resourceDebounce') ?? 0)
+    // dispose all created resources on stop
+    this.hooks.once('stop', debounceResource.flushAll)
   }
 }

--- a/@xen-orchestra/proxy/src/app/index.js
+++ b/@xen-orchestra/proxy/src/app/index.js
@@ -42,9 +42,7 @@ export default class App {
     })
 
     // dispose all created resources on stop
-    this.hooks.once('stop', () => {
-      debounceResource.flushAll().catch(() => {})
-    })
+    this.hooks.once('stop', () => debounceResource.flushAll().catch(() => {}))
   }
 
   debounceResource(pDisposable) {

--- a/@xen-orchestra/proxy/src/app/mixins/backups/_RemoteAdapter.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/_RemoteAdapter.js
@@ -63,11 +63,12 @@ const createSafeReaddir = (handler, methodName) => (path, options) =>
   })
 
 function getDebouncedResource(resource) {
-  return debounceResource(resource, this._app.hooks, this._app.config.getDuration('resourceDebounce'))
+  return debounceResource(resource, this._addDisposeListener, this._app.config.getDuration('resourceDebounce'))
 }
 
 export class RemoteAdapter {
-  constructor(handler, { app }) {
+  constructor(handler, { addDisposeListener, app }) {
+    this._addDisposeListener = addDisposeListener
     this._app = app
     this._handler = handler
   }

--- a/@xen-orchestra/proxy/src/app/mixins/backups/_RemoteAdapter.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/_RemoteAdapter.js
@@ -10,7 +10,6 @@ import { decorateWith } from '@vates/decorate-with'
 import { execFile } from 'child_process'
 import { readdir, stat } from 'fs-extra'
 
-import { debounceResource } from '../../_debounceResource'
 import { decorateResult } from '../../_decorateResult'
 import { deduped } from '../../_deduped'
 
@@ -63,12 +62,12 @@ const createSafeReaddir = (handler, methodName) => (path, options) =>
   })
 
 function getDebouncedResource(resource) {
-  return debounceResource(resource, this._addDisposeListener, this._app.config.getDuration('resourceDebounce'))
+  return this._debounceResource(resource)
 }
 
 export class RemoteAdapter {
-  constructor(handler, { addDisposeListener, app }) {
-    this._addDisposeListener = addDisposeListener
+  constructor(handler, { debounceResource, app }) {
+    this._debounceResource = debounceResource
     this._app = app
     this._handler = handler
   }

--- a/@xen-orchestra/proxy/src/app/mixins/backups/index.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/index.js
@@ -16,7 +16,6 @@ import { ZipFile } from 'yazl'
 
 import { asyncMap } from '../../../_asyncMap'
 
-import { debounceResource } from '../../_debounceResource'
 import { decorateResult } from '../../_decorateResult'
 import { deduped } from '../../_deduped'
 
@@ -429,7 +428,7 @@ export default class Backups {
 
   // FIXME: invalidate cache on options change
   @decorateResult(function (resource) {
-    return debounceResource(resource, this.addDisposeListener, this._app.config.getDuration('resourceDebounce'))
+    return this._app.debounceResource(resource)
   })
   @decorateWith(deduped, ({ url }) => [url])
   @decorateWith(Disposable.factory)

--- a/@xen-orchestra/proxy/src/app/mixins/backups/index.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/index.js
@@ -53,13 +53,6 @@ export default class Backups {
       await fromCallback(execFile, 'pvscan', ['--cache'])
     })
 
-    // dispose created resources on stop
-    this.addDisposeListener = dispose => {
-      const hooks = this._app.hooks
-      hooks.on('stop', dispose)
-      return () => hooks.removeListener('stop', dispose)
-    }
-
     let run = ({ xapis, ...rest }) =>
       new Backup({
         ...rest,

--- a/@xen-orchestra/proxy/src/app/mixins/backups/index.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/index.js
@@ -54,6 +54,13 @@ export default class Backups {
       await fromCallback(execFile, 'pvscan', ['--cache'])
     })
 
+    // dispose created resources on stop
+    this.addDisposeListener = dispose => {
+      const hooks = this._app.hooks
+      hooks.on('stop', dispose)
+      return () => hooks.removeListener('stop', dispose)
+    }
+
     let run = ({ xapis, ...rest }) =>
       new Backup({
         ...rest,
@@ -422,7 +429,7 @@ export default class Backups {
 
   // FIXME: invalidate cache on options change
   @decorateResult(function (resource) {
-    return debounceResource(resource, this._app.hooks, this._app.config.getDuration('resourceDebounce'))
+    return debounceResource(resource, this.addDisposeListener, this._app.config.getDuration('resourceDebounce'))
   })
   @decorateWith(deduped, ({ url }) => [url])
   @decorateWith(Disposable.factory)

--- a/@xen-orchestra/proxy/src/app/mixins/hooks.js
+++ b/@xen-orchestra/proxy/src/app/mixins/hooks.js
@@ -18,18 +18,6 @@ const runHook = async (emitter, hook) => {
 }
 
 export default class Hooks extends EventEmitter {
-  constructor(app) {
-    super()
-
-    // work-around cyclic mixin dependency with Config
-    setImmediate(() => {
-      // `debounceResource` opens a listener on each method call
-      app.config.watch('maxHooksListeners', n => {
-        this.setMaxListeners(n)
-      })
-    })
-  }
-
   // Run *clean* async listeners.
   //
   // They normalize existing data, clear invalid entries, etc.

--- a/@xen-orchestra/proxy/src/app/mixins/remotes.js
+++ b/@xen-orchestra/proxy/src/app/mixins/remotes.js
@@ -10,7 +10,8 @@ import { deduped } from '../_deduped'
 import { RemoteAdapter } from './backups/_RemoteAdapter'
 
 function getDebouncedResource(resource) {
-  return debounceResource(resource, this._app.hooks, this._app.config.getDuration('resourceDebounce'))
+  const app = this._app
+  return debounceResource(resource, app.backups.addDisposeListener, app.config.getDuration('resourceDebounce'))
 }
 
 export default class Remotes {
@@ -63,6 +64,10 @@ export default class Remotes {
   @decorateWith(deduped, remote => [remote.url])
   @decorateWith(Disposable.factory)
   *getAdapter(remote) {
-    return new RemoteAdapter(yield this.getHandler(remote), { app: this._app })
+    const app = this._app
+    return new RemoteAdapter(yield this.getHandler(remote), {
+      app,
+      addDisposeListener: app.backups.addDisposeListener,
+    })
   }
 }

--- a/@xen-orchestra/proxy/src/app/mixins/remotes.js
+++ b/@xen-orchestra/proxy/src/app/mixins/remotes.js
@@ -66,8 +66,8 @@ export default class Remotes {
   *getAdapter(remote) {
     const app = this._app
     return new RemoteAdapter(yield this.getHandler(remote), {
-      app,
       addDisposeListener: app.backups.addDisposeListener,
+      app,
     })
   }
 }

--- a/@xen-orchestra/proxy/src/app/mixins/remotes.js
+++ b/@xen-orchestra/proxy/src/app/mixins/remotes.js
@@ -3,15 +3,13 @@ import using from 'promise-toolbox/using'
 import { decorateWith } from '@vates/decorate-with'
 import { getHandler } from '@xen-orchestra/fs'
 
-import { debounceResource } from '../_debounceResource'
 import { decorateResult } from '../_decorateResult'
 import { deduped } from '../_deduped'
 
 import { RemoteAdapter } from './backups/_RemoteAdapter'
 
 function getDebouncedResource(resource) {
-  const app = this._app
-  return debounceResource(resource, app.backups.addDisposeListener, app.config.getDuration('resourceDebounce'))
+  return this._app.debounceResource(resource)
 }
 
 export default class Remotes {
@@ -66,7 +64,7 @@ export default class Remotes {
   *getAdapter(remote) {
     const app = this._app
     return new RemoteAdapter(yield this.getHandler(remote), {
-      addDisposeListener: app.backups.addDisposeListener,
+      debounceResource: app.debounceResource.bind(app),
       app,
     })
   }


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
