### PR TITLE
fix(backups): don't throw error when offline backup and rolling snapshot are disabled

### DIFF
--- a/@xen-orchestra/backups/_VmBackup.js
+++ b/@xen-orchestra/backups/_VmBackup.js
@@ -1,3 +1,4 @@
+const assert = require('assert')
 const findLast = require('lodash/findLast')
 const ignoreErrors = require('promise-toolbox/ignoreErrors')
 const keyBy = require('lodash/keyBy')
@@ -114,9 +115,7 @@ exports.VmBackup = class VmBackup {
 
     const settings = this._settings
 
-    if (settings.offlineBackup && settings.snapshotRetention !== 0) {
-      throw new Error('offline backup is not compatible with rolling snapshot')
-    }
+    assert(!settings.offlineBackup || settings.snapshotRetention === 0)
 
     const doSnapshot =
       this._isDelta || (!settings.offlineBackup && vm.power_state === 'Running') || settings.snapshotRetention !== 0

--- a/@xen-orchestra/backups/_VmBackup.js
+++ b/@xen-orchestra/backups/_VmBackup.js
@@ -1,4 +1,3 @@
-const assert = require('assert')
 const findLast = require('lodash/findLast')
 const ignoreErrors = require('promise-toolbox/ignoreErrors')
 const keyBy = require('lodash/keyBy')
@@ -115,7 +114,9 @@ exports.VmBackup = class VmBackup {
 
     const settings = this._settings
 
-    assert.notStrictEqual(settings.offlineBackup, settings.snapshotRetention !== 0)
+    if (settings.offlineBackup && settings.snapshotRetention !== 0) {
+      throw new Error('offline backup is not compatible with rolling snapshot')
+    }
 
     const doSnapshot =
       this._isDelta || (!settings.offlineBackup && vm.power_state === 'Running') || settings.snapshotRetention !== 0


### PR DESCRIPTION
Introduced by 7aa10ef4be26b913c76f1157bcbcac1605f400c5

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
