### PR TITLE
fix(lite/tree): navigate with keyboard into tree-view

### DIFF
--- a/@xen-orchestra/lite/src/components/Tree.tsx
+++ b/@xen-orchestra/lite/src/components/Tree.tsx
@@ -73,21 +73,26 @@ interface Computed {}
 // Inspired by https://mui.com/components/tree-view/#contentcomponent-prop.
 const CustomContent = React.forwardRef(function CustomContent(props: CustomContentProps, ref) {
   const { classes, className, label, expansionIcon, nodeId, to } = props
-  const { handleExpansion, handleSelection, selected } = useTreeItem(nodeId)
+  const { focused, handleExpansion, handleSelection, selected } = useTreeItem(nodeId)
   const history = useHistory()
+
+  React.useEffect(() => {
+    if (selected) {
+      to !== undefined && history.push(to)
+    }
+  }, [selected])
 
   const handleExpansionClick = (event: React.SyntheticEvent) => {
     event.stopPropagation()
     handleExpansion(event)
   }
 
-  const handleSelectionClick = (event: React.SyntheticEvent) => {
-    to !== undefined && history.push(to)
-    handleSelection(event)
-  }
-
   return (
-    <span className={classNames(className, { [classes.selected]: selected })} onClick={handleSelectionClick} ref={ref}>
+    <span
+      className={classNames(className, { [classes.focused]: focused, [classes.selected]: selected })}
+      onClick={handleSelection}
+      ref={ref}
+    >
       <span className={classes.iconContainer} onClick={handleExpansionClick}>
         {expansionIcon}
       </span>

--- a/@xen-orchestra/lite/src/components/Tree.tsx
+++ b/@xen-orchestra/lite/src/components/Tree.tsx
@@ -65,7 +65,7 @@ interface CustomContentProps extends TreeItemContentProps {
 interface ParentEffects {}
 
 interface Effects {
-  setSelectedNodeIds: (event: React.SyntheticEvent, nodeIds: string) => void
+  setSelectedNodeIds: (event: React.SyntheticEvent, nodeIds: Array<string>) => void
 }
 
 interface Computed {}
@@ -124,7 +124,7 @@ const Tree = withState<State, Props, Effects, Computed, ParentState, ParentEffec
     }),
     effects: {
       setSelectedNodeIds: function (event, nodeIds) {
-        this.state.selectedNodes = [nodeIds]
+        this.state.selectedNodes = [nodeIds[0]]
       },
     },
   },
@@ -134,6 +134,7 @@ const Tree = withState<State, Props, Effects, Computed, ParentState, ParentEffec
       defaultCollapseIcon={<Icon icon='chevron-up' />}
       defaultExpandIcon={<Icon icon='chevron-down' />}
       onNodeSelect={effects.setSelectedNodeIds}
+      multiSelect
       selected={selectedNodes}
     >
       {collection.map(renderItem)}

--- a/@xen-orchestra/lite/src/components/Tree.tsx
+++ b/@xen-orchestra/lite/src/components/Tree.tsx
@@ -65,7 +65,7 @@ interface CustomContentProps extends TreeItemContentProps {
 interface ParentEffects {}
 
 interface Effects {
-  setSelectedNodeIds: (event: React.SyntheticEvent, nodeIds: Array<string>) => void
+  setSelectedNodeIds: (event: React.SyntheticEvent, nodeIds: string) => void
 }
 
 interface Computed {}
@@ -124,7 +124,7 @@ const Tree = withState<State, Props, Effects, Computed, ParentState, ParentEffec
     }),
     effects: {
       setSelectedNodeIds: function (event, nodeIds) {
-        this.state.selectedNodes = nodeIds
+        this.state.selectedNodes = [nodeIds]
       },
     },
   },
@@ -134,7 +134,6 @@ const Tree = withState<State, Props, Effects, Computed, ParentState, ParentEffec
       defaultCollapseIcon={<Icon icon='chevron-up' />}
       defaultExpandIcon={<Icon icon='chevron-down' />}
       onNodeSelect={effects.setSelectedNodeIds}
-      multiSelect
       selected={selectedNodes}
     >
       {collection.map(renderItem)}


### PR DESCRIPTION
### Description

A user cannot navigate correctly into the treeview with his keyboard, because there is no highlight on focused label, and no solution to select a node(s)

### Gif

![Peek 22-12-2021 16-38](https://user-images.githubusercontent.com/70369997/147117559-515c04c3-b062-44f0-a524-f4dfd8b2c63d.gif)

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
