### PR TITLE
fix(xo-server/checkBackupNg): wait for VM to be running before watching guest metrics

### DIFF
--- a/@xen-orchestra/xapi/index.js
+++ b/@xen-orchestra/xapi/index.js
@@ -191,7 +191,30 @@ class Xapi extends Base {
     }
     return removeWatcher.bind(watchers, predicate, cb)
   }
+
+  // wait for an object to be in a specified state
+
+  waitObjectState(refOrUuid, predicate, { timeout } = {}) {
+    return new Promise((resolve, reject) => {
+      let timeoutHandle
+      const stop = this.watchObject(refOrUuid, object => {
+        if (predicate(object)) {
+          clearTimeout(timeoutHandle)
+          stop()
+          resolve(object)
+        }
+      })
+
+      if (timeout !== undefined) {
+        timeoutHandle = setTimeout(() => {
+          stop()
+          reject(new Error(`waitObjectState: timeout reached before ${refOrUuid} in expected state`))
+        }, timeout)
+      }
+    })
+  }
 }
+
 function mixin(mixins) {
   const xapiProto = Xapi.prototype
   const { defineProperties, getOwnPropertyDescriptor, getOwnPropertyNames } = Object

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,3 +27,5 @@
 > - major: if the change breaks compatibility
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
+
+- xo-server patch

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,4 +28,5 @@
 >
 > In case of conflict, the highest (lowest in previous list) `$version` wins.
 
+- @xen-orchestra/xapi minor
 - xo-server patch

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
@@ -559,16 +559,17 @@ export default class BackupNg {
       const remainingTimeout = timeout - startDuration
 
       await new Promise((resolve, reject) => {
-        const stopWatch = xapi.watchObject(restoredVm.$ref, vm => {
-          if (vm.$guest_metrics) {
-            stopWatch()
+        const vmInterval = setInterval(() => {
+          const vm = xapi.getObject(restoredId)
+          if (vm.$guest_metrics?.PV_drivers_version?.major) {
             timeoutId !== undefined && clearTimeout(timeoutId)
+            clearTimeout(vmInterval)
             resolve()
           }
-        })
+        }, 5000)
 
         const timeoutId = setTimeout(() => {
-          stopWatch()
+          vmInterval && clearTimeout(vmInterval)
           reject(new Error(`Guest tools of VM ${restoredId} not started after ${timeout / 1000} second`))
         }, remainingTimeout)
       })

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
@@ -563,7 +563,6 @@ export default class BackupNg {
         timeout: remainingTimeout,
       })
       const running = new Date()
-      restoredVm = xapi.getObject(restoredId)
       remainingTimeout -= running - started
       await xapi.waitObjectState(restoredVm.guest_metrics, gm => gm?.PV_drivers_version?.major !== undefined, {
         timeout: remainingTimeout,


### PR DESCRIPTION
Introduced by 7d6e83222

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
