### PR TITLE
feat(xo-server/api): don't filters error sent to admin users

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,4 +27,6 @@
 
 <!--packages-start-->
 
+- xo-server minor
+
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- Show raw errors to administrators instead of _unknown error from the peer_ (PR [#6260](https://github.com/vatesfr/xen-orchestra/pull/6260))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”

--- a/packages/xo-server/src/xo-mixins/api.mjs
+++ b/packages/xo-server/src/xo-mixins/api.mjs
@@ -383,6 +383,11 @@ export default class Api {
         })
       }
 
+      // don't return *unknown error from the peer* if the user is admin
+      if (error.toJsonRpcError === undefined && context?.user.permission === 'admin') {
+        throw new JsonRpcError(error.message, undefined, serializeError(serializedError))
+      }
+
       throw error
     }
   }


### PR DESCRIPTION
Previous behavior was hiding all errors not explicitly dedicated to be sent to API users and replacing them with an *unknown error from the peer*.

This was done to avoid leaking sensitive information, but it often hides important info.

Administrators can already see the raw errors in Settings/Logs, therefore it makes sense to not hide them for these users.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
