### PR TITLE
fix(vhd-lib/VhdDirectory/mergeBlock): write BAT on block creation

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,6 +30,7 @@
 <!--packages-start-->
 
 - @xen-orchestra/fs minor
+- vhd-lib patch
 - xo-server minor
 - xo-web minor
 

--- a/packages/vhd-lib/Vhd/VhdDirectory.js
+++ b/packages/vhd-lib/Vhd/VhdDirectory.js
@@ -132,7 +132,7 @@ exports.VhdDirectory = class VhdDirectory extends VhdAbstract {
     this._path = path
     this._opts = opts
     this.#compressor = getCompressor(opts?.compression)
-    this.writeBlockAllocationTable = synchronized.withKey()(this.writeBlockAllocationTable)
+    this.writeBlockAllocationTable = synchronized()(this.writeBlockAllocationTable)
   }
 
   async readBlockAllocationTable() {

--- a/packages/vhd-lib/merge.js
+++ b/packages/vhd-lib/merge.js
@@ -42,13 +42,13 @@ const { warn } = createLogger('vhd-lib:merge')
 //         \_____________rename_____________/
 
 // write the merge progress file at most  every `delay` seconds
-function makeThrottledWriter(handler, path, delay) {
+function makeThrottleFn(fn, delay) {
   let lastWrite = Date.now()
-  return async json => {
+  return async (...args) => {
     const now = Date.now()
     if (now - lastWrite > delay) {
       lastWrite = now
-      await handler.writeFile(path, JSON.stringify(json), { flags: 'w' }).catch(warn)
+      await fn(...args)
     }
   }
 }
@@ -153,6 +153,11 @@ module.exports.mergeVhdChain = limitConcurrency(2)(async function mergeVhdChain(
         mergedDataSize: 0,
         chain: chain.map(vhdPath => handlerPath.relativeFromFile(mergeStatePath, vhdPath)),
       }
+
+      // finds first allocated block for the 2 following loops
+      while (mergeState.currentBlock < maxTableEntries && !childVhd.containsBlock(mergeState.currentBlock)) {
+        ++mergeState.currentBlock
+      }
     }
 
     // counts number of allocated blocks
@@ -167,12 +172,21 @@ module.exports.mergeVhdChain = limitConcurrency(2)(async function mergeVhdChain(
 
     const merging = new Set()
     let counter = 0
+    let hasNewBlock = false
 
-    const mergeStateWriter = makeThrottledWriter(handler, mergeStatePath, 10e3)
+    const mergeProgressWriter = makeThrottleFn(async () => {
+      await handler.writeFile(mergeStatePath, JSON.stringify(mergeState), { flags: 'w' }).catch(warn)
+      if (hasNewBlock) {
+        hasNewBlock = false
+        await parentVhd.writeBlockAllocationTable().catch(warn)
+      }
+    }, 10e3)
+
     await asyncEach(
       toMerge,
       async blockId => {
         merging.add(blockId)
+        hasNewBlock = hasNewBlock || !parentVhd.containsBlock(blockId)
         mergeState.mergedDataSize += await parentVhd.mergeBlock(childVhd, blockId, isResuming)
 
         mergeState.currentBlock = Math.min(...merging)
@@ -183,7 +197,7 @@ module.exports.mergeVhdChain = limitConcurrency(2)(async function mergeVhdChain(
           done: counter + 1,
         })
         counter++
-        mergeStateWriter(mergeState)
+        mergeProgressWriter()
       },
       {
         concurrency,

--- a/packages/vhd-lib/merge.js
+++ b/packages/vhd-lib/merge.js
@@ -153,11 +153,6 @@ module.exports.mergeVhdChain = limitConcurrency(2)(async function mergeVhdChain(
         mergedDataSize: 0,
         chain: chain.map(vhdPath => handlerPath.relativeFromFile(mergeStatePath, vhdPath)),
       }
-
-      // finds first allocated block for the 2 following loops
-      while (mergeState.currentBlock < maxTableEntries && !childVhd.containsBlock(mergeState.currentBlock)) {
-        ++mergeState.currentBlock
-      }
     }
 
     // counts number of allocated blocks

--- a/packages/vhd-lib/package.json
+++ b/packages/vhd-lib/package.json
@@ -21,6 +21,7 @@
     "@xen-orchestra/fs": "^3.0.0",
     "@xen-orchestra/log": "^0.3.0",
     "async-iterator-to-stream": "^1.0.2",
+    "decorator-synchronized": "^0.6.0",
     "fs-extra": "^10.0.0",
     "limit-concurrency-decorator": "^0.5.0",
     "lodash": "^4.17.4",


### PR DESCRIPTION
merge don't update BAT. if new block have been created AND the merge is resuming, these block will be lost 

This PR try to update the parent BAT each time the progress is written if a block have been created

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [x] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
