### PR TITLE
fix(xo-web/vm/tab-network): an error has occurred when trying to sort empty network

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Editable number] When you are trying to edit a number and it's failing, display an error (PR [#5634](https://github.com/vatesfr/xen-orchestra/pull/5634))
+- [VM/Network] fix `an error has occurred` if try to sort empty network
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Editable number] When you are trying to edit a number and it's failing, display an error (PR [#5634](https://github.com/vatesfr/xen-orchestra/pull/5634))
-- [VM/Network] fix `an error has occurred` if try to sort empty network (PR [#5639](https://github.com/vatesfr/xen-orchestra/pull/5639))
+- [VM/Network] Fix `an error has occurred` when trying to sort the table by the network's name (PR [#5639](https://github.com/vatesfr/xen-orchestra/pull/5639))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Editable number] When you are trying to edit a number and it's failing, display an error (PR [#5634](https://github.com/vatesfr/xen-orchestra/pull/5634))
-- [VM/Network] fix `an error has occurred` if try to sort empty network
+- [VM/Network] fix `an error has occurred` if try to sort empty network (PR [#5639](https://github.com/vatesfr/xen-orchestra/pull/5639))
 
 ### Packages to release
 

--- a/packages/xo-web/src/xo-app/vm/tab-network.js
+++ b/packages/xo-web/src/xo-app/vm/tab-network.js
@@ -710,7 +710,12 @@ const COLUMNS = [
       <VifNetwork vif={vif} network={networks[vif.$network]} resourceSet={resourceSet} />
     ),
     name: _('vifNetworkLabel'),
-    sortCriteria: (vif, userData) => userData.networks[vif.$network].name_label,
+    sortCriteria: (vif, userData) => {
+      if (isEmpty(userData.ip)) {
+        return
+      }
+      return userData.networks[vif.$network].name_label
+    },
   },
   {
     itemRenderer: ({ id, rateLimit }) => (

--- a/packages/xo-web/src/xo-app/vm/tab-network.js
+++ b/packages/xo-web/src/xo-app/vm/tab-network.js
@@ -710,12 +710,7 @@ const COLUMNS = [
       <VifNetwork vif={vif} network={networks[vif.$network]} resourceSet={resourceSet} />
     ),
     name: _('vifNetworkLabel'),
-    sortCriteria: (vif, userData) => {
-      if (isEmpty(userData.ip)) {
-        return
-      }
-      return userData.networks[vif.$network].name_label
-    },
+    sortCriteria: (vif, userData) => get(() => userData.networks[vif.$network].name_label),
   },
   {
     itemRenderer: ({ id, rateLimit }) => (


### PR DESCRIPTION
### Description

This issue happens when you have an ACL role on one VM, but you don't have an ACL role on the network of this VM.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
