### PR TITLE
fix(xo-web):   handle missing result of broken merge tasks in backup logs

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,6 @@
 
 - [New SR] Fix `method.startsWith is not a function` when creating an _ext_ SR
 - Import VDI content now works when there is a HTTP proxy between XO and the host (PR [#6261](https://github.com/vatesfr/xen-orchestra/pull/6261))
-- Fix `an error occured` in the backup logs view (PR [#6275](https://github.com/vatesfr/xen-orchestra/pull/6275))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 
 - [New SR] Fix `method.startsWith is not a function` when creating an _ext_ SR
 - Import VDI content now works when there is a HTTP proxy between XO and the host (PR [#6261](https://github.com/vatesfr/xen-orchestra/pull/6261))
+- Fix `an error occured` in the backup logs view (PR [#6275](https://github.com/vatesfr/xen-orchestra/pull/6275))
 
 ### Packages to release
 
@@ -34,5 +35,6 @@
 - xo-cli minor
 - @xen-orchestra/xapi minor
 - xo-server minor
+- xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-web/src/xo-app/logs/backup-ng/index.js
+++ b/packages/xo-web/src/xo-app/logs/backup-ng/index.js
@@ -136,10 +136,10 @@ const COLUMNS = [
               return
             }
             if (operationTask.message === 'transfer' && vmTransferSize === undefined) {
-              vmTransferSize = operationTask.result.size
+              vmTransferSize = operationTask.result?.size
             }
             if (operationTask.message === 'merge' && vmMergeSize === undefined) {
-              vmMergeSize = operationTask.result.size
+              vmMergeSize = operationTask.result?.size
             }
 
             if (vmTransferSize !== undefined && vmMergeSize !== undefined) {


### PR DESCRIPTION
These broken tasks have probably been created during the health check dev.

It should have impacted `master` but no released versions.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
