### PR TITLE
feat(xo-web/host): manage evacuation failure during host shutdown

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -10,6 +10,7 @@
 - [Tasks] Filter out short tasks using a default filter (PR [#5921](https://github.com/vatesfr/xen-orchestra/pull/5921))
 - [Jobs] Ability to copy a job ID (PR [#5951](https://github.com/vatesfr/xen-orchestra/pull/5951))
 - [Host/advanced] Add button to enable/disable the host (PR [#5952](https://github.com/vatesfr/xen-orchestra/pull/5952))
+- [Host] Handle evacuation failure during host shutdown (PR [#5966](https://github.com/vatesfr/xen-orchestra/pull/#5966))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/api/host.mjs
+++ b/packages/xo-server/src/api/host.mjs
@@ -184,7 +184,10 @@ start.resolve = {
 // -------------------------------------------------------------------
 
 export function stop({ host, force }) {
-  return this.getXapi(host).shutdownHost(host._xapiId, force)
+  if (force) {
+    return this.getXapi(host).forceShutdownHost(host._xapiId)
+  }
+  return this.getXapi(host).shutdownHost(host._xapiId)
 }
 
 stop.description = 'stop the host'

--- a/packages/xo-server/src/api/host.mjs
+++ b/packages/xo-server/src/api/host.mjs
@@ -183,18 +183,15 @@ start.resolve = {
 
 // -------------------------------------------------------------------
 
-export function stop({ host, force }) {
-  if (force) {
-    return this.getXapi(host).forceShutdownHost(host._xapiId)
-  }
-  return this.getXapi(host).shutdownHost(host._xapiId)
+export function stop({ host, bypassEvacuate }) {
+  return this.getXapi(host).shutdownHost(host._xapiId, { bypassEvacuate })
 }
 
 stop.description = 'stop the host'
 
 stop.params = {
   id: { type: 'string' },
-  force: { type: 'boolean', optional: true },
+  bypassEvacuate: { type: 'boolean', optional: true },
 }
 
 stop.resolve = {

--- a/packages/xo-server/src/api/host.mjs
+++ b/packages/xo-server/src/api/host.mjs
@@ -194,7 +194,7 @@ stop.description = 'stop the host'
 
 stop.params = {
   id: { type: 'string' },
-  force: { type: 'boolean' },
+  force: { type: 'boolean', optional: true },
 }
 
 stop.resolve = {

--- a/packages/xo-server/src/api/host.mjs
+++ b/packages/xo-server/src/api/host.mjs
@@ -183,14 +183,15 @@ start.resolve = {
 
 // -------------------------------------------------------------------
 
-export function stop({ host }) {
-  return this.getXapi(host).shutdownHost(host._xapiId)
+export function stop({ host, force }) {
+  return this.getXapi(host).shutdownHost(host._xapiId, force)
 }
 
 stop.description = 'stop the host'
 
 stop.params = {
   id: { type: 'string' },
+  force: { type: 'boolean' },
 }
 
 stop.resolve = {

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -297,12 +297,14 @@ export default class Xapi extends XapiBase {
     await this.call('host.syslog_reconfigure', host.$ref)
   }
 
-  // if force is 'true', only stops the host without evacuating its VMs.
+  async forceShutdownHost(hostId) {
+    const host = this.getObject(hostId)
+    await this.callAsync('host.shutdown', host.$ref)
+  }
+
   async shutdownHost(hostId, force = false) {
     const host = this.getObject(hostId)
-    if (!force) {
-      await this.clearHost(host, force)
-    }
+    await this.clearHost(host, force)
     await this.callAsync('host.shutdown', host.$ref)
   }
 

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -297,15 +297,13 @@ export default class Xapi extends XapiBase {
     await this.call('host.syslog_reconfigure', host.$ref)
   }
 
-  async forceShutdownHost(hostId) {
-    const hostRef = this.getObject(hostId).$ref
-    await this.call('host.disable', hostRef)
-    await this.callAsync('host.shutdown', hostRef)
-  }
-
-  async shutdownHost(hostId, force = false) {
+  async shutdownHost(hostId, { force = false, bypassEvacuate = force }) {
     const host = this.getObject(hostId)
-    await this.clearHost(host, force)
+    if (bypassEvacuate) {
+      await this.call('host.disable', host.$ref)
+    } else {
+      await this.clearHost(host, force)
+    }
     await this.callAsync('host.shutdown', host.$ref)
   }
 

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -297,7 +297,7 @@ export default class Xapi extends XapiBase {
     await this.call('host.syslog_reconfigure', host.$ref)
   }
 
-  async shutdownHost(hostId, { force = false, bypassEvacuate = force }) {
+  async shutdownHost(hostId, { force = false, bypassEvacuate = false }) {
     const host = this.getObject(hostId)
     if (bypassEvacuate) {
       await this.call('host.disable', host.$ref)

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -298,8 +298,9 @@ export default class Xapi extends XapiBase {
   }
 
   async forceShutdownHost(hostId) {
-    const host = this.getObject(hostId)
-    await this.callAsync('host.shutdown', host.$ref)
+    const hostRef = this.getObject(hostId).$ref
+    await this.call('host.disable', hostRef)
+    await this.callAsync('host.shutdown', hostRef)
   }
 
   async shutdownHost(hostId, force = false) {

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -297,10 +297,12 @@ export default class Xapi extends XapiBase {
     await this.call('host.syslog_reconfigure', host.$ref)
   }
 
+  // if force is 'true', only stops the host without evacuating its VMs.
   async shutdownHost(hostId, force = false) {
     const host = this.getObject(hostId)
-
-    await this.clearHost(host, force)
+    if (!force) {
+      await this.clearHost(host, force)
+    }
     await this.callAsync('host.shutdown', host.$ref)
   }
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1651,7 +1651,7 @@ const messages = {
   stopHostModalTitle: 'Shutdown host',
   stopHostModalMessage:
     "This will shutdown your host. Do you want to continue? If it's the pool master, your connection to the pool will be lost",
-  ForceStopHost: 'Force shutdown host',
+  forceStopHost: 'Force shutdown host',
   forceStopHostMessage: 'This will shutdown your host without evacuating its VMs. Do you want to continue?',
   addHostModalTitle: 'Add host',
   addHostModalMessage: 'Are you sure you want to add {host} to {pool}?',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1651,6 +1651,8 @@ const messages = {
   stopHostModalTitle: 'Shutdown host',
   stopHostModalMessage:
     "This will shutdown your host. Do you want to continue? If it's the pool master, your connection to the pool will be lost",
+  ForceStopHost: 'Force shutdown host',
+  forceStopHostMessage: 'This will shutdown your host without evacuating its VMs. Do you want to continue?',
   addHostModalTitle: 'Add host',
   addHostModalMessage: 'Are you sure you want to add {host} to {pool}?',
   restartHostModalTitle: 'Restart host',

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -808,7 +808,7 @@ export const stopHost = async host => {
       } catch (e) {
         return
       }
-      return _call('host.stop', { id: resolveId(host), force: true })
+      return _call('host.stop', { id: resolveId(host), bypassEvacuate: true })
     }
     throw error
   }

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -799,7 +799,7 @@ export const stopHost = async host => {
     await _call('host.stop', { id: resolveId(host) })
   } catch (err) {
     if (err.message === 'no hosts available') {
-      // Retry with force.
+      // Retry with bypassEvacuate.
       try {
         await confirm({
           body: _('forceStopHostMessage'),

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -791,11 +791,13 @@ export const stopHost = async host => {
       body: _('stopHostModalMessage'),
       title: _('stopHostModalTitle'),
     })
+  } catch (e) {
+    return
+  }
+
+  try {
     await _call('host.stop', { id: resolveId(host) })
   } catch (err) {
-    if (err === undefined) {
-      return
-    }
     if (err.message === 'no hosts available') {
       // Retry with force.
       try {
@@ -803,7 +805,7 @@ export const stopHost = async host => {
           body: _('forceStopHostMessage'),
           title: _('forceStopHost'),
         })
-      } catch (error) {
+      } catch (e) {
         return
       }
       return _call('host.stop', { id: resolveId(host), force: true })

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -788,25 +788,25 @@ export const startHost = host => _call('host.start', { id: resolveId(host) })
 export const stopHost = async host => {
   try {
     await confirm({
-      title: _('stopHostModalTitle'),
       body: _('stopHostModalMessage'),
+      title: _('stopHostModalTitle'),
     })
     await _call('host.stop', { id: resolveId(host) })
   } catch (err) {
     if (err === undefined) {
       return
     }
-    if (err.code === 'NO_HOSTS_AVAILABLE') {
+    if (err.message === 'no hosts available') {
       // Retry with force.
       try {
         await confirm({
-          body: _('forceStopHost'),
-          title: _('forceStopHostMessage'),
+          body: _('forceStopHostMessage'),
+          title: _('forceStopHost'),
         })
       } catch (error) {
         return
       }
-      return _call('vm.stop', { id: resolveId(host), force: true })
+      return _call('host.stop', { id: resolveId(host), force: true })
     }
     throw error
   }

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -786,28 +786,20 @@ export const restartHostsAgents = hosts => {
 export const startHost = host => _call('host.start', { id: resolveId(host) })
 
 export const stopHost = async host => {
-  try {
-    await confirm({
-      body: _('stopHostModalMessage'),
-      title: _('stopHostModalTitle'),
-    })
-  } catch (e) {
-    return
-  }
+  await confirm({
+    body: _('stopHostModalMessage'),
+    title: _('stopHostModalTitle'),
+  })
 
   try {
     await _call('host.stop', { id: resolveId(host) })
   } catch (err) {
     if (err.message === 'no hosts available') {
       // Retry with bypassEvacuate.
-      try {
-        await confirm({
-          body: _('forceStopHostMessage'),
-          title: _('forceStopHost'),
-        })
-      } catch (e) {
-        return
-      }
+      await confirm({
+        body: _('forceStopHostMessage'),
+        title: _('forceStopHost'),
+      })
       return _call('host.stop', { id: resolveId(host), bypassEvacuate: true })
     }
     throw error

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -787,18 +787,16 @@ export const startHost = host => _call('host.start', { id: resolveId(host) })
 
 export const stopHost = async host => {
   try {
-    confirm({
+    await confirm({
       title: _('stopHostModalTitle'),
       body: _('stopHostModalMessage'),
     })
-  } catch (e) {
-    return
-  }
-
-  try {
     await _call('host.stop', { id: resolveId(host) })
   } catch (err) {
-    if (err != null && err.code === 'NO_HOSTS_AVAILABLE') {
+    if (err === undefined) {
+      return
+    }
+    if (err.code === 'NO_HOSTS_AVAILABLE') {
       // Retry with force.
       try {
         await confirm({


### PR DESCRIPTION
See zammad#3354

### Gif

![shutdowhost](https://user-images.githubusercontent.com/7724491/139087151-029dae5d-47ca-4da4-8391-b708f388f487.gif)

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
