### PR TITLE
fix(xo-web/user): SSH key formatting

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [SSH keys] Allow SSH key to be broken anywhere to avoid breaking page formatting (Thanks @tstivers1990!) [#5891](https://github.com/vatesfr/xen-orchestra/issues/5891) (PR [#5892](https://github.com/vatesfr/xen-orchestra/pull/5892))
+
 ### Packages to release
 
 > Packages will be released in the order they are here, therefore, they should
@@ -27,3 +29,5 @@
 > - major: if the change breaks compatibility
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
+
+- xo-web patch

--- a/packages/xo-web/src/xo-app/user/index.js
+++ b/packages/xo-web/src/xo-app/user/index.js
@@ -55,7 +55,7 @@ const FILTER_TYPE_TO_LABEL_ID = {
   'VM-template': 'homeTypeVmTemplate',
 }
 
-const SSH_KEY_STYLE = { wordWrap: 'break-word' }
+const SSH_KEY_STYLE = { wordWrap: 'anywhere' }
 
 const getDefaultFilter = (defaultFilters, type) => {
   if (defaultFilters == null) {


### PR DESCRIPTION
Allow SSH key to be broken anywhere to avoid breaking page formatting.

![image](https://user-images.githubusercontent.com/14251176/131465033-d16ea439-9275-4d1e-be9c-4da81f6b3967.png)


Fixes #5891

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing