### PR TITLE
fix(xo-server-auth-ldap): create logger inside plugin

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,4 +28,5 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
+- xo-server-auth-ldap patch
 - xo-web minor

--- a/packages/xo-server-auth-ldap/package.json
+++ b/packages/xo-server-auth-ldap/package.json
@@ -31,6 +31,7 @@
     "node": ">=10"
   },
   "dependencies": {
+    "@xen-orchestra/log": "^0.2.1",
     "exec-promise": "^0.7.0",
     "inquirer": "^8.0.0",
     "ldapts": "^2.2.1",

--- a/packages/xo-server-auth-ldap/src/index.js
+++ b/packages/xo-server-auth-ldap/src/index.js
@@ -2,8 +2,11 @@
 
 import fromCallback from 'promise-toolbox/fromCallback'
 import { Client } from 'ldapts'
+import { createLogger } from '@xen-orchestra/log'
 import { Filter } from 'ldapts/filters/Filter'
 import { readFile } from 'fs'
+
+const logger = createLogger('xo:xo-server-backup-reports')
 
 // ===================================================================
 
@@ -25,8 +28,6 @@ const evalFilter = (filter, vars) =>
 
     return escape(value)
   })
-
-const noop = Function.prototype
 
 export const configurationSchema = {
   type: 'object',
@@ -183,8 +184,7 @@ export const testSchema = {
 // ===================================================================
 
 class AuthLdap {
-  constructor({ logger = noop, xo }) {
-    this._logger = logger
+  constructor({ xo }) {
     this._xo = xo
 
     this._authenticate = this._authenticate.bind(this)
@@ -256,10 +256,8 @@ class AuthLdap {
   }
 
   async _authenticate({ username, password }) {
-    const logger = this._logger
-
     if (username === undefined || password === undefined) {
-      logger('require `username` and `password` to authenticate!')
+      logger.error('require `username` and `password` to authenticate!')
 
       return null
     }
@@ -275,29 +273,29 @@ class AuthLdap {
       {
         const { _credentials: credentials } = this
         if (credentials) {
-          logger(`attempting to bind with as ${credentials.dn}...`)
+          logger.debug(`attempting to bind with as ${credentials.dn}...`)
           await client.bind(credentials.dn, credentials.password)
-          logger(`successfully bound as ${credentials.dn}`)
+          logger.debug(`successfully bound as ${credentials.dn}`)
         }
       }
 
       // Search for the user.
-      logger('searching for entries...')
+      logger.debug('searching for entries...')
       const { searchEntries: entries } = await client.search(this._searchBase, {
         scope: 'sub',
         filter: evalFilter(this._searchFilter, {
           name: username,
         }),
       })
-      logger(`${entries.length} entries found`)
+      logger.debug(`${entries.length} entries found`)
 
       // Try to find an entry which can be bind with the given password.
       for (const entry of entries) {
         try {
-          logger(`attempting to bind as ${entry.dn}`)
+          logger.debug(`attempting to bind as ${entry.dn}`)
           await client.bind(entry.dn, password)
-          logger(`successfully bound as ${entry.dn} => ${username} authenticated`)
-          logger(JSON.stringify(entry, null, 2))
+          logger.info(`successfully bound as ${entry.dn} => ${username} authenticated`)
+          logger.debug(JSON.stringify(entry, null, 2))
 
           let user
           if (this._userIdAttribute === undefined) {
@@ -314,18 +312,18 @@ class AuthLdap {
               try {
                 await this._synchronizeGroups(user, entry[groupsConfig.membersMapping.userAttribute])
               } catch (error) {
-                logger(`failed to synchronize groups: ${error.message}`)
+                logger.error(`failed to synchronize groups: ${error.message}`)
               }
             }
           }
 
           return { userId: user.id }
         } catch (error) {
-          logger(`failed to bind as ${entry.dn}: ${error.message}`)
+          logger.error(`failed to bind as ${entry.dn}: ${error.message}`)
         }
       }
 
-      logger(`could not authenticate ${username}`)
+      logger.error(`could not authenticate ${username}`)
       return null
     } finally {
       await client.unbind()
@@ -334,7 +332,6 @@ class AuthLdap {
 
   // Synchronize user's groups OR all groups if no user is passed
   async _synchronizeGroups(user, memberId) {
-    const logger = this._logger
     const client = new Client(this._clientOpts)
 
     try {
@@ -346,12 +343,12 @@ class AuthLdap {
       {
         const { _credentials: credentials } = this
         if (credentials) {
-          logger(`attempting to bind with as ${credentials.dn}...`)
+          logger.debug(`attempting to bind with as ${credentials.dn}...`)
           await client.bind(credentials.dn, credentials.password)
-          logger(`successfully bound as ${credentials.dn}`)
+          logger.debug(`successfully bound as ${credentials.dn}`)
         }
       }
-      logger('syncing groups...')
+      logger.info('syncing groups...')
       const { base, displayNameAttribute, filter, idAttribute, membersMapping } = this._groupsConfig
       const { searchEntries: ldapGroups } = await client.search(base, {
         scope: 'sub',
@@ -373,7 +370,7 @@ class AuthLdap {
 
         // Empty or undefined names/IDs are invalid
         if (!groupLdapId || !groupLdapName) {
-          logger(`Invalid group ID (${groupLdapId}) or name (${groupLdapName})`)
+          logger.error(`Invalid group ID (${groupLdapId}) or name (${groupLdapName})`)
           continue
         }
 
@@ -393,7 +390,7 @@ class AuthLdap {
         if (xoGroupIndex === -1) {
           if (xoGroups.find(group => group.name === groupLdapName) !== undefined) {
             // TODO: check against LDAP groups that are being created as well
-            logger(`A group called ${groupLdapName} already exists`)
+            logger.error(`A group called ${groupLdapName} already exists`)
             continue
           }
           xoGroup = await this._xo.createGroup({
@@ -459,6 +456,8 @@ class AuthLdap {
           xoGroups.filter(group => group.provider === 'ldap').map(group => this._xo.deleteGroup(group.id))
         )
       }
+
+      logger.info('done syncing groups')
     } finally {
       await client.unbind()
     }

--- a/packages/xo-server-auth-ldap/src/index.js
+++ b/packages/xo-server-auth-ldap/src/index.js
@@ -6,13 +6,13 @@ import { createLogger } from '@xen-orchestra/log'
 import { Filter } from 'ldapts/filters/Filter'
 import { readFile } from 'fs'
 
-const logger = createLogger('xo:xo-server-backup-reports')
+const logger = createLogger('xo:xo-server-auth-ldap')
 
 // ===================================================================
 
 const DEFAULTS = {
   checkCertificate: true,
-  filter: '(uid={{name}})',
+  filter: '(uid={{name}})'
 }
 
 const { escape } = Filter.prototype
@@ -35,7 +35,7 @@ export const configurationSchema = {
     uri: {
       title: 'URI',
       description: 'URI of the LDAP server.',
-      type: 'string',
+      type: 'string'
     },
     certificateAuthorities: {
       title: 'Certificate Authorities',
@@ -46,24 +46,24 @@ If not specified, it will use a default set of well-known CAs.
 `.trim(),
       type: 'array',
       items: {
-        type: 'string',
-      },
+        type: 'string'
+      }
     },
     checkCertificate: {
       title: 'Check certificate',
       description:
         "Enforce the validity of the server's certificates. You can disable it when connecting to servers that use a self-signed certificate.",
       type: 'boolean',
-      default: DEFAULTS.checkCertificate,
+      default: DEFAULTS.checkCertificate
     },
     startTls: {
       title: 'Use StartTLS',
-      type: 'boolean',
+      type: 'boolean'
     },
     base: {
       title: 'Base',
       description: 'The base is the part of the description tree where the users and groups are looked for.',
-      type: 'string',
+      type: 'string'
     },
     bind: {
       title: 'Credentials',
@@ -78,14 +78,14 @@ Example: uid=xoa-auth,ou=people,dc=company,dc=net
 
 For Microsoft Active Directory, it can also be \`<user>@<domain>\`.
 `.trim(),
-          type: 'string',
+          type: 'string'
         },
         password: {
           description: 'Password of the user permitted of search the LDAP directory.',
-          type: 'string',
-        },
+          type: 'string'
+        }
       },
-      required: ['dn', 'password'],
+      required: ['dn', 'password']
     },
     filter: {
       title: 'User filter',
@@ -109,12 +109,12 @@ Or something like this if you also want to filter by group:
 - \`(&(sAMAccountName={{name}})(memberOf=<group DN>))\`
 `.trim(),
       type: 'string',
-      default: DEFAULTS.filter,
+      default: DEFAULTS.filter
     },
     userIdAttribute: {
       title: 'ID attribute',
       description: 'Attribute used to map LDAP user to XO user. Must be unique. e.g.: `dn`',
-      type: 'string',
+      type: 'string'
     },
     groups: {
       title: 'Synchronize groups',
@@ -124,22 +124,22 @@ Or something like this if you also want to filter by group:
         base: {
           title: 'Base',
           description: 'Where to look for the groups.',
-          type: 'string',
+          type: 'string'
         },
         filter: {
           title: 'Filter',
           description: 'Filter used to find the groups. e.g.: `(objectClass=groupOfNames)`',
-          type: 'string',
+          type: 'string'
         },
         idAttribute: {
           title: 'ID attribute',
           description: 'Attribute used to map LDAP group to XO group. Must be unique. e.g.: `gid`',
-          type: 'string',
+          type: 'string'
         },
         displayNameAttribute: {
           title: 'Display name attribute',
           description: "Attribute used to determine the group's name in XO. e.g.: `cn`",
-          type: 'string',
+          type: 'string'
         },
         membersMapping: {
           title: 'Members mapping',
@@ -149,21 +149,21 @@ Or something like this if you also want to filter by group:
               title: 'Group attribute',
               description:
                 'Attribute used to find the members of a group. e.g.: `memberUid`. The values must reference the user IDs (cf. user ID attribute)',
-              type: 'string',
+              type: 'string'
             },
             userAttribute: {
               title: 'User attribute',
               description: 'User attribute used to match group members to the users. e.g.: `uidNumber`',
-              type: 'string',
-            },
+              type: 'string'
+            }
           },
-          required: ['groupAttribute', 'userAttribute'],
-        },
+          required: ['groupAttribute', 'userAttribute']
+        }
       },
-      required: ['base', 'filter', 'idAttribute', 'displayNameAttribute', 'membersMapping'],
-    },
+      required: ['base', 'filter', 'idAttribute', 'displayNameAttribute', 'membersMapping']
+    }
   },
-  required: ['uri', 'base'],
+  required: ['uri', 'base']
 }
 
 export const testSchema = {
@@ -171,20 +171,20 @@ export const testSchema = {
   properties: {
     username: {
       description: 'LDAP username',
-      type: 'string',
+      type: 'string'
     },
     password: {
       description: 'LDAP password',
-      type: 'string',
-    },
+      type: 'string'
+    }
   },
-  required: ['username', 'password'],
+  required: ['username', 'password']
 }
 
 // ===================================================================
 
 class AuthLdap {
-  constructor({ xo }) {
+  constructor({ xo } = {}) {
     this._xo = xo
 
     this._authenticate = this._authenticate.bind(this)
@@ -193,7 +193,7 @@ class AuthLdap {
   async configure(conf) {
     const clientOpts = (this._clientOpts = {
       url: conf.uri,
-      maxConnections: 5,
+      maxConnections: 5
     })
 
     {
@@ -218,7 +218,7 @@ class AuthLdap {
       startTls = false,
       groups,
       uri,
-      userIdAttribute,
+      userIdAttribute
     } = conf
 
     this._credentials = credentials
@@ -234,8 +234,8 @@ class AuthLdap {
     this._xo.registerAuthenticationProvider(this._authenticate)
     this._removeApiMethods = this._xo.addApiMethods({
       ldap: {
-        synchronizeGroups: () => this._synchronizeGroups(),
-      },
+        synchronizeGroups: () => this._synchronizeGroups()
+      }
     })
   }
 
@@ -247,7 +247,7 @@ class AuthLdap {
   test({ username, password }) {
     return this._authenticate({
       username,
-      password,
+      password
     }).then(result => {
       if (result === null) {
         throw new Error('could not authenticate user')
@@ -284,8 +284,8 @@ class AuthLdap {
       const { searchEntries: entries } = await client.search(this._searchBase, {
         scope: 'sub',
         filter: evalFilter(this._searchFilter, {
-          name: username,
-        }),
+          name: username
+        })
       })
       logger.debug(`${entries.length} entries found`)
 
@@ -304,7 +304,7 @@ class AuthLdap {
           } else {
             const ldapId = entry[this._userIdAttribute]
             user = await this._xo.registerUser2('ldap', {
-              user: { id: ldapId, name: username },
+              user: { id: ldapId, name: username }
             })
 
             const groupsConfig = this._groupsConfig
@@ -352,7 +352,7 @@ class AuthLdap {
       const { base, displayNameAttribute, filter, idAttribute, membersMapping } = this._groupsConfig
       const { searchEntries: ldapGroups } = await client.search(base, {
         scope: 'sub',
-        filter: filter || '', // may be undefined
+        filter: filter || '' // may be undefined
       })
 
       const xoUsers =
@@ -396,7 +396,7 @@ class AuthLdap {
           xoGroup = await this._xo.createGroup({
             name: groupLdapName,
             provider: 'ldap',
-            providerGroupId: groupLdapId,
+            providerGroupId: groupLdapId
           })
         } else {
           // Remove it from xoGroups as we will then delete all the remaining
@@ -417,11 +417,11 @@ class AuthLdap {
 
         for (const memberId of ldapGroupMembers) {
           const {
-            searchEntries: [ldapUser],
+            searchEntries: [ldapUser]
           } = await client.search(this._searchBase, {
             scope: 'sub',
             filter: `(${escape(membersMapping.userAttribute)}=${escape(memberId)})`,
-            sizeLimit: 1,
+            sizeLimit: 1
           })
           if (ldapUser === undefined) {
             continue

--- a/packages/xo-server-auth-ldap/src/index.js
+++ b/packages/xo-server-auth-ldap/src/index.js
@@ -12,7 +12,7 @@ const logger = createLogger('xo:xo-server-auth-ldap')
 
 const DEFAULTS = {
   checkCertificate: true,
-  filter: '(uid={{name}})'
+  filter: '(uid={{name}})',
 }
 
 const { escape } = Filter.prototype
@@ -35,7 +35,7 @@ export const configurationSchema = {
     uri: {
       title: 'URI',
       description: 'URI of the LDAP server.',
-      type: 'string'
+      type: 'string',
     },
     certificateAuthorities: {
       title: 'Certificate Authorities',
@@ -46,24 +46,24 @@ If not specified, it will use a default set of well-known CAs.
 `.trim(),
       type: 'array',
       items: {
-        type: 'string'
-      }
+        type: 'string',
+      },
     },
     checkCertificate: {
       title: 'Check certificate',
       description:
         "Enforce the validity of the server's certificates. You can disable it when connecting to servers that use a self-signed certificate.",
       type: 'boolean',
-      default: DEFAULTS.checkCertificate
+      default: DEFAULTS.checkCertificate,
     },
     startTls: {
       title: 'Use StartTLS',
-      type: 'boolean'
+      type: 'boolean',
     },
     base: {
       title: 'Base',
       description: 'The base is the part of the description tree where the users and groups are looked for.',
-      type: 'string'
+      type: 'string',
     },
     bind: {
       title: 'Credentials',
@@ -78,14 +78,14 @@ Example: uid=xoa-auth,ou=people,dc=company,dc=net
 
 For Microsoft Active Directory, it can also be \`<user>@<domain>\`.
 `.trim(),
-          type: 'string'
+          type: 'string',
         },
         password: {
           description: 'Password of the user permitted of search the LDAP directory.',
-          type: 'string'
-        }
+          type: 'string',
+        },
       },
-      required: ['dn', 'password']
+      required: ['dn', 'password'],
     },
     filter: {
       title: 'User filter',
@@ -109,12 +109,12 @@ Or something like this if you also want to filter by group:
 - \`(&(sAMAccountName={{name}})(memberOf=<group DN>))\`
 `.trim(),
       type: 'string',
-      default: DEFAULTS.filter
+      default: DEFAULTS.filter,
     },
     userIdAttribute: {
       title: 'ID attribute',
       description: 'Attribute used to map LDAP user to XO user. Must be unique. e.g.: `dn`',
-      type: 'string'
+      type: 'string',
     },
     groups: {
       title: 'Synchronize groups',
@@ -124,22 +124,22 @@ Or something like this if you also want to filter by group:
         base: {
           title: 'Base',
           description: 'Where to look for the groups.',
-          type: 'string'
+          type: 'string',
         },
         filter: {
           title: 'Filter',
           description: 'Filter used to find the groups. e.g.: `(objectClass=groupOfNames)`',
-          type: 'string'
+          type: 'string',
         },
         idAttribute: {
           title: 'ID attribute',
           description: 'Attribute used to map LDAP group to XO group. Must be unique. e.g.: `gid`',
-          type: 'string'
+          type: 'string',
         },
         displayNameAttribute: {
           title: 'Display name attribute',
           description: "Attribute used to determine the group's name in XO. e.g.: `cn`",
-          type: 'string'
+          type: 'string',
         },
         membersMapping: {
           title: 'Members mapping',
@@ -149,21 +149,21 @@ Or something like this if you also want to filter by group:
               title: 'Group attribute',
               description:
                 'Attribute used to find the members of a group. e.g.: `memberUid`. The values must reference the user IDs (cf. user ID attribute)',
-              type: 'string'
+              type: 'string',
             },
             userAttribute: {
               title: 'User attribute',
               description: 'User attribute used to match group members to the users. e.g.: `uidNumber`',
-              type: 'string'
-            }
+              type: 'string',
+            },
           },
-          required: ['groupAttribute', 'userAttribute']
-        }
+          required: ['groupAttribute', 'userAttribute'],
+        },
       },
-      required: ['base', 'filter', 'idAttribute', 'displayNameAttribute', 'membersMapping']
-    }
+      required: ['base', 'filter', 'idAttribute', 'displayNameAttribute', 'membersMapping'],
+    },
   },
-  required: ['uri', 'base']
+  required: ['uri', 'base'],
 }
 
 export const testSchema = {
@@ -171,14 +171,14 @@ export const testSchema = {
   properties: {
     username: {
       description: 'LDAP username',
-      type: 'string'
+      type: 'string',
     },
     password: {
       description: 'LDAP password',
-      type: 'string'
-    }
+      type: 'string',
+    },
   },
-  required: ['username', 'password']
+  required: ['username', 'password'],
 }
 
 // ===================================================================
@@ -193,7 +193,7 @@ class AuthLdap {
   async configure(conf) {
     const clientOpts = (this._clientOpts = {
       url: conf.uri,
-      maxConnections: 5
+      maxConnections: 5,
     })
 
     {
@@ -218,7 +218,7 @@ class AuthLdap {
       startTls = false,
       groups,
       uri,
-      userIdAttribute
+      userIdAttribute,
     } = conf
 
     this._credentials = credentials
@@ -234,8 +234,8 @@ class AuthLdap {
     this._xo.registerAuthenticationProvider(this._authenticate)
     this._removeApiMethods = this._xo.addApiMethods({
       ldap: {
-        synchronizeGroups: () => this._synchronizeGroups()
-      }
+        synchronizeGroups: () => this._synchronizeGroups(),
+      },
     })
   }
 
@@ -247,7 +247,7 @@ class AuthLdap {
   test({ username, password }) {
     return this._authenticate({
       username,
-      password
+      password,
     }).then(result => {
       if (result === null) {
         throw new Error('could not authenticate user')
@@ -284,8 +284,8 @@ class AuthLdap {
       const { searchEntries: entries } = await client.search(this._searchBase, {
         scope: 'sub',
         filter: evalFilter(this._searchFilter, {
-          name: username
-        })
+          name: username,
+        }),
       })
       logger.debug(`${entries.length} entries found`)
 
@@ -297,6 +297,11 @@ class AuthLdap {
           logger.info(`successfully bound as ${entry.dn} => ${username} authenticated`)
           logger.debug(JSON.stringify(entry, null, 2))
 
+          // CLI test: don't register user/sync groups
+          if (this._xo === undefined) {
+            return
+          }
+
           let user
           if (this._userIdAttribute === undefined) {
             // Support legacy config
@@ -304,7 +309,7 @@ class AuthLdap {
           } else {
             const ldapId = entry[this._userIdAttribute]
             user = await this._xo.registerUser2('ldap', {
-              user: { id: ldapId, name: username }
+              user: { id: ldapId, name: username },
             })
 
             const groupsConfig = this._groupsConfig
@@ -352,7 +357,7 @@ class AuthLdap {
       const { base, displayNameAttribute, filter, idAttribute, membersMapping } = this._groupsConfig
       const { searchEntries: ldapGroups } = await client.search(base, {
         scope: 'sub',
-        filter: filter || '' // may be undefined
+        filter: filter || '', // may be undefined
       })
 
       const xoUsers =
@@ -396,7 +401,7 @@ class AuthLdap {
           xoGroup = await this._xo.createGroup({
             name: groupLdapName,
             provider: 'ldap',
-            providerGroupId: groupLdapId
+            providerGroupId: groupLdapId,
           })
         } else {
           // Remove it from xoGroups as we will then delete all the remaining
@@ -417,11 +422,11 @@ class AuthLdap {
 
         for (const memberId of ldapGroupMembers) {
           const {
-            searchEntries: [ldapUser]
+            searchEntries: [ldapUser],
           } = await client.search(this._searchBase, {
             scope: 'sub',
             filter: `(${escape(membersMapping.userAttribute)}=${escape(memberId)})`,
-            sizeLimit: 1
+            sizeLimit: 1,
           })
           if (ldapUser === undefined) {
             continue

--- a/packages/xo-server-auth-ldap/src/index.js
+++ b/packages/xo-server-auth-ldap/src/index.js
@@ -257,7 +257,7 @@ class AuthLdap {
 
   async _authenticate({ username, password }) {
     if (username === undefined || password === undefined) {
-      logger.error('require `username` and `password` to authenticate!')
+      logger.debug('require `username` and `password` to authenticate!')
 
       return null
     }
@@ -319,11 +319,11 @@ class AuthLdap {
 
           return { userId: user.id }
         } catch (error) {
-          logger.error(`failed to bind as ${entry.dn}: ${error.message}`)
+          logger.debug(`failed to bind as ${entry.dn}: ${error.message}`)
         }
       }
 
-      logger.error(`could not authenticate ${username}`)
+      logger.debug(`could not authenticate ${username}`)
       return null
     } finally {
       await client.unbind()

--- a/packages/xo-server-auth-ldap/src/test-cli.js
+++ b/packages/xo-server-auth-ldap/src/test-cli.js
@@ -34,8 +34,8 @@ execPromise(async args => {
     {
       filter: process.env.DEBUG ?? 'xo:xo-server-auth-ldap',
       level: 'debug',
-      transport: transportConsole()
-    }
+      transport: transportConsole(),
+    },
   ])
 
   const plugin = createPlugin()
@@ -43,8 +43,8 @@ execPromise(async args => {
 
   await plugin._authenticate({
     username: await input('Username', {
-      validate: input => !!input.length
+      validate: input => !!input.length,
     }),
-    password: await password('Password')
+    password: await password('Password'),
   })
 })

--- a/packages/xo-server-auth-ldap/src/test-cli.js
+++ b/packages/xo-server-auth-ldap/src/test-cli.js
@@ -33,7 +33,6 @@ execPromise(async args => {
   configure([
     {
       filter: process.env.DEBUG ?? 'xo:xo-server-auth-ldap',
-      level: 'debug',
       transport: transportConsole(),
     },
   ])

--- a/packages/xo-server-auth-ldap/src/test-cli.js
+++ b/packages/xo-server-auth-ldap/src/test-cli.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import execPromise from 'exec-promise'
+import transportConsole from '@xen-orchestra/log/transports/console'
+import { configure } from '@xen-orchestra/log/configure.js'
 import { fromCallback } from 'promise-toolbox'
 import { readFile, writeFile } from 'fs'
 
@@ -28,15 +30,21 @@ execPromise(async args => {
     }
   )
 
-  const plugin = createPlugin({
-    logger: console.log.bind(console),
-  })
+  configure([
+    {
+      filter: process.env.DEBUG ?? 'xo:xo-server-auth-ldap',
+      level: 'debug',
+      transport: transportConsole()
+    }
+  ])
+
+  const plugin = createPlugin()
   await plugin.configure(config)
 
   await plugin._authenticate({
     username: await input('Username', {
-      validate: input => !!input.length,
+      validate: input => !!input.length
     }),
-    password: await password('Password'),
+    password: await password('Password')
   })
 })


### PR DESCRIPTION
The plugin was wrongly expecting a logger instance to be passed on
instanciation

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
