### PR TITLE
fix(xo-web/licenses): move message for XCP-ng license binding

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -41,5 +41,6 @@
 - vhd-lib patch
 - xo-server minor
 - xo-server-perf-alert patch
+- xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -113,6 +113,7 @@ const messages = {
   editCustomField: 'Edit custom field',
   deleteCustomField: 'Delete custom field',
   onlyAvailableXoaUsers: 'Only available to XOA users',
+  xcpNg: 'XCP-ng',
 
   // ----- Modals -----
   alertOk: 'OK',

--- a/packages/xo-web/src/xo-app/xoa/licenses/index.js
+++ b/packages/xo-web/src/xo-app/xoa/licenses/index.js
@@ -375,9 +375,9 @@ export default class Licenses extends Component {
         <Row>
           <Col>
             <h2>{_('xcpNg')}</h2>
-            <div className='text-info'>
+            <Link to='home?t=pool' className='text-info'>
               <Icon icon='info' /> <i>{_('xcpngLicensesBindingAvancedView')}</i>
-            </div>
+            </Link>
           </Col>
         </Row>
       </Container>

--- a/packages/xo-web/src/xo-app/xoa/licenses/index.js
+++ b/packages/xo-web/src/xo-app/xoa/licenses/index.js
@@ -323,9 +323,6 @@ export default class Licenses extends Component {
 
     return (
       <Container>
-        <Row className='text-info mb-1'>
-          <Icon icon='info' /> <i>{_('xcpngLicensesBindingAvancedView')}</i>
-        </Row>
         <Row className='mb-1'>
           <Col>
             <a
@@ -373,6 +370,14 @@ export default class Licenses extends Component {
           <Col>
             <h2>{_('proxies')}</h2>
             <Proxies proxyLicenses={this.state.licenses.proxy} updateLicenses={this._updateLicenses} />
+          </Col>
+        </Row>
+        <Row>
+          <Col>
+            <h2>{_('xcpNg')}</h2>
+            <div className='text-info'>
+              <Icon icon='info' /> <i>{_('xcpngLicensesBindingAvancedView')}</i>
+            </div>
           </Col>
         </Row>
       </Container>


### PR DESCRIPTION
### Screenshot

![Capture d’écran de 2023-01-18 15-54-30](https://user-images.githubusercontent.com/70369997/213204341-f4ccc5b1-e265-4fa1-a84f-a7f8e6695a19.png)

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
