### PR TITLE
fix(xen-api/putResource): use agent for both requests

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,4 +27,6 @@
 
 <!--packages-start-->
 
+- xen-api patch
+
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -10,6 +10,7 @@
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
+> Import Vdi content now works when server is behind http proxy
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -10,7 +10,8 @@
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
-> Import VDI content now works when there is a HTTP proxy between XO and the host (PR [#6261](https://github.com/vatesfr/xen-orchestra/pull/6261))
+
+- Import VDI content now works when there is a HTTP proxy between XO and the host (PR [#6261](https://github.com/vatesfr/xen-orchestra/pull/6261))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -10,7 +10,7 @@
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
-> Import Vdi content now works when server is behind http proxy
+> Import VDI content now works when there is a HTTP proxy between XO and the host (PR [#6261](https://github.com/vatesfr/xen-orchestra/pull/6261))
 
 ### Packages to release
 

--- a/packages/xen-api/src/index.js
+++ b/packages/xen-api/src/index.js
@@ -485,7 +485,6 @@ export class Xapi extends EventEmitter {
           query: 'task_id' in query ? omit(query, 'task_id') : query,
 
           maxRedirects: 0,
-          agent: this.httpAgent,
         }).then(
           response => {
             response.cancel()

--- a/packages/xen-api/src/index.js
+++ b/packages/xen-api/src/index.js
@@ -465,14 +465,17 @@ export class Xapi extends EventEmitter {
     await this._setHostAddressInUrl(url, host)
 
     const doRequest = httpRequest.put.bind(undefined, $cancelToken, {
+      agent: this.httpAgent,
+
       body,
       headers,
       rejectUnauthorized: !this._allowUnauthorized,
+      
       // this is an inactivity timeout (unclear in Node doc)
       timeout: this._httpInactivityTimeout,
+      
       // Support XS <= 6.5 with Node => 12
       minVersion: 'TLSv1',
-      agent: this.httpAgent,
     })
 
     // if body is a stream, sends a dummy request to probe for a redirection

--- a/packages/xen-api/src/index.js
+++ b/packages/xen-api/src/index.js
@@ -470,10 +470,10 @@ export class Xapi extends EventEmitter {
       body,
       headers,
       rejectUnauthorized: !this._allowUnauthorized,
-      
+
       // this is an inactivity timeout (unclear in Node doc)
       timeout: this._httpInactivityTimeout,
-      
+
       // Support XS <= 6.5 with Node => 12
       minVersion: 'TLSv1',
     })

--- a/packages/xen-api/src/index.js
+++ b/packages/xen-api/src/index.js
@@ -468,12 +468,11 @@ export class Xapi extends EventEmitter {
       body,
       headers,
       rejectUnauthorized: !this._allowUnauthorized,
-
       // this is an inactivity timeout (unclear in Node doc)
       timeout: this._httpInactivityTimeout,
-
       // Support XS <= 6.5 with Node => 12
       minVersion: 'TLSv1',
+      agent: this.httpAgent,
     })
 
     // if body is a stream, sends a dummy request to probe for a redirection


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- Fixes #6260

- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
