### PR TITLE
fix(xo-web/backup): cleanup settings correctly when deselecting health check

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Pool] Add tooltip on "no XCP-ng Pro support" warning icon (PR [#6505](https://github.com/vatesfr/xen-orchestra/pull/6505))
+- [Backup] Really disable Healthcheck when unchecking settings (PR [#6515](https://github.com/vatesfr/xen-orchestra/pull/6515))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Pool] Add tooltip on "no XCP-ng Pro support" warning icon (PR [#6505](https://github.com/vatesfr/xen-orchestra/pull/6505))
-- [Backup] Really disable Healthcheck when unchecking settings (PR [#6515](https://github.com/vatesfr/xen-orchestra/pull/6515))
+- [Backup] Really disable Healthcheck when unchecking settings [#6501](https://github.com/vatesfr/xen-orchestra/issues/6501) (PR [#6515](https://github.com/vatesfr/xen-orchestra/pull/6515))
 
 ### Packages to release
 

--- a/packages/xo-web/src/xo-app/backup/new/new-schedule.js
+++ b/packages/xo-web/src/xo-app/backup/new/new-schedule.js
@@ -80,6 +80,7 @@ const New = decorate([
       toggleHealthCheck({ setSchedule }, { target: { checked } }) {
         setSchedule({
           healthCheckVmsWithTags: checked ? [] : undefined,
+          healthCheckSr: checked ? this.state.healthCheckSr : undefined,
         })
       },
       setHealthCheckSr({ setSchedule }, sr) {


### PR DESCRIPTION
Fix #6501 

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
