### PR TITLE
feat(backups/Backup): pass directly getConnectedRecord

### DIFF
--- a/@xen-orchestra/backups/Backup.js
+++ b/@xen-orchestra/backups/Backup.js
@@ -28,17 +28,15 @@ exports.Backup = class Backup {
   constructor({
     config,
     getAdapter,
-    getConnectedXapi,
+    getConnectedRecord,
     job,
 
-    recordToXapi,
     remotes,
     schedule,
   }) {
     this._config = config
-    this._getConnectedXapi = getConnectedXapi
+    this._getRecord = getConnectedRecord
     this._job = job
-    this._recordToXapi = recordToXapi
     this._remotes = remotes
     this._schedule = schedule
 
@@ -217,16 +215,5 @@ exports.Backup = class Backup {
         await asyncMapSettled(vmIds, concurrency === 0 ? handleVm : limitConcurrency(concurrency)(handleVm))
       }
     )
-  }
-
-  _getRecord = Disposable.factory(this._getRecord)
-  async *_getRecord(type, uuid) {
-    const xapiId = this._recordToXapi[uuid]
-    if (xapiId === undefined) {
-      throw new Error('no XAPI associated to ' + uuid)
-    }
-
-    const xapi = yield this._getConnectedXapi(xapiId)
-    return xapi.getRecordByUuid(type, uuid)
   }
 }


### PR DESCRIPTION
This should make it easier to interface with xo-server.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
