### PR TITLE
feat(decorate-with): decorateClass()

### DIFF
--- a/@vates/decorate-with/.USAGE.md
+++ b/@vates/decorate-with/.USAGE.md
@@ -40,9 +40,9 @@ decorateClass(Foo, {
     // without arguments
     get: lodash.memoize,
 
-  // with arguments
-    set: [lodash.debounce, 150]
-  }
+    // with arguments
+    set: [lodash.debounce, 150],
+  },
 
   // method (with or without arguments)
   baz: lodash.curry,

--- a/@vates/decorate-with/.USAGE.md
+++ b/@vates/decorate-with/.USAGE.md
@@ -13,15 +13,19 @@ class Foo {
 }
 ```
 
-### `decorateMethodsWith(class, map)`
+### `decorateClass(class, map)`
 
-Decorates a number of methods directly, without using the decorator syntax:
+Decorates a number of accessors and methods directly, without using the decorator syntax:
 
 ```js
-import { decorateMethodsWith } from '@vates/decorate-with'
+import { decorateClass } from '@vates/decorate-with'
 
 class Foo {
-  bar() {
+  get bar() {
+    // body
+  }
+
+  set bar(value) {
     // body
   }
 
@@ -30,22 +34,28 @@ class Foo {
   }
 }
 
-decorateMethodsWith(Foo, {
-  // without arguments
-  bar: lodash.curry,
+decorateClass(Foo, {
+  // getter and/or setter
+  bar: {
+    // without arguments
+    get: lodash.memoize,
 
   // with arguments
-  baz: [lodash.debounce, 150],
+    set: [lodash.debounce, 150]
+  }
+
+  // method (with or without arguments)
+  baz: lodash.curry,
 })
 ```
 
 The decorated class is returned, so you can export it directly.
 
-To apply multiple transforms to a method, you can either call `decorateMethodsWith` multiple times or use [`@vates/compose`](https://www.npmjs.com/package/@vates/compose):
+To apply multiple transforms to an accessor/method, you can either call `decorateClass` multiple times or use [`@vates/compose`](https://www.npmjs.com/package/@vates/compose):
 
 ```js
-decorateMethodsWith(Foo, {
-  bar: compose([
+decorateClass(Foo, {
+  baz: compose([
     [lodash.debounce, 150]
     lodash.curry,
   ])
@@ -69,4 +79,8 @@ class Foo {
 }
 ```
 
-Because it's a normal function, it can also be used with `decorateMethodsWith`, with `compose` or even by itself.
+Because it's a normal function, it can also be used with `decorateClass`, with `compose` or even by itself.
+
+### `decorateMethodsWith(class, map)`
+
+> Deprecated alias for [`decorateClass(class, map)`](#decorateclassclass-map).

--- a/@vates/decorate-with/README.md
+++ b/@vates/decorate-with/README.md
@@ -58,9 +58,9 @@ decorateClass(Foo, {
     // without arguments
     get: lodash.memoize,
 
-  // with arguments
-    set: [lodash.debounce, 150]
-  }
+    // with arguments
+    set: [lodash.debounce, 150],
+  },
 
   // method (with or without arguments)
   baz: lodash.curry,

--- a/@vates/decorate-with/README.md
+++ b/@vates/decorate-with/README.md
@@ -31,15 +31,19 @@ class Foo {
 }
 ```
 
-### `decorateMethodsWith(class, map)`
+### `decorateClass(class, map)`
 
-Decorates a number of methods directly, without using the decorator syntax:
+Decorates a number of accessors and methods directly, without using the decorator syntax:
 
 ```js
-import { decorateMethodsWith } from '@vates/decorate-with'
+import { decorateClass } from '@vates/decorate-with'
 
 class Foo {
-  bar() {
+  get bar() {
+    // body
+  }
+
+  set bar(value) {
     // body
   }
 
@@ -48,22 +52,28 @@ class Foo {
   }
 }
 
-decorateMethodsWith(Foo, {
-  // without arguments
-  bar: lodash.curry,
+decorateClass(Foo, {
+  // getter and/or setter
+  bar: {
+    // without arguments
+    get: lodash.memoize,
 
   // with arguments
-  baz: [lodash.debounce, 150],
+    set: [lodash.debounce, 150]
+  }
+
+  // method (with or without arguments)
+  baz: lodash.curry,
 })
 ```
 
 The decorated class is returned, so you can export it directly.
 
-To apply multiple transforms to a method, you can either call `decorateMethodsWith` multiple times or use [`@vates/compose`](https://www.npmjs.com/package/@vates/compose):
+To apply multiple transforms to an accessor/method, you can either call `decorateClass` multiple times or use [`@vates/compose`](https://www.npmjs.com/package/@vates/compose):
 
 ```js
-decorateMethodsWith(Foo, {
-  bar: compose([
+decorateClass(Foo, {
+  baz: compose([
     [lodash.debounce, 150]
     lodash.curry,
   ])
@@ -87,7 +97,11 @@ class Foo {
 }
 ```
 
-Because it's a normal function, it can also be used with `decorateMethodsWith`, with `compose` or even by itself.
+Because it's a normal function, it can also be used with `decorateClass`, with `compose` or even by itself.
+
+### `decorateMethodsWith(class, map)`
+
+> Deprecated alias for [`decorateClass(class, map)`](#decorateclassclass-map).
 
 ## Contributions
 

--- a/@vates/decorate-with/index.spec.js
+++ b/@vates/decorate-with/index.spec.js
@@ -93,7 +93,7 @@ describe('decorateClass', function () {
     assert.deepStrictEqual(newDescriptors.qux, { ...descriptors.qux, set: newSetQux })
   })
 
-  it('throws if using a accessor decorator for a method', function () {
+  it('throws if using an accessor decorator for a method', function () {
     assert.throws(() =>
       decorateClass(
         class {

--- a/@vates/decorate-with/index.spec.js
+++ b/@vates/decorate-with/index.spec.js
@@ -33,8 +33,8 @@ describe('decorateWith', () => {
   })
 })
 
-describe('decorateClass', function () {
-  it('works', function () {
+describe('decorateClass', () => {
+  it('works', () => {
     class C {
       foo() {}
       bar() {}

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,6 +32,7 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
+- @vates/decorate-with major
 - xen-api major
 - @xen-orchestra/xapi minor
 - vhd-cli minor


### PR DESCRIPTION
Generalization of `decorateMethodsWith` which also works for accessors.

The suffix `With` is not part of the name because it's not fluent (unlike for `@decorateWith(decorator)`).

`decorateMethodsWith` is now a deprecated alias for this new implementation.

### Check list

> Check if done, if not relevant leave unchecked.

- [x] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [x] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
