### PR TITLE
feat(lite/tooltips): enhance and simplify tooltips

### DIFF
--- a/@xen-orchestra/lite/src/components/AppTooltip.vue
+++ b/@xen-orchestra/lite/src/components/AppTooltip.vue
@@ -7,6 +7,7 @@
 
 <script lang="ts" setup>
 import type { TooltipOptions } from "@/stores/tooltip.store";
+import { isString } from "lodash-es";
 import place from "placement.js";
 import { computed, ref, watchEffect } from "vue";
 
@@ -17,9 +18,17 @@ const props = defineProps<{
 
 const tooltipElement = ref<HTMLElement>();
 
-const isDisabled = computed(
-  () => props.options.content === "" || props.options.content === false
-);
+const isDisabled = computed(() => {
+  if (props.options.content === false) {
+    return true;
+  }
+
+  if (isString(props.options.content)) {
+    return props.options.content.trim() === "";
+  }
+
+  return false;
+});
 
 const placement = computed(() => props.options.placement ?? "top");
 

--- a/@xen-orchestra/lite/src/components/AppTooltip.vue
+++ b/@xen-orchestra/lite/src/components/AppTooltip.vue
@@ -18,17 +18,11 @@ const props = defineProps<{
 
 const tooltipElement = ref<HTMLElement>();
 
-const isDisabled = computed(() => {
-  if (props.options.content === false) {
-    return true;
-  }
-
-  if (isString(props.options.content)) {
-    return props.options.content.trim() === "";
-  }
-
-  return false;
-});
+const isDisabled = computed(() =>
+  isString(props.options.content)
+    ? props.options.content.trim() === ""
+    : props.options.content === false
+);
 
 const placement = computed(() => props.options.placement ?? "top");
 

--- a/@xen-orchestra/lite/src/components/AppTooltip.vue
+++ b/@xen-orchestra/lite/src/components/AppTooltip.vue
@@ -1,15 +1,14 @@
 <template>
   <div v-if="!isDisabled" ref="tooltipElement" class="app-tooltip">
     <span class="triangle" />
-    <span class="label">{{ content }}</span>
+    <span class="label">{{ options.content }}</span>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { isEmpty, isFunction, isString } from "lodash-es";
+import type { TooltipOptions } from "@/stores/tooltip.store";
 import place from "placement.js";
 import { computed, ref, watchEffect } from "vue";
-import type { TooltipOptions } from "@/stores/tooltip.store";
 
 const props = defineProps<{
   target: HTMLElement;
@@ -18,29 +17,11 @@ const props = defineProps<{
 
 const tooltipElement = ref<HTMLElement>();
 
-const content = computed(() =>
-  isString(props.options) ? props.options : props.options.content
+const isDisabled = computed(
+  () => props.options.content === "" || props.options.content === false
 );
 
-const isDisabled = computed(() => {
-  if (isEmpty(content.value)) {
-    return true;
-  }
-
-  if (isString(props.options)) {
-    return false;
-  }
-
-  if (isFunction(props.options.disabled)) {
-    return props.options.disabled(props.target);
-  }
-
-  return props.options.disabled ?? false;
-});
-
-const placement = computed(() =>
-  isString(props.options) ? "top" : props.options.placement ?? "top"
-);
+const placement = computed(() => props.options.placement ?? "top");
 
 watchEffect(() => {
   if (tooltipElement.value) {

--- a/@xen-orchestra/lite/src/components/infra/InfraHostItem.vue
+++ b/@xen-orchestra/lite/src/components/infra/InfraHostItem.vue
@@ -1,12 +1,5 @@
 <template>
-  <li
-    v-if="host !== undefined"
-    v-tooltip="{
-      content: host.name_label,
-      disabled: isTooltipDisabled,
-    }"
-    class="infra-host-item"
-  >
+  <li v-if="host" class="infra-host-item">
     <InfraItemLabel
       :active="isCurrentHost"
       :icon="faServer"
@@ -36,7 +29,6 @@ import InfraAction from "@/components/infra/InfraAction.vue";
 import InfraItemLabel from "@/components/infra/InfraItemLabel.vue";
 import InfraVmList from "@/components/infra/InfraVmList.vue";
 import { vTooltip } from "@/directives/tooltip.directive";
-import { hasEllipsis } from "@/libs/utils";
 import { useHostStore } from "@/stores/host.store";
 import { usePoolStore } from "@/stores/pool.store";
 import { useUiStore } from "@/stores/ui.store";
@@ -66,9 +58,6 @@ const isCurrentHost = computed(
   () => props.hostOpaqueRef === uiStore.currentHostOpaqueRef
 );
 const [isExpanded, toggle] = useToggle(true);
-
-const isTooltipDisabled = (target: HTMLElement) =>
-  !hasEllipsis(target.querySelector(".text"));
 </script>
 
 <style lang="postcss" scoped>

--- a/@xen-orchestra/lite/src/components/infra/InfraHostItem.vue
+++ b/@xen-orchestra/lite/src/components/infra/InfraHostItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <li v-if="host" class="infra-host-item">
+  <li v-if="host !== undefined" class="infra-host-item">
     <InfraItemLabel
       :active="isCurrentHost"
       :icon="faServer"

--- a/@xen-orchestra/lite/src/components/infra/InfraItemLabel.vue
+++ b/@xen-orchestra/lite/src/components/infra/InfraItemLabel.vue
@@ -7,9 +7,9 @@
       class="infra-item-label"
       v-bind="$attrs"
     >
-      <a :href="href" class="link" @click="navigate">
+      <a :href="href" class="link" @click="navigate" v-tooltip="hasTooltip">
         <UiIcon :icon="icon" class="icon" />
-        <div ref="textElement" v-tooltip="hasTooltip" class="text">
+        <div ref="textElement" class="text">
           <slot />
         </div>
       </a>

--- a/@xen-orchestra/lite/src/components/infra/InfraItemLabel.vue
+++ b/@xen-orchestra/lite/src/components/infra/InfraItemLabel.vue
@@ -9,7 +9,7 @@
     >
       <a :href="href" class="link" @click="navigate">
         <UiIcon :icon="icon" class="icon" />
-        <div class="text">
+        <div ref="textElement" v-tooltip="hasTooltip" class="text">
           <slot />
         </div>
       </a>
@@ -22,7 +22,10 @@
 
 <script lang="ts" setup>
 import UiIcon from "@/components/ui/icon/UiIcon.vue";
+import { vTooltip } from "@/directives/tooltip.directive";
+import { hasEllipsis } from "@/libs/utils";
 import type { IconDefinition } from "@fortawesome/fontawesome-common-types";
+import { computed, ref } from "vue";
 import type { RouteLocationRaw } from "vue-router";
 
 defineProps<{
@@ -30,6 +33,9 @@ defineProps<{
   route: RouteLocationRaw;
   active?: boolean;
 }>();
+
+const textElement = ref<HTMLElement>();
+const hasTooltip = computed(() => hasEllipsis(textElement.value));
 </script>
 
 <style lang="postcss" scoped>

--- a/@xen-orchestra/lite/src/components/infra/InfraVmItem.vue
+++ b/@xen-orchestra/lite/src/components/infra/InfraVmItem.vue
@@ -1,13 +1,5 @@
 <template>
-  <li
-    v-if="vm !== undefined"
-    ref="rootElement"
-    v-tooltip="{
-      content: vm.name_label,
-      disabled: isTooltipDisabled,
-    }"
-    class="infra-vm-item"
-  >
+  <li ref="rootElement" class="infra-vm-item">
     <InfraItemLabel
       v-if="isVisible"
       :icon="faDisplay"
@@ -27,8 +19,6 @@
 import InfraAction from "@/components/infra/InfraAction.vue";
 import InfraItemLabel from "@/components/infra/InfraItemLabel.vue";
 import PowerStateIcon from "@/components/PowerStateIcon.vue";
-import { vTooltip } from "@/directives/tooltip.directive";
-import { hasEllipsis } from "@/libs/utils";
 import { useVmStore } from "@/stores/vm.store";
 import { faDisplay } from "@fortawesome/free-solid-svg-icons";
 import { useIntersectionObserver } from "@vueuse/core";
@@ -49,9 +39,6 @@ const { stop } = useIntersectionObserver(rootElement, ([entry]) => {
     stop();
   }
 });
-
-const isTooltipDisabled = (target: HTMLElement) =>
-  !hasEllipsis(target.querySelector(".text"));
 </script>
 
 <style lang="postcss" scoped>

--- a/@xen-orchestra/lite/src/components/infra/InfraVmItem.vue
+++ b/@xen-orchestra/lite/src/components/infra/InfraVmItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <li ref="rootElement" class="infra-vm-item">
+  <li v-if="vm !== undefined" ref="rootElement" class="infra-vm-item">
     <InfraItemLabel
       v-if="isVisible"
       :icon="faDisplay"

--- a/@xen-orchestra/lite/src/components/ui/UiBadge.vue
+++ b/@xen-orchestra/lite/src/components/ui/UiBadge.vue
@@ -16,6 +16,7 @@ defineProps<{
 
 <style lang="postcss" scoped>
 .ui-badge {
+  white-space: nowrap;
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;

--- a/@xen-orchestra/lite/src/components/ui/progress/UiProgressLegend.vue
+++ b/@xen-orchestra/lite/src/components/ui/progress/UiProgressLegend.vue
@@ -1,7 +1,13 @@
 <template>
   <div class="legend">
-    <span class="circle" />
-    <slot name="label">{{ label }}</slot>
+    <template v-if="$slots.label || label">
+      <span class="circle" />
+      <div class="label-container">
+        <div ref="labelElement" v-tooltip="isTooltipEnabled" class="label">
+          <slot name="label">{{ label }}</slot>
+        </div>
+      </div>
+    </template>
     <UiBadge class="badge">
       <slot name="value">{{ value }}</slot>
     </UiBadge>
@@ -10,14 +16,23 @@
 
 <script lang="ts" setup>
 import UiBadge from "@/components/ui/UiBadge.vue";
+import { vTooltip } from "@/directives/tooltip.directive";
+import { hasEllipsis } from "@/libs/utils";
+import { computed, ref } from "vue";
 
 defineProps<{
   label?: string;
   value?: string;
 }>();
+
+const labelElement = ref<HTMLElement>();
+
+const isTooltipEnabled = computed(() =>
+  hasEllipsis(labelElement.value, { vertical: true })
+);
 </script>
 
-<style scoped lang="postcss">
+<style lang="postcss" scoped>
 .badge {
   font-size: 0.9em;
   font-weight: 700;
@@ -25,8 +40,8 @@ defineProps<{
 
 .circle {
   display: inline-block;
-  width: 1rem;
-  height: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
   border-radius: 0.5rem;
   background-color: var(--progress-bar-color);
 }
@@ -37,5 +52,15 @@ defineProps<{
   justify-content: flex-end;
   gap: 0.5rem;
   margin: 1.6em 0;
+}
+
+.label-container {
+  overflow: hidden;
+}
+
+.label {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 </style>

--- a/@xen-orchestra/lite/src/directives/tooltip.directive.md
+++ b/@xen-orchestra/lite/src/directives/tooltip.directive.md
@@ -1,36 +1,71 @@
 # Tooltip Directive
 
-By default, tooltip will appear centered above the target element.
+By default, the tooltip will appear centered above the target element.
+
+## Directive argument
+
+The directive argument can be either:
+
+- The tooltip content
+- An object containing the tooltip content and/or placement: `{ content: "...", placement: "..." }` (both optional)
+
+## Tooltip content
+
+The tooltip content can be either:
+
+- `false` or an empty-string to disable the tooltip
+- `true` or `undefined` to enable the tooltip and extract its content from the element's innerText.
+- Non-empty string to enable the tooltip and use the string as content.
+
+## Tooltip placement
+
+Tooltip can be placed on the following positions:
+
+- `top`
+- `top-start`
+- `top-end`
+- `bottom`
+- `bottom-start`
+- `bottom-end`
+- `left`
+- `left-start`
+- `left-end`
+- `right`
+- `right-start`
+- `right-end`
 
 ## Usage
 
 ```vue
 <template>
-  <!-- Static -->
+  <!-- Boolean / Undefined -->
+  <span v-tooltip="true"
+    >This content will be ellipsized by CSS but displayed entirely in the
+    tooltip</span
+  >
+  <span v-tooltip
+    >This content will be ellipsized by CSS but displayed entirely in the
+    tooltip</span
+  >
+
+  <!-- String -->
   <span v-tooltip="'Tooltip content'">Item</span>
 
-  <!-- Dynamic -->
-  <span v-tooltip="myTooltipContent">Item</span>
-
-  <!-- Placement  -->
+  <!-- Object -->
   <span v-tooltip="{ content: 'Foobar', placement: 'left-end' }">Item</span>
 
-  <!-- Disabling (variable) -->
-  <span v-tooltip="{ content: 'Foobar', disabled: isDisabled }">Item</span>
+  <!-- Dynamic -->
+  <span v-tooltip="myTooltip">Item</span>
 
-  <!-- Disabling (function) -->
-  <span v-tooltip="{ content: 'Foobar', disabled: isDisabledFn }">Item</span>
+  <!-- Conditional -->
+  <span v-tooltip="isTooltipEnabled && 'Foobar'">Item</span>
 </template>
 
 <script setup>
 import { ref } from "vue";
 import { vTooltip } from "@/directives/tooltip.directive";
 
-const myTooltipContent = ref("Content");
-const isDisabled = ref(true);
-
-const isDisabledFn = (target: Element) => {
-  // return boolean;
-};
+const myTooltip = ref("Content"); // or ref({ content: "Content", placement: "left-end" })
+const isTooltipEnabled = ref(true);
 </script>
 ```

--- a/@xen-orchestra/lite/src/libs/utils.ts
+++ b/@xen-orchestra/lite/src/libs/utils.ts
@@ -71,8 +71,20 @@ export function parseDateTime(dateTime: string) {
   return date.getTime();
 }
 
-export const hasEllipsis = (target: Element | undefined | null) =>
-  target != undefined && target.clientWidth < target.scrollWidth;
+export const hasEllipsis = (
+  target: Element | undefined | null,
+  { vertical = false }: { vertical?: boolean } = {}
+) => {
+  if (target == null) {
+    return false;
+  }
+
+  if (vertical) {
+    return target.clientHeight < target.scrollHeight;
+  }
+
+  return target.clientWidth < target.scrollWidth;
+};
 
 export function percent(currentValue: number, maxValue: number, precision = 2) {
   return round((currentValue / maxValue) * 100, precision);

--- a/@xen-orchestra/lite/src/stores/tooltip.store.ts
+++ b/@xen-orchestra/lite/src/stores/tooltip.store.ts
@@ -4,13 +4,10 @@ import type { Options } from "placement.js";
 import { type EffectScope, computed, effectScope, ref } from "vue";
 import { type WindowEventName, useEventListener } from "@vueuse/core";
 
-export type TooltipOptions =
-  | string
-  | {
-      content: string;
-      placement?: Options["placement"];
-      disabled?: boolean | ((target: HTMLElement) => boolean);
-    };
+export type TooltipOptions = {
+  content: string | false;
+  placement: Options["placement"];
+};
 
 export type TooltipEvents = { on: WindowEventName; off: WindowEventName };
 


### PR DESCRIPTION
Removed the `disabled` option.

The tooltip is now disabled when content is an empty string or `false`.

If content is `true` or `undefined`, it will be extracted from element's `innerText`.

Moved `v-tooltip` from `InfraHostItem` and `InfraVmItem` to `InfraItemLabel`.

### Check list

> Check if done, if not relevant leave unchecked.

- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [x] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
