### PR TITLE
fix(vhd-lib): resolve alias shouldn't load the full file in memory without control

### DIFF
--- a/packages/vhd-lib/src/Vhd/VhdAbstract.js
+++ b/packages/vhd-lib/src/Vhd/VhdAbstract.js
@@ -213,6 +213,12 @@ export class VhdAbstract {
     const aliasDir = path.dirname(path.resolve('/', aliasPath))
     // only store the relative path from alias to target
     const relativePathToTarget = path.relative(aliasDir, path.resolve('/', targetPath))
+
+    if (relativePathToTarget.length > ALIAS_MAX_PATH_LENGTH) {
+      throw new Error(
+        `Alias relative path ${relativePathToTarget} is too long : ${relativePathToTarget.length} chars, max is ${ALIAS_MAX_PATH_LENGTH}`
+      )
+    }
     await handler.writeFile(aliasPath, relativePathToTarget)
   }
 

--- a/packages/vhd-lib/src/Vhd/VhdAbstract.js
+++ b/packages/vhd-lib/src/Vhd/VhdAbstract.js
@@ -1,5 +1,13 @@
 import { computeBatSize, computeSectorOfBitmap, computeSectorsPerBlock, sectorsToBytes } from './_utils'
-import { PLATFORMS, SECTOR_SIZE, PARENT_LOCATOR_ENTRIES, FOOTER_SIZE, HEADER_SIZE, BLOCK_UNUSED } from '../_constants'
+import {
+  ALIAS_MAX_PATH_LENGTH,
+  PLATFORMS,
+  SECTOR_SIZE,
+  PARENT_LOCATOR_ENTRIES,
+  FOOTER_SIZE,
+  HEADER_SIZE,
+  BLOCK_UNUSED,
+} from '../_constants'
 import assert from 'assert'
 import path from 'path'
 import asyncIteratorToStream from 'async-iterator-to-stream'

--- a/packages/vhd-lib/src/_constants.js
+++ b/packages/vhd-lib/src/_constants.js
@@ -36,3 +36,5 @@ export const PLATFORMS = {
 
 export const FILE_FORMAT_VERSION = 1 << 16
 export const HEADER_VERSION = 1 << 16
+
+export const ALIAS_MAX_PATH_LENGTH = 1024

--- a/packages/vhd-lib/src/_resolveAlias.integ.spec.js
+++ b/packages/vhd-lib/src/_resolveAlias.integ.spec.js
@@ -33,24 +33,23 @@ test('resolve return the path in argument for a non alias file ', async () => {
 test('resolve get the path of the target file for an alias', async () => {
   await Disposable.use(async function* () {
     // same directory
-    const handler = yield getSyncedHandler({ url: 'file:///' })
-    const tempDirFomRemoteUrl = tempDir.slice(1) // remove the / which is included in the remote url
-    const alias = `${tempDirFomRemoteUrl}/alias.alias.vhd`
+    const handler = yield getSyncedHandler({ url: `file://${tempDir}` })
+    const alias = `alias.alias.vhd`
     await handler.writeFile(alias, 'target.vhd')
-    await expect(await resolveAlias(handler, alias)).toEqual(`${tempDirFomRemoteUrl}/target.vhd`)
+    await expect(await resolveAlias(handler, alias)).toEqual(`target.vhd`)
 
     // different directory
-    await handler.mkdir(`${tempDirFomRemoteUrl}/sub/`)
+    await handler.mkdir(`sub`)
     await handler.writeFile(alias, 'sub/target.vhd', { flags: 'w' })
-    await expect(await resolveAlias(handler, alias)).toEqual(`${tempDirFomRemoteUrl}/sub/target.vhd`)
+    await expect(await resolveAlias(handler, alias)).toEqual(`sub/target.vhd`)
   })
 })
 
 test('resolve throws an error an alias to an alias', async () => {
   await Disposable.use(async function* () {
-    const handler = yield getSyncedHandler({ url: 'file:///' })
-    const alias = `${tempDir}/alias.alias.vhd`
-    const target = `${tempDir}/target.alias.vhd`
+    const handler = yield getSyncedHandler({ url: `file://${tempDir}` })
+    const alias = `alias.alias.vhd`
+    const target = `target.alias.vhd`
     await handler.writeFile(alias, target)
     await expect(async () => await resolveAlias(handler, alias)).rejects.toThrow(Error)
   })

--- a/packages/vhd-lib/src/_resolveAlias.js
+++ b/packages/vhd-lib/src/_resolveAlias.js
@@ -1,3 +1,4 @@
+import { ALIAS_MAX_PATH_LENGTH } from './_constants'
 import resolveRelativeFromFile from './_resolveRelativeFromFile'
 
 export function isVhdAlias(filename) {
@@ -7,6 +8,11 @@ export function isVhdAlias(filename) {
 export async function resolveAlias(handler, filename) {
   if (!isVhdAlias(filename)) {
     return filename
+  }
+  const size = await handler.getSize(filename)
+  if (size > ALIAS_MAX_PATH_LENGTH) {
+    // seems reasonnable for a relative path
+    throw new Error(`The alias file ${filename} is too big (${size} bytes)`)
   }
   const aliasContent = (await handler.readFile(filename)).toString().trim()
   // also handle circular references and unreasonnably long chains


### PR DESCRIPTION
current alias resolving for vhd load all the file in memory. It can lead to crash is the alias is malformed (for example a full vhd named .alias.vhd ) 


### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
