### PR TITLE
fix(backups): task warning if beforeBackup or checkBaseVdis steps fail

### DIFF
--- a/@xen-orchestra/backups/_VmBackup.js
+++ b/@xen-orchestra/backups/_VmBackup.js
@@ -153,6 +153,9 @@ class VmBackup {
         errors.push(error)
         this.delete(writer)
         warn(warnMessage, { error, writer: writer.constructor.name })
+        Task.warning(
+          `the writer ${writer.constructor.name} has failed the step ${warnMessage} with error ${error.message}. It won't be used anymore in this job execution.`
+        )
       }
     })
     if (writers.size === 0) {
@@ -433,7 +436,7 @@ class VmBackup {
     )
 
     await this._callWriters(async writer => {
-      await writer.beforeBackup()
+      await Task.run({ name: 'beforeBackup' }, () => writer.beforeBackup())
       $defer(async () => {
         await writer.afterBackup()
       })

--- a/@xen-orchestra/backups/_VmBackup.js
+++ b/@xen-orchestra/backups/_VmBackup.js
@@ -153,9 +153,13 @@ class VmBackup {
         errors.push(error)
         this.delete(writer)
         warn(warnMessage, { error, writer: writer.constructor.name })
-        Task.warning(
-          `the writer ${writer.constructor.name} has failed the step ${warnMessage} with error ${error.message}. It won't be used anymore in this job execution.`
-        )
+
+        // these two steps are the only one that are not already in their own sub tasks
+        if (warnMessage === 'writer.checkBaseVdis()' || warnMessage === 'writer.beforeBackup()') {
+          Task.warning(
+            `the writer ${writer.constructor.name} has failed the step ${warnMessage} with error ${error.message}. It won't be used anymore in this job execution.`
+          )
+        }
       }
     })
     if (writers.size === 0) {
@@ -436,7 +440,7 @@ class VmBackup {
     )
 
     await this._callWriters(async writer => {
-      await Task.run({ name: 'beforeBackup' }, () => writer.beforeBackup())
+      await writer.beforeBackup()
       $defer(async () => {
         await writer.afterBackup()
       })

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [Backup] show a warning in the task log if a writer fails, an error if they all fail (PR [#6266](https://github.com/vatesfr/xen-orchestra/pull/6266))
+- [Backup] Ensure a warning is shown if a target preparation step fails (PR [#6266](https://github.com/vatesfr/xen-orchestra/pull/6266))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Backup] show a warning in the task log if a writer fails, an error if they all fail (PR [#6266](https://github.com/vatesfr/xen-orchestra/pull/6266))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -26,6 +28,7 @@
 <!--packages-start-->
 
 - @xen-orchestra/xapi minor
+- @xen-orchestra/backups minor
 - xo-server patch
 
 <!--packages-end-->


### PR DESCRIPTION
## screenshot 
![image](https://user-images.githubusercontent.com/50174/171822113-dd806e39-4b5b-47c0-8f23-80c5d1d44c24.png)


### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
