### PR TITLE
feat(lite): enhance Component Story skeleton generator

### DIFF
--- a/@xen-orchestra/lite/src/views/story/HomeView.vue
+++ b/@xen-orchestra/lite/src/views/story/HomeView.vue
@@ -193,12 +193,14 @@ watch(
         current.push(`default(${quote(prop.default)})`);
       }
 
-      if (prop.type) {
+      if (prop.type !== undefined) {
         const type = castArray(prop.type)
           .map((ctor) => extractTypeFromConstructor(ctor, propName))
           .join(" | ");
 
-        current.push(`type(${quote(type)})`);
+        if (type !== "unknown") {
+          current.push(`type(${quote(type)})`);
+        }
       }
 
       const isModel = component.emits?.includes(`update:${propName}`);
@@ -226,7 +228,7 @@ watch(
         }
 
         shouldImportEvent = true;
-        lines.value.push(`event("${eventName}")`);
+        lines.value.push(`event(${quote(eventName)})`);
       }
     }
 


### PR DESCRIPTION
Since I already have a lot of waiting PR and this one concerns a internal tool that I wrote in a hurry, I suggest not to pay too much attention to it.

Here is a list of changes:
- Updated form to use our own components
- Added a warning for props whose type cannot be extracted
- Fixed setting name for scopes containing a dash
- Handled cases when a prop can be multiple types
- Better guess of prop type
- Remove `.widget()` for `.model()`
- Remove `.event('update:modelValue')` for `.model()`

![Component story generator](https://user-images.githubusercontent.com/19408/227965289-3af35672-ff12-4636-838e-2bf7dc185744.png)

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [x] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
