### PR TITLE
fix(xo-server/config): configure plugins on config import

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Plugins] Automatically configure plugins when a configuration file is imported
+
 ### Packages to release
 
 > Packages will be released in the order they are here, therefore, they should
@@ -30,3 +32,4 @@
 
 - xen-api minor
 - @xen-orchestra/proxy patch
+- xo-server patch

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [Plugins] Automatically configure plugins when a configuration file is imported
+- [Plugins] Automatically configure plugins when a configuration file is imported (PR [#6171](https://github.com/vatesfr/xen-orchestra/pull/6171))
 
 ### Packages to release
 

--- a/packages/xo-server/src/xo-mixins/plugins.mjs
+++ b/packages/xo-server/src/xo-mixins/plugins.mjs
@@ -27,7 +27,17 @@ export default class {
       app.addConfigManager(
         'plugins',
         () => this._pluginsMetadata.get(),
-        plugins => Promise.all(plugins.map(plugin => this._pluginsMetadata.save(plugin)))
+        plugins =>
+          Promise.all(
+            plugins.map(async plugin => {
+              const metadata = await this._pluginsMetadata.save(plugin)
+              if (plugin.configuration !== undefined && this._plugins[plugin.id] !== undefined) {
+                await this.configurePlugin(plugin.id, plugin.configuration)
+              }
+
+              return metadata
+            })
+          )
       )
     })
   }

--- a/packages/xo-server/src/xo-mixins/plugins.mjs
+++ b/packages/xo-server/src/xo-mixins/plugins.mjs
@@ -30,12 +30,10 @@ export default class {
         plugins =>
           Promise.all(
             plugins.map(async plugin => {
-              const metadata = await this._pluginsMetadata.save(plugin)
+              await this._pluginsMetadata.save(plugin)
               if (plugin.configuration !== undefined && this._plugins[plugin.id] !== undefined) {
                 await this.configurePlugin(plugin.id, plugin.configuration)
               }
-
-              return metadata
             })
           )
       )


### PR DESCRIPTION
See https://xcp-ng.org/forum/topic/5720/ztp-restore-xoa-from-backup

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
