### PR TITLE
fix(backups/cleanVm): don't warn on size change due to merged VHDs

### DIFF
--- a/@xen-orchestra/backups/_cleanVm.integ.spec.js
+++ b/@xen-orchestra/backups/_cleanVm.integ.spec.js
@@ -178,7 +178,7 @@ test('it merges delta of non destroyed chain', async () => {
     `metadata.json`,
     JSON.stringify({
       mode: 'delta',
-      size: 209920,
+      size: 12000, // a size too small
       vhds: [
         `${basePath}/grandchild.vhd`, // grand child should not be merged
         `${basePath}/child.vhd`,
@@ -216,8 +216,11 @@ test('it merges delta of non destroyed chain', async () => {
   expect(unused).toEqual(`the parent /${basePath}/orphan.vhd of the child /${basePath}/child.vhd is unused`)
   expect(merging).toEqual(`merging /${basePath}/child.vhd into /${basePath}/orphan.vhd`)
 
-  // merging is already tested in vhd-lib, don't retest it here (and theses vhd are as empty as my stomach at 12h12)
+  const metadata = JSON.parse(await handler.readFile(`metadata.json`))
+  // size should be the size of children + grand children after the merge
+  expect(metadata.size).toEqual(209920)
 
+  // merging is already tested in vhd-lib, don't retest it here (and theses vhd are as empty as my stomach at 12h12)
   // only check deletion
   const remainingVhds = await handler.list(basePath)
   expect(remainingVhds.length).toEqual(2)
@@ -230,7 +233,7 @@ test('it finish unterminated merge ', async () => {
     `metadata.json`,
     JSON.stringify({
       mode: 'delta',
-      size: 209920,
+      size: undefined,
       vhds: [
         `${basePath}/orphan.vhd`, // grand child should not be merged
         `${basePath}/child.vhd`,
@@ -363,6 +366,10 @@ describe('tests mulitple combination ', () => {
           })
         )
         await adapter.cleanVm('/', { remove: true, merge: true })
+
+        const metadata = JSON.parse(await handler.readFile(`metadata.json`))
+        // size should be the size of children + grand children + clean after the merge
+        expect(metadata.size).toEqual(vhdMode === 'file' ? 314880 : undefined)
 
         // broken vhd, non referenced, abandonned should be deleted ( alias and data)
         // ancestor and child should be merged

--- a/@xen-orchestra/backups/_cleanVm.integ.spec.js
+++ b/@xen-orchestra/backups/_cleanVm.integ.spec.js
@@ -204,15 +204,17 @@ test('it merges delta of non destroyed chain', async () => {
     },
   })
 
-  let loggued = ''
+  let loggued = []
   const onLog = message => {
-    loggued += message + '\n'
+    loggued.push(message)
   }
   await adapter.cleanVm('/', { remove: true, onLog })
-  expect(loggued).toEqual(`the parent /${basePath}/orphan.vhd of the child /${basePath}/child.vhd is unused\n`)
-  loggued = ''
+  expect(loggued[0]).toEqual(`the parent /${basePath}/orphan.vhd of the child /${basePath}/child.vhd is unused`)
+  expect(loggued[1]).toEqual(`incorrect size in metadata: 12000 instead of 209920`)
+
+  loggued = []
   await adapter.cleanVm('/', { remove: true, merge: true, onLog })
-  const [unused, merging] = loggued.split('\n')
+  const [unused, merging] = loggued
   expect(unused).toEqual(`the parent /${basePath}/orphan.vhd of the child /${basePath}/child.vhd is unused`)
   expect(merging).toEqual(`merging /${basePath}/child.vhd into /${basePath}/orphan.vhd`)
 

--- a/@xen-orchestra/backups/_cleanVm.js
+++ b/@xen-orchestra/backups/_cleanVm.js
@@ -392,14 +392,8 @@ exports.cleanVm = async function cleanVm(
   // check for the other that the size is the same as the real file size
 
   await asyncMap(jsons, async metadataPath => {
-    let metadata
-    try {
-      metadata = JSON.parse(await handler.readFile(metadataPath))
-    } catch (e) {
-      // metadata can't be openned, no need to update size
-      // it may have been deleted id incomplete
-      return
-    }
+    const metadata = JSON.parse(await handler.readFile(metadataPath))
+
     let fileSystemSize
     const merged = metadataWithMergedVhd[metadataPath] !== undefined
 

--- a/@xen-orchestra/backups/_cleanVm.js
+++ b/@xen-orchestra/backups/_cleanVm.js
@@ -414,17 +414,16 @@ exports.cleanVm = async function cleanVm(
       }
     } catch (error) {
       onLog(`failed to get size of ${metadataPath}`, { error })
+      return
     }
 
     // systematically update size after a merge
-    if (merged || fixMetadata) {
-      if (size !== fileSystemSize || fileSystemSize === undefined) {
-        metadata.size = fileSystemSize
-        try {
-          await handler.writeFile(metadataPath, JSON.stringify(metadata), { flags: 'w' })
-        } catch (error) {
-          onLog(`failed to update size in backup metadata ${metadataPath} after merge`, { error })
-        }
+    if (merged || (fixMetadata && size !== fileSystemSize)) {
+      metadata.size = fileSystemSize
+      try {
+        await handler.writeFile(metadataPath, JSON.stringify(metadata), { flags: 'w' })
+      } catch (error) {
+        onLog(`failed to update size in backup metadata ${metadataPath} after merge`, { error })
       }
     }
   })

--- a/@xen-orchestra/backups/_cleanVm.js
+++ b/@xen-orchestra/backups/_cleanVm.js
@@ -408,7 +408,7 @@ exports.cleanVm = async function cleanVm(
         fileSystemSize = await computeVhdsSize(handler, vhds)
 
         // don't warn if the size has changed after a merge
-        if (fileSystemSize !== size && metadataWithMergedVhd[metadataPath] === undefined) {
+        if (!merged && fileSystemSize !== size) {
           onLog(`incorrect size in metadata: ${size ?? 'none'} instead of ${fileSystemSize}`)
         }
       }

--- a/@xen-orchestra/backups/_cleanVm.js
+++ b/@xen-orchestra/backups/_cleanVm.js
@@ -418,7 +418,7 @@ exports.cleanVm = async function cleanVm(
     }
 
     // systematically update size after a merge
-    if (merged || (fixMetadata && size !== fileSystemSize)) {
+    if ((merged || fixMetadata) && size !== fileSystemSize) {
       metadata.size = fileSystemSize
       try {
         await handler.writeFile(metadataPath, JSON.stringify(metadata), { flags: 'w' })

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Backup] Remove incorrect size warning following a merge [Forum #5727](https://xcp-ng.org/forum/topic/4769/warnings-showing-in-system-logs-following-each-backup-job/4) (PR [#6010](https://github.com/vatesfr/xen-orchestra/pull/6010))
+
 ### Packages to release
 
 > Packages will be released in the order they are here, therefore, they should
@@ -28,5 +30,7 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
-- @xen-orchestra/proxy patch
 - vhd-lib minor
+- @xen-orchestra/backups patch
+- xo-server patch
+- @xen-orchestra/proxy patch

--- a/packages/vhd-lib/src/Vhd/_utils.js
+++ b/packages/vhd-lib/src/Vhd/_utils.js
@@ -4,6 +4,10 @@ import { fuFooter, fuHeader, checksumStruct, unpackField } from '../_structs'
 import checkFooter from '../checkFooter'
 import checkHeader from '../_checkHeader'
 
+// Sectors conversions.
+export const sectorsRoundUpNoZero = bytes => Math.ceil(bytes / SECTOR_SIZE) || 1
+export const sectorsToBytes = sectors => sectors * SECTOR_SIZE
+
 export const computeBatSize = entries => sectorsToBytes(sectorsRoundUpNoZero(entries * 4))
 
 export const computeSectorsPerBlock = blockSize => blockSize / SECTOR_SIZE
@@ -11,10 +15,7 @@ export const computeSectorsPerBlock = blockSize => blockSize / SECTOR_SIZE
 export const computeBlockBitmapSize = blockSize => computeSectorsPerBlock(blockSize) >>> 3
 export const computeFullBlockSize = blockSize => blockSize + SECTOR_SIZE * computeSectorOfBitmap(blockSize)
 export const computeSectorOfBitmap = blockSize => sectorsRoundUpNoZero(computeBlockBitmapSize(blockSize))
-
-// Sectors conversions.
-export const sectorsRoundUpNoZero = bytes => Math.ceil(bytes / SECTOR_SIZE) || 1
-export const sectorsToBytes = sectors => sectors * SECTOR_SIZE
+export const computeBlockSize = blockSize => sectorsToBytes(computeSectorOfBitmap(blockSize))
 
 export const assertChecksum = (name, buf, struct) => {
   const actual = unpackField(struct.fields.checksum, buf)

--- a/packages/vhd-lib/src/Vhd/_utils.js
+++ b/packages/vhd-lib/src/Vhd/_utils.js
@@ -4,10 +4,6 @@ import { fuFooter, fuHeader, checksumStruct, unpackField } from '../_structs'
 import checkFooter from '../checkFooter'
 import checkHeader from '../_checkHeader'
 
-// Sectors conversions.
-export const sectorsRoundUpNoZero = bytes => Math.ceil(bytes / SECTOR_SIZE) || 1
-export const sectorsToBytes = sectors => sectors * SECTOR_SIZE
-
 export const computeBatSize = entries => sectorsToBytes(sectorsRoundUpNoZero(entries * 4))
 
 export const computeSectorsPerBlock = blockSize => blockSize / SECTOR_SIZE
@@ -15,7 +11,10 @@ export const computeSectorsPerBlock = blockSize => blockSize / SECTOR_SIZE
 export const computeBlockBitmapSize = blockSize => computeSectorsPerBlock(blockSize) >>> 3
 export const computeFullBlockSize = blockSize => blockSize + SECTOR_SIZE * computeSectorOfBitmap(blockSize)
 export const computeSectorOfBitmap = blockSize => sectorsRoundUpNoZero(computeBlockBitmapSize(blockSize))
-export const computeBlockSize = blockSize => sectorsToBytes(computeSectorOfBitmap(blockSize))
+
+// Sectors conversions.
+export const sectorsRoundUpNoZero = bytes => Math.ceil(bytes / SECTOR_SIZE) || 1
+export const sectorsToBytes = sectors => sectors * SECTOR_SIZE
 
 export const assertChecksum = (name, buf, struct) => {
   const actual = unpackField(struct.fields.checksum, buf)


### PR DESCRIPTION
see : https://xcp-ng.org/forum/topic/4769/warnings-showing-in-system-logs-following-each-backup-job/4

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [x] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
