### PR TITLE
feat(vhd-cli): use any remote for copy and compare

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,4 +30,6 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
+- @xen-orchestra/fs minor
 - xo-server patch
+- vhd-cli minor

--- a/packages/vhd-cli/src/commands/compare.js
+++ b/packages/vhd-cli/src/commands/compare.js
@@ -1,6 +1,5 @@
 import { getSyncedHandler } from '@xen-orchestra/fs'
 import { openVhd, Constants } from 'vhd-lib'
-import { resolve } from 'path'
 import Disposable from 'promise-toolbox/Disposable'
 import omit from 'lodash/omit'
 
@@ -38,9 +37,9 @@ export default async args => {
 
   await Disposable.use(async function* () {
     const sourceHandler = yield getSyncedHandler({ url: sourceRemoteUrl })
-    const src = yield openVhd(sourceHandler, resolve(sourcePath))
+    const src = yield openVhd(sourceHandler, sourcePath)
     const destHandler = yield getSyncedHandler({ url: destRemoteUrl })
-    const dest = yield openVhd(destHandler, resolve(destPath))
+    const dest = yield openVhd(destHandler, destPath)
 
     // parent locator entries contains offset that can be different without impacting the vhd
     // we'll compare them later

--- a/packages/vhd-cli/src/commands/compare.js
+++ b/packages/vhd-cli/src/commands/compare.js
@@ -31,15 +31,16 @@ const deepCompareObjects = function (src, dest, path) {
 }
 
 export default async args => {
-  if (args.length < 2 || args.some(_ => _ === '-h' || _ === '--help')) {
-    return `Usage: compare <source VHD> <destination> `
+  if (args.length < 4 || args.some(_ => _ === '-h' || _ === '--help')) {
+    return `Usage: compare <sourceRemoteUrl> <source VHD> <destionationRemoteUrl> <destination> `
   }
-  const [sourcePath, destPath] = args
+  const [sourceRemoteUrl, sourcePath, destRemoteUrl, destPath] = args
 
   await Disposable.use(async function* () {
-    const handler = yield getSyncedHandler({ url: 'file:///' })
-    const src = yield openVhd(handler, resolve(sourcePath))
-    const dest = yield openVhd(handler, resolve(destPath))
+    const sourceHandler = yield getSyncedHandler({ url: sourceRemoteUrl })
+    const src = yield openVhd(sourceHandler, resolve(sourcePath))
+    const destHandler = yield getSyncedHandler({ url: destRemoteUrl })
+    const dest = yield openVhd(destHandler, resolve(destPath))
 
     // parent locator entries contains offset that can be different without impacting the vhd
     // we'll compare them later

--- a/packages/vhd-cli/src/commands/copy.js
+++ b/packages/vhd-cli/src/commands/copy.js
@@ -22,16 +22,14 @@ export default async rawArgs => {
   if (args.length < 4 || help) {
     return `Usage: index.js copy <sourceRemoteUrl> <source VHD> <destionationRemoteUrl> <destination> --directory`
   }
-  const [sourceRemoteUrl,sourcePath, destRemoteUrl, destPath] = args
+  const [sourceRemoteUrl, sourcePath, destRemoteUrl, destPath] = args
 
   await Disposable.use(async function* () {
-    const sourceHandler = yield getSyncedHandler({url: sourceRemoteUrl})
-    let src = yield openVhd(sourceHandler, sourcePath)
+    const sourceHandler = yield getSyncedHandler({ url: sourceRemoteUrl })
+    const src = yield openVhd(sourceHandler, sourcePath)
     await src.readBlockAllocationTable()
-    const destHandler = yield getSyncedHandler({url: destRemoteUrl})
-    const dest = yield directory
-      ? VhdDirectory.create(destHandler, destPath)
-      : VhdFile.create(destHandler, destPath)
+    const destHandler = yield getSyncedHandler({ url: destRemoteUrl })
+    const dest = yield directory ? VhdDirectory.create(destHandler, destPath) : VhdFile.create(destHandler, destPath)
     // copy data
     dest.header = src.header
     dest.footer = src.footer


### PR DESCRIPTION
* Modify S3 to raise an EISDIR error when openning a directory
* Modifiy parameters of copy and compare to use url and path instead of only path 

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
