### PR TITLE
fix(xo-web/remotes): form not saving HTTPS and allow unauthorized during S3 creation

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [S3] Fix S3 remote with empty directory not showing anything to restore (PR [#6218](https://github.com/vatesfr/xen-orchestra/pull/6218))
+- [S3] remote fom did not save the `https` and `allow unatuhorized`during remote creation (PR [#6219](https://github.com/vatesfr/xen-orchestra/pull/6219))
 
 ### Packages to release
 

--- a/packages/xo-web/src/xo-app/settings/remotes/remote.js
+++ b/packages/xo-web/src/xo-app/settings/remotes/remote.js
@@ -125,8 +125,10 @@ export default decorate([
             type,
           }
           if (type === 's3') {
-            const { bucket, directory } = state
+            const { allowUnauthorized, bucket, directory, protocol = 'https' } = state
             urlParams.path = bucket + '/' + directory
+            urlParams.allowUnauthorized = allowUnauthorized
+            urlParams.protocol = protocol
           }
           username && (urlParams.username = username)
           password && (urlParams.password = password)


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/50174/166719210-a6283345-4b4d-4954-a6c8-82c99a57b0d9.png)

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
