### PR TITLE
Litecactus docs GitHub edit

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- Updated the Docs > Users.md file to better explain the Github Auth plugin setup process
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,8 +7,6 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- Updated the Docs > Users.md file to better explain the Github Auth plugin setup process
-
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”

--- a/docs/users.md
+++ b/docs/users.md
@@ -113,7 +113,7 @@ Save the configuration and then activate the plugin (button on top).
 
 This plugin allows GitHub users to authenticate to Xen-Orchestra.
 
-The first time a user signs in, XO will create a new XO user with the same identifier (i.e. Github name), with "user" permissions. An existing admin will need to apply the appropriate permissions for your environment.
+The first time a user signs in, XO will create a new XO user with the same identifier (i.e. Github name), with *user* permissions. An existing admin will need to apply the appropriate permissions for your environment.
 
 First you need to configure a new app in your GitHub account:
 
@@ -121,9 +121,9 @@ First you need to configure a new app in your GitHub account:
 
 Go to your Github settings > "Developer Settings" > "OAuth Apps" > "New OAuth App".
 
-Name your Github application under "Application Name".
-Enter your Xen Orchestra URL (or IP) under "Homepage URL" 
-Add your "Authorization callback URL" (for example, https://homepageUrl/signin/github/callback)
+1. Name your Github application under "Application Name".
+2. Enter your Xen Orchestra URL (or IP) under "Homepage URL" 
+3. Add your "Authorization callback URL" (for example, https://homepageUrl/signin/github/callback)
 
 When you get your `clientID` and your `clientSecret`, you can configure them in the GitHub Plugin inside the "Settings/Plugins" view of Xen Orchestra.
 

--- a/docs/users.md
+++ b/docs/users.md
@@ -113,11 +113,17 @@ Save the configuration and then activate the plugin (button on top).
 
 This plugin allows GitHub users to authenticate to Xen-Orchestra.
 
-The first time a user signs in, XO will create a new XO user with the same identifier, without any permissions.
+The first time a user signs in, XO will create a new XO user with the same identifier (i.e. Github name), with "user" permissions. An existing admin will need to apply the appropriate permissions for your environment.
 
 First you need to configure a new app in your GitHub account:
 
 ![](https://raw.githubusercontent.com/vatesfr/xen-orchestra/master/packages/xo-server-auth-github/github.png)
+
+Go to your Github settings > "Developer Settings" > "OAuth Apps" > "New OAuth App".
+
+Name your Github application under "Application Name".
+Enter your Xen Orchestra URL (or IP) under "Homepage URL" 
+Add your "Authorization callback URL" (for example, https://homepageUrl/signin/github/callback)
 
 When you get your `clientID` and your `clientSecret`, you can configure them in the GitHub Plugin inside the "Settings/Plugins" view of Xen Orchestra.
 

--- a/docs/users.md
+++ b/docs/users.md
@@ -111,7 +111,7 @@ Save the configuration and then activate the plugin (button on top).
 
 ### GitHub
 
-This plugin allows GitHub users to authenticate to Xen-Orchestra.
+This plugin allows any GitHub user to authenticate to Xen-Orchestra.
 
 The first time a user signs in, XO will create a new XO user with the same identifier (i.e. GitHub name), with *user* permissions. An existing admin will need to apply the appropriate permissions for your environment.
 

--- a/docs/users.md
+++ b/docs/users.md
@@ -113,7 +113,7 @@ Save the configuration and then activate the plugin (button on top).
 
 This plugin allows GitHub users to authenticate to Xen-Orchestra.
 
-The first time a user signs in, XO will create a new XO user with the same identifier (i.e. Github name), with *user* permissions. An existing admin will need to apply the appropriate permissions for your environment.
+The first time a user signs in, XO will create a new XO user with the same identifier (i.e. GitHub name), with *user* permissions. An existing admin will need to apply the appropriate permissions for your environment.
 
 First you need to configure a new app in your GitHub account:
 
@@ -121,7 +121,7 @@ First you need to configure a new app in your GitHub account:
 
 Go to your Github settings > "Developer Settings" > "OAuth Apps" > "New OAuth App".
 
-1. Name your Github application under "Application Name".
+1. Name your GitHub application under "Application Name".
 2. Enter your Xen Orchestra URL (or IP) under "Homepage URL" 
 3. Add your "Authorization callback URL" (for example, https://homepageUrl/signin/github/callback)
 


### PR DESCRIPTION
I have added a few lines to the docs **Users.md** file to better explain how the Github Auth plugin is setup. I spent a while trying to get it setup and thought the docs could do with some more information which would make it easier for someone else. Very minor change to documentation only.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [x] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
