### PR TITLE
fix(xo-server-usage-report): change dataset size

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Plugins/usage-report] Compute stats on configured period instead of the whole year (PR [#6723](https://github.com/vatesfr/xen-orchestra/pull/6723))
 - [Backup] Fix `Invalid parameters` when deleting `speed limit` value (PR [#6768](https://github.com/vatesfr/xen-orchestra/pull/6768))
 
 ### Packages to release

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,5 +31,6 @@
 
 - xo-web patch
 - xo-server minor
+- xo-server-usage-report patch
 
 <!--packages-end-->

--- a/packages/xo-server-usage-report/src/index.js
+++ b/packages/xo-server-usage-report/src/index.js
@@ -149,8 +149,8 @@ Handlebars.registerHelper(
     new Handlebars.SafeString(
       isFinite((value = round(value, 2))) && value !== 0
         ? value > 0
-          ? `(<b style="color: green;">&#x25B2; ${value}%</b>)`
-          : `(<b style="color: red;">&#x25BC; ${String(value).slice(1)}%</b>)`
+          ? `(<b style="color: green;">▲ ${value}%</b>)`
+          : `(<b style="color: red;">▼ ${String(value).slice(1)}%</b>)`
         : ''
     )
 )

--- a/packages/xo-server-usage-report/src/index.js
+++ b/packages/xo-server-usage-report/src/index.js
@@ -349,8 +349,8 @@ async function getHostsStats({ runningHosts, xo }) {
           cpu: METRICS_MEAN.cpu(getLastDays(stats.cpus)),
           ram: METRICS_MEAN.ram(getLastDays(getMemoryUsedMetric(stats))),
           load: METRICS_MEAN.load(getLastDays(stats.load)),
-          netReception: METRICS_MEAN.net(getLastDays(get(stats.vifs, 'rx'))),
-          netTransmission: METRICS_MEAN.net(getLastDays(get(stats.vifs, 'tx'))),
+          netReception: METRICS_MEAN.net(getLastDays(get(stats.pifs, 'rx'))),
+          netTransmission: METRICS_MEAN.net(getLastDays(get(stats.pifs, 'tx'))),
         }
       })
     ),

--- a/packages/xo-server-usage-report/src/index.js
+++ b/packages/xo-server-usage-report/src/index.js
@@ -269,19 +269,13 @@ const METRICS_MEAN = {
   ram: value => computeMean(value) / gibPower,
 }
 
+const DAYS_TO_KEEP = {
+  daily: 1,
+  weekly: 7,
+  monthly: 30,
+}
 function getLastDays(data, periodicity) {
-  let daysToKeep
-  switch (periodicity) {
-    case 'daily':
-      daysToKeep = 1
-      break
-    case 'weekly':
-      daysToKeep = 7
-      break
-    case 'monthly':
-      daysToKeep = 30
-      break
-  }
+  const daysToKeep = DAYS_TO_KEEP[periodicity]
   const expectedData = {}
   for (const [key, value] of Object.entries(data)) {
     if (Array.isArray(value)) {

--- a/packages/xo-server-usage-report/src/index.js
+++ b/packages/xo-server-usage-report/src/index.js
@@ -283,9 +283,13 @@ function getLastDays(data, periodicity) {
       break
   }
   const expectedData = {}
-  for (const value of Object.entries(data)) {
-    expectedData[value[0]] =
-      typeof value[1] !== 'object' ? value[1] : value[1] !== null ? value[1].slice(-daysToKeep) : 0
+  for (const [key, value] of Object.entries(data)) {
+    if (Array.isArray(value)) {
+      // slice only applies to array
+      expectedData[key] = value.slice(-daysToKeep)
+    } else {
+      expectedData[key] = value
+    }
   }
   return expectedData
 }


### PR DESCRIPTION
Fixes Zammad#12215

### Screenshots

The CPU usage for the VM ```xolab.localdomain```:
![stats_day](https://user-images.githubusercontent.com/64731573/228878700-c1e79eee-7c49-40b8-b3ac-b8f468a68dba.png)
The old report:
![report_before](https://user-images.githubusercontent.com/64731573/228878783-8947cb53-e818-499b-810c-c8ac2c274346.png)
The report now:
![report_after](https://user-images.githubusercontent.com/64731573/228878846-574fb590-921c-40f0-8528-4e3ea05fac7d.png)

### Description

Basically, the plugin is sending a usage report corresponding to the average usage on one year even though the user chose the daily option (therefore the report should show the last day usage).

On the second screenshot, you can see the CPU usage sent by the report (2.09%) is not matching the last day consumption of the CPU in the stats tab on XO (first screenshot).
The last screenshot, you can see that the new version of the plugin is sending an accurate value for the CPU usage.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
