### PR TITLE
feat(backups): can limit parallel VDI transfers per VM per job

### DIFF
--- a/@xen-orchestra/backups/_runners/VmsXapi.js
+++ b/@xen-orchestra/backups/_runners/VmsXapi.js
@@ -19,7 +19,7 @@ const DEFAULT_XAPI_VM_SETTINGS = {
   concurrency: 2,
   copyRetention: 0,
   deleteFirst: false,
-  diskPerVmConcurrency: 2,
+  diskPerVmConcurrency: 99,
   exportRetention: 0,
   fullInterval: 0,
   healthCheckSr: undefined,

--- a/@xen-orchestra/backups/_runners/VmsXapi.js
+++ b/@xen-orchestra/backups/_runners/VmsXapi.js
@@ -19,6 +19,7 @@ const DEFAULT_XAPI_VM_SETTINGS = {
   concurrency: 2,
   copyRetention: 0,
   deleteFirst: false,
+  diskPerVmConcurrency: 2,
   exportRetention: 0,
   fullInterval: 0,
   healthCheckSr: undefined,

--- a/@xen-orchestra/backups/_runners/VmsXapi.js
+++ b/@xen-orchestra/backups/_runners/VmsXapi.js
@@ -19,7 +19,7 @@ const DEFAULT_XAPI_VM_SETTINGS = {
   concurrency: 2,
   copyRetention: 0,
   deleteFirst: false,
-  diskPerVmConcurrency: 99,
+  diskPerVmConcurrency: 0, // not limited by default
   exportRetention: 0,
   fullInterval: 0,
   healthCheckSr: undefined,

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.js
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.js
@@ -3,6 +3,7 @@
 const assert = require('assert')
 const mapValues = require('lodash/mapValues.js')
 const ignoreErrors = require('promise-toolbox/ignoreErrors')
+const { asyncEach } = require('@vates/async-each')
 const { asyncMap } = require('@xen-orchestra/async-map')
 const { chainVhd, checkVhdChain, openVhd, VhdAbstract } = require('vhd-lib')
 const { createLogger } = require('@xen-orchestra/log')
@@ -19,7 +20,6 @@ const { AbstractIncrementalWriter } = require('./_AbstractIncrementalWriter.js')
 const { checkVhd } = require('./_checkVhd.js')
 const { packUuid } = require('./_packUuid.js')
 const { Disposable } = require('promise-toolbox')
-const { asyncEach } = require('@vates/async-each')
 
 const { warn } = createLogger('xo:backups:DeltaBackupWriter')
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 - [Dashboard/Health] Button to copy UUID of an orphan VDI to the clipboard (PR [#6893](https://github.com/vatesfr/xen-orchestra/pull/6893))
 - [Kubernetes recipe] Add the possibility to choose the version for the cluster [#6842](https://github.com/vatesfr/xen-orchestra/issues/6842) (PR [#6880](https://github.com/vatesfr/xen-orchestra/pull/6880))
 - [New VM] cloud-init drives are now bootable in a Windows VM (PR [#6889](https://github.com/vatesfr/xen-orchestra/pull/6889))
-- [Backups] Add a setting to limit the number of disk transferred in parallel per VM (PR [#6787](https://github.com/vatesfr/xen-orchestra/pull/6787))
+- [Backups] Add setting `backups.metadata.defaultSettings.diskPerVmConcurrency` in xo-server's configuration file to limit the number of disks transferred in parallel per VM, this is useful to avoid transfer overloading remote and Sr (PR [#6787](https://github.com/vatesfr/xen-orchestra/pull/6787))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,7 @@
 - [Dashboard/Health] Button to copy UUID of an orphan VDI to the clipboard (PR [#6893](https://github.com/vatesfr/xen-orchestra/pull/6893))
 - [Kubernetes recipe] Add the possibility to choose the version for the cluster [#6842](https://github.com/vatesfr/xen-orchestra/issues/6842) (PR [#6880](https://github.com/vatesfr/xen-orchestra/pull/6880))
 - [New VM] cloud-init drives are now bootable in a Windows VM (PR [#6889](https://github.com/vatesfr/xen-orchestra/pull/6889))
+- [Backups] Add a setting to limit the number of disk transferred in parallel per VM (PR [#6787](https://github.com/vatesfr/xen-orchestra/pull/6787))
 
 ### Bug fixes
 


### PR DESCRIPTION
### Check list

On slower infrastructure, VM with huge number ( more than 5 ) of disks may kill the storage.. We limit the transfer to two in parallel per VM, this value can be changed in the config file 

Tested : waiting a few hours before starting to transfer does not trigger a timeout


- [ ] PR reference the relevant issue (e.g. `Fixes #007` or `See xoa-support#42`)
- [ ] if UI changes, a screenshot has been added to the PR
- [ ] documentation updated
- `CHANGELOG.unreleased.md`:
  - [ ] enhancement/bug fix entry added
  - [ ] list of packages to release updated (`${name} v${new version}`)
- **I have tested added/updated features** (and impacted code)
  - [ ] unit tests (e.g. [`cron/parse.spec.js`](https://github.com/vatesfr/xen-orchestra/blob/b24400b21de1ebafa1099c56bac1de5c988d9202/%40xen-orchestra/cron/src/parse.spec.js))
  - [ ] if `xo-server` API changes, the corresponding test has been added to/updated on [`xo-server-test`](https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-test)
  - [ ] at least manual testing

### Process

1. create a PR as soon as possible
1. mark it as `WiP:` (Work in Progress) if not ready to be merged
1. when you want a review, add a reviewer (and only one)
1. if necessary, update your PR, and re- add a reviewer

From [_the Four Agreements_](https://en.wikipedia.org/wiki/Don_Miguel_Ruiz#The_Four_Agreements):

1. Be impeccable with your word.
1. Don't take anything personally.
1. Don't make assumptions.
1. Always do your best.
