### PR TITLE
fix(vhd-lib): resuming merge of vhd should still use a chain from parent to child

### DIFF
--- a/@xen-orchestra/backups/_cleanVm.js
+++ b/@xen-orchestra/backups/_cleanVm.js
@@ -430,7 +430,7 @@ exports.cleanVm = async function cleanVm(
 
     // merge interrupted VHDs
     for (const parent of interruptedVhds.keys()) {
-      vhdChainsToMerge[parent] = [vhdChildren[parent], parent]
+      vhdChainsToMerge[parent] = [parent, vhdChildren[parent]]
     }
 
     Object.values(vhdChainsToMerge).forEach(chain => {

--- a/@xen-orchestra/fs/package.json
+++ b/@xen-orchestra/fs/package.json
@@ -17,7 +17,7 @@
     "xo-fs": "./cli.js"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=14.13"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.54.0",
@@ -67,5 +67,9 @@
   "author": {
     "name": "Vates SAS",
     "url": "https://vates.fr"
+  },
+  "exports": {
+    ".": "./dist/index.js",
+    "./path": "./dist/path.js"
   }
 }

--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -9,7 +9,7 @@ import { pipeline } from 'stream'
 import { randomBytes } from 'crypto'
 import { synchronized } from 'decorator-synchronized'
 
-import { basename, dirname, normalize as normalizePath } from './_path'
+import { basename, dirname, normalize as normalizePath } from './path'
 import { createChecksumStream, validChecksumOfReadStream } from './checksum'
 
 const { warn } = createLogger('@xen-orchestra:fs')

--- a/@xen-orchestra/fs/src/path.js
+++ b/@xen-orchestra/fs/src/path.js
@@ -1,6 +1,6 @@
 import path from 'path'
 
-const { basename, dirname, join, resolve, sep } = path.posix
+const { basename, dirname, join, resolve, relative, sep } = path.posix
 
 export { basename, dirname, join }
 
@@ -19,3 +19,6 @@ export function split(path) {
 
   return parts
 }
+
+export const relativeFromFile = (file, path) => relative(dirname(file), path)
+export const resolveFromFile = (file, path) => resolve('/', dirname(file), path).slice(1)

--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -27,7 +27,7 @@ import copyStreamToBuffer from './_copyStreamToBuffer.js'
 import createBufferFromStream from './_createBufferFromStream.js'
 import guessAwsRegion from './_guessAwsRegion.js'
 import RemoteHandlerAbstract from './abstract'
-import { basename, join, split } from './_path'
+import { basename, join, split } from './path'
 import { asyncEach } from '@vates/async-each'
 
 // endpoints https://docs.aws.amazon.com/general/latest/gr/s3.html

--- a/@xen-orchestra/fs/src/smb-mount.js
+++ b/@xen-orchestra/fs/src/smb-mount.js
@@ -1,7 +1,7 @@
 import { parse } from 'xo-remote-parser'
 
 import MountHandler from './_mount'
-import { normalize } from './_path'
+import { normalize } from './path'
 
 export default class SmbMountHandler extends MountHandler {
   constructor(remote, opts) {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Backup] Fix `incorrect backup size in metadata` on each merged VHD (PR [#6331](https://github.com/vatesfr/xen-orchestra/pull/6331))
+- [Backup] Fix `assertionError [ERR_ASSERTION]: Expected values to be strictly equal` when resuming a merge (PR [#6349](https://github.com/vatesfr/xen-orchestra/pull/6349))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,6 +31,7 @@
 <!--packages-start-->
 
 - @xen-orchestra/backups patch
+- @xen-orchestra/fs minor
 - @xen-orchestra/mixins patch
 - vhd-cli minor
 - vhd-lib patch

--- a/packages/vhd-lib/package.json
+++ b/packages/vhd-lib/package.json
@@ -18,6 +18,7 @@
     "@vates/async-each": "^1.0.0",
     "@vates/read-chunk": "^1.0.0",
     "@xen-orchestra/async-map": "^0.1.2",
+    "@xen-orchestra/fs": "^2.0.0",
     "@xen-orchestra/log": "^0.3.0",
     "async-iterator-to-stream": "^1.0.2",
     "fs-extra": "^10.0.0",


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
