### PR TITLE
fix(xo-server#_migrateVmWithStorageMotion): don't migrate VM VDIs to default SR 

### DIFF
--- a/packages/xo-server/src/api/vm.js
+++ b/packages/xo-server/src/api/vm.js
@@ -454,7 +454,7 @@ export async function migrate({ vm, host, sr, mapVdisSrs, mapVifsNetworks, migra
   if (mapVdisSrs) {
     mapVdisSrsXapi = {}
     forEach(mapVdisSrs, (srId, vdiId) => {
-      const vdiXapiId = this.getObject(vdiId, ['VDI', 'VDI-snapshot'])._xapiId
+      const vdiXapiId = this.getObject(vdiId, 'VDI')._xapiId
       mapVdisSrsXapi[vdiXapiId] = this.getObject(srId, 'SR')._xapiId
       return permissions.push([srId, 'administrate'])
     })

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -15,21 +15,7 @@ import { parseDuration } from '@vates/parse-duration'
 import { PassThrough } from 'stream'
 import { forbiddenOperation } from 'xo-common/api-errors'
 import { Xapi as XapiBase, NULL_REF } from 'xen-api'
-import {
-  every,
-  filter,
-  find,
-  flatMap,
-  flatten,
-  groupBy,
-  identity,
-  includes,
-  isEmpty,
-  noop,
-  omit,
-  once,
-  uniq,
-} from 'lodash'
+import { every, filter, find, flatMap, flatten, groupBy, identity, includes, isEmpty, noop, omit, uniq } from 'lodash'
 import { satisfies as versionSatisfies } from 'semver'
 
 import createSizeStream from '../size-stream'
@@ -1111,25 +1097,15 @@ export default class Xapi extends XapiBase {
       force = false,
     }
   ) {
-    const getDefaultSrRef = once(() => {
-      if (sr !== undefined) {
-        return hostXapi.getObject(sr).$ref
-      }
-      const defaultSr = host.$pool.$default_SR
-      if (defaultSr === undefined) {
-        throw new Error(`This operation requires a default SR to be set on the pool ${host.$pool.name_label}`)
-      }
-      return defaultSr.$ref
-    })
-
     // VDIs/SRs mapping
+    const srRef = hostXapi.getObject(sr).$ref
     const vdis = {}
     const vbds = flatMap(vm.$snapshots, '$VBDs').concat(vm.$VBDs)
     for (const vbd of vbds) {
       const vdi = vbd.$VDI
       if (vbd.type === 'Disk') {
         vdis[vdi.$ref] =
-          mapVdisSrs && mapVdisSrs[vdi.$id] ? hostXapi.getObject(mapVdisSrs[vdi.$id]).$ref : getDefaultSrRef()
+          mapVdisSrs && mapVdisSrs[vdi.$id] ? hostXapi.getObject(mapVdisSrs[vdi.$id]).$ref : srRef ?? vdi.$SR.$ref
       }
     }
 

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1140,7 +1140,7 @@ export default class Xapi extends XapiBase {
     // - Else: use the migration main SR or the pool's default SR (error if none of them is defined)
     // For VDI-snapshot:
     // - If VDI-snapshot is an orphan snapshot: same logic as a VDI
-    // - Else: don't add it to the map (VDI -> SR). It will be managed By the XAPI (snapshot will be migrated to the same SR as an active VDI)
+    // - Else: don't add it to the map (VDI -> SR). It will be managed by the XAPI (snapshot will be migrated to the same SR as its parent active VDI)
     const vdis = {}
     const vbds = flatMap(vm.$snapshots, '$VBDs').concat(vm.$VBDs)
     for (const vbd of vbds) {

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1134,14 +1134,14 @@ export default class Xapi extends XapiBase {
     }
 
     // VDIs/SRs mapping
+    // - If SR was explicitly passed: use it
+    // - Else if VDI SR is reachable from the destination host: use it
+    // - Else: use the default SR for this migration or default SR for this pool
     const vdis = {}
     const vbds = flatMap(vm.$snapshots, '$VBDs').concat(vm.$VBDs)
     for (const vbd of vbds) {
       const vdi = vbd.$VDI
       if (vbd.type === 'Disk') {
-        // - If SR was explicitly passed: use it
-        // - Else if VDI SR is reachable from the destination host: use it
-        // - Else: use the default SR for this migration or default SR for this pool
         vdis[vdi.$ref] =
           mapVdisSrs[vdi.$id] !== undefined
             ? hostXapi.getObject(mapVdisSrs[vdi.$id]).$ref

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1136,7 +1136,7 @@ export default class Xapi extends XapiBase {
     // VDIs/SRs mapping
     // - If SR was explicitly passed: use it
     // - Else if VDI SR is reachable from the destination host: use it
-    // - Else: use the default SR for this migration or default SR for this pool
+    // - Else: use the default SR for migration or default SR for pool
     const vdis = {}
     const vbds = flatMap(vm.$snapshots, '$VBDs').concat(vm.$VBDs)
     for (const vbd of vbds) {

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1137,7 +1137,7 @@ export default class Xapi extends XapiBase {
     // For VDI:
     // - If SR was explicitly passed: use it
     // - Else if VDI SR is reachable from the destination host: use it
-    // - Else: use the migration main SR or the pool's default SR
+    // - Else: use the migration main SR or the pool's default SR (error if none of them is defined)
     // For VDI-snapshot:
     // - If VDI-snapshot is an orphan snapshot: same logic as a VDI
     // - Else: don't add it to the map (VDI -> SR). It will be managed By the XAPI (snapshot will be migrated to the same SR as an active VDI)

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1127,7 +1127,7 @@ export default class Xapi extends XapiBase {
     const isConnectedSr = sr => {
       let isConnected = connectedSrs.get(sr.$ref)
       if (isConnected === undefined) {
-        isConnected = sr.PBDs.find(ref => hostPbds.has(ref))
+        isConnected = sr.PBDs.some(ref => hostPbds.has(ref))
         connectedSrs.set(sr.$ref, isConnected)
       }
       return isConnected !== undefined

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1130,7 +1130,7 @@ export default class Xapi extends XapiBase {
       const vdi = vbd.$VDI
       if (vbd.type === 'Disk') {
         vdis[vdi.$ref] =
-          mapVdisSrs && mapVdisSrs[vdi.$id]
+          mapVdisSrs !== undefined && mapVdisSrs[vdi.$id] !== undefined
             ? hostXapi.getObject(mapVdisSrs[vdi.$id]).$ref
             : intersection(vdi.$SR.$PBDs, hostPbds).length === 0
             ? getDefaultSrRef()

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -15,7 +15,22 @@ import { parseDuration } from '@vates/parse-duration'
 import { PassThrough } from 'stream'
 import { forbiddenOperation } from 'xo-common/api-errors'
 import { Xapi as XapiBase, NULL_REF } from 'xen-api'
-import { every, filter, find, flatMap, flatten, groupBy, identity, includes, isEmpty, noop, omit, uniq } from 'lodash'
+import {
+  every,
+  filter,
+  find,
+  flatMap,
+  flatten,
+  groupBy,
+  identity,
+  includes,
+  intersection,
+  isEmpty,
+  noop,
+  omit,
+  once,
+  uniq,
+} from 'lodash'
 import { satisfies as versionSatisfies } from 'semver'
 
 import createSizeStream from '../size-stream'
@@ -1097,15 +1112,29 @@ export default class Xapi extends XapiBase {
       force = false,
     }
   ) {
+    const getDefaultSrRef = once(() => {
+      if (sr !== undefined) {
+        return hostXapi.getObject(sr).$ref
+      }
+      const defaultSr = host.$pool.$default_SR
+      if (defaultSr === undefined) {
+        throw new Error(`This operation requires a default SR to be set on the pool ${host.$pool.name_label}`)
+      }
+      return defaultSr.$ref
+    })
     // VDIs/SRs mapping
-    const srRef = hostXapi.getObject(sr).$ref
     const vdis = {}
+    const hostPbds = host.$PBDs
     const vbds = flatMap(vm.$snapshots, '$VBDs').concat(vm.$VBDs)
     for (const vbd of vbds) {
       const vdi = vbd.$VDI
       if (vbd.type === 'Disk') {
         vdis[vdi.$ref] =
-          mapVdisSrs && mapVdisSrs[vdi.$id] ? hostXapi.getObject(mapVdisSrs[vdi.$id]).$ref : srRef ?? vdi.$SR.$ref
+          mapVdisSrs && mapVdisSrs[vdi.$id]
+            ? hostXapi.getObject(mapVdisSrs[vdi.$id]).$ref
+            : intersection(vdi.$SR.$PBDs, hostPbds).length === 0
+            ? getDefaultSrRef()
+            : vdi.$SR.$ref
       }
     }
 

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1106,7 +1106,7 @@ export default class Xapi extends XapiBase {
     {
       migrationNetwork = find(host.$PIFs, pif => pif.management).$network, // TODO: handle not found
       sr,
-      mapVdisSrs,
+      mapVdisSrs = {},
       mapVifsNetworks,
       force = false,
     }
@@ -1139,8 +1139,11 @@ export default class Xapi extends XapiBase {
     for (const vbd of vbds) {
       const vdi = vbd.$VDI
       if (vbd.type === 'Disk') {
+        // - If SR was explicitly passed: use it
+        // - Else if VDI SR is reachable from the destination host: use it
+        // - Else: use the default SR for this migration or default SR for this pool
         vdis[vdi.$ref] =
-          mapVdisSrs !== undefined && mapVdisSrs[vdi.$id] !== undefined
+          mapVdisSrs[vdi.$id] !== undefined
             ? hostXapi.getObject(mapVdisSrs[vdi.$id]).$ref
             : isConnectedSr(vdi.$SR)
             ? vdi.$SR.$ref


### PR DESCRIPTION
See xoa-support#3248 and xoa-support#3355

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
