### PR TITLE
fix(xo-web/new/network): correct type for vlan

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [VM] Fix `VBD_IS_EMPTY` error when converting to template [Forum#61653](https://xcp-ng.org/forum/post/61653) (PR [#6808](https://github.com/vatesfr/xen-orchestra/pull/6808))
+- -[New/Network] Fix `invalid parameter error` when not providing a VLAN [Forum#62090](https://xcp-ng.org/forum/post/62090) (PR [#6829](https://github.com/vatesfr/xen-orchestra/pull/6829))
 
 ### Packages to release
 
@@ -30,5 +31,6 @@
 <!--packages-start-->
 
 - xo-server patch
+- xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-server/src/api/network.mjs
+++ b/packages/xo-server/src/api/network.mjs
@@ -10,7 +10,7 @@ export async function create({ pool, name, description, pif, mtu = 1500, vlan = 
     description,
     pifId: pif && this.getObject(pif, 'PIF')._xapiId,
     mtu: +mtu,
-    vlan: +vlan,
+    vlan,
   })
 
   if (nbd) {
@@ -27,7 +27,7 @@ create.params = {
   description: { type: 'string', minLength: 0, optional: true },
   pif: { type: 'string', optional: true },
   mtu: { type: 'integer', optional: true },
-  vlan: { type: ['integer', 'string'], optional: true },
+  vlan: { type: 'integer', optional: true },
 }
 
 create.resolve = {

--- a/packages/xo-web/src/xo-app/new/network/index.js
+++ b/packages/xo-web/src/xo-app/new/network/index.js
@@ -197,11 +197,11 @@ const NewNetwork = decorate([
         networks,
         pif,
         pifs,
-        vlan,
       } = state
 
-      let { mtu } = state
+      let { mtu, vlan } = state
       mtu = mtu === '' ? undefined : +mtu
+      vlan = vlan === '' ? undefined : +vlan
 
       return bonded
         ? createBondedNetwork({


### PR DESCRIPTION
### Description

BREAKING CHANGE: API method `network.create` no longer accepts a `string` for `vlan` param.

Fixes https://xcp-ng.org/forum/post/62090

Either `number` or `undefined`, not an empty string.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
