### PR TITLE
WiP: Fix/master dont trash last byte during s3 upload

### DIFF
--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -294,8 +294,8 @@ export default class S3Handler extends RemoteHandlerAbstract {
           let suffixFragmentOffset = suffixOffset
           for (let i = 0; i < suffixFragments; i++) {
             const fragmentEnd = suffixFragmentOffset + MAX_PART_SIZE
-            assert.strictEqual(Math.min(fileSize, fragmentEnd) - suffixFragmentOffset <= MAX_PART_SIZE, true)
-            const suffixRange = `bytes=${suffixFragmentOffset}-${Math.min(fileSize, fragmentEnd) - 1}`
+            assert.strictEqual(Math.min(fileSize - 1 , fragmentEnd) - suffixFragmentOffset <= MAX_PART_SIZE, true)
+            const suffixRange = `bytes=${suffixFragmentOffset}-${Math.min(fileSize -1, fragmentEnd)}`
             const copySuffixParams = { ...copyMultipartParams, PartNumber: partNumber++, CopySourceRange: suffixRange }
             const suffixPart = (await this._s3.uploadPartCopy(copySuffixParams)).CopyPartResult
             parts.push({ ETag: suffixPart.ETag, PartNumber: copySuffixParams.PartNumber })

--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -267,7 +267,7 @@ export default class S3Handler extends RemoteHandlerAbstract {
         if (prefixLastFragmentSize) {
           // grab everything from the prefix that was too small to be copied, download and merge to the edit buffer.
           const downloadParams = { ...uploadParams, Range: `bytes=${prefixPosition}-${prefixSize - 1}` }
-          const prefixBuffer = prefixSize > 0 ? (await this._s3.getObject(downloadParams)).Body : Buffer.alloc(0)
+          const prefixBuffer = await this._s3.getObject(downloadParams)
           editBuffer = Buffer.concat([prefixBuffer, buffer])
           editBufferOffset -= prefixLastFragmentSize
         }
@@ -294,8 +294,8 @@ export default class S3Handler extends RemoteHandlerAbstract {
           let suffixFragmentOffset = suffixOffset
           for (let i = 0; i < suffixFragments; i++) {
             const fragmentEnd = suffixFragmentOffset + MAX_PART_SIZE
-            assert.strictEqual(Math.min(fileSize - 1 , fragmentEnd) - suffixFragmentOffset <= MAX_PART_SIZE, true)
-            const suffixRange = `bytes=${suffixFragmentOffset}-${Math.min(fileSize -1, fragmentEnd)}`
+            assert.strictEqual(Math.min(fileSize - 1, fragmentEnd) - suffixFragmentOffset <= MAX_PART_SIZE, true)
+            const suffixRange = `bytes=${suffixFragmentOffset}-${Math.min(fileSize - 1, fragmentEnd)}`
             const copySuffixParams = { ...copyMultipartParams, PartNumber: partNumber++, CopySourceRange: suffixRange }
             const suffixPart = (await this._s3.uploadPartCopy(copySuffixParams)).CopyPartResult
             parts.push({ ETag: suffixPart.ETag, PartNumber: copySuffixParams.PartNumber })


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Usage

1- get a vhd from xo. My test file is 3.5GB for reference.
2- declare a parser `const parser = new InputStreamVhdParser(fs.createReadStream(src))`
3- use this parser to write to another file : `eventsToStream(fs.createWriteStream(dest), parser)`
4- use this parser to write to a S3 compatible `eventsToS3(s3, parser, 'xoa', 'xoa_backup/') ` . 
5- use a S3VhdParser instead of InputStreamVhdParser to read from s3 
6- compare with `cmp source dest` that the files are equals, bits for bits

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
