### PR TITLE
fix(ova import): drain disk entry completly

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [VDI Import] Fix `this._getOrWaitObject is not a function`
+- [OVA Import] Fix import stuck after first disk
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,5 +32,6 @@
 
 - @vates/read-chunk major
 - xo-server patch
+- xo-vmdk-to-vhd patch
 
 <!--packages-end-->

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -762,7 +762,8 @@ export default class Xapi extends XapiBase {
           stream,
           table.grainLogicalAddressList,
           table.grainFileOffsetList,
-          compression[entry.name] === 'gzip'
+          compression[entry.name] === 'gzip',
+          entry.size
         )
         try {
           await vdi.$importContent(vhdStream, { format: VDI_FORMAT_VHD })

--- a/packages/xo-vmdk-to-vhd/src/index.js
+++ b/packages/xo-vmdk-to-vhd/src/index.js
@@ -16,8 +16,8 @@ export { default as readVmdkGrainTable, readCapacityAndGrainTable } from './vmdk
  * @param gzipped
  * @returns a stream whose bytes represent a VHD file containing the VMDK data
  */
-async function vmdkToVhd(vmdkReadStream, grainLogicalAddressList, grainFileOffsetList, gzipped = false) {
-  const parser = new VMDKDirectParser(vmdkReadStream, grainLogicalAddressList, grainFileOffsetList, gzipped)
+async function vmdkToVhd(vmdkReadStream, grainLogicalAddressList, grainFileOffsetList, gzipped = false, length) {
+  const parser = new VMDKDirectParser(vmdkReadStream, grainLogicalAddressList, grainFileOffsetList, gzipped, length)
   const header = await parser.readHeader()
   return createReadableSparseStream(
     header.capacitySectors * 512,

--- a/packages/xo-vmdk-to-vhd/src/vmdk-read.js
+++ b/packages/xo-vmdk-to-vhd/src/vmdk-read.js
@@ -197,8 +197,15 @@ export default class VMDKDirectParser {
       yield { logicalAddressBytes: lba, data: grain }
     }
     // drain remaining
+    // stream.resume does not seems to be enough to consume completly the stream
+    // especially when this stream is part of a tar ( ova) , potentially gzipped
     if (this._length !== undefined) {
-      await this.virtualBuffer.readChunk(this._length - this.virtualBuffer.position, 'draining')
+      while (this.virtualBuffer.position < this._length) {
+        await this.virtualBuffer.readChunk(
+          Math.min(this._length - this.virtualBuffer.position, 1024 * 1024),
+          'draining'
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
