### PR TITLE
feat(xo-server): inject HTTP proxy in env

### DIFF
--- a/packages/xo-server/sample.config.toml
+++ b/packages/xo-server/sample.config.toml
@@ -15,6 +15,11 @@
 # See: https://github.com/TooTallNate/node-proxy-agent#maps-proxy-protocols-to-httpagent-implementations
 # httpProxy = 'http://jsmith:qwerty@proxy.lan:3128'
 
+# List of host names (optionally with a port), separated by commas, for which
+# the proxy above will not be used.
+#
+# noProxy = 'example.net, example.com:443'
+
 #=====================================================================
 
 # It may be necessary to run XO-Server as a privileged user (e.g. `root`) for

--- a/packages/xo-server/src/xo-mixins/http.mjs
+++ b/packages/xo-server/src/xo-mixins/http.mjs
@@ -1,8 +1,12 @@
 import hrp from 'http-request-plus'
 import ProxyAgent from 'proxy-agent'
-import firstDefined from '@xen-orchestra/defined'
+
+const { env } = process
 
 export default class Http {
+  // automatically fetches the proxy to use for the requested URL from the environnement
+  _agent = new ProxyAgent()
+
   // whether XO has a proxy set from its own config/environment
   get hasOwnHttpProxy() {
     return this._hasOwnHttpProxy
@@ -12,16 +16,14 @@ export default class Http {
     return this._agent
   }
 
-  constructor(_, { config: { httpProxy = firstDefined(process.env.http_proxy, process.env.HTTP_PROXY) } }) {
-    this._hasOwnHttpProxy = httpProxy != null
+  constructor(_, { config: { httpProxy, noProxy } }) {
+    if (httpProxy !== undefined) {
+      this._hasOwnHttpProxy = true
 
-    this.setHttpProxy(httpProxy)
+      this.setHttpProxy(httpProxy, noProxy)
+    }
   }
 
-  // TODO: find a way to decide for which addresses the proxy should be used
-  //
-  // For the moment, use this method only to access external resources (e.g.
-  // patches, upgrades, support tunnel)
   httpRequest(...args) {
     return hrp(
       {
@@ -31,11 +33,24 @@ export default class Http {
     )
   }
 
-  setHttpProxy(proxy) {
+  // Inject the proxy into the environnement, it will be automatically used by `_agent` and by most libs (e.g `axios`)
+  setHttpProxy(proxy, noProxy) {
     if (proxy == null) {
-      this._agent = undefined
+      delete env.http_proxy
+      delete env.HTTP_PROXY
+      delete env.https_proxy
+      delete env.HTTPS_PROXY
     } else {
-      this._agent = new ProxyAgent(proxy)
+      env.http_proxy = env.HTTP_PROXY = env.https_proxy = env.HTTPS_PROXY = proxy
+    }
+
+    if (noProxy !== undefined) {
+      if (proxy === null) {
+        delete env.no_proxy
+        delete env.NO_PROXY
+      } else {
+        env.no_proxy = env.NO_PROXY = noProxy
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes zammad#8073

Related to #6320

- brings `no_proxy` supports
- implicit supports for other libs

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
