### PR TITLE
fix(proxy/backups): fix resource function not called with backup context

### DIFF
--- a/@xen-orchestra/proxy/src/app/mixins/backups/index.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/index.js
@@ -142,8 +142,8 @@ export default class Backups {
         fetchPartitionFiles: [
           ({ disk: diskId, remote, partition: partitionId, paths }) => {
             const { promise, reject, resolve } = pDefer()
-            using
-              .call(this, async function* () {
+            using(
+              async function* () {
                 const adapter = yield this.getAdapter(remote)
                 const files = yield adapter.usePartitionFiles(diskId, partitionId, paths)
                 const zip = new ZipFile()
@@ -152,11 +152,11 @@ export default class Backups {
                 const { outputStream } = zip
                 resolve(outputStream)
                 await fromEvent(outputStream, 'end')
-              })
-              .catch(error => {
-                warn(error)
-                reject(error)
-              })
+              }.bind(this)
+            ).catch(error => {
+              warn(error)
+              reject(error)
+            })
             return promise
           },
           {

--- a/@xen-orchestra/proxy/src/app/mixins/backups/index.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/index.js
@@ -142,19 +142,21 @@ export default class Backups {
         fetchPartitionFiles: [
           ({ disk: diskId, remote, partition: partitionId, paths }) => {
             const { promise, reject, resolve } = pDefer()
-            using(async function* () {
-              const adapter = yield this.getAdapter(remote)
-              const files = yield adapter.usePartitionFiles(diskId, partitionId, paths)
-              const zip = new ZipFile()
-              files.forEach(({ realPath, metadataPath }) => zip.addFile(realPath, metadataPath))
-              zip.end()
-              const { outputStream } = zip
-              resolve(outputStream)
-              await fromEvent(outputStream, 'end')
-            }).catch(error => {
-              warn(error)
-              reject(error)
-            })
+            using
+              .call(this, async function* () {
+                const adapter = yield this.getAdapter(remote)
+                const files = yield adapter.usePartitionFiles(diskId, partitionId, paths)
+                const zip = new ZipFile()
+                files.forEach(({ realPath, metadataPath }) => zip.addFile(realPath, metadataPath))
+                zip.end()
+                const { outputStream } = zip
+                resolve(outputStream)
+                await fromEvent(outputStream, 'end')
+              })
+              .catch(error => {
+                warn(error)
+                reject(error)
+              })
             return promise
           },
           {


### PR DESCRIPTION
Introduced by c19326ed501629afdefe954a7ac375f9328aea63

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
