### PR TITLE
fix(lite/Select): fix controlled input with undefined value

### DIFF
--- a/@xen-orchestra/lite/src/components/Select.tsx
+++ b/@xen-orchestra/lite/src/components/Select.tsx
@@ -16,7 +16,6 @@ interface State {}
 
 interface Props extends SelectProps {
   additionalProps?: AdditionalProps
-  isControlled?: boolean
   onChange: (e: SelectChangeEvent<unknown>) => void
   optionRenderer?: string | { (item: any): number | string }
   options: any[] | undefined
@@ -66,7 +65,6 @@ const Select = withState<State, Props, Effects, Computed, ParentState, ParentEff
     additionalProps,
     displayEmpty = true,
     effects,
-    isControlled = true,
     multiple,
     options,
     required,
@@ -80,7 +78,7 @@ const Select = withState<State, Props, Effects, Computed, ParentState, ParentEff
         multiple={multiple}
         required={required}
         displayEmpty={displayEmpty}
-        value={value ?? (isControlled ? '' : undefined)}
+        value={value ?? (multiple ? [] : '')}
         {...props}
       >
         {!multiple && (

--- a/@xen-orchestra/lite/src/components/Select.tsx
+++ b/@xen-orchestra/lite/src/components/Select.tsx
@@ -80,7 +80,7 @@ const Select = withState<State, Props, Effects, Computed, ParentState, ParentEff
         multiple={multiple}
         required={required}
         displayEmpty={displayEmpty}
-        value={value ?? (isControlled ? '' : value)}
+        value={value ?? (isControlled ? '' : undefined)}
         {...props}
       >
         {!multiple && (

--- a/@xen-orchestra/lite/src/components/Select.tsx
+++ b/@xen-orchestra/lite/src/components/Select.tsx
@@ -16,6 +16,7 @@ interface State {}
 
 interface Props extends SelectProps {
   additionalProps?: AdditionalProps
+  isControlled?: boolean
   onChange: (e: SelectChangeEvent<unknown>) => void
   optionRenderer?: string | { (item: any): number | string }
   options: any[] | undefined
@@ -61,9 +62,27 @@ const Select = withState<State, Props, Effects, Computed, ParentState, ParentEff
         }),
     },
   },
-  ({ additionalProps, displayEmpty = true, effects, multiple, options, required, resetState, state, ...props }) => (
+  ({
+    additionalProps,
+    displayEmpty = true,
+    effects,
+    isControlled = true,
+    multiple,
+    options,
+    required,
+    resetState,
+    state,
+    value,
+    ...props
+  }) => (
     <FormControl>
-      <SelectMaterialUi multiple={multiple} required={required} displayEmpty={displayEmpty} {...props}>
+      <SelectMaterialUi
+        multiple={multiple}
+        required={required}
+        displayEmpty={displayEmpty}
+        value={value ?? (isControlled ? '' : value)}
+        {...props}
+      >
         {!multiple && (
           <MenuItem value=''>
             <em>


### PR DESCRIPTION
### Description

Fix `MUI: The 'value' prop must be an array when using the 'Select' component with 'multiple'.` in case we toggle the `multiple` prop `false -> true` with a controlled input initialized with undefined value.

### To reproduce

```ts
# reaclette

import Checkbox from '/path/to/Checkbox'
import Select from '/path/to/components/Select'
...
const options = ['Foo', 'Bar']
...
initialState: () => ({
    multiple: false,
    value: []
})
...
effects:  {
    toggleMultiple: function () {
        this.state.multiple = !this.state.multiple
    },
}
...
({ effects, state }) => (
<>
    <Checkbox checked={state.multiple} onChange={effects.toggleMultiple} />
    <Select
        onChange={() => {}}
        multiple={state.multiple}
        value={state.multiple ? state.value : state.value[0]}
        options={options}
    />
</>
)
```

In this case we initialize the `<Select />` component with `state.value[0]` that result to `undefined` value.
For MUI, if the prop `value` is equal to `undefined` it mean the component aren't controlled.
[SelectInput](https://github.com/mui-org/material-ui/blob/master/packages/mui-material/src/Select/SelectInput.js#L135)

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
