### PR TITLE
fix(xo-web): "Pro Support" instead of "pool support" in XCP-ng support tooltips

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Pool] Add tooltip on "no XCP-ng Pro support" warning icon (PR [#6505](https://github.com/vatesfr/xen-orchestra/pull/6505))
-- [Pool] Change `Pool support not available for source users` to `XCP-ng pro support not available for source users` (PR [#6517](https://github.com/vatesfr/xen-orchestra/pull/6517))
+- [Pool] Change `Pool support not available for source users` to `XCP-ng pro support not available for source users` [#6535](https://xcp-ng.org/forum/topic/6535/xo-from-source-pool-support-not-available-for-source-users?lang=fr) (PR [#6517](https://github.com/vatesfr/xen-orchestra/pull/6517))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Pool] Add tooltip on "no XCP-ng Pro support" warning icon (PR [#6505](https://github.com/vatesfr/xen-orchestra/pull/6505))
+- [Pool] Change `Pool support not available for source users` to `XCP-ng pro support not available for source users` (PR [#6517](https://github.com/vatesfr/xen-orchestra/pull/6517))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Pool] Add tooltip on "no XCP-ng Pro support" warning icon (PR [#6505](https://github.com/vatesfr/xen-orchestra/pull/6505))
-- [Pool] Change `Pool support not available for source users` to `XCP-ng pro support not available for source users` [#6535](https://xcp-ng.org/forum/topic/6535/xo-from-source-pool-support-not-available-for-source-users?lang=fr) (PR [#6517](https://github.com/vatesfr/xen-orchestra/pull/6517))
+- [Pool] Improve XCP-ng Pro Support tooltips wording [Forum#6535](https://xcp-ng.org/forum/topic/6535) (PR [#6517](https://github.com/vatesfr/xen-orchestra/pull/6517))
 
 ### Packages to release
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -839,7 +839,7 @@ const messages = {
   poolHaDisabled: 'Disabled',
   poolGpuGroups: 'GPU groups',
   poolRemoteSyslogPlaceHolder: 'Logging host',
-  poolSupportSourceUsers: 'Pool support not available for source users',
+  poolSupportSourceUsers: 'XCP-ng pro support not available for source users',
   poolSupportXcpngOnly: 'Only available for pool of XCP-ng hosts',
   poolLicenseAlreadyFullySupported: 'The pool is already fully supported',
   setpoolMaster: 'Master',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -839,7 +839,7 @@ const messages = {
   poolHaDisabled: 'Disabled',
   poolGpuGroups: 'GPU groups',
   poolRemoteSyslogPlaceHolder: 'Logging host',
-  poolSupportSourceUsers: 'XCP-ng pro support not available for source users',
+  poolSupportSourceUsers: 'XCP-ng Pro Support not available for source users',
   poolSupportXcpngOnly: 'Only available for pool of XCP-ng hosts',
   poolLicenseAlreadyFullySupported: 'The pool is already fully supported',
   setpoolMaster: 'Master',


### PR DESCRIPTION
See [xcp-ngForum#6525](https://xcp-ng.org/forum/topic/6535/xo-from-source-pool-support-not-available-for-source-users?lang=fr)

### Screenshot

![Capture d’écran de 2022-11-07 10-01-02](https://user-images.githubusercontent.com/70369997/200269765-b67112e8-f36d-4431-b724-b8a21a2b63d9.png)

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
