### PR TITLE
fix(xo-web/pool/license): fix empty modal on license binding

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,7 @@
 
 - [Continuous Replication] Fix `VDI_IO_ERROR` when after a VDI has been resized
 - [REST API] Fix VDI import
+- [Pool/License] Fix license expiration on license binding modal (PR [#6666](https://github.com/vatesfr/xen-orchestra/pull/6666))
 
 ### Packages to release
 
@@ -33,5 +34,6 @@
 - @xen-orchestra/backups patch
 - xen-api patch
 - xo-server patch
+- xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-web/src/xo-app/pool/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/pool/tab-advanced.js
@@ -63,9 +63,10 @@ const BindLicensesButton = decorate([
           return error(_('licensesBinding'), _('notEnoughXcpngLicenses'))
         }
 
-        const hostsWithoutLicense = poolHosts.filter(
-          host => this.state.xcpngLicenseByBoundObjectId[host.id] === undefined
-        )
+        const hostsWithoutLicense = poolHosts.filter(host => {
+          const license = this.state.xcpngLicenseByBoundObjectId[host.id]
+          return license === undefined || license.expires < Date.now()
+        })
         const licenseIdByHost = await confirm({
           body: <PoolBindLicenseModal hosts={hostsWithoutLicense} />,
           icon: 'connect',


### PR DESCRIPTION
See zammad#12626

### Check list

> Check if done, if not relevant leave unchecked.

- [x] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
