### PR TITLE
fix(backups): race condition in checkBaseVdi preventing delta backup

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Import/Disk] Fix `JSON.parse` and `createReadableSparseStream is not a function` errors [#6068](https://github.com/vatesfr/xen-orchestra/issues/6068)
-- [Backup]  Fix delta backup are almost always full backup instead of differencials [forum1](https://xcp-ng.org/forum/topic/5256/s3-backup-try-it/80) and [forum2](https://xcp-ng.org/forum/topic/5371/delta-backup-changes-in-5-66/24?_=1641289226655)
+- [Backup]  Fix delta backup are almost always full backup instead of differentials [Forum#5256](https://xcp-ng.org/forum/topic/5256/s3-backup-try-it/69) [Forum#5371](https://xcp-ng.org/forum/topic/5371/delta-backup-changes-in-5-66)
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,8 +33,7 @@
 
 - vhd-lib major
 - xo-vmdk-to-vhd patch
-- @xen-orchestra/backups
-- @xen-orchestra/backups-cli
-- @xen-orchestra/proxy
+- @xen-orchestra/backups patch
+- @xen-orchestra/proxy patch
 - xo-server patch
 - xo-web patch

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Import/Disk] Fix `JSON.parse` and `createReadableSparseStream is not a function` errors [#6068](https://github.com/vatesfr/xen-orchestra/issues/6068)
+- [Backup]  Fix delta backup are almost always full backup instead of differencials [forum1](https://xcp-ng.org/forum/topic/5256/s3-backup-try-it/80) and [forum2](https://xcp-ng.org/forum/topic/5371/delta-backup-changes-in-5-66/24?_=1641289226655)
 
 ### Packages to release
 
@@ -32,5 +33,8 @@
 
 - vhd-lib major
 - xo-vmdk-to-vhd patch
+- @xen-orchestra/backups
+- @xen-orchestra/backups-cli
+- @xen-orchestra/proxy
 - xo-server patch
 - xo-web patch

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Import/Disk] Fix `JSON.parse` and `createReadableSparseStream is not a function` errors [#6068](https://github.com/vatesfr/xen-orchestra/issues/6068)
-- [Backup]  Fix delta backup are almost always full backup instead of differentials [Forum#5256](https://xcp-ng.org/forum/topic/5256/s3-backup-try-it/69) [Forum#5371](https://xcp-ng.org/forum/topic/5371/delta-backup-changes-in-5-66)
+- [Backup]  Fix delta backup are almost always full backup instead of differentials [Forum#5256](https://xcp-ng.org/forum/topic/5256/s3-backup-try-it/69) [Forum#5371](https://xcp-ng.org/forum/topic/5371/delta-backup-changes-in-5-66) (PR [#6075](https://github.com/vatesfr/xen-orchestra/pull/6075))
 
 ### Packages to release
 


### PR DESCRIPTION
Fixes zammad#4751, 4729, 4665 and 4300

```js
;(async () => {
  let found = false
  await Promise.all(
    Array.from({ length: 100 }).map(async () => {
      found = found || await new Promise(resolve =>
        setTimeout(() => resolve(Math.random() < 0.1), Math.random() * 1000)
      )
      console.log( found)
    })
  )
})()
```
this will reproduce the race condition with found that changes from false to true mutliple times

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
