### PR TITLE
fix(xo-server/xapi-objects-to-xo/VM/addresses): handle newline-delimited IPs

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,7 @@
 
 - [SSH keys] Allow SSH key to be broken anywhere to avoid breaking page formatting (Thanks @tstivers1990!) [#5891](https://github.com/vatesfr/xen-orchestra/issues/5891) (PR [#5892](https://github.com/vatesfr/xen-orchestra/pull/5892))
 - [VM/Advanced] Fix conversion from UEFI to BIOS boot firmware (PR [#5895](https://github.com/vatesfr/xen-orchestra/pull/5895))
+- [VM/network] Support newline-delimited IP addresses reported by some guest tools
 
 ### Packages to release
 

--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -341,10 +341,7 @@ const TRANSFORMS = {
     const addresses = {}
     for (const key in networks) {
       const [, device, index] = /^(\d+)\/ip(?:v[46]\/(\d))?$/.exec(key) ?? []
-      let ips = networks[key].split(' ')
-      if (ips.length === 1) {
-        ips = networks[key].split('\n')
-      }
+      const ips = networks[key].split(/\s+/)
       if (ips.length === 1 && index !== undefined) {
         // New protocol or alias
         addresses[key] = networks[key]

--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -328,7 +328,7 @@ const TRANSFORMS = {
     // See: https://github.com/xapi-project/xen-api/blob/324bc6ee6664dd915c0bbe57185f1d6243d9ed7e/ocaml/xapi/xapi_guest_agent.ml#L59-L81
 
     // Old protocol: when there's more than 1 IP on an interface, the IPs
-    // are space-delimited in the same `x/ip` field
+    // are space or newline delimited in the same `x/ip` field
     // See https://github.com/vatesfr/xen-orchestra/issues/5801#issuecomment-854337568
 
     // The `x/ip` field may have a `x/ipv4/0` alias
@@ -341,7 +341,10 @@ const TRANSFORMS = {
     const addresses = {}
     for (const key in networks) {
       const [, device, index] = /^(\d+)\/ip(?:v[46]\/(\d))?$/.exec(key) ?? []
-      const ips = networks[key].split(' ')
+      let ips = networks[key].split(' ')
+      if (ips.length === 1) {
+        ips = networks[key].split('\n')
+      }
       if (ips.length === 1 && index !== undefined) {
         // New protocol or alias
         addresses[key] = networks[key]


### PR DESCRIPTION
See xoa-support#3812
See #5860

This is related to a505cd9 which handled space delimited IPs, but apparently,
IPs can also be newline delimited depending on which Xen tools version is used.

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
