### PR TITLE
feat(complex-matcher): allow most letters to be unquoted

### DIFF
--- a/packages/complex-matcher/src/index.js
+++ b/packages/complex-matcher/src/index.js
@@ -2,39 +2,18 @@ import { escapeRegExp, isPlainObject, some } from 'lodash'
 
 // ===================================================================
 
-const RAW_STRING_CHARS = (() => {
-  const chars = { __proto__: null }
-  const add = (a, b = a) => {
-    let i = a.charCodeAt(0)
-    const j = b.charCodeAt(0)
-    while (i <= j) {
-      chars[String.fromCharCode(i++)] = true
-    }
-  }
-  add('$')
-  add('-')
-  add('.')
-  add('0', '9')
-  add('_')
-  add('É')
-  add('é')
-  add('Ö')
-  add('ö')
-  add('A', 'Z')
-  add('a', 'z')
-  add('Ä', 'Å')
-  add('ä', 'å')
-  return chars
-})()
-const isRawString = string => {
-  const { length } = string
-  for (let i = 0; i < length; ++i) {
-    if (!(string[i] in RAW_STRING_CHARS)) {
-      return false
-    }
-  }
-  return true
+const RAW_STRING_SYMBOLS = {
+  __proto__: null,
+  _: true,
+  '-': true,
+  '.': true,
+  $: true,
 }
+
+const isRawStringChar = c =>
+  (c >= '0' && c <= '9') || c in RAW_STRING_SYMBOLS || !(c === c.toUpperCase() && c === c.toLowerCase())
+
+const isRawString = string => [...string].every(isRawStringChar)
 
 // -------------------------------------------------------------------
 
@@ -465,7 +444,7 @@ const parser = P.grammar({
   globPattern: new P((input, pos, end) => {
     let value = ''
     let c
-    while (pos < end && ((c = input[pos]) === '*' || c in RAW_STRING_CHARS)) {
+    while (pos < end && ((c = input[pos]) === '*' || isRawStringChar(c))) {
       ++pos
       value += c
     }
@@ -492,7 +471,7 @@ const parser = P.grammar({
   rawString: new P((input, pos, end) => {
     let value = ''
     let c
-    while (pos < end && RAW_STRING_CHARS[(c = input[pos])]) {
+    while (pos < end && isRawStringChar((c = input[pos]))) {
       ++pos
       value += c
     }

--- a/packages/complex-matcher/src/index.js
+++ b/packages/complex-matcher/src/index.js
@@ -16,8 +16,14 @@ const RAW_STRING_CHARS = (() => {
   add('.')
   add('0', '9')
   add('_')
+  add('É')
+  add('é')
+  add('Ö')
+  add('ö')
   add('A', 'Z')
   add('a', 'z')
+  add('Ä', 'Å')
+  add('ä', 'å')
   return chars
 })()
 const isRawString = string => {


### PR DESCRIPTION
I noticed that searching for unquoted strings with `é`, or any other weird character always returns zero matches in XO. When using complex matcher in my own code `CM.parse()` throws exceptions about the same type of characters.

To me it seems the cause is `RAW_STRING_CHARS` which only contains the (to english speakers?) more "normal" characters.

First of, is this something you want solved? I do realize that the current solution might be a bit problematic if people from every language wanted their weird characters added.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
