### PR TITLE
chore(xo-server,xo-server-load-balancer): phase out mapToArray

### DIFF
--- a/packages/xo-server-load-balancer/src/index.js
+++ b/packages/xo-server-load-balancer/src/index.js
@@ -1,5 +1,5 @@
 import { createSchedule } from '@xen-orchestra/cron'
-import { intersection, map as mapToArray, uniq } from 'lodash'
+import { intersection, uniq } from 'lodash'
 
 import DensityPlan from './density-plan'
 import PerformancePlan from './performance-plan'
@@ -140,7 +140,7 @@ class LoadBalancerPlugin {
   _executePlans() {
     debug('Execute plans!')
 
-    return Promise.all(mapToArray(this._plans, plan => plan.execute()))
+    return Promise.all(this._plans.map(plan => plan.execute()))
   }
 }
 

--- a/packages/xo-server-load-balancer/src/performance-plan.js
+++ b/packages/xo-server-load-balancer/src/performance-plan.js
@@ -1,4 +1,4 @@
-import { filter, find, map as mapToArray } from 'lodash'
+import { filter, find } from 'lodash'
 
 import Plan from './plan'
 import { debug } from './utils'
@@ -33,13 +33,10 @@ export default class PerformancePlan extends Plan {
     // Try to power on a hosts set.
     try {
       await Promise.all(
-        mapToArray(
-          filter(this._getHosts({ powerState: 'Halted' }), host => host.powerOnMode !== ''),
-          host => {
-            const { id } = host
-            return this.xo.getXapi(id).powerOnHost(id)
-          }
-        )
+        filter(this._getHosts({ powerState: 'Halted' }), host => host.powerOnMode !== '').map(host => {
+          const { id } = host
+          return this.xo.getXapi(id).powerOnHost(id)
+        })
       )
     } catch (error) {
       console.error(error)

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -212,7 +212,7 @@ export default class Plan {
     const hostsStats = {}
 
     await Promise.all(
-      mapToArray(hosts, host =>
+      hosts.map(host =>
         this.xo.getXapiHostStats(host, granularity).then(hostStats => {
           hostsStats[host.id] = {
             nPoints: hostStats.stats.cpus[0].length,
@@ -230,7 +230,7 @@ export default class Plan {
     const vmsStats = {}
 
     await Promise.all(
-      mapToArray(vms, vm =>
+      vms.map(vm =>
         this.xo.getXapiVmStats(vm, granularity).then(vmStats => {
           vmsStats[vm.id] = {
             nPoints: vmStats.stats.cpus[0].length,

--- a/packages/xo-server/src/api/network.js
+++ b/packages/xo-server/src/api/network.js
@@ -1,5 +1,4 @@
 import xapiObjectToXo from '../xapi-object-to-xo'
-import { mapToArray } from '../utils'
 
 export function getBondModes() {
   return ['balance-slb', 'active-backup', 'lacp']
@@ -37,7 +36,7 @@ export async function createBonded({ pool, name, description, pifs, mtu = 1500, 
   return this.getXapi(pool).createBondedNetwork({
     name,
     description,
-    pifIds: mapToArray(pifs, pif => this.getObject(pif, 'PIF')._xapiId),
+    pifIds: pifs.map(pif => this.getObject(pif, 'PIF')._xapiId),
     mtu: +mtu,
     bondMode,
   })

--- a/packages/xo-server/src/api/user.js
+++ b/packages/xo-server/src/api/user.js
@@ -1,6 +1,6 @@
 import { forbiddenOperation, invalidParameters } from 'xo-common/api-errors'
 import { isEmpty } from 'lodash'
-import { getUserPublicProperties, mapToArray } from '../utils'
+import { getUserPublicProperties } from '../utils'
 
 // ===================================================================
 
@@ -49,7 +49,7 @@ export async function getAll() {
   const users = await this.getAllUsers()
 
   // Filters out private properties.
-  return mapToArray(users, getUserPublicProperties)
+  return users.map(getUserPublicProperties)
 }
 
 getAll.description = 'returns all the existing users'

--- a/packages/xo-server/src/models/acl.js
+++ b/packages/xo-server/src/models/acl.js
@@ -1,6 +1,6 @@
 import Collection from '../collection/redis'
 import Model from '../model'
-import { forEach, mapToArray, multiKeyHash } from '../utils'
+import { forEach, multiKeyHash } from '../utils'
 
 // ===================================================================
 
@@ -54,11 +54,11 @@ export class Acls extends Collection {
     })
     if (toUpdate.length) {
       // Removes all existing entries.
-      await this.remove(mapToArray(toUpdate, 'id'))
+      await this.remove(toUpdate.map(_ => _.id))
 
       // Compute the new ids (new hashes).
       await Promise.all(
-        mapToArray(toUpdate, acl =>
+        toUpdate.map(acl =>
           multiKeyHash(acl.subject, acl.object, acl.action).then(id => {
             acl.id = id
           })

--- a/packages/xo-server/src/utils.js
+++ b/packages/xo-server/src/utils.js
@@ -223,7 +223,6 @@ export { default as forEach } from 'lodash/forEach'
 export { default as isEmpty } from 'lodash/isEmpty'
 export { default as isInteger } from 'lodash/isInteger'
 export { default as isObject } from 'lodash/isObject'
-export { default as mapToArray } from 'lodash/map'
 
 // -------------------------------------------------------------------
 

--- a/packages/xo-server/src/xapi-object-to-xo.js
+++ b/packages/xo-server/src/xapi-object-to-xo.js
@@ -1,7 +1,7 @@
 import * as sensitiveValues from './sensitive-values'
 import ensureArray from './_ensureArray'
 import { extractIpFromVmNetworks } from './_extractIpFromVmNetworks'
-import { extractProperty, forEach, isEmpty, mapFilter, mapToArray, parseXml } from './utils'
+import { extractProperty, forEach, isEmpty, mapFilter, parseXml } from './utils'
 import { getVmDomainType, isHostRunning, isVmRunning, parseDateTime } from './xapi'
 import { useUpdateSystem } from './xapi/utils'
 
@@ -44,7 +44,7 @@ function link(obj, prop, idField = '$id') {
   }
 
   if (Array.isArray(dynamicValue)) {
-    return mapToArray(dynamicValue, idField)
+    return dynamicValue.map(_ => _[idField])
   }
 
   return dynamicValue[idField]

--- a/packages/xo-server/src/xapi/mixins/patching.js
+++ b/packages/xo-server/src/xapi/mixins/patching.js
@@ -7,7 +7,7 @@ import { timeout } from 'promise-toolbox'
 
 import ensureArray from '../../_ensureArray'
 import { debounceWithKey } from '../../_pDebounceWithKey'
-import { forEach, mapFilter, mapToArray, parseXml } from '../../utils'
+import { forEach, mapFilter, parseXml } from '../../utils'
 
 import { extractOpaqueRef, parseDateTime, useUpdateSystem } from '../utils'
 
@@ -76,8 +76,8 @@ export default {
         url: patch['patch-url'],
         id: patch.uuid,
         uuid: patch.uuid,
-        conflicts: mapToArray(ensureArray(patch.conflictingpatches), patch => patch.conflictingpatch.uuid),
-        requirements: mapToArray(ensureArray(patch.requiredpatches), patch => patch.requiredpatch.uuid),
+        conflicts: ensureArray(patch.conflictingpatches).map(patch => patch.conflictingpatch.uuid),
+        requirements: ensureArray(patch.requiredpatches).map(patch => patch.requiredpatch.uuid),
         paid: patch['update-stream'] === 'premium',
         upgrade: /^(XS|CH)\d{2,}$/.test(patch['name-label']),
         // TODO: what does it mean, should we handle it?

--- a/packages/xo-server/src/xapi/mixins/storage.js
+++ b/packages/xo-server/src/xapi/mixins/storage.js
@@ -2,13 +2,11 @@ import createLogger from '@xen-orchestra/log'
 import defer from 'golike-defer'
 import { filter, forEach, groupBy } from 'lodash'
 
-import { mapToArray } from '../../utils'
-
 const log = createLogger('xo:storage')
 
 export default {
   _connectAllSrPbds(sr) {
-    return Promise.all(mapToArray(sr.$PBDs, pbd => this._plugPbd(pbd)))
+    return Promise.all(sr.$PBDs.map(pbd => this._plugPbd(pbd)))
   },
 
   async connectAllSrPbds(id) {
@@ -16,7 +14,7 @@ export default {
   },
 
   _disconnectAllSrPbds(sr) {
-    return Promise.all(mapToArray(sr.$PBDs, pbd => this._unplugPbd(pbd)))
+    return Promise.all(sr.$PBDs.map(pbd => this._unplugPbd(pbd)))
   },
 
   async disconnectAllSrPbds(id) {

--- a/packages/xo-server/src/xapi/mixins/vm.js
+++ b/packages/xo-server/src/xapi/mixins/vm.js
@@ -1,9 +1,9 @@
 import deferrable from 'golike-defer'
-import { find, gte, includes, isEmpty, lte, mapValues, noop } from 'lodash'
+import { find, gte, includes, isEmpty, lte, map as mapToArray, mapValues, noop } from 'lodash'
 import { cancelable, ignoreErrors, pCatch } from 'promise-toolbox'
 import { Ref } from 'xen-api'
 
-import { forEach, mapToArray, parseSize } from '../../utils'
+import { forEach, parseSize } from '../../utils'
 
 import { extractOpaqueRef, isVmHvm, isVmRunning, makeEditObject } from '../utils'
 
@@ -195,7 +195,7 @@ export default {
     }
 
     // Destroys the VIFs cloned from the template.
-    await Promise.all(mapToArray(vm.$VIFs, vif => this._deleteVif(vif)))
+    await Promise.all(vm.$VIFs.map(vif => this._deleteVif(vif)))
 
     // Creates the VIFs specified by the user.
     if (vifs) {

--- a/packages/xo-server/src/xapi/utils.js
+++ b/packages/xo-server/src/xapi/utils.js
@@ -6,7 +6,7 @@ import pickBy from 'lodash/pickBy'
 import { utcParse } from 'd3-time-format'
 import { satisfies as versionSatisfies } from 'semver'
 
-import { camelToSnakeCase, forEach, isInteger, map, mapFilter, mapToArray, noop } from '../utils'
+import { camelToSnakeCase, forEach, isInteger, map, mapFilter, noop } from '../utils'
 
 // ===================================================================
 
@@ -168,7 +168,7 @@ export const makeEditObject = specs => {
       throw new Error('must be an array, a function or a string')
     }
 
-    set = mapToArray(set, normalizeSet)
+    set = set.map(normalizeSet)
 
     const { length } = set
     if (!length) {
@@ -180,7 +180,7 @@ export const makeEditObject = specs => {
     }
 
     return function (value, object) {
-      return Promise.all(mapToArray(set, set => set.call(this, value, object)))
+      return Promise.all(set.map(set => set.call(this, value, object)))
     }
   }
 
@@ -296,7 +296,7 @@ export const makeEditObject = specs => {
         })
 
         if (cbs.length) {
-          return () => Promise.all(mapToArray(cbs, cb => cb())).then(cb)
+          return () => Promise.all(cbs.map(cb => cb())).then(cb)
         }
       }
 
@@ -309,7 +309,7 @@ export const makeEditObject = specs => {
       await checkLimits(limits, object)
     }
 
-    return Promise.all(mapToArray(cbs, cb => cb())).then(noop)
+    return Promise.all(cbs.map(cb => cb())).then(noop)
   }
 }
 

--- a/packages/xo-server/src/xo-mixins/backups.js
+++ b/packages/xo-server/src/xo-mixins/backups.js
@@ -10,7 +10,7 @@ import { decorateWith } from '@vates/decorate-with'
 import { satisfies as versionSatisfies } from 'semver'
 import { utcFormat } from 'd3-time-format'
 import { basename, dirname } from 'path'
-import { escapeRegExp, filter, find, includes, once, range, sortBy } from 'lodash'
+import { escapeRegExp, filter, find, includes, map as mapToArray, once, range, sortBy } from 'lodash'
 import { chainVhd, createSyntheticStream as createVhdReadStream, mergeVhd } from 'vhd-lib'
 
 import createSizeStream from '../size-stream'
@@ -21,7 +21,6 @@ import {
   forEach,
   getFirstPropertyName,
   mapFilter,
-  mapToArray,
   pFinally,
   pFromCallback,
   pSettle,
@@ -286,7 +285,7 @@ export default class {
       const deltaBackups = filter(files, isDeltaBackup)
 
       backups.push(
-        ...mapToArray(deltaBackups, deltaBackup => {
+        ...deltaBackups.map(deltaBackup => {
           return `${deltaDir}/${getDeltaBackupNameWithoutExt(deltaBackup)}`
         })
       )
@@ -602,7 +601,7 @@ export default class {
     const fullVdisRequired = []
 
     await Promise.all(
-      mapToArray(vm.$VBDs, async vbd => {
+      vm.$VBDs.map(async vbd => {
         if (!vbd.VDI || vbd.type !== 'Disk') {
           return
         }
@@ -686,7 +685,7 @@ export default class {
 
     // Here we have a completed backup. We can merge old vdis.
     await Promise.all(
-      mapToArray(vdiBackups, vdiBackup => {
+      vdiBackups.map(vdiBackup => {
         const backupName = vdiBackup.value().path
         const backupDirectory = backupName.slice(0, backupName.lastIndexOf('/'))
         const backupDir = `${dir}/${backupDirectory}`
@@ -996,7 +995,7 @@ export default class {
 
     const entriesMap = {}
     await Promise.all(
-      mapToArray(entries, async name => {
+      entries.map(async name => {
         const stats = await pFromCallback(cb => stat(`${path}/${name}`, cb))::ignoreErrors()
         if (stats) {
           entriesMap[stats.isDirectory() ? `${name}/` : name] = {}
@@ -1015,7 +1014,7 @@ export default class {
         partition.unmount()
       }
     }
-    return mapToArray(paths, path => {
+    return paths.map(path => {
       ++i
       return createReadStream(resolveSubpath(partition.path, path)).once('end', onEnd)
     })

--- a/packages/xo-server/src/xo-mixins/jobs/index.js
+++ b/packages/xo-server/src/xo-mixins/jobs/index.js
@@ -8,7 +8,6 @@ import emitAsync from '@xen-orchestra/emit-async'
 
 import { CancelToken, ignoreErrors } from 'promise-toolbox'
 import { defer } from 'golike-defer'
-import { map as mapToArray } from 'lodash'
 import { noSuchObject } from 'xo-common/api-errors'
 
 import Collection from '../../collection/redis'
@@ -156,7 +155,7 @@ export default class Jobs {
       xo.addConfigManager(
         'jobs',
         () => jobsDb.get(),
-        jobs => Promise.all(mapToArray(jobs, job => jobsDb.save(job))),
+        jobs => Promise.all(jobs.map(job => jobsDb.save(job))),
         ['users']
       )
     })
@@ -395,7 +394,7 @@ export default class Jobs {
   }
 
   async runJobSequence(idSequence: Array<string>, schedule?: Schedule, data?: any) {
-    const jobs = await Promise.all(mapToArray(idSequence, id => this.getJob(id)))
+    const jobs = await Promise.all(idSequence.map(id => this.getJob(id)))
 
     for (const job of jobs) {
       await this._runJob(job, schedule, data)

--- a/packages/xo-server/src/xo-mixins/plugins.js
+++ b/packages/xo-server/src/xo-mixins/plugins.js
@@ -1,10 +1,10 @@
 import Ajv from 'ajv'
 import createLogger from '@xen-orchestra/log'
+import mapToArray from 'lodash/map'
 import { invalidParameters, noSuchObject } from 'xo-common/api-errors'
 
 import * as sensitiveValues from '../sensitive-values'
 import { PluginsMetadata } from '../models/plugin-metadata'
-import { mapToArray } from '../utils'
 
 // ===================================================================
 
@@ -26,7 +26,7 @@ export default class {
       xo.addConfigManager(
         'plugins',
         () => this._pluginsMetadata.get(),
-        plugins => Promise.all(mapToArray(plugins, plugin => this._pluginsMetadata.save(plugin)))
+        plugins => Promise.all(plugins.map(plugin => this._pluginsMetadata.save(plugin)))
       )
     })
   }

--- a/packages/xo-server/src/xo-mixins/remotes.js
+++ b/packages/xo-server/src/xo-mixins/remotes.js
@@ -7,7 +7,6 @@ import { noSuchObject } from 'xo-common/api-errors'
 
 import * as sensitiveValues from '../sensitive-values'
 import patch from '../patch'
-import { mapToArray } from '../utils'
 import { Remotes } from '../models/remote'
 
 // ===================================================================
@@ -34,7 +33,7 @@ export default class {
       xo.addConfigManager(
         'remotes',
         () => this._remotes.get(),
-        remotes => Promise.all(mapToArray(remotes, remote => this._remotes.update(remote)))
+        remotes => Promise.all(remotes.map(remote => this._remotes.update(remote)))
       )
 
       const remotes = await this._remotes.get()

--- a/packages/xo-server/src/xo-mixins/resource-sets.js
+++ b/packages/xo-server/src/xo-mixins/resource-sets.js
@@ -70,7 +70,7 @@ export default class {
       xo.addConfigManager(
         'resourceSets',
         () => this.getAllResourceSets(),
-        resourceSets => Promise.all(mapToArray(resourceSets, resourceSet => this._save(resourceSet))),
+        resourceSets => Promise.all(resourceSets.map(resourceSet => this._save(resourceSet))),
         ['groups', 'users']
       )
 

--- a/packages/xo-server/src/xo-mixins/subjects.js
+++ b/packages/xo-server/src/xo-mixins/subjects.js
@@ -7,7 +7,7 @@ import { invalidCredentials, noSuchObject } from 'xo-common/api-errors'
 import * as XenStore from '../_XenStore'
 import { Groups } from '../models/group'
 import { Users } from '../models/user'
-import { forEach, isEmpty, lightSet, mapToArray } from '../utils'
+import { forEach, isEmpty, lightSet } from '../utils'
 
 // ===================================================================
 
@@ -39,7 +39,7 @@ export default class {
       xo.addConfigManager(
         'groups',
         () => groupsDb.get(),
-        groups => Promise.all(mapToArray(groups, group => groupsDb.save(group))),
+        groups => Promise.all(groups.map(group => groupsDb.save(group))),
         ['users']
       )
       xo.addConfigManager(
@@ -47,11 +47,11 @@ export default class {
         () => usersDb.get(),
         users =>
           Promise.all(
-            mapToArray(users, async user => {
+            users.map(async user => {
               const userId = user.id
               const conflictUsers = await usersDb.get({ email: user.email })
               if (!isEmpty(conflictUsers)) {
-                await Promise.all(mapToArray(conflictUsers, ({ id }) => id !== userId && this.deleteUser(id)))
+                await Promise.all(conflictUsers.map(({ id }) => id !== userId && this.deleteUser(id)))
               }
               return usersDb.save(user)
             })
@@ -425,8 +425,8 @@ export default class {
 
     const saveUser = ::this._users.save
     await Promise.all([
-      Promise.all(mapToArray(newUsers, saveUser)),
-      Promise.all(mapToArray(oldUsers, saveUser)),
+      Promise.all(newUsers.map(saveUser)),
+      Promise.all(oldUsers.map(saveUser)),
       this._groups.save(group),
     ])
   }

--- a/packages/xo-server/src/xo.js
+++ b/packages/xo-server/src/xo.js
@@ -6,7 +6,7 @@ import { createClient as createRedisClient } from 'redis'
 import { createDebounceResource } from '@vates/disposable/debounceResource'
 import { EventEmitter } from 'events'
 import { noSuchObject } from 'xo-common/api-errors'
-import { forEach, includes, isEmpty, iteratee, map as mapToArray, stubTrue } from 'lodash'
+import { forEach, includes, isEmpty, iteratee, stubTrue } from 'lodash'
 import { parseDuration } from '@vates/parse-duration'
 
 import mixins from './xo-mixins'
@@ -17,7 +17,7 @@ import { generateToken, noop } from './utils'
 
 const log = createLogger('xo:xo')
 
-@mixin(mapToArray(mixins))
+@mixin(Object.values(mixins))
 export default class Xo extends EventEmitter {
   constructor(config) {
     super()


### PR DESCRIPTION
Use native `Array#map` or `Object.values` where possible and import directly from `lodash`.

Reasons:
- less dependencies
- more idiomatic
- better example for new code

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
