### PR TITLE
fix(xo-server): handle unfetched VDIs in pool.$ha_statefiles

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,4 +27,6 @@
 
 <!--packages-start-->
 
+- xo-server patch
+
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Storage/Pool] Fix `an error as occured` (PR [#6404](https://github.com/vatesfr/xen-orchestra/pull/6404))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -40,9 +40,6 @@ const ALLOCATION_BY_TYPE = {
 const { defineProperties, freeze } = Object
 
 function link(obj, prop, idField = '$id') {
-  if (obj === undefined) {
-    return undefined
-  }
   const dynamicValue = obj[`$${prop}`]
   if (dynamicValue == null) {
     return dynamicValue // Properly handles null and undefined.
@@ -110,7 +107,7 @@ const TRANSFORMS = {
       current_operations: obj.current_operations,
       default_SR: link(obj, 'default_SR'),
       HA_enabled: Boolean(obj.ha_enabled),
-      haSrs: obj.$ha_statefiles.map(vdi => link(vdi, 'SR')).filter(sr => sr !== undefined),
+      haSrs: obj.$ha_statefiles.filter(vdi => vdi !== undefined).map(vdi => link(vdi, 'SR')),
       master: link(obj, 'master'),
       tags: obj.tags,
       name_description: obj.name_description,

--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -40,6 +40,9 @@ const ALLOCATION_BY_TYPE = {
 const { defineProperties, freeze } = Object
 
 function link(obj, prop, idField = '$id') {
+  if (obj === undefined) {
+    return undefined
+  }
   const dynamicValue = obj[`$${prop}`]
   if (dynamicValue == null) {
     return dynamicValue // Properly handles null and undefined.
@@ -107,7 +110,7 @@ const TRANSFORMS = {
       current_operations: obj.current_operations,
       default_SR: link(obj, 'default_SR'),
       HA_enabled: Boolean(obj.ha_enabled),
-      haSrs: obj.$ha_statefiles.map(vdi => link(vdi, 'SR')),
+      haSrs: obj.$ha_statefiles.map(vdi => link(vdi, 'SR')).filter(sr => sr !== undefined),
       master: link(obj, 'master'),
       tags: obj.tags,
       name_description: obj.name_description,

--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -107,7 +107,10 @@ const TRANSFORMS = {
       current_operations: obj.current_operations,
       default_SR: link(obj, 'default_SR'),
       HA_enabled: Boolean(obj.ha_enabled),
+
+      // ignore undefined VDIs, which occurs if the objects were not fetched/cached yet.
       haSrs: obj.$ha_statefiles.filter(vdi => vdi !== undefined).map(vdi => link(vdi, 'SR')),
+
       master: link(obj, 'master'),
       tags: obj.tags,
       name_description: obj.name_description,


### PR DESCRIPTION
introduced by #6384

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
