### PR TITLE
fix(xo-server-perf-alert): skip special SRs which are always full

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,6 +32,7 @@
 
 <!--packages-start-->
 
+- xo-server-perf-alert patch
 - @xen-orchestra/fs patch
 - @xen-orchestra/vmware-explorer patch
 - @xen-orchestra/backups minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [Perf Alert] Fix storage usage alerts triggered by particular SRs (PR [#6755](https://github.com/vatesfr/xen-orchestra/pull/6755))
+- [Plugin/perf-alert] Ignore special SRs (e.g. *XCP-ng Tools*, *DVD drives*, etc) as their usage is always 100% (PR [#6755](https://github.com/vatesfr/xen-orchestra/pull/6755))
 - [Backup/Restore] Fix restore via a proxy showing as interupted (PR [#6702](https://github.com/vatesfr/xen-orchestra/pull/6702))
 - [REST API] Backup logs are now available at `/rest/v0/backups/logs`
 - [ESXI import] Fix failing imports when using non default datacenter name [Forum#59543](https://xcp-ng.org/forum/post/59543) PR [#6729](https://github.com/vatesfr/xen-orchestra/pull/6729)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Perf Alert] Stop sending an alert for the `XCP-ng Tools` SR usage (PR [#6755](https://github.com/vatesfr/xen-orchestra/pull/6755))
 - [Backup/Restore] Fix restore via a proxy showing as interupted (PR [#6702](https://github.com/vatesfr/xen-orchestra/pull/6702))
 - [REST API] Backup logs are now available at `/rest/v0/backups/logs`
 - [ESXI import] Fix failing imports when using non default datacenter name [Forum#59543](https://xcp-ng.org/forum/post/59543) PR [#6729](https://github.com/vatesfr/xen-orchestra/pull/6729)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [Perf Alert] Stop sending an alert for the `XCP-ng Tools` SR usage (PR [#6755](https://github.com/vatesfr/xen-orchestra/pull/6755))
+- [Perf Alert] Stop raising an alert for the `XCP-ng Tools` SR storage usage (PR [#6755](https://github.com/vatesfr/xen-orchestra/pull/6755))
 - [Backup/Restore] Fix restore via a proxy showing as interupted (PR [#6702](https://github.com/vatesfr/xen-orchestra/pull/6702))
 - [REST API] Backup logs are now available at `/rest/v0/backups/logs`
 - [ESXI import] Fix failing imports when using non default datacenter name [Forum#59543](https://xcp-ng.org/forum/post/59543) PR [#6729](https://github.com/vatesfr/xen-orchestra/pull/6729)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [Perf Alert] Stop raising an alert for the `XCP-ng Tools` SR storage usage (PR [#6755](https://github.com/vatesfr/xen-orchestra/pull/6755))
+- [Perf Alert] Fix storage usage alerts triggered by particular SRs (PR [#6755](https://github.com/vatesfr/xen-orchestra/pull/6755))
 - [Backup/Restore] Fix restore via a proxy showing as interupted (PR [#6702](https://github.com/vatesfr/xen-orchestra/pull/6702))
 - [REST API] Backup logs are now available at `/rest/v0/backups/logs`
 - [ESXI import] Fix failing imports when using non default datacenter name [Forum#59543](https://xcp-ng.org/forum/post/59543) PR [#6729](https://github.com/vatesfr/xen-orchestra/pull/6729)
@@ -33,11 +33,11 @@
 
 <!--packages-start-->
 
-- xo-server-perf-alert patch
 - @xen-orchestra/fs patch
 - @xen-orchestra/vmware-explorer patch
 - @xen-orchestra/backups minor
 - xo-cli patch
 - xo-server minor
+- xo-server-perf-alert patch
 
 <!--packages-end-->

--- a/packages/xo-server-perf-alert/src/index.js
+++ b/packages/xo-server-perf-alert/src/index.js
@@ -589,7 +589,7 @@ ${monitorBodies.join('\n')}`
 
       const entriesWithMissingStats = []
       for (const entry of snapshot) {
-        if (entry.object.physical_size === -1) continue
+        if (entry.object.physical_size <= 0) continue
         if (entry.value === undefined) {
           entriesWithMissingStats.push(entry)
           continue

--- a/packages/xo-server-perf-alert/src/index.js
+++ b/packages/xo-server-perf-alert/src/index.js
@@ -589,7 +589,8 @@ ${monitorBodies.join('\n')}`
 
       const entriesWithMissingStats = []
       for (const entry of snapshot) {
-        if (entry.object.physical_size <= 0) continue
+        // Ignore special SRs (e.g. *XCP-ng Tools*, *DVD drives*, etc) as their usage is always 100%
+        if (entry.object.physical_size <= 0 && entry.object.content_type === 'iso') continue
         if (entry.value === undefined) {
           entriesWithMissingStats.push(entry)
           continue

--- a/packages/xo-server-perf-alert/src/index.js
+++ b/packages/xo-server-perf-alert/src/index.js
@@ -589,6 +589,7 @@ ${monitorBodies.join('\n')}`
 
       const entriesWithMissingStats = []
       for (const entry of snapshot) {
+        if (entry.object.name_label === 'XCP-ng Tools') continue
         if (entry.value === undefined) {
           entriesWithMissingStats.push(entry)
           continue

--- a/packages/xo-server-perf-alert/src/index.js
+++ b/packages/xo-server-perf-alert/src/index.js
@@ -589,7 +589,7 @@ ${monitorBodies.join('\n')}`
 
       const entriesWithMissingStats = []
       for (const entry of snapshot) {
-        if (entry.object.name_label === 'XCP-ng Tools') continue
+        if (entry.object.physical_size === -1) continue
         if (entry.value === undefined) {
           entriesWithMissingStats.push(entry)
           continue


### PR DESCRIPTION
### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [x] enhancement/bug fix entry added
  - [x] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
