### PR TITLE
feat(proxy/backups): move fetchPartitionFiles implementation to RemoteAdapter

### DIFF
--- a/@xen-orchestra/proxy/src/app/mixins/backups/_RemoteAdapter.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/_RemoteAdapter.js
@@ -223,7 +223,7 @@ export class RemoteAdapter {
   }
 
   @decorateWith(Disposable.factory)
-  async *usePartitionFiles(diskId, partitionId, paths) {
+  async *_usePartitionFiles(diskId, partitionId, paths) {
     const path = yield this.getPartition(diskId, partitionId)
 
     const files = []
@@ -238,7 +238,7 @@ export class RemoteAdapter {
     const { promise, reject, resolve } = pDefer()
     using(
       async function* () {
-        const files = yield this.usePartitionFiles(diskId, partitionId, paths)
+        const files = yield this._usePartitionFiles(diskId, partitionId, paths)
         const zip = new ZipFile()
         files.forEach(({ realPath, metadataPath }) => zip.addFile(realPath, metadataPath))
         zip.end()

--- a/@xen-orchestra/proxy/src/app/mixins/backups/_RemoteAdapter.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/_RemoteAdapter.js
@@ -1,6 +1,8 @@
 import asyncMapSettled from '@xen-orchestra/async-map'
 import Disposable from 'promise-toolbox/Disposable'
 import fromCallback from 'promise-toolbox/fromCallback'
+import fromEvent from 'promise-toolbox/fromEvent'
+import pDefer from 'promise-toolbox/defer'
 import pump from 'pump'
 import using from 'promise-toolbox/using'
 import Vhd, { createSyntheticStream, mergeVhd } from 'vhd-lib'
@@ -9,6 +11,7 @@ import { createLogger } from '@xen-orchestra/log'
 import { decorateWith } from '@vates/decorate-with'
 import { execFile } from 'child_process'
 import { readdir, stat } from 'fs-extra'
+import { ZipFile } from 'yazl'
 
 import { decorateResult } from '../../_decorateResult'
 import { deduped } from '../../_deduped'
@@ -229,6 +232,25 @@ export class RemoteAdapter {
     )
 
     return files
+  }
+
+  fetchPartitionFiles(diskId, partitionId, paths) {
+    const { promise, reject, resolve } = pDefer()
+    using(
+      async function* () {
+        const files = yield this.usePartitionFiles(diskId, partitionId, paths)
+        const zip = new ZipFile()
+        files.forEach(({ realPath, metadataPath }) => zip.addFile(realPath, metadataPath))
+        zip.end()
+        const { outputStream } = zip
+        resolve(outputStream)
+        await fromEvent(outputStream, 'end')
+      }.bind(this)
+    ).catch(error => {
+      warn(error)
+      reject(error)
+    })
+    return promise
   }
 
   async deleteDeltaVmBackups(backups) {


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
