### PR TITLE
feat(xo-web/storage): display SR used for the HA state files

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Home/Storage] Display SR used for HA state files [#6339](https://github.com/vatesfr/xen-orchestra/issues/6339)(PR [#6384](https://github.com/vatesfr/xen-orchestra/pull/6384))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -37,6 +39,6 @@
 - xen-api patch
 - xo-vmdk-to-vhd patch
 - xo-server minor
-- xo-web patch
+- xo-web minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,7 +7,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [Home/Storage] Display SR used for HA state files [#6339](https://github.com/vatesfr/xen-orchestra/issues/6339)(PR [#6384](https://github.com/vatesfr/xen-orchestra/pull/6384))
+- [Home/Storage] Show which SRs are used for HA state files [#6339](https://github.com/vatesfr/xen-orchestra/issues/6339) (PR [#6384](https://github.com/vatesfr/xen-orchestra/pull/6384))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -107,7 +107,7 @@ const TRANSFORMS = {
       current_operations: obj.current_operations,
       default_SR: link(obj, 'default_SR'),
       HA_enabled: Boolean(obj.ha_enabled),
-      haStatefiles: link(obj, 'ha_statefiles'),
+      haSrs: obj.$ha_statefiles.map(vdi => link(vdi, 'SR')),
       master: link(obj, 'master'),
       tags: obj.tags,
       name_description: obj.name_description,

--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -107,7 +107,7 @@ const TRANSFORMS = {
       current_operations: obj.current_operations,
       default_SR: link(obj, 'default_SR'),
       HA_enabled: Boolean(obj.ha_enabled),
-      ha_statefiles: link(obj, 'ha_statefiles'),
+      haStatefiles: link(obj, 'ha_statefiles'),
       master: link(obj, 'master'),
       tags: obj.tags,
       name_description: obj.name_description,

--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -107,6 +107,7 @@ const TRANSFORMS = {
       current_operations: obj.current_operations,
       default_SR: link(obj, 'default_SR'),
       HA_enabled: Boolean(obj.ha_enabled),
+      ha_statefiles: link(obj, 'ha_statefiles'),
       master: link(obj, 'master'),
       tags: obj.tags,
       name_description: obj.name_description,

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1280,7 +1280,7 @@ const messages = {
   protectFromDeletion: 'Protect from accidental deletion',
   protectFromShutdown: 'Protect from accidental shutdown',
   ha: 'HA',
-  srHaTooltip: 'SR used for the high availability',
+  srHaTooltip: 'SR used for High Availability',
   nestedVirt: 'Nested virtualization',
   vmAffinityHost: 'Affinity host',
   vmVga: 'VGA',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1280,6 +1280,7 @@ const messages = {
   protectFromDeletion: 'Protect from accidental deletion',
   protectFromShutdown: 'Protect from accidental shutdown',
   ha: 'HA',
+  srHaTooltip: 'SR used for the high availability',
   nestedVirt: 'Nested virtualization',
   vmAffinityHost: 'Affinity host',
   vmVga: 'VGA',

--- a/packages/xo-web/src/xo-app/home/sr-item.js
+++ b/packages/xo-web/src/xo-app/home/sr-item.js
@@ -118,7 +118,11 @@ export default class SrItem extends Component {
                   <Text value={sr.name_label} onChange={this._setNameLabel} useLongClick />
                 </Ellipsis>
                 {isDefaultSr && <span className='tag tag-pill tag-info ml-1'>{_('defaultSr')}</span>}
-                {isHa && <span className='tag tag-pill tag-info ml-1'>{_('ha')}</span>}
+                {isHa && (
+                  <Tooltip content={_('srHaTooltip')}>
+                    <span className='tag tag-pill tag-info ml-1'>{_('ha')}</span>
+                  </Tooltip>
+                )}
                 {sr.inMaintenanceMode && <span className='tag tag-pill tag-warning ml-1'>{_('maintenanceMode')}</span>}
               </EllipsisContainer>
             </Col>

--- a/packages/xo-web/src/xo-app/home/sr-item.js
+++ b/packages/xo-web/src/xo-app/home/sr-item.js
@@ -22,7 +22,7 @@ import styles from './index.css'
     (_, props) => props.item,
     (state, props) => {
       const _createGetObject = cb => createGetObject(cb)(state, props)
-      return _createGetObject((_, props) => props.item.$poolId).ha_statefiles.map(id => _createGetObject(() => id))
+      return _createGetObject((_, props) => props.item.$poolId).haStatefiles.map(id => _createGetObject(() => id))
     },
     (sr, statefiles) => statefiles.find(vdi => vdi.$SR === sr.id) !== undefined
   ),

--- a/packages/xo-web/src/xo-app/home/sr-item.js
+++ b/packages/xo-web/src/xo-app/home/sr-item.js
@@ -20,11 +20,8 @@ import styles from './index.css'
   container: createGetObject((_, props) => props.item.$container),
   isHa: createSelector(
     (_, props) => props.item,
-    (state, props) => {
-      const _createGetObject = cb => createGetObject(cb)(state, props)
-      return _createGetObject((_, props) => props.item.$poolId).haStatefiles.map(id => _createGetObject(() => id))
-    },
-    (sr, statefiles) => statefiles.find(vdi => vdi.$SR === sr.id) !== undefined
+    createGetObject((_, props) => props.item.$poolId),
+    (sr, pool) => pool.haSrs.includes(sr.id)
   ),
   isDefaultSr: createSelector(
     createGetObjectsOfType('pool').find((_, props) => pool => props.item.$pool === pool.id),

--- a/packages/xo-web/src/xo-app/home/sr-item.js
+++ b/packages/xo-web/src/xo-app/home/sr-item.js
@@ -18,6 +18,14 @@ import styles from './index.css'
 
 @connectStore({
   container: createGetObject((_, props) => props.item.$container),
+  isHa: createSelector(
+    (_, props) => props.item,
+    (state, props) => {
+      const _createGetObject = cb => createGetObject(cb)(state, props)
+      return _createGetObject((_, props) => props.item.$poolId).ha_statefiles.map(id => _createGetObject(() => id))
+    },
+    (sr, statefiles) => statefiles.find(vdi => vdi.$SR === sr.id) !== undefined
+  ),
   isDefaultSr: createSelector(
     createGetObjectsOfType('pool').find((_, props) => pool => props.item.$pool === pool.id),
     (_, props) => props.item,
@@ -97,7 +105,7 @@ export default class SrItem extends Component {
   }
 
   render() {
-    const { container, expandAll, isDefaultSr, isShared, item: sr, selected } = this.props
+    const { container, expandAll, isDefaultSr, isHa, isShared, item: sr, selected } = this.props
 
     return (
       <div className={styles.item}>
@@ -113,6 +121,7 @@ export default class SrItem extends Component {
                   <Text value={sr.name_label} onChange={this._setNameLabel} useLongClick />
                 </Ellipsis>
                 {isDefaultSr && <span className='tag tag-pill tag-info ml-1'>{_('defaultSr')}</span>}
+                {isHa && <span className='tag tag-pill tag-info ml-1'>{_('ha')}</span>}
                 {sr.inMaintenanceMode && <span className='tag tag-pill tag-warning ml-1'>{_('maintenanceMode')}</span>}
               </EllipsisContainer>
             </Col>


### PR DESCRIPTION
Fixes #6339

### Screenshot

![Capture d’écran de 2022-08-29 10-48-01](https://user-images.githubusercontent.com/70369997/187162361-b39d9750-cc7a-4b2c-aeec-b6315973b370.png)

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
