### PR TITLE
feat(lite): update `useCollectionFilter` composable

### DIFF
--- a/@xen-orchestra/lite/src/components/CollectionTable.vue
+++ b/@xen-orchestra/lite/src/components/CollectionTable.vue
@@ -66,7 +66,9 @@ const emit = defineEmits<{
 
 const isSelectable = computed(() => props.modelValue !== undefined);
 
-const { filters, addFilter, removeFilter, predicate } = useCollectionFilter();
+const { filters, addFilter, removeFilter, predicate } = useCollectionFilter({
+  queryStringParam: "filter",
+});
 const { sorts, addSort, removeSort, toggleSortDirection, compareFn } =
   useCollectionSorter<Record<string, any>>({ queryStringParam: "sort" });
 

--- a/@xen-orchestra/lite/src/composables/collection-filter.composable.md
+++ b/@xen-orchestra/lite/src/composables/collection-filter.composable.md
@@ -3,34 +3,37 @@
 ## Usage
 
 ```typescript
-const { filters, addFilter, removeFilter, predicate } = useCollectionFilter();
+const { filters, addFilter, removeFilter, predicate } =
+  useCollectionFilter(options);
 
-const filteredCollection = myCollection.filter(predicate);
+const filteredCollection = computed(() => myCollection.filter(predicate));
+addFilter("name:/^Foo/");
+addFilter("count:>3");
 ```
 
-## URL Query String
+## Options
 
-By default, when adding/removing filters, the URL will update automatically.
+### `queryStringParam`
+
+This option allows to activate the URL Query String support.
 
 ```typescript
+const { addFilter } = useCollectionFilter({ queryStringParam: "filter" });
 addFilter("name:/^foo/i"); // Will update the URL with ?filter=name:/^foo/i
 ```
 
-### Change the URL query string parameter name
+### Initial filters
+
+This option allows to set some initial filters.
 
 ```typescript
 const {
   /* ... */
-} = useCollectionFilter({ queryStringParam: "f" }); // ?f=name:/^foo/i
+} = useCollectionFilter({ initialFilters: ["!name_label:foobar"] });
 ```
 
-### Disable the usage of URL query string
-
-```typescript
-const {
-  /* ... */
-} = useCollectionFilter({ queryStringParam: undefined });
-```
+When using the `initialFilters` option with the `queryStringParam` option,
+`initialFilters` will only be applied if no query string parameter is defined in the URL.
 
 ## Example of using the composable with the `CollectionFilter` component
 

--- a/@xen-orchestra/lite/src/composables/collection-filter.composable.ts
+++ b/@xen-orchestra/lite/src/composables/collection-filter.composable.ts
@@ -16,9 +16,12 @@ export default function useCollectionFilter<T>(config: Config = {}) {
   const filters = computed(() => Array.from(filtersSet.value.values()));
 
   if (queryStringParam !== undefined) {
-    if (route.query[queryStringParam] !== undefined) {
-      filtersSet.value = queryToSet(getFirst(route.query[queryStringParam]));
+    const queryString = route.query[queryStringParam];
+
+    if (queryString !== undefined) {
+      filtersSet.value = queryToSet(getFirst(queryString));
     }
+
     watch(filters, (value) =>
       router.replace({
         query: { ...route.query, [queryStringParam]: value.join(" ") },

--- a/@xen-orchestra/lite/src/composables/collection-filter.composable.ts
+++ b/@xen-orchestra/lite/src/composables/collection-filter.composable.ts
@@ -1,25 +1,24 @@
+import { getFirst } from "@/libs/utils";
 import * as CM from "complex-matcher";
 import { computed, ref, watch } from "vue";
 import { type LocationQueryValue, useRoute, useRouter } from "vue-router";
 
 interface Config {
   queryStringParam?: string;
+  initialFilters?: string[];
 }
 
-export default function useCollectionFilter(
-  config: Config = { queryStringParam: "filter" }
-) {
+export default function useCollectionFilter<T>(config: Config = {}) {
   const route = useRoute();
   const router = useRouter();
-  const filtersSet = ref(
-    config.queryStringParam
-      ? queryToSet(route.query[config.queryStringParam] as LocationQueryValue)
-      : new Set<string>()
-  );
+  const { queryStringParam, initialFilters = [] } = config;
+  const filtersSet = ref<Set<string>>(new Set(initialFilters));
   const filters = computed(() => Array.from(filtersSet.value.values()));
 
-  if (config.queryStringParam) {
-    const queryStringParam = config.queryStringParam;
+  if (queryStringParam !== undefined) {
+    if (route.query[queryStringParam] !== undefined) {
+      filtersSet.value = queryToSet(getFirst(route.query[queryStringParam]));
+    }
     watch(filters, (value) =>
       router.replace({
         query: { ...route.query, [queryStringParam]: value.join(" ") },
@@ -35,7 +34,7 @@ export default function useCollectionFilter(
     filtersSet.value.delete(filter);
   };
 
-  const predicate = computed(() => {
+  const predicate = computed<(value: T) => boolean>(() => {
     return CM.parse(
       Array.from(filters.value.values()).join(" ")
     ).createPredicate();


### PR DESCRIPTION
- Query String support must now be explicitly enabled with the `queryStringParam` option
- Added `initialFilters` option
- Added generic type support
- Updated documentation

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [x] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
