### PR TITLE
fix(xo-server-netbox): handle nested prefixes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [SSH keys] Allow SSH key to be broken anywhere to avoid breaking page formatting (Thanks @tstivers1990!) [#5891](https://github.com/vatesfr/xen-orchestra/issues/5891) (PR [#5892](https://github.com/vatesfr/xen-orchestra/pull/5892))
-- [Netbox] Handle nested prefixes by always assigning an IP to the smallest prefix it matches
+- [Netbox] Handle nested prefixes by always assigning an IP to the smallest prefix it matches (PR [#5908](https://github.com/vatesfr/xen-orchestra/pull/5908))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [SSH keys] Allow SSH key to be broken anywhere to avoid breaking page formatting (Thanks @tstivers1990!) [#5891](https://github.com/vatesfr/xen-orchestra/issues/5891) (PR [#5892](https://github.com/vatesfr/xen-orchestra/pull/5892))
+- [Netbox] Handle nested prefixes by always assigning an IP to the smallest prefix it matches
 
 ### Packages to release
 
@@ -30,4 +31,5 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
+- xo-server-netbox patch
 - xo-web patch

--- a/packages/xo-server-netbox/src/index.js
+++ b/packages/xo-server-netbox/src/index.js
@@ -478,7 +478,7 @@ class Netbox {
       .forEach(newInterfaces => Object.assign(interfaces, newInterfaces))
 
     // IPs
-    const [oldNetboxIps, prefixes] = await Promise.all([
+    const [oldNetboxIps, netboxPrefixes] = await Promise.all([
       this.#makeRequest('/ipam/ip-addresses/', 'GET').then(addresses =>
         groupBy(
           // In Netbox, a device interface and a VM interface can have the same
@@ -517,27 +517,33 @@ class Netbox {
           const parsedIp = ipaddr.parse(ip)
           const ipKind = parsedIp.kind()
           const ipCompactNotation = parsedIp.toString()
-          // FIXME: Should we compare the IPs with their range? ie: can 2 IPs
-          // look identical but belong to 2 different ranges?
-          const netboxIpIndex = interfaceOldIps.findIndex(
-            netboxIp => ipaddr.parse(netboxIp.address.split('/')[0]).toString() === ipCompactNotation
-          )
+
+          let smallestPrefix
+          let highestBits = 0
+          netboxPrefixes.forEach(({ prefix }) => {
+            const [range, bits] = prefix.split('/')
+            const parsedRange = ipaddr.parse(range)
+            if (parsedRange.kind() === ipKind && parsedIp.match(parsedRange, bits) && bits > highestBits) {
+              smallestPrefix = prefix
+              highestBits = bits
+            }
+          })
+          if (smallestPrefix === undefined) {
+            ignoredIps.push(ip)
+            continue
+          }
+
+          const netboxIpIndex = interfaceOldIps.findIndex(netboxIp => {
+            const [ip, bits] = netboxIp.address.split('/')
+            return ipaddr.parse(ip).toString() === ipCompactNotation && bits === highestBits
+          })
+
           if (netboxIpIndex >= 0) {
             netboxIpsByVif[vifId].push(interfaceOldIps[netboxIpIndex])
             interfaceOldIps.splice(netboxIpIndex, 1)
           } else {
-            const prefix = prefixes.find(({ prefix }) => {
-              const [range, bits] = prefix.split('/')
-              const parsedRange = ipaddr.parse(range)
-              return parsedRange.kind() === ipKind && parsedIp.match(parsedRange, bits)
-            })
-            if (prefix === undefined) {
-              ignoredIps.push(ip)
-              continue
-            }
-
             ipsToCreate.push({
-              address: `${ip}/${prefix.prefix.split('/')[1]}`,
+              address: `${ip}/${smallestPrefix.split('/')[1]}`,
               assigned_object_type: 'virtualization.vminterface',
               assigned_object_id: interface_.id,
               vifId, // needed to populate netboxIpsByVif with newly created IPs


### PR DESCRIPTION
See xoa-support#4018

When assigning prefixes to VMs, always pick the smallest prefix that the IP
matches

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
