### PR TITLE
Feat(xo-server): implement Api for esxi migration UX

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@
 
 - [xo-cli] Fix `write EPIPE` error when used with piped output is closed (e.g. like `| head`) [#6680](https://github.com/vatesfr/xen-orchestra/issues/6680)
 - [VM] Show distro icon for openSUSE [Forum#6965](https://xcp-ng.org/forum/topic/6965)
+- [ESXI import] Handle listing more than 100 VMs
 
 ### Packages to release
 
@@ -35,6 +36,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/vmware-explorer patch
 - @xen-orchestra/backups minor
 - xo-cli minor
 - xo-server-auth-oidc minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,7 +36,7 @@
 
 <!--packages-start-->
 
-- @xen-orchestra/vmware-explorer patch
+- @xen-orchestra/vmware-explorer minor
 - @xen-orchestra/backups minor
 - xo-cli minor
 - xo-server-auth-oidc minor

--- a/packages/xo-server/src/api/esxi.mjs
+++ b/packages/xo-server/src/api/esxi.mjs
@@ -1,0 +1,12 @@
+export function listVms({ host, password, sslVerify = true, user }) {
+  return this.connectToEsxiAndList({ host, user, password, sslVerify })
+}
+
+listVms.params = {
+  host: { type: 'string' },
+  user: { type: 'string' },
+  password: { type: 'string' },
+  sslVerify: { type: 'boolean', optional: true },
+}
+
+listVms.permission = 'admin'

--- a/packages/xo-server/src/xo-mixins/migrate-vm.mjs
+++ b/packages/xo-server/src/xo-mixins/migrate-vm.mjs
@@ -161,6 +161,11 @@ export default class MigrateVm {
     })
   }
 
+  async connectToEsxiAndList({ host, user, password, sslVerify }) {
+    const esxi = await this.#connectToEsxi(host, user, password, sslVerify)
+    return esxi.getAllVmMetadata()
+  }
+
   @decorateWith(deferrable)
   async migrationfromEsxi(
     $defer,
@@ -173,7 +178,7 @@ export default class MigrateVm {
       return esxi.getTransferableVmMetadata(vmId)
     })
 
-    const { disks, firmware, memory, name_label, networks, numCpu, powerState, snapshots } = esxiVmMetadata
+    const { disks, firmware, memory, name_label, networks, nCpus, powerState, snapshots } = esxiVmMetadata
     const isRunning = powerState !== 'poweredOff'
 
     const chainsByNodes = await new Task({ name: `build disks and snapshots chains for ${vmId}` }).run(async () => {
@@ -194,8 +199,8 @@ export default class MigrateVm {
           memory_static_min: memory,
           name_description: 'from esxi',
           name_label,
-          VCPUs_at_startup: numCpu,
-          VCPUs_max: numCpu,
+          VCPUs_at_startup: nCpus,
+          VCPUs_max: nCpus,
         })
       )
       await Promise.all([


### PR DESCRIPTION
review by commits

 * add new method exxi.listVms({host, user, password, sslVerify=true}) to api
this will return 

```js
[
  {
    "id": "1",
    "nameLabel": "test_linux",
    "memory": 2147483648,
    "nCpus": 1,
    "guestToolsInstalled": false,
    "firmware": "bios",
    "powerState": "poweredOff",
    "storage": {
      "used": 216761,
      "free": 2318061568
    }
  },
  {
    "id": "2",
    "nameLabel": "test_small",
    "memory": 2147483648,
    "nCpus": 1,
    "guestToolsInstalled": false,
    "firmware": "bios",
    "powerState": "poweredOff",
    "storage": {
      "used": 10696,
      "free": 2586497520
    }
  },
  {
    "id": "4",
    "nameLabel": "test flo",
    "memory": 1073741824,
    "nCpus": 2,
    "guestToolsInstalled": false,
    "firmware": "bios",
    "powerState": "poweredOff",
    "storage": {
      "used": 6860092734,
      "free": 35570518969
    }
  },
  {
    "id": "8",
    "nameLabel": "damnsmalllinux",
    "memory": 268435456,
    "nCpus": 1,
    "guestToolsInstalled": false,
    "firmware": "bios",
    "powerState": "poweredOff",
    "storage": {
      "used": 154318782,
      "free": 553288173
    }
  },
  {
    "id": "9",
    "nameLabel": "miniubuntu",
    "memory": 2147483648,
    "nCpus": 3,
    "guestToolsInstalled": false,
    "firmware": "bios",
    "powerState": "poweredOn",
    "storage": {
      "used": 7720281547,
      "free": 8588887706
    }
  },
  {
    "id": "10",
    "nameLabel": "ubuntu2",
    "memory": 2147483648,
    "nCpus": 4,
    "guestToolsInstalled": false,
    "firmware": "bios",
    "powerState": "poweredOn",
    "storage": {
      "used": 6132889490,
      "free": 8555332434
    }
  },
  {
    "id": "20",
    "nameLabel": "windows",
    "memory": 2147483648,
    "nCpus": 1,
    "guestToolsInstalled": false,
    "firmware": "uefi",
    "powerState": "poweredOff",
    "storage": {
      "used": 1971,
      "free": 36662014449
    }
  }
]
```
memoy, used, and free are in bytes 

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [x] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
