### PR TITLE
feat(xen-api): add an HTTP proxy support

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 - [Jobs] Ability to copy a job ID (PR [#5951](https://github.com/vatesfr/xen-orchestra/pull/5951))
 - [Host/advanced] Add button to enable/disable the host (PR [#5952](https://github.com/vatesfr/xen-orchestra/pull/5952))
 - [VM/export] Ability to copy the export URL (PR [#5948](https://github.com/vatesfr/xen-orchestra/pull/5948))
-- [XenApi] Ability to set a http prox between XO and the server
+- [XenApi] Ability to set a http proxy between XO and the server
 
 ### Bug fixes
 
@@ -43,10 +43,10 @@
 
 - xo-server-netbox patch
 - vhd-lib minor
+- xen-api minor
 - @xen-orchestra/backup minor
 - @xen-orchestra/proxy minor
 - vhd-cli minor
 - xapi-explore-sr minor
-- xen-api minor
 - xo-server patch
 - xo-web minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,7 @@
 - [Jobs] Ability to copy a job ID (PR [#5951](https://github.com/vatesfr/xen-orchestra/pull/5951))
 - [Host/advanced] Add button to enable/disable the host (PR [#5952](https://github.com/vatesfr/xen-orchestra/pull/5952))
 - [VM/export] Ability to copy the export URL (PR [#5948](https://github.com/vatesfr/xen-orchestra/pull/5948))
+- [XenApi] Ability to set a http prox between XO and the server
 
 ### Bug fixes
 
@@ -45,5 +46,6 @@
 - @xen-orchestra/backup minor
 - @xen-orchestra/proxy minor
 - vhd-cli minor
+- xen-api minor
 - xo-server patch
 - xo-web minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -46,6 +46,7 @@
 - @xen-orchestra/backup minor
 - @xen-orchestra/proxy minor
 - vhd-cli minor
+- xapi-explore-sr minor
 - xen-api minor
 - xo-server patch
 - xo-web minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 - [Jobs] Ability to copy a job ID (PR [#5951](https://github.com/vatesfr/xen-orchestra/pull/5951))
 - [Host/advanced] Add button to enable/disable the host (PR [#5952](https://github.com/vatesfr/xen-orchestra/pull/5952))
 - [VM/export] Ability to copy the export URL (PR [#5948](https://github.com/vatesfr/xen-orchestra/pull/5948))
-- [XenApi] Ability to set a http proxy between XO and the server
+- [Servers] Ability to use an HTTP proxy between XO and a server
 
 ### Bug fixes
 

--- a/packages/xapi-explore-sr/src/index.js
+++ b/packages/xapi-explore-sr/src/index.js
@@ -69,11 +69,13 @@ execPromise(async args => {
     url = required('Host URL'),
     user = required('Host user'),
     password = await askPassword('Host password'),
+    httpProxy = await askPassword('Http proxy'),
   ] = args
 
   const xapi = createClient({
     allowUnauthorized: true,
     auth: { user, password },
+    httpProxy,
     readOnly: true,
     url,
     watchEvents: false,

--- a/packages/xapi-explore-sr/src/index.js
+++ b/packages/xapi-explore-sr/src/index.js
@@ -3,6 +3,7 @@
 import archy from 'archy'
 import chalk from 'chalk'
 import execPromise from 'exec-promise'
+import firstDefined from '@xen-orchestra/defined'
 import humanFormat from 'human-format'
 import pw from 'pw'
 import { createClient } from 'xen-api'
@@ -69,7 +70,7 @@ execPromise(async args => {
     url = required('Host URL'),
     user = required('Host user'),
     password = await askPassword('Host password'),
-    httpProxy = await askPassword('Http proxy'),
+    httpProxy = firstDefined(process.env.http_proxy, process.env.HTTP_PROXY),
   ] = args
 
   const xapi = createClient({

--- a/packages/xen-api/README.md
+++ b/packages/xen-api/README.md
@@ -52,6 +52,7 @@ Options:
 - `auth`: credentials used to sign in (can also be specified in the URL)
 - `readOnly = false`: if true, no methods with side-effects can be called
 - `callTimeout`: number of milliseconds after which a call is considered failed (can also be a map of timeouts by methods)
+- `httpProxy` : url of the http / https proxy used to reach the host. Can include the credentials
 
 ```js
 // Force connection.

--- a/packages/xen-api/README.md
+++ b/packages/xen-api/README.md
@@ -52,7 +52,7 @@ Options:
 - `auth`: credentials used to sign in (can also be specified in the URL)
 - `readOnly = false`: if true, no methods with side-effects can be called
 - `callTimeout`: number of milliseconds after which a call is considered failed (can also be a map of timeouts by methods)
-- `httpProxy` : url of the http / https proxy used to reach the host. Can include the credentials
+- `httpProxy`: URL of the HTTP/HTTPS proxy used to reach the host, can include credentials
 
 ```js
 // Force connection.

--- a/packages/xen-api/src/index.js
+++ b/packages/xen-api/src/index.js
@@ -115,6 +115,7 @@ export class Xapi extends EventEmitter {
     }
 
     this._allowUnauthorized = opts.allowUnauthorized
+    this._httpProxy = opts.httpProxy
     this._setUrl(url)
 
     this._connected = new Promise(resolve => {
@@ -851,6 +852,7 @@ export class Xapi extends EventEmitter {
         rejectUnauthorized: !this._allowUnauthorized,
       },
       url,
+      httpProxy: this._httpProxy,
     })
     this._url = url
   }

--- a/packages/xen-api/src/transports/json-rpc.js
+++ b/packages/xen-api/src/transports/json-rpc.js
@@ -8,7 +8,7 @@ import UnsupportedTransport from './_UnsupportedTransport'
 
 // https://github.com/xenserver/xenadmin/blob/0df39a9d83cd82713f32d24704852a0fd57b8a64/XenModel/XenAPI/Session.cs#L403-L433
 export default ({ secureOptions, url, httpProxy }) => {
-  if (httpProxy) {
+  if (httpProxy !== undefined) {
     secureOptions.agent = new ProxyAgent(httpProxy)
   }
   return (method, args) =>

--- a/packages/xen-api/src/transports/json-rpc.js
+++ b/packages/xen-api/src/transports/json-rpc.js
@@ -1,4 +1,5 @@
 import httpRequestPlus from 'http-request-plus'
+import ProxyAgent from 'proxy-agent'
 import { format, parse } from 'json-rpc-protocol'
 
 import XapiError from '../_XapiError'
@@ -6,7 +7,11 @@ import XapiError from '../_XapiError'
 import UnsupportedTransport from './_UnsupportedTransport'
 
 // https://github.com/xenserver/xenadmin/blob/0df39a9d83cd82713f32d24704852a0fd57b8a64/XenModel/XenAPI/Session.cs#L403-L433
-export default ({ secureOptions, url }) => {
+export default ({ secureOptions, url, httpProxy }) => {
+  // httpProxyUrl = 'http://172.16.210.156:3128'
+  if (httpProxy) {
+    secureOptions.agent = new ProxyAgent(httpProxy)
+  }
   return (method, args) =>
     httpRequestPlus
       .post(url, {

--- a/packages/xen-api/src/transports/json-rpc.js
+++ b/packages/xen-api/src/transports/json-rpc.js
@@ -8,17 +8,21 @@ import UnsupportedTransport from './_UnsupportedTransport'
 
 // https://github.com/xenserver/xenadmin/blob/0df39a9d83cd82713f32d24704852a0fd57b8a64/XenModel/XenAPI/Session.cs#L403-L433
 export default ({ secureOptions, url, httpProxy }) => {
+  let agent
+  if (httpProxy !== undefined) {
+    agent = new ProxyAgent(httpProxy)
+  }
   return (method, args) =>
     httpRequestPlus
       .post(url, {
         ...secureOptions,
-        agent: httpProxy !== undefined ? new ProxyAgent(httpProxy) : undefined,
         body: format.request(0, method, args),
         headers: {
           Accept: 'application/json',
           'Content-Type': 'application/json',
         },
         path: '/jsonrpc',
+        agent,
       })
       .readAll('utf8')
       .then(

--- a/packages/xen-api/src/transports/json-rpc.js
+++ b/packages/xen-api/src/transports/json-rpc.js
@@ -8,13 +8,11 @@ import UnsupportedTransport from './_UnsupportedTransport'
 
 // https://github.com/xenserver/xenadmin/blob/0df39a9d83cd82713f32d24704852a0fd57b8a64/XenModel/XenAPI/Session.cs#L403-L433
 export default ({ secureOptions, url, httpProxy }) => {
-  if (httpProxy !== undefined) {
-    secureOptions.agent = new ProxyAgent(httpProxy)
-  }
   return (method, args) =>
     httpRequestPlus
       .post(url, {
         ...secureOptions,
+        agent: httpProxy !== undefined ? new ProxyAgent(httpProxy) : undefined,
         body: format.request(0, method, args),
         headers: {
           Accept: 'application/json',

--- a/packages/xen-api/src/transports/json-rpc.js
+++ b/packages/xen-api/src/transports/json-rpc.js
@@ -8,7 +8,6 @@ import UnsupportedTransport from './_UnsupportedTransport'
 
 // https://github.com/xenserver/xenadmin/blob/0df39a9d83cd82713f32d24704852a0fd57b8a64/XenModel/XenAPI/Session.cs#L403-L433
 export default ({ secureOptions, url, httpProxy }) => {
-  // httpProxyUrl = 'http://172.16.210.156:3128'
   if (httpProxy) {
     secureOptions.agent = new ProxyAgent(httpProxy)
   }

--- a/packages/xen-api/src/transports/xml-rpc-json.js
+++ b/packages/xen-api/src/transports/xml-rpc-json.js
@@ -73,16 +73,14 @@ const parseResult = result => {
 
 export default ({ secureOptions, url: { hostname, port, protocol }, httpProxy }) => {
   const secure = protocol === 'https:'
-  const { ...options } = secure ? secureOptions : {}
-  if (httpProxy) {
-    options.agent = new ProxyAgent(httpProxy)
-  }
   const client = (secure ? createSecureClient : createClient)({
-    ...options,
+    ...(secure ? secureOptions : undefined),
+    agent: httpProxy !== undefined ? new ProxyAgent(httpProxy) : undefined,
     host: hostname,
     path: '/json',
     port,
   })
   const call = promisify(client.methodCall, client)
+
   return (method, args) => call(method, prepareXmlRpcParams(args)).then(parseResult, logError)
 }

--- a/packages/xen-api/src/transports/xml-rpc-json.js
+++ b/packages/xen-api/src/transports/xml-rpc-json.js
@@ -73,9 +73,13 @@ const parseResult = result => {
 
 export default ({ secureOptions, url: { hostname, port, protocol }, httpProxy }) => {
   const secure = protocol === 'https:'
+  let agent
+  if (httpProxy !== undefined) {
+    agent = new ProxyAgent(httpProxy)
+  }
   const client = (secure ? createSecureClient : createClient)({
     ...(secure ? secureOptions : undefined),
-    agent: httpProxy !== undefined ? new ProxyAgent(httpProxy) : undefined,
+    agent,
     host: hostname,
     path: '/json',
     port,

--- a/packages/xen-api/src/transports/xml-rpc.js
+++ b/packages/xen-api/src/transports/xml-rpc.js
@@ -1,5 +1,6 @@
 import { createClient, createSecureClient } from 'xmlrpc'
 import { promisify } from 'promise-toolbox'
+import ProxyAgent from 'proxy-agent'
 
 import XapiError from '../_XapiError'
 
@@ -30,10 +31,14 @@ const parseResult = result => {
   return result.Value
 }
 
-export default ({ secureOptions, url: { hostname, port, protocol } }) => {
+export default ({ secureOptions, url: { hostname, port, protocol, httpProxy } }) => {
   const secure = protocol === 'https:'
+  const { ...options } = secure ? secureOptions : {}
+  if (httpProxy) {
+    options.agent = new ProxyAgent(httpProxy)
+  }
   const client = (secure ? createSecureClient : createClient)({
-    ...(secure ? secureOptions : undefined),
+    ...options,
     host: hostname,
     port,
   })

--- a/packages/xen-api/src/transports/xml-rpc.js
+++ b/packages/xen-api/src/transports/xml-rpc.js
@@ -33,10 +33,13 @@ const parseResult = result => {
 
 export default ({ secureOptions, url: { hostname, port, protocol, httpProxy } }) => {
   const secure = protocol === 'https:'
-
+  let agent
+  if (httpProxy !== undefined) {
+    agent = new ProxyAgent(httpProxy)
+  }
   const client = (secure ? createSecureClient : createClient)({
     ...(secure ? secureOptions : undefined),
-    agent: httpProxy !== undefined ? new ProxyAgent(httpProxy) : undefined,
+    agent,
     host: hostname,
     port,
   })

--- a/packages/xen-api/src/transports/xml-rpc.js
+++ b/packages/xen-api/src/transports/xml-rpc.js
@@ -33,12 +33,10 @@ const parseResult = result => {
 
 export default ({ secureOptions, url: { hostname, port, protocol, httpProxy } }) => {
   const secure = protocol === 'https:'
-  const { ...options } = secure ? secureOptions : {}
-  if (httpProxy) {
-    options.agent = new ProxyAgent(httpProxy)
-  }
+
   const client = (secure ? createSecureClient : createClient)({
-    ...options,
+    ...(secure ? secureOptions : undefined),
+    agent: httpProxy !== undefined ? new ProxyAgent(httpProxy) : undefined,
     host: hostname,
     port,
   })

--- a/packages/xo-server/src/api/server.mjs
+++ b/packages/xo-server/src/api/server.mjs
@@ -36,6 +36,10 @@ add.params = {
     optional: true,
     type: 'boolean',
   },
+  httpProxy: {
+    optional: true,
+    type: 'string',
+  },
 }
 
 // -------------------------------------------------------------------
@@ -103,6 +107,10 @@ set.params = {
   readOnly: {
     optional: true,
     type: 'boolean',
+  },
+  httpProxy: {
+    optional: true,
+    type: 'string',
   },
 }
 

--- a/packages/xo-server/src/api/server.mjs
+++ b/packages/xo-server/src/api/server.mjs
@@ -110,7 +110,7 @@ set.params = {
   },
   httpProxy: {
     optional: true,
-    type: 'string',
+    type: ['string', 'null'],
   },
 }
 

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -94,7 +94,7 @@ export default class {
     // TODO: disconnect servers on stop.
   }
 
-  async registerXenServer({ allowUnauthorized = false, host, label, password, readOnly = false, username }) {
+  async registerXenServer({ allowUnauthorized = false, host, label, password, readOnly = false, username, httpProxy }) {
     // FIXME: We are storing passwords which is bad!
     //        Could we use tokens instead?
     // TODO: use plain objects
@@ -102,6 +102,7 @@ export default class {
       allowUnauthorized,
       enabled: true,
       host,
+      httpProxy,
       label: label || undefined,
       password,
       readOnly,

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -119,7 +119,10 @@ export default class {
     }
   }
 
-  async updateXenServer(id, { allowUnauthorized, enabled, error, host, label, password, readOnly, username }) {
+  async updateXenServer(
+    id,
+    { allowUnauthorized, enabled, error, host, label, password, readOnly, username, httpProxy }
+  ) {
     const server = await this._getXenServer(id)
     const xapi = this._xapis[id]
     const requireDisconnected =
@@ -151,6 +154,10 @@ export default class {
 
     if (allowUnauthorized !== undefined) {
       server.set('allowUnauthorized', allowUnauthorized)
+    }
+
+    if (httpProxy !== undefined) {
+      server.set('httpProxy', httpProxy)
     }
 
     await this._servers.update(server)
@@ -288,6 +295,7 @@ export default class {
       readOnly: server.readOnly,
 
       ...config.get('xapiOptions'),
+      httpProxy: server.httpProxy,
       guessVhdSizeOnImport: config.get('guessVhdSizeOnImport'),
 
       auth: {

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -127,7 +127,11 @@ export default class {
     const server = await this._getXenServer(id)
     const xapi = this._xapis[id]
     const requireDisconnected =
-      allowUnauthorized !== undefined || host !== undefined || password !== undefined || username !== undefined
+      allowUnauthorized !== undefined ||
+      host !== undefined ||
+      password !== undefined ||
+      username !== undefined ||
+      httpProxy !== undefined
 
     if (requireDisconnected && xapi !== undefined && xapi.status !== 'disconnected') {
       throw new Error('this entry require disconnecting the server to update it')
@@ -158,9 +162,9 @@ export default class {
     }
 
     if (httpProxy !== undefined) {
-      server.set('httpProxy', httpProxy)
+      // if value is null, pass undefined to the model , so it will delete this optionnal property from the Server object
+      server.set('httpProxy', httpProxy === null ? undefined : httpProxy)
     }
-
     await this._servers.update(server)
   }
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1826,8 +1826,8 @@ const messages = {
   serverEnabled: 'Enabled',
   serverDisabled: 'Disabled',
   serverDisable: 'Disable server',
-  serverHttpProxy: ' Http proxy Url',
-  serverHttpProxyPlaceHolder: ' Http proxy Url',
+  serverHttpProxy: ' HTTP proxy URL',
+  serverHttpProxyPlaceHolder: ' HTTP proxy URL',
 
   // ----- Copy VM -----
   copyVm: 'Copy VM',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1826,6 +1826,8 @@ const messages = {
   serverEnabled: 'Enabled',
   serverDisabled: 'Disabled',
   serverDisable: 'Disable server',
+  serverHttpProxy: ' Http proxy Url',
+  serverHttpProxyPlaceHolder: ' Http proxy Url',
 
   // ----- Copy VM -----
   copyVm: 'Copy VM',

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -564,10 +564,10 @@ export const addServer = (host, username, password, label, allowUnauthorized, ht
   _call('server.add', {
     allowUnauthorized,
     host,
+    httpProxy,
     label,
     password,
     username,
-    httpProxy,
   })::tap(subscribeServers.forceRefresh, () => error(_('serverError'), _('serverAddFailed')))
 
 export const editServer = (server, props) =>

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -560,13 +560,14 @@ export const exportConfig = () =>
 
 // Server ------------------------------------------------------------
 
-export const addServer = (host, username, password, label, allowUnauthorized) =>
+export const addServer = (host, username, password, label, allowUnauthorized, httpProxy) =>
   _call('server.add', {
     allowUnauthorized,
     host,
     label,
     password,
     username,
+    httpProxy,
   })::tap(subscribeServers.forceRefresh, () => error(_('serverError'), _('serverAddFailed')))
 
 export const editServer = (server, props) =>

--- a/packages/xo-web/src/xo-app/settings/servers/index.js
+++ b/packages/xo-web/src/xo-app/settings/servers/index.js
@@ -132,6 +132,17 @@ const COLUMNS = [
     itemRenderer: ({ poolId }) => poolId !== undefined && <Pool id={poolId} link />,
     name: _('pool'),
   },
+  {
+    itemRenderer: (server, formatMessage) => (
+      <Text
+        value={server.httpProxy || ''}
+        onChange={httpProxy => editServer(server, { httpProxy })}
+        placeholder={formatMessage(messages.serverHttpProxyPlaceHolder)}
+      />
+    ),
+    name: _('serverHttpProxy'),
+    sortCriteria: _ => _.httpProxy,
+  },
 ]
 const INDIVIDUAL_ACTIONS = [
   {
@@ -152,9 +163,8 @@ export default class Servers extends Component {
   }
 
   _addServer = async () => {
-    const { label, host, password, username, allowUnauthorized } = this.state
-
-    await addServer(host, username, password, label, allowUnauthorized)
+    const { label, host, password, username, allowUnauthorized, httpProxy } = this.state
+    await addServer(host, username, password, label, allowUnauthorized, httpProxy)
 
     this.setState({
       allowUnauthorized: false,
@@ -162,6 +172,7 @@ export default class Servers extends Component {
       label: '',
       password: '',
       username: '',
+      httpProxy: '',
     })
   }
 
@@ -226,6 +237,15 @@ export default class Servers extends Component {
             <Tooltip content={_('serverAllowUnauthorizedCertificates')}>
               <Toggle onChange={this.linkState('allowUnauthorized')} value={state.allowUnauthorized} />
             </Tooltip>
+          </div>{' '}
+          <div className='form-group'>
+            <input
+              className='form-control'
+              onChange={this.linkState('httpProxy')}
+              placeholder={formatMessage(messages.serverHttpProxy)}
+              type='url'
+              value={state.httpProxy || ''}
+            />
           </div>{' '}
           <ActionButton btnStyle='primary' form='form-add-server' handler={this._addServer} icon='save'>
             {_('serverConnect')}

--- a/packages/xo-web/src/xo-app/settings/servers/index.js
+++ b/packages/xo-web/src/xo-app/settings/servers/index.js
@@ -136,7 +136,8 @@ const COLUMNS = [
     itemRenderer: (server, formatMessage) => (
       <Text
         value={server.httpProxy || ''}
-        onChange={httpProxy => editServer(server, { httpProxy })}
+        // force a null value for falsish value to ensure the value is removed from object if set to ''
+        onChange={httpProxy => editServer(server, { httpProxy: httpProxy || null })}
         placeholder={formatMessage(messages.serverHttpProxyPlaceHolder)}
       />
     ),
@@ -243,7 +244,7 @@ export default class Servers extends Component {
               className='form-control'
               onChange={this.linkState('httpProxy')}
               placeholder={formatMessage(messages.serverHttpProxy)}
-              type='url'
+              type='text'
               value={state.httpProxy || ''}
             />
           </div>{' '}

--- a/packages/xo-web/src/xo-app/settings/servers/index.js
+++ b/packages/xo-web/src/xo-app/settings/servers/index.js
@@ -169,10 +169,10 @@ export default class Servers extends Component {
     this.setState({
       allowUnauthorized: false,
       host: '',
+      httpProxy: '',
       label: '',
       password: '',
       username: '',
-      httpProxy: '',
     })
   }
 


### PR DESCRIPTION


connecting to an HTTPS xen api with its api show this warning `DeprecationWarning: Setting the TLS ServerName to an IP address is not permitted by RFC 6066.`

The corresponding issue is there  : https://github.com/TooTallNate/node-https-proxy-agent/issues/127

New field in the server UI (edit and add)
![image](https://user-images.githubusercontent.com/50174/138430569-378a906a-477b-4271-b674-5c7f8eb35243.png)
 

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
