### PR TITLE
fix(vhd-lib): tests shouldn't need root access to run

### DIFF
--- a/packages/vhd-lib/src/Vhd/VhdAbstract.integ.spec.js
+++ b/packages/vhd-lib/src/Vhd/VhdAbstract.integ.spec.js
@@ -55,9 +55,9 @@ test('It creates an alias', async () => {
 
 test('alias must have *.alias.vhd extension', async () => {
   await Disposable.use(async function* () {
-    const handler = yield getSyncedHandler({ url: 'file:///' })
-    const aliasPath = `${tempDir}/invalidalias.vhd`
-    const targetPath = `${tempDir}/targets.vhd`
+    const handler = yield getSyncedHandler({ url: `file://${tempDir}` })
+    const aliasPath = 'invalidalias.vhd'
+    const targetPath = 'targets.vhd'
     expect(async () => await VhdAbstract.createAlias(handler, aliasPath, targetPath)).rejects.toThrow()
 
     expect(await fs.exists(aliasPath)).toEqual(false)
@@ -66,9 +66,9 @@ test('alias must have *.alias.vhd extension', async () => {
 
 test('alias must not be chained', async () => {
   await Disposable.use(async function* () {
-    const handler = yield getSyncedHandler({ url: 'file:///' })
-    const aliasPath = `${tempDir}/valid.alias.vhd`
-    const targetPath = `${tempDir}/an.other.valid.alias.vhd`
+    const handler = yield getSyncedHandler({ url: `file://${tempDir}` })
+    const aliasPath = 'valid.alias.vhd'
+    const targetPath = 'an.other.valid.alias.vhd'
     expect(async () => await VhdAbstract.createAlias(handler, aliasPath, targetPath)).rejects.toThrow()
     expect(await fs.exists(aliasPath)).toEqual(false)
   })
@@ -78,19 +78,17 @@ test('It rename and unlink a VHDFile', async () => {
   const initalSize = 4
   const rawFileName = `${tempDir}/randomfile`
   await createRandomFile(rawFileName, initalSize)
-  const vhdFileName = `${tempDir}/randomfile.vhd`
-  await convertFromRawToVhd(rawFileName, vhdFileName)
+  await convertFromRawToVhd(rawFileName, `${tempDir}/randomfile.vhd`)
   await Disposable.use(async function* () {
-    const handler = yield getSyncedHandler({ url: 'file:///' })
-    const { size } = await fs.stat(vhdFileName)
-    const targetFileName = `${tempDir}/renamed.vhd`
+    const handler = yield getSyncedHandler({ url: `file://${tempDir}` })
+    const { size } = await fs.stat(`${tempDir}/randomfile.vhd`)
 
-    await VhdAbstract.rename(handler, vhdFileName, targetFileName)
-    expect(await fs.exists(vhdFileName)).toEqual(false)
-    const { size: renamedSize } = await fs.stat(targetFileName)
+    await VhdAbstract.rename(handler, 'randomfile.vhd', 'renamed.vhd')
+    expect(await fs.exists(`${tempDir}/randomfile.vhd`)).toEqual(false)
+    const { size: renamedSize } = await fs.stat(`${tempDir}/renamed.vhd`)
     expect(size).toEqual(renamedSize)
-    await VhdAbstract.unlink(handler, targetFileName)
-    expect(await fs.exists(targetFileName)).toEqual(false)
+    await VhdAbstract.unlink(handler, 'renamed.vhd')
+    expect(await fs.exists(`${tempDir}/renamed.vhd`)).toEqual(false)
   })
 })
 
@@ -100,16 +98,15 @@ test('It rename and unlink a VhdDirectory', async () => {
   await createRandomVhdDirectory(vhdDirectory, initalSize)
 
   await Disposable.use(async function* () {
-    const handler = yield getSyncedHandler({ url: 'file:///' })
-    const vhd = yield openVhd(handler, vhdDirectory)
+    const handler = yield getSyncedHandler({ url: `file://${tempDir}` })
+    const vhd = yield openVhd(handler, 'randomfile.dir')
     expect(vhd.header.cookie).toEqual('cxsparse')
     expect(vhd.footer.cookie).toEqual('conectix')
 
-    const targetFileName = `${tempDir}/renamed.vhd`
-    await VhdAbstract.rename(handler, vhdDirectory, targetFileName)
-    expect(await fs.exists(vhdDirectory)).toEqual(false)
-    await VhdAbstract.unlink(handler, targetFileName)
-    expect(await fs.exists(targetFileName)).toEqual(false)
+    await VhdAbstract.rename(handler, 'randomfile.dir', 'renamed.vhd')
+    expect(await fs.exists(`${tempDir}/randomfile.dir`)).toEqual(false)
+    await VhdAbstract.unlink(handler, `renamed.vhd`)
+    expect(await fs.exists(`${tempDir}/renamed.vhd`)).toEqual(false)
   })
 })
 
@@ -123,17 +120,17 @@ test('It create , rename and unlink alias', async () => {
   const aliasFileNameRenamed = `${tempDir}/aliasFileNameRenamed.alias.vhd`
 
   await Disposable.use(async function* () {
-    const handler = yield getSyncedHandler({ url: 'file:///' })
-    await VhdAbstract.createAlias(handler, aliasFileName, vhdFileName)
+    const handler = yield getSyncedHandler({ url: `file://${tempDir}` })
+    await VhdAbstract.createAlias(handler, 'aliasFileName.alias.vhd', 'randomfile.vhd')
     expect(await fs.exists(aliasFileName)).toEqual(true)
     expect(await fs.exists(vhdFileName)).toEqual(true)
 
-    await VhdAbstract.rename(handler, aliasFileName, aliasFileNameRenamed)
+    await VhdAbstract.rename(handler, 'aliasFileName.alias.vhd', 'aliasFileNameRenamed.alias.vhd')
     expect(await fs.exists(aliasFileName)).toEqual(false)
     expect(await fs.exists(vhdFileName)).toEqual(true)
     expect(await fs.exists(aliasFileNameRenamed)).toEqual(true)
 
-    await VhdAbstract.unlink(handler, aliasFileNameRenamed)
+    await VhdAbstract.unlink(handler, 'aliasFileNameRenamed.alias.vhd')
     expect(await fs.exists(aliasFileName)).toEqual(false)
     expect(await fs.exists(vhdFileName)).toEqual(false)
     expect(await fs.exists(aliasFileNameRenamed)).toEqual(false)

--- a/packages/vhd-lib/src/_resolveAlias.integ.spec.js
+++ b/packages/vhd-lib/src/_resolveAlias.integ.spec.js
@@ -32,24 +32,34 @@ test('resolve return the path in argument for a non alias file ', async () => {
 test('resolve get the path of the target file for an alias', async () => {
   await Disposable.use(async function* () {
     // same directory
-    const handler = yield getSyncedHandler({ url: 'file:///' })
-    const tempDirFomRemoteUrl = tempDir.slice(1) // remove the / which is included in the remote url
-    const alias = `${tempDirFomRemoteUrl}/alias.alias.vhd`
-    await handler.writeFile(alias, 'target.vhd')
-    expect(await resolveAlias(handler, alias)).toEqual(`${tempDirFomRemoteUrl}/target.vhd`)
+    const handler = yield getSyncedHandler({ url: `file://${tempDir}` })
+    await handler.mkdir(`alias`)
+    const aliasPath = 'alias/alias.alias.vhd'
+    const testOneCombination = async ({ targetPath, targetContent }) => {
+      await handler.writeFile(aliasPath, targetPath, { flags: 'w' })
+      const resolved = await resolveAlias(handler, aliasPath)
+      expect(resolved).toEqual(targetContent)
+      await handler.unlink(aliasPath)
+    }
+    // the alias contain the relative path to the file. The resolved values is the full path from the root of the remote
+    const combinations = [
+      { targetPath: `../targets.vhd`, targetContent: `targets.vhd` },
+      { targetPath: `targets.vhd`, targetContent: `alias/targets.vhd` },
+      { targetPath: `sub/targets.vhd`, targetContent: `alias/sub/targets.vhd` },
+      { targetPath: `../sibling/targets.vhd`, targetContent: `sibling/targets.vhd` },
+    ]
 
-    // different directory
-    await handler.mkdir(`${tempDirFomRemoteUrl}/sub/`)
-    await handler.writeFile(alias, 'sub/target.vhd', { flags: 'w' })
-    expect(await resolveAlias(handler, alias)).toEqual(`${tempDirFomRemoteUrl}/sub/target.vhd`)
+    for (const { targetPath, targetContent } of combinations) {
+      await testOneCombination({ targetPath, targetContent })
+    }
   })
 })
 
 test('resolve throws an error an alias to an alias', async () => {
   await Disposable.use(async function* () {
-    const handler = yield getSyncedHandler({ url: 'file:///' })
-    const alias = `${tempDir}/alias.alias.vhd`
-    const target = `${tempDir}/target.alias.vhd`
+    const handler = yield getSyncedHandler({ url: `file://${tempDir}` })
+    const alias = 'alias.alias.vhd'
+    const target = 'target.alias.vhd'
     await handler.writeFile(alias, target)
     expect(async () => await resolveAlias(handler, alias)).rejects.toThrow(Error)
   })

--- a/packages/vhd-lib/src/merge.integ.spec.js
+++ b/packages/vhd-lib/src/merge.integ.spec.js
@@ -26,53 +26,53 @@ afterEach(async () => {
 
 test('coalesce works in normal cases', async () => {
   const mbOfRandom = 5
-  const randomFileName = `${tempDir}/randomfile`
-  const random2FileName = `${tempDir}/randomfile2`
-  const smallRandomFileName = `${tempDir}/small_randomfile`
-  const parentFileName = `${tempDir}/parent.vhd`
-  const child1FileName = `${tempDir}/child1.vhd`
-  const child2FileName = `${tempDir}/child2.vhd`
-  const recoveredFileName = `${tempDir}/recovered`
-  await createRandomFile(randomFileName, mbOfRandom)
-  await createRandomFile(smallRandomFileName, Math.ceil(mbOfRandom / 2))
-  await execa('qemu-img', ['create', '-fvpc', parentFileName, mbOfRandom + 1 + 'M'])
-  await checkFile(parentFileName)
-  await convertFromRawToVhd(randomFileName, child1FileName)
-  const handler = getHandler({ url: 'file://' })
-  await execa('vhd-util', ['snapshot', '-n', child2FileName, '-p', child1FileName])
-  const vhd = new VhdFile(handler, child2FileName)
+  const randomFilePath = `${tempDir}/randomfile`
+  const random2FilePath = `${tempDir}/randomfile2`
+  const smallRandomFilePath = `${tempDir}/small_randomfile`
+  const parentFilePath = `${tempDir}/parent.vhd`
+  const child1FilePath = `${tempDir}/child1.vhd`
+  const child2FilePath = `${tempDir}/child2.vhd`
+  const recoveredFilePath = `${tempDir}/recovered`
+  await createRandomFile(randomFilePath, mbOfRandom)
+  await createRandomFile(smallRandomFilePath, Math.ceil(mbOfRandom / 2))
+  await execa('qemu-img', ['create', '-fvpc', parentFilePath, mbOfRandom + 1 + 'M'])
+  await checkFile(parentFilePath)
+  await convertFromRawToVhd(randomFilePath, child1FilePath)
+  const handler = getHandler({ url: `file://${tempDir}/` })
+  await execa('vhd-util', ['snapshot', '-n', child2FilePath, '-p', child1FilePath])
+  const vhd = new VhdFile(handler, 'child2.vhd')
   await vhd.readHeaderAndFooter()
   await vhd.readBlockAllocationTable()
   vhd.footer.creatorApplication = 'xoa'
   await vhd.writeFooter()
 
-  const originalSize = await handler._getSize(randomFileName)
-  await checkFile(child1FileName)
-  await chainVhd(handler, parentFileName, handler, child1FileName, true)
-  await checkFile(child1FileName)
-  await chainVhd(handler, child1FileName, handler, child2FileName, true)
-  await checkFile(child2FileName)
-  const smallRandom = await fs.readFile(smallRandomFileName)
-  const newVhd = new VhdFile(handler, child2FileName)
+  const originalSize = await handler._getSize('randomfile')
+  await checkFile(child1FilePath)
+  await chainVhd(handler, 'parent.vhd', handler, 'child1.vhd', true)
+  await checkFile(child1FilePath)
+  await chainVhd(handler, 'child1.vhd', handler, 'child2.vhd', true)
+  await checkFile(child2FilePath)
+  const smallRandom = await fs.readFile(smallRandomFilePath)
+  const newVhd = new VhdFile(handler, 'child2.vhd')
   await newVhd.readHeaderAndFooter()
   await newVhd.readBlockAllocationTable()
   await newVhd.writeData(5, smallRandom)
-  await checkFile(child2FileName)
-  await checkFile(child1FileName)
-  await checkFile(parentFileName)
-  await vhdMerge(handler, parentFileName, handler, child1FileName)
-  await checkFile(parentFileName)
-  await chainVhd(handler, parentFileName, handler, child2FileName, true)
-  await checkFile(child2FileName)
-  await vhdMerge(handler, parentFileName, handler, child2FileName)
-  await checkFile(parentFileName)
-  await recoverRawContent(parentFileName, recoveredFileName, originalSize)
-  await execa('cp', [randomFileName, random2FileName])
-  const fd = await fs.open(random2FileName, 'r+')
+  await checkFile(child2FilePath)
+  await checkFile(child1FilePath)
+  await checkFile(parentFilePath)
+  await vhdMerge(handler, 'parent.vhd', handler, 'child1.vhd')
+  await checkFile(parentFilePath)
+  await chainVhd(handler, 'parent.vhd', handler, 'child2.vhd', true)
+  await checkFile(child2FilePath)
+  await vhdMerge(handler, 'parent.vhd', handler, 'child2.vhd')
+  await checkFile(parentFilePath)
+  await recoverRawContent(parentFilePath, recoveredFilePath, originalSize)
+  await execa('cp', [randomFilePath, random2FilePath])
+  const fd = await fs.open(random2FilePath, 'r+')
   try {
     await fs.write(fd, smallRandom, 0, smallRandom.length, 5 * SECTOR_SIZE)
   } finally {
     await fs.close(fd)
   }
-  expect(await fs.readFile(recoveredFileName)).toEqual(await fs.readFile(random2FileName))
+  expect(await fs.readFile(recoveredFilePath)).toEqual(await fs.readFile(random2FilePath))
 })

--- a/packages/vhd-lib/src/openVhd.integ.spec.js
+++ b/packages/vhd-lib/src/openVhd.integ.spec.js
@@ -29,16 +29,16 @@ test('It opens a vhd file ( alias or not)', async () => {
   const vhdFileName = `${tempDir}/randomfile.vhd`
   await convertFromRawToVhd(rawFileName, vhdFileName)
   await Disposable.use(async function* () {
-    const handler = yield getSyncedHandler({ url: 'file://' })
-    const vhd = yield openVhd(handler, vhdFileName)
+    const handler = yield getSyncedHandler({ url: `file://${tempDir}/` })
+    const vhd = yield openVhd(handler, 'randomfile.vhd')
     expect(vhd.header.cookie).toEqual('cxsparse')
     expect(vhd.footer.cookie).toEqual('conectix')
 
-    const aliasFileName = `${tempDir}/out.alias.vhd`
-    await VhdAbstract.createAlias(handler, aliasFileName, vhdFileName)
-    const alias = yield openVhd(handler, aliasFileName)
+    await VhdAbstract.createAlias(handler, 'out.alias.vhd', 'randomfile.vhd')
+    const alias = yield openVhd(handler, 'out.alias.vhd')
     expect(alias.header.cookie).toEqual('cxsparse')
     expect(alias.footer.cookie).toEqual('conectix')
+    expect(alias._path?.path).toEqual('/randomfile.vhd')
   })
 })
 
@@ -48,15 +48,15 @@ test('It opens a vhd directory', async () => {
   await createRandomVhdDirectory(vhdDirectory, initalSize)
 
   await Disposable.use(async function* () {
-    const handler = yield getSyncedHandler({ url: 'file://' })
-    const vhd = yield openVhd(handler, vhdDirectory)
+    const handler = yield getSyncedHandler({ url: `file://${tempDir}/` })
+    const vhd = yield openVhd(handler, 'randomfile.dir')
     expect(vhd.header.cookie).toEqual('cxsparse')
     expect(vhd.footer.cookie).toEqual('conectix')
 
-    const aliasFileName = `${tempDir}/out.alias.vhd`
-    await VhdAbstract.createAlias(handler, aliasFileName, vhdDirectory)
-    const alias = yield openVhd(handler, aliasFileName)
+    await VhdAbstract.createAlias(handler, 'out.alias.vhd', 'randomfile.dir')
+    const alias = yield openVhd(handler, 'out.alias.vhd')
     expect(alias.header.cookie).toEqual('cxsparse')
     expect(alias.footer.cookie).toEqual('conectix')
+    expect(alias._path).toEqual('randomfile.dir')
   })
 })


### PR DESCRIPTION
`getSyncHandler` make a  writing check to the root of the remote. Tests using a remote should not use / as their base but a directory writable by the current process


### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [x] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
