### PR TITLE
fix(xo-web): don't send empty MTU while creating network

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,5 +31,6 @@
 
 - @xen-orchestra/backups minor
 - xo-server patch
+- xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-server/src/api/network.mjs
+++ b/packages/xo-server/src/api/network.mjs
@@ -26,7 +26,7 @@ create.params = {
   nbd: { type: 'boolean', optional: true },
   description: { type: 'string', optional: true },
   pif: { type: 'string', optional: true },
-  mtu: { type: ['integer', 'string'], optional: true },
+  mtu: { type: 'integer', optional: true },
   vlan: { type: ['integer', 'string'], optional: true },
 }
 
@@ -56,7 +56,7 @@ createBonded.params = {
       type: 'string',
     },
   },
-  mtu: { type: ['integer', 'string'], optional: true },
+  mtu: { type: 'integer', optional: true },
   bondMode: { enum: getBondModes() },
 }
 

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -1135,7 +1135,7 @@ export default class Xapi extends XapiBase {
     const networkRef = await this.call('network.create', {
       name_label: name,
       name_description: description,
-      MTU: asInteger(mtu),
+      MTU: mtu,
       // Set automatic to false so XenCenter does not get confused
       // https://citrix.github.io/xenserver-sdk/#network
       other_config: { automatic: 'false' },

--- a/packages/xo-web/src/xo-app/new/network/index.js
+++ b/packages/xo-web/src/xo-app/new/network/index.js
@@ -192,7 +192,6 @@ const NewNetwork = decorate([
         description,
         encapsulation,
         encrypted,
-        mtu,
         name,
         nbd,
         networks,
@@ -200,6 +199,10 @@ const NewNetwork = decorate([
         pifs,
         vlan,
       } = state
+
+      let { mtu } = state
+      mtu = mtu === '' ? undefined : +mtu
+
       return bonded
         ? createBondedNetwork({
             bondMode: bondMode.value,
@@ -224,7 +227,7 @@ const NewNetwork = decorate([
               description,
               encapsulation,
               encrypted,
-              mtu: mtu !== '' ? +mtu : undefined,
+              mtu,
               preferredCenter: networkCenter,
             })
           })()


### PR DESCRIPTION
Fixes #6717

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
