### PR TITLE
feat(console): support consoles behind  HTTP proxy

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Console] Supports host and VM consoles behind HTTP proxies [#6133](https://github.com/vatesfr/xen-orchestra/pull/6133)
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”

--- a/packages/xen-api/src/transports/json-rpc.js
+++ b/packages/xen-api/src/transports/json-rpc.js
@@ -1,5 +1,4 @@
 import httpRequestPlus from 'http-request-plus'
-import ProxyAgent from 'proxy-agent'
 import { format, parse } from 'json-rpc-protocol'
 
 import XapiError from '../_XapiError'
@@ -7,11 +6,7 @@ import XapiError from '../_XapiError'
 import UnsupportedTransport from './_UnsupportedTransport'
 
 // https://github.com/xenserver/xenadmin/blob/0df39a9d83cd82713f32d24704852a0fd57b8a64/XenModel/XenAPI/Session.cs#L403-L433
-export default ({ secureOptions, url, httpProxy }) => {
-  let agent
-  if (httpProxy !== undefined) {
-    agent = new ProxyAgent(httpProxy)
-  }
+export default ({ secureOptions, url, agent }) => {
   return (method, args) =>
     httpRequestPlus
       .post(url, {

--- a/packages/xen-api/src/transports/xml-rpc-json.js
+++ b/packages/xen-api/src/transports/xml-rpc-json.js
@@ -1,6 +1,5 @@
 import { createClient, createSecureClient } from 'xmlrpc'
 import { promisify } from 'promise-toolbox'
-import ProxyAgent from 'proxy-agent'
 
 import XapiError from '../_XapiError'
 
@@ -71,12 +70,8 @@ const parseResult = result => {
   throw new UnsupportedTransport()
 }
 
-export default ({ secureOptions, url: { hostname, port, protocol }, httpProxy }) => {
+export default ({ secureOptions, url: { hostname, port, protocol }, agent }) => {
   const secure = protocol === 'https:'
-  let agent
-  if (httpProxy !== undefined) {
-    agent = new ProxyAgent(httpProxy)
-  }
   const client = (secure ? createSecureClient : createClient)({
     ...(secure ? secureOptions : undefined),
     agent,

--- a/packages/xen-api/src/transports/xml-rpc.js
+++ b/packages/xen-api/src/transports/xml-rpc.js
@@ -1,6 +1,5 @@
 import { createClient, createSecureClient } from 'xmlrpc'
 import { promisify } from 'promise-toolbox'
-import ProxyAgent from 'proxy-agent'
 
 import XapiError from '../_XapiError'
 
@@ -31,12 +30,8 @@ const parseResult = result => {
   return result.Value
 }
 
-export default ({ secureOptions, url: { hostname, port, protocol, httpProxy } }) => {
+export default ({ secureOptions, url: { hostname, port, protocol, agent } }) => {
   const secure = protocol === 'https:'
-  let agent
-  if (httpProxy !== undefined) {
-    agent = new ProxyAgent(httpProxy)
-  }
   const client = (secure ? createSecureClient : createClient)({
     ...(secure ? secureOptions : undefined),
     agent,

--- a/packages/xo-server/src/index.mjs
+++ b/packages/xo-server/src/index.mjs
@@ -683,7 +683,7 @@ const setUpConsoleProxy = (webServer, xo) => {
 
       // FIXME: lost connection due to VM restart is not detected.
       webSocketServer.handleUpgrade(req, socket, head, connection => {
-        proxyConsole(connection, vmConsole, xapi.sessionId)
+        proxyConsole(connection, vmConsole, xapi.sessionId, xapi.httpAgent)
       })
     } catch (error) {
       try {

--- a/packages/xo-server/src/proxy-console.mjs
+++ b/packages/xo-server/src/proxy-console.mjs
@@ -1,16 +1,16 @@
-import partialStream from 'partial-stream'
-import { connect } from 'tls'
 import { createLogger } from '@xen-orchestra/log'
-import { parse } from 'url'
+import { URL } from 'url'
+import WebSocket from 'ws'
 
 const log = createLogger('xo:proxy-console')
 
-export default function proxyConsole(ws, vmConsole, sessionId) {
-  const url = parse(vmConsole.location)
-  let { hostname } = url
+export default function proxyConsole(ws, vmConsole, sessionId, agent) {
+  const url = new URL(vmConsole.location)
+  url.protocol = 'wss:'
+  const { hostname } = url
   if (hostname === null || hostname === '') {
     const { address } = vmConsole.$VM.$resident_on
-    hostname = address
+    url.hostname = address
 
     log.warn(
       `host is missing in console (${vmConsole.uuid}) URI (${vmConsole.location}) using host address (${address}) as fallback`
@@ -19,72 +19,48 @@ export default function proxyConsole(ws, vmConsole, sessionId) {
 
   let closed = false
 
-  const socket = connect(
-    {
-      host: hostname,
-      port: url.port || 443,
-      rejectUnauthorized: false,
-
-      // Support XS <= 6.5 with Node => 12
-      minVersion: 'TLSv1',
-    },
-    () => {
-      // Write headers.
-      socket.write(
-        [`CONNECT ${url.path} HTTP/1.0`, `Host: ${hostname}`, `Cookie: session_id=${sessionId}`, '', ''].join('\r\n')
-      )
-
-      const onSend = error => {
-        if (error) {
-          log.debug('error sending to the XO client:', { error })
-        }
-      }
-
-      socket
-        .pipe(
-          partialStream('\r\n\r\n', headers => {
-            // TODO: check status code 200.
-            log.debug('connected')
-          })
-        )
-        .on('data', data => {
-          if (!closed) {
-            ws.send(data, onSend)
-          }
-        })
-        .on('end', () => {
-          if (!closed) {
-            closed = true
-            log.debug('disconnected from the console')
-          }
-
-          ws.close()
-        })
-
-      ws.on('error', error => {
-        closed = true
-        log.debug('error from the XO client:', { error })
-
-        socket.end()
-      })
-        .on('message', data => {
-          if (!closed) {
-            socket.write(data)
-          }
-        })
-        .on('close', () => {
-          if (!closed) {
-            closed = true
-            log.debug('disconnected from the XO client')
-          }
-
-          socket.end()
-        })
+  const onSend = error => {
+    if (error) {
+      log.debug('error sending to the XO client:', { error })
     }
-  ).on('error', error => {
-    closed = true
-    log.debug('error from the console:', { error })
+  }
 
-    ws.close()
+  const socket = new WebSocket(url, ['binary'], {
+    agent,
+    rejectUnauthorized: false,
+    headers: {
+      cookie: `session_id=${sessionId}`,
+    },
   })
+
+  socket
+    .on('message', data => {
+      if (!closed) {
+        ws.send(data, onSend)
+      }
+    })
+    .on('error', error => {
+      log.warn('error,', error, socket.protocol)
+    })
+    .on('close', () => {
+      closed = true
+      ws.close()
+    })
+
+  ws.on('error', error => {
+    closed = true
+    log.debug('error from the XO client:', { error })
+    socket.end()
+  })
+    .on('message', data => {
+      if (!closed) {
+        socket.send(data, { binary: true })
+      }
+    })
+    .on('close', () => {
+      if (!closed) {
+        closed = true
+        log.debug('disconnected from the XO client')
+      }
+    })
 }


### PR DESCRIPTION
This is a major change in the way xo-server connect to a console, from connecting directly as a TCP socket to using a WebSocket in binary mode.

This was already the case prior c17620efb but was changed due to XenServer issues with their WebSocket console implementation, it appears to be working fine now.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
