### PR TITLE
feat(lite/console): handle case where host sends self-signed certificate

### DIFF
--- a/@xen-orchestra/lite/src/components/Console.tsx
+++ b/@xen-orchestra/lite/src/components/Console.tsx
@@ -82,31 +82,28 @@ const Console = withState<State, Props, Effects, Computed, ParentState, ParentEf
       },
       _handleDisconnect: async function () {
         this.state.rfbConnected = false
+        const {
+          state: { objectsByType, url },
+          effects: { _connect },
+        } = this
         const { protocol } = window.location
         if (protocol === Protocols.https) {
           try {
-            await fetch(`${protocol}//${this.state.url?.host}`)
+            await fetch(`${protocol}//${url?.host}`)
           } catch (error) {
             console.error(error)
             try {
               await confirm({
                 icon: 'exclamation-triangle',
                 message: (
-                  <div>
-                    <p>
-                      <IntlMessage
-                        id='unreachableHost'
-                        values={{
-                          name: this.state.objectsByType
-                            .get('host')
-                            ?.find(host => host.address === this.state.url?.host)?.name_label,
-                        }}
-                      />
-                    </p>
-                    <a href={`${protocol}//${this.state.url?.host}`} rel='noopener noreferrer' target='_blank'>
-                      {this.state.url?.host}
-                    </a>
-                  </div>
+                  <a href={`${protocol}//${url?.host}`} rel='noopener noreferrer' target='_blank'>
+                    <IntlMessage
+                      id='unreachableHost'
+                      values={{
+                        name: objectsByType.get('host')?.find(host => host.address === url?.host)?.name_label,
+                      }}
+                    />
+                  </a>
                 ),
                 title: <IntlMessage id='connectionError' />,
               })
@@ -117,7 +114,7 @@ const Console = withState<State, Props, Effects, Computed, ParentState, ParentEf
         }
 
         if (this.state.tryToReconnect) {
-          this.effects._connect()
+          _connect()
         }
       },
       _connect: async function () {

--- a/@xen-orchestra/lite/src/components/Console.tsx
+++ b/@xen-orchestra/lite/src/components/Console.tsx
@@ -5,7 +5,7 @@ import { fibonacci } from 'iterable-backoff'
 import { withState } from 'reaclette'
 
 import IntlMessage from './IntlMessage'
-import { confirm } from './Modal'
+import { alert, confirm } from './Modal'
 
 import XapiConnection, { ObjectsByType, Vm } from '../libs/xapi'
 
@@ -22,6 +22,7 @@ interface State {
   rfb: any
   rfbConnected: boolean
   timeout?: NodeJS.Timeout
+  url?: URL
 }
 
 interface Props {
@@ -35,7 +36,7 @@ interface ParentEffects {}
 interface Effects {
   _connect: () => Promise<void>
   _handleConnect: () => void
-  _handleDisconnect: () => void
+  _handleDisconnect: () => Promise<void>
   sendCtrlAltDel: () => void
 }
 
@@ -45,6 +46,14 @@ interface PropsStyledConsole {
   scale: number
   visible: boolean
 }
+
+enum Protocols {
+  https = 'https:',
+  http = 'http:',
+  ws = 'ws:',
+  wss = 'wss:',
+}
+
 const StyledConsole = styled.div<PropsStyledConsole>`
   height: ${props => props.scale}%;
   margin: auto;
@@ -60,6 +69,7 @@ const Console = withState<State, Props, Effects, Computed, ParentState, ParentEf
       rfb: undefined,
       rfbConnected: false,
       timeout: undefined,
+      url: undefined,
     }),
     effects: {
       initialize: function () {
@@ -68,9 +78,41 @@ const Console = withState<State, Props, Effects, Computed, ParentState, ParentEf
       _handleConnect: function () {
         this.state.rfbConnected = true
       },
-      _handleDisconnect: function () {
+      _handleDisconnect: async function () {
         this.state.rfbConnected = false
-        this.effects._connect()
+        let reconnect = true
+
+        const protocol = window.location.protocol
+        if (protocol === Protocols.https) {
+          try {
+            await fetch(`${protocol}//${this.state.url?.host}`)
+          } catch (error) {
+            console.error(error)
+            try {
+              await confirm({
+                icon: 'exclamation-triangle',
+                message: (
+                  <div>
+                    <p>
+                      The host seems unreachable. Please verify the host is alive and in case the host use self signed
+                      certificat, ensure your browser support it.
+                    </p>
+                    <a href={`${protocol}//${this.state.url?.host}`} target='_blank' rel='noopener noreferrer'>
+                      {this.state.url?.host}
+                    </a>
+                  </div>
+                ),
+                title: <IntlMessage id='connectionError' />,
+              })
+            } catch {
+              reconnect = false
+            }
+          }
+        }
+
+        if (reconnect) {
+          this.effects._connect()
+        }
       },
       _connect: async function () {
         const { vmId } = this.props
@@ -97,11 +139,11 @@ const Console = withState<State, Props, Effects, Computed, ParentState, ParentEf
               throw new Error('Not connected to XAPI')
             }
 
-            const url = new URL(consoles[0].location)
-            url.protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-            url.searchParams.set('session_id', xapi.sessionId)
+            this.state.url = new URL(consoles[0].location)
+            this.state.url.protocol = window.location.protocol === Protocols.https ? Protocols.wss : Protocols.ws
+            this.state.url.searchParams.set('session_id', xapi.sessionId)
 
-            this.state.rfb = new RFB(this.state.container.current, url, {
+            this.state.rfb = new RFB(this.state.container.current, this.state.url, {
               wsProtocols: ['binary'],
             })
             this.state.rfb.addEventListener('connect', this.effects._handleConnect)

--- a/@xen-orchestra/lite/src/components/Console.tsx
+++ b/@xen-orchestra/lite/src/components/Console.tsx
@@ -49,8 +49,8 @@ interface PropsStyledConsole {
 }
 
 enum Protocols {
-  https = 'https:',
   http = 'http:',
+  https = 'https:',
   ws = 'ws:',
   wss = 'wss:',
 }
@@ -94,7 +94,14 @@ const Console = withState<State, Props, Effects, Computed, ParentState, ParentEf
                 message: (
                   <div>
                     <p>
-                      <IntlMessage id='hostSeemsUnreachable' />
+                      <IntlMessage
+                        id='unreachableHost'
+                        values={{
+                          name: this.state.objectsByType
+                            .get('host')
+                            ?.find(host => host.address === this.state.url?.host)?.name_label,
+                        }}
+                      />
                     </p>
                     <a href={`${protocol}//${this.state.url?.host}`} rel='noopener noreferrer' target='_blank'>
                       {this.state.url?.host}

--- a/@xen-orchestra/lite/src/lang/en.json
+++ b/@xen-orchestra/lite/src/lang/en.json
@@ -6,6 +6,7 @@
   "confirm": "Confirm",
   "confirmCtrlAltDel": "Send Ctrl+Alt+Del to VM?",
   "connect": "Connect",
+  "connectionError": "Connection error",
   "consoleNotAvailable": "Console is only available for running VMs",
   "ctrlAltDel": "Ctrl+Alt+Del",
   "description": "Description",

--- a/@xen-orchestra/lite/src/lang/en.json
+++ b/@xen-orchestra/lite/src/lang/en.json
@@ -16,8 +16,7 @@
   "errorOccurred": "An error has occurred.",
   "gateway": "Gateway",
   "halted": "Halted",
-  "hostSeemsUnreachable": "The host seems to be unreachable. Please verify the host is alive and in case the host use self signed certificat, ensure your browser support it.",
-  "hostUnreachable":"Host unreachable",
+  "hostUnreachable": "Host unreachable",
   "infrastructure": "Infrastructure",
   "ip": "IP",
   "loading": "Loading…",
@@ -39,6 +38,7 @@
   "running": "Running",
   "size": "Size",
   "suspended": "Suspended",
+  "unreachableHost": "The host ({name}) seems to be unreachable. Please verify the host is alive and in case the host use self signed certificat, ensure your browser allow it.",
   "version": "Version",
   "versionValue": "Version {version}",
   "vmStartLabel": "Start"

--- a/@xen-orchestra/lite/src/lang/en.json
+++ b/@xen-orchestra/lite/src/lang/en.json
@@ -38,7 +38,7 @@
   "running": "Running",
   "size": "Size",
   "suspended": "Suspended",
-  "unreachableHost": "The host ({name}) seems to be unreachable. Please verify the host is alive and in case the host use self signed certificat, ensure your browser allow it.",
+  "unreachableHost": "Click here to ensure your ({name}) host is reachable.",
   "version": "Version",
   "versionValue": "Version {version}",
   "vmStartLabel": "Start"

--- a/@xen-orchestra/lite/src/lang/en.json
+++ b/@xen-orchestra/lite/src/lang/en.json
@@ -16,6 +16,8 @@
   "errorOccurred": "An error has occurred.",
   "gateway": "Gateway",
   "halted": "Halted",
+  "hostSeemsUnreachable": "The host seems to be unreachable. Please verify the host is alive and in case the host use self signed certificat, ensure your browser support it.",
+  "hostUnreachable":"Host unreachable",
   "infrastructure": "Infrastructure",
   "ip": "IP",
   "loading": "Loading…",

--- a/@xen-orchestra/lite/src/lang/en.json
+++ b/@xen-orchestra/lite/src/lang/en.json
@@ -38,7 +38,7 @@
   "running": "Running",
   "size": "Size",
   "suspended": "Suspended",
-  "unreachableHost": "Click here to ensure your ({name}) host is reachable.",
+  "unreachableHost": "Click here to make sure your host ({name}) is reachable.",
   "version": "Version",
   "versionValue": "Version {version}",
   "vmStartLabel": "Start"

--- a/@xen-orchestra/lite/src/lang/en.json
+++ b/@xen-orchestra/lite/src/lang/en.json
@@ -38,7 +38,7 @@
   "running": "Running",
   "size": "Size",
   "suspended": "Suspended",
-  "unreachableHost": "Click here to make sure your host ({name}) is reachable.",
+  "unreachableHost": "Click here to make sure your host ({name}) is reachable. You may have to allow self-signed SSL certificates in your browser.",
   "version": "Version",
   "versionValue": "Version {version}",
   "vmStartLabel": "Start"

--- a/@xen-orchestra/lite/src/libs/xapi.ts
+++ b/@xen-orchestra/lite/src/libs/xapi.ts
@@ -64,6 +64,7 @@ interface HostMetrics {
 }
 export interface Host extends XapiObject {
   $metrics: HostMetrics
+  address: string
   name_label: string
   power_state: string
 }


### PR DESCRIPTION
### Description
To test the feature locally, you have to run `xo-lite` using `https` protocol.
For that you can:
Generate a certificat. ([mkcert](https://github.com/FiloSottile/mkcert) for exemple)
Then update `webpack configuration`
```js
// @xen-orchestra/lite/webpack.config.js
...
const fs = require('fs')
...
module.exports = {
   ...
   devServer: {
    ...
    https: true,
    key: fs.readFileSync('/path/to/key.pem'),
    cert:fs.readFileSync('/path/to/pem')
  },
}
```

### Gif

![Peek 14-02-2022 16-09](https://user-images.githubusercontent.com/70369997/153890241-299a960e-63b8-4cbe-94f9-74354d6bcf7a.gif)

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
