### PR TITLE
feat(xo-server-backup-reports): show health check

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -49,5 +49,6 @@
 - @xen-orchestra/proxy minor
 - xo-server minor
 - xo-web minor
+- xo-server-backup-reports minor
 
 <!--packages-end-->

--- a/packages/xo-server-backup-reports/src/index.js
+++ b/packages/xo-server-backup-reports/src/index.js
@@ -497,18 +497,23 @@ class BackupReportsXoPlugin {
         }
 
         forEach(subTaskLog.tasks, operationLog => {
-          if (operationLog.message !== 'merge' && operationLog.message !== 'transfer') {
+          if (
+            operationLog.message !== 'merge' &&
+            operationLog.message !== 'transfer' &&
+            operationLog.message !== 'healthcheck'
+          ) {
             return
           }
 
-          const size = operationLog.result?.size
+          const size = operationLog.result?.size ?? 0
           if (size > 0) {
             if (operationLog.message === 'merge') {
               globalMergeSize += size
             } else {
               globalTransferSize += size
             }
-          } else if (operationLog.status === 'success') {
+          } // don't ignore health check
+          else if (operationLog.status === 'success' && operationLog.message !== 'healthcheck') {
             return
           }
 

--- a/packages/xo-server-backup-reports/src/index.js
+++ b/packages/xo-server-backup-reports/src/index.js
@@ -505,7 +505,7 @@ class BackupReportsXoPlugin {
             return
           }
 
-          const size = operationLog.result?.size ?? 0
+          const size = operationLog.result?.size
           if (size > 0) {
             if (operationLog.message === 'merge') {
               globalMergeSize += size

--- a/packages/xo-server-backup-reports/src/index.js
+++ b/packages/xo-server-backup-reports/src/index.js
@@ -500,7 +500,7 @@ class BackupReportsXoPlugin {
           if (
             operationLog.message !== 'merge' &&
             operationLog.message !== 'transfer' &&
-            operationLog.message !== 'healthcheck'
+            operationLog.message !== 'health check'
           ) {
             return
           }
@@ -513,7 +513,7 @@ class BackupReportsXoPlugin {
               globalTransferSize += size
             }
           } // don't ignore health check
-          else if (operationLog.status === 'success' && operationLog.message !== 'healthcheck') {
+          else if (operationLog.status === 'success' && operationLog.message !== 'health check') {
             return
           }
 


### PR DESCRIPTION
### Screenshot 
 ![image](https://user-images.githubusercontent.com/50174/169004448-b00c6e35-2434-4be2-9b83-65e8241f8127.png)

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
