### PR TITLE
fix(@xen-orchestra/fs): s3 use upload instead of putObject to fix HTTP timeout

### DIFF
--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -118,7 +118,15 @@ export default class S3Handler extends RemoteHandlerAbstract {
   }
 
   async _writeFile(file, data, options) {
-    return this._s3.putObject({ ...this._createParams(file), Body: data })
+    return  this._s3.upload(
+      {
+        ...this._createParams(file),
+        Body: data,
+      },
+      // concurrency is handled by xo, adding the concurrency
+      // of aws may overload the upload link and lead to timeout
+      { queueSize: 1 }
+    )
   }
 
   async _createReadStream(path, options) {


### PR DESCRIPTION
upload allow for a more precise control, retry automatically on fail and handle file bigger than 5GB

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
