### PR TITLE
feat(xo-web): add warning on restoring metadata backup

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Metadata Backup] Add a warning on restoring a metadata backup (PR [#5769](https://github.com/vatesfr/xen-orchestra/pull/5769))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -32,4 +34,5 @@
 
 - @xen-orchestra/fs minor
 - @xen-orchestra/backups minor
+- xo-web minor
 - xo-server patch

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1582,7 +1582,7 @@ const messages = {
   restoreVmBackupsBulkMessage:
     'Restore {nVms, number} VM{nVms, plural, one {} other {s}} from {nVms, plural, one {its} other {their}} {oldestOrLatest} backup.',
   restoreMetadataBackupWarning:
-    'This operation will overwrites the XAPI database of the host. Only perform a metadata restore if it is a new server with nothing running on it.',
+    'This operation will overwrite the host metadata. Only perform a metadata restore if it is a new server with nothing running on it.',
   oldest: 'oldest',
   latest: 'latest',
   restoreVmBackupsStart: 'Start VM{nVms, plural, one {} other {s}} after restore',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1581,6 +1581,8 @@ const messages = {
   restoreVmBackupsBulkTitle: 'Restore {nVms, number} VM{nVms, plural, one {} other {s}}',
   restoreVmBackupsBulkMessage:
     'Restore {nVms, number} VM{nVms, plural, one {} other {s}} from {nVms, plural, one {its} other {their}} {oldestOrLatest} backup.',
+  restoreMetadataBackupWarning:
+    'This operation will overwrites the XAPI database of the host. Only perform a metadata restore if it is a new server with nothing running on it.',
   oldest: 'oldest',
   latest: 'latest',
   restoreVmBackupsStart: 'Start VM{nVms, plural, one {} other {s}} after restore',
@@ -1590,8 +1592,6 @@ const messages = {
     'Restore {nMetadataBackups, number} metadata backup{nMetadataBackups, plural, one {} other {s}}',
   bulkRestoreMetadataBackupMessage:
     'Restore {nMetadataBackups, number} metadata backup{nMetadataBackups, plural, one {} other {s}} from {nMetadataBackups, plural, one {its} other {their}} {oldestOrLatest} backup',
-  metadataRestorationWarning:
-    'This operation will overwrites the XAPI database of the host. Only perform a metadata restore if it is a new server with nothing running on it.',
   deleteMetadataBackupTitle: 'Delete {item} backup',
   restoreVmBackupsBulkErrorMessage: 'You need to select a destination SR',
   deleteVmBackups: 'Delete backups…',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1590,6 +1590,8 @@ const messages = {
     'Restore {nMetadataBackups, number} metadata backup{nMetadataBackups, plural, one {} other {s}}',
   bulkRestoreMetadataBackupMessage:
     'Restore {nMetadataBackups, number} metadata backup{nMetadataBackups, plural, one {} other {s}} from {nMetadataBackups, plural, one {its} other {their}} {oldestOrLatest} backup',
+  metadataRestorationWarning:
+    'This operation will overwrites the XAPI database of the host. Only perform a metadata restore if it is a new server with nothing running on it.',
   deleteMetadataBackupTitle: 'Delete {item} backup',
   restoreVmBackupsBulkErrorMessage: 'You need to select a destination SR',
   deleteVmBackups: 'Delete backups…',

--- a/packages/xo-web/src/xo-app/backup/restore/restore-metadata-backups-modal-body.js
+++ b/packages/xo-web/src/xo-app/backup/restore/restore-metadata-backups-modal-body.js
@@ -11,7 +11,7 @@ import { Select } from 'form'
 
 const restorationWarning = (
   <p className='text-warning mt-1'>
-    <Icon icon='alarm' /> {_('metadataRestorationWarning')}
+    <Icon icon='alarm' /> {_('restoreMetadataBackupWarning')}
   </p>
 )
 

--- a/packages/xo-web/src/xo-app/backup/restore/restore-metadata-backups-modal-body.js
+++ b/packages/xo-web/src/xo-app/backup/restore/restore-metadata-backups-modal-body.js
@@ -1,5 +1,6 @@
 import _ from 'intl'
 import Component from 'base-component'
+import Icon from 'icon'
 import PropTypes from 'prop-types'
 import React from 'react'
 import SingleLineRow from 'single-line-row'
@@ -7,6 +8,12 @@ import StateButton from 'state-button'
 import { Container, Col } from 'grid'
 import { FormattedDate } from 'react-intl'
 import { Select } from 'form'
+
+const restorationWarning = (
+  <p className='text-warning mt-1'>
+    <Icon icon='alarm' /> {_('metadataRestorationWarning')}
+  </p>
+)
 
 export default class RestoreMetadataBackupModalBody extends Component {
   static propTypes = {
@@ -46,6 +53,7 @@ export default class RestoreMetadataBackupModalBody extends Component {
             />
           </Col>
         </SingleLineRow>
+        <SingleLineRow>{restorationWarning}</SingleLineRow>
       </Container>
     )
   }
@@ -76,6 +84,7 @@ export class RestoreMetadataBackupsBulkModalBody extends Component {
             />
           ),
         })}
+        {restorationWarning}
       </div>
     )
   }


### PR DESCRIPTION
See xoa-support#3691

Warning message source: https://xen-orchestra.com/docs/metadata_backup.html#performing-a-restore

**Single restoration**:
![image](https://user-images.githubusercontent.com/21563339/117159875-f030fb00-adc0-11eb-8ada-c76dc0c99f1d.png)

**Bulk restoration**

![image](https://user-images.githubusercontent.com/21563339/117159931-fd4dea00-adc0-11eb-9770-858259c37d3d.png)


### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
