### PR TITLE
fix(vhd-lib): fix VhdDirectory merge on non-S3 remote

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,4 +27,5 @@
 
 <!--packages-start-->
 
+- vhd-lib patch
 <!--packages-end-->

--- a/packages/vhd-lib/Vhd/VhdDirectory.js
+++ b/packages/vhd-lib/Vhd/VhdDirectory.js
@@ -163,8 +163,10 @@ exports.VhdDirectory = class VhdDirectory extends VhdAbstract {
       `Can't write a chunk ${partName} in ${this._path} with read permission`
     )
 
+    // in case of VhdDirectory, we want to create the file if it does not exists
+    const flags = this._opts?.flags === 'r+' ? 'w' : this._opts?.flags
     const compressed = await this.#compressor.compress(buffer)
-    return this._handler.outputFile(this.#getChunkPath(partName), compressed, { flags: 'w' })
+    return this._handler.outputFile(this.#getChunkPath(partName), compressed, { flags })
   }
 
   // put block in subdirectories to limit impact when doing directory listing

--- a/packages/vhd-lib/Vhd/VhdDirectory.js
+++ b/packages/vhd-lib/Vhd/VhdDirectory.js
@@ -117,7 +117,7 @@ exports.VhdDirectory = class VhdDirectory extends VhdAbstract {
   }
 
   static async create(handler, path, { flags = 'wx+', compression } = {}) {
-    await handler.mkdir(path)
+    await handler.mktree(path)
     const vhd = new VhdDirectory(handler, path, { flags, compression })
     return {
       dispose: () => {},

--- a/packages/vhd-lib/Vhd/VhdDirectory.js
+++ b/packages/vhd-lib/Vhd/VhdDirectory.js
@@ -164,7 +164,7 @@ exports.VhdDirectory = class VhdDirectory extends VhdAbstract {
     )
 
     const compressed = await this.#compressor.compress(buffer)
-    return this._handler.outputFile(this.#getChunkPath(partName), compressed, this._opts)
+    return this._handler.outputFile(this.#getChunkPath(partName), compressed, { flags: 'w' })
   }
 
   // put block in subdirectories to limit impact when doing directory listing

--- a/packages/vhd-lib/Vhd/VhdSynthetic.js
+++ b/packages/vhd-lib/Vhd/VhdSynthetic.js
@@ -109,11 +109,7 @@ const VhdSynthetic = class VhdSynthetic extends VhdAbstract {
 
   // return true if all the vhds ar an instance of cls
   checkVhdsClass(cls) {
-    let ok = true
-    for (const vhd of this.#vhds) {
-      ok = ok && vhd instanceof cls
-    }
-    return ok
+    return this.#vhds.every(vhd => vhd instanceof cls)
   }
 }
 

--- a/packages/vhd-lib/Vhd/VhdSynthetic.js
+++ b/packages/vhd-lib/Vhd/VhdSynthetic.js
@@ -106,6 +106,15 @@ const VhdSynthetic = class VhdSynthetic extends VhdAbstract {
     const vhd = this.#getVhdWithBlock(blockId)
     return vhd?._getFullBlockPath(blockId)
   }
+
+  // return true if all the vhds ar an instance of cls
+  checkVhdsClass(cls) {
+    let ok = true
+    for (const vhd of this.#vhds) {
+      ok = ok && vhd instanceof cls
+    }
+    return ok
+  }
 }
 
 // add decorated  static method

--- a/packages/vhd-lib/chain.js
+++ b/packages/vhd-lib/chain.js
@@ -8,7 +8,7 @@ const { Disposable } = require('promise-toolbox')
 
 module.exports = async function chain(parentHandler, parentPath, childHandler, childPath, force = false) {
   await Disposable.use(
-    [openVhd(parentHandler, parentPath), openVhd(childHandler, childPath)],
+    [openVhd(parentHandler, parentPath), openVhd(childHandler, childPath, { flags: 'r+' })],
     async ([parentVhd, childVhd]) => {
       await childVhd.readHeaderAndFooter()
       const { header, footer } = childVhd

--- a/packages/vhd-lib/createVhdDirectoryFromStream.js
+++ b/packages/vhd-lib/createVhdDirectoryFromStream.js
@@ -50,7 +50,7 @@ exports.createVhdDirectoryFromStream = async function createVhdDirectoryFromStre
     }
   } catch (error) {
     // cleanup on error
-    await handler.rmtree(path)
+    await handler.rmtree(path).catch(() => {})
     throw error
   }
 }

--- a/packages/vhd-lib/createVhdDirectoryFromStream.js
+++ b/packages/vhd-lib/createVhdDirectoryFromStream.js
@@ -1,9 +1,12 @@
 'use strict'
 
+const { createLogger } = require('@xen-orchestra/log')
 const { parseVhdStream } = require('./parseVhdStream.js')
 const { VhdDirectory } = require('./Vhd/VhdDirectory.js')
 const { Disposable } = require('promise-toolbox')
 const { asyncEach } = require('@vates/async-each')
+
+const { warn } = createLogger('vhd-lib:createVhdDirectoryFromStream')
 
 const buildVhd = Disposable.wrap(async function* (handler, path, inputStream, { concurrency, compression }) {
   const vhd = yield VhdDirectory.create(handler, path, { compression })
@@ -50,7 +53,7 @@ exports.createVhdDirectoryFromStream = async function createVhdDirectoryFromStre
     }
   } catch (error) {
     // cleanup on error
-    await handler.rmtree(path).catch(() => {})
+    await handler.rmtree(path).catch(warn)
     throw error
   }
 }

--- a/packages/vhd-lib/merge.js
+++ b/packages/vhd-lib/merge.js
@@ -107,14 +107,17 @@ module.exports.mergeVhd = limitConcurrency(2)(async function merge(
       checkSecondFooter: mergeState === undefined,
     })
     let childVhd
+    const parentIsVhdDirectory = parentVhd instanceof VhdDirectory
+    let childIsVhdDirectory
     if (Array.isArray(childPath)) {
       childVhd = yield VhdSynthetic.open(childHandler, childPath)
+      childIsVhdDirectory = childVhd.checkVhdsClass(VhdDirectory)
     } else {
       childVhd = yield openVhd(childHandler, childPath)
+      childIsVhdDirectory = childVhd instanceof VhdDirectory
     }
 
-    const concurrency = childVhd instanceof VhdDirectory ? 16 : 1
-
+    const concurrency = parentIsVhdDirectory && childIsVhdDirectory ? 16 : 1
     if (mergeState === undefined) {
       // merge should be along a vhd chain
       assert.strictEqual(UUID.stringify(childVhd.header.parentUuid), UUID.stringify(parentVhd.footer.uuid))


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
