### PR TITLE
feat(backups): update VM backups cache

### DIFF
--- a/@xen-orchestra/backups/RemoteAdapter.js
+++ b/@xen-orchestra/backups/RemoteAdapter.js
@@ -35,7 +35,7 @@ exports.DIR_XO_CONFIG_BACKUPS = DIR_XO_CONFIG_BACKUPS
 const DIR_XO_POOL_METADATA_BACKUPS = 'xo-pool-metadata-backups'
 exports.DIR_XO_POOL_METADATA_BACKUPS = DIR_XO_POOL_METADATA_BACKUPS
 
-const { warn } = createLogger('xo:backups:RemoteAdapter')
+const { debug, warn } = createLogger('xo:backups:RemoteAdapter')
 
 const compareTimestamp = (a, b) => a.timestamp - b.timestamp
 
@@ -235,6 +235,7 @@ class RemoteAdapter {
       // detached async action, will not reject
       this._updateCache(dir + '/cache.json.gz', backups => {
         for (const filename of filenames) {
+          debug('removing cache entry', { entry: filename })
           delete backups[filename]
         }
       })
@@ -615,6 +616,7 @@ class RemoteAdapter {
 
     // will not throw
     this._updateCache(this.#getVmBackupsCache(vmUuid), backups => {
+      debug('adding cache entry', { entry: path })
       backups[path] = {
         ...metadata,
 

--- a/@xen-orchestra/backups/RemoteAdapter.js
+++ b/@xen-orchestra/backups/RemoteAdapter.js
@@ -233,7 +233,7 @@ class RemoteAdapter {
       )
     )) {
       // detached async action, will not reject
-      this.#updateCache(dir + '/cache.json.gz', backups => {
+      this._updateCache(dir + '/cache.json.gz', backups => {
         for (const filename of filenames) {
           delete backups[filename]
         }
@@ -490,7 +490,9 @@ class RemoteAdapter {
     }
   }
 
-  async #updateCache(path, fn) {
+  _updateCache = synchronized.withKey()(this._updateCache)
+  // eslint-disable-next-line no-dupe-class-members
+  async _updateCache(path, fn) {
     const cache = await this.#readCache(path)
     if (cache !== undefined) {
       fn(cache)
@@ -612,7 +614,7 @@ class RemoteAdapter {
     })
 
     // will not throw
-    this.#updateCache(this.#getVmBackupsCache(vmUuid), backups => {
+    this._updateCache(this.#getVmBackupsCache(vmUuid), backups => {
       backups[path] = {
         ...metadata,
 

--- a/@xen-orchestra/backups/RemoteAdapter.js
+++ b/@xen-orchestra/backups/RemoteAdapter.js
@@ -226,21 +226,19 @@ class RemoteAdapter {
   }
 
   #removeVmBackupsFromCache(backups) {
-    // will not throw
-    asyncMap(
-      Object.entries(
-        groupBy(
-          backups.map(_ => _._filename),
-          dirname
-        )
-      ),
-      ([dir, filenames]) =>
-        this.#updateCache(dir + '/cache.json.gz', backups => {
-          for (const filename of filenames) {
-            delete backups[filename]
-          }
-        })
-    )
+    for (const [dir, filenames] of Object.entries(
+      groupBy(
+        backups.map(_ => _._filename),
+        dirname
+      )
+    )) {
+      // detached async action, will not reject
+      this.#updateCache(dir + '/cache.json.gz', backups => {
+        for (const filename of filenames) {
+          delete backups[filename]
+        }
+      })
+    }
   }
 
   async deleteDeltaVmBackups(backups) {

--- a/@xen-orchestra/backups/_cleanVm.js
+++ b/@xen-orchestra/backups/_cleanVm.js
@@ -533,8 +533,7 @@ exports.cleanVm = async function cleanVm(
 
   // purge cache if a metadata file has been deleted
   if (mustInvalidateCache) {
-    // cleanvm is always invoked as a method of RemoteAdapter
-    await this._invalidateVmBackupListCacheDir(vmDir)
+    await handler.unlink(vmDir + '/cache.json.gz')
   }
 
   return {

--- a/@xen-orchestra/backups/writers/DeltaBackupWriter.js
+++ b/@xen-orchestra/backups/writers/DeltaBackupWriter.js
@@ -158,7 +158,6 @@ exports.DeltaBackupWriter = class DeltaBackupWriter extends MixinBackupWriter(Ab
         }/${adapter.getVhdFileName(basename)}`
     )
 
-    const metadataFilename = (this._metadataFileName = `${backupDir}/${basename}.json`)
     const metadataContent = {
       jobId,
       mode: job.mode,
@@ -223,9 +222,7 @@ exports.DeltaBackupWriter = class DeltaBackupWriter extends MixinBackupWriter(Ab
       }
     })
     metadataContent.size = size
-    await handler.outputFile(metadataFilename, JSON.stringify(metadataContent), {
-      dirMode: backup.config.dirMode,
-    })
+    this._metadataFileName = await adapter.writeVmBackupMetadata(vm.uuid, metadataContent)
 
     // TODO: run cleanup?
   }

--- a/@xen-orchestra/backups/writers/FullBackupWriter.js
+++ b/@xen-orchestra/backups/writers/FullBackupWriter.js
@@ -34,7 +34,6 @@ exports.FullBackupWriter = class FullBackupWriter extends MixinBackupWriter(Abst
     const { job, scheduleId, vm } = backup
 
     const adapter = this._adapter
-    const handler = adapter.handler
     const backupDir = getVmBackupDir(vm.uuid)
 
     // TODO: clean VM backup directory
@@ -50,7 +49,7 @@ exports.FullBackupWriter = class FullBackupWriter extends MixinBackupWriter(Abst
     const dataBasename = basename + '.xva'
     const dataFilename = backupDir + '/' + dataBasename
 
-    const metadataFilename = (this._metadataFileName = `${backupDir}/${basename}.json`)
+    const metadataFilename = `${backupDir}/${basename}.json`
     const metadata = {
       jobId: job.id,
       mode: job.mode,
@@ -74,9 +73,7 @@ exports.FullBackupWriter = class FullBackupWriter extends MixinBackupWriter(Abst
       return { size: sizeContainer.size }
     })
     metadata.size = sizeContainer.size
-    await handler.outputFile(metadataFilename, JSON.stringify(metadata), {
-      dirMode: backup.config.dirMode,
-    })
+    this._metadataFileName = await adapter.writeVmBackupMetadata(vm.uuid, metadata)
 
     if (!deleteFirst) {
       await deleteOldBackups()

--- a/@xen-orchestra/backups/writers/_MixinBackupWriter.js
+++ b/@xen-orchestra/backups/writers/_MixinBackupWriter.js
@@ -74,7 +74,6 @@ exports.MixinBackupWriter = (BaseClass = Object) =>
         const remotePath = handler._getRealPath()
         await MergeWorker.run(remotePath)
       }
-      await this._adapter.invalidateVmBackupListCache(this._backup.vm.uuid)
     }
 
     healthCheck(sr) {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Backup] Improve listing speed by updating caches instead of regenerating them on backup creation/deletion (PR [#6411](https://github.com/vatesfr/xen-orchestra/pull/6411))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”


### PR DESCRIPTION
Instead of complete invalidation/regeneration on creation/deletion.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
