### PR TITLE
fix(destroy VM): try harder to destroy VDIs

### DIFF
--- a/@xen-orchestra/xapi/src/_AttachedVdiError.js
+++ b/@xen-orchestra/xapi/src/_AttachedVdiError.js
@@ -1,7 +1,0 @@
-const { BaseError } = require('make-error')
-
-module.exports = class AttachedVdiError extends BaseError {
-  constructor() {
-    super('this VDI is currently attached')
-  }
-}

--- a/@xen-orchestra/xapi/src/index.js
+++ b/@xen-orchestra/xapi/src/index.js
@@ -32,12 +32,17 @@ const hasProps = o => {
 }
 
 class Xapi extends Base {
-  constructor({ ignoreNobakVdis, maxUncoalescedVdis, ...opts }) {
+  constructor({ ignoreNobakVdis, maxUncoalescedVdis, vdiDestroyRetryWhenInUse, ...opts }) {
     assert.notStrictEqual(ignoreNobakVdis, undefined)
 
     super(opts)
     this._ignoreNobakVdis = ignoreNobakVdis
     this._maxUncoalescedVdis = maxUncoalescedVdis
+    this._vdiDestroyRetryWhenInUse = {
+      ...vdiDestroyRetryWhenInUse,
+      delay: 5e3,
+      retries: 10,
+    }
 
     const genericWatchers = (this._genericWatchers = new Set())
     const objectWatchers = (this._objectWatchers = { __proto__: null })

--- a/@xen-orchestra/xapi/src/vm.js
+++ b/@xen-orchestra/xapi/src/vm.js
@@ -308,12 +308,7 @@ module.exports = class Vm {
               }
             }
 
-            return pRetry(() => this.VDI_destroy(vdiRef), {
-              // work around a race condition in XCP-ng/XenServer where the disk is not fully unmounted yet.
-              delay: 5e3,
-              retries: 5,
-              when: { code: 'VDI_IN_USE' },
-            })
+            await this.VDI_destroy(vdiRef)
           })
         ),
     ])

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 
 - [Editable number] When you are trying to edit a number and it's failing, display an error (PR [#5634](https://github.com/vatesfr/xen-orchestra/pull/5634))
 - [VM/Network] Fix `an error has occurred` when trying to sort the table by the network's name (PR [#5639](https://github.com/vatesfr/xen-orchestra/pull/5639))
+- [Backup] Try harder to avoid orphan VDI snapshots, especially with iSCSI SRs [#4926](https://github.com/vatesfr/xen-orchestra/issues/4926)
 
 ### Packages to release
 
@@ -33,6 +34,8 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
+- xen-api patch
+- @xen-orchestra/xapi patch
 - @xen-orchestra/backups minor
 - xo-server minor
 - xo-web patch

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,7 +34,6 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
-- xen-api patch
 - @xen-orchestra/xapi patch
 - @xen-orchestra/backups minor
 - xo-server minor


### PR DESCRIPTION
Should fix #4926

Work-around XCP-ng/XenServer unmount from control-domain delay, especially with iSCSI SRs.

This issue impacts a lot XO backups which create snapshots, export them and delete them.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
