### PR TITLE
feat(xo-server): announce appliance in pool.other_config

### DIFF
--- a/@xen-orchestra/mixins/Config.js
+++ b/@xen-orchestra/mixins/Config.js
@@ -41,6 +41,10 @@ module.exports = class Config {
     return parseDuration(this.get(path))
   }
 
+  getOptional(path) {
+    return get(this._config, path)
+  }
+
   watch(path, cb) {
     // internal arg
     const processor = arguments.length > 2 ? arguments[2] : identity

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,3 +27,6 @@
 > - major: if the change breaks compatibility
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
+
+- @xen-orchestra/mixins minor
+- xo-server minor

--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -173,6 +173,10 @@ vdiExportConcurrency = 12
 vmExportConcurrency = 2
 vmSnapshotConcurrency = 2
 
+poolMarkingInterval = '6 hours'
+poolMarkingMaxAge = '48 hours'
+poolMarkingPrefix = 'xo:clientInfo:'
+
 [xo-proxy]
 callTimeout = '1 min'
 

--- a/packages/xo-server/sample.config.toml
+++ b/packages/xo-server/sample.config.toml
@@ -58,6 +58,15 @@
 # configuration.
 # redirectToHttps = true
 
+# Public URL to connect to this XO
+#
+# This optional entry is used to communicate to external entities (e.g. XO Lite)
+# how to connect to this XO.
+#
+# It SHOULD be defined in case the IP address of the current machine is not
+# good enough (e.g. a domain name must be used or there is a reverse proxy).
+#publicUrl = 'https://xoa.company.lan'
+
 # Settings applied to cookies created by xo-server's embedded HTTP server.
 #
 # See https://www.npmjs.com/package/cookie#options-1


### PR DESCRIPTION
It will be used by XO Lite to list available XOs on the pool.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
