### PR TITLE
fix(xo-web/DropdownButton): add required `id` prop

### DIFF
--- a/packages/xo-web/src/common/sorted-table/index.js
+++ b/packages/xo-web/src/common/sorted-table/index.js
@@ -769,7 +769,7 @@ class SortedTable extends Component {
     )
 
     const dropdownItemsPerPage = (
-      <DropdownButton bsStyle='info' title={itemsPerPage}>
+      <DropdownButton bsStyle='info' id='itemsPerPage' title={itemsPerPage}>
         {ITEMS_PER_PAGE_OPTIONS.map(nItems => (
           <MenuItem key={nItems} onClick={() => this._setNItemsPerPage(nItems)}>
             {nItems}

--- a/packages/xo-web/src/common/sorted-table/index.js
+++ b/packages/xo-web/src/common/sorted-table/index.js
@@ -744,6 +744,7 @@ class SortedTable extends Component {
       onSelect,
       paginationContainer,
       shortcutsTarget,
+      stateUrlParam,
     } = props
     const { all, itemsPerPage } = state
     const groupedActions = this._getGroupedActions()
@@ -769,7 +770,7 @@ class SortedTable extends Component {
     )
 
     const dropdownItemsPerPage = (
-      <DropdownButton bsStyle='info' id='itemsPerPage' title={itemsPerPage}>
+      <DropdownButton bsStyle='info' id={stateUrlParam} title={itemsPerPage}>
         {ITEMS_PER_PAGE_OPTIONS.map(nItems => (
           <MenuItem key={nItems} onClick={() => this._setNItemsPerPage(nItems)}>
             {nItems}

--- a/packages/xo-web/src/xo-app/home/index.js
+++ b/packages/xo-web/src/xo-app/home/index.js
@@ -1187,7 +1187,7 @@ export default class Home extends Component {
             <Button onClick={this._expandAll}>
               <Icon icon='nav' />
             </Button>{' '}
-            <DropdownButton bsStyle='info' title={homeItemsPerPage}>
+            <DropdownButton bsStyle='info' id='itemsPerPage' title={homeItemsPerPage}>
               {ITEMS_PER_PAGE_OPTIONS.map(nItems => (
                 <MenuItem key={nItems} onClick={() => this._setNItemsPerPage(nItems)}>
                   {nItems}


### PR DESCRIPTION
See: https://react-bootstrap.netlify.app/components/dropdowns/#dropdown-button-props
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
