### PR TITLE
fix(xo-server-netbox): filter out devices' interfaces

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,7 +22,7 @@
 - [Backup] Limit number of connections to hosts, which should reduce the occurences of `ECONNRESET`
 - [Plugins/perf-alert] All mode: only selects running hosts and VMs (PR [5811](https://github.com/vatesfr/xen-orchestra/pull/5811))
 - [New VM] Fix summary section always showing "0 B" for RAM (PR [#5817](https://github.com/vatesfr/xen-orchestra/pull/5817))
-- [Netbox] Fix a bug where some devices' IPs would get deleted from Netbox
+- [Netbox] Fix a bug where some devices' IPs would get deleted from Netbox (PR [#5821](https://github.com/vatesfr/xen-orchestra/pull/5821))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@
 - [Backup] Limit number of connections to hosts, which should reduce the occurences of `ECONNRESET`
 - [Plugins/perf-alert] All mode: only selects running hosts and VMs (PR [5811](https://github.com/vatesfr/xen-orchestra/pull/5811))
 - [New VM] Fix summary section always showing "0 B" for RAM (PR [#5817](https://github.com/vatesfr/xen-orchestra/pull/5817))
+- [Netbox] Fix a bug where some devices' IPs would get deleted from Netbox
 
 ### Packages to release
 
@@ -40,6 +41,7 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
+- xo-server-netbox patch
 - xo-server-perf-alert patch
 - xo-server-load-balancer minor
 - xo-server patch

--- a/packages/xo-server-netbox/src/index.js
+++ b/packages/xo-server-netbox/src/index.js
@@ -462,6 +462,10 @@ class Netbox {
     const [oldNetboxIps, prefixes] = await Promise.all([
       this.#makeRequest('/ipam/ip-addresses/', 'GET').then(addresses =>
         groupBy(
+          // In Netbox, a device interface and a VM interface can have the same
+          // ID and an IP address can be assigned to both types of interface, so
+          // we need to make sure that we only get IPs that are assigned to a VM
+          // interface before grouping them by their `assigned_object_id`
           addresses.filter(address => address.assigned_object_type === 'virtualization.vminterface'),
           'assigned_object_id'
         )

--- a/packages/xo-server-netbox/src/index.js
+++ b/packages/xo-server-netbox/src/index.js
@@ -460,7 +460,12 @@ class Netbox {
 
     // IPs
     const [oldNetboxIps, prefixes] = await Promise.all([
-      this.#makeRequest('/ipam/ip-addresses/', 'GET').then(addresses => groupBy(addresses, 'assigned_object_id')),
+      this.#makeRequest('/ipam/ip-addresses/', 'GET').then(addresses =>
+        groupBy(
+          addresses.filter(address => address.assigned_object_type === 'virtualization.vminterface'),
+          'assigned_object_id'
+        )
+      ),
       this.#makeRequest('/ipam/prefixes/', 'GET'),
     ])
 


### PR DESCRIPTION
See xoa-support#3812

In Netbox, a device interface and a VM interface can have the same ID `x`,
which means that listing IPs with `assigned_object_id=x` won't only get the
VM's interface's IPs but also the device's interface's IPs. This made XO
believe that those extra IPs shouldn't exist and delete them. This change
makes sure to only grab VM interface IPs.

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
