### PR TITLE
fix(scripts/gen-deps-list): fix packages order

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@vates/async-each": "^1.0.0",
     "babel-jest": "^29.0.3",
     "benchmark": "^2.1.4",
-    "deptree": "^1.0.0",
     "eslint": "^8.7.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-config-standard": "^17.0.0",

--- a/scripts/_computeDepOrder.js
+++ b/scripts/_computeDepOrder.js
@@ -1,0 +1,44 @@
+'use strict'
+
+function addPkgDepsToTree(deps, internalDeps) {
+  if (deps !== undefined) {
+    for (const depName of Object.keys(deps)) {
+      const dep = this.pkgs[depName]
+      if (dep !== undefined) {
+        internalDeps.push(depName)
+        addPkgToTree.call(this, dep)
+      }
+    }
+  }
+}
+
+function addPkgToTree(pkg) {
+  const { name, package: pkgJson } = pkg
+
+  if (!(name in this.tree)) {
+    const internalDeps = (this.tree[name] = [])
+
+    addPkgDepsToTree.call(this, pkgJson.dependencies, internalDeps)
+    addPkgDepsToTree.call(this, pkgJson.devDependencies, internalDeps)
+    addPkgDepsToTree.call(this, pkgJson.optionalDependencies, internalDeps)
+  }
+}
+
+function addPkgToResolution(name) {
+  if (!this.resolution.has(name)) {
+    this.tree[name].sort().forEach(addPkgToResolution, this)
+    this.resolution.add(name)
+  }
+}
+
+/**
+ * @returns {string[]} package names in the order they should be released
+ */
+module.exports = function computeDepOrder(pkgsByName) {
+  const tree = { __proto__: null }
+  Object.values(pkgsByName).forEach(addPkgToTree, { pkgs: pkgsByName, tree })
+
+  const resolution = new Set()
+  Object.keys(tree).sort().forEach(addPkgToResolution, { resolution, tree })
+  return Array.from(resolution)
+}


### PR DESCRIPTION
The release order computation is now uncoupled of the packages to release computation, and is now done for all packages so that transitive dependencies are still correctly ordered.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
