### PR TITLE
feat(lite): placeholders for pool/host/VM name_label

### DIFF
--- a/@xen-orchestra/lite/src/components/infra/InfraHostItem.vue
+++ b/@xen-orchestra/lite/src/components/infra/InfraHostItem.vue
@@ -5,7 +5,7 @@
       :icon="faServer"
       :route="{ name: 'host.dashboard', params: { uuid: host.uuid } }"
     >
-      {{ host.name_label }}
+      {{ host.name_label || '(Host)' }}
       <template #actions>
         <InfraAction
           :icon="isExpanded ? faAngleDown : faAngleUp"

--- a/@xen-orchestra/lite/src/components/infra/InfraPoolList.vue
+++ b/@xen-orchestra/lite/src/components/infra/InfraPoolList.vue
@@ -7,7 +7,7 @@
         :route="{ name: 'pool.dashboard', params: { uuid: pool.uuid } }"
         current
       >
-        {{ pool.name_label }}
+        {{ pool.name_label || '(Pool)' }}
       </InfraItemLabel>
 
       <InfraHostList />

--- a/@xen-orchestra/lite/src/components/infra/InfraVmItem.vue
+++ b/@xen-orchestra/lite/src/components/infra/InfraVmItem.vue
@@ -5,7 +5,7 @@
       :icon="faDisplay"
       :route="{ name: 'vm.console', params: { uuid: vm.uuid } }"
     >
-      {{ vm.name_label }}
+      {{ vm.name_label || '(VM)' }}
       <template #actions>
         <InfraAction>
           <PowerStateIcon :state="vm?.power_state" />


### PR DESCRIPTION
Some objects may have an empty `name_label`. This is to avoid confusion in the
tree view.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
