### PR TITLE
fix(xo-web/TabButtonLink): should not be empty on small screens

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,8 +7,6 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [ACL/network] Ability to create network for administator users on the pool. (PR [#5873](https://github.com/vatesfr/xen-orchestra/pull/5873))
-
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -36,5 +34,5 @@
 
 - @xen-orchestra/log minor
 - xo-server-auth-ldap patch
-- xo-server minor
+- xo-server patch
 - xo-web minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 
 - [VM/network] Fix an issue where multiple IPs would be displayed in the same tag when using old Xen tools. This also fixes Netbox's IP synchronization for the affected VMs. (PR [#5860](https://github.com/vatesfr/xen-orchestra/pull/5860))
 - [LDAP] Handle groups with no members (PR [#5862](https://github.com/vatesfr/xen-orchestra/pull/5862))
-- Fix empty button on small size screen
+- Fix empty button on small size screen (PR [#5874](https://github.com/vatesfr/xen-orchestra/pull/5874))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 
 - [VM/network] Fix an issue where multiple IPs would be displayed in the same tag when using old Xen tools. This also fixes Netbox's IP synchronization for the affected VMs. (PR [#5860](https://github.com/vatesfr/xen-orchestra/pull/5860))
 - [LDAP] Handle groups with no members (PR [#5862](https://github.com/vatesfr/xen-orchestra/pull/5862))
+- Fix empty button on small size screen
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [ACL/network] Ability to create network for administator users on the pool.
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -33,5 +35,5 @@
 
 - @xen-orchestra/log minor
 - xo-server-auth-ldap patch
-- xo-server patch
+- xo-server minor
 - xo-web minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,7 +7,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [ACL/network] Ability to create network for administator users on the pool.
+- [ACL/network] Ability to create network for administator users on the pool. (PR [#5873](https://github.com/vatesfr/xen-orchestra/pull/5873))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/api/network.mjs
+++ b/packages/xo-server/src/api/network.mjs
@@ -28,7 +28,6 @@ create.params = {
 create.resolve = {
   pool: ['pool', 'pool', 'administrate'],
 }
-create.permission = 'admin'
 
 // =================================================================
 
@@ -63,7 +62,6 @@ createBonded.params = {
 createBonded.resolve = {
   pool: ['pool', 'pool', 'administrate'],
 }
-createBonded.permission = 'admin'
 createBonded.description = 'Create a bonded network. bondMode can be balance-slb, active-backup or lacp'
 
 // ===================================================================

--- a/packages/xo-server/src/api/network.mjs
+++ b/packages/xo-server/src/api/network.mjs
@@ -28,6 +28,7 @@ create.params = {
 create.resolve = {
   pool: ['pool', 'pool', 'administrate'],
 }
+create.permission = 'admin'
 
 // =================================================================
 
@@ -62,6 +63,7 @@ createBonded.params = {
 createBonded.resolve = {
   pool: ['pool', 'pool', 'administrate'],
 }
+create.permission = 'admin'
 createBonded.description = 'Create a bonded network. bondMode can be balance-slb, active-backup or lacp'
 
 // ===================================================================

--- a/packages/xo-server/src/api/network.mjs
+++ b/packages/xo-server/src/api/network.mjs
@@ -63,7 +63,7 @@ createBonded.params = {
 createBonded.resolve = {
   pool: ['pool', 'pool', 'administrate'],
 }
-create.permission = 'admin'
+createBonded.permission = 'admin'
 createBonded.description = 'Create a bonded network. bondMode can be balance-slb, active-backup or lacp'
 
 // ===================================================================

--- a/packages/xo-web/src/common/tab-button.js
+++ b/packages/xo-web/src/common/tab-button.js
@@ -19,13 +19,11 @@ export { TabButton as default }
 
 export const TabButtonLink = ({ labelId, icon, ...props }) => (
   <Link {...props} className='btn btn-lg btn-primary' style={STYLE}>
-    <span className='hidden-md-down'>
-      {icon && (
-        <span>
-          <Icon icon={icon} />{' '}
-        </span>
-      )}
-      {_(labelId)}
-    </span>
+    {icon && (
+      <span>
+        <Icon icon={icon} />{' '}
+      </span>
+    )}
+    <span className='hidden-md-down'>{_(labelId)}</span>
   </Link>
 )


### PR DESCRIPTION
### Description
On small size window, for the `Pool/tab-network` and `Storage/tab-disk` the button in the right corner is empty.
![Capture d’écran de 2021-08-12 15-01-32](https://user-images.githubusercontent.com/70369997/129205742-c50b4fcb-97f5-4316-b1ad-1f0d0316c5e0.png)

### Screenshot

![Capture d’écran de 2021-08-12 15-36-51](https://user-images.githubusercontent.com/70369997/129206470-708f9eca-375b-4ece-b3b7-2c5d5417e2f0.png)

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
