### PR TITLE
Revert "chore(backups/DeltaReplication): unify base VM detection"

### DIFF
--- a/@xen-orchestra/backups/ImportVmBackup.js
+++ b/@xen-orchestra/backups/ImportVmBackup.js
@@ -44,6 +44,7 @@ exports.ImportVmBackup = class ImportVmBackup {
           ? await xapi.VM_import(backup, srRef)
           : await importDeltaVm(backup, await xapi.getRecord('SR', srRef), {
               ...this._importDeltaVmSettings,
+              detectBase: false,
             })
 
         await Promise.all([

--- a/@xen-orchestra/backups/writers/DeltaReplicationWriter.js
+++ b/@xen-orchestra/backups/writers/DeltaReplicationWriter.js
@@ -12,8 +12,6 @@ const { MixinReplicationWriter } = require('./_MixinReplicationWriter.js')
 const { listReplicatedVms } = require('./_listReplicatedVms.js')
 
 exports.DeltaReplicationWriter = class DeltaReplicationWriter extends MixinReplicationWriter(AbstractDeltaWriter) {
-  #baseVm
-
   async checkBaseVdis(baseUuidToSrcVdi, baseVm) {
     const sr = this._sr
     const replicatedVm = listReplicatedVms(sr.$xapi, this._backup.job.id, sr.uuid, this._backup.vm.uuid).find(
@@ -22,8 +20,6 @@ exports.DeltaReplicationWriter = class DeltaReplicationWriter extends MixinRepli
     if (replicatedVm === undefined) {
       return baseUuidToSrcVdi.clear()
     }
-
-    this.#baseVm = replicatedVm
 
     const xapi = replicatedVm.$xapi
     const replicatedVdis = new Set(
@@ -92,7 +88,6 @@ exports.DeltaReplicationWriter = class DeltaReplicationWriter extends MixinRepli
       targetVmRef = await importDeltaVm(
         {
           __proto__: deltaExport,
-          baseVm: this.#baseVm,
           vm: {
             ...deltaExport.vm,
             tags: [...deltaExport.vm.tags, 'Continuous Replication'],


### PR DESCRIPTION
This reverts commit 9139c5e9d6b4306ba4078e6fa128a36f65417792.
See https://xcp-ng.org/forum/topic/4817

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
