### PR TITLE
feat(xo-server/network.create): allow pool admins

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,8 +7,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [ACL/network] Ability to create network for administator users on the pool. (PR [#5873](https://github.com/vatesfr/xen-orchestra/pull/5873))
-
+- [New network] Ability for pool's admin to create a new network within the pool (PR [#5873](https://github.com/vatesfr/xen-orchestra/pull/5873))
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [ACL/network] Ability to create network for administator users on the pool.
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -33,5 +35,5 @@
 
 - @xen-orchestra/log minor
 - xo-server-auth-ldap patch
-- xo-server patch
+- xo-server minor
 - xo-web minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,7 +7,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [ACL/network] Ability to create network for administator users on the pool.
+- [ACL/network] Ability to create network for administator users on the pool. (PR [#5873](https://github.com/vatesfr/xen-orchestra/pull/5873))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/api/network.mjs
+++ b/packages/xo-server/src/api/network.mjs
@@ -28,7 +28,6 @@ create.params = {
 create.resolve = {
   pool: ['pool', 'pool', 'administrate'],
 }
-create.permission = 'admin'
 
 // =================================================================
 
@@ -63,7 +62,6 @@ createBonded.params = {
 createBonded.resolve = {
   pool: ['pool', 'pool', 'administrate'],
 }
-createBonded.permission = 'admin'
 createBonded.description = 'Create a bonded network. bondMode can be balance-slb, active-backup or lacp'
 
 // ===================================================================


### PR DESCRIPTION
See xoa-support#3945

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
