### PR TITLE
fix(lite/tree): clicking next to VM name should work

### DIFF
--- a/@xen-orchestra/lite/src/components/Tree.tsx
+++ b/@xen-orchestra/lite/src/components/Tree.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames'
 import React from 'react'
 import Tooltip from '@mui/material/Tooltip'
 import TreeView from '@mui/lab/TreeView'
-import TreeItem, { useTreeItem } from '@mui/lab/TreeItem'
+import TreeItem, { useTreeItem, TreeItemContentProps } from '@mui/lab/TreeItem'
 import { withState } from 'reaclette'
 
 import Link from './Link'
@@ -58,6 +58,10 @@ interface Props {
   defaultSelectedNodes?: Array<string>
 }
 
+interface CustomContentProps extends TreeItemContentProps {
+  to?: string
+}
+
 interface ParentEffects {}
 
 interface Effects {
@@ -67,18 +71,27 @@ interface Effects {
 interface Computed {}
 
 // Inspired by https://mui.com/components/tree-view/#contentcomponent-prop.
-const CustomContent = React.forwardRef(function CustomContent(props, ref) {
-  const { classes, className, label, nodeId, expansionIcon } = props
+const CustomContent = React.forwardRef(function CustomContent(props: CustomContentProps, ref) {
+  const { classes, className, label, expansionIcon, nodeId, to } = props
   const { handleExpansion, handleSelection, selected } = useTreeItem(nodeId)
 
-  return (
+  return expansionIcon === undefined ? (
+    <Link decorated={false} to={to}>
+      <span className={classNames(className, { [classes.selected]: selected })} onClick={handleSelection} ref={ref}>
+        <span className={classes.iconContainer} />
+        <span className={classNames(classes.label)}>{label}</span>
+      </span>
+    </Link>
+  ) : (
     <span className={classNames(className, { [classes.selected]: selected })} ref={ref}>
       <span className={classes.iconContainer} onClick={handleExpansion}>
         {expansionIcon}
       </span>
-      <span className={classes.label} onClick={handleSelection}>
-        {label}
-      </span>
+      <Link decorated={false} to={to}>
+        <span className={classes.label} onClick={handleSelection}>
+          {label}
+        </span>
+      </Link>
     </span>
   )
 })
@@ -87,11 +100,9 @@ const renderItem = ({ children, id, label, to, tooltip }: ItemType) => {
   return (
     <TreeItem
       ContentComponent={CustomContent}
-      label={
-        <Link decorated={false} to={to}>
-          {tooltip ? <Tooltip title={tooltip}>{label}</Tooltip> : label}
-        </Link>
-      }
+      // FIXME: when https://github.com/mui-org/material-ui/issues/28668 is fixed
+      ContentProps={{ to } as CustomContentProps}
+      label={tooltip ? <Tooltip title={tooltip}>{label}</Tooltip> : label}
       key={id}
       nodeId={id}
     >

--- a/@xen-orchestra/lite/src/components/Tree.tsx
+++ b/@xen-orchestra/lite/src/components/Tree.tsx
@@ -84,6 +84,7 @@ const CustomContent = React.forwardRef(function CustomContent(props: CustomConte
   return (
     <span
       className={classNames(className, { [classes.selected]: selected })}
+      // To trigger click event in the front of 'label' if there is no 'expansionIcon'.
       onClick={expansionIcon === undefined ? handleSelectionClick : undefined}
       ref={ref}
     >

--- a/@xen-orchestra/lite/src/components/Tree.tsx
+++ b/@xen-orchestra/lite/src/components/Tree.tsx
@@ -4,8 +4,8 @@ import Tooltip from '@mui/material/Tooltip'
 import TreeView from '@mui/lab/TreeView'
 import TreeItem, { useTreeItem, TreeItemContentProps } from '@mui/lab/TreeItem'
 import { withState } from 'reaclette'
+import { useHistory } from 'react-router-dom'
 
-import Link from './Link'
 import Icon from '../components/Icon'
 
 interface ParentState {}
@@ -74,24 +74,25 @@ interface Computed {}
 const CustomContent = React.forwardRef(function CustomContent(props: CustomContentProps, ref) {
   const { classes, className, label, expansionIcon, nodeId, to } = props
   const { handleExpansion, handleSelection, selected } = useTreeItem(nodeId)
+  const history = useHistory()
 
-  return expansionIcon === undefined ? (
-    <Link decorated={false} to={to}>
-      <span className={classNames(className, { [classes.selected]: selected })} onClick={handleSelection} ref={ref}>
-        <span className={classes.iconContainer} />
-        <span className={classNames(classes.label)}>{label}</span>
-      </span>
-    </Link>
-  ) : (
-    <span className={classNames(className, { [classes.selected]: selected })} ref={ref}>
+  const handleSelectionClick = (event: React.SyntheticEvent) => {
+    to !== undefined && history.push(to)
+    handleSelection(event)
+  }
+
+  return (
+    <span
+      className={classNames(className, { [classes.selected]: selected })}
+      onClick={expansionIcon === undefined ? handleSelectionClick : undefined}
+      ref={ref}
+    >
       <span className={classes.iconContainer} onClick={handleExpansion}>
         {expansionIcon}
       </span>
-      <Link decorated={false} to={to}>
-        <span className={classes.label} onClick={handleSelection}>
-          {label}
-        </span>
-      </Link>
+      <span className={classes.label} onClick={handleSelectionClick}>
+        {label}
+      </span>
     </span>
   )
 })

--- a/@xen-orchestra/lite/src/components/Tree.tsx
+++ b/@xen-orchestra/lite/src/components/Tree.tsx
@@ -100,7 +100,8 @@ const renderItem = ({ children, id, label, to, tooltip }: ItemType) => {
   return (
     <TreeItem
       ContentComponent={CustomContent}
-      // FIXME: when https://github.com/mui-org/material-ui/issues/28668 is fixed
+      // FIXME: ContentProps should only be React.HTMLAttributes<HTMLElement> or undefined, it doesn't support other type.
+      // when https://github.com/mui-org/material-ui/issues/28668 is fixed, remove 'as CustomContentProps'.
       ContentProps={{ to } as CustomContentProps}
       label={tooltip ? <Tooltip title={tooltip}>{label}</Tooltip> : label}
       key={id}

--- a/@xen-orchestra/lite/src/components/Tree.tsx
+++ b/@xen-orchestra/lite/src/components/Tree.tsx
@@ -76,24 +76,22 @@ const CustomContent = React.forwardRef(function CustomContent(props: CustomConte
   const { handleExpansion, handleSelection, selected } = useTreeItem(nodeId)
   const history = useHistory()
 
+  const handleExpansionClick = (event: React.SyntheticEvent) => {
+    event.stopPropagation()
+    handleExpansion(event)
+  }
+
   const handleSelectionClick = (event: React.SyntheticEvent) => {
     to !== undefined && history.push(to)
     handleSelection(event)
   }
 
   return (
-    <span
-      className={classNames(className, { [classes.selected]: selected })}
-      // To trigger click event in the front of 'label' if there is no 'expansionIcon'.
-      onClick={expansionIcon === undefined ? handleSelectionClick : undefined}
-      ref={ref}
-    >
-      <span className={classes.iconContainer} onClick={handleExpansion}>
+    <span className={classNames(className, { [classes.selected]: selected })} onClick={handleSelectionClick} ref={ref}>
+      <span className={classes.iconContainer} onClick={handleExpansionClick}>
         {expansionIcon}
       </span>
-      <span className={classes.label} onClick={handleSelectionClick}>
-        {label}
-      </span>
+      <span className={classes.label}>{label}</span>
     </span>
   )
 })


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
