### PR TITLE
Revert "fix(xo-web/job): properly handle array arguments (#5944)"

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@
 - [Backup/Restore] Fix missing backups on Backblaze
 - [Templates] Fix "incorrect state" error when trying to delete a default template [#6124](https://github.com/vatesfr/xen-orchestra/issues/6124) (PR [#6119](https://github.com/vatesfr/xen-orchestra/pull/6119))
 - [New SR] Fix "SR_BACKEND_FAILURE_103" error when selecting "No selected value" for the path [#5991](https://github.com/vatesfr/xen-orchestra/issues/5991) (PR [#6137](https://github.com/vatesfr/xen-orchestra/pull/6137))
+- [Jobs] Fix "invalid parameters" error when running jobs in some cases (PR [#6156](https://github.com/vatesfr/xen-orchestra/pull/6156))
 
 ### Packages to release
 

--- a/packages/xo-web/src/xo-app/jobs/new/index.js
+++ b/packages/xo-web/src/xo-app/jobs/new/index.js
@@ -93,10 +93,10 @@ const reduceObject = (value, propertyName = 'id') => (value != null && value[pro
 /**
  * Adapts all data "arrayed" by UI-multiple-selectors to job's cross-product trick
  */
-const dataToParamVectorItems = function (params, data, properties) {
+const dataToParamVectorItems = function (params, data) {
   const items = []
   forEach(params, (param, name) => {
-    if (properties[name].multi && param.items) {
+    if (Array.isArray(data[name]) && param.items) {
       // We have an array for building cross product, the "real" type was $type
       const values = []
       if (data[name].length === 1) {
@@ -287,9 +287,8 @@ export default class Jobs extends Component {
 
   _handleSubmit = () => {
     const { name, method, params } = this.refs
-    const { action, actions, job, owner, timeout } = this.state
 
-    const _action = job === undefined ? action : find(actions, { method: job.method })
+    const { job, owner, timeout } = this.state
     const _job = {
       type: 'call',
       name: name.value,
@@ -297,7 +296,7 @@ export default class Jobs extends Component {
       method: method.value.method,
       paramsVector: {
         type: 'crossProduct',
-        items: dataToParamVectorItems(method.value.info.properties, params.value, _action.uiSchema.properties),
+        items: dataToParamVectorItems(method.value.info.properties, params.value),
       },
       userId: owner !== undefined ? owner : this.props.currentUser.id,
       timeout: timeout ? timeout * 1e3 : undefined,


### PR DESCRIPTION
This reverts commit e2e453985fb7271145874e4765d4c97010e1b673.

See #5983
See #5973
See zammad#5844

This change broke other methods' params.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
