### PR TITLE
fix: run .mjs unit tests

### DIFF
--- a/@xen-orchestra/babel-config/index.js
+++ b/@xen-orchestra/babel-config/index.js
@@ -46,7 +46,7 @@ module.exports = function (pkg, configs = {}) {
 
   return {
     comments: !__PROD__,
-    ignore: __PROD__ ? [/\btests?\//, /\.spec\.js$/] : undefined,
+    ignore: __PROD__ ? [/\btests?\//, /\.spec\.(?:m?j|t)sx?$/] : undefined,
     plugins: Object.keys(plugins)
       .map(plugin => [plugin, plugins[plugin]])
       .sort(([a], [b]) => {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,10 @@
       "/xo-server-test/",
       "/xo-web/"
     ],
-    "testRegex": "\\.spec\\.js$"
+    "testRegex": "\\.spec\\.(?:m?j|t)sx?$",
+    "transform": {
+      "\\.(?:m?j|t)sx?$": "babel-jest"
+    }
   },
   "lint-staged": {
     "*.{md,ts,ts}": "prettier --write"
@@ -71,14 +74,14 @@
     "build": "scripts/run-script --parallel build",
     "clean": "scripts/run-script --parallel clean",
     "dev": "scripts/run-script --parallel dev",
-    "dev-test": "jest --bail --watch \"^(?!.*\\.integ\\.spec\\.js$)\"",
+    "dev-test": "jest --bail --watch \"^(?!.*\\.integ\\.spec\\.m?js$)\"",
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs",
     "prettify": "prettier --ignore-path .gitignore --write '**/*.{cjs,js,jsx,md,mjs,ts,tsx}'",
     "test": "npm run test-lint && npm run test-unit",
-    "test-integration": "jest \".integ\\.spec\\.js$\"",
+    "test-integration": "jest \".integ\\.spec\\.m?js$\"",
     "test-lint": "eslint --ignore-path .gitignore .",
-    "test-unit": "jest \"^(?!.*\\.integ\\.spec\\.js$)\" && scripts/run-script test",
+    "test-unit": "jest \"^(?!.*\\.integ\\.spec\\.m?js$)\" && scripts/run-script test",
     "travis-tests": "scripts/travis-tests"
   },
   "workspaces": [


### PR DESCRIPTION
This does not work, Jest still does not find/see these files (e.g. `utils.spec.mjs`), I'm open to ideas.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
