### PR TITLE
feat(xo-web/storage/NFS): ability to specify subdirectory

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,6 +8,7 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - [Backup] Improve listing speed by updating caches instead of regenerating them on backup creation/deletion (PR [#6411](https://github.com/vatesfr/xen-orchestra/pull/6411))
+- [Storage/NFS] Ability to use subdirectory when creating new NFS storage [#3919](https://github.com/vatesfr/xen-orchestra/issues/3919) (PR [#6425](https://github.com/vatesfr/xen-orchestra/pull/6425))
 
 ### Bug fixes
 
@@ -35,6 +36,6 @@
 
 - @xen-orchestra/backups minor
 - xo-server-auth-saml patch
-- xo-web patch
+- xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -30,6 +30,7 @@ const messages = {
   messageFrom: 'From',
   messageReply: 'Reply',
   sr: 'SR',
+  subdirectory: 'Subdirectory',
   tryXoa: 'Try XOA for free and deploy it here.',
   notInstalled: 'Not installed',
 

--- a/packages/xo-web/src/xo-app/new/sr/index.js
+++ b/packages/xo-web/src/xo-app/new/sr/index.js
@@ -699,7 +699,7 @@ export default class New extends Component {
                         id='selectSrPath'
                         onChange={event => {
                           const selectedPath = event.target.value
-                          this.linkState('selectedMainPath')(selectedPath)
+                          this.setState({ selectedMainPath: selectedPath })
                           this._handleSrPathSelection(selectedPath)
                         }}
                         ref='path'

--- a/packages/xo-web/src/xo-app/new/sr/index.js
+++ b/packages/xo-web/src/xo-app/new/sr/index.js
@@ -509,10 +509,9 @@ export default class New extends Component {
         path,
         usage: true,
         summary: true,
-        isValidPath: true,
       })
     } catch (err) {
-      this.setState({ isValidPath: false, summary: false, usage: false })
+      this.setState({ summary: false, usage: false })
       error('NFS Error', err.message || String(err))
     } finally {
       this.setState(({ loading }) => ({ loading: loading - 1 }))
@@ -564,7 +563,6 @@ export default class New extends Component {
       auth,
       host,
       iqns,
-      isValidPath,
       hbaDevices,
       loading,
       lockCreation,
@@ -910,7 +908,7 @@ export default class New extends Component {
               )}
             </Section>
             <Section icon='summary' title='newSrSummary'>
-              {summary && isValidPath !== false && (
+              {summary && (
                 <div>
                   <dl className='dl-horizontal'>
                     <dt>{_('newSrName')}</dt>


### PR DESCRIPTION
Fixes #3919 

### Recipe

Create directory:
```
sudo mkdir -p /tmp/srv/nfs/test
```
Update `/etc/exports`:
```
...
/tmp/srv/nfs        *(rw,no_root_squash,sync,no_subtree_check)
```
Refresh the current NFS exports:
```
sudo exportfs -ra
```
Confirm your folder is now exported:
```
showmount -e localhost
```

You are ready to test the feature using the subdirectory: `test`

### Screenshot

![Capture d’écran de 2022-09-15 17-07-43](https://user-images.githubusercontent.com/70369997/190589251-d5e06398-ff9e-4d46-870b-f62a4215055c.png)

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
