### PR TITLE
fix(xo-server/proxies): remove state cache after the proxy update

### DIFF
--- a/packages/xo-server/src/xo-mixins/proxies.mjs
+++ b/packages/xo-server/src/xo-mixins/proxies.mjs
@@ -180,7 +180,6 @@ export default class Proxy {
     const { vmUuid } = await this._getProxy(id)
     const xapi = this._app.getXapi(vmUuid)
     await xapi.getObject(vmUuid).update_xenstore_data(xenstoreData)
-    this.getProxyApplianceUpdaterState(REMOVE_CACHE_ENTRY, id)
 
     try {
       await xapi.rebootVm(vmUuid)
@@ -191,6 +190,8 @@ export default class Proxy {
 
       await xapi.startVm(vmUuid)
     }
+
+    this.getProxyApplianceUpdaterState(REMOVE_CACHE_ENTRY, id)
 
     await xapi._waitObjectState(vmUuid, vm => extractIpFromVmNetworks(vm.$guest_metrics?.networks) !== undefined)
   }

--- a/packages/xo-server/src/xo-mixins/proxies.mjs
+++ b/packages/xo-server/src/xo-mixins/proxies.mjs
@@ -23,7 +23,7 @@ import { timeout } from 'promise-toolbox'
 
 import Collection from '../collection/redis.mjs'
 import patch from '../patch.mjs'
-import { debounceWithKey } from '../_pDebounceWithKey.mjs'
+import { debounceWithKey, REMOVE_CACHE_ENTRY } from '../_pDebounceWithKey.mjs'
 import { extractIpFromVmNetworks } from '../_extractIpFromVmNetworks.mjs'
 import { generateToken } from '../utils.mjs'
 
@@ -180,6 +180,7 @@ export default class Proxy {
     const { vmUuid } = await this._getProxy(id)
     const xapi = this._app.getXapi(vmUuid)
     await xapi.getObject(vmUuid).update_xenstore_data(xenstoreData)
+    this.getProxyApplianceUpdaterState(REMOVE_CACHE_ENTRY, id)
 
     try {
       await xapi.rebootVm(vmUuid)


### PR DESCRIPTION
See kanban#573

- After the proxy update, the notification in the menu is still present, and to fix the issue I cleared the cache right after the proxy update.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
