### PR TITLE
feat(xo-server/rest-api): expose backup logs

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Backup/Restore] Fix restore via a proxy showing as interupted (PR [#6702](https://github.com/vatesfr/xen-orchestra/pull/6702))
+- [REST API] Backup logs are now available at `/rest/v0/backups/logs`
 
 ### Packages to release
 
@@ -30,6 +31,6 @@
 <!--packages-start-->
 
 - @xen-orchestra/backups minor
-- xo-server patch
+- xo-server minor
 
 <!--packages-end-->

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -119,6 +119,8 @@ export default class RestApi {
       })
     )
 
+    collections.backups = { id: 'backups' }
+
     collections.vms.actions = {
       __proto__: null,
 
@@ -159,6 +161,25 @@ export default class RestApi {
     })
 
     api.get('/', (req, res) => sendObjects(collections, req, res))
+
+    api
+      .get('/backups', (req, res) => {
+        sendObjects([{ id: 'logs' }], req, res)
+      })
+      .get(
+        '/backups/logs',
+        wrap(async (req, res) => {
+          const logs = await app.getBackupNgLogsSorted({})
+          sendObjects(logs, req, res)
+        })
+      )
+      .get(
+        '/backups/logs/:id',
+        wrap(async (req, res) => {
+          res.json(await app.getBackupNgLogs(req.params.id))
+        })
+      )
+
     api.get(
       '/:collection',
       wrap(async (req, res) => {

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -164,17 +164,29 @@ export default class RestApi {
 
     api
       .get('/backups', (req, res) => {
-        sendObjects([{ id: 'logs' }], req, res)
+        sendObjects([{ id: 'logs' }, { id: 'restore' }], req, res)
       })
       .get(
         '/backups/logs',
         wrap(async (req, res) => {
-          const logs = await app.getBackupNgLogsSorted({})
+          const logs = await app.getBackupNgLogsSorted({
+            filter: ({ message: m }) => m === 'backup' || m === 'metadata',
+          })
+          sendObjects(logs, req, res)
+        })
+      )
+      .get('/backups/restore', (req, res) => {
+        sendObjects([{ id: 'logs' }], req, res)
+      })
+      .get(
+        '/backups/restore/logs',
+        wrap(async (req, res) => {
+          const logs = await app.getBackupNgLogsSorted({ filter: _ => _.message === 'restore' })
           sendObjects(logs, req, res)
         })
       )
       .get(
-        '/backups/logs/:id',
+        ['/backups/logs/:id', '/backups/restore/logs/:id'],
         wrap(async (req, res) => {
           res.json(await app.getBackupNgLogs(req.params.id))
         })

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -120,6 +120,7 @@ export default class RestApi {
     )
 
     collections.backups = { id: 'backups' }
+    collections.restore = { id: 'restore' }
 
     collections.vms.actions = {
       __proto__: null,
@@ -163,8 +164,8 @@ export default class RestApi {
     api.get('/', (req, res) => sendObjects(collections, req, res))
 
     api
-      .get('/backups', (req, res) => {
-        sendObjects([{ id: 'logs' }, { id: 'restore' }], req, res)
+      .get(['/backups', '/restore'], (req, res) => {
+        sendObjects([{ id: 'logs' }], req, res)
       })
       .get(
         '/backups/logs',
@@ -175,18 +176,15 @@ export default class RestApi {
           sendObjects(logs, req, res)
         })
       )
-      .get('/backups/restore', (req, res) => {
-        sendObjects([{ id: 'logs' }], req, res)
-      })
       .get(
-        '/backups/restore/logs',
+        '/restore/logs',
         wrap(async (req, res) => {
           const logs = await app.getBackupNgLogsSorted({ filter: _ => _.message === 'restore' })
           sendObjects(logs, req, res)
         })
       )
       .get(
-        ['/backups/logs/:id', '/backups/restore/logs/:id'],
+        ['/backups/logs/:id', '/restore/logs/:id'],
         wrap(async (req, res) => {
           res.json(await app.getBackupNgLogs(req.params.id))
         })


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
