### PR TITLE
fix(xo-web/home): don't make VM's resource set name clickable for non-admins

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@
 - [S3] Fix S3 remote with empty directory not showing anything to restore (PR [#6218](https://github.com/vatesfr/xen-orchestra/pull/6218))
 - [S3] remote fom did not save the `https` and `allow unatuhorized`during remote creation (PR [#6219](https://github.com/vatesfr/xen-orchestra/pull/6219))
 - [VM/advanced] Fix various errors when adding ACLs [#6213](https://github.com/vatesfr/xen-orchestra/issues/6213) (PR [#6230](https://github.com/vatesfr/xen-orchestra/pull/6230))
+- [Home/Self] Don't make VM's resource set name clickable for non admin users as they aren't allowed to view the Self Service page
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,7 +21,7 @@
 - [S3] Fix S3 remote with empty directory not showing anything to restore (PR [#6218](https://github.com/vatesfr/xen-orchestra/pull/6218))
 - [S3] remote fom did not save the `https` and `allow unatuhorized`during remote creation (PR [#6219](https://github.com/vatesfr/xen-orchestra/pull/6219))
 - [VM/advanced] Fix various errors when adding ACLs [#6213](https://github.com/vatesfr/xen-orchestra/issues/6213) (PR [#6230](https://github.com/vatesfr/xen-orchestra/pull/6230))
-- [Home/Self] Don't make VM's resource set name clickable for non admin users as they aren't allowed to view the Self Service page
+- [Home/Self] Don't make VM's resource set name clickable for non admin users as they aren't allowed to view the Self Service page (PR [#6252](https://github.com/vatesfr/xen-orchestra/pull/6252))
 
 ### Packages to release
 

--- a/packages/xo-web/src/xo-app/home/vm-item.js
+++ b/packages/xo-web/src/xo-app/home/vm-item.js
@@ -13,7 +13,7 @@ import { Text, XoSelect } from 'editable'
 import { isEmpty, map } from 'lodash'
 import { addTag, editVm, fetchVmStats, migrateVm, removeTag, startVm, stopVm, subscribeResourceSets } from 'xo'
 import { addSubscriptions, connectStore, formatSizeShort, osFamily } from 'utils'
-import { createFinder, createGetObject, createGetVmDisks, createSelector, createSumBy } from 'selectors'
+import { createFinder, createGetObject, createGetVmDisks, createSelector, createSumBy, isAdmin } from 'selectors'
 
 import MiniStats from './mini-stats'
 import styles from './index.css'
@@ -23,6 +23,7 @@ import styles from './index.css'
 })
 @connectStore(() => ({
   container: createGetObject((_, props) => props.item.$container),
+  isAdmin,
   totalDiskSize: createSumBy(
     createGetVmDisks((_, props) => props.item),
     'size'
@@ -65,7 +66,7 @@ export default class VmItem extends Component {
   )
 
   render() {
-    const { item: vm, container, expandAll, selected } = this.props
+    const { item: vm, container, expandAll, isAdmin, selected } = this.props
     const resourceSet = this._getResourceSet()
     const state = this._getVmState()
 
@@ -189,7 +190,11 @@ export default class VmItem extends Component {
                   {resourceSet && (
                     <span>
                       {_('homeResourceSet', {
-                        resourceSet: <Link to={`self?resourceSet=${resourceSet.id}`}>{resourceSet.name}</Link>,
+                        resourceSet: isAdmin ? (
+                          <Link to={`self?resourceSet=${resourceSet.id}`}>{resourceSet.name}</Link>
+                        ) : (
+                          resourceSet.name
+                        ),
                       })}
                     </span>
                   )}


### PR DESCRIPTION
See https://xcp-ng.org/forum/topic/5902/permissions-for-users-to-be-able-to-snapshot/5?_=1653902135402

Non-admin users aren't allowed to view the Self Service page so it doesn't make
sense to have a link to that page

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
