### PR TITLE
Make xo-server log transport configurable

### DIFF
--- a/@xen-orchestra/log/.USAGE.md
+++ b/@xen-orchestra/log/.USAGE.md
@@ -1,3 +1,5 @@
+### Producers
+
 Everywhere something should be logged:
 
 ```js
@@ -25,6 +27,8 @@ log.error('could not join server', {
 })
 ```
 
+### Consumer
+
 Then, at application level, configure the logs are handled:
 
 ```js
@@ -45,13 +49,6 @@ const transport = transportEmail({
 
 configure([
   {
-    // if filter is a string, then it is pattern
-    // (https://github.com/visionmedia/debug#wildcards) which is
-    // matched against the namespace of the logs
-    //
-    // If it's an array, it will be handled as an array of filters
-    // and the transport will be used if any one of them match the
-    // current log
     filter: process.env.DEBUG,
 
     transport: transportConsole(),
@@ -62,12 +59,32 @@ configure([
 
     transport,
   },
+  {
+    type: 'email',
+
+    service: 'gmail',
+    auth: {
+      user: 'jane.smith@gmail.com',
+      pass: 'H&NbECcpXF|pyXe#%ZEb',
+    },
+    from: 'jane.smith@gmail.com',
+    to: ['jane.smith@gmail.com', 'sam.doe@yahoo.com'],
+  },
 ])
 
 // send all global errors (uncaught exceptions, warnings, unhandled rejections)
 // to this logger
 catchGlobalErrors(createLogger('app'))
 ```
+
+A transport as expected by `configure(transport)` can be:
+
+- a function that will receive emitted logs;
+- an object with a `type` property and options which will be used to create a transport (see next section);
+- an object with a nested `transport` which will be used if one of the following conditions is fulfilled:
+  - `filter`: [pattern](https://github.com/visionmedia/debug#wildcards) which is matched against the log namespace (can also be an array of filters);
+  - `level`: the minimal level of accepted logs;
+- an array of transports.
 
 ### Transports
 
@@ -122,5 +139,5 @@ import transportSyslog from '@xen-orchestra/log/transports/syslog'
 configure(transportSyslog())
 
 // But TCP, a different host, or a different port can be used
-configure(transportSyslog('tcp://syslog.company.lan'))
+configure(transportSyslog({ target: 'tcp://syslog.company.lan' }))
 ```

--- a/@xen-orchestra/log/README.md
+++ b/@xen-orchestra/log/README.md
@@ -16,6 +16,8 @@ Installation of the [npm package](https://npmjs.org/package/@xen-orchestra/log):
 
 ## Usage
 
+### Producers
+
 Everywhere something should be logged:
 
 ```js
@@ -43,6 +45,8 @@ log.error('could not join server', {
 })
 ```
 
+### Consumer
+
 Then, at application level, configure the logs are handled:
 
 ```js
@@ -63,13 +67,6 @@ const transport = transportEmail({
 
 configure([
   {
-    // if filter is a string, then it is pattern
-    // (https://github.com/visionmedia/debug#wildcards) which is
-    // matched against the namespace of the logs
-    //
-    // If it's an array, it will be handled as an array of filters
-    // and the transport will be used if any one of them match the
-    // current log
     filter: process.env.DEBUG,
 
     transport: transportConsole(),
@@ -80,12 +77,32 @@ configure([
 
     transport,
   },
+  {
+    type: 'email',
+
+    service: 'gmail',
+    auth: {
+      user: 'jane.smith@gmail.com',
+      pass: 'H&NbECcpXF|pyXe#%ZEb',
+    },
+    from: 'jane.smith@gmail.com',
+    to: ['jane.smith@gmail.com', 'sam.doe@yahoo.com'],
+  },
 ])
 
 // send all global errors (uncaught exceptions, warnings, unhandled rejections)
 // to this logger
 catchGlobalErrors(createLogger('app'))
 ```
+
+A transport as expected by `configure(transport)` can be:
+
+- a function that will receive emitted logs;
+- an object with a `type` property and options which will be used to create a transport (see next section);
+- an object with a nested `transport` which will be used if one of the following conditions is fulfilled:
+  - `filter`: [pattern](https://github.com/visionmedia/debug#wildcards) which is matched against the log namespace (can also be an array of filters);
+  - `level`: the minimal level of accepted logs;
+- an array of transports.
 
 ### Transports
 
@@ -140,7 +157,7 @@ import transportSyslog from '@xen-orchestra/log/transports/syslog'
 configure(transportSyslog())
 
 // But TCP, a different host, or a different port can be used
-configure(transportSyslog('tcp://syslog.company.lan'))
+configure(transportSyslog({ target: 'tcp://syslog.company.lan' }))
 ```
 
 ## Contributions

--- a/@xen-orchestra/log/configure.js
+++ b/@xen-orchestra/log/configure.js
@@ -57,6 +57,20 @@ const createTransport = config => {
     }
   }
 
+  const { type } = config
+  if (type !== undefined) {
+    if (typeof type !== 'string') {
+      throw new TypeError('transport type property must be a string')
+    }
+
+    if (type.includes('/')) {
+      throw new TypeError('invalid transport type')
+    }
+
+    const { ...opts } = config
+    return require(`./transports/${type}.js`)(opts)
+  }
+
   const level = resolve(config.level)
   const filter = compileFilter([config.filter, level === undefined ? undefined : log => log.level >= level])
 
@@ -73,6 +87,7 @@ const createTransport = config => {
 
   return transport
 }
+exports.createTransport = createTransport
 
 const symbol = typeof Symbol !== 'undefined' ? Symbol.for('@xen-orchestra/log') : '@@@xen-orchestra/log'
 

--- a/@xen-orchestra/log/transports/syslog.js
+++ b/@xen-orchestra/log/transports/syslog.js
@@ -20,6 +20,10 @@ const LEVEL_TO_SEVERITY = {
 const facility = Facility.User
 
 function createTransport(target) {
+  if (typeof target === 'object') {
+    target = target.target
+  }
+
   const opts = {}
   if (target !== undefined) {
     if (target.startsWith('tcp://')) {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,6 +28,7 @@
 <!--packages-start-->
 
 - @vates/read-chunk patch
+- @xen-orchestra/log minor
 - xo-remote-parser patch
 - xo-server-transport-nagios patch
 - xo-web patch

--- a/packages/xo-server/src/xo-mixins/logs/index.mjs
+++ b/packages/xo-server/src/xo-mixins/logs/index.mjs
@@ -10,8 +10,8 @@ export default class Logs {
 
     app.hooks.on('clean', () => this._gc())
 
-    const transport = transportConsole()
-    app.config.watch('logs', ({ filter, level }) => {
+    const defaultTransport = transportConsole()
+    app.config.watch('logs', ({ filter, level, transport = defaultTransport }) => {
       configure([
         {
           filter: [process.env.DEBUG, filter],


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
