### PR TITLE
feat(backups): add cache for backup metadata

### DIFF
--- a/@xen-orchestra/backups/RemoteAdapter.js
+++ b/@xen-orchestra/backups/RemoteAdapter.js
@@ -454,16 +454,7 @@ class RemoteAdapter {
   }
 
   async invalidateVmBackupListCache(vmUuid) {
-    try {
-      await this.handler.unlink(`${BACKUP_DIR}/${vmUuid}/cache.json.gz`)
-
-      // remove any pending loc
-    } catch (error) {
-      if (error.code === 'ENOENT') {
-        return
-      }
-      throw error
-    }
+    await this.handler.unlink(`${BACKUP_DIR}/${vmUuid}/cache.json.gz`)
   }
 
   async #getCachabledDataListVmBackups(vmUuid) {

--- a/@xen-orchestra/backups/package.json
+++ b/@xen-orchestra/backups/package.json
@@ -27,6 +27,7 @@
     "@xen-orchestra/template": "^0.1.0",
     "compare-versions": "^4.0.1",
     "d3-time-format": "^3.0.0",
+    "decorator-synchronized": "^0.6.0",
     "end-of-stream": "^1.4.4",
     "fs-extra": "^10.0.0",
     "golike-defer": "^0.5.1",

--- a/@xen-orchestra/backups/writers/_MixinBackupWriter.js
+++ b/@xen-orchestra/backups/writers/_MixinBackupWriter.js
@@ -64,5 +64,6 @@ exports.MixinBackupWriter = (BaseClass = Object) =>
         const remotePath = handler._getRealPath()
         await MergeWorker.run(remotePath)
       }
+      await this._adapter.invalidateVmBackupListCache(this._backup.vm.uuid)
     }
   }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,6 +8,7 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - [Backup] Merge multiple VHDs at once which will speed up the merging ĥase after reducing the retention of a backup job(PR [#6184](https://github.com/vatesfr/xen-orchestra/pull/6184))
+- [Backup] Implement file cache for listing the backups of a VM (PR [#6220](https://github.com/vatesfr/xen-orchestra/pull/6220))
 
 ### Bug fixes
 
@@ -38,8 +39,6 @@
 - vhd-lib patch
 - @xen-orchestra/fs patch
 - vhd-cli patch
-- @xen-orchestra/backups patch
-- xo-server patch
 - xo-vmdk-to-vhd minor
 - @xen-orchestra/upload-ova patch
 - @xen-orchestra/backups minor


### PR DESCRIPTION
Listing all the backup can be slow. To speed it up, we will cache the metadata of all the backup of each vm as gzipped json file.

The cache should be invalidated when a backup is deleted or created

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
