### PR TITLE
feat(xo-server/vm.create): add resourceSet tags to created VM

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,4 +27,6 @@
 
 <!--packages-start-->
 
+- xo-server minor
+
 <!--packages-end-->

--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -186,7 +186,12 @@ export const create = defer(async function ($defer, params) {
     }
   }
 
-  params.tags = resourceSet !== undefined ? (await this.getResourceSet(resourceSet)).tags : undefined
+  const resourceSetTags = resourceSet !== undefined ? (await this.getResourceSet(resourceSet)).tags : undefined
+  if (resourceSetTags !== undefined && params.tags !== undefined) {
+    params.tags.concat(resourceSetTags)
+  } else if (resourceSetTags !== undefined) {
+    params.tags = resourceSetTags
+  }
 
   const xapiVm = await xapi.createVm(template._xapiId, params, checkLimits, user.id)
   $defer.onFailure(() => xapi.VM_destroy(xapiVm.$ref, { deleteDisks: true, force: true }))

--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -187,10 +187,9 @@ export const create = defer(async function ($defer, params) {
   }
 
   const resourceSetTags = resourceSet !== undefined ? (await this.getResourceSet(resourceSet)).tags : undefined
-  if (resourceSetTags !== undefined && params.tags !== undefined) {
-    params.tags.concat(resourceSetTags)
-  } else if (resourceSetTags !== undefined) {
-    params.tags = resourceSetTags
+  const paramsTags = params.tags
+  if (resourceSetTags !== undefined) {
+    params.tags = paramsTags !== undefined ? paramsTags.concat(resourceSetTags) : resourceSetTags
   }
 
   const xapiVm = await xapi.createVm(template._xapiId, params, checkLimits, user.id)

--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -186,6 +186,8 @@ export const create = defer(async function ($defer, params) {
     }
   }
 
+  params.tags = resourceSet !== undefined ? (await this.getResourceSet(resourceSet)).tags : undefined
+
   const xapiVm = await xapi.createVm(template._xapiId, params, checkLimits, user.id)
   $defer.onFailure(() => xapi.VM_destroy(xapiVm.$ref, { deleteDisks: true, force: true }))
 

--- a/packages/xo-server/src/xapi/mixins/vm.mjs
+++ b/packages/xo-server/src/xapi/mixins/vm.mjs
@@ -44,6 +44,8 @@ export default {
 
       copyHostBiosStrings = false,
 
+      tags = [],
+
       ...props
     } = {},
     checkLimits,
@@ -81,6 +83,8 @@ export default {
         this.getObject(props.affinityHost ?? this.getObject(template.$pool).master).$ref
       )
     }
+
+    await Promise.all(tags.map(tag => this.call('VM.add_tags', vmRef, tag)))
 
     // Removes disks from the provision XML, we will create them by
     // ourselves.

--- a/packages/xo-server/src/xapi/mixins/vm.mjs
+++ b/packages/xo-server/src/xapi/mixins/vm.mjs
@@ -44,8 +44,6 @@ export default {
 
       copyHostBiosStrings = false,
 
-      tags = [],
-
       ...props
     } = {},
     checkLimits,
@@ -83,8 +81,6 @@ export default {
         this.getObject(props.affinityHost ?? this.getObject(template.$pool).master).$ref
       )
     }
-
-    await Promise.all(tags.map(tag => this.call('VM.add_tags', vmRef, tag)))
 
     // Removes disks from the provision XML, we will create them by
     // ourselves.


### PR DESCRIPTION
### Description

Add resourceSet tags at VM creation.

Changelog entry is added in the [front PR](https://github.com/vatesfr/xen-orchestra/pull/6810).

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
