### PR TITLE
feat(proxy/backups): move ImportVmBackup to its own module

### DIFF
--- a/@xen-orchestra/proxy/src/app/mixins/backups/_ImportVmBackup.js
+++ b/@xen-orchestra/proxy/src/app/mixins/backups/_ImportVmBackup.js
@@ -1,0 +1,38 @@
+import assert from 'assert'
+import { formatFilenameDate } from '@xen-orchestra/backups/filenameDate'
+
+import { importDeltaVm } from './_deltaVm'
+
+export class ImportVmBackup {
+  constructor({ adapter, backupId, srUuid, xapi }) {
+    this._adapter = adapter
+    this._backupId = backupId
+    this._srUuid = srUuid
+    this._xapi = xapi
+  }
+
+  async run() {
+    const xapi = this._xapi
+    const srRef = await xapi.call('SR.get_by_uuid', this._srUuid)
+
+    const adapter = this._adapter
+    const metadata = await adapter.readVmBackupMetadata(this._backupId)
+    let vmRef
+    if (metadata.mode === 'full') {
+      vmRef = await xapi.VM_import(await adapter.readFullVmBackup(metadata), srRef)
+    } else {
+      assert.strictEqual(metadata.mode, 'delta')
+
+      vmRef = await importDeltaVm(await adapter.readDeltaVmBackup(metadata), await xapi.getRecord('SR', srRef), {
+        detectBase: false,
+      })
+    }
+
+    await Promise.all([
+      xapi.call('VM.add_tags', vmRef, 'restored from backup'),
+      xapi.call('VM.set_name_label', vmRef, `${metadata.vm.name_label} (${formatFilenameDate(metadata.timestamp)})`),
+    ])
+
+    return xapi.getField('VM', vmRef, 'uuid')
+  }
+}


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
