### PR TITLE
feat(xo-server/self): ignore snapshots CPU and RAM usage

### DIFF
--- a/packages/xo-server/src/xo-mixins/resource-sets.mjs
+++ b/packages/xo-server/src/xo-mixins/resource-sets.mjs
@@ -31,6 +31,8 @@ const computeVmXapiResourcesUsage = vm => {
   let disks = 0
   let disk = 0
 
+  const canUseLiveResources = !(vm.is_a_snapshot || vm.is_a_template)
+
   forEach(vm.$VBDs, vbd => {
     let vdi, vdiId
     if (vbd.type === 'Disk' && !processed[(vdiId = vbd.VDI)] && (vdi = vbd.$VDI)) {
@@ -41,11 +43,11 @@ const computeVmXapiResourcesUsage = vm => {
   })
 
   return {
-    cpus: vm.VCPUs_at_startup,
+    cpus: canUseLiveResources ? vm.VCPUs_at_startup : 0,
     disk,
     disks,
-    memory: vm.memory_dynamic_max,
-    vms: 1,
+    memory: canUseLiveResources ? vm.memory_dynamic_max : 0,
+    vms: canUseLiveResources ? 1 : 0,
   }
 }
 


### PR DESCRIPTION
### Description

In Self Service quota computation, do not take into account snapshots' CPU and RAM usage since snapshots never use those 2 resources.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
