### PR TITLE
chore(@xen-orchestra/backups): fix logger names

### DIFF
--- a/@xen-orchestra/backups/RemoteAdapter.js
+++ b/@xen-orchestra/backups/RemoteAdapter.js
@@ -24,7 +24,7 @@ exports.DIR_XO_CONFIG_BACKUPS = DIR_XO_CONFIG_BACKUPS
 const DIR_XO_POOL_METADATA_BACKUPS = 'xo-pool-metadata-backups'
 exports.DIR_XO_POOL_METADATA_BACKUPS = DIR_XO_POOL_METADATA_BACKUPS
 
-const { warn } = createLogger('xo:proxy:backups:RemoteAdapter')
+const { warn } = createLogger('xo:backups:RemoteAdapter')
 
 const compareTimestamp = (a, b) => a.timestamp - b.timestamp
 

--- a/@xen-orchestra/backups/_DeltaBackupWriter.js
+++ b/@xen-orchestra/backups/_DeltaBackupWriter.js
@@ -14,7 +14,7 @@ const { getVmBackupDir } = require('./_getVmBackupDir')
 const { packUuid } = require('./_packUuid')
 const { Task } = require('./Task')
 
-const { warn } = createLogger('xo:proxy:backups:DeltaBackupWriter')
+const { warn } = createLogger('xo:backups:DeltaBackupWriter')
 
 exports.DeltaBackupWriter = class DeltaBackupWriter {
   constructor(backup, remoteId, settings) {

--- a/@xen-orchestra/backups/_VmBackup.js
+++ b/@xen-orchestra/backups/_VmBackup.js
@@ -16,7 +16,7 @@ const { getOldEntries } = require('./_getOldEntries')
 const { Task } = require('./Task')
 const { watchStreamSize } = require('./_watchStreamSize')
 
-const { debug, warn } = createLogger('xo:proxy:backups:VmBackup')
+const { debug, warn } = createLogger('xo:backups:VmBackup')
 
 const forkDeltaExport = deltaExport =>
   Object.create(deltaExport, {

--- a/@xen-orchestra/backups/_listPartitions.js
+++ b/@xen-orchestra/backups/_listPartitions.js
@@ -3,7 +3,7 @@ const { createLogger } = require('@xen-orchestra/log')
 const { createParser } = require('parse-pairs')
 const { execFile } = require('child_process')
 
-const { debug } = createLogger('xo:proxy:api')
+const { debug } = createLogger('xo:backups:listPartitions')
 
 const IGNORED_PARTITION_TYPES = {
   // https://github.com/jhermsmeier/node-mbr/blob/master/lib/partition.js#L38


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
