### PR TITLE
fix(xo-server-test/backupNg): remove obsolete snapshots

### DIFF
--- a/packages/xo-server-test/src/backupNg/__snapshots__/backupNg.spec.js.snap
+++ b/packages/xo-server-test/src/backupNg/__snapshots__/backupNg.spec.js.snap
@@ -1,24 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`backupNg .runJob() : fails trying to run a backup job with a VM without disks 1`] = `
-Object {
-  "data": Object {
-    "id": Any<String>,
-    "type": "VM",
-  },
-  "end": Any<Number>,
-  "id": Any<String>,
-  "message": Any<String>,
-  "result": Object {
-    "message": "no disks found",
-    "name": "Error",
-    "stack": Any<String>,
-  },
-  "start": Any<Number>,
-  "status": "skipped",
-}
-`;
-
 exports[`backupNg .runJob() : fails trying to run a backup job with no matching VMs 1`] = `[JsonRpcError: unknown error from the peer]`;
 
 exports[`backupNg .runJob() : fails trying to run a backup job with non-existent vm 1`] = `
@@ -37,25 +18,6 @@ Object {
 `;
 
 exports[`backupNg .runJob() : fails trying to run a backup job without schedule 1`] = `[JsonRpcError: invalid parameters]`;
-
-exports[`backupNg .runJob() : fails trying to run backup job without retentions 1`] = `
-Object {
-  "data": Object {
-    "id": Any<String>,
-    "type": "VM",
-  },
-  "end": Any<Number>,
-  "id": Any<String>,
-  "message": Any<String>,
-  "result": Object {
-    "message": "copy, export and snapshot retentions cannot both be 0",
-    "name": "Error",
-    "stack": Any<String>,
-  },
-  "start": Any<Number>,
-  "status": "failure",
-}
-`;
 
 exports[`backupNg create and execute backup with enabled offline backup 1`] = `
 Object {


### PR DESCRIPTION
Introduced by ffacc0d8d0eb06ca837752056156c49325d850ee

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
