### PR TITLE
feat(xo-web/backup): expose maxExportRate from UI

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Backup/Advanced setting] Add transfer limit per job (PRs [#6737](https://github.com/vatesfr/xen-orchestra/pull/6737), [#6728](https://github.com/vatesfr/xen-orchestra/pull/6728))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -35,5 +37,6 @@
 - @xen-orchestra/backups minor
 - xo-cli patch
 - xo-server minor
+- xo-web minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,7 +7,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [Backup/Advanced setting] Add transfer limit per job (PRs [#6737](https://github.com/vatesfr/xen-orchestra/pull/6737), [#6728](https://github.com/vatesfr/xen-orchestra/pull/6728))
+- [Backup/Advanced setting] Ability to add transfer limit per job (PRs [#6737](https://github.com/vatesfr/xen-orchestra/pull/6737), [#6728](https://github.com/vatesfr/xen-orchestra/pull/6728))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/api/backup-ng.mjs
+++ b/packages/xo-server/src/api/backup-ng.mjs
@@ -17,6 +17,11 @@ const SCHEMA_SETTINGS = {
           minimum: 0,
           optional: true,
         },
+        maxExportRate: {
+          type: 'number',
+          minimum: 0,
+          optional: true,
+        },
       },
       additionalProperties: true,
     },

--- a/packages/xo-web/src/common/form/index.js
+++ b/packages/xo-web/src/common/form/index.js
@@ -152,6 +152,7 @@ export class SizeInput extends BaseComponent {
     readOnly: PropTypes.bool,
     required: PropTypes.bool,
     style: PropTypes.object,
+    suffix: PropTypes.string,
     value: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([null])]),
   }
 
@@ -266,7 +267,7 @@ export class SizeInput extends BaseComponent {
   }
 
   render() {
-    const { autoFocus, className, readOnly, placeholder, required, style } = this.props
+    const { autoFocus, className, readOnly, placeholder, required, style, suffix } = this.props
 
     return (
       <span className={classNames('input-group', className)} style={style}>
@@ -281,10 +282,17 @@ export class SizeInput extends BaseComponent {
           value={this.state.input}
         />
         <span className='input-group-btn'>
-          <DropdownButton bsStyle='secondary' id='size' pullRight disabled={readOnly} title={this.state.unit}>
+          <DropdownButton
+            bsStyle='secondary'
+            id='size'
+            pullRight
+            disabled={readOnly}
+            title={this.state.unit.concat(suffix)}
+          >
             {map(UNITS, unit => (
               <MenuItem key={unit} onClick={() => this._updateUnit(unit)}>
-                {unit}
+                {unit.concat(suffix)}
+                {}
               </MenuItem>
             ))}
           </DropdownButton>

--- a/packages/xo-web/src/common/form/index.js
+++ b/packages/xo-web/src/common/form/index.js
@@ -14,7 +14,7 @@ import { DropdownButton, MenuItem } from 'react-bootstrap-4/lib'
 import Button from '../button'
 import Component from '../base-component'
 import getEventValue from '../get-event-value'
-import { formatSizeRaw, formatSpeed, parseSize } from '../utils'
+import { formatSizeRaw, parseSize } from '../utils'
 
 export Number from './number'
 export Select from './select'
@@ -139,16 +139,14 @@ export class Range extends Component {
 export Toggle from './toggle'
 
 const UNITS = ['kiB', 'MiB', 'GiB']
-const UNITS_SPEED = ['KiB/s', 'MiB/s', 'GiB/s']
 const DEFAULT_UNIT = 'GiB'
 
 export class SizeInput extends BaseComponent {
   static propTypes = {
     autoFocus: PropTypes.bool,
     className: PropTypes.string,
-    defaultUnit: PropTypes.oneOf([...UNITS, ...UNITS_SPEED]),
+    defaultUnit: PropTypes.oneOf(UNITS),
     defaultValue: PropTypes.number,
-    isSpeed: PropTypes.bool,
     onChange: PropTypes.func,
     placeholder: PropTypes.string,
     readOnly: PropTypes.bool,
@@ -185,20 +183,10 @@ export class SizeInput extends BaseComponent {
       }
     }
 
-    const { isSpeed } = this.props
-    let bytesFormat = isSpeed ? formatSpeed(bytes, 1000) : formatSizeRaw(bytes)
-    if (isSpeed) {
-      const [value, prefix] = bytesFormat.split(' ')
-      bytesFormat = {
-        value,
-        prefix,
-      }
-    }
-
-    const { prefix, value } = bytesFormat
+    const { prefix, value } = formatSizeRaw(bytes)
     return {
       input: String(round(value, 2)),
-      unit: prefix.concat(!isSpeed ? 'B' : ''),
+      unit: `${prefix}B`,
     }
   }
 
@@ -220,10 +208,9 @@ export class SizeInput extends BaseComponent {
   }
 
   _onChange(input, unit) {
-    const { onChange, isSpeed } = this.props
-    const _unit = isSpeed ? unit.split('/')[0] : unit
+    const { onChange } = this.props
     // Empty input equals null.
-    const bytes = input ? parseSize(`${+input} ${_unit}`) : null
+    const bytes = input ? parseSize(`${+input} ${unit}`) : null
 
     const isControlled = this.props.value !== undefined
     if (isControlled) {
@@ -278,7 +265,7 @@ export class SizeInput extends BaseComponent {
   }
 
   render() {
-    const { autoFocus, className, readOnly, placeholder, required, style, isSpeed } = this.props
+    const { autoFocus, className, readOnly, placeholder, required, style } = this.props
 
     return (
       <span className={classNames('input-group', className)} style={style}>
@@ -294,7 +281,7 @@ export class SizeInput extends BaseComponent {
         />
         <span className='input-group-btn'>
           <DropdownButton bsStyle='secondary' id='size' pullRight disabled={readOnly} title={this.state.unit}>
-            {(isSpeed ? UNITS_SPEED : UNITS).map(unit => (
+            {map(UNITS, unit => (
               <MenuItem key={unit} onClick={() => this._updateUnit(unit)}>
                 {unit}
               </MenuItem>

--- a/packages/xo-web/src/common/form/index.js
+++ b/packages/xo-web/src/common/form/index.js
@@ -292,7 +292,6 @@ export class SizeInput extends BaseComponent {
             {map(UNITS, unit => (
               <MenuItem key={unit} onClick={() => this._updateUnit(unit)}>
                 {unit.concat(suffix)}
-                {}
               </MenuItem>
             ))}
           </DropdownButton>

--- a/packages/xo-web/src/common/form/index.js
+++ b/packages/xo-web/src/common/form/index.js
@@ -14,7 +14,7 @@ import { DropdownButton, MenuItem } from 'react-bootstrap-4/lib'
 import Button from '../button'
 import Component from '../base-component'
 import getEventValue from '../get-event-value'
-import { formatSizeRaw, parseSize } from '../utils'
+import { formatSizeRaw, formatSpeed, parseSize } from '../utils'
 
 export Number from './number'
 export Select from './select'
@@ -139,20 +139,21 @@ export class Range extends Component {
 export Toggle from './toggle'
 
 const UNITS = ['kiB', 'MiB', 'GiB']
+const UNITS_SPEED = ['KiB/s', 'MiB/s', 'GiB/s']
 const DEFAULT_UNIT = 'GiB'
 
 export class SizeInput extends BaseComponent {
   static propTypes = {
     autoFocus: PropTypes.bool,
     className: PropTypes.string,
-    defaultUnit: PropTypes.oneOf(UNITS),
+    defaultUnit: PropTypes.oneOf([...UNITS, ...UNITS_SPEED]),
     defaultValue: PropTypes.number,
+    isSpeed: PropTypes.bool,
     onChange: PropTypes.func,
     placeholder: PropTypes.string,
     readOnly: PropTypes.bool,
     required: PropTypes.bool,
     style: PropTypes.object,
-    suffix: PropTypes.string,
     value: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([null])]),
   }
 
@@ -184,10 +185,20 @@ export class SizeInput extends BaseComponent {
       }
     }
 
-    const { prefix, value } = formatSizeRaw(bytes)
+    const { isSpeed } = this.props
+    let bytesFormat = isSpeed ? formatSpeed(bytes, 1000) : formatSizeRaw(bytes)
+    if (isSpeed) {
+      const [value, prefix] = bytesFormat.split(' ')
+      bytesFormat = {
+        value,
+        prefix,
+      }
+    }
+
+    const { prefix, value } = bytesFormat
     return {
       input: String(round(value, 2)),
-      unit: `${prefix}B`,
+      unit: prefix.concat(!isSpeed ? 'B' : ''),
     }
   }
 
@@ -209,10 +220,10 @@ export class SizeInput extends BaseComponent {
   }
 
   _onChange(input, unit) {
-    const { onChange } = this.props
-
+    const { onChange, isSpeed } = this.props
+    const _unit = isSpeed ? unit.split('/')[0] : unit
     // Empty input equals null.
-    const bytes = input ? parseSize(`${+input} ${unit}`) : null
+    const bytes = input ? parseSize(`${+input} ${_unit}`) : null
 
     const isControlled = this.props.value !== undefined
     if (isControlled) {
@@ -267,7 +278,7 @@ export class SizeInput extends BaseComponent {
   }
 
   render() {
-    const { autoFocus, className, readOnly, placeholder, required, style, suffix } = this.props
+    const { autoFocus, className, readOnly, placeholder, required, style, isSpeed } = this.props
 
     return (
       <span className={classNames('input-group', className)} style={style}>
@@ -282,16 +293,10 @@ export class SizeInput extends BaseComponent {
           value={this.state.input}
         />
         <span className='input-group-btn'>
-          <DropdownButton
-            bsStyle='secondary'
-            id='size'
-            pullRight
-            disabled={readOnly}
-            title={this.state.unit.concat(suffix)}
-          >
-            {map(UNITS, unit => (
+          <DropdownButton bsStyle='secondary' id='size' pullRight disabled={readOnly} title={this.state.unit}>
+            {(isSpeed ? UNITS_SPEED : UNITS).map(unit => (
               <MenuItem key={unit} onClick={() => this._updateUnit(unit)}>
-                {unit.concat(suffix)}
+                {unit}
               </MenuItem>
             ))}
           </DropdownButton>

--- a/packages/xo-web/src/common/form/index.js
+++ b/packages/xo-web/src/common/form/index.js
@@ -209,6 +209,7 @@ export class SizeInput extends BaseComponent {
 
   _onChange(input, unit) {
     const { onChange } = this.props
+
     // Empty input equals null.
     const bytes = input ? parseSize(`${+input} ${unit}`) : null
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -582,7 +582,7 @@ const messages = {
   confirmDeleteBackupJobsBody:
     'Are you sure you want to delete {nJobs, number} backup job{nJobs, plural, one {} other {s}}?',
   runBackupJob: 'Run backup job once',
-  speedLimit: 'Speed limit (in TODO/s)',
+  speedLimit: 'Speed limit (in octet / s)',
 
   // ------ Remote -----
   remoteName: 'Name',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -582,7 +582,7 @@ const messages = {
   confirmDeleteBackupJobsBody:
     'Are you sure you want to delete {nJobs, number} backup job{nJobs, plural, one {} other {s}}?',
   runBackupJob: 'Run backup job once',
-  speedLimit: 'Speed limit',
+  speedLimit: 'Speed limit (in bytes/s)',
 
   // ------ Remote -----
   remoteName: 'Name',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -583,7 +583,6 @@ const messages = {
     'Are you sure you want to delete {nJobs, number} backup job{nJobs, plural, one {} other {s}}?',
   runBackupJob: 'Run backup job once',
   speedLimit: 'Speed limit',
-  '/s': '/s', // Per secondes
 
   // ------ Remote -----
   remoteName: 'Name',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -581,8 +581,8 @@ const messages = {
   confirmDeleteBackupJobsTitle: 'Delete backup job{nJobs, plural, one {} other {s}}',
   confirmDeleteBackupJobsBody:
     'Are you sure you want to delete {nJobs, number} backup job{nJobs, plural, one {} other {s}}?',
-  maxExportRate: 'Max export rate',
   runBackupJob: 'Run backup job once',
+  speedLimit: 'Speed limit (in TODO/s)',
 
   // ------ Remote -----
   remoteName: 'Name',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -582,7 +582,7 @@ const messages = {
   confirmDeleteBackupJobsBody:
     'Are you sure you want to delete {nJobs, number} backup job{nJobs, plural, one {} other {s}}?',
   runBackupJob: 'Run backup job once',
-  speedLimit: 'Speed limit (in octet / s)',
+  speedLimit: 'Speed limit',
 
   // ------ Remote -----
   remoteName: 'Name',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -581,6 +581,7 @@ const messages = {
   confirmDeleteBackupJobsTitle: 'Delete backup job{nJobs, plural, one {} other {s}}',
   confirmDeleteBackupJobsBody:
     'Are you sure you want to delete {nJobs, number} backup job{nJobs, plural, one {} other {s}}?',
+  maxExportRate: 'Max export rate',
   runBackupJob: 'Run backup job once',
 
   // ------ Remote -----

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -583,6 +583,7 @@ const messages = {
     'Are you sure you want to delete {nJobs, number} backup job{nJobs, plural, one {} other {s}}?',
   runBackupJob: 'Run backup job once',
   speedLimit: 'Speed limit',
+  '/s': '/s', // Per secondes
 
   // ------ Remote -----
   remoteName: 'Name',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -582,7 +582,7 @@ const messages = {
   confirmDeleteBackupJobsBody:
     'Are you sure you want to delete {nJobs, number} backup job{nJobs, plural, one {} other {s}}?',
   runBackupJob: 'Run backup job once',
-  speedLimit: 'Speed limit (in bytes/s)',
+  speedLimit: 'Speed limit (in MiB/s)',
 
   // ------ Remote -----
   remoteName: 'Name',

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -608,6 +608,11 @@ const New = decorate([
           fullInterval,
         })
       },
+      setMaxExportRate({ setGlobalSettings }, rate) {
+        setGlobalSettings({
+          maxExportRate: rate,
+        })
+      },
       setOfflineBackup:
         ({ setGlobalSettings }, { target: { checked: offlineBackup } }) =>
         () => {
@@ -621,6 +626,7 @@ const New = decorate([
       formId: generateId,
       inputConcurrencyId: generateId,
       inputFullIntervalId: generateId,
+      inputMaxExportRate: generateId,
       inputTimeoutId: generateId,
 
       // In order to keep the user preference, the offline backup is kept in the DB
@@ -731,6 +737,7 @@ const New = decorate([
       checkpointSnapshot,
       concurrency,
       fullInterval,
+      maxExportRate,
       offlineBackup,
       offlineSnapshot,
       reportRecipients,
@@ -1005,6 +1012,17 @@ const New = decorate([
                           />
                         </FormGroup>
                       )}
+                      <FormGroup>
+                        <label htmlFor={state.inputMaxExportRate}>
+                          <strong>{_('maxExportRate')}</strong>
+                        </label>
+                        <Number
+                          id={state.inputMaxExportRate}
+                          min={0}
+                          onChange={effects.setMaxExportRate}
+                          value={maxExportRate}
+                        />
+                      </FormGroup>
                       {state.isFull && (
                         <div>
                           <FormGroup>

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -1014,7 +1014,7 @@ const New = decorate([
                       )}
                       <FormGroup>
                         <label htmlFor={state.inputMaxExportRate}>
-                          <strong>{_('maxExportRate')}</strong>
+                          <strong>{_('speedLimit')}</strong>
                         </label>
                         <Number
                           id={state.inputMaxExportRate}

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -21,7 +21,7 @@ import { generateId, linkState } from 'reaclette-utils'
 import { injectIntl } from 'react-intl'
 import { injectState, provideState } from 'reaclette'
 import { Map } from 'immutable'
-import { Number, SizeInput } from 'form'
+import { Number } from 'form'
 import { renderXoItemFromId, Remote } from 'render-xo-item'
 import { SelectRemote, SelectSr, SelectVm } from 'select-objects'
 import {

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -21,7 +21,7 @@ import { generateId, linkState } from 'reaclette-utils'
 import { injectIntl } from 'react-intl'
 import { injectState, provideState } from 'reaclette'
 import { Map } from 'immutable'
-import { Number } from 'form'
+import { Number, SizeInput } from 'form'
 import { renderXoItemFromId, Remote } from 'render-xo-item'
 import { SelectRemote, SelectSr, SelectVm } from 'select-objects'
 import {
@@ -1016,9 +1016,8 @@ const New = decorate([
                         <label htmlFor={state.inputMaxExportRate}>
                           <strong>{_('speedLimit')}</strong>
                         </label>
-                        <Number
+                        <SizeInput
                           id={state.inputMaxExportRate}
-                          min={0}
                           onChange={effects.setMaxExportRate}
                           value={maxExportRate}
                         />

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -610,7 +610,7 @@ const New = decorate([
       },
       setMaxExportRate({ setGlobalSettings }, rate) {
         setGlobalSettings({
-          maxExportRate: rate,
+          maxExportRate: rate * (1024 * 1024),
         })
       },
       setOfflineBackup:
@@ -1020,7 +1020,7 @@ const New = decorate([
                           id={state.inputMaxExportRate}
                           min={0}
                           onChange={effects.setMaxExportRate}
-                          value={maxExportRate}
+                          value={maxExportRate / (1024 * 1024)}
                         />
                       </FormGroup>
                       {state.isFull && (

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -1019,6 +1019,7 @@ const New = decorate([
                         <SizeInput
                           id={state.inputMaxExportRate}
                           onChange={effects.setMaxExportRate}
+                          suffix={formatMessage(messages['/s'])}
                           value={maxExportRate}
                         />
                       </FormGroup>

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -1016,10 +1016,9 @@ const New = decorate([
                         <label htmlFor={state.inputMaxExportRate}>
                           <strong>{_('speedLimit')}</strong>
                         </label>
-                        <SizeInput
-                          defaultUnit='MiB/s'
+                        <Number
                           id={state.inputMaxExportRate}
-                          isSpeed
+                          min={0}
                           onChange={effects.setMaxExportRate}
                           value={maxExportRate}
                         />

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -1017,9 +1017,10 @@ const New = decorate([
                           <strong>{_('speedLimit')}</strong>
                         </label>
                         <SizeInput
+                          defaultUnit='MiB/s'
                           id={state.inputMaxExportRate}
+                          isSpeed
                           onChange={effects.setMaxExportRate}
-                          suffix={formatMessage(messages['/s'])}
                           value={maxExportRate}
                         />
                       </FormGroup>


### PR DESCRIPTION
### Screenshot

![Capture d’écran de 2023-03-29 14-40-01](https://user-images.githubusercontent.com/70369997/228538147-dac4d312-a066-4135-bbe6-e804e0840600.png)

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
