### PR TITLE
fix(xo-server/backups-ng): continue execution when VM/SR is missing

### DIFF
--- a/packages/xo-server/src/xo-mixins/backups-ng/index.js
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.js
@@ -285,9 +285,13 @@ export default class BackupNg {
           const recordToXapi = {}
           const servers = new Set()
           const handleRecord = uuid => {
-            const serverId = app.getXenServerIdByObject(uuid)
-            recordToXapi[uuid] = serverId
-            servers.add(serverId)
+            try {
+              const serverId = app.getXenServerIdByObject(uuid)
+              recordToXapi[uuid] = serverId
+              servers.add(serverId)
+            } catch (error) {
+              log.warn(error)
+            }
           }
           vmIds.forEach(handleRecord)
           unboxIdsFromPattern(job.srs).forEach(handleRecord)


### PR DESCRIPTION
Introduced by 60ecfbfb8e96add8178a30508705511069768409

Before the above commit, the backup job execution wasn't interrupted when a VM is missing.

![image](https://user-images.githubusercontent.com/21563339/114886656-0245fc00-9e08-11eb-80fa-886745e2e8d8.png)


### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
