### PR TITLE
fix(lite): handle escape key on CollectionFilter and CollectionSorter modals

### DIFF
--- a/@xen-orchestra/lite/src/components/CollectionFilter.vue
+++ b/@xen-orchestra/lite/src/components/CollectionFilter.vue
@@ -14,7 +14,12 @@
     </UiActionButton>
   </UiFilterGroup>
 
-  <UiModal v-if="isOpen" :icon="faFilter" @submit.prevent="handleSubmit">
+  <UiModal
+    v-if="isOpen"
+    :icon="faFilter"
+    @submit.prevent="handleSubmit"
+    @close="handleCancel"
+  >
     <div class="rows">
       <CollectionFilterRow
         v-for="(newFilter, index) in newFilters"

--- a/@xen-orchestra/lite/src/components/CollectionSorter.vue
+++ b/@xen-orchestra/lite/src/components/CollectionSorter.vue
@@ -17,7 +17,12 @@
     </UiActionButton>
   </UiFilterGroup>
 
-  <UiModal v-if="isOpen" :icon="faSort" @submit.prevent="handleSubmit">
+  <UiModal
+    v-if="isOpen"
+    :icon="faSort"
+    @submit.prevent="handleSubmit"
+    @close="handleCancel"
+  >
     <div class="form-widgets">
       <FormWidget :label="$t('sort-by')">
         <select v-model="newSortProperty">


### PR DESCRIPTION
### Description

UiModal `@close` event was not defined on `CollectionFilter` and `CollectionSorter` modals.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
