### PR TITLE
feat(@xen-orchestra/fs): implement null writer for performance testing

### DIFF
--- a/@xen-orchestra/fs/src/index.js
+++ b/@xen-orchestra/fs/src/index.js
@@ -3,6 +3,7 @@ import { parse } from 'xo-remote-parser'
 
 import RemoteHandlerLocal from './local'
 import RemoteHandlerNfs from './nfs'
+import RemoteHandlerNull from './null'
 import RemoteHandlerS3 from './s3'
 import RemoteHandlerSmb from './smb'
 export { DEFAULT_ENCRYPTION_ALGORITHM, UNENCRYPTED_ALGORITHM, isLegacyEncryptionAlgorithm } from './_encryptor'
@@ -10,6 +11,7 @@ export { DEFAULT_ENCRYPTION_ALGORITHM, UNENCRYPTED_ALGORITHM, isLegacyEncryption
 const HANDLERS = {
   file: RemoteHandlerLocal,
   nfs: RemoteHandlerNfs,
+  null: RemoteHandlerNull,
   s3: RemoteHandlerS3,
 }
 

--- a/@xen-orchestra/fs/src/null.js
+++ b/@xen-orchestra/fs/src/null.js
@@ -1,0 +1,14 @@
+import LocalHandler from './local'
+
+export default class NullHandler extends LocalHandler {
+  get type() {
+    return 'null'
+  }
+  _outputStream() {}
+  _writeFile(file, data, options) {
+    if (file.indexOf('xo-vm-backups') === -1) {
+      // metadata, remote tests
+      return super._writeFile(file, data, options)
+    }
+  }
+}

--- a/packages/xo-remote-parser/src/index.js
+++ b/packages/xo-remote-parser/src/index.js
@@ -38,8 +38,8 @@ const makeOptionList = options => {
 export const parse = string => {
   let object = {}
   let [type, rest] = string.split('://')
-  if (type === 'file') {
-    object.type = 'file'
+  if (type === 'file' || type === 'null') {
+    object.type = type
     let optionList
     ;[rest, optionList] = rest.split('?')
     object.path = `/${trimStart(rest, '/')}` // the leading slash has been forgotten on client side first implementation


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
