### PR TITLE
fix(xapi,load-balancer): missing shutdownHost default parameter

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [load-balancer] Fix density mode failing to shutdown hosts (PR [#6253](https://github.com/vatesfr/xen-orchestra/pull/6253))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -24,5 +26,7 @@
 > - major: if the change breaks compatibility
 
 <!--packages-start-->
+
+- xo-server patch
 
 <!--packages-end-->

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -304,7 +304,7 @@ export default class Xapi extends XapiBase {
     await this.call('host.syslog_reconfigure', host.$ref)
   }
 
-  async shutdownHost(hostId, { force = false, bypassEvacuate = false }) {
+  async shutdownHost(hostId, { force = false, bypassEvacuate = false } = {}) {
     const host = this.getObject(hostId)
     if (bypassEvacuate) {
       await this.call('host.disable', host.$ref)
@@ -919,7 +919,12 @@ export default class Xapi extends XapiBase {
     throw new Error(`unsupported type: '${type}'`)
   }
 
-  async migrateVm(vmId, hostXapi, hostId, { force = false, mapVdisSrs, mapVifsNetworks, migrationNetworkId, sr, bypassAssert } = {}) {
+  async migrateVm(
+    vmId,
+    hostXapi,
+    hostId,
+    { force = false, mapVdisSrs, mapVifsNetworks, migrationNetworkId, sr, bypassAssert } = {}
+  ) {
     const vm = this.getObject(vmId)
     const host = hostXapi.getObject(hostId)
 


### PR DESCRIPTION
Add a default empty object parameter to enable calls to shutdownHost with only one parameter.
This implicitly fixes the density load-balancer, since it calls shutdownHost with only one parameter.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
