### PR TITLE
feat(xo-web/remote): show encryption in remote UI

### DIFF
--- a/@xen-orchestra/fs/src/_encryptor.js
+++ b/@xen-orchestra/fs/src/_encryptor.js
@@ -3,6 +3,11 @@ const { readChunk } = require('@vates/read-chunk')
 const crypto = require('crypto')
 
 export const DEFAULT_ENCRYPTION_ALGORITHM = 'aes-256-gcm'
+export const UNENCRYPTED_ALGORITHM = 'none'
+
+export function isLegacyEncryptionAlgorithm(algorithm) {
+  return algorithm !== UNENCRYPTED_ALGORITHM && algorithm !== DEFAULT_ENCRYPTION_ALGORITHM
+}
 
 function getEncryptor(algorithm = DEFAULT_ENCRYPTION_ALGORITHM, key) {
   if (key === undefined) {

--- a/@xen-orchestra/fs/src/index.js
+++ b/@xen-orchestra/fs/src/index.js
@@ -5,6 +5,7 @@ import RemoteHandlerLocal from './local'
 import RemoteHandlerNfs from './nfs'
 import RemoteHandlerS3 from './s3'
 import RemoteHandlerSmb from './smb'
+export { DEFAULT_ENCRYPTION_ALGORITHM, UNENCRYPTED_ALGORITHM, isLegacyEncryptionAlgorithm } from './_encryptor'
 
 const HANDLERS = {
   file: RemoteHandlerLocal,

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -4,8 +4,11 @@
 > understandable by them.
 
 ### Enhancements
+
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
+
 - [Backup/Encryption] Use `aes-256-gcm` instead of `aes-256-ccm` to mitigate [padding oracle attacks](https://en.wikipedia.org/wiki/Padding_oracle_attack) (PR [#6447](https://github.com/vatesfr/xen-orchestra/pull/6447))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -32,6 +35,7 @@
 - @xen-orchestra/fs minor
 - @xen-orchestra/log minor
 - xo-remote-parser patch
+- xo-server minor
 - xo-server-transport-nagios patch
 - xo-web patch
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,6 +8,7 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - [Backup/Encryption] Use `aes-256-gcm` instead of `aes-256-ccm` to mitigate [padding oracle attacks](https://en.wikipedia.org/wiki/Padding_oracle_attack) (PR [#6447](https://github.com/vatesfr/xen-orchestra/pull/6447))
+- [Settings/Remote] Display `lock` icon for encrypted remote and a warning if the remote uses a legacy encryption algorithm (PR [#6465](https://github.com/vatesfr/xen-orchestra/pull/6465))
 
 ### Bug fixes
 
@@ -37,6 +38,6 @@
 - xo-remote-parser patch
 - xo-server minor
 - xo-server-transport-nagios patch
-- xo-web patch
+- xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-server/src/xo-mixins/remotes.mjs
+++ b/packages/xo-server/src/xo-mixins/remotes.mjs
@@ -1,6 +1,11 @@
 import asyncMapSettled from '@xen-orchestra/async-map/legacy.js'
 import { format, parse } from 'xo-remote-parser'
-import { getHandler } from '@xen-orchestra/fs'
+import {
+  DEFAULT_ENCRYPTION_ALGORITHM,
+  getHandler,
+  isLegacyEncryptionAlgorithm,
+  UNENCRYPTED_ALGORITHM,
+} from '@xen-orchestra/fs'
 import { ignoreErrors, timeout } from 'promise-toolbox'
 import { noSuchObject } from 'xo-common/api-errors.js'
 import { synchronized } from 'decorator-synchronized'
@@ -124,6 +129,17 @@ export default class {
         return
       }
 
+      let encryption
+
+      if (this._handlers[remote.id] !== undefined) {
+        const algorithm = this._handlers[remote.id]._encryptor?.algorithm ?? UNENCRYPTED_ALGORITHM
+        encryption = {
+          algorithm,
+          isLegacy: isLegacyEncryptionAlgorithm(algorithm),
+          recommendedAlgorithm: DEFAULT_ENCRYPTION_ALGORITHM,
+        }
+      }
+
       const promise =
         remote.proxy !== undefined
           ? this._app.callProxyMethod(remote.proxy, 'remote.getInfo', {
@@ -134,7 +150,10 @@ export default class {
       try {
         await timeout.call(
           promise.then(info => {
-            remotesInfo[remote.id] = info
+            remotesInfo[remote.id] = {
+              ...info,
+              encryption,
+            }
           }),
           5e3
         )

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -611,6 +611,10 @@ const messages = {
   remoteEncryptionKey: 'Encrypt all new data sent to this remote',
   remoteEncryptionKeyStorageLocation:
     "You won't be able to get your data back if you lose the encryption key. The encryption key is saved in the XO config backup, they should be secured correctly. Be careful, if you saved it on an encrypted remote, then you won't be able to access it without the remote encryption key.",
+  remoteEncryption: 'Encryption',
+  remoteEncryptionLegacy:
+    'A legacy encryption algorithm is used ({algorithm}), please create a new remote with the recommanded algorithm {recommendedAlgorithm}',
+
   // ------ New Storage -----
 
   newSr: 'New SR',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -611,9 +611,9 @@ const messages = {
   remoteEncryptionKey: 'Encrypt all new data sent to this remote',
   remoteEncryptionKeyStorageLocation:
     "You won't be able to get your data back if you lose the encryption key. The encryption key is saved in the XO config backup, they should be secured correctly. Be careful, if you saved it on an encrypted remote, then you won't be able to access it without the remote encryption key.",
-  remoteEncryption: 'Encryption',
+  encryption: 'Encryption',
   remoteEncryptionLegacy:
-    'A legacy encryption algorithm is used ({algorithm}), please create a new remote with the recommanded algorithm {recommendedAlgorithm}',
+    'A legacy encryption algorithm is used ({algorithm}), please create a new remote with the recommended algorithm {recommendedAlgorithm}',
 
   // ------ New Storage -----
 

--- a/packages/xo-web/src/xo-app/settings/remotes/index.js
+++ b/packages/xo-web/src/xo-app/settings/remotes/index.js
@@ -124,6 +124,35 @@ const COLUMN_PROXY = {
   name: _('proxy'),
 }
 
+const COLUMN_ENCRYPTION = {
+  itemRenderer: remote => {
+    // remote is not sync, not a lot of data
+    if (remote.info?.encryption === undefined) {
+      return remote.encryptionKey !== undefined ? <Icon size='lg' icon='lock' /> : null
+    } else {
+      // not encrypted
+      if (remote.info.encryption.algorithm === 'none') {
+        return null
+      }
+      const { algorithm, isLegacy, recommendedAlgorithm } = remote.info.encryption
+      return (
+        <span>
+          <Tooltip content={algorithm}>
+            <Icon icon='lock' size='lg' />
+          </Tooltip>
+
+          {isLegacy && (
+            <Tooltip content={_('remoteEncryptionLegacy', { algorithm, recommendedAlgorithm })}>
+              <Icon icon='error' size='lg' />
+            </Tooltip>
+          )}
+        </span>
+      )
+    }
+  },
+  name: _('remoteEncryption'),
+}
+
 const fixRemoteUrl = remote => editRemote(remote, { url: format(remote) })
 const COLUMNS_LOCAL_REMOTE = [
   COLUMN_NAME,
@@ -141,6 +170,7 @@ const COLUMNS_LOCAL_REMOTE = [
   },
   COLUMN_STATE,
   COLUMN_DISK,
+  COLUMN_ENCRYPTION,
   COLUMN_SPEED,
   COLUMN_PROXY,
 ]
@@ -198,6 +228,7 @@ const COLUMNS_NFS_REMOTE = [
   },
   COLUMN_STATE,
   COLUMN_DISK,
+  COLUMN_ENCRYPTION,
   COLUMN_SPEED,
   COLUMN_PROXY,
 ]
@@ -245,6 +276,7 @@ const COLUMNS_SMB_REMOTE = [
     ),
     name: _('remoteAuth'),
   },
+  COLUMN_ENCRYPTION,
   COLUMN_SPEED,
   COLUMN_PROXY,
 ]
@@ -300,6 +332,7 @@ const COLUMNS_S3_REMOTE = [
     ),
     name: 'Key',
   },
+  COLUMN_ENCRYPTION,
   COLUMN_SPEED,
   COLUMN_PROXY,
 ]

--- a/packages/xo-web/src/xo-app/settings/remotes/index.js
+++ b/packages/xo-web/src/xo-app/settings/remotes/index.js
@@ -126,11 +126,12 @@ const COLUMN_PROXY = {
 
 const COLUMN_ENCRYPTION = {
   itemRenderer: remote => {
-    // remote is not sync, not a lot of data
+    // remote.info?.encryption undefined means that remote is not enabled and synced
+    // we don't have the agorithm used at this step
     if (remote.info?.encryption === undefined) {
       return remote.encryptionKey !== undefined ? <Icon size='lg' icon='lock' /> : null
     } else {
-      // not encrypted
+      // remote enabled and not encrypted
       if (remote.info.encryption.algorithm === 'none') {
         return null
       }
@@ -138,7 +139,7 @@ const COLUMN_ENCRYPTION = {
       return (
         <span>
           <Tooltip content={algorithm}>
-            <Icon icon='lock' size='lg' />
+            <Icon className='mr-1' icon='lock' size='lg' />
           </Tooltip>
 
           {isLegacy && (
@@ -150,7 +151,7 @@ const COLUMN_ENCRYPTION = {
       )
     }
   },
-  name: _('remoteEncryption'),
+  name: _('encryption'),
 }
 
 const fixRemoteUrl = remote => editRemote(remote, { url: format(remote) })


### PR DESCRIPTION
* if remote is disabled we don't know the used algorithm : only show the lock if there is an encryption key
* if remote is enabled : 
  *  if algorithm is undefined or none : show nothing, remote is not encrypted
  * if algorithm is defined to DEFAULT_ENCRYPTION_ALGORITHM : show the lock with the name of the algorithm as a tooltip
  * else show the lock and a warning advising to create a new remote with an up to date algorithm 

### Screenshot
![image](https://user-images.githubusercontent.com/50174/196631527-9c1212e9-f514-478c-b926-857b8a76c615.png)


### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [x] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [x] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
