### PR TITLE
fix(xo-server): typo in authorization level enterprise

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Backup] Fix `plan enterprise is not defined in the PLANS object` (PR [#6168](https://github.com/vatesfr/xen-orchestra/pull/6168))
+
 ### Packages to release
 
 > Packages will be released in the order they are here, therefore, they should
@@ -27,3 +29,5 @@
 > - major: if the change breaks compatibility
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
+
+- xo-server patch

--- a/packages/xo-server/src/xo-mixins/authorization.mjs
+++ b/packages/xo-server/src/xo-mixins/authorization.mjs
@@ -4,24 +4,24 @@ import assert from 'assert'
 
 const FREE = 1
 const STARTER = 2
-const ENTREPRISE = 3
+const ENTERPRISE = 3
 const PREMIUM = 4
 
 export const PLANS = {
   free: FREE,
   starter: STARTER,
-  entreprise: ENTREPRISE,
+  enterprise: ENTERPRISE,
   premium: PREMIUM,
 }
 
 const AUTHORIZATIONS = {
   BACKUP: {
     DELTA: STARTER,
-    DELTA_REPLICATION: ENTREPRISE,
+    DELTA_REPLICATION: ENTERPRISE,
     FULL: STARTER,
-    METADATA: ENTREPRISE,
-    WITH_RAM: ENTREPRISE,
-    SMART_BACKUP: ENTREPRISE,
+    METADATA: ENTERPRISE,
+    WITH_RAM: ENTERPRISE,
+    SMART_BACKUP: ENTERPRISE,
     S3: STARTER,
   },
   DOCKER: STARTER, // @todo  _doDockerAction in xen-orchestra/packages/xo-server/src/xapi/index.mjs


### PR DESCRIPTION
Introduced by 8ce1b4bf71522ce53531eae7c5eb8e996c8c318e
See zammad#6043

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [x] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
