### PR TITLE
fix(xo-web/job): properly handle array arguments

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [Jobs] Fix `job.runSequence` method
+- [Jobs] Fix `job.runSequence` method (PR [#5944](https://github.com/vatesfr/xen-orchestra/pull/5944))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Jobs] Fix `job.runSequence` method
+
 ### Packages to release
 
 > Packages will be released in the order they are here, therefore, they should

--- a/packages/xo-web/src/xo-app/jobs/new/index.js
+++ b/packages/xo-web/src/xo-app/jobs/new/index.js
@@ -92,10 +92,10 @@ const reduceObject = (value, propertyName = 'id') => (value != null && value[pro
 /**
  * Adapts all data "arrayed" by UI-multiple-selectors to job's cross-product trick
  */
-const dataToParamVectorItems = function (params, data) {
+const dataToParamVectorItems = function (params, data, properties) {
   const items = []
   forEach(params, (param, name) => {
-    if (Array.isArray(data[name]) && param.items) {
+    if (properties[name].multi && param.items) {
       // We have an array for building cross product, the "real" type was $type
       const values = []
       if (data[name].length === 1) {
@@ -287,7 +287,8 @@ export default class Jobs extends Component {
   _handleSubmit = () => {
     const { name, method, params } = this.refs
 
-    const { job, owner, timeout } = this.state
+    const { actions, job, owner, timeout } = this.state
+    const action = find(actions, { method: job.method })
     const _job = {
       type: 'call',
       name: name.value,
@@ -295,7 +296,7 @@ export default class Jobs extends Component {
       method: method.value.method,
       paramsVector: {
         type: 'crossProduct',
-        items: dataToParamVectorItems(method.value.info.properties, params.value),
+        items: dataToParamVectorItems(method.value.info.properties, params.value, action.uiSchema.properties),
       },
       userId: owner !== undefined ? owner : this.props.currentUser.id,
       timeout: timeout ? timeout * 1e3 : undefined,

--- a/packages/xo-web/src/xo-app/jobs/new/index.js
+++ b/packages/xo-web/src/xo-app/jobs/new/index.js
@@ -286,9 +286,9 @@ export default class Jobs extends Component {
 
   _handleSubmit = () => {
     const { name, method, params } = this.refs
+    const { action, actions, job, owner, timeout } = this.state
 
-    const { actions, job, owner, timeout } = this.state
-    const action = find(actions, { method: job.method })
+    const _action = job === undefined ? action : find(actions, { method: job.method })
     const _job = {
       type: 'call',
       name: name.value,
@@ -296,7 +296,7 @@ export default class Jobs extends Component {
       method: method.value.method,
       paramsVector: {
         type: 'crossProduct',
-        items: dataToParamVectorItems(method.value.info.properties, params.value, action.uiSchema.properties),
+        items: dataToParamVectorItems(method.value.info.properties, params.value, _action.uiSchema.properties),
       },
       userId: owner !== undefined ? owner : this.props.currentUser.id,
       timeout: timeout ? timeout * 1e3 : undefined,


### PR DESCRIPTION
See https://xcp-ng.org/forum/topic/5010

When creating/editing a job, properties of type `array` must not go through the
cross product builder, they must be saved as arrays.

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
