### PR TITLE
fix(lite): use browser timestamps for stats

### DIFF
--- a/@xen-orchestra/lite/src/libs/xapi-stats.ts
+++ b/@xen-orchestra/lite/src/libs/xapi-stats.ts
@@ -302,13 +302,6 @@ export type XapiStatsResponse<T> = {
 
 export default class XapiStats {
   #xapi;
-  #timestampByHost: Record<
-    string,
-    {
-      expires: number;
-      timestamp: number;
-    }
-  > = {};
   #statsByObject: {
     [uuid: string]: {
       [step: string]: XapiStatsResponse<HostStats | any>;
@@ -372,15 +365,7 @@ export default class XapiStats {
         `Unknown granularity: '${granularity}'. Use 'seconds', 'minutes', 'hours', or 'days'.`
       );
     }
-
-    const now = new Date().getTime();
-    if ((this.#timestampByHost[host.uuid]?.expires ?? 0) < now) {
-      this.#timestampByHost[host.uuid] = {
-        expires: now + RRD_STEP.Seconds * 1000,
-        timestamp: await this.#xapi.getHostServertime(host),
-      };
-    }
-    const currentTimeStamp = this.#timestampByHost[host.uuid].timestamp;
+    const currentTimeStamp = Math.floor(new Date().getTime() / 1000);
 
     const stats = this.#getCachedStats(uuid, step, currentTimeStamp);
     if (stats !== undefined) {

--- a/@xen-orchestra/lite/src/libs/xapi-stats.ts
+++ b/@xen-orchestra/lite/src/libs/xapi-stats.ts
@@ -373,11 +373,10 @@ export default class XapiStats {
       );
     }
 
-    if (
-      (this.#timestampByHost[host.uuid]?.expires ?? 0) < new Date().getTime()
-    ) {
+    const now = new Date().getTime();
+    if ((this.#timestampByHost[host.uuid]?.expires ?? 0) < now) {
       this.#timestampByHost[host.uuid] = {
-        expires: new Date().getTime() + RRD_STEP.Seconds * 1000,
+        expires: now + RRD_STEP.Seconds * 1000,
         timestamp: await this.#xapi.getHostServertime(host),
       };
     }


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
