### PR TITLE
feat(xo-web/new/sr): add confirmation message before creating local SR

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@
 - [Self service] Change identifiers used for VM templates to avoid them from being removed on XCP-ng upgrade
 - [Proxy] Always connect to XAPI via [backup network if defined](https://xen-orchestra.com/blog/xen-orchestra-5-64/#backupmigrationnetwork)
 - [Backup/File restore] Do not list backups on non-compatible remotes (S3) (PR [#6116](https://github.com/vatesfr/xen-orchestra/pull/6116))
+- [New SR] Add confirmation message before creating local SR (PR [#6121](https://github.com/vatesfr/xen-orchestra/pull/6121))
 
 ### Packages to release
 
@@ -40,4 +41,4 @@
 - @xen-orchestra/proxy patch
 - xo-cli minor
 - xo-server minor
-- xo-web patch
+- xo-web minor

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -595,7 +595,7 @@ const messages = {
 
   newSr: 'New SR',
   newSrConfirm:
-    'This will erase the entire disk or partition to create a new storage repository. Are you sure you want to continue?',
+    'This will erase the entire disk ({name}) or partition to create a new storage repository. Are you sure you want to continue?',
   newSrTitle: 'Create a new SR',
   newSrGeneral: 'General',
   newSrTypeSelection: 'Select storage type:',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -595,7 +595,7 @@ const messages = {
 
   newSr: 'New SR',
   newSrConfirm:
-    'This will erase the entire disk ({name}) or partition to create a new storage repository. Are you sure you want to continue?',
+    'This will erase the entire disk or partition ({name}) to create a new storage repository. Are you sure you want to continue?',
   newSrTitle: 'Create a new SR',
   newSrGeneral: 'General',
   newSrTypeSelection: 'Select storage type:',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -592,8 +592,9 @@ const messages = {
   remotePlaceHolderPassword: 'Password(fill to edit)',
 
   // ------ New Storage -----
-  createSrConfirm: 'New SR',
-  createSrConfirmMessage:
+
+  newSr: 'New SR',
+  newSrConfirm:
     'This will erase the entire disk or partition to create a new storage repository. Are you sure you want to continue?',
   newSrTitle: 'Create a new SR',
   newSrGeneral: 'General',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -592,6 +592,9 @@ const messages = {
   remotePlaceHolderPassword: 'Password(fill to edit)',
 
   // ------ New Storage -----
+  createSrConfirm: 'New SR',
+  createSrConfirmMessage:
+    'This will erase the entire disk or partition to create a new storage repository. Are you sure you want to continue?',
   newSrTitle: 'Create a new SR',
   newSrGeneral: 'General',
   newSrTypeSelection: 'Select storage type:',

--- a/packages/xo-web/src/xo-app/new/sr/index.js
+++ b/packages/xo-web/src/xo-app/new/sr/index.js
@@ -360,8 +360,8 @@ export default class New extends Component {
       if (type === 'ext' || type === 'lvm' || type === 'zfs' || type === 'local') {
         try {
           await confirm({
-            title: _('createSrConfirm', { type }),
-            body: <p>{_('createSrConfirmMessage')}</p>,
+            title: _('newSr'),
+            body: <p>{_('newSrConfirm')}</p>,
           })
         } catch (e) {
           return

--- a/packages/xo-web/src/xo-app/new/sr/index.js
+++ b/packages/xo-web/src/xo-app/new/sr/index.js
@@ -356,6 +356,18 @@ export default class New extends Component {
     }
 
     try {
+      // local SR
+      if (type === 'ext' || type === 'lvm' || type === 'zfs' || type === 'local') {
+        try {
+          await confirm({
+            title: _('createSrConfirm', { type }),
+            body: <p>{_('createSrConfirmMessage')}</p>,
+          })
+        } catch (e) {
+          return
+        }
+      }
+
       return await createMethodFactories[type]()
     } catch (err) {
       error('SR Creation', err.message || String(err))

--- a/packages/xo-web/src/xo-app/new/sr/index.js
+++ b/packages/xo-web/src/xo-app/new/sr/index.js
@@ -361,7 +361,7 @@ export default class New extends Component {
       if (SR_TYPE_REQUIRE_DISK_FORMATTING.includes(type)) {
         await confirm({
           title: _('newSr'),
-          body: <p>{_('newSrConfirm')}</p>,
+          body: <p>{_('newSrConfirm', { name: device.value })}</p>,
         })
       }
       return await createMethodFactories[type]()

--- a/packages/xo-web/src/xo-app/new/sr/index.js
+++ b/packages/xo-web/src/xo-app/new/sr/index.js
@@ -184,6 +184,8 @@ const SR_GROUP_TO_LABEL = {
   isosr: 'ISO SR',
 }
 
+const SR_TYPE_REQUIRE_DISK_FORMATTING = ['ext', 'lvm']
+
 const typeGroups = {
   vdisr: ['ext', 'hba', 'iscsi', 'lvm', 'nfs', 'zfs'],
   isosr: ['local', 'nfsiso', 'smb'],
@@ -356,20 +358,17 @@ export default class New extends Component {
     }
 
     try {
-      // local SR
-      if (type === 'ext' || type === 'lvm' || type === 'zfs' || type === 'local') {
-        try {
-          await confirm({
-            title: _('newSr'),
-            body: <p>{_('newSrConfirm')}</p>,
-          })
-        } catch (e) {
-          return
-        }
+      if (SR_TYPE_REQUIRE_DISK_FORMATTING.includes(type)) {
+        await confirm({
+          title: _('newSr'),
+          body: <p>{_('newSrConfirm')}</p>,
+        })
       }
-
       return await createMethodFactories[type]()
     } catch (err) {
+      if (err === undefined) {
+        return
+      }
       error('SR Creation', err.message || String(err))
     }
   }


### PR DESCRIPTION
See #5996 

### Screenshots

![Capture d’écran de 2022-02-23 18-23-10](https://user-images.githubusercontent.com/7724491/155373053-c005c07e-236d-4248-bf98-75ef19563b21.png)


### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
