### PR TITLE
fix(xo-web/backup/restore): don't use `UNSAFE_componentWillReceiveProps`

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Backup/Restore] Fix backup list not loading on page load (PR [#6364](https://github.com/vatesfr/xen-orchestra/pull/6364))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -30,5 +32,6 @@
 - @xen-orchestra/fs minor
 - vhd-lib major
 - xo-server minor
+- xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-web/src/xo-app/backup/restore/index.js
+++ b/packages/xo-web/src/xo-app/backup/restore/index.js
@@ -94,7 +94,7 @@ export default class Restore extends Component {
     backupDataByVm: {},
   }
 
-  UNSAFE_componentWillReceiveProps(props) {
+  componentWillReceiveProps(props) {
     if (props.remotes !== this.props.remotes || props.jobs !== this.props.jobs) {
       this._refreshBackupList(props.remotes, props.jobs)
     }

--- a/scripts/babel-eslintrc.js
+++ b/scripts/babel-eslintrc.js
@@ -30,4 +30,9 @@ module.exports = {
       },
     },
   ],
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
 }


### PR DESCRIPTION
Introduced by 7d6e8322267ff30463e1dbfcbed7e5cc9ee70f27

`UNSAFE_componentWillReceiveProps` method was only introduced in React 16 but we
are using React 15
`.eslintrc`: ask eslint to check the React version so that it doesn't suggest to
change it to `UNSAFE_componentWillReceiveProps`

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
