### PR TITLE
fix(xo-server/metadata-backups): fix interrupted status on backup running

### DIFF
--- a/packages/xo-server/src/xo-mixins/metadata-backups.js
+++ b/packages/xo-server/src/xo-mixins/metadata-backups.js
@@ -862,13 +862,15 @@ export default class metadataBackup {
           const { parentId } = log
           if (parentId === undefined) {
             rootTaskId = localTaskIds[taskId] = logger.notice(message, common)
+            this._runningMetadataRestores.add(rootTaskId)
           } else {
             common.parentId = localTaskIds[parentId]
             localTaskIds[taskId] = logger.notice(message, common)
           }
         } else {
           const localTaskId = localTaskIds[taskId]
-          if (localTaskId === rootTaskId && dir === DIR_XO_CONFIG_BACKUPS && log.status === 'success') {
+          const isRootTask = localTaskId === rootTaskId
+          if (isRootTask && dir === DIR_XO_CONFIG_BACKUPS && log.status === 'success') {
             try {
               await app.importConfig(log.result)
             } catch (error) {
@@ -879,6 +881,9 @@ export default class metadataBackup {
 
           common.taskId = localTaskId
           logger.notice(message, common)
+          if (isRootTask) {
+            this._runningMetadataRestores.delete(localTaskId)
+          }
         }
       }
       return

--- a/packages/xo-server/src/xo-mixins/metadata-backups.js
+++ b/packages/xo-server/src/xo-mixins/metadata-backups.js
@@ -816,114 +816,113 @@ export default class metadataBackup {
     const metadataFolder = `${dir}/${path.join('/')}`
 
     const { proxy, url, options } = await app.getRemoteWithCredentials(remoteId)
-    if (proxy !== undefined) {
-      let xapi
-      if (dir === DIR_XO_POOL_METADATA_BACKUPS) {
-        const poolUuid = path[1]
-        const { allowUnauthorized, host, password, username } = await app.getXenServer(
-          app.getXenServerIdByObject(poolUuid)
-        )
-        xapi = {
-          allowUnauthorized,
-          credentials: {
-            username,
-            password,
-          },
-          url: host,
-        }
-      }
 
-      const logsStream = await app.callProxyMethod(
-        proxy,
-        'backup.restoreMetadataBackup',
-        {
-          backupId: metadataFolder,
-          remote: { url, options },
-          xapi,
-        },
-        {
-          assertType: 'iterator',
-        }
-      )
-
-      let rootTaskId
-      const localTaskIds = { __proto__: null }
-      for await (const log of logsStream) {
-        const { event, message, taskId } = log
-
-        const common = {
-          data: log.data,
-          event: 'task.' + event,
-          result: log.result,
-          status: log.status,
-        }
-
-        if (event === 'start') {
-          const { parentId } = log
-          if (parentId === undefined) {
-            rootTaskId = localTaskIds[taskId] = logger.notice(message, common)
-            this._runningMetadataRestores.add(rootTaskId)
-          } else {
-            common.parentId = localTaskIds[parentId]
-            localTaskIds[taskId] = logger.notice(message, common)
-          }
-        } else {
-          const localTaskId = localTaskIds[taskId]
-          const isRootTask = localTaskId === rootTaskId
-          if (isRootTask && dir === DIR_XO_CONFIG_BACKUPS && log.status === 'success') {
-            try {
-              await app.importConfig(log.result)
-            } catch (error) {
-              common.result = serializeError(error)
-              common.status = 'failure'
-            }
-          }
-
-          common.taskId = localTaskId
-          logger.notice(message, common)
-          if (isRootTask) {
-            this._runningMetadataRestores.delete(localTaskId)
-          }
-        }
-      }
-      return
-    }
-
-    const message = 'metadataRestore'
-    const handler = await app.getRemoteHandler(remoteId)
-
-    const taskId = logger.notice(message, {
-      event: 'task.start',
-      data: JSON.parse(String(await handler.readFile(`${metadataFolder}/metadata.json`))),
-    })
+    let rootTaskId
     try {
-      this._runningMetadataRestores.add(taskId)
+      if (proxy !== undefined) {
+        let xapi
+        if (dir === DIR_XO_POOL_METADATA_BACKUPS) {
+          const poolUuid = path[1]
+          const { allowUnauthorized, host, password, username } = await app.getXenServer(
+            app.getXenServerIdByObject(poolUuid)
+          )
+          xapi = {
+            allowUnauthorized,
+            credentials: {
+              username,
+              password,
+            },
+            url: host,
+          }
+        }
 
-      let result
-      if (dir === DIR_XO_CONFIG_BACKUPS) {
-        result = await app.importConfig(await handler.readFile(`${metadataFolder}/data.json`))
-      } else {
-        result = await app
-          .getXapi(path[1])
-          .importPoolMetadata(await handler.createReadStream(`${metadataFolder}/data`), true)
+        const logsStream = await app.callProxyMethod(
+          proxy,
+          'backup.restoreMetadataBackup',
+          {
+            backupId: metadataFolder,
+            remote: { url, options },
+            xapi,
+          },
+          {
+            assertType: 'iterator',
+          }
+        )
+
+        const localTaskIds = { __proto__: null }
+        for await (const log of logsStream) {
+          const { event, message, taskId } = log
+
+          const common = {
+            data: log.data,
+            event: 'task.' + event,
+            result: log.result,
+            status: log.status,
+          }
+
+          if (event === 'start') {
+            const { parentId } = log
+            if (parentId === undefined) {
+              rootTaskId = localTaskIds[taskId] = logger.notice(message, common)
+              this._runningMetadataRestores.add(rootTaskId)
+            } else {
+              common.parentId = localTaskIds[parentId]
+              localTaskIds[taskId] = logger.notice(message, common)
+            }
+          } else {
+            const localTaskId = localTaskIds[taskId]
+            if (localTaskId === rootTaskId && dir === DIR_XO_CONFIG_BACKUPS && log.status === 'success') {
+              try {
+                await app.importConfig(log.result)
+              } catch (error) {
+                common.result = serializeError(error)
+                common.status = 'failure'
+              }
+            }
+
+            common.taskId = localTaskId
+            logger.notice(message, common)
+          }
+        }
+        return
       }
 
-      logger.notice(message, {
-        event: 'task.end',
-        result,
-        status: 'success',
-        taskId,
+      const message = 'metadataRestore'
+      const handler = await app.getRemoteHandler(remoteId)
+
+      rootTaskId = logger.notice(message, {
+        event: 'task.start',
+        data: JSON.parse(String(await handler.readFile(`${metadataFolder}/metadata.json`))),
       })
-    } catch (error) {
-      logger.error(message, {
-        event: 'task.end',
-        result: serializeError(error),
-        status: 'failure',
-        taskId,
-      })
-      throw error
+      try {
+        this._runningMetadataRestores.add(rootTaskId)
+
+        let result
+        if (dir === DIR_XO_CONFIG_BACKUPS) {
+          result = await app.importConfig(await handler.readFile(`${metadataFolder}/data.json`))
+        } else {
+          result = await app
+            .getXapi(path[1])
+            .importPoolMetadata(await handler.createReadStream(`${metadataFolder}/data`), true)
+        }
+
+        logger.notice(message, {
+          event: 'task.end',
+          result,
+          status: 'success',
+          taskId: rootTaskId,
+        })
+      } catch (error) {
+        logger.error(message, {
+          event: 'task.end',
+          result: serializeError(error),
+          status: 'failure',
+          taskId: rootTaskId,
+        })
+        throw error
+      }
     } finally {
-      this._runningMetadataRestores.delete(taskId)
+      this._runningMetadataRestores.delete(rootTaskId)
     }
   }
 


### PR DESCRIPTION
Introduced by 8a3ae59f77017552ed71eb3409e9ffef4154cfcc

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
