### PR TITLE
feat(stats): add http proxy support for stat and resource upload

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Vm stats] : support http proxy [#6132](https://github.com/vatesfr/xen-orchestra/pull/6132)
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -32,4 +34,4 @@
 
 - xen-api major
 - vhd-cli minor
-- xo-server patch
+- xo-server minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,7 +7,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [Vm stats] : support http proxy [#6132](https://github.com/vatesfr/xen-orchestra/pull/6132)
+- [Vm stats] : support http proxy and resource upload [#6132](https://github.com/vatesfr/xen-orchestra/pull/6132)
 
 ### Bug fixes
 

--- a/packages/xen-api/src/index.js
+++ b/packages/xen-api/src/index.js
@@ -3,6 +3,7 @@ import dns from 'dns'
 import kindOf from 'kindof'
 import ms from 'ms'
 import httpRequest from 'http-request-plus'
+import ProxyAgent from 'proxy-agent'
 import { coalesceCalls } from '@vates/coalesce-calls'
 import { Collection } from 'xo-collection'
 import { EventEmitter } from 'events'
@@ -373,6 +374,10 @@ export class Xapi extends EventEmitter {
     url.pathname = pathname
     url.search = new URLSearchParams(query)
     await this._setHostAddressInUrl(url, host)
+    let agent
+    if (this._httpProxy !== undefined) {
+      agent = new ProxyAgent(this._httpProxy)
+    }
 
     const response = await pRetry(
       async () =>
@@ -386,6 +391,7 @@ export class Xapi extends EventEmitter {
 
           // Support XS <= 6.5 with Node => 12
           minVersion: 'TLSv1',
+          agent,
         }),
       {
         when: { code: 302 },

--- a/packages/xen-api/src/index.js
+++ b/packages/xen-api/src/index.js
@@ -475,6 +475,7 @@ export class Xapi extends EventEmitter {
           query: 'task_id' in query ? omit(query, 'task_id') : query,
 
           maxRedirects: 0,
+          agent: this._httpProxyAgent,
         }).then(
           response => {
             response.cancel()

--- a/packages/xen-api/src/transports/json-rpc.js
+++ b/packages/xen-api/src/transports/json-rpc.js
@@ -1,5 +1,4 @@
 import httpRequestPlus from 'http-request-plus'
-import ProxyAgent from 'proxy-agent'
 import { format, parse } from 'json-rpc-protocol'
 
 import XapiError from '../_XapiError'
@@ -7,11 +6,7 @@ import XapiError from '../_XapiError'
 import UnsupportedTransport from './_UnsupportedTransport'
 
 // https://github.com/xenserver/xenadmin/blob/0df39a9d83cd82713f32d24704852a0fd57b8a64/XenModel/XenAPI/Session.cs#L403-L433
-export default ({ secureOptions, url, httpProxy }) => {
-  let agent
-  if (httpProxy !== undefined) {
-    agent = new ProxyAgent(httpProxy)
-  }
+export default ({ secureOptions, url, agent }) => {
   return (method, args) =>
     httpRequestPlus
       .post(url, {

--- a/packages/xen-api/src/transports/xml-rpc-json.js
+++ b/packages/xen-api/src/transports/xml-rpc-json.js
@@ -1,6 +1,5 @@
 import { createClient, createSecureClient } from 'xmlrpc'
 import { promisify } from 'promise-toolbox'
-import ProxyAgent from 'proxy-agent'
 
 import XapiError from '../_XapiError'
 
@@ -71,12 +70,8 @@ const parseResult = result => {
   throw new UnsupportedTransport()
 }
 
-export default ({ secureOptions, url: { hostname, port, protocol }, httpProxy }) => {
+export default ({ secureOptions, url: { hostname, port, protocol }, agent }) => {
   const secure = protocol === 'https:'
-  let agent
-  if (httpProxy !== undefined) {
-    agent = new ProxyAgent(httpProxy)
-  }
   const client = (secure ? createSecureClient : createClient)({
     ...(secure ? secureOptions : undefined),
     agent,

--- a/packages/xen-api/src/transports/xml-rpc.js
+++ b/packages/xen-api/src/transports/xml-rpc.js
@@ -1,6 +1,5 @@
 import { createClient, createSecureClient } from 'xmlrpc'
 import { promisify } from 'promise-toolbox'
-import ProxyAgent from 'proxy-agent'
 
 import XapiError from '../_XapiError'
 
@@ -31,12 +30,8 @@ const parseResult = result => {
   return result.Value
 }
 
-export default ({ secureOptions, url: { hostname, port, protocol, httpProxy } }) => {
+export default ({ secureOptions, url: { hostname, port, protocol, agent } }) => {
   const secure = protocol === 'https:'
-  let agent
-  if (httpProxy !== undefined) {
-    agent = new ProxyAgent(httpProxy)
-  }
   const client = (secure ? createSecureClient : createClient)({
     ...(secure ? secureOptions : undefined),
     agent,


### PR DESCRIPTION
Continuation of 2412f8b1e

To test: 
create a folder in `/tmp/proxy`

1. get the squid.conf file [squid.conf.txt](https://github.com/vatesfr/xen-orchestra/files/8190420/squid.conf.txt) and remove the .txt extension in `/tmp/proxy`
2. launch the proxy with the command : `docker run --name squid -d --restart=always   --publish 3128:3128   --volume /tmp/proxy/squid.conf:/etc/squid/squid.conf   sameersbn/squid:latest`
3. Set the proxy to `http://localhost:3128/` in the server view 

Xo should still work , especially the stats and exports

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.


