### PR TITLE
fix(backups/_cleanVm): fixes for aliases cleaning

### DIFF
--- a/@xen-orchestra/backups/_cleanVm.js
+++ b/@xen-orchestra/backups/_cleanVm.js
@@ -119,7 +119,7 @@ const listVhds = async (handler, vmDir) => {
           const list = await handler.list(vdiDir, {
             filter: file => isVhdFile(file) || INTERRUPTED_VHDS_REG.test(file),
           })
-          aliases[vdiDir] = list.filter(vhd => isVhdAlias(vhd))
+          aliases[vdiDir] = list.filter(vhd => isVhdAlias(vhd)).map(file => `${vdiDir}/${file}`)
           list.forEach(file => {
             const res = INTERRUPTED_VHDS_REG.exec(file)
             if (res === null) {
@@ -249,15 +249,11 @@ exports.cleanVm = async function cleanVm(
     }
   }
 
-  // 2022-01-17 - FBP & JFT - Temporary disable aliases checking as it appears problematic
-  //
   // check if alias are correct
   // check if all vhd in data subfolder have a corresponding alias
-  // await asyncMap(Object.keys(aliases), async dir => {
-  //   await checkAliases(aliases[dir], `${dir}/data`, { handler, onLog, remove })
-  // })
-  // Avoid a ESLint unused variable
-  noop(aliases)
+  await asyncMap(Object.keys(aliases), async dir => {
+    await checkAliases(aliases[dir], `${dir}/data`, { handler, onLog, remove })
+  })
 
   // remove VHDs with missing ancestors
   {

--- a/packages/vhd-lib/index.js
+++ b/packages/vhd-lib/index.js
@@ -12,3 +12,6 @@ exports.VhdDirectory = require('./Vhd/VhdDirectory').VhdDirectory
 exports.VhdFile = require('./Vhd/VhdFile').VhdFile
 exports.VhdSynthetic = require('./Vhd/VhdSynthetic').VhdSynthetic
 exports.Constants = require('./_constants')
+const {isVhdAlias, resolveAlias} = require('./_resolveAlias')
+exports.isVhdAlias = isVhdAlias
+exports.resolveAlias = resolveAlias


### PR DESCRIPTION
Introduced in 249f638495e00357bf93a3aa80f83b56e0bcd889

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
