### PR TITLE
fix(xo-vmk-to-vhd): failing tests

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,7 +32,6 @@
 
 <!--packages-start-->
 
-- xo-vmdk-to-vhd patch
 - xo-web patch
 - xo-server minor
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,6 +32,7 @@
 
 <!--packages-start-->
 
+- xo-vmdk-to-vhd patch
 - xo-web patch
 - xo-server minor
 

--- a/packages/xo-vmdk-to-vhd/src/vmdk-to-vhd.integ.spec.js
+++ b/packages/xo-vmdk-to-vhd/src/vmdk-to-vhd.integ.spec.js
@@ -94,8 +94,8 @@ test('Can generate an empty VMDK file', async () => {
 test('Can generate a small VMDK file', async () => {
   const defaultVhdToVmdkRatio = 16
   const blockSize = 1024 * 1024
-  const b1 = Buffer.allocUnsafe(blockSize)
-  const b2 = Buffer.allocUnsafe(blockSize)
+  const b1 = Buffer.alloc(blockSize, 255)
+  const b2 = Buffer.alloc(blockSize, 255)
   const blockGenerator = [
     { lba: 0, block: b1 },
     { lba: blockSize, block: b2 },


### PR DESCRIPTION
Sometimes buffer.allocunsafe  was generating an empty buffer, that buffer was filtered in `packages/xo-vmdk-to-vhd/src/vmdk-generate.js` line 140 , thus the generated vmdk was variable

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [x] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
