### PR TITLE
fix(xo-server/proxy-console): don't close client socket before legacy fallback

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,3 +27,5 @@
 > - major: if the change breaks compatibility
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
+
+- xo-server patch

--- a/packages/xo-server/src/proxy-console.mjs
+++ b/packages/xo-server/src/proxy-console.mjs
@@ -79,18 +79,20 @@ export default async function proxyConsole(clientSocket, vmConsole, sessionId, a
       log.debug('error from the client', { error })
     })
     .add('message', data => sendToServer(data))
-  serverEvents
-    .add('close', (code, reason) => {
-      log.debug('disconnected from the server', { code, reason })
-      close(clientSocket)
-    })
-    .add('error', error => {
-      log.debug('error from the server', { error })
-    })
-    .add('message', createSend(clientSocket, 'client'))
+  serverEvents.add('message', createSend(clientSocket, 'client'))
 
   try {
     await fromEvent(serverSocket, 'open')
+
+    // add close and event handler after the socket really openned
+    serverEvents
+      .add('close', (code, reason) => {
+        log.debug('disconnected from the server', { code, reason })
+        close(clientSocket)
+      })
+      .add('error', error => {
+        log.debug('error from the server', { error })
+      })
   } catch (error) {
     clientEvents.removeAll()
     serverEvents.removeAll()

--- a/packages/xo-server/src/proxy-console.mjs
+++ b/packages/xo-server/src/proxy-console.mjs
@@ -84,7 +84,7 @@ export default async function proxyConsole(clientSocket, vmConsole, sessionId, a
   try {
     await fromEvent(serverSocket, 'open')
 
-    // add close and event handler after the socket really openned
+    // add close and event handler after the socket really opened to avoid breaking legacy fallback
     serverEvents
       .add('close', (code, reason) => {
         log.debug('disconnected from the server', { code, reason })


### PR DESCRIPTION
a race condition was closing the socket when fallin back to legacy code. Add the error/close listenner only when the sock

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
