### PR TITLE
feat(xo-web/vm/new disk): generate random name

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,6 +8,7 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - [VM/snapshots] Identify VM's current snapshot with an icon next to the snapshot's name (PR [#5824](https://github.com/vatesfr/xen-orchestra/pull/5824))
+- [VM/new disk] Auto-fill disk name input with generated unique name
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,7 +8,7 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - [VM/snapshots] Identify VM's current snapshot with an icon next to the snapshot's name (PR [#5824](https://github.com/vatesfr/xen-orchestra/pull/5824))
-- [VM/new disk] Auto-fill disk name input with generated unique name
+- [VM/new disk] Auto-fill disk name input with generated unique name (PR [#5828](https://github.com/vatesfr/xen-orchestra/pull/5828))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/xo-app/vm/tab-disks.js
+++ b/packages/xo-web/src/xo-app/vm/tab-disks.js
@@ -30,6 +30,7 @@ import {
   createCompare,
   createCompareContainers,
   formatSize,
+  generateReadableRandomString,
   noop,
   resolveResourceSet,
 } from 'utils'
@@ -203,6 +204,10 @@ class NewDisk extends Component {
     checkSr: PropTypes.func.isRequired,
     onClose: PropTypes.func,
     vm: PropTypes.object.isRequired,
+  }
+
+  state = {
+    name: `${this.props.vm.name_label}_${generateReadableRandomString(5)}`,
   }
 
   _createDisk = () => {
@@ -450,8 +455,10 @@ class AttachDisk extends Component {
 }))
 @connectStore(() => {
   const getAllVbds = createGetObjectsOfType('VBD')
-  const getIsoSrs = createGetObjectsOfType('SR').filter((_, { pool: { $pool } }) => sr =>
-    sr.$pool === $pool && sr.SR_type === 'iso'
+  const getIsoSrs = createGetObjectsOfType('SR').filter(
+    (_, { pool: { $pool } }) =>
+      sr =>
+        sr.$pool === $pool && sr.SR_type === 'iso'
   )
 
   return (state, props) => ({


### PR DESCRIPTION
### Screenshots

![newdiskname](https://user-images.githubusercontent.com/10992860/123606711-797f0f80-d7fd-11eb-8aea-0cf23686fab7.gif)

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
