### PR TITLE
feat(xo-web/new VM): only send `memory` param so that it doesn't enable DMC

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [VM] Don't make a VM use [DMC](https://docs.citrix.com/en-us/xencenter/7-1/dmc-about.html) on creation by default [#5729](https://github.com/vatesfr/xen-orchestra/issues/5729)
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -34,3 +36,4 @@
 - @xen-orchestra/backups-cli patch
 - @xen-orchestra/mixins minor
 - xo-server minor
+- xo-web minor

--- a/packages/xo-web/src/xo-app/new-vm/index.js
+++ b/packages/xo-web/src/xo-app/new-vm/index.js
@@ -431,7 +431,7 @@ export default class NewVm extends BaseComponent {
 
     // Either use `memory` OR `memory*` params
     let { memory, memoryStaticMax, memoryDynamicMin, memoryDynamicMax } = state
-    if ((state.memoryStaticMax != null || state.memoryDynamicMin != null) && memoryDynamicMax == null) {
+    if ((memoryStaticMax != null || memoryDynamicMin != null) && memoryDynamicMax == null) {
       memoryDynamicMax = memory
     }
     if (memoryDynamicMax != null) {
@@ -456,9 +456,9 @@ export default class NewVm extends BaseComponent {
       cpuCap: state.cpuCap === '' ? null : state.cpuCap,
       name_description: state.name_description,
       memory,
-      memoryStaticMax,
-      memoryMin: memoryDynamicMin,
       memoryMax: memoryDynamicMax,
+      memoryMin: memoryDynamicMin,
+      memoryStaticMax,
       pv_args: state.pv_args,
       autoPoweron: state.autoPoweron,
       bootAfterCreate: state.bootAfterCreate,


### PR DESCRIPTION
Fixes xoa-support#3591
See 70d1537ecc5d42befc4de22275db032c813f44bf

- If only "RAM" field is filled: only send `memory` param
- If any of the advanced memory fields are filled:
  - only send those
  - if "Dynamic memory max" field is empty, use the "RAM" field value for
  `memoryDynamicMax` param

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
