### PR TITLE
feat(proxy): move getAdapter from remotes to backups

### DIFF
--- a/@xen-orchestra/proxy/src/app/mixins/backups/_Backup.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/_Backup.js
@@ -219,7 +219,7 @@ export class Backup {
 
   @decorateWith(Disposable.factory)
   *_getAdapter(remoteId) {
-    const adapter = yield this._app.remotes.getAdapter(this._remotes[remoteId])
+    const adapter = yield this._app.backups.getAdapter(this._remotes[remoteId])
     return {
       adapter,
       remoteId,

--- a/@xen-orchestra/proxy/src/app/mixins/backups/index.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/index.js
@@ -23,6 +23,7 @@ import { Backup } from './_Backup'
 import { importDeltaVm } from './_deltaVm'
 import { Task } from './_Task'
 import { Readable } from 'stream'
+import { RemoteAdapter } from './_RemoteAdapter'
 import { RestoreMetadataBackup } from './_RestoreMetadataBackup'
 
 const noop = Function.prototype
@@ -119,8 +120,7 @@ export default class Backups {
     app.api.addMethods({
       backup: {
         deleteMetadataBackup: [
-          ({ backupId, remote }) =>
-            using(app.remotes.getAdapter(remote), adapter => adapter.deleteMetadataBackup(backupId)),
+          ({ backupId, remote }) => using(this.getAdapter(remote), adapter => adapter.deleteMetadataBackup(backupId)),
           {
             description: 'delete Metadata backup',
             params: {
@@ -130,7 +130,7 @@ export default class Backups {
           },
         ],
         deleteVmBackup: [
-          ({ filename, remote }) => using(app.remotes.getAdapter(remote), adapter => adapter.deleteVmBackup(filename)),
+          ({ filename, remote }) => using(this.getAdapter(remote), adapter => adapter.deleteVmBackup(filename)),
           {
             description: 'delete VM backup',
             params: {
@@ -143,7 +143,7 @@ export default class Backups {
           ({ disk: diskId, remote, partition: partitionId, paths }) => {
             const { promise, reject, resolve } = pDefer()
             using(async function* () {
-              const adapter = yield app.remotes.getAdapter(remote)
+              const adapter = yield this.getAdapter(remote)
               const files = yield adapter.usePartitionFiles(diskId, partitionId, paths)
               const zip = new ZipFile()
               files.forEach(({ realPath, metadataPath }) => zip.addFile(realPath, metadataPath))
@@ -169,7 +169,7 @@ export default class Backups {
         ],
         importVmBackup: [
           defer(($defer, { backupId, remote, srUuid, xapi: xapiOpts }) =>
-            using(app.remotes.getAdapter(remote), this.getXapi(xapiOpts), async (adapter, xapi) => {
+            using(this.getAdapter(remote), this.getXapi(xapiOpts), async (adapter, xapi) => {
               const srRef = await xapi.call('SR.get_by_uuid', srUuid)
 
               const metadata = await adapter.readVmBackupMetadata(backupId)
@@ -209,8 +209,7 @@ export default class Backups {
           },
         ],
         listDiskPartitions: [
-          ({ disk: diskId, remote }) =>
-            using(app.remotes.getAdapter(remote), adapter => adapter.listPartitions(diskId)),
+          ({ disk: diskId, remote }) => using(this.getAdapter(remote), adapter => adapter.listPartitions(diskId)),
           {
             description: 'list disk partitions',
             params: {
@@ -221,7 +220,7 @@ export default class Backups {
         ],
         listPartitionFiles: [
           ({ disk: diskId, remote, partition: partitionId, path }) =>
-            using(app.remotes.getAdapter(remote), adapter => adapter.listPartitionFiles(diskId, partitionId, path)),
+            using(this.getAdapter(remote), adapter => adapter.listPartitionFiles(diskId, partitionId, path)),
           {
             description: 'list partition files',
             params: {
@@ -237,7 +236,7 @@ export default class Backups {
             const backupsByRemote = {}
             await asyncMap(Object.entries(remotes), async ([remoteId, remote]) => {
               try {
-                await using(app.remotes.getAdapter(remote), async adapter => {
+                await using(this.getAdapter(remote), async adapter => {
                   backupsByRemote[remoteId] = await adapter.listPoolMetadataBackups()
                 })
               } catch (error) {
@@ -261,7 +260,7 @@ export default class Backups {
             const backups = {}
             await asyncMap(Object.keys(remotes), async remoteId => {
               try {
-                await using(app.remotes.getAdapter(remotes[remoteId]), async adapter => {
+                await using(this.getAdapter(remotes[remoteId]), async adapter => {
                   backups[remoteId] = mapValues(await adapter.listAllVmBackups(), vmBackups =>
                     vmBackups.map(backup => formatVmBackup(backup))
                   )
@@ -293,7 +292,7 @@ export default class Backups {
             const backupsByRemote = {}
             await asyncMap(Object.entries(remotes), async ([remoteId, remote]) => {
               try {
-                await using(app.remotes.getAdapter(remote), async adapter => {
+                await using(this.getAdapter(remote), async adapter => {
                   backupsByRemote[remoteId] = await adapter.listXoMetadataBackups()
                 })
               } catch (error) {
@@ -359,7 +358,7 @@ export default class Backups {
     })
 
     const getPartition = Disposable.factory(function* ({ disk, partition, remote }) {
-      const adapter = yield app.remotes.getAdapter(remote)
+      const adapter = yield this.getAdapter(remote)
       return yield adapter.getPartition(disk, partition)
     })
 
@@ -416,6 +415,20 @@ export default class Backups {
           },
         ],
       },
+    })
+  }
+
+  // FIXME: invalidate cache on remote option change
+  @decorateResult(function (resource) {
+    return this._app.debounceResource(resource)
+  })
+  @decorateWith(deduped, remote => [remote.url])
+  @decorateWith(Disposable.factory)
+  *getAdapter(remote) {
+    const app = this._app
+    return new RemoteAdapter(yield app.remotes.getHandler(remote), {
+      debounceResource: app.debounceResource.bind(app),
+      dirMode: app.config.get('backups.dirMode'),
     })
   }
 


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
