### PR TITLE
fix(backups/cleanVm):  correctly wait VHD deletions

### DIFF
--- a/@xen-orchestra/backups/_cleanVm.js
+++ b/@xen-orchestra/backups/_cleanVm.js
@@ -287,15 +287,15 @@ exports.cleanVm = async function cleanVm(vmDir, { remove, merge, onLog = noop })
   }
 
   await Promise.all([
-    unusedVhdsDeletion,
-    asyncMap(unusedXvas, path => {
+    ...unusedVhdsDeletion,
+    ...asyncMap(unusedXvas, path => {
       onLog(`the XVA ${path} is unused`)
       if (remove) {
         onLog(`deleting unused XVA ${path}`)
         return handler.unlink(path)
       }
     }),
-    asyncMap(xvaSums, path => {
+    ...asyncMap(xvaSums, path => {
       // no need to handle checksums for XVAs deleted by the script, they will be handled by `unlink()`
       if (!xvas.has(path.slice(0, -'.checksum'.length))) {
         onLog(`the XVA checksum ${path} is unused`)

--- a/@xen-orchestra/backups/_cleanVm.js
+++ b/@xen-orchestra/backups/_cleanVm.js
@@ -288,14 +288,14 @@ exports.cleanVm = async function cleanVm(vmDir, { remove, merge, onLog = noop })
 
   await Promise.all([
     ...unusedVhdsDeletion,
-    ...asyncMap(unusedXvas, path => {
+    asyncMap(unusedXvas, path => {
       onLog(`the XVA ${path} is unused`)
       if (remove) {
         onLog(`deleting unused XVA ${path}`)
         return handler.unlink(path)
       }
     }),
-    ...asyncMap(xvaSums, path => {
+    asyncMap(xvaSums, path => {
       // no need to handle checksums for XVAs deleted by the script, they will be handled by `unlink()`
       if (!xvas.has(path.slice(0, -'.checksum'.length))) {
         onLog(`the XVA checksum ${path} is unused`)


### PR DESCRIPTION
Introduced by c955da9bc6d26e7b7db3a84bc79589dc629c4494

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
