### PR TITLE
feat(lite): update `useCollectionSorter` composable

### DIFF
--- a/@xen-orchestra/lite/src/components/CollectionSorter.vue
+++ b/@xen-orchestra/lite/src/components/CollectionSorter.vue
@@ -66,7 +66,7 @@ import useModal from "@/composables/modal.composable";
 
 defineProps<{
   availableSorts: Sorts;
-  activeSorts: ActiveSorts;
+  activeSorts: ActiveSorts<Record<string, any>>;
 }>();
 
 const emit = defineEmits<{

--- a/@xen-orchestra/lite/src/components/CollectionTable.vue
+++ b/@xen-orchestra/lite/src/components/CollectionTable.vue
@@ -68,7 +68,7 @@ const isSelectable = computed(() => props.modelValue !== undefined);
 
 const { filters, addFilter, removeFilter, predicate } = useCollectionFilter();
 const { sorts, addSort, removeSort, toggleSortDirection, compareFn } =
-  useCollectionSorter();
+  useCollectionSorter({ queryStringParam: "sort" });
 
 const filteredCollection = useFilteredCollection(
   toRef(props, "collection"),

--- a/@xen-orchestra/lite/src/components/CollectionTable.vue
+++ b/@xen-orchestra/lite/src/components/CollectionTable.vue
@@ -68,7 +68,7 @@ const isSelectable = computed(() => props.modelValue !== undefined);
 
 const { filters, addFilter, removeFilter, predicate } = useCollectionFilter();
 const { sorts, addSort, removeSort, toggleSortDirection, compareFn } =
-  useCollectionSorter({ queryStringParam: "sort" });
+  useCollectionSorter<Record<string, any>>({ queryStringParam: "sort" });
 
 const filteredCollection = useFilteredCollection(
   toRef(props, "collection"),

--- a/@xen-orchestra/lite/src/composables/collection-sorter.composable.md
+++ b/@xen-orchestra/lite/src/composables/collection-sorter.composable.md
@@ -26,14 +26,13 @@ addSort("name", true); // Will update the URL with ?sort=name:1
 
 This option allows to set some initial sorts.
 
+Use `key` for ascending sort and `-key` for descending sort.
+
 ```typescript
 const {
   /* ... */
 } = useCollectionSorter({
-  initialSorts: [
-    ["name", true],
-    ["age", false],
-  ],
+  initialSorts: ["name", "-age"],
 });
 ```
 

--- a/@xen-orchestra/lite/src/composables/collection-sorter.composable.md
+++ b/@xen-orchestra/lite/src/composables/collection-sorter.composable.md
@@ -1,0 +1,33 @@
+# useCollectionSorter composable
+
+## Usage
+
+```typescript
+const { sorts, addSort, removeSort, compareFn, toggleSortDirection } = useCollectionSorter(options);
+
+const sortedCollection = computed(() => myCollection.sort(compareFn));
+addSort("name", true);
+addSort("age", false);
+```
+
+## Options
+
+### `queryStringPram`
+
+This option allows to activate the URL Query String support.
+
+```typescript
+const { addSort } = useCollectionSorter({ queryStringParam: 'sort' });
+addSort("name", true); // Will update the URL with ?sort=name:1
+```
+
+### Initial sorts
+
+This options allows to set some initial sorts.
+
+```typescript
+const { /* ... */ } = useCollectionSorter({ initialSorts: [["name", true], ["age", false]] })
+```
+
+When using the `initialSorts` option with the `queryStringParam` option,
+`initialSorts` will only be applied if no query string parameter is defined in the URL.

--- a/@xen-orchestra/lite/src/composables/collection-sorter.composable.md
+++ b/@xen-orchestra/lite/src/composables/collection-sorter.composable.md
@@ -3,7 +3,8 @@
 ## Usage
 
 ```typescript
-const { sorts, addSort, removeSort, compareFn, toggleSortDirection } = useCollectionSorter(options);
+const { sorts, addSort, removeSort, compareFn, toggleSortDirection } =
+  useCollectionSorter(options);
 
 const sortedCollection = computed(() => myCollection.sort(compareFn));
 addSort("name", true);
@@ -12,21 +13,28 @@ addSort("age", false);
 
 ## Options
 
-### `queryStringPram`
+### `queryStringParam`
 
 This option allows to activate the URL Query String support.
 
 ```typescript
-const { addSort } = useCollectionSorter({ queryStringParam: 'sort' });
+const { addSort } = useCollectionSorter({ queryStringParam: "sort" });
 addSort("name", true); // Will update the URL with ?sort=name:1
 ```
 
 ### Initial sorts
 
-This options allows to set some initial sorts.
+This option allows to set some initial sorts.
 
 ```typescript
-const { /* ... */ } = useCollectionSorter({ initialSorts: [["name", true], ["age", false]] })
+const {
+  /* ... */
+} = useCollectionSorter({
+  initialSorts: [
+    ["name", true],
+    ["age", false],
+  ],
+});
 ```
 
 When using the `initialSorts` option with the `queryStringParam` option,

--- a/@xen-orchestra/lite/src/composables/collection-sorter.composable.ts
+++ b/@xen-orchestra/lite/src/composables/collection-sorter.composable.ts
@@ -16,9 +16,12 @@ export default function useCollectionSorter<T>(config: SortConfig<T> = {}) {
   );
 
   if (queryStringParam !== undefined) {
-    if (route.query[queryStringParam] !== undefined) {
-      sorts.value = queryToMap(getFirst(route.query[queryStringParam]));
+    const queryString = route.query[queryStringParam];
+
+    if (queryString !== undefined) {
+      sorts.value = queryToMap(getFirst(queryString));
     }
+
     watch(sortsAsString, (value) =>
       router.replace({
         query: { ...route.query, [queryStringParam]: value },

--- a/@xen-orchestra/lite/src/composables/collection-sorter.composable.ts
+++ b/@xen-orchestra/lite/src/composables/collection-sorter.composable.ts
@@ -1,3 +1,4 @@
+import { getFirst } from "@/libs/utils";
 import type { ActiveSorts } from "@/types/sort";
 import { computed, ref, watch } from "vue";
 import { type LocationQueryValue, useRoute, useRouter } from "vue-router";
@@ -21,9 +22,7 @@ export default function useCollectionSorter<T>(config: Config<T> = {}) {
 
   if (queryStringParam !== undefined) {
     if (route.query[queryStringParam] !== undefined) {
-      sorts.value = queryToMap(
-        route.query[queryStringParam] as LocationQueryValue
-      );
+      sorts.value = queryToMap(getFirst(route.query[queryStringParam]));
     }
     watch(sortsAsString, (value) =>
       router.replace({

--- a/@xen-orchestra/lite/src/libs/utils.ts
+++ b/@xen-orchestra/lite/src/libs/utils.ts
@@ -157,3 +157,6 @@ export function parseRamUsage(
     used: memoryFree === undefined ? 0 : used / _nSequence,
   };
 }
+
+export const getFirst = <T>(value: T | T[]): T =>
+  Array.isArray(value) ? value[0] : value;

--- a/@xen-orchestra/lite/src/libs/utils.ts
+++ b/@xen-orchestra/lite/src/libs/utils.ts
@@ -158,5 +158,5 @@ export function parseRamUsage(
   };
 }
 
-export const getFirst = <T>(value: T | T[]): T =>
+export const getFirst = <T>(value: T | T[]): T | undefined =>
   Array.isArray(value) ? value[0] : value;

--- a/@xen-orchestra/lite/src/types/sort.ts
+++ b/@xen-orchestra/lite/src/types/sort.ts
@@ -5,6 +5,15 @@ interface Sort {
   icon?: IconDefinition;
 }
 
-export type Sorts = { [key: string]: Sort };
+export interface Sorts {
+  [key: string]: Sort;
+}
 
 export type ActiveSorts<T> = Map<keyof T, boolean>;
+
+export type InitialSorts<T> = `${"-" | ""}${Extract<keyof T, string>}`[];
+
+export interface SortConfig<T> {
+  queryStringParam?: string;
+  initialSorts?: InitialSorts<T>;
+}

--- a/@xen-orchestra/lite/src/types/sort.ts
+++ b/@xen-orchestra/lite/src/types/sort.ts
@@ -7,4 +7,4 @@ interface Sort {
 
 export type Sorts = { [key: string]: Sort };
 
-export type ActiveSorts = Map<string, boolean>;
+export type ActiveSorts<T> = Map<keyof T, boolean>;


### PR DESCRIPTION
- Query String support must now be explicitly enabled with the `queryStringParam` option
- Added `initialFilters` option
- Added generic type support
- Updated documentation

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [x] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
