### PR TITLE
feat(xo-server/backups-ng): handle proxy VM restoration logs

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,7 @@
 - [Proxy] Ask for a confirmation before upgrading a proxy with running backups (PR [#5533](https://github.com/vatesfr/xen-orchestra/pull/5533))
 - [Backup/restore] Allow backup restore to any licence even if XOA isn't registered (PR [#5547](https://github.com/vatesfr/xen-orchestra/pull/5547))
 - [Import] Ignore case when detecting file type (PR [#5574](https://github.com/vatesfr/xen-orchestra/pull/5574))
+- [Proxy] Log VM backup restoration (PR [#5576](https://github.com/vatesfr/xen-orchestra/pull/5576))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -880,8 +880,7 @@ export default class BackupNg {
 
           return
         } catch (error) {
-          // XO API invalid parameters error
-          if (error.code === 10) {
+          if (invalidParameters.is(error)) {
             delete params.streamLogs
             return app.callProxyMethod(proxy, 'backup.importVmBackup', params)
           }

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -29,7 +29,7 @@ import {
   sum,
   values,
 } from 'lodash'
-import { CancelToken, ignoreErrors, pFinally, timeout } from 'promise-toolbox'
+import { CancelToken, ignoreErrors, timeout } from 'promise-toolbox'
 import Vhd, { chainVhd, checkVhdChain, createSyntheticStream as createVhdReadStream } from 'vhd-lib'
 
 import type Logger from '../logs/loggers/abstract'
@@ -820,53 +820,103 @@ export default class BackupNg {
 
     const { metadataFilename, remoteId } = parseVmBackupId(id)
     const { proxy, url, options } = await app.getRemoteWithCredentials(remoteId)
-    if (proxy !== undefined) {
-      const { allowUnauthorized, host, password, username } = await app.getXenServer(app.getXenServerIdByObject(sr.$id))
-      return app.callProxyMethod(proxy, 'backup.importVmBackup', {
-        backupId: metadataFilename,
-        remote: {
-          url,
-          options,
-        },
-        srUuid: sr.uuid,
-        xapi: {
-          allowUnauthorized,
-          credentials: {
-            username,
-            password,
-          },
-          url: host,
-        },
-      })
-    }
 
-    const handler = await app.getRemoteHandler(remoteId)
-    const metadata: Metadata = JSON.parse(String(await handler.readFile(metadataFilename)))
-
-    const importer = importers[metadata.mode]
-    if (importer === undefined) {
-      throw new Error(`no importer for backup mode ${metadata.mode}`)
-    }
-
-    const { jobId, timestamp: time } = metadata
+    let rootTaskId
     const logger = this._logger
-    return wrapTaskFn(
-      {
-        data: {
-          jobId,
-          srId,
-          time,
-        },
-        logger,
-        message: 'restore',
-      },
-      taskId => {
-        this._runningRestores.add(taskId)
-        return importer(handler, metadataFilename, metadata, xapi, sr, taskId, logger)::pFinally(() => {
-          this._runningRestores.delete(taskId)
-        })
+    try {
+      if (proxy !== undefined) {
+        const { allowUnauthorized, host, password, username } = await app.getXenServer(
+          app.getXenServerIdByObject(sr.$id)
+        )
+
+        const params = {
+          backupId: metadataFilename,
+          remote: {
+            url,
+            options,
+          },
+          srUuid: sr.uuid,
+          streamLogs: true,
+          xapi: {
+            allowUnauthorized,
+            credentials: {
+              username,
+              password,
+            },
+            url: host,
+          },
+        }
+
+        try {
+          const logsStream = await app.callProxyMethod(proxy, 'backup.importVmBackup', params, {
+            assertType: 'iterator',
+          })
+
+          const localTaskIds = { __proto__: null }
+          for await (const log of logsStream) {
+            const { event, message, taskId } = log
+
+            const common = {
+              data: log.data,
+              event: 'task.' + event,
+              result: log.result,
+              status: log.status,
+            }
+
+            if (event === 'start') {
+              const { parentId } = log
+              if (parentId === undefined) {
+                rootTaskId = localTaskIds[taskId] = logger.notice(message, common)
+                this._runningRestores.add(rootTaskId)
+              } else {
+                common.parentId = localTaskIds[parentId]
+                localTaskIds[taskId] = logger.notice(message, common)
+              }
+            } else {
+              common.taskId = localTaskIds[taskId]
+              logger.notice(message, common)
+            }
+          }
+
+          return
+        } catch (error) {
+          // XO API invalid parameters error
+          if (error.code === 10) {
+            delete params.streamLogs
+            return app.callProxyMethod(proxy, 'backup.importVmBackup', params)
+          }
+          throw error
+        }
       }
-    )()
+
+      const handler = await app.getRemoteHandler(remoteId)
+      const metadata: Metadata = JSON.parse(String(await handler.readFile(metadataFilename)))
+
+      const importer = importers[metadata.mode]
+      if (importer === undefined) {
+        throw new Error(`no importer for backup mode ${metadata.mode}`)
+      }
+
+      const { jobId, timestamp: time } = metadata
+      return wrapTaskFn(
+        {
+          data: {
+            jobId,
+            srId,
+            time,
+          },
+          logger,
+          message: 'restore',
+        },
+        taskId => {
+          rootTaskId = taskId
+          this._runningRestores.add(taskId)
+          return importer(handler, metadataFilename, metadata, xapi, sr, taskId, logger)
+        }
+      )()
+    } finally {
+      this._runningRestores.delete(rootTaskId)
+    }
   }
 
   @decorateWith(


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
