### PR TITLE
fix(xo-web/editable/number): throw error if onChange fails

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Editable number] When you are trying to edit a number and it's failing, display an error (PR [#5634](https://github.com/vatesfr/xen-orchestra/pull/5634))
+
 ### Packages to release
 
 > Packages will be released in the order they are here, therefore, they should
@@ -30,3 +32,4 @@
 
 - @xen-orchestra/async-map minor
 - xo-server minor
+- xo-web patch

--- a/packages/xo-web/src/common/editable/index.js
+++ b/packages/xo-web/src/common/editable/index.js
@@ -295,21 +295,17 @@ export class Number extends Component {
   }
 
   _onChange = async (value, params) => {
-    try {
-      if (value === '') {
-        if (this.props.nullable) {
-          value = null
-        } else {
-          return
-        }
+    if (value === '') {
+      if (this.props.nullable) {
+        value = null
       } else {
-        value = +value
+        return
       }
-
-      await this.props.onChange(value, params)
-    } catch (error) {
-      throw error
+    } else {
+      value = +value
     }
+
+    await this.props.onChange(value, params)
   }
 
   render() {

--- a/packages/xo-web/src/common/editable/index.js
+++ b/packages/xo-web/src/common/editable/index.js
@@ -294,18 +294,22 @@ export class Number extends Component {
     return +this.refs.input.value
   }
 
-  _onChange = (value, params) => {
-    if (value === '') {
-      if (this.props.nullable) {
-        value = null
+  _onChange = async (value, params) => {
+    try {
+      if (value === '') {
+        if (this.props.nullable) {
+          value = null
+        } else {
+          return
+        }
       } else {
-        return
+        value = +value
       }
-    } else {
-      value = +value
-    }
 
-    this.props.onChange(value, params)
+      await this.props.onChange(value, params)
+    } catch (error) {
+      throw error
+    }
   }
 
   render() {


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
