### PR TITLE
fix(xo-server/installPatches): fix pool wide detection

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Pool/Patches] Fix failure to install patches on Citrix Hypervisor
+
 ### Packages to release
 
 > Packages will be released in the order they are here, therefore, they should

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [Pool/Patches] Fix failure to install patches on Citrix Hypervisor
+- [Pool/Patches] Fix failure to install patches on Citrix Hypervisor (PR [#6231](https://github.com/vatesfr/xen-orchestra/pull/6231))
 
 ### Packages to release
 

--- a/packages/xo-server/src/api/pool.mjs
+++ b/packages/xo-server/src/api/pool.mjs
@@ -116,6 +116,7 @@ listMissingPatches.resolve = {
 // -------------------------------------------------------------------
 
 export async function installPatches({ pool, patches, hosts }) {
+  const opts = { patches }
   let xapi
   if (pool !== undefined) {
     pool = this.getXapiObject(pool, 'pool')
@@ -123,6 +124,7 @@ export async function installPatches({ pool, patches, hosts }) {
     hosts = Object.values(xapi.objects.indexes.type.host)
   } else {
     hosts = hosts.map(_ => this.getXapiObject(_))
+    opts.hosts = hosts
     xapi = hosts[0].$xapi
     pool = xapi.pool
   }
@@ -136,7 +138,7 @@ export async function installPatches({ pool, patches, hosts }) {
     })
   }
 
-  await xapi.installPatches({ hosts, patches })
+  await xapi.installPatches(opts)
 
   const masterRef = pool.master
   if (moveFirst(hosts, _ => _.$ref === masterRef)) {


### PR DESCRIPTION
Introduced by 3f1c41a4f

Fixes zammad#6819 zammad#6781 zammad#6827

In #6186 the behavior was changed to always pass hosts, which broke the pool wide detection.

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
