### PR TITLE
docs(backup/troubleshooting): add `no XAPI associated` error

### DIFF
--- a/docs/backup_troubleshooting.md
+++ b/docs/backup_troubleshooting.md
@@ -133,4 +133,4 @@ This error comes directly from your host/dom0, and not XO. Essentially, XO asked
 
 ## Error: no XAPI associated to <UUID>
 
-This message means that XO recorded the UUID to backup but couldn't find any object matching it. The reason can be that the pool where this VM runs is not connected to XOA at the moment. Double-check that the pool hosting the VM is currently connected in Settings/Server. You can also search the VM UUID in the Home/VM search bar. If you can see it, run the backup job again, it will work. If you cannot, either the VM was removed or the pool is not connected.
+This message means that XO had a UUID of a VM to backup, but when the job ran it couldn't find any object matching it. This could be caused by the pool where this VM lived no longer being connected to XO. Double-check that the pool hosting the VM is currently connected under Settings > Servers. You can also search for the VM UUID in the Home > VMs search bar. If you can see it, run the backup job again and it will work. If you cannot, either the VM was removed or the pool is not connected.

--- a/docs/backup_troubleshooting.md
+++ b/docs/backup_troubleshooting.md
@@ -130,3 +130,7 @@ This means the same job is still running, typically from the last scheduled run.
 ## Error: VDI_IO_ERROR
 
 This error comes directly from your host/dom0, and not XO. Essentially, XO asked the host to expose a VM disk to export via HTTP (as usual), XO managed to make the HTTP GET connection, and even start the transfer. But then at some point the host couldn't read the VM disk any further, causing this error on the host side. This might happen if the VDI is corrupted on the storage, or if there's a race condition during snapshots. More rarely, this can also occur if your SR is just too slow to keep up with the export as well as live VM traffic.
+
+## Error: no XAPI associated to <UUID>
+
+This message means that XO recorded the UUID to backup but couldn't find any object matching it. The reason can be that the pool where this VM runs is not connected to XOA at the moment. Double-check that the pool hosting the VM is currently connected in Settings/Server. You can also search the VM UUID in the Home/VM search bar. If you can see it, run the backup job again, it will work. If you cannot, either the VM was removed or the pool is not connected.


### PR DESCRIPTION
Hello team,

We would like to update the documentation about backup troubleshooting. We would like to add the error message "no XAPI associated to <UUID>". This is related to Ticket# 777480 in Zammad.

Thank you in advance for your time.

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
