### PR TITLE
fix(xo-web,xo-server): store health check settings in job instead of schedule

### DIFF
--- a/packages/xo-server/src/api/schedule.mjs
+++ b/packages/xo-server/src/api/schedule.mjs
@@ -17,12 +17,10 @@ get.params = {
   id: { type: 'string' },
 }
 
-export function create({ cron, enabled, healthCheckSr, healthCheckVmsWithTags, jobId, name, timezone }) {
+export function create({ cron, enabled, jobId, name, timezone }) {
   return this.createSchedule({
     cron,
     enabled,
-    healthCheckSr,
-    healthCheckVmsWithTags,
     jobId,
     name,
     timezone,
@@ -35,15 +33,13 @@ create.description = 'Creates a new schedule'
 create.params = {
   cron: { type: 'string' },
   enabled: { type: 'boolean', optional: true },
-  healthCheckSr: { type: 'string', optional: true },
-  healthCheckVmsWithTags: { type: 'array', items: { type: 'string' }, optional: true },
   jobId: { type: 'string' },
   name: { type: 'string', optional: true },
   timezone: { type: 'string', optional: true },
 }
 
-export async function set({ cron, enabled, healthCheckSr, healthCheckVmsWithTags, id, jobId, name, timezone }) {
-  await this.updateSchedule({ cron, enabled, healthCheckSr, healthCheckVmsWithTags, id, jobId, name, timezone })
+export async function set({ cron, enabled, id, jobId, name, timezone }) {
+  await this.updateSchedule({ cron, enabled, id, jobId, name, timezone })
 }
 
 set.permission = 'admin'
@@ -51,8 +47,6 @@ set.description = 'Modifies an existing schedule'
 set.params = {
   cron: { type: 'string', optional: true },
   enabled: { type: 'boolean', optional: true },
-  healthCheckSr: { type: 'string', optional: true },
-  healthCheckVmsWithTags: { type: 'array', items: { type: 'string' }, optional: true },
   id: { type: 'string' },
   jobId: { type: 'string', optional: true },
   name: { type: ['string', 'null'], optional: true },

--- a/packages/xo-server/src/xo-mixins/scheduling.mjs
+++ b/packages/xo-server/src/xo-mixins/scheduling.mjs
@@ -73,13 +73,11 @@ export default class Scheduling {
     })
   }
 
-  async createSchedule({ cron, enabled, healthCheckSr, healthCheckVmsWithTags, jobId, name = '', timezone, userId }) {
+  async createSchedule({ cron, enabled, jobId, name = '', timezone, userId }) {
     const schedule = (
       await this._db.add({
         cron,
         enabled,
-        healthCheckSr,
-        healthCheckVmsWithTags: JSON.stringify(healthCheckVmsWithTags),
         jobId,
         name,
         timezone,
@@ -95,10 +93,7 @@ export default class Scheduling {
     if (schedule === undefined) {
       throw noSuchObject(id, 'schedule')
     }
-    return {
-      ...schedule.properties,
-      healthCheckVmsWithTags: ifDef(schedule.properties.healthCheckVmsWithTags, JSON.parse),
-    }
+    return schedule.properties
   }
 
   async getAllSchedules() {

--- a/packages/xo-server/src/xo-mixins/scheduling.mjs
+++ b/packages/xo-server/src/xo-mixins/scheduling.mjs
@@ -1,7 +1,6 @@
 import asyncMapSettled from '@xen-orchestra/async-map/legacy.js'
 import keyBy from 'lodash/keyBy.js'
 import { createSchedule } from '@xen-orchestra/cron'
-import { ifDef } from '@xen-orchestra/defined'
 import { ignoreErrors } from 'promise-toolbox'
 import { noSuchObject } from 'xo-common/api-errors.js'
 
@@ -97,10 +96,7 @@ export default class Scheduling {
   }
 
   async getAllSchedules() {
-    return (await this._db.get()).map(schedule => ({
-      ...schedule,
-      healthCheckVmsWithTags: ifDef(schedule.healthCheckVmsWithTags, JSON.parse),
-    }))
+    return await this._db.get()
   }
 
   async deleteSchedule(id) {
@@ -108,14 +104,11 @@ export default class Scheduling {
     await this._db.remove(id)
   }
 
-  async updateSchedule({ cron, enabled, healthCheckSr, healthCheckVmsWithTags, id, jobId, name, timezone, userId }) {
+  async updateSchedule({ cron, enabled, id, jobId, name, timezone, userId }) {
     const schedule = await this.getSchedule(id)
     patch(schedule, {
       cron,
       enabled,
-      // null to delete the key of the object in case we remove healthcheck
-      healthCheckSr: healthCheckVmsWithTags !== undefined ? healthCheckSr : null,
-      healthCheckVmsWithTags: JSON.stringify(healthCheckVmsWithTags) ?? null,
       jobId,
       name,
       timezone,

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -2108,13 +2108,8 @@ export const cancelJob = ({ id, name, runId }) =>
 
 // Backup/Schedule ---------------------------------------------------------
 
-export const createSchedule = (
-  jobId,
-  { cron, enabled, healthCheckSr, healthCheckVmsWithTags, name = undefined, timezone = undefined }
-) =>
-  _call('schedule.create', { jobId, cron, enabled, healthCheckSr, healthCheckVmsWithTags, name, timezone })::tap(
-    subscribeSchedules.forceRefresh
-  )
+export const createSchedule = (jobId, { cron, enabled, name = undefined, timezone = undefined }) =>
+  _call('schedule.create', { jobId, cron, enabled, name, timezone })::tap(subscribeSchedules.forceRefresh)
 
 export const deleteBackupSchedule = async schedule => {
   await confirm({
@@ -2145,10 +2140,8 @@ export const deleteSchedules = schedules =>
 
 export const disableSchedule = id => editSchedule({ id, enabled: false })
 
-export const editSchedule = ({ id, jobId, cron, enabled, healthCheckSr, healthCheckVmsWithTags, name, timezone }) =>
-  _call('schedule.set', { id, jobId, cron, enabled, healthCheckSr, healthCheckVmsWithTags, name, timezone })::tap(
-    subscribeSchedules.forceRefresh
-  )
+export const editSchedule = ({ id, jobId, cron, enabled, name, timezone }) =>
+  _call('schedule.set', { id, jobId, cron, enabled, name, timezone })::tap(subscribeSchedules.forceRefresh)
 
 export const enableSchedule = id => editSchedule({ id, enabled: true })
 

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -299,9 +299,7 @@ const New = decorate([
               newSchedule.cron !== oldSchedule.cron ||
               newSchedule.name !== oldSchedule.name ||
               newSchedule.timezone !== oldSchedule.timezone ||
-              newSchedule.enabled !== oldSchedule.enabled ||
-              newSchedule.healthCheckSr !== oldSchedule.healthCheckSr ||
-              newSchedule.healthCheckVmsWithTags !== oldSchedule.healthCheckVmsWithTags
+              newSchedule.enabled !== oldSchedule.enabled
             ) {
               return editSchedule({
                 id,
@@ -309,8 +307,6 @@ const New = decorate([
                 name: newSchedule.name,
                 timezone: newSchedule.timezone,
                 enabled: newSchedule.enabled,
-                healthCheckSr: newSchedule.healthCheckSr,
-                healthCheckVmsWithTags: newSchedule.healthCheckVmsWithTags,
               })
             }
           })
@@ -326,8 +322,6 @@ const New = decorate([
                 name: schedule.name,
                 timezone: schedule.timezone,
                 enabled: schedule.enabled,
-                healthCheckSr: schedule.healthCheckSr,
-                healthCheckVmsWithTags: schedule.healthCheckVmsWithTags,
               })
 
               settings = settings.withMutations(settings => {
@@ -515,8 +509,6 @@ const New = decorate([
               ...schedules[id],
               cron,
               enabled,
-              healthCheckSr,
-              healthCheckVmsWithTags,
               id,
               name,
               timezone,
@@ -526,6 +518,8 @@ const New = decorate([
             copyRetention,
             exportRetention,
             fullInterval,
+            healthCheckSr,
+            healthCheckVmsWithTags,
             snapshotRetention,
           }),
         }),


### PR DESCRIPTION
Introduced by cae3555ca787f9648e4b5a75384a96ec87303b50

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
