### PR TITLE
feat(xo-web): replace XenServer by XCP-ng

### DIFF
--- a/packages/xo-web/src/common/intl/locales/es.js
+++ b/packages/xo-web/src/common/intl/locales/es.js
@@ -242,7 +242,7 @@ export default {
   // Original text: "Welcome on Xen Orchestra!"
   homeWelcome: '¡Bienvenido a Xen Orchestra!',
 
-  // Original text: "Add your XenServer hosts or pools"
+  // Original text: "Add your XCP-ng hosts or pools"
   homeWelcomeText: 'Añade tus hosts/pools de XenServer',
 
   // Original text: 'Some XenServers have been registered but are not connected'

--- a/packages/xo-web/src/common/intl/locales/fr.js
+++ b/packages/xo-web/src/common/intl/locales/fr.js
@@ -245,7 +245,7 @@ export default {
   // Original text: "Welcome on Xen Orchestra!"
   homeWelcome: 'Bienvenue sur Xen Orchestra !',
 
-  // Original text: "Add your XenServer hosts or pools"
+  // Original text: "Add your XCP-ng hosts or pools"
   homeWelcomeText: 'Ajouter vos serveurs ou pools XenServer',
 
   // Original text: "Some XenServers have been registered but are not connected"

--- a/packages/xo-web/src/common/intl/locales/he.js
+++ b/packages/xo-web/src/common/intl/locales/he.js
@@ -209,7 +209,7 @@ export default {
   // Original text: "Welcome on Xen Orchestra!"
   homeWelcome: 'ברוכים הבאים',
 
-  // Original text: "Add your XenServer hosts or pools"
+  // Original text: "Add your XCP-ng hosts or pools"
   homeWelcomeText: 'נא להוסיף שרתים או משאבים',
 
   // Original text: "Want some help?"

--- a/packages/xo-web/src/common/intl/locales/hu.js
+++ b/packages/xo-web/src/common/intl/locales/hu.js
@@ -227,7 +227,7 @@ export default {
   // Original text: "Welcome on Xen Orchestra!"
   homeWelcome: 'Üdvözöljük a Felhőben!',
 
-  // Original text: "Add your XenServer hosts or pools"
+  // Original text: "Add your XCP-ng hosts or pools"
   homeWelcomeText: 'Hozzáadása your XenServer kiszolgálók or pools',
 
   // Original text: "Some XenServers have been registered but are not connected"

--- a/packages/xo-web/src/common/intl/locales/it.js
+++ b/packages/xo-web/src/common/intl/locales/it.js
@@ -515,7 +515,7 @@ export default {
   // Original text: 'Welcome to Xen Orchestra!'
   homeWelcome: 'Benvenuti in Xen Orchestra!',
 
-  // Original text: 'Add your XenServer hosts or pools'
+  // Original text: 'Add your XCP-ng hosts or pools'
   homeWelcomeText: 'Aggiungi i tuoi hosts o pools XenServer',
 
   // Original text: 'Some XenServers have been registered but are not connected'

--- a/packages/xo-web/src/common/intl/locales/pl.js
+++ b/packages/xo-web/src/common/intl/locales/pl.js
@@ -212,7 +212,7 @@ export default {
   // Original text: "Welcome on Xen Orchestra!"
   homeWelcome: 'Witaj w Xen Orchestra!',
 
-  // Original text: "Add your XenServer hosts or pools"
+  // Original text: "Add your XCP-ng hosts or pools"
   homeWelcomeText: 'Dodaj serwery XenServer lub pule',
 
   // Original text: "Want some help?"

--- a/packages/xo-web/src/common/intl/locales/pt.js
+++ b/packages/xo-web/src/common/intl/locales/pt.js
@@ -209,7 +209,7 @@ export default {
   // Original text: "Welcome on Xen Orchestra!"
   homeWelcome: 'Bem-vindo ao Xen Orchestra',
 
-  // Original text: "Add your XenServer hosts or pools"
+  // Original text: "Add your XCP-ng hosts or pools"
   homeWelcomeText: 'Adicione seu XenServer hosts e pools',
 
   // Original text: "Want some help?"

--- a/packages/xo-web/src/common/intl/locales/tr.js
+++ b/packages/xo-web/src/common/intl/locales/tr.js
@@ -296,7 +296,7 @@ export default {
   // Original text: "Welcome to Xen Orchestra!"
   homeWelcome: "Xen Orchestra'ya Hoşgeldiniz!",
 
-  // Original text: "Add your XenServer hosts or pools"
+  // Original text: "Add your XCP-ng hosts or pools"
   homeWelcomeText: 'XenServer sunucu veya havuzunu ekle',
 
   // Original text: "Some XenServers have been registered but are not connected"

--- a/packages/xo-web/src/common/intl/locales/zh.js
+++ b/packages/xo-web/src/common/intl/locales/zh.js
@@ -167,7 +167,7 @@ export default {
   // Original text: "Welcome on Xen Orchestra!"
   homeWelcome: '欢迎使用Xen Orchestra',
 
-  // Original text: "Add your XenServer hosts or pools"
+  // Original text: "Add your XCP-ng hosts or pools"
   homeWelcomeText: '添加您的XenServer主机或资源池',
 
   // Original text: "Want some help?"

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -231,7 +231,7 @@ const messages = {
   notBackedUpVms: 'Not backed up VMs',
   homeFetchingData: 'Fetching data…',
   homeWelcome: 'Welcome to Xen Orchestra!',
-  homeWelcomeText: 'Add your XenServer hosts or pools',
+  homeWelcomeText: 'Add your XCP-ng hosts or pools',
   homeConnectServerText: 'Some XenServers have been registered but are not connected',
   homeHelp: 'Want some help?',
   homeAddServer: 'Add server',


### PR DESCRIPTION
I have installed a XO source for testing purposes, and I found XenServer was still mentioned in the home page
So I replace it with XCP-ng :D

Tested on XO latest commit (22038)

Image with my modification:
![image](https://user-images.githubusercontent.com/58917141/192817228-c52ea21e-fcdd-42ea-bb46-60a0c3e9e8f7.png)

Signed-off-by: Cécile MORANGE <contact@ataxya.net>

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [X] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [X] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
