### PR TITLE
fix(xo-web/backups): scheduled health check is available to enterprise

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 - [load-balancer] Fix density mode failing to shutdown hosts (PR [#6253](https://github.com/vatesfr/xen-orchestra/pull/6253))
 - [Health] Make "Too many snapshots" table sortable by number of snapshots (PR [#6255](https://github.com/vatesfr/xen-orchestra/pull/6255))
 - [Remote] Show complete errors instead of only a potentially missing message (PR [#6216](https://github.com/vatesfr/xen-orchestra/pull/6216))
+- [Backup] Scheduled health check of a backup is available from the enterprise level (PR [#6257](https://github.com/vatesfr/xen-orchestra/pull/6257))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@
 - [load-balancer] Fix density mode failing to shutdown hosts (PR [#6253](https://github.com/vatesfr/xen-orchestra/pull/6253))
 - [Health] Make "Too many snapshots" table sortable by number of snapshots (PR [#6255](https://github.com/vatesfr/xen-orchestra/pull/6255))
 - [Remote] Show complete errors instead of only a potentially missing message (PR [#6216](https://github.com/vatesfr/xen-orchestra/pull/6216))
-- [Backup] Scheduled health check of a backup is available from the enterprise level (PR [#6257](https://github.com/vatesfr/xen-orchestra/pull/6257))
+- [Backup] Scheduled Health Check should be available in Enterprise Edition (PR [#6257](https://github.com/vatesfr/xen-orchestra/pull/6257))
 
 ### Packages to release
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1666,7 +1666,7 @@ const messages = {
   healthCheck: 'Health check',
   healthCheckChooseSr: 'Choose SR used for VMs restoration',
   healthCheckTagsInfo: 'If no tags are specified, all VMs in the backup will be tested.',
-  healthCheckAvailablePremiumUser: 'Only available to premium users',
+  healthCheckAvailableEnterpriseUser: 'Only available to enterprise users',
   remoteNotCompatibleWithSelectedProxy:
     "The backup will not be run on this remote because it's not compatible with the selected proxy",
   remoteLoadBackupsFailure: 'Loading backups failed',

--- a/packages/xo-web/src/xo-app/backup/new/new-schedule.js
+++ b/packages/xo-web/src/xo-app/backup/new/new-schedule.js
@@ -12,7 +12,7 @@ import { Number } from 'form'
 
 import { FormGroup, Input } from './../utils'
 import Tags from '../../../common/tags'
-import { getXoaPlan, PREMIUM } from '../../../common/xoa-plans'
+import { ENTERPRISE, getXoaPlan } from '../../../common/xoa-plans'
 import { SelectSr } from '../../../common/select-objects'
 
 const New = decorate([
@@ -139,11 +139,11 @@ const New = decorate([
             {conditionalTooltip(
               <input
                 checked={schedule.healthCheckVmsWithTags !== undefined}
-                disabled={getXoaPlan().value < PREMIUM.value}
+                disabled={getXoaPlan().value < ENTERPRISE.value}
                 onChange={effects.toggleHealthCheck}
                 type='checkbox'
               />,
-              getXoaPlan().value < PREMIUM.value ? _('healthCheckAvailablePremiumUser') : undefined
+              getXoaPlan().value < ENTERPRISE.value ? _('healthCheckAvailableEnterpriseUser') : undefined
             )}
           </label>
           {schedule.healthCheckVmsWithTags !== undefined && (


### PR DESCRIPTION
Introduced by cae3555ca

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
