### PR TITLE
fix(xo-lite/Tree): unselect node

### DIFF
--- a/@xen-orchestra/lite/src/App/Infrastructure.tsx
+++ b/@xen-orchestra/lite/src/App/Infrastructure.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { withState } from 'reaclette'
-import { withRouter } from 'react-router'
+import { RouteChildrenProps, withRouter } from 'react-router'
 import { Switch, Route } from 'react-router-dom'
 
 import TabConsole from './TabConsole'
@@ -28,12 +28,10 @@ const MainPanel = styled.div`
 
 interface ParentState {}
 
-interface State {
-  selectedVm?: string
-}
+interface State {}
 
 interface Props {
-  location: object
+  location: RouteChildrenProps['location']
 }
 
 interface ParentEffects {}
@@ -42,18 +40,20 @@ interface Effects {
   initialize: () => void
 }
 
-interface Computed {}
+interface Computed {
+  selectedVm?: string
+}
 
 const Infrastructure = withState<State, Props, Effects, Computed, ParentState, ParentEffects>(
   {
-    initialState: props => ({
-      selectedVm: props.location.pathname.split('/')[3],
-    }),
+    computed: {
+      selectedVm: (_, { location }) => location.pathname.split('/')[3],
+    },
   },
   ({ state: { selectedVm } }) => (
     <Container>
       <LeftPanel>
-        <TreeView defaultSelectedNodes={selectedVm === undefined ? undefined : [selectedVm]} />
+        <TreeView defaultSelectedNodes={[selectedVm]} />
       </LeftPanel>
       <MainPanel>
         <Switch>

--- a/@xen-orchestra/lite/src/App/Infrastructure.tsx
+++ b/@xen-orchestra/lite/src/App/Infrastructure.tsx
@@ -28,9 +28,7 @@ const MainPanel = styled.div`
 
 interface ParentState {}
 
-interface State {
-  selectedNodes: Array<string>
-}
+interface State {}
 
 interface Props extends RouteComponentProps {}
 

