### PR TITLE
fix(vhd-lib): parseVhdStream int overflow when rebuilding the bat

### DIFF
--- a/packages/vhd-lib/src/parseVhdStream.js
+++ b/packages/vhd-lib/src/parseVhdStream.js
@@ -80,10 +80,6 @@ export async function* parseVhdStream(stream) {
     const { type } = item
     if (type === 'bat') {
       // found the BAT : read it and add block to index
-      // since we may reorder  / remove empty space, we recompute the bat instead of returning the source
-
-      const bat = Buffer.alloc(header.maxTableEntries * 4)
-      item.buffer = bat
 
       let blockCount = 0
       for (let blockCounter = 0; blockCounter < header.maxTableEntries; blockCounter++) {
@@ -99,10 +95,7 @@ export async function* parseVhdStream(stream) {
             offset: batEntryBytes,
             size: fullBlockSize,
           })
-          bat.writeInt32BE(batEntryBytes, 4 * blockCounter)
           blockCount++
-        } else {
-          bat.writeInt32BE(BLOCK_UNUSED, 4 * blockCounter)
         }
       }
       // sort again index to ensure block and parent locator are in the right order


### PR DESCRIPTION
BAT should contain sector address, not byte address
we were not really rebuilding the BAT, since we were using the data read in the old bat and write it as is in the new one

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
