### PR TITLE
fix(xo-web/migrateVm): don't automatically select migration network

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,7 +18,7 @@
 - [VM/Snapshot export] Fix `Error: no available place in queue` on canceling an export via browser then starting a new one when the concurrency threshold is reached [#5535](https://github.com/vatesfr/xen-orchestra/issues/5535) (PR [#5538](https://github.com/vatesfr/xen-orchestra/pull/5538))
 - [Servers] Hide pool's objects if its master is unreachable [#5475](https://github.com/vatesfr/xen-orchestra/issues/5475) (PR [#5526](https://github.com/vatesfr/xen-orchestra/pull/5526))
 - [Host] Restart toolstack: fix `ECONNREFUSED` error (PR [#5553](https://github.com/vatesfr/xen-orchestra/pull/5553))
-- [VM migration] Don't automatically select migration network if no default migration network is defined on the pool (PR [#5564](https://github.com/vatesfr/xen-orchestra/pull/5564))
+- [VM migration] Intra-pool: don't automatically select migration network if no default migration network is defined on the pool (PR [#5564](https://github.com/vatesfr/xen-orchestra/pull/5564))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@
 - [VM/Snapshot export] Fix `Error: no available place in queue` on canceling an export via browser then starting a new one when the concurrency threshold is reached [#5535](https://github.com/vatesfr/xen-orchestra/issues/5535) (PR [#5538](https://github.com/vatesfr/xen-orchestra/pull/5538))
 - [Servers] Hide pool's objects if its master is unreachable [#5475](https://github.com/vatesfr/xen-orchestra/issues/5475) (PR [#5526](https://github.com/vatesfr/xen-orchestra/pull/5526))
 - [Host] Restart toolstack: fix `ECONNREFUSED` error (PR [#5553](https://github.com/vatesfr/xen-orchestra/pull/5553))
+- [VM migration] Don't automatically select migration network if no default migration network is defined on the pool (PR [#5564](https://github.com/vatesfr/xen-orchestra/pull/5564))
 
 ### Packages to release
 

--- a/packages/xo-web/src/common/xo/migrate-vm-modal/index.js
+++ b/packages/xo-web/src/common/xo/migrate-vm-modal/index.js
@@ -163,7 +163,7 @@ export default class MigrateVmModalBody extends BaseComponent {
         host,
         intraPool,
         mapVifsNetworks: undefined,
-        migrationNetworkId: getDefaultMigrationNetwork(host, pools, pifs),
+        migrationNetworkId: getDefaultMigrationNetwork(intraPool, host, pools, pifs),
         targetSrs: {},
       })
       return
@@ -190,7 +190,7 @@ export default class MigrateVmModalBody extends BaseComponent {
       host,
       intraPool,
       mapVifsNetworks: defaultNetworksForVif,
-      migrationNetworkId: getDefaultMigrationNetwork(host, pools, pifs),
+      migrationNetworkId: getDefaultMigrationNetwork(intraPool, host, pools, pifs),
       targetSrs: { mainSr: pools[host.$pool].default_SR },
     })
   }

--- a/packages/xo-web/src/common/xo/migrate-vms-modal/index.js
+++ b/packages/xo-web/src/common/xo/migrate-vms-modal/index.js
@@ -180,11 +180,11 @@ export default class MigrateVmsModalBody extends BaseComponent {
       return
     }
     const { pools, pifs } = this.props
-    const defaultMigrationNetworkId = getDefaultMigrationNetwork(host, pools, pifs)
+    const intraPool = every(this.props.vms, vm => vm.$pool === host.$pool)
+    const defaultMigrationNetworkId = getDefaultMigrationNetwork(intraPool, host, pools, pifs)
     const defaultSrId = pools[host.$pool].default_SR
     const defaultSrConnectedToHost = some(host.$PBDs, pbd => this._getObject(pbd).SR === defaultSrId)
 
-    const intraPool = every(this.props.vms, vm => vm.$pool === host.$pool)
     const doNotMigrateVmVdis = {}
     const doNotMigrateVdi = {}
     let noVdisMigration = false

--- a/packages/xo-web/src/common/xo/utils.js
+++ b/packages/xo-web/src/common/xo/utils.js
@@ -24,8 +24,12 @@ export const getDefaultNetworkForVif = (vif, destHost, pifs, networks) => {
   return destNetworkId
 }
 
-export const getDefaultMigrationNetwork = (destHost, pools, pifs) => {
+export const getDefaultMigrationNetwork = (intraPool, destHost, pools, pifs) => {
   const migrationNetwork = pools[destHost.$pool].otherConfig['xo:migrationNetwork']
+  if (intraPool) {
+    return migrationNetwork
+  }
+
   let defaultPif
   return defined(
     find(pifs, pif => {

--- a/packages/xo-web/src/common/xo/utils.js
+++ b/packages/xo-web/src/common/xo/utils.js
@@ -26,10 +26,6 @@ export const getDefaultNetworkForVif = (vif, destHost, pifs, networks) => {
 
 export const getDefaultMigrationNetwork = (intraPool, destHost, pools, pifs) => {
   const migrationNetwork = pools[destHost.$pool].otherConfig['xo:migrationNetwork']
-  if (intraPool) {
-    return migrationNetwork
-  }
-
   let defaultPif
   return defined(
     find(pifs, pif => {
@@ -42,6 +38,6 @@ export const getDefaultMigrationNetwork = (intraPool, destHost, pools, pifs) => 
         }
       }
     }),
-    defaultPif
+    intraPool ? {} : defaultPif
   ).$network
 }


### PR DESCRIPTION
See xoa-support#3355

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
