### PR TITLE
fix(xo-server): ignore disabled remotes when running VM backup

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@
 - [Plugin/auth-saml] Certificate input support multiline (PR [#6403](https://github.com/vatesfr/xen-orchestra/pull/6403))
 - [Backup] Launch Health Check after a full backup (PR [#6401](https://github.com/vatesfr/xen-orchestra/pull/6401))
 - [Backup] Fix `Lock file is already being held` error when deleting a VM backup while the VM is currently being backed up
-- [Backup] Fix Backup stoping on `remote is disabled` error when other remotes are working (PR [#6430](https://github.com/vatesfr/xen-orchestra/pull/6430))
+- [Backup] Fix Backup stoping on `remote is disabled` error when other remotes are working [#6347](https://github.com/vatesfr/xen-orchestra/issues/6374) (PR [#6430](https://github.com/vatesfr/xen-orchestra/pull/6430))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@
 - [Plugin/auth-saml] Certificate input support multiline (PR [#6403](https://github.com/vatesfr/xen-orchestra/pull/6403))
 - [Backup] Launch Health Check after a full backup (PR [#6401](https://github.com/vatesfr/xen-orchestra/pull/6401))
 - [Backup] Fix `Lock file is already being held` error when deleting a VM backup while the VM is currently being backed up
-- [Backup] Fix Backup stoping on `remote is disabled` error when other remotes are working [#6347](https://github.com/vatesfr/xen-orchestra/issues/6374) (PR [#6430](https://github.com/vatesfr/xen-orchestra/pull/6430))
+- [Backup] Ignore disabled remotes instead of failing the execution [#6347](https://github.com/vatesfr/xen-orchestra/issues/6374) (PR [#6430](https://github.com/vatesfr/xen-orchestra/pull/6430))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 - [Plugin/auth-saml] Certificate input support multiline (PR [#6403](https://github.com/vatesfr/xen-orchestra/pull/6403))
 - [Backup] Launch Health Check after a full backup (PR [#6401](https://github.com/vatesfr/xen-orchestra/pull/6401))
 - [Backup] Fix `Lock file is already being held` error when deleting a VM backup while the VM is currently being backed up
+- [Backup] Fix Backup stoping on `remote is disabled` error when other remotes are working (PR [#6430](https://github.com/vatesfr/xen-orchestra/pull/6430))
 
 ### Packages to release
 

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
@@ -230,7 +230,9 @@ export default class BackupNg {
             }),
           ])
           if (Object.keys(remotes).length === 0) {
-            throw new Error(`couldn't instantiate any remote`, { errors: remoteErrors })
+            const error = new Error(`couldn't instantiate any remote`)
+            error.errors = remoteErrors
+            throw error
           }
           // update remotes list with only the enabled remotes
           job.remotes = {

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
@@ -197,10 +197,10 @@ export default class BackupNg {
           await waitAll([
             asyncMapSettled(remoteIds, async id => {
               let remote
-              try{
+              try {
                 remote = await app.getRemoteWithCredentials(id)
-              }catch(error){
-                log.warn('Error while instantiating remote', {error, remoteId: id})
+              } catch (error) {
+                log.warn('Error while instantiating remote', { error, remoteId: id })
                 remoteErrors[id] = error
                 return
               }
@@ -229,8 +229,14 @@ export default class BackupNg {
               }
             }),
           ])
-          if(Object.keys(remotes).length === 0){
-            throw new Error(`couldn't instantiate any remote`, { errors: remoteErrors})
+          if (Object.keys(remotes).length === 0) {
+            throw new Error(`couldn't instantiate any remote`, { errors: remoteErrors })
+          }
+          // update remotes list with only the enabled remotes
+          job.remotes = {
+            id: {
+              __or: Object.keys(remotes),
+            },
           }
 
           const params = {


### PR DESCRIPTION
from https://github.com/vatesfr/xen-orchestra/issues/6374

### Test recipe

* create a backup with at least two remote
* run backup 
* [ ] it should succeed
* disable a backup
* rerun backup
* [ ] it should succeed with a warning in the log about the disabled remote

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
