### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,7 @@ user = 'nobody'
 group = 'nogroup'
 ```
 
-**Warning!** A non-privileged user requires the use of `sudo` to mount NFS shares. See [installation from the sources](from_the_sources.md).
+**Warning!** A non-privileged user requires the use of `sudo` to mount NFS shares. See [installation from the sources](installation.md#from-the-sources).
 
 ## HTTP listen address and port
 


### PR DESCRIPTION
There was / is a broken link on the "Configuration" documentation page (https://xen-orchestra.com/docs/configuration.html#user-to-run-xo-server-as).  
This PR updates the link to point to the correct target.

I tested the change using the vuepress dev server and confirmed the fixed link is working.  
To reproduce the check run `yarn docs:dev`, visit http://127.0.0.1:8080/docs/configuration.html#user-to-run-xo-server-as and click on the link.