### PR TITLE
fix(vhd-lib/VhdDirectory#writeChunkFilters): correctly overwrite chunk-filter.json

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,4 +33,12 @@
 
 <!--packages-start-->
 
+- vhd-lib patch
+- vhd-cli patch
+- @xen-orchestra/backups patch
+- xo-server patch
+- xo-vmdk-to-vhd patch
+- @xen-orchestra/upload-ova patch
+- @xen-orchestra/backups-cli patch
+- @xen-orchestra/proxy patch
 <!--packages-end-->

--- a/packages/vhd-lib/Vhd/VhdDirectory.js
+++ b/packages/vhd-lib/Vhd/VhdDirectory.js
@@ -277,7 +277,7 @@ exports.VhdDirectory = class VhdDirectory extends VhdAbstract {
     if (compressionType === undefined) {
       await this._handler.unlink(path)
     } else {
-      await this._handler.writeFile(path, JSON.stringify([compressionType]))
+      await this._handler.writeFile(path, JSON.stringify([compressionType]), { flags: 'w' })
     }
   }
 


### PR DESCRIPTION
- writeChunkFilters would have crashed if filter file does not exists and we set a empty compression
- it would not have updated the filter file if used with a fs implementation respecting fs permissions flags

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
