### PR TITLE
Revert "fix(xo-server/migrateVm): take VDIs of snapshot into account (#3298)"

### DIFF
--- a/packages/xo-server/src/api/vm.js
+++ b/packages/xo-server/src/api/vm.js
@@ -454,7 +454,7 @@ export async function migrate({ vm, host, sr, mapVdisSrs, mapVifsNetworks, migra
   if (mapVdisSrs) {
     mapVdisSrsXapi = {}
     forEach(mapVdisSrs, (srId, vdiId) => {
-      const vdiXapiId = this.getObject(vdiId, ['VDI', 'VDI-snapshot'])._xapiId
+      const vdiXapiId = this.getObject(vdiId, 'VDI')._xapiId
       mapVdisSrsXapi[vdiXapiId] = this.getObject(srId, 'SR')._xapiId
       return permissions.push([srId, 'administrate'])
     })

--- a/packages/xo-server/src/xapi/index.js
+++ b/packages/xo-server/src/xapi/index.js
@@ -1124,8 +1124,7 @@ export default class Xapi extends XapiBase {
 
     // VDIs/SRs mapping
     const vdis = {}
-    const vbds = flatMap(vm.$snapshots, '$VBDs').concat(vm.$VBDs)
-    for (const vbd of vbds) {
+    for (const vbd of vm.$VBDs) {
       const vdi = vbd.$VDI
       if (vbd.type === 'Disk') {
         vdis[vdi.$ref] =


### PR DESCRIPTION
This reverts commit 4a0b29e1f2b3a54afc20230d022f5ed1d34ce73d.

A VDI snapshot can't be migrated to a different SR than its active VDI and if
a VDI snapshot is missing from `mapVdisSrs`, it will automatically be migrated
to the same SR as its active VDI.

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
