### PR TITLE
fix(xo-web/home/VMs): do not delete VMs when confirm modal has been cancelled

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@
 - [Tasks] Fix the pool filter that did not display tasks even if they existed (PR [#6424](https://github.com/vatesfr/xen-orchestra/pull/6424))
 - [Tasks] Fix tasks being displayed for all users (PR [#6422](https://github.com/vatesfr/xen-orchestra/pull/6422))
 - [Storage/advanced] Fix the display of VDI to coalesce [#6334](https://xcp-ng.org/forum/topic/6334/coalesce-not-showing-anymore) (PR [#6429](https://github.com/vatesfr/xen-orchestra/pull/6429))
+- [Home/VMs] Fix VMs being deleted despite clicking on Cancel in the bulk deletion modal
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,7 +22,7 @@
 - [Tasks] Fix the pool filter that did not display tasks even if they existed (PR [#6424](https://github.com/vatesfr/xen-orchestra/pull/6424))
 - [Tasks] Fix tasks being displayed for all users (PR [#6422](https://github.com/vatesfr/xen-orchestra/pull/6422))
 - [Storage/advanced] Fix the display of VDI to coalesce [#6334](https://xcp-ng.org/forum/topic/6334/coalesce-not-showing-anymore) (PR [#6429](https://github.com/vatesfr/xen-orchestra/pull/6429))
-- [Home/VMs] Fix VMs being deleted despite clicking on Cancel in the bulk deletion modal
+- [Home/VMs] Fix VMs being deleted despite clicking on Cancel in the bulk deletion modal (PR [#6435](https://github.com/vatesfr/xen-orchestra/pull/6435))
 
 ### Packages to release
 

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -1618,14 +1618,18 @@ export const deleteVms = async vms => {
   if (vms.length === 1) {
     return deleteVm(vms[0])
   }
-  await confirm({
-    title: _('deleteVmsModalTitle', { vms: vms.length }),
-    body: _('deleteVmsModalMessage', { vms: vms.length }),
-    strongConfirm: vms.length > 1 && {
-      messageId: 'deleteVmsConfirmText',
-      values: { nVms: vms.length },
-    },
-  }).catch(noop)
+  try {
+    await confirm({
+      title: _('deleteVmsModalTitle', { vms: vms.length }),
+      body: _('deleteVmsModalMessage', { vms: vms.length }),
+      strongConfirm: vms.length > 1 && {
+        messageId: 'deleteVmsConfirmText',
+        values: { nVms: vms.length },
+      },
+    })
+  } catch (err) {
+    return
+  }
 
   let nErrors = 0
   await Promise.all(


### PR DESCRIPTION
See Zammad#9735
Introduced by 11e09e1f87b0dc218ead77cba490131a88931398

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
