### PR TITLE
fix(xo-web/host/smart reboot): XOA Premium only

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,4 +27,6 @@
 
 <!--packages-start-->
 
+- xo-web patch
+
 <!--packages-end-->

--- a/packages/xo-web/src/xo-app/host/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/host/tab-advanced.js
@@ -21,6 +21,7 @@ import { FormattedRelative, FormattedTime } from 'react-intl'
 import { Sr } from 'render-xo-item'
 import { Text } from 'editable'
 import { Toggle, Select, SizeInput } from 'form'
+import * as xoaPlans from 'xoa-plans'
 import {
   detachHost,
   disableHost,
@@ -44,6 +45,7 @@ import {
 import { installCertificate } from './install-certificate'
 
 const ALLOW_INSTALL_SUPP_PACK = process.env.XOA_PLAN > 1
+const ALLOW_SMART_REBOOT = xoaPlans.CURRENT.value >= xoaPlans.PREMIUM.value
 
 const SCHED_GRAN_TYPE_OPTIONS = [
   {
@@ -62,7 +64,9 @@ const SCHED_GRAN_TYPE_OPTIONS = [
 
 const forceReboot = host => restartHost(host, true)
 
-const smartReboot = host => restartHost(host, false, true) // don't force, suspend resident VMs
+const smartReboot = ALLOW_SMART_REBOOT
+  ? host => restartHost(host, false, true) // don't force, suspend resident VMs
+  : () => {}
 
 const formatPack = ({ name, author, description, version }, key) => (
   <tr key={key}>
@@ -259,11 +263,12 @@ export default class extends Component {
               <TabButton
                 key='smart-reboot'
                 btnStyle='warning'
+                disabled={!ALLOW_SMART_REBOOT}
                 handler={smartReboot}
                 handlerParam={host}
                 icon='freeze'
                 labelId='smartRebootHostLabel'
-                tooltip={_('smartRebootHostTooltip')}
+                tooltip={ALLOW_SMART_REBOOT ? _('smartRebootHostTooltip') : _('availableXoaPremium')}
               />,
               <TabButton
                 key='force-reboot'


### PR DESCRIPTION
See #6795

### Description

Put Smart Host Reboot feature in XOA Premium

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
