### PR TITLE
feat(xo-vmdk-to-vhd): overprovision vmdk size to generate ova in one pass

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,6 +8,7 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - [Remotes] Prevent remote path from ending with `xo-vm-backups` as it's usually a mistake
+- [Ova export] speed up ova generation by 2. Generated file will be bigger ( as big as non compressed xva) (PR [#6487](https://github.com/vatesfr/xen-orchestra/pull/6487))
 
 ### Bug fixes
 
@@ -39,6 +40,7 @@
 - vhd-lib minor
 - xo-cli patch
 - xo-server minor
+- xo-vmdk-to-vhd minor
 - xo-web minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,7 +8,7 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - [Remotes] Prevent remote path from ending with `xo-vm-backups` as it's usually a mistake
-- [Ova export] speed up ova generation by 2. Generated file will be bigger ( as big as non compressed xva) (PR [#6487](https://github.com/vatesfr/xen-orchestra/pull/6487))
+- [OVA export] Speed up OVA generation by 2. Generated file will be bigger (as big as uncompressed XVA) (PR [#6487](https://github.com/vatesfr/xen-orchestra/pull/6487))
 
 ### Bug fixes
 

--- a/packages/xo-vmdk-to-vhd/src/index.js
+++ b/packages/xo-vmdk-to-vhd/src/index.js
@@ -47,7 +47,7 @@ export async function vhdToVMDK(diskName, vhdReadStreamGetter, withLength = fals
   const { iterator, size } = await vhdToVMDKIterator(diskName, await vhdReadStreamGetter())
   let length
   const stream = await asyncIteratorToStream(iterator)
-  if(withLength){
+  if (withLength) {
     if (size === undefined) {
       length = await computeVmdkLength(diskName, await vhdReadStreamGetter())
     } else {

--- a/packages/xo-vmdk-to-vhd/src/index.js
+++ b/packages/xo-vmdk-to-vhd/src/index.js
@@ -46,13 +46,13 @@ export async function computeVmdkLength(diskName, vhdReadStream) {
 export async function vhdToVMDK(diskName, vhdReadStreamGetter, withLength = false) {
   const { iterator, size } = await vhdToVMDKIterator(diskName, await vhdReadStreamGetter())
   let length
-  if (size === undefined) {
-    length = await computeVmdkLength(diskName, await vhdReadStreamGetter())
-  } else {
-    length = size
-  }
   const stream = await asyncIteratorToStream(iterator)
-  if (withLength) {
+  if(withLength){
+    if (size === undefined) {
+      length = await computeVmdkLength(diskName, await vhdReadStreamGetter())
+    } else {
+      length = size
+    }
     stream.length = length
   }
   return stream

--- a/packages/xo-vmdk-to-vhd/src/index.js
+++ b/packages/xo-vmdk-to-vhd/src/index.js
@@ -29,7 +29,8 @@ async function vmdkToVhd(vmdkReadStream, grainLogicalAddressList, grainFileOffse
 
 export async function computeVmdkLength(diskName, vhdReadStream) {
   let length = 0
-  for await (const b of await vhdToVMDKIterator(diskName, vhdReadStream)) {
+  const { iterator } = await vhdToVMDKIterator(diskName, vhdReadStream)
+  for await (const b of iterator) {
     length += b.length
   }
   return length
@@ -43,12 +44,14 @@ export async function computeVmdkLength(diskName, vhdReadStream) {
  * @returns a readable stream representing a VMDK file
  */
 export async function vhdToVMDK(diskName, vhdReadStreamGetter, withLength = false) {
+  const { iterator, size } = await vhdToVMDKIterator(diskName, await vhdReadStreamGetter())
   let length
-  if (withLength) {
+  if (size === undefined) {
     length = await computeVmdkLength(diskName, await vhdReadStreamGetter())
+  } else {
+    length = size
   }
-  const iterable = await vhdToVMDKIterator(diskName, await vhdReadStreamGetter())
-  const stream = await asyncIteratorToStream(iterable)
+  const stream = await asyncIteratorToStream(iterator)
   if (withLength) {
     stream.length = length
   }
@@ -62,8 +65,15 @@ export async function vhdToVMDK(diskName, vhdReadStreamGetter, withLength = fals
  * @returns a readable stream representing a VMDK file
  */
 export async function vhdToVMDKIterator(diskName, vhdReadStream) {
-  const { blockSize, blocks, diskSize, geometry } = await parseVhdToBlocks(vhdReadStream)
-  return generateVmdkData(diskName, diskSize, blockSize, blocks, geometry)
+  const { blockSize, blockCount, blocks, diskSize, geometry } = await parseVhdToBlocks(vhdReadStream)
+
+  const vmdkTargetSize = blockSize * blockCount + 3 * 1024 * 1024 // header/footer/descriptor
+  const iterator = await generateVmdkData(diskName, diskSize, blockSize, blocks, geometry, vmdkTargetSize)
+
+  return {
+    iterator,
+    size: vmdkTargetSize,
+  }
 }
 
 export { ParsableFile, parseOVAFile, vmdkToVhd, writeOvaOn }

--- a/packages/xo-vmdk-to-vhd/src/ova-generate.js
+++ b/packages/xo-vmdk-to-vhd/src/ova-generate.js
@@ -32,17 +32,18 @@ export async function writeOvaOn(
 
   // https://github.com/mafintosh/tar-stream/issues/24#issuecomment-558358268
   async function pushDisk(disk) {
-    const size = await computeVmdkLength(disk.name, await disk.getStream())
+    let { iterator, size } = await vhdToVMDKIterator(disk.name, await disk.getStream())
+    if (size === undefined) {
+      size = await computeVmdkLength(disk.name, await disk.getStream())
+    }
     disk.fileSize = size
-    const blockIterator = await vhdToVMDKIterator(disk.name, await disk.getStream())
-
     return new Promise((resolve, reject) => {
       const entry = pack.entry({ name: `${disk.name}.vmdk`, size: size }, err => {
         if (err == null) {
           return resolve()
         } else return reject(err)
       })
-      return writeDisk(entry, blockIterator).then(
+      return writeDisk(entry, iterator).then(
         () => entry.end(),
         e => reject(e)
       )

--- a/packages/xo-vmdk-to-vhd/src/vmdk-generate.js
+++ b/packages/xo-vmdk-to-vhd/src/vmdk-generate.js
@@ -33,7 +33,8 @@ export async function generateVmdkData(
     sectorsPerTrackCylinder: 63,
     heads: 16,
     cylinders: 10402,
-  }
+  },
+  targetSize
 ) {
   const cid = Math.floor(Math.random() * Math.pow(2, 32))
   const diskCapacitySectors = Math.ceil(diskCapacityBytes / SECTOR_SIZE)
@@ -150,10 +151,39 @@ ddb.geometry.cylinders = "${geometry.cylinders}"
     }
   }
 
+  function* padding() {
+    if (targetSize === undefined) {
+      return
+    }
+    let remaining = targetSize - streamPosition
+    remaining -= SECTOR_SIZE // MARKER_GT
+    remaining -= tableBuffer.length
+    remaining -= SECTOR_SIZE // MARKER_GD
+    remaining -= roundToSector(headerData.grainDirectoryEntries * 4)
+    remaining -= SECTOR_SIZE // MARKER_GT
+    remaining -= tableBuffer.length
+    remaining -= SECTOR_SIZE // MARKER_GD
+    remaining -= roundToSector(headerData.grainDirectoryEntries * 4)
+    remaining -= SECTOR_SIZE // MARKER_FOOTER
+    remaining -= SECTOR_SIZE // stream optimizedheader
+    remaining -= SECTOR_SIZE // MARKER_EOS
+
+    if (remaining < 0) {
+      throw new Error('vmdk is smaller than precalculed size ')
+    }
+    const size = 1024 * 1024
+    while (remaining > 0) {
+      const yieldSize = Math.min(size, remaining)
+      remaining -= yieldSize
+      yield track(Buffer.alloc(yieldSize))
+    }
+  }
+
   async function* iterator() {
     yield track(headerData.buffer)
     yield track(descriptorBuffer)
     yield* emitBlocks(grainSizeBytes, blockGenerator)
+    yield* padding()
     yield track(createEmptyMarker(MARKER_GT))
     let tableOffset = streamPosition
     // grain tables
@@ -181,6 +211,5 @@ ddb.geometry.cylinders = "${geometry.cylinders}"
     yield track(footer.buffer)
     yield track(createEmptyMarker(MARKER_EOS))
   }
-
   return iterator()
 }

--- a/packages/xo-vmdk-to-vhd/src/vmdk-generate.js
+++ b/packages/xo-vmdk-to-vhd/src/vmdk-generate.js
@@ -169,7 +169,7 @@ ddb.geometry.cylinders = "${geometry.cylinders}"
     remaining -= SECTOR_SIZE // MARKER_EOS
 
     if (remaining < 0) {
-      throw new Error('vmdk is smaller than precalculed size ')
+      throw new Error('vmdk is bigger than precalculed size ')
     }
     const size = 1024 * 1024
     while (remaining > 0) {


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
