### PR TITLE
feat(lite/xapi-subscriptions): add subscribe options + TypeScript enhancement

### DIFF
--- a/@xen-orchestra/lite/src/libs/utils.ts
+++ b/@xen-orchestra/lite/src/libs/utils.ts
@@ -1,13 +1,12 @@
 import type {
-  RawObjectType,
   RawXenApiRecord,
   XenApiHost,
   XenApiHostMetrics,
   XenApiRecord,
   XenApiVm,
 } from "@/libs/xen-api";
-import type { CollectionSubscription } from "@/stores/xapi-collection.store";
 import type { Filter } from "@/types/filter";
+import type { CollectionSubscription } from "@/types/xapi-collection";
 import { faSquareCheck } from "@fortawesome/free-regular-svg-icons";
 import { faFont, faHashtag, faList } from "@fortawesome/free-solid-svg-icons";
 import { utcParse } from "d3-time-format";
@@ -182,15 +181,6 @@ export function parseRamUsage(
 
 export const getFirst = <T>(value: T | T[]): T | undefined =>
   Array.isArray(value) ? value[0] : value;
-
-export function requireSubscription<T>(
-  subscription: T | undefined,
-  type: RawObjectType
-): asserts subscription is T {
-  if (subscription === undefined) {
-    throw new Error(`You need to provide a ${type} subscription`);
-  }
-}
 
 export const isOperationsPending = (
   obj: XenApiVm,

--- a/@xen-orchestra/lite/src/types/xapi-collection.ts
+++ b/@xen-orchestra/lite/src/types/xapi-collection.ts
@@ -1,0 +1,91 @@
+import type {
+  XenApiConsole,
+  XenApiHost,
+  XenApiHostMetrics,
+  XenApiPool,
+  XenApiRecord,
+  XenApiSr,
+  XenApiTask,
+  XenApiVm,
+  XenApiVmGuestMetrics,
+  XenApiVmMetrics,
+} from "@/libs/xen-api";
+import type { ComputedRef, Ref } from "vue";
+
+export interface SubscribeOptions<Immediate extends boolean> {
+  immediate?: Immediate;
+}
+
+export interface CollectionSubscription<T extends XenApiRecord> {
+  records: ComputedRef<T[]>;
+  getByOpaqueRef: (opaqueRef: string) => T | undefined;
+  getByUuid: (uuid: string) => T | undefined;
+  hasUuid: (uuid: string) => boolean;
+  isReady: Readonly<Ref<boolean>>;
+  isFetching: Readonly<Ref<boolean>>;
+  isReloading: ComputedRef<boolean>;
+  hasError: ComputedRef<boolean>;
+  lastError: Readonly<Ref<string | undefined>>;
+}
+
+export interface DeferredCollectionSubscription<T extends XenApiRecord>
+  extends CollectionSubscription<T> {
+  start: () => void;
+  isStarted: ComputedRef<boolean>;
+}
+
+export type RawTypeToObject = {
+  Bond: never;
+  Certificate: never;
+  Cluster: never;
+  Cluster_host: never;
+  DR_task: never;
+  Feature: never;
+  GPU_group: never;
+  PBD: never;
+  PCI: never;
+  PGPU: never;
+  PIF: never;
+  PIF_metrics: never;
+  PUSB: never;
+  PVS_cache_storage: never;
+  PVS_proxy: never;
+  PVS_server: never;
+  PVS_site: never;
+  SDN_controller: never;
+  SM: never;
+  SR: XenApiSr;
+  USB_group: never;
+  VBD: never;
+  VBD_metrics: never;
+  VDI: never;
+  VGPU: never;
+  VGPU_type: never;
+  VIF: never;
+  VIF_metrics: never;
+  VLAN: never;
+  VM: XenApiVm;
+  VMPP: never;
+  VMSS: never;
+  VM_guest_metrics: XenApiVmGuestMetrics;
+  VM_metrics: XenApiVmMetrics;
+  VUSB: never;
+  blob: never;
+  console: XenApiConsole;
+  crashdump: never;
+  host: XenApiHost;
+  host_cpu: never;
+  host_crashdump: never;
+  host_metrics: XenApiHostMetrics;
+  host_patch: never;
+  network: never;
+  network_sriov: never;
+  pool: XenApiPool;
+  pool_patch: never;
+  pool_update: never;
+  role: never;
+  secret: never;
+  subject: never;
+  task: XenApiTask;
+  tunnel: never;
+};


### PR DESCRIPTION
### Description

`subscribe` now takes an optional `options` argument: `subscribe(options?: { immediate: boolean })`.

By default, `immediate` is set to `true`.

Setting `immediate` to `false` allows deferring the subscription. In this case, it can be started later with `.start()`.

The subscription status can be checked with `.isStarted`

Additionally:
- Typing has been extracted to its own file
- The `subscribe` signature has been enhanced with overloading
- The Host/VM stores' `subscribe` signatures have been enhanced with overloading and additional typing

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
