### PR TITLE
fix(xo-web/proxies): fix "invalid parameters" error on canceling proxy deploy

### DIFF
--- a/packages/xo-web/src/xo-app/proxies/deploy-proxy.js
+++ b/packages/xo-web/src/xo-app/proxies/deploy-proxy.js
@@ -1,7 +1,6 @@
 import _, { messages } from 'intl'
 import decorate from 'apply-decorators'
 import Icon from 'icon'
-import noop from 'lodash/noop'
 import React from 'react'
 import SingleLineRow from 'single-line-row'
 import Tooltip from 'tooltip'
@@ -249,8 +248,8 @@ const deployProxy = async ({ proxy } = {}) => {
 
   const title = isRedeployMode ? _('redeployProxy') : _('deployProxy')
   if (license === undefined) {
-    const value = 'trial'
-    const choice = await chooseAction({
+    // it rejects with undefined when the start trial option isn't chose
+    await chooseAction({
       body: (
         <div className='text-muted'>
           <Icon icon='info' /> {_('noLicenseAvailable')}
@@ -261,16 +260,11 @@ const deployProxy = async ({ proxy } = {}) => {
           btnStyle: 'success',
           icon: 'trial',
           label: _('trialStartButton'),
-          value,
         },
       ],
       icon: 'proxy',
       title,
-    }).catch(noop)
-    if (choice !== value) {
-      // throw undefined to interrupt the deployment process and let the ActionButton properly ignore this error
-      throw undefined
-    }
+    })
 
     try {
       license = await createProxyTrialLicense()

--- a/packages/xo-web/src/xo-app/proxies/deploy-proxy.js
+++ b/packages/xo-web/src/xo-app/proxies/deploy-proxy.js
@@ -248,7 +248,7 @@ const deployProxy = async ({ proxy } = {}) => {
 
   const title = isRedeployMode ? _('redeployProxy') : _('deployProxy')
   if (license === undefined) {
-    // it rejects with undefined when the start trial option isn't chose
+    // it rejects with undefined when the start trial option isn't chosen
     await chooseAction({
       body: (
         <div className='text-muted'>

--- a/packages/xo-web/src/xo-app/proxies/deploy-proxy.js
+++ b/packages/xo-web/src/xo-app/proxies/deploy-proxy.js
@@ -268,7 +268,8 @@ const deployProxy = async ({ proxy } = {}) => {
       title,
     }).catch(noop)
     if (choice !== value) {
-      return
+      // throw undefined to interrupt the deployment process and let the ActionButton properly ignore this error
+      throw undefined
     }
 
     try {


### PR DESCRIPTION
**Issue**:  [fetchProxyUpgrades](https://github.com/vatesfr/xen-orchestra/blob/d601290c46f64e0e28824f9080195e9ef16e2fd6/packages/xo-web/src/xo-app/proxies/index.js#L204) called with an undefined proxy in the proxies collection.

**Solution**: Interrupt the deployment process on cancel, in order to not fetch updates in this case.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
