### PR TITLE
fix(lite/build): "Big integer literals are not available in the configured target environment"

### DIFF
--- a/@xen-orchestra/lite/vite.config.ts
+++ b/@xen-orchestra/lite/vite.config.ts
@@ -25,8 +25,12 @@ export default defineConfig({
     commonjsOptions: {
       include: [/complex-matcher/, /node_modules/],
     },
+    target: "es2020",
   },
   optimizeDeps: {
     include: ["complex-matcher"],
+    esbuildOptions: {
+      target: "es2020",
+    },
   },
 });


### PR DESCRIPTION
Introduced by a281682f7a0f52f8556e9ec9d10b1961554701c8

<details>
	<summary>
	Error stack
	</summary>

	@xen-orchestra/lite:build: [vite:esbuild-transpile] Transform failed with 9 errors:
	@xen-orchestra/lite:build: assets/index.95c9766e.js:102401:18: ERROR: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: assets/index.95c9766e.js:102404:16: ERROR: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: assets/index.95c9766e.js:102407:20: ERROR: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: assets/index.95c9766e.js:102407:27: ERROR: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: assets/index.95c9766e.js:102410:20: ERROR: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: ...
	@xen-orchestra/lite:build: 
	@xen-orchestra/lite:build: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: 102399|  
	@xen-orchestra/lite:build: 102400|      _modPow(b, e, m) {
	@xen-orchestra/lite:build: 102401|          if (m === 1n) {
	@xen-orchestra/lite:build:    |                    ^
	@xen-orchestra/lite:build: 102402|              return 0;
	@xen-orchestra/lite:build: 102403|          }
	@xen-orchestra/lite:build: 
	@xen-orchestra/lite:build: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: 102402|              return 0;
	@xen-orchestra/lite:build: 102403|          }
	@xen-orchestra/lite:build: 102404|          let r = 1n;
	@xen-orchestra/lite:build:    |                  ^
	@xen-orchestra/lite:build: 102405|          b = b % m;
	@xen-orchestra/lite:build: 102406|          while (e > 0) {
	@xen-orchestra/lite:build: 
	@xen-orchestra/lite:build: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: 102405|          b = b % m;
	@xen-orchestra/lite:build: 102406|          while (e > 0) {
	@xen-orchestra/lite:build: 102407|              if (e % 2n === 1n) {
	@xen-orchestra/lite:build:    |                      ^
	@xen-orchestra/lite:build: 102408|                  r = (r * b) % m;
	@xen-orchestra/lite:build: 102409|              }
	@xen-orchestra/lite:build: 
	@xen-orchestra/lite:build: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: 102405|          b = b % m;
	@xen-orchestra/lite:build: 102406|          while (e > 0) {
	@xen-orchestra/lite:build: 102407|              if (e % 2n === 1n) {
	@xen-orchestra/lite:build:    |                             ^
	@xen-orchestra/lite:build: 102408|                  r = (r * b) % m;
	@xen-orchestra/lite:build: 102409|              }
	@xen-orchestra/lite:build: 
	@xen-orchestra/lite:build: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: 102408|                  r = (r * b) % m;
	@xen-orchestra/lite:build: 102409|              }
	@xen-orchestra/lite:build: 102410|              e = e / 2n;
	@xen-orchestra/lite:build:    |                      ^
	@xen-orchestra/lite:build: 102411|              b = (b * b) % m;
	@xen-orchestra/lite:build: 102412|          }
	@xen-orchestra/lite:build: 
	@xen-orchestra/lite:build: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: 105514|          let e = BigInt(exponentHex);
	@xen-orchestra/lite:build: 105515|          let m = BigInt(modulusHex);
	@xen-orchestra/lite:build: 105516|          let r = 1n;
	@xen-orchestra/lite:build:    |                  ^
	@xen-orchestra/lite:build: 105517|          b = b % m;
	@xen-orchestra/lite:build: 105518|          while (e > 0) {
	@xen-orchestra/lite:build: 
	@xen-orchestra/lite:build: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: 105517|          b = b % m;
	@xen-orchestra/lite:build: 105518|          while (e > 0) {
	@xen-orchestra/lite:build: 105519|              if (e % 2n === 1n) {
	@xen-orchestra/lite:build:    |                      ^
	@xen-orchestra/lite:build: 105520|                  r = (r * b) % m;
	@xen-orchestra/lite:build: 105521|              }
	@xen-orchestra/lite:build: 
	@xen-orchestra/lite:build: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: 105517|          b = b % m;
	@xen-orchestra/lite:build: 105518|          while (e > 0) {
	@xen-orchestra/lite:build: 105519|              if (e % 2n === 1n) {
	@xen-orchestra/lite:build:    |                             ^
	@xen-orchestra/lite:build: 105520|                  r = (r * b) % m;
	@xen-orchestra/lite:build: 105521|              }
	@xen-orchestra/lite:build: 
	@xen-orchestra/lite:build: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: 105520|                  r = (r * b) % m;
	@xen-orchestra/lite:build: 105521|              }
	@xen-orchestra/lite:build: 105522|              e = e / 2n;
	@xen-orchestra/lite:build:    |                      ^
	@xen-orchestra/lite:build: 105523|              b = (b * b) % m;
	@xen-orchestra/lite:build: 105524|          }
	@xen-orchestra/lite:build: 
	@xen-orchestra/lite:build: error during build:
	@xen-orchestra/lite:build: Error: Transform failed with 9 errors:
	@xen-orchestra/lite:build: assets/index.95c9766e.js:102401:18: ERROR: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: assets/index.95c9766e.js:102404:16: ERROR: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: assets/index.95c9766e.js:102407:20: ERROR: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: assets/index.95c9766e.js:102407:27: ERROR: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: assets/index.95c9766e.js:102410:20: ERROR: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
	@xen-orchestra/lite:build: ...
	@xen-orchestra/lite:build:     at failureErrorWithLog (/xen-orchestra/@xen-orchestra/lite/node_modules/esbuild/lib/main.js:1575:15)
	@xen-orchestra/lite:build:     at /xen-orchestra/@xen-orchestra/lite/node_modules/esbuild/lib/main.js:814:29
	@xen-orchestra/lite:build:     at responseCallbacks.<computed> (/xen-orchestra/@xen-orchestra/lite/node_modules/esbuild/lib/main.js:680:9)
	@xen-orchestra/lite:build:     at handleIncomingPacket (/xen-orchestra/@xen-orchestra/lite/node_modules/esbuild/lib/main.js:735:9)
	@xen-orchestra/lite:build:     at Socket.readFromStdout (/xen-orchestra/@xen-orchestra/lite/node_modules/esbuild/lib/main.js:656:7)
	@xen-orchestra/lite:build:     at Socket.emit (node:events:513:28)
	@xen-orchestra/lite:build:     at addChunk (node:internal/streams/readable:324:12)
	@xen-orchestra/lite:build:     at readableAddChunk (node:internal/streams/readable:297:9)
	@xen-orchestra/lite:build:     at Readable.push (node:internal/streams/readable:234:10)
	@xen-orchestra/lite:build:     at Pipe.onStreamRead (node:internal/stream_base_commons:190:23)
	@xen-orchestra/lite:build: error Command failed with exit code 1.
	@xen-orchestra/lite:build: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
	@xen-orchestra/lite:build: ERROR: "build-only" exited with 1.
	@xen-orchestra/lite:build: error Command failed with exit code 1.
	@xen-orchestra/lite:build: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
	@xen-orchestra/lite:build: ERROR: command finished with error: command (/xen-orchestra/@xen-orchestra/lite) yarn run build exited (1)
</details>

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
