### PR TITLE
feat(xo-server,xo-web): disable HA during Rolling Pool Update

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -10,6 +10,7 @@
 - [About] Show commit instead of version numbers for source users (PR [#6045](https://github.com/vatesfr/xen-orchestra/pull/6045))
 - [Health] Display default SRs that aren't shared [#5871](https://github.com/vatesfr/xen-orchestra/issues/5871) (PR [#6033](https://github.com/vatesfr/xen-orchestra/pull/6033))
 - [Pool,VM/advanced] Ability to change the suspend SR [#4163](https://github.com/vatesfr/xen-orchestra/issues/4163) (PR [#6044](https://github.com/vatesfr/xen-orchestra/pull/6044))
+- [Rolling Pool Update] Automatically disable High Availability during the update [#5711](https://github.com/vatesfr/xen-orchestra/issues/5711)
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -10,7 +10,7 @@
 - [About] Show commit instead of version numbers for source users (PR [#6045](https://github.com/vatesfr/xen-orchestra/pull/6045))
 - [Health] Display default SRs that aren't shared [#5871](https://github.com/vatesfr/xen-orchestra/issues/5871) (PR [#6033](https://github.com/vatesfr/xen-orchestra/pull/6033))
 - [Pool,VM/advanced] Ability to change the suspend SR [#4163](https://github.com/vatesfr/xen-orchestra/issues/4163) (PR [#6044](https://github.com/vatesfr/xen-orchestra/pull/6044))
-- [Rolling Pool Update] Automatically disable High Availability during the update [#5711](https://github.com/vatesfr/xen-orchestra/issues/5711)
+- [Rolling Pool Update] Automatically disable High Availability during the update [#5711](https://github.com/vatesfr/xen-orchestra/issues/5711) (PR [#6057](https://github.com/vatesfr/xen-orchestra/pull/6057))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1003,6 +1003,7 @@ const messages = {
   rollingPoolUpdate: 'Rolling pool update',
   rollingPoolUpdateMessage:
     'Are you sure you want to start a rolling pool update? Running VMs will be migrated back and forth and this can take a while.',
+  rollingPoolUpdateHaWarning: 'High Availability is enabled. This will automatically disable it during the update.',
   poolNeedsDefaultSr: 'The pool needs a default SR to install the patches.',
   vmsHaveCds: '{nVms, number} VM{nVms, plural, one {} other {s}} {nVms, plural, one {has} other {have}} CDs',
   ejectCds: 'Eject CDs',

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -936,9 +936,10 @@ export const installAllPatchesOnPool = ({ pool }) => {
   )
 }
 
+import RollingPoolUpdateModal from './rolling-pool-updates-modal' // eslint-disable-line import/first
 export const rollingPoolUpdate = poolId =>
   confirm({
-    body: _('rollingPoolUpdateMessage'),
+    body: <RollingPoolUpdateModal pool={poolId} />,
     title: _('rollingPoolUpdate'),
     icon: 'pool-rolling-update',
   }).then(

--- a/packages/xo-web/src/common/xo/rolling-pool-updates-modal/index.js
+++ b/packages/xo-web/src/common/xo/rolling-pool-updates-modal/index.js
@@ -1,0 +1,31 @@
+import _ from 'intl'
+import BaseComponent from 'base-component'
+import Icon from 'icon'
+import React from 'react'
+import { connectStore } from 'utils'
+import { createGetObjectsOfType } from 'selectors'
+
+@connectStore(
+  {
+    pools: createGetObjectsOfType('pool'),
+  },
+  { withRef: true }
+)
+export default class RollingPoolUpdateModal extends BaseComponent {
+  render() {
+    const pool = this.props.pools[this.props.pool]
+
+    return (
+      <div>
+        <p>{_('rollingPoolUpdateMessage')}</p>
+        {pool.HA_enabled && (
+          <p>
+            <em className='text-warning'>
+              <Icon icon='alarm' /> {_('rollingPoolUpdateHaWarning')}
+            </em>
+          </p>
+        )}
+      </div>
+    )
+  }
+}


### PR DESCRIPTION
See #5711

### Screenshots

![Capture_2021-12-15_16:16:03](https://user-images.githubusercontent.com/10992860/146219071-08bd26f6-3e33-49ca-98ab-c25b8cad51e1.png)

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
