### PR TITLE
refactor(xapi/VDI_exportContent): can export from NBD

### DIFF
--- a/@vates/nbd-client/index.js
+++ b/@vates/nbd-client/index.js
@@ -231,15 +231,21 @@ module.exports = class NbdClient {
     buffer.writeInt32BE(size, 24)
 
     return new Promise((resolve, reject) => {
+      function decoratedReject(error) {
+        error.index = index
+        error.size = size
+        reject(error)
+      }
+
       // this will handle one block response, but it can be another block
       // since server does not guaranty to handle query in order
       this.#commandQueryBacklog.set(queryId, {
         size,
         resolve,
-        reject,
+        reject: decoratedReject,
       })
       // really send the command to the server
-      this.#write(buffer).catch(reject)
+      this.#write(buffer).catch(decoratedReject)
 
       // #readBlockResponse never throws directly
       // but if it fails it will reject all the promises in the backlog
@@ -261,34 +267,22 @@ module.exports = class NbdClient {
     }
     const readAhead = []
     const readAheadMaxLength = 10
-    const errors = []
+
+    // read all blocks, but try to keep readAheadMaxLength promise waiting ahead
     for (const { index, size } of indexGenerator()) {
+      // stack readAheadMaxLengthpromise before starting to handle the results
       if (readAhead.length === readAheadMaxLength) {
-        const block = await readAhead.shift()
-        if (block instanceof Error) {
-          break
-        }
-        yield block
+        // any error will stop reading blocks
+        yield readAhead.shift()
       }
-      readAhead.push(
-        this.readBlock(index, size).catch(error => {
-          errors.push(error)
-          return error
-        })
-      )
+
+      // error is handled during unshift
+      const promise = this.readBlock(index, size)
+      promise.catch(() => {})
+      readAhead.push(promise)
     }
     while (readAhead.length > 0) {
-      const block = await readAhead.shift()
-      if (!(block instanceof Error)) {
-        yield block
-      }
-    }
-    // reading a block shoul be quite fast, we wait for all errors
-    // before rethrowing them
-    if (errors.length > 0) {
-      const error = new Error('fail during blocks reading')
-      error.errors = errors
-      throw error
+      yield readAhead.shift()
     }
   }
 }

--- a/@vates/nbd-client/index.js
+++ b/@vates/nbd-client/index.js
@@ -246,4 +246,21 @@ module.exports = class NbdClient {
       this.#readBlockResponse()
     })
   }
+
+  async *readBlocks(indexGenerator) {
+    // default : read all blocks
+    if (indexGenerator === undefined) {
+      const exportSize = this.#exportSize
+      const chunkSize = 2 * 1024 * 1024
+      indexGenerator = function* () {
+        const nbBlocks = Math.ceil(exportSize / chunkSize)
+        for (let index = 0; index < nbBlocks; index++) {
+          yield { index, size: chunkSize }
+        }
+      }
+    }
+    for (const { index, size } of indexGenerator()) {
+      yield this.readBlock(index, size)
+    }
+  }
 }

--- a/@vates/nbd-client/index.js
+++ b/@vates/nbd-client/index.js
@@ -259,8 +259,17 @@ module.exports = class NbdClient {
         }
       }
     }
+    const readAhead = []
+    const readAheadMaxLength = 10
     for (const { index, size } of indexGenerator()) {
-      yield this.readBlock(index, size)
+      if (readAhead.length === readAheadMaxLength) {
+        const block = readAhead.shift()
+        yield block
+      }
+      readAhead.push(this.readBlock(index, size))
+    }
+    while (readAhead.length > 0) {
+      yield readAhead.shift()
     }
   }
 }

--- a/@xen-orchestra/backups/RemoteAdapter.js
+++ b/@xen-orchestra/backups/RemoteAdapter.js
@@ -666,7 +666,7 @@ class RemoteAdapter {
     return path
   }
 
