### PR TITLE
feat(docs/backup_troubleshooting): Lock file is already being held

### DIFF
--- a/docs/backup_troubleshooting.md
+++ b/docs/backup_troubleshooting.md
@@ -90,10 +90,10 @@ This error can be caused by leaving any removable device (such as USB storage) a
 
 ## Error: Lock file is already being held
 
-This error message shows in the logs in the case of a failed backup job. It means that the VM’s folder is already used by a process. This could be:
-- another backup job,
-- a merge process on the Virtual Hard Disk (VHD).
+This error message appears in the logs in some instances of a failed backup job. It means that the VM’s folder on the remote is already used by a process. This could be:
+- another backup job
+- a merge process on the Virtual Hard Disk (VHD)
 
-To solve the issue, we recommend you to:
-- wait until the other backup job is completed/the merge process is done.
-- make sure your remote storage is not being overworked.
+To solve this issue, we recommend that you:
+- wait until the other backup job is completed/the merge process is done
+- make sure your remote storage is not being overworked

--- a/docs/backup_troubleshooting.md
+++ b/docs/backup_troubleshooting.md
@@ -87,3 +87,13 @@ Edit your job and try to see matching VMs or check if your pool is connected to 
 ## Error: SR_OPERATION_NOT_SUPPORTED
 
 This error can be caused by leaving any removable device (such as USB storage) attached to the VM that you are backing up or snapshotting, detach the device and retry. This can also be caused if you created a VM disk using the [RAW format](https://xcp-ng.org/docs/storage.html#using-raw-format).
+
+## Error: Lock file is already being held
+
+This error message shows in the logs in the case of a failed backup job. It means that the VM’s folder is already used by a process. This could be:
+- another backup job,
+- a merge process on the Virtual Hard Disk (VHD).
+
+To solve the issue, we recommend you to:
+- wait until the other backup job is completed/the merge process is done.
+- make sure your remote storage is not being overworked.


### PR DESCRIPTION
Dear team, please review the changes and let me know if I can do anything to assist.

Thank you in advance for your time.

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
