### PR TITLE
feat(proxy/backups): make RemoteAdapter not depend on app

### DIFF
--- a/@xen-orchestra/proxy/src/app/mixins/backups/_RemoteAdapter.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/_RemoteAdapter.js
@@ -66,9 +66,9 @@ function getDebouncedResource(resource) {
 }
 
 export class RemoteAdapter {
-  constructor(handler, { debounceResource, app }) {
+  constructor(handler, { debounceResource, dirMode }) {
     this._debounceResource = debounceResource
-    this._app = app
+    this._dirMode = dirMode
     this._handler = handler
   }
 
@@ -491,7 +491,7 @@ export class RemoteAdapter {
     const tmpPath = `${dirname(path)}/.${basename(path)}`
     const output = await handler.createOutputStream(tmpPath, {
       checksum,
-      dirMode: this._app.config.get('backups.dirMode'),
+      dirMode: this._dirMode,
     })
     try {
       await Promise.all([fromCallback(pump, input, output), output.checksumWritten, input.task])

--- a/@xen-orchestra/proxy/src/app/mixins/remotes.js
+++ b/@xen-orchestra/proxy/src/app/mixins/remotes.js
@@ -65,7 +65,7 @@ export default class Remotes {
     const app = this._app
     return new RemoteAdapter(yield this.getHandler(remote), {
       debounceResource: app.debounceResource.bind(app),
-      app,
+      dirMode: app.config.get('backups.dirMode'),
     })
   }
 }


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