-  async writeVhd(path, input, { checksum = true, validator = noop, writeBlockConcurrency, nbdClient } = {}) {
+  async writeVhd(path, input, { checksum = true, validator = noop, writeBlockConcurrency } = {}) {
     const handler = this._handler
     if (this.useVhdDirectory()) {
       const dataPath = `${dirname(path)}/data/${uuidv4()}.vhd`
@@ -677,7 +677,6 @@ class RemoteAdapter {
           await input.task
           return validator.apply(this, arguments)
         },
-        nbdClient,
       })
       await VhdAbstract.createAlias(handler, path, dataPath)
       return size

--- a/@xen-orchestra/backups/_VmBackup.js
+++ b/@xen-orchestra/backups/_VmBackup.js
@@ -245,6 +245,11 @@ class VmBackup {
     const deltaExport = await exportDeltaVm(exportedVm, baseVm, {
       fullVdisRequired,
     })
+    // since NBD is network based, if one disk use nbd , all the disk use them
+    // except the suspended VDI
+    if (Object.values(deltaExport.streams).some(({ _nbd }) => _nbd)) {
+      Task.info('Transfer data using NBD')
+    }
     const sizeContainers = mapValues(deltaExport.streams, stream => watchStreamSize(stream))
     deltaExport.streams = mapValues(deltaExport.streams, this._throttleStream)
 

--- a/@xen-orchestra/xapi/index.js
+++ b/@xen-orchestra/xapi/index.js
@@ -147,9 +147,9 @@ class Xapi extends Base {
       when: { code: 'TOO_MANY_PENDING_TASKS' },
     }
     this._maxUncoalescedVdis = maxUncoalescedVdis
+    this._preferNbd = preferNbd
     this._syncHookSecret = syncHookSecret
     this._syncHookTimeout = syncHookTimeout
-    this._preferNbd = preferNbd
     this._vdiDestroyRetryWhenInUse = {
       ...vdiDestroyRetryWhenInUse,
       onRetry,

--- a/@xen-orchestra/xapi/index.js
+++ b/@xen-orchestra/xapi/index.js
@@ -134,6 +134,7 @@ class Xapi extends Base {
   constructor({
     callRetryWhenTooManyPendingTasks = { delay: 5e3, tries: 10 },
     maxUncoalescedVdis,
+    preferNbd,
     syncHookSecret,
     syncHookTimeout,
     vdiDestroyRetryWhenInUse = { delay: 5e3, tries: 10 },
@@ -148,6 +149,7 @@ class Xapi extends Base {
     this._maxUncoalescedVdis = maxUncoalescedVdis
     this._syncHookSecret = syncHookSecret
     this._syncHookTimeout = syncHookTimeout
+    this._preferNbd = preferNbd
     this._vdiDestroyRetryWhenInUse = {
       ...vdiDestroyRetryWhenInUse,
       onRetry,

--- a/@xen-orchestra/xapi/index.js
+++ b/@xen-orchestra/xapi/index.js
@@ -134,7 +134,7 @@ class Xapi extends Base {
   constructor({
     callRetryWhenTooManyPendingTasks = { delay: 5e3, tries: 10 },
     maxUncoalescedVdis,
-    preferNbd,
+    preferNbd = false,
     syncHookSecret,
     syncHookTimeout,
     vdiDestroyRetryWhenInUse = { delay: 5e3, tries: 10 },

--- a/@xen-orchestra/xapi/package.json
+++ b/@xen-orchestra/xapi/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@vates/decorate-with": "^2.0.0",
-    "@vates/nbd-client": "*",
+    "@vates/nbd-client": "1.0.1",
     "@xen-orchestra/async-map": "^0.1.2",
     "@xen-orchestra/log": "^0.6.0",
     "d3-time-format": "^3.0.0",

--- a/@xen-orchestra/xapi/package.json
+++ b/@xen-orchestra/xapi/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@vates/decorate-with": "^2.0.0",
+    "@vates/nbd-client": "*",
     "@xen-orchestra/async-map": "^0.1.2",
     "@xen-orchestra/log": "^0.6.0",
     "d3-time-format": "^3.0.0",

--- a/@xen-orchestra/xapi/vdi.js
+++ b/@xen-orchestra/xapi/vdi.js
@@ -62,7 +62,7 @@ class Vdi {
     })
   }
 
-  async exportContent(ref, { baseRef, cancelToken = CancelToken.none, format, preferNbd = true }) {
+  async exportContent(ref, { baseRef, cancelToken = CancelToken.none, format }) {
     const query = {
       format,
       vdi: ref,
@@ -75,7 +75,7 @@ class Vdi {
     }
     let nbdClient
     try {
-      if (preferNbd) {
+      if (this._preferNbd) {
         const nbdInfos = await this.call('VDI.get_nbd_info', ref)
         if (nbdInfos.length > 0) {
           // a little bit of randomization to spread the load

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,6 +27,10 @@
 
 <!--packages-start-->
 
+- @vates/nbd-client minor
 - @vates/read-chunk minor
+- @xen-orchestra/backups minor
+- @xen-orchestra/xapi minor
+- vhd-lib minor
 
 <!--packages-end-->

--- a/packages/vhd-lib/createStreamNbd.js
+++ b/packages/vhd-lib/createStreamNbd.js
@@ -1,5 +1,5 @@
 'use strict'
-const { readChunkStrict, skipChunk } = require('@vates/read-chunk')
+const { readChunkStrict, skipStrict } = require('@vates/read-chunk')
 const { Readable } = require('node:stream')
 const { unpackHeader } = require('./Vhd/_utils')
 const {
@@ -28,7 +28,7 @@ exports.createNbdVhdStream = async function createVhdStream(nbdClient, sourceStr
   const header = unpackHeader(await readChunkStrict(sourceStream, HEADER_SIZE))
   // compute BAT in order
   const batSize = Math.ceil((header.maxTableEntries * 4) / SECTOR_SIZE) * SECTOR_SIZE
-  await skipChunk(sourceStream, header.tableOffset - (FOOTER_SIZE + HEADER_SIZE))
+  await skipStrict(sourceStream, header.tableOffset - (FOOTER_SIZE + HEADER_SIZE))
   const streamBat = await readChunkStrict(sourceStream, batSize)
   let offset = FOOTER_SIZE + HEADER_SIZE + batSize
   // check if parentlocator are ordered
@@ -79,7 +79,7 @@ exports.createNbdVhdStream = async function createVhdStream(nbdClient, sourceStr
       const parentLocatorOffset = header.parentLocatorEntry[i].platformDataOffset
       const space = header.parentLocatorEntry[i].platformDataSpace * SECTOR_SIZE
       if (space > 0) {
-        await skipChunk(sourceStream, parentLocatorOffset - precBlocOffset)
+        await skipStrict(sourceStream, parentLocatorOffset - precBlocOffset)
         const data = await readChunkStrict(sourceStream, space)
         precBlocOffset = parentLocatorOffset + space
         yield data

--- a/packages/vhd-lib/createStreamNbd.js
+++ b/packages/vhd-lib/createStreamNbd.js
@@ -1,0 +1,105 @@
+'use strict'
+const { readChunkStrict, skipChunk } = require('@vates/read-chunk')
+const { Readable } = require('node:stream')
+const { unpackHeader } = require('./Vhd/_utils')
+const {
+  FOOTER_SIZE,
+  HEADER_SIZE,
+  PARENT_LOCATOR_ENTRIES,
+  SECTOR_SIZE,
+  BLOCK_UNUSED,
+  DEFAULT_BLOCK_SIZE,
+  PLATFORMS,
+} = require('./_constants')
+const { fuHeader, checksumStruct } = require('./_structs')
+const assert = require('node:assert')
+
+exports.createNbdRawStream = async function createRawStream(nbdClient) {
+  return Readable.from(nbdClient.readBlocks())
+}
+
+exports.createNbdVhdStream = async function createVhdStream(nbdClient, sourceStream) {
+  const bufFooter = await readChunkStrict(sourceStream, FOOTER_SIZE)
+
+  const header = unpackHeader(await readChunkStrict(sourceStream, HEADER_SIZE))
+  // compute BAT in order
+  const batSize = Math.ceil((header.maxTableEntries * 4) / SECTOR_SIZE) * SECTOR_SIZE
+  await skipChunk(sourceStream, header.tableOffset - (FOOTER_SIZE + HEADER_SIZE))
+  const streamBat = await readChunkStrict(sourceStream, batSize)
+  let offset = FOOTER_SIZE + HEADER_SIZE + batSize
+  // check if parentlocator are ordered
+  let precLocator = 0
+  for (let i = 0; i < PARENT_LOCATOR_ENTRIES; i++) {
+    header.parentLocatorEntry[i] = {
+      ...header.parentLocatorEntry[i],
+      platformDataOffset: offset,
+    }
+    offset += header.parentLocatorEntry[i].platformDataSpace * SECTOR_SIZE
+    if (header.parentLocatorEntry[i].platformCode !== PLATFORMS.NONE) {
+      assert(
+        precLocator < offset,
+        `locator must be ordered. numer ${i} is  at ${offset}, precedent is at ${precLocator}`
+      )
+      precLocator = offset
+    }
+  }
+  header.tableOffset = FOOTER_SIZE + HEADER_SIZE
+  const rawHeader = fuHeader.pack(header)
+  checksumStruct(rawHeader, fuHeader)
+
+  // BAT
+  const bat = Buffer.allocUnsafe(batSize)
+  let offsetSector = offset / SECTOR_SIZE
+  const blockSizeInSectors = DEFAULT_BLOCK_SIZE / SECTOR_SIZE + 1 /* bitmap */
+  // compute a BAT with the position that the block will have in the resulting stream
+  // blocks starts directly after parent locator entries
+  const entries = []
+  for (let i = 0; i < header.maxTableEntries; i++) {
+    const entry = streamBat.readUInt32BE(i * 4)
+    if (entry !== BLOCK_UNUSED) {
+      bat.writeUInt32BE(offsetSector, i * 4)
+      offsetSector += blockSizeInSectors
+      entries.push(i)
+    } else {
+      bat.writeUInt32BE(BLOCK_UNUSED, i * 4)
+    }
+  }
+
+  async function* iterator() {
+    yield bufFooter
+    yield rawHeader
+    yield bat
+
+    let precBlocOffset = FOOTER_SIZE + HEADER_SIZE + batSize
+    for (let i = 0; i < PARENT_LOCATOR_ENTRIES; i++) {
+      const parentLocatorOffset = header.parentLocatorEntry[i].platformDataOffset
+      const space = header.parentLocatorEntry[i].platformDataSpace * SECTOR_SIZE
+      if (space > 0) {
+        await skipChunk(sourceStream, parentLocatorOffset - precBlocOffset)
+        const data = await readChunkStrict(sourceStream, space)
+        precBlocOffset = parentLocatorOffset + space
+        yield data
+      }
+    }
+
+    // close export stream we won't use it anymore
+    sourceStream.destroy()
+
+    // yield  blocks from nbd
+    const nbdIterator = nbdClient.readBlocks(function* () {
+      for (const entry of entries) {
+        yield { index: entry, size: DEFAULT_BLOCK_SIZE }
+      }
+    })
+    const bitmap = Buffer.alloc(SECTOR_SIZE, 255)
+    for await (const block of nbdIterator) {
+      yield Buffer.concat([bitmap, block])
+    }
+    yield bufFooter
+  }
+
+  const stream = Readable.from(iterator())
+  stream.headers = {}
+  stream.statusCode = 200
+  return stream
+}

--- a/packages/vhd-lib/createStreamNbd.js
+++ b/packages/vhd-lib/createStreamNbd.js
@@ -104,7 +104,7 @@ exports.createNbdVhdStream = async function createVhdStream(nbdClient, sourceStr
   }
 
   const stream = Readable.from(iterator())
-
+  stream.length = (offsetSector + blockSizeInSectors + 1) /* end footer */ * SECTOR_SIZE
   stream.on('error', () => nbdClient.disconnect())
   stream.on('end', () => nbdClient.disconnect())
   return stream

--- a/packages/vhd-lib/createStreamNbd.js
+++ b/packages/vhd-lib/createStreamNbd.js
@@ -105,6 +105,7 @@ exports.createNbdVhdStream = async function createVhdStream(nbdClient, sourceStr
 
   const stream = Readable.from(iterator())
   stream.length = (offsetSector + blockSizeInSectors + 1) /* end footer */ * SECTOR_SIZE
+  stream._nbd = true
   stream.on('error', () => nbdClient.disconnect())
   stream.on('end', () => nbdClient.disconnect())
   return stream

--- a/packages/vhd-lib/createVhdDirectoryFromStream.js
+++ b/packages/vhd-lib/createVhdDirectoryFromStream.js
@@ -8,10 +8,10 @@ const { asyncEach } = require('@vates/async-each')
 
 const { warn } = createLogger('vhd-lib:createVhdDirectoryFromStream')
 
-const buildVhd = Disposable.wrap(async function* (handler, path, inputStream, { concurrency, compression, nbdClient }) {
+const buildVhd = Disposable.wrap(async function* (handler, path, inputStream, { concurrency, compression }) {
   const vhd = yield VhdDirectory.create(handler, path, { compression })
   await asyncEach(
-    parseVhdStream(inputStream, nbdClient),
+    parseVhdStream(inputStream),
     async function (item) {
       switch (item.type) {
         case 'footer':
@@ -45,10 +45,10 @@ exports.createVhdDirectoryFromStream = async function createVhdDirectoryFromStre
   handler,
   path,
   inputStream,
-  { validator, concurrency = 16, compression, nbdClient } = {}
+  { validator, concurrency = 16, compression } = {}
 ) {
   try {
-    const size = await buildVhd(handler, path, inputStream, { concurrency, compression, nbdClient })
+    const size = await buildVhd(handler, path, inputStream, { concurrency, compression })
     if (validator !== undefined) {
       await validator.call(this, path)
     }

--- a/packages/vhd-lib/parseVhdStream.js
+++ b/packages/vhd-lib/parseVhdStream.js
@@ -42,6 +42,7 @@ class StreamParser {
     if (this._bytesRead < offset) {
       // empty spaces
       await skipStrict(this._stream, offset - this._bytesRead)
+      this._bytesRead += offset - this._bytesRead
     }
 
     try {

--- a/packages/vhd-lib/parseVhdStream.js
+++ b/packages/vhd-lib/parseVhdStream.js
@@ -1,10 +1,9 @@
 'use strict'
 
 const { BLOCK_UNUSED, FOOTER_SIZE, HEADER_SIZE, SECTOR_SIZE } = require('./_constants')
-const { readChunk } = require('@vates/read-chunk')
+const { readChunkStrict, skipChunk } = require('@vates/read-chunk')
 const assert = require('assert')
 const { unpackFooter, unpackHeader, computeFullBlockSize } = require('./Vhd/_utils')
-const { asyncEach } = require('@vates/async-each')
 
 const cappedBufferConcat = (buffers, maxSize) => {
   let buffer = Buffer.concat(buffers)
@@ -42,10 +41,9 @@ class StreamParser {
     assert(this._bytesRead <= offset, `offset is ${offset} but we already read ${this._bytesRead} bytes`)
     if (this._bytesRead < offset) {
       // empty spaces
-      await this._read(this._bytesRead, offset - this._bytesRead)
+      await skipChunk(this._stream, offset - this._bytesRead)
     }
-    const buf = await readChunk(this._stream, size)
-    assert.strictEqual(buf.length, size, `read ${buf.length} instead of ${size}`)
+    const buf = await readChunkStrict(this._stream, size)
     this._bytesRead += size
     return buf
   }
@@ -154,111 +152,7 @@ class StreamParser {
     yield* this.blocks()
   }
 }
-
-// hybrid mode : read the headers from the vhd stream, and read the blocks from nbd
-class StreamNbdParser extends StreamParser {
-  #nbdClient = null
-  #concurrency = 16
-
-  constructor(stream, nbdClient = {}) {
-    super(stream)
-    this.#nbdClient = nbdClient
-  }
-
-  async _readBlockData(item) {
-    const SECTOR_BITMAP = Buffer.alloc(512, 255)
-    const client = this.#nbdClient
-    // we read in a raw file, so the block position is id x length, and have nothing to do with the offset
-    // in the vhd stream
-    const rawDataLength = item.size - SECTOR_BITMAP.length
-    const data = await client.readBlock(item.id, rawDataLength)
-
-    // end of file , non aligned vhd block
-    const buffer = Buffer.concat([SECTOR_BITMAP, data])
-    const block = {
-      ...item,
-      size: rawDataLength,
-      bitmap: SECTOR_BITMAP,
-      data,
-      buffer,
-    }
-    return block
-  }
-
-  async *blocks() {
-    // at most this array will be this.#concurrency long
-    const blocksReady = []
-    let waitingForBlock
-    let done = false
-    let error
-
-    function waitForYield(block) {
-      return new Promise(resolve => {
-        blocksReady.push({
-          block,
-          yielded: resolve,
-        })
-        if (waitingForBlock !== undefined) {
-          const resolver = waitingForBlock
-          waitingForBlock = undefined
-          resolver()
-        }
-      })
-    }
-
-    asyncEach(
-      this._index,
-      async blockId => {
-        const block = await this._readBlockData(blockId)
-        await waitForYield(block)
-      },
-      { concurrency: this.#concurrency }
-    )
-      .then(() => {
-        done = true
-        waitingForBlock?.()
-      })
-      .catch(err => {
-        // will keep only the last error if multiple throws
-        error = err
-        waitingForBlock?.()
-      })
-    // eslint-disable-next-line no-unmodified-loop-condition
-    while (!done) {
-      if (error) {
-        throw error
-      }
-      if (blocksReady.length > 0) {
-        const { block, yielded } = blocksReady.shift()
-        yielded()
-        yield block
-      } else {
-        await new Promise(resolve => {
-          waitingForBlock = resolve
-        })
-      }
-    }
-  }
-
-  async *parse() {
-    yield* this.headers()
-
-    // the VHD stream is no longer necessary, destroy it
-    //
-    // - not destroying it would leave other writers stuck
-    // - resuming it would download the whole stream unnecessarily if not other writers
-    this._stream.destroy()
-
-    yield* this.blocks()
-  }
-}
-
-exports.parseVhdStream = async function* parseVhdStream(stream, nbdClient) {
-  let parser
-  if (nbdClient) {
-    parser = new StreamNbdParser(stream, nbdClient)
-  } else {
-    parser = new StreamParser(stream)
-  }
+exports.parseVhdStream = async function* parseVhdStream(stream) {
+  const parser = new StreamParser(stream)
   yield* parser.parse()
 }

--- a/packages/vhd-lib/parseVhdStream.js
+++ b/packages/vhd-lib/parseVhdStream.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { BLOCK_UNUSED, FOOTER_SIZE, HEADER_SIZE, SECTOR_SIZE } = require('./_constants')
-const { readChunkStrict, skipChunk } = require('@vates/read-chunk')
+const { readChunkStrict, skipStrict } = require('@vates/read-chunk')
 const assert = require('assert')
 const { unpackFooter, unpackHeader, computeFullBlockSize } = require('./Vhd/_utils')
 
@@ -41,7 +41,7 @@ class StreamParser {
     assert(this._bytesRead <= offset, `offset is ${offset} but we already read ${this._bytesRead} bytes`)
     if (this._bytesRead < offset) {
       // empty spaces
-      await skipChunk(this._stream, offset - this._bytesRead)
+      await skipStrict(this._stream, offset - this._bytesRead)
     }
 
     try {

--- a/packages/vhd-lib/parseVhdStream.js
+++ b/packages/vhd-lib/parseVhdStream.js
@@ -43,9 +43,16 @@ class StreamParser {
       // empty spaces
       await skipChunk(this._stream, offset - this._bytesRead)
     }
-    const buf = await readChunkStrict(this._stream, size)
-    this._bytesRead += size
-    return buf
+
+    try {
+      const buf = await readChunkStrict(this._stream, size)
+      this._bytesRead += size
+      return buf
+    } catch (err) {
+      err._bytesRead = this._bytesRead
+      err.size = size
+      throw err
+    }
   }
 
   async *headers() {

--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -178,6 +178,7 @@ vmSnapshotConcurrency = 2
 poolMarkingInterval = '6 hours'
 poolMarkingMaxAge = '48 hours'
 poolMarkingPrefix = 'xo:clientInfo:'
+preferNbd = false
 
 [xo-proxy]
 callTimeout = '1 min'

--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -178,7 +178,6 @@ vmSnapshotConcurrency = 2
 poolMarkingInterval = '6 hours'
 poolMarkingMaxAge = '48 hours'
 poolMarkingPrefix = 'xo:clientInfo:'
-preferNbd = false
 
 [xo-proxy]
 callTimeout = '1 min'


### PR DESCRIPTION
### Goal
use NBD wherever it's possible . Today, NBD is only used for delta backup on vhd block storage.  In this case, the blocks are read in parallel, but this reading process is completly separated from other reading neeeding for other remotes  or for continuous replication.

### Impacts
NBD is used for 
 * export vhd
 * export vmdk
 * export ova
 * export raw disk 
 * delta backup,  vhd file or blocks , full disk backup or delta disk backup
 * continuous replication
 * no more constrained by the 24 maximum task duration, especially when doing a full disk export

It is **not** used for 
 * xva export
 * full VM backup
 * disaster recovery

NBD block reading is done sequentially. It reads block only once even with multiple target of a backup job. 

NBD is enabled as a xapi option : if a NBD network is present and is accessible between the VM and XO, it will be used.  

NBD server is choosen at random between the available one. That means that if the VM use a shared storage, all the host of the pool can be used. 

No more visible task during export , need to implement the new task  system + UX 

### futures

* implement retry when reading a block fail ( thus allowing us to not fail a backup when there is a short network outage between host and XO )
* implement resume / global retry  of a backup  (for example at the end of a backup job, retry all the failed VMs before cleanVM) 
* create and handle task manually


review by commit

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
