### PR TITLE
fix(xapi/VM_destroy): throw forbiddenOperation if operation blocked

### DIFF
--- a/@xen-orchestra/xapi/vm.js
+++ b/@xen-orchestra/xapi/vm.js
@@ -343,7 +343,7 @@ class Vm {
     const vm = await this.getRecord('VM', vmRef)
 
     if (!bypassBlockedOperation && 'destroy' in vm.blocked_operations) {
-      throw forbiddenOperation('destroy is blocked')
+      throw forbiddenOperation(`destroy: ${vm.blocked_operations.destroy}`)
     }
 
     if (!forceDeleteDefaultTemplate && isDefaultTemplate(vm)) {

--- a/@xen-orchestra/xapi/vm.js
+++ b/@xen-orchestra/xapi/vm.js
@@ -11,7 +11,7 @@ const { asyncMap } = require('@xen-orchestra/async-map')
 const { createLogger } = require('@xen-orchestra/log')
 const { decorateClass } = require('@vates/decorate-with')
 const { defer } = require('golike-defer')
-const { incorrectState } = require('xo-common/api-errors.js')
+const { incorrectState, forbiddenOperation } = require('xo-common/api-errors.js')
 const { Ref } = require('xen-api')
 
 const extractOpaqueRef = require('./_extractOpaqueRef.js')
@@ -343,7 +343,7 @@ class Vm {
     const vm = await this.getRecord('VM', vmRef)
 
     if (!bypassBlockedOperation && 'destroy' in vm.blocked_operations) {
-      throw new Error('destroy is blocked')
+      throw forbiddenOperation('destroy is blocked')
     }
 
     if (!forceDeleteDefaultTemplate && isDefaultTemplate(vm)) {

--- a/@xen-orchestra/xapi/vm.js
+++ b/@xen-orchestra/xapi/vm.js
@@ -343,7 +343,13 @@ class Vm {
     const vm = await this.getRecord('VM', vmRef)
 
     if (!bypassBlockedOperation && 'destroy' in vm.blocked_operations) {
-      throw forbiddenOperation(`destroy: ${vm.blocked_operations.destroy}`)
+      throw forbiddenOperation(
+        `destroy is blocked: ${
+          vm.blocked_operations.destroy === 'true'
+            ? 'protected from accidental deletion'
+            : vm.blocked_operations.destroy
+        }`
+      )
     }
 
     if (!forceDeleteDefaultTemplate && isDefaultTemplate(vm)) {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [VDI Import] Fix `this._getOrWaitObject is not a function`
-- [VM delete] In case the "Protect from accidental deletion" is set to `true` on a VM, a force modal is displayed when trying to delete it. (PR [#6290](https://github.com/vatesfr/xen-orchestra/pull/6290))
+- [VM] Attempting to delete a protected VM should display a modal with the error and the ability to bypass it (PR [#6290](https://github.com/vatesfr/xen-orchestra/pull/6290))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,7 +31,7 @@
 <!--packages-start-->
 
 - @vates/read-chunk major
-- @xen-orchestra patch
+- @xen-orchestra/xapi minor
 - xo-server patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [VDI Import] Fix `this._getOrWaitObject is not a function`
-- [VM delete] In case the "Protect from accidental deletion" is set to `true` on a VM, a force modal is displayed when trying to delete it. [#6283](https://github.com/vatesfr/xen-orchestra/issues/6283) (PR [#6290](https://github.com/vatesfr/xen-orchestra/pull/6290))
+- [VM delete] In case the "Protect from accidental deletion" is set to `true` on a VM, a force modal is displayed when trying to delete it. (PR [#6290](https://github.com/vatesfr/xen-orchestra/pull/6290))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [VDI Import] Fix `this._getOrWaitObject is not a function`
+- [VM delete] In case the "Protect from accidental deletion" is set to `true` on a VM, a force modal is displayed when trying to delete it. [#6283](https://github.com/vatesfr/xen-orchestra/issues/6283) (PR [#6290](https://github.com/vatesfr/xen-orchestra/pull/6290))
 
 ### Packages to release
 
@@ -30,6 +31,7 @@
 <!--packages-start-->
 
 - @vates/read-chunk major
+- @xen-orchestra patch
 - xo-server patch
 
 <!--packages-end-->


### PR DESCRIPTION
### Description
This small change will fix the force modal confirm for VM deletion.
See [UI error checking](https://github.com/vatesfr/xen-orchestra/blob/master/packages/xo-web/src/common/xo/index.js#L1612)
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
