### PR TITLE
chore(xo-server): `using` → `Disposable.use`

### DIFF
--- a/@xen-orchestra/backups/Backup.js
+++ b/@xen-orchestra/backups/Backup.js
@@ -2,7 +2,6 @@ const { asyncMap, asyncMapSettled } = require('@xen-orchestra/async-map')
 const Disposable = require('promise-toolbox/Disposable')
 const ignoreErrors = require('promise-toolbox/ignoreErrors')
 const limitConcurrency = require('limit-concurrency-decorator').default
-const using = require('promise-toolbox/using')
 const { compileTemplate } = require('@xen-orchestra/template')
 
 const { extractIdsFromSimplePattern } = require('./_extractIdsFromSimplePattern')
@@ -87,7 +86,7 @@ exports.Backup = class Backup {
       throw new Error('no retentions corresponding to the metadata modes found')
     }
 
-    await using(
+    await Disposable.use(
       Disposable.all(
         poolIds.map(id =>
           this._getRecord('pool', id).catch(error => {
@@ -196,7 +195,7 @@ exports.Backup = class Backup {
       ...settings[schedule.id],
     }
 
-    await using(
+    await Disposable.use(
       Disposable.all(
         extractIdsFromSimplePattern(job.srs).map(id =>
           this._getRecord('SR', id).catch(error => {
@@ -242,7 +241,7 @@ exports.Backup = class Backup {
 
         const handleVm = vmUuid =>
           runTask({ name: 'backup VM', data: { type: 'VM', id: vmUuid } }, () =>
-            using(this._getRecord('VM', vmUuid), vm =>
+            Disposable.use(this._getRecord('VM', vmUuid), vm =>
               new VmBackup({
                 config,
                 getSnapshotNameLabel,

--- a/@xen-orchestra/proxy/src/app/mixins/appliance.js
+++ b/@xen-orchestra/proxy/src/app/mixins/appliance.js
@@ -3,7 +3,6 @@ import fromCallback from 'promise-toolbox/fromCallback'
 import fromEvent from 'promise-toolbox/fromEvent'
 import JsonRpcWebsocketClient from 'jsonrpc-websocket-client'
 import parsePairs from 'parse-pairs'
-import using from 'promise-toolbox/using'
 import { createLogger } from '@xen-orchestra/log/dist'
 import { deduped } from '@vates/disposable/deduped'
 import { execFile, spawn } from 'child_process'
@@ -20,7 +19,7 @@ const getUpdater = deduped(async function () {
 })
 
 const callUpdate = params =>
-  using(
+  Disposable.use(
     getUpdater(),
     updater =>
       new Promise((resolve, reject) => {
@@ -144,7 +143,7 @@ export default class Appliance {
           ],
         },
         updater: {
-          getLocalManifest: () => using(getUpdater(), _ => _.call('getLocalManifest')),
+          getLocalManifest: () => Disposable.use(getUpdater(), _ => _.call('getLocalManifest')),
           getState: () => callUpdate(),
           upgrade: () => callUpdate({ upgrade: true }),
         },
@@ -154,6 +153,6 @@ export default class Appliance {
 
   // A proxy can be bound to a unique license
   getSelfLicense() {
-    return using(getUpdater(), _ => _.call('getSelfLicenses').then(licenses => licenses[0]))
+    return Disposable.use(getUpdater(), _ => _.call('getSelfLicenses').then(licenses => licenses[0]))
   }
 }

--- a/@xen-orchestra/proxy/src/app/mixins/remotes.js
+++ b/@xen-orchestra/proxy/src/app/mixins/remotes.js
@@ -1,5 +1,4 @@
 import Disposable from 'promise-toolbox/Disposable'
-import using from 'promise-toolbox/using'
 import { compose } from '@vates/compose'
 import { decorateWith } from '@vates/decorate-with'
 import { deduped } from '@vates/disposable/deduped'
@@ -12,7 +11,7 @@ export default class Remotes {
     app.api.addMethods({
       remote: {
         getInfo: [
-          ({ remote }) => using(this.getHandler(remote), handler => handler.getInfo()),
+          ({ remote }) => Disposable.use(this.getHandler(remote), handler => handler.getInfo()),
           {
             params: {
               remote: { type: 'object' },
@@ -22,7 +21,7 @@ export default class Remotes {
 
         test: [
           ({ remote }) =>
-            using(this.getHandler(remote), handler => handler.test()).catch(error => ({
+            Disposable.use(this.getHandler(remote), handler => handler.test()).catch(error => ({
               success: false,
               error: error.message ?? String(error),
             })),

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -4,7 +4,7 @@
 import asyncMapSettled from '@xen-orchestra/async-map/legacy'
 import createLogger from '@xen-orchestra/log'
 import type RemoteHandler from '@xen-orchestra/fs'
-import using from 'promise-toolbox/using'
+import Disposable from 'promise-toolbox/Disposable'
 import { Backup } from '@xen-orchestra/backups/Backup'
 import { decorateWith } from '@vates/decorate-with'
 import { formatVmBackups } from '@xen-orchestra/backups/formatVmBackups'
@@ -404,7 +404,7 @@ export default class BackupNg {
         },
       })
     } else {
-      await using(app.getBackupsRemoteAdapter(remoteId), adapter => adapter.deleteVmBackup(metadataFilename))
+      await Disposable.use(app.getBackupsRemoteAdapter(remoteId), adapter => adapter.deleteVmBackup(metadataFilename))
     }
 
     this._listVmBackupsOnRemote(REMOVE_CACHE_ENTRY, remoteId)
@@ -474,7 +474,7 @@ export default class BackupNg {
           throw error
         }
       } else {
-        await using(app.getBackupsRemoteAdapter(remote), async adapter => {
+        await Disposable.use(app.getBackupsRemoteAdapter(remote), async adapter => {
           const metadata: Metadata = await adapter.readVmBackupMetadata(metadataFilename)
           const localTaskIds = { __proto__: null }
           return Task.run(
@@ -535,7 +535,7 @@ export default class BackupNg {
           },
         }))
       } else {
-        backupsByVm = await using(app.getBackupsRemoteAdapter(remote), async adapter =>
+        backupsByVm = await Disposable.use(app.getBackupsRemoteAdapter(remote), async adapter =>
           formatVmBackups(await adapter.listAllVmBackups())
         )
       }

--- a/packages/xo-server/src/xo-mixins/file-restore-ng.js
+++ b/packages/xo-server/src/xo-mixins/file-restore-ng.js
@@ -1,5 +1,5 @@
+import Disposable from 'promise-toolbox/Disposable'
 import execa from 'execa'
-import { using } from 'promise-toolbox'
 
 // - [x] list partitions
 // - [x] list files in a partition
@@ -52,7 +52,9 @@ export default class BackupNgFileRestore {
           },
           { assertType: 'stream' }
         )
-      : using(app.getBackupsRemoteAdapter(remote), adapter => adapter.fetchPartitionFiles(diskId, partitionId, paths))
+      : Disposable.use(app.getBackupsRemoteAdapter(remote), adapter =>
+          adapter.fetchPartitionFiles(diskId, partitionId, paths)
+        )
   }
 
   async listBackupNgDiskPartitions(remoteId, diskId) {
@@ -78,7 +80,7 @@ export default class BackupNgFileRestore {
       }
       return partitions
     } else {
-      return using(app.getBackupsRemoteAdapter(remote), adapter => adapter.listPartitions(diskId))
+      return Disposable.use(app.getBackupsRemoteAdapter(remote), adapter => adapter.listPartitions(diskId))
     }
   }
 
@@ -95,6 +97,8 @@ export default class BackupNgFileRestore {
           partition: partitionId,
           path,
         })
-      : using(app.getBackupsRemoteAdapter(remote), adapter => adapter.listPartitionFiles(diskId, partitionId, path))
+      : Disposable.use(app.getBackupsRemoteAdapter(remote), adapter =>
+          adapter.listPartitionFiles(diskId, partitionId, path)
+        )
   }
 }

--- a/packages/xo-server/src/xo-mixins/metadata-backups.js
+++ b/packages/xo-server/src/xo-mixins/metadata-backups.js
@@ -2,7 +2,7 @@
 import asyncMapSettled from '@xen-orchestra/async-map/legacy'
 import cloneDeep from 'lodash/cloneDeep'
 import createLogger from '@xen-orchestra/log'
-import using from 'promise-toolbox/using'
+import Disposable from 'promise-toolbox/Disposable'
 import { Backup } from '@xen-orchestra/backups/Backup'
 import { parseDuration } from '@vates/parse-duration'
 import { parseMetadataBackupId } from '@xen-orchestra/backups/parseMetadataBackupId'
@@ -289,7 +289,7 @@ export default class metadataBackup {
         },
       }))
     } else {
-      backups = await using(app.getBackupsRemoteAdapter(remote), adapter => adapter.listXoMetadataBackups())
+      backups = await Disposable.use(app.getBackupsRemoteAdapter(remote), adapter => adapter.listXoMetadataBackups())
     }
 
     // inject the remote id on the backup which is needed for restoreMetadataBackup()
@@ -328,7 +328,9 @@ export default class metadataBackup {
         },
       }))
     } else {
-      backupsByPool = await using(app.getBackupsRemoteAdapter(remote), adapter => adapter.listPoolMetadataBackups())
+      backupsByPool = await Disposable.use(app.getBackupsRemoteAdapter(remote), adapter =>
+        adapter.listPoolMetadataBackups()
+      )
     }
 
     // inject the remote id on the backup which is needed for restoreMetadataBackup()
@@ -480,7 +482,7 @@ export default class metadataBackup {
         remote: { url: remote.url, options: remote.options },
       })
     } else {
-      await using(app.getBackupsRemoteAdapter(remote), adapter => adapter.deleteMetadataBackup(backupId))
+      await Disposable.use(app.getBackupsRemoteAdapter(remote), adapter => adapter.deleteMetadataBackup(backupId))
     }
 
     if (parseMetadataBackupId(backupId).type === 'xoConfig') {


### PR DESCRIPTION
`using` is deprecated.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