--- a/@xen-orchestra/lite/src/App/Infrastructure.tsx
+++ b/@xen-orchestra/lite/src/App/Infrastructure.tsx
@@ -53,7 +53,7 @@ const Infrastructure = withState<State, Props, Effects, Computed, ParentState, P
   ({ state: { selectedVm } }) => (
     <Container>
       <LeftPanel>
-        <TreeView defaultSelectedNode={selectedVm} />
+        <TreeView defaultSelectedNodes={selectedVm === undefined ? undefined : [selectedVm]} />
       </LeftPanel>
       <MainPanel>
         <Switch>

--- a/@xen-orchestra/lite/src/App/Infrastructure.tsx
+++ b/@xen-orchestra/lite/src/App/Infrastructure.tsx
@@ -28,7 +28,9 @@ const MainPanel = styled.div`
 
 interface ParentState {}
 
-interface State {}
+interface State {
+  selectedNodes: Array<string>
+}
 
 interface Props {
   location: RouteChildrenProps['location']
@@ -36,24 +38,20 @@ interface Props {
 
 interface ParentEffects {}
 
-interface Effects {
-  initialize: () => void
-}
+interface Effects {}
 
-interface Computed {
-  selectedVm?: string
-}
+interface Computed {}
 
 const Infrastructure = withState<State, Props, Effects, Computed, ParentState, ParentEffects>(
   {
-    computed: {
-      selectedVm: (_, { location }) => location.pathname.split('/')[3],
-    },
+    initialState: ({ location }) => ({
+      selectedNodes: [location.pathname.split('/')[3]],
+    }),
   },
-  ({ state: { selectedVm } }) => (
+  ({ state: { selectedNodes } }) => (
     <Container>
       <LeftPanel>
-        <TreeView defaultSelectedNodes={selectedVm === undefined ? undefined : [selectedVm]} />
+        <TreeView selectedNodes={selectedNodes} />
       </LeftPanel>
       <MainPanel>
         <Switch>

--- a/@xen-orchestra/lite/src/App/Infrastructure.tsx
+++ b/@xen-orchestra/lite/src/App/Infrastructure.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import styled from 'styled-components'
-import { withState } from 'reaclette'
 import { RouteComponentProps, withRouter } from 'react-router'
 import { Switch, Route } from 'react-router-dom'
+import { withState } from 'reaclette'
 
 import TabConsole from './TabConsole'
 import TreeView from './TreeView'

--- a/@xen-orchestra/lite/src/App/Infrastructure.tsx
+++ b/@xen-orchestra/lite/src/App/Infrastructure.tsx
@@ -42,34 +42,27 @@ interface Effects {}
 
 interface Computed {}
 
-const Infrastructure = withState<State, Props, Effects, Computed, ParentState, ParentEffects>(
-  {
-    initialState: ({ location }) => ({
-      selectedNodes: [location.pathname.split('/')[3]],
-    }),
-  },
-  ({ state: { selectedNodes } }) => (
-    <Container>
-      <LeftPanel>
-        <TreeView selectedNodes={selectedNodes} />
-      </LeftPanel>
-      <MainPanel>
-        <Switch>
-          <Route exact path='/infrastructure'>
-            Select a VM
-          </Route>
-          <Route
-            path='/infrastructure/vms/:id/console'
-            render={({
-              match: {
-                params: { id },
-              },
-            }) => <TabConsole key={id} vmId={id} />}
-          />
-        </Switch>
-      </MainPanel>
-    </Container>
-  )
-)
+const Infrastructure = withState<State, Props, Effects, Computed, ParentState, ParentEffects>({}, ({ location }) => (
+  <Container>
+    <LeftPanel>
+      <TreeView pathname={location.pathname} />
+    </LeftPanel>
+    <MainPanel>
+      <Switch>
+        <Route exact path='/infrastructure'>
+          Select a VM
+        </Route>
+        <Route
+          path='/infrastructure/vms/:id/console'
+          render={({
+            match: {
+              params: { id },
+            },
+          }) => <TabConsole key={id} vmId={id} />}
+        />
+      </Switch>
+    </MainPanel>
+  </Container>
+))
 
 export default withRouter(Infrastructure)

--- a/@xen-orchestra/lite/src/App/Infrastructure.tsx
+++ b/@xen-orchestra/lite/src/App/Infrastructure.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import styled from 'styled-components'
-import { RouteComponentProps, withRouter } from 'react-router'
 import { Switch, Route } from 'react-router-dom'
 import { withState } from 'reaclette'
 
@@ -30,7 +29,7 @@ interface ParentState {}
 
 interface State {}
 
-interface Props extends RouteComponentProps {}
+interface Props {}
 
 interface ParentEffects {}
 
@@ -61,4 +60,4 @@ const Infrastructure = withState<State, Props, Effects, Computed, ParentState, P
   </Container>
 ))
 
-export default withRouter(Infrastructure)
+export default Infrastructure

--- a/@xen-orchestra/lite/src/App/Infrastructure.tsx
+++ b/@xen-orchestra/lite/src/App/Infrastructure.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { withState } from 'reaclette'
-import { RouteChildrenProps, withRouter } from 'react-router'
+import { RouteComponentProps, withRouter } from 'react-router'
 import { Switch, Route } from 'react-router-dom'
 
 import TabConsole from './TabConsole'
@@ -32,9 +32,7 @@ interface State {
   selectedNodes: Array<string>
 }
 
-interface Props {
-  location: RouteChildrenProps['location']
-}
+interface Props extends RouteComponentProps {}
 
 interface ParentEffects {}
 
@@ -42,10 +40,10 @@ interface Effects {}
 
 interface Computed {}
 
-const Infrastructure = withState<State, Props, Effects, Computed, ParentState, ParentEffects>({}, ({ location }) => (
+const Infrastructure = withState<State, Props, Effects, Computed, ParentState, ParentEffects>({}, () => (
   <Container>
     <LeftPanel>
-      <TreeView pathname={location.pathname} />
+      <TreeView />
     </LeftPanel>
     <MainPanel>
       <Switch>

--- a/@xen-orchestra/lite/src/App/Infrastructure.tsx
+++ b/@xen-orchestra/lite/src/App/Infrastructure.tsx
@@ -53,7 +53,7 @@ const Infrastructure = withState<State, Props, Effects, Computed, ParentState, P
   ({ state: { selectedVm } }) => (
     <Container>
       <LeftPanel>
-        <TreeView defaultSelectedNodes={[selectedVm]} />
+        <TreeView defaultSelectedNode={selectedVm} />
       </LeftPanel>
       <MainPanel>
         <Switch>

--- a/@xen-orchestra/lite/src/App/TreeView.tsx
+++ b/@xen-orchestra/lite/src/App/TreeView.tsx
@@ -149,7 +149,7 @@ const TreeView = withState<State, Props, Effects, Computed, ParentState, ParentE
         <Tree
           collection={state.collection}
           selectedNodes={state.selectedNodes}
-          setSelectedNodeIds={effects.setSelectedNodes}
+          onNodeSelect={effects.setSelectedNodes}
         />
       </div>
     )

--- a/@xen-orchestra/lite/src/App/TreeView.tsx
+++ b/@xen-orchestra/lite/src/App/TreeView.tsx
@@ -46,13 +46,16 @@ const getIconColor = (obj: Host | Vm) => {
 
 const TreeView = withState<State, Props, Effects, Computed, ParentState, ParentEffects>(
   {
-    initialState: ({ location }) => ({
-      _selectedNodes: location.pathname.split('/')[3] !== undefined ? [location.pathname.split('/')[3]] : [],
-    }),
+    initialState: ({ location }) => {
+      const selectedNode = location.pathname.split('/')[3]
+      return {
+        _selectedNodes: selectedNode !== undefined ? [selectedNode] : [],
+      }
+    },
     effects: {
       setSelectedNodes: function (_, nodeIds) {
         if (this.state.objectId === undefined) {
-          window.location.hash = '/infrastructure/type/' + nodeIds[0]
+          this.props.history.push('/infrastructure/type/' + nodeIds[0])
         }
         this.state._selectedNodes = [nodeIds[0]]
       },

--- a/@xen-orchestra/lite/src/App/TreeView.tsx
+++ b/@xen-orchestra/lite/src/App/TreeView.tsx
@@ -14,7 +14,7 @@ interface ParentState {
 interface State {}
 
 interface Props {
-  defaultSelectedNodes?: Array<string | undefined>
+  defaultSelectedNode?: string
 }
 
 interface ParentEffects {}
@@ -119,10 +119,10 @@ const TreeView = withState<State, Props, Effects, Computed, ParentState, ParentE
         ),
     },
   },
-  ({ state, defaultSelectedNodes }) =>
+  ({ state, defaultSelectedNode }) =>
     state.collection === undefined ? null : (
       <div style={{ padding: '10px' }}>
-        <Tree collection={state.collection} defaultSelectedNodes={defaultSelectedNodes} />
+        <Tree collection={state.collection} defaultSelectedNode={defaultSelectedNode} />
       </div>
     )
 )

--- a/@xen-orchestra/lite/src/App/TreeView.tsx
+++ b/@xen-orchestra/lite/src/App/TreeView.tsx
@@ -14,7 +14,7 @@ interface ParentState {
 interface State {}
 
 interface Props {
-  defaultSelectedNodes?: Array<string>
+  defaultSelectedNodes?: Array<string | undefined>
 }
 
 interface ParentEffects {}

--- a/@xen-orchestra/lite/src/App/TreeView.tsx
+++ b/@xen-orchestra/lite/src/App/TreeView.tsx
@@ -57,7 +57,7 @@ const TreeView = withState<State, Props, Effects, Computed, ParentState, ParentE
         if (this.state.objectId === undefined) {
           this.props.history.push('/infrastructure/type/' + nodeIds[0])
         }
-        this.state._selectedNodes = [nodeIds[0]]
+        this.state._selectedNodes = nodeIds
       },
     },
     computed: {

--- a/@xen-orchestra/lite/src/App/TreeView.tsx
+++ b/@xen-orchestra/lite/src/App/TreeView.tsx
@@ -12,9 +12,7 @@ interface ParentState {
   objectsByType: ObjectsByType
 }
 
-interface State {
-  _selectedNodes: Array<string>
-}
+interface State {}
 
 interface Props extends RouteComponentProps {}
 
@@ -46,18 +44,14 @@ const getIconColor = (obj: Host | Vm) => {
 
 const TreeView = withState<State, Props, Effects, Computed, ParentState, ParentEffects>(
   {
-    initialState: ({ location }) => {
-      const selectedNode = location.pathname.split('/')[3]
-      return {
-        _selectedNodes: selectedNode !== undefined ? [selectedNode] : [],
-      }
-    },
     effects: {
       setSelectedNodes: function (_, nodeIds) {
-        if (this.state.objectId === undefined) {
-          this.props.history.push('/infrastructure/type/' + nodeIds[0])
-        }
-        this.state._selectedNodes = nodeIds
+        const { objectId } = this.state
+        this.props.history.push(
+          objectId?.match(/^[0-9a-z]{8}-([0-9a-z]{4}-){3}[0-9a-z]{12}$/) != null
+            ? this.props.history.location.pathname.replace(objectId, nodeIds[0])
+            : '/infrastructure/type/' + nodeIds[0]
+        )
       },
     },
     computed: {
@@ -129,7 +123,7 @@ const TreeView = withState<State, Props, Effects, Computed, ParentState, ParentE
       hostsByPool: state => state.objectsByType?.get('host')?.groupBy((host: Host) => host.$pool.$id),
       objectId: (_, { location }) => location.pathname.split('/')[3],
       pools: state => state.objectsByType?.get('pool'),
-      selectedNodes: ({ objectId, _selectedNodes }) => (objectId !== undefined ? _selectedNodes : []),
+      selectedNodes: ({ objectId }) => (objectId !== undefined ? [objectId] : []),
       vms: state =>
         state.objectsByType
           ?.get('VM')

--- a/@xen-orchestra/lite/src/App/TreeView.tsx
+++ b/@xen-orchestra/lite/src/App/TreeView.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Collection, Map } from 'immutable'
+import { RouteComponentProps, withRouter } from 'react-router-dom'
 import { withState } from 'reaclette'
 
 import Icon from '../components/Icon'
@@ -15,9 +16,7 @@ interface State {
   _selectedNodes: Array<string>
 }
 
-interface Props {
-  pathname: string
-}
+interface Props extends RouteComponentProps {}
 
 interface ParentEffects {}
 
@@ -47,8 +46,8 @@ const getIconColor = (obj: Host | Vm) => {
 
 const TreeView = withState<State, Props, Effects, Computed, ParentState, ParentEffects>(
   {
-    initialState: ({ pathname }) => ({
-      _selectedNodes: [pathname.split('/')[3]],
+    initialState: ({ location }) => ({
+      _selectedNodes: [location.pathname.split('/')[3]],
     }),
     effects: {
       setSelectedNodes: function (_, nodeIds) {
@@ -125,7 +124,7 @@ const TreeView = withState<State, Props, Effects, Computed, ParentState, ParentE
         return collection
       },
       hostsByPool: state => state.objectsByType?.get('host')?.groupBy((host: Host) => host.$pool.$id),
-      objectId: (_, { pathname }) => pathname.split('/')[3],
+      objectId: (_, { location }) => location.pathname.split('/')[3],
       pools: state => state.objectsByType?.get('pool'),
       selectedNodes: ({ objectId, _selectedNodes }) => (objectId !== undefined ? _selectedNodes : []),
       vms: state =>
@@ -146,4 +145,4 @@ const TreeView = withState<State, Props, Effects, Computed, ParentState, ParentE
     )
 )
 
-export default TreeView
+export default withRouter(TreeView)

--- a/@xen-orchestra/lite/src/App/TreeView.tsx
+++ b/@xen-orchestra/lite/src/App/TreeView.tsx
@@ -14,7 +14,7 @@ interface ParentState {
 interface State {}
 
 interface Props {
-  defaultSelectedNode?: string
+  defaultSelectedNodes?: Array<string>
 }
 
 interface ParentEffects {}
@@ -119,10 +119,10 @@ const TreeView = withState<State, Props, Effects, Computed, ParentState, ParentE
         ),
     },
   },
-  ({ state, defaultSelectedNode }) =>
+  ({ state, defaultSelectedNodes }) =>
     state.collection === undefined ? null : (
       <div style={{ padding: '10px' }}>
-        <Tree collection={state.collection} defaultSelectedNode={defaultSelectedNode} />
+        <Tree collection={state.collection} defaultSelectedNodes={defaultSelectedNodes} />
       </div>
     )
 )

--- a/@xen-orchestra/lite/src/App/TreeView.tsx
+++ b/@xen-orchestra/lite/src/App/TreeView.tsx
@@ -47,7 +47,7 @@ const getIconColor = (obj: Host | Vm) => {
 const TreeView = withState<State, Props, Effects, Computed, ParentState, ParentEffects>(
   {
     initialState: ({ location }) => ({
-      _selectedNodes: [location.pathname.split('/')[3]],
+      _selectedNodes: location.pathname.split('/')[3] !== undefined ? [location.pathname.split('/')[3]] : [],
     }),
     effects: {
       setSelectedNodes: function (_, nodeIds) {

--- a/@xen-orchestra/lite/src/components/Tree.tsx
+++ b/@xen-orchestra/lite/src/components/Tree.tsx
@@ -10,9 +10,7 @@ import Icon from '../components/Icon'
 
 interface ParentState {}
 
-interface State {
-  selectedNodes?: Array<string>
-}
+interface State {}
 
 export interface ItemType {
   children?: Array<ItemType>
@@ -55,7 +53,7 @@ interface Props {
   //   }
   // ]
   collection: Array<ItemType>
-  defaultSelectedNodes?: Array<string>
+  defaultSelectedNodes?: Array<string | undefined>
 }
 
 interface CustomContentProps extends TreeItemContentProps {
@@ -64,9 +62,7 @@ interface CustomContentProps extends TreeItemContentProps {
 
 interface ParentEffects {}
 
-interface Effects {
-  setSelectedNodeIds: (event: React.SyntheticEvent, nodeIds: Array<string>) => void
-}
+interface Effects {}
 
 interface Computed {}
 
@@ -118,24 +114,14 @@ const renderItem = ({ children, id, label, to, tooltip }: ItemType) => {
 }
 
 const Tree = withState<State, Props, Effects, Computed, ParentState, ParentEffects>(
-  {
-    initialState: ({ defaultSelectedNodes }) => ({
-      selectedNodes: defaultSelectedNodes === undefined ? [] : defaultSelectedNodes,
-    }),
-    effects: {
-      setSelectedNodeIds: function (event, nodeIds) {
-        this.state.selectedNodes = [nodeIds[0]]
-      },
-    },
-  },
-  ({ effects, state: { selectedNodes }, collection }) => (
+  {},
+  ({ collection, defaultSelectedNodes }) => (
     <TreeView
       defaultExpanded={[collection[0].id]}
       defaultCollapseIcon={<Icon icon='chevron-up' />}
       defaultExpandIcon={<Icon icon='chevron-down' />}
-      onNodeSelect={effects.setSelectedNodeIds}
       multiSelect
-      selected={selectedNodes}
+      selected={defaultSelectedNodes}
     >
       {collection.map(renderItem)}
     </TreeView>

--- a/@xen-orchestra/lite/src/components/Tree.tsx
+++ b/@xen-orchestra/lite/src/components/Tree.tsx
@@ -10,9 +10,7 @@ import Icon from '../components/Icon'
 
 interface ParentState {}
 
-interface State {
-  _selectedNodes?: Array<string>
-}
+interface State {}
 
 export interface ItemType {
   children?: Array<ItemType>
@@ -56,6 +54,8 @@ interface Props {
   // ]
   collection: Array<ItemType>
   defaultSelectedNodes?: Array<string>
+  selectedNodes: Array<string>
+  setSelectedNodeIds: (event: React.SyntheticEvent<Element, Event>, nodeIds: Array<string>) => void
 }
 
 interface CustomContentProps extends TreeItemContentProps {
@@ -64,9 +64,7 @@ interface CustomContentProps extends TreeItemContentProps {
 
 interface ParentEffects {}
 
-interface Effects {
-  setSelectedNodeIds: (event: React.SyntheticEvent, nodeIds: Array<string>) => void
-}
+interface Effects {}
 
 interface Computed {
   selectedNodes: Array<string>
@@ -120,27 +118,14 @@ const renderItem = ({ children, id, label, to, tooltip }: ItemType) => {
 }
 
 const Tree = withState<State, Props, Effects, Computed, ParentState, ParentEffects>(
-  {
-    initialState: () => ({
-      _selectedNodes: undefined,
-    }),
-    effects: {
-      setSelectedNodeIds: function (event, nodeIds) {
-        this.state._selectedNodes = nodeIds
-      },
-    },
-    computed: {
-      selectedNodes: ({ _selectedNodes }, { defaultSelectedNodes }) =>
-        defaultSelectedNodes === undefined ? [] : _selectedNodes ?? defaultSelectedNodes,
-    },
-  },
-  ({ effects, state: { selectedNodes }, collection }) => (
+  {},
+  ({ setSelectedNodeIds, selectedNodes, collection }) => (
     <TreeView
       defaultExpanded={[collection[0].id]}
       defaultCollapseIcon={<Icon icon='chevron-up' />}
       defaultExpandIcon={<Icon icon='chevron-down' />}
-      onNodeSelect={effects.setSelectedNodeIds}
       multiSelect
+      onNodeSelect={setSelectedNodeIds}
       selected={selectedNodes}
     >
       {collection.map(renderItem)}

--- a/@xen-orchestra/lite/src/components/Tree.tsx
+++ b/@xen-orchestra/lite/src/components/Tree.tsx
@@ -10,7 +10,9 @@ import Icon from '../components/Icon'
 
 interface ParentState {}
 
-interface State {}
+interface State {
+  selectedNodes?: Array<string>
+}
 
 export interface ItemType {
   children?: Array<ItemType>
@@ -53,7 +55,7 @@ interface Props {
   //   }
   // ]
   collection: Array<ItemType>
-  defaultSelectedNodes?: Array<string | undefined>
+  defaultSelectedNode?: string
 }
 
 interface CustomContentProps extends TreeItemContentProps {
@@ -62,9 +64,9 @@ interface CustomContentProps extends TreeItemContentProps {
 
 interface ParentEffects {}
 
-interface Effects {}
-
-interface Computed {}
+interface Effects {
+  setSelectedNodeIds: (event: React.SyntheticEvent, nodeIds: Array<string>) => void
+}
 
 // Inspired by https://mui.com/components/tree-view/#contentcomponent-prop.
 const CustomContent = React.forwardRef(function CustomContent(props: CustomContentProps, ref) {
@@ -114,14 +116,24 @@ const renderItem = ({ children, id, label, to, tooltip }: ItemType) => {
 }
 
 const Tree = withState<State, Props, Effects, Computed, ParentState, ParentEffects>(
-  {},
-  ({ collection, defaultSelectedNodes }) => (
+  {
+    initialState: ({ defaultSelectedNode }) => ({
+      selectedNodes: [defaultSelectedNode ?? ''],
+    }),
+    effects: {
+      setSelectedNodeIds: function (event, nodeIds) {
+        this.state.selectedNodes = nodeIds
+      },
+    },
+  },
+  ({ effects, state: { selectedNodes }, collection, defaultSelectedNode }) => (
     <TreeView
       defaultExpanded={[collection[0].id]}
       defaultCollapseIcon={<Icon icon='chevron-up' />}
       defaultExpandIcon={<Icon icon='chevron-down' />}
       multiSelect
-      selected={defaultSelectedNodes}
+      onNodeSelect={effects.setSelectedNodeIds}
+      selected={defaultSelectedNode === undefined ? [''] : selectedNodes}
     >
       {collection.map(renderItem)}
     </TreeView>

--- a/@xen-orchestra/lite/src/components/Tree.tsx
+++ b/@xen-orchestra/lite/src/components/Tree.tsx
@@ -68,6 +68,8 @@ interface Effects {
   setSelectedNodeIds: (event: React.SyntheticEvent, nodeIds: Array<string>) => void
 }
 
+interface Computed {}
+
 // Inspired by https://mui.com/components/tree-view/#contentcomponent-prop.
 const CustomContent = React.forwardRef(function CustomContent(props: CustomContentProps, ref) {
   const { classes, className, label, expansionIcon, nodeId, to } = props
@@ -131,8 +133,8 @@ const Tree = withState<State, Props, Effects, Computed, ParentState, ParentEffec
       defaultExpanded={[collection[0].id]}
       defaultCollapseIcon={<Icon icon='chevron-up' />}
       defaultExpandIcon={<Icon icon='chevron-down' />}
-      multiSelect
       onNodeSelect={effects.setSelectedNodeIds}
+      multiSelect
       selected={defaultSelectedNode === undefined ? [''] : selectedNodes}
     >
       {collection.map(renderItem)}

--- a/@xen-orchestra/lite/src/components/Tree.tsx
+++ b/@xen-orchestra/lite/src/components/Tree.tsx
@@ -131,7 +131,7 @@ const Tree = withState<State, Props, Effects, Computed, ParentState, ParentEffec
     },
     computed: {
       selectedNodes: ({ _selectedNodes }, { defaultSelectedNodes }) =>
-        defaultSelectedNodes === undefined ? [''] : _selectedNodes ?? defaultSelectedNodes,
+        defaultSelectedNodes === undefined ? [] : _selectedNodes ?? defaultSelectedNodes,
     },
   },
   ({ effects, state: { selectedNodes }, collection }) => (

--- a/@xen-orchestra/lite/src/components/Tree.tsx
+++ b/@xen-orchestra/lite/src/components/Tree.tsx
@@ -54,7 +54,7 @@ interface Props {
   // ]
   collection: Array<ItemType>
   selectedNodes: Array<string>
-  setSelectedNodeIds: (event: React.SyntheticEvent<Element, Event>, nodeIds: Array<string>) => void
+  onNodeSelect: (event: React.SyntheticEvent<Element, Event>, nodeIds: Array<string>) => void
 }
 
 interface CustomContentProps extends TreeItemContentProps {
@@ -116,13 +116,13 @@ const renderItem = ({ children, id, label, to, tooltip }: ItemType) => {
 
 const Tree = withState<State, Props, Effects, Computed, ParentState, ParentEffects>(
   {},
-  ({ setSelectedNodeIds, selectedNodes, collection }) => (
+  ({ onNodeSelect, selectedNodes, collection }) => (
     <TreeView
       defaultExpanded={[collection[0].id]}
       defaultCollapseIcon={<Icon icon='chevron-up' />}
       defaultExpandIcon={<Icon icon='chevron-down' />}
       multiSelect
-      onNodeSelect={setSelectedNodeIds}
+      onNodeSelect={onNodeSelect}
       selected={selectedNodes}
     >
       {collection.map(renderItem)}

--- a/@xen-orchestra/lite/src/components/Tree.tsx
+++ b/@xen-orchestra/lite/src/components/Tree.tsx
@@ -55,7 +55,7 @@ interface Props {
   //   }
   // ]
   collection: Array<ItemType>
-  defaultSelectedNode?: string
+  defaultSelectedNodes?: Array<string>
 }
 
 interface CustomContentProps extends TreeItemContentProps {
@@ -119,8 +119,8 @@ const renderItem = ({ children, id, label, to, tooltip }: ItemType) => {
 
 const Tree = withState<State, Props, Effects, Computed, ParentState, ParentEffects>(
   {
-    initialState: ({ defaultSelectedNode }) => ({
-      selectedNodes: [defaultSelectedNode ?? ''],
+    initialState: ({ defaultSelectedNodes }) => ({
+      selectedNodes: defaultSelectedNodes === undefined ? [''] : defaultSelectedNodes,
     }),
     effects: {
       setSelectedNodeIds: function (event, nodeIds) {
@@ -128,14 +128,14 @@ const Tree = withState<State, Props, Effects, Computed, ParentState, ParentEffec
       },
     },
   },
-  ({ effects, state: { selectedNodes }, collection, defaultSelectedNode }) => (
+  ({ effects, state: { selectedNodes }, collection, defaultSelectedNodes }) => (
     <TreeView
       defaultExpanded={[collection[0].id]}
       defaultCollapseIcon={<Icon icon='chevron-up' />}
       defaultExpandIcon={<Icon icon='chevron-down' />}
       onNodeSelect={effects.setSelectedNodeIds}
       multiSelect
-      selected={defaultSelectedNode === undefined ? [''] : selectedNodes}
+      selected={defaultSelectedNodes === undefined ? [''] : selectedNodes}
     >
       {collection.map(renderItem)}
     </TreeView>

--- a/@xen-orchestra/lite/src/components/Tree.tsx
+++ b/@xen-orchestra/lite/src/components/Tree.tsx
@@ -53,7 +53,6 @@ interface Props {
   //   }
   // ]
   collection: Array<ItemType>
-  defaultSelectedNodes?: Array<string>
   selectedNodes: Array<string>
   setSelectedNodeIds: (event: React.SyntheticEvent<Element, Event>, nodeIds: Array<string>) => void
 }

--- a/@xen-orchestra/lite/src/components/Tree.tsx
+++ b/@xen-orchestra/lite/src/components/Tree.tsx
@@ -66,9 +66,7 @@ interface ParentEffects {}
 
 interface Effects {}
 
-interface Computed {
-  selectedNodes: Array<string>
-}
+interface Computed {}
 
 // Inspired by https://mui.com/components/tree-view/#contentcomponent-prop.
 const CustomContent = React.forwardRef(function CustomContent(props: CustomContentProps, ref) {

--- a/@xen-orchestra/lite/src/components/Tree.tsx
+++ b/@xen-orchestra/lite/src/components/Tree.tsx
@@ -11,7 +11,7 @@ import Icon from '../components/Icon'
 interface ParentState {}
 
 interface State {
-  selectedNodes?: Array<string>
+  _selectedNodes?: Array<string>
 }
 
 export interface ItemType {
@@ -68,7 +68,9 @@ interface Effects {
   setSelectedNodeIds: (event: React.SyntheticEvent, nodeIds: Array<string>) => void
 }
 
-interface Computed {}
+interface Computed {
+  selectedNodes: Array<string>
+}
 
 // Inspired by https://mui.com/components/tree-view/#contentcomponent-prop.
 const CustomContent = React.forwardRef(function CustomContent(props: CustomContentProps, ref) {
@@ -119,23 +121,27 @@ const renderItem = ({ children, id, label, to, tooltip }: ItemType) => {
 
 const Tree = withState<State, Props, Effects, Computed, ParentState, ParentEffects>(
   {
-    initialState: ({ defaultSelectedNodes }) => ({
-      selectedNodes: defaultSelectedNodes === undefined ? [''] : defaultSelectedNodes,
+    initialState: () => ({
+      _selectedNodes: undefined,
     }),
     effects: {
       setSelectedNodeIds: function (event, nodeIds) {
-        this.state.selectedNodes = nodeIds
+        this.state._selectedNodes = nodeIds
       },
     },
+    computed: {
+      selectedNodes: ({ _selectedNodes }, { defaultSelectedNodes }) =>
+        defaultSelectedNodes === undefined ? [''] : _selectedNodes ?? defaultSelectedNodes,
+    },
   },
-  ({ effects, state: { selectedNodes }, collection, defaultSelectedNodes }) => (
+  ({ effects, state: { selectedNodes }, collection }) => (
     <TreeView
       defaultExpanded={[collection[0].id]}
       defaultCollapseIcon={<Icon icon='chevron-up' />}
       defaultExpandIcon={<Icon icon='chevron-down' />}
       onNodeSelect={effects.setSelectedNodeIds}
       multiSelect
-      selected={defaultSelectedNodes === undefined ? [''] : selectedNodes}
+      selected={selectedNodes}
     >
       {collection.map(renderItem)}
     </TreeView>


### PR DESCRIPTION
### Description
In case we unselect an item in the `Treeview`, the item stay highlighted

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
