### PR TITLE
feat(xapi,xo-server): create SRs with other_config.auto-scan=true

### DIFF
--- a/@xen-orchestra/xapi/sr.js
+++ b/@xen-orchestra/xapi/sr.js
@@ -5,7 +5,39 @@ const { defer } = require('golike-defer')
 const { VDI_FORMAT_RAW } = require('./index.js')
 const peekFooterFromStream = require('vhd-lib/peekFooterFromVhdStream')
 
+const { warn } = require('@xen-orchestra/log').createLogger('xo:xapi:sr')
+
 class Sr {
+  async create({
+    content_type = 'user', // recommended by Citrix
+    device_config,
+    host,
+    name_description = '',
+    name_label,
+    physical_size = 0,
+    shared,
+    sm_config = {},
+    type,
+  }) {
+    const ref = await this.call(
+      'SR.create',
+      host,
+      device_config,
+      physical_size,
+      name_label,
+      name_description,
+      type,
+      content_type,
+      shared,
+      sm_config
+    )
+
+    // https://developer-docs.citrix.com/projects/citrix-hypervisor-sdk/en/latest/xc-api-extensions/#sr
+    this.setFieldEntry('SR', ref, 'other_config', 'auto-scan', 'true').catch(warn)
+
+    return ref
+  }
+
   async importVdi(
     $defer,
     ref,

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- Created SRs will now have auto-scan enabled similarly to what XenCenter does (PR [#6246](https://github.com/vatesfr/xen-orchestra/pull/6246))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -27,6 +29,7 @@
 
 <!--packages-start-->
 
-- xo-server patch
+- @xen-orchestra/xapi minor
+- xo-server minor
 
 <!--packages-end-->

--- a/packages/xo-server/src/api/sr.mjs
+++ b/packages/xo-server/src/api/sr.mjs
@@ -170,18 +170,15 @@ export async function createIso({
     })
   }
 
-  const srRef = await xapi.call(
-    'SR.create',
-    host._xapiRef,
-    deviceConfig,
-    '0', // SR size 0 because ISO
-    nameLabel,
-    nameDescription,
-    'iso', // SR type ISO
-    'iso', // SR content type ISO
-    type !== 'local',
-    {}
-  )
+  const srRef = await xapi.SR_create({
+    content_type: 'iso',
+    device_config: deviceConfig,
+    host: host._xapiRef,
+    name_description: nameDescription,
+    name_label: nameLabel,
+    shared: type !== 'local',
+    type: 'iso',
+  })
 
   const sr = await xapi.call('SR.get_record', srRef)
   return sr.uuid
@@ -247,18 +244,14 @@ export async function createNfs({
     })
   }
 
-  const srRef = await xapi.call(
-    'SR.create',
-    host._xapiRef,
-    deviceConfig,
-    '0',
-    nameLabel,
-    nameDescription,
-    'nfs', // SR LVM over iSCSI
-    'user', // recommended by Citrix
-    true,
-    {}
-  )
+  const srRef = await xapi.SR_create({
+    device_config: deviceConfig,
+    host: host._xapiRef,
+    name_description: nameDescription,
+    name_label: nameLabel,
+    shared: true,
+    type: 'nfs', // SR LVM over iSCSI
+  })
 
   const sr = await xapi.call('SR.get_record', srRef)
   return sr.uuid
@@ -302,18 +295,14 @@ export async function createHba({ host, nameLabel, nameDescription, scsiId, srUu
     })
   }
 
-  const srRef = await xapi.call(
-    'SR.create',
-    host._xapiRef,
-    deviceConfig,
-    '0',
-    nameLabel,
-    nameDescription,
-    'lvmohba', // SR LVM over HBA
-    'user', // recommended by Citrix
-    true,
-    {}
-  )
+  const srRef = await xapi.SR_create({
+    device_config: deviceConfig,
+    host: host._xapiRef,
+    name_description: nameDescription,
+    name_label: nameLabel,
+    shared: true,
+    type: 'lvmohba', // SR LVM over HBA
+  })
 
   const sr = await xapi.call('SR.get_record', srRef)
   return sr.uuid
@@ -343,18 +332,14 @@ export async function createLvm({ host, nameLabel, nameDescription, device }) {
     device,
   }
 
-  const srRef = await xapi.call(
-    'SR.create',
-    host._xapiRef,
-    deviceConfig,
-    '0',
-    nameLabel,
-    nameDescription,
-    'lvm', // SR LVM
-    'user', // recommended by Citrix
-    false,
-    {}
-  )
+  const srRef = await xapi.SR_create({
+    device_config: deviceConfig,
+    host: host._xapiRef,
+    name_description: nameDescription,
+    name_label: nameLabel,
+    shared: false,
+    type: 'lvm', // SR LVM
+  })
 
   const sr = await xapi.call('SR.get_record', srRef)
   return sr.uuid
@@ -383,18 +368,14 @@ export async function createExt({ host, nameLabel, nameDescription, device }) {
     device,
   }
 
-  const srRef = await xapi.call(
-    'SR.create',
-    host._xapiRef,
-    deviceConfig,
-    '0',
-    nameLabel,
-    nameDescription,
-    'ext', // SR ext
-    'user', // recommended by Citrix
-    false,
-    {}
-  )
+  const srRef = await xapi.call({
+    device_config: deviceConfig,
+    host: host._xapiRef,
+    name_description: nameDescription,
+    name_label: nameLabel,
+    shared: false,
+    type: 'ext', // SR ext
+  })
 
   const sr = await xapi.call('SR.get_record', srRef)
   return sr.uuid
@@ -458,13 +439,18 @@ export async function createZfs({ host, nameLabel, nameDescription, location }) 
   const xapi = this.getXapi(host)
   // only XCP-ng >=8.2 support the ZFS SR
   const types = await xapi.call('SR.get_supported_types')
-  return xapi.createSr({
-    hostRef: host._xapiRef,
-    name_label: nameLabel,
-    name_description: nameDescription,
-    type: types.includes('zfs') ? 'zfs' : 'file',
-    device_config: { location },
-  })
+  return await xapi.getField(
+    'SR',
+    await xapi.SR_create({
+      device_config: { location },
+      host: host._xapiRef,
+      name_description: nameDescription,
+      name_label: nameLabel,
+      shared: false,
+      type: types.includes('zfs') ? 'zfs' : 'file',
+    }),
+    'uuid'
+  )
 }
 
 createZfs.params = {
@@ -614,18 +600,14 @@ export async function createIscsi({
     })
   }
 
-  const srRef = await xapi.call(
-    'SR.create',
-    host._xapiRef,
-    deviceConfig,
-    '0',
-    nameLabel,
-    nameDescription,
-    'lvmoiscsi', // SR LVM over iSCSI
-    'user', // recommended by Citrix
-    true,
-    {}
-  )
+  const srRef = await xapi.SR_create({
+    device_config: deviceConfig,
+    host: host._xapiRef,
+    name_description: nameDescription,
+    name_label: nameLabel,
+    shared: true,
+    type: 'lvmoiscsi', // SR LVM over iSCSI
+  })
 
   const sr = await xapi.call('SR.get_record', srRef)
   return sr.uuid

--- a/packages/xo-server/src/api/xosan.mjs
+++ b/packages/xo-server/src/api/xosan.mjs
@@ -638,18 +638,16 @@ export const createSR = defer(async function (
     ).join(':')
     const config = { server: ipAndHosts[0].address + ':/xosan', backupservers }
     CURRENT_POOL_OPERATIONS[poolId] = { ...OPERATION_OBJECT, state: 5 }
-    const xosanSrRef = await xapi.call(
-      'SR.create',
-      firstSr.$PBDs[0].$host.$ref,
-      config,
-      0,
-      'XOSAN',
-      'XOSAN',
-      'xosan',
-      '',
-      true,
-      {}
-    )
+    const xosanSrRef = await xapi.SR_create({
+      content_type: '',
+      device_config: config,
+      host: firstSr.$PBDs[0].$host.$ref,
+      name_description: 'XOSAN',
+      name_label: 'XOSAN',
+      physical_size: 0,
+      shared: true,
+      type: 'xosan',
+    })
     log.debug('sr created')
     // we just forget because the cleanup actions are stacked in the $onFailure system
     $defer.onFailure(() => xapi.forgetSr(xosanSrRef))

--- a/packages/xo-server/src/xapi/mixins/storage.mjs
+++ b/packages/xo-server/src/xapi/mixins/storage.mjs
@@ -87,34 +87,6 @@ export default {
     return unhealthyVdis
   },
 
-  async createSr({
-    hostRef,
-
-    content_type = 'user', // recommended by Citrix
-    device_config = {},
-    name_description = '',
-    name_label,
-    shared = false,
-    physical_size = 0,
-    sm_config = {},
-    type,
-  }) {
-    const srRef = await this.call(
-      'SR.create',
-      hostRef,
-      device_config,
-      physical_size,
-      name_label,
-      name_description,
-      type,
-      content_type,
-      shared,
-      sm_config
-    )
-
-    return (await this.barrier(srRef)).uuid
-  },
-
   // This function helps to reattach a forgotten NFS/iSCSI/HBA SR
   @decorateWith(defer)
   async reattachSr($defer, { uuid, nameLabel, nameDescription, type, deviceConfig }) {


### PR DESCRIPTION
Fixes https://team.vates.fr/vates/pl/nf18hnr51f8f3f3brcbra57uar

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
