### PR TITLE
fix(xo-web/SortedTable): handle pending state for collapsed actions

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,9 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Import/VM/From VMware] Fix `Property description must be an object: undefined` [Forum#61834](https://xcp-ng.org/forum/post/61834) [Forum#61900](https://xcp-ng.org/forum/post/61900)
+- [Sorted table] In collapsed actions, a spinner is displayed during the action time
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -26,5 +29,9 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- @vates/task patch
+- xo-server minor
+- xo-web patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Import/VM/From VMware] Fix `Property description must be an object: undefined` [Forum#61834](https://xcp-ng.org/forum/post/61834) [Forum#61900](https://xcp-ng.org/forum/post/61900)
-- [Sorted table] In collapsed actions, a spinner is displayed during the action time
+- [Sorted table] In collapsed actions, a spinner is displayed during the action time (PR [#6831](https://github.com/vatesfr/xen-orchestra/pull/6831))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,6 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [Import/VM/From VMware] Fix `Property description must be an object: undefined` [Forum#61834](https://xcp-ng.org/forum/post/61834) [Forum#61900](https://xcp-ng.org/forum/post/61900)
 - [Sorted table] In collapsed actions, a spinner is displayed during the action time (PR [#6831](https://github.com/vatesfr/xen-orchestra/pull/6831))
 
 ### Packages to release
@@ -30,8 +29,6 @@
 
 <!--packages-start-->
 
-- @vates/task patch
-- xo-server minor
 - xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-web/src/common/sorted-table/index.js
+++ b/packages/xo-web/src/common/sorted-table/index.js
@@ -168,8 +168,12 @@ const handleFnProps = (prop, items, userData) => (typeof prop === 'function' ? p
 const CollapsedActions = decorate([
   withRouter,
   provideState({
+    initialState: () => ({
+      runningActions: [],
+    }),
     effects: {
       async execute(state, { handler, label, redirectOnSuccess }) {
+        this.state.runningActions = [...this.state.runningActions, label]
         try {
           await handler()
           ifDef(redirectOnSuccess, this.props.router.push)
@@ -183,18 +187,26 @@ const CollapsedActions = decorate([
               _error(label, defined(error.message, String(error)))
             }
           }
+        } finally {
+          this.state.runningActions = this.state.runningActions.filter(action => action !== label)
         }
       },
     },
     computed: {
+      wrappedActions: ({ runningActions }, { actions }) => {
+        actions.forEach((action, index) => {
+          actions[index].isRunning = runningActions.includes(action.label)
+        })
+        return [...actions]
+      },
       dropdownId: generateId,
-      actions: (_, { actions, items, userData }) =>
-        actions.map(({ disabled, grouped, handler, icon, label, level, redirectOnSuccess }) => {
+      actions: ({ wrappedActions: actions }, { items, userData }) =>
+        actions.map(({ disabled, grouped, handler, icon, isRunning, label, level, redirectOnSuccess }) => {
           const actionItems = Array.isArray(items) || !grouped ? items : [items]
           return {
-            disabled: handleFnProps(disabled, actionItems, userData),
+            disabled: isRunning || handleFnProps(disabled, actionItems, userData),
             handler: () => handler(actionItems, userData),
-            icon: handleFnProps(icon, actionItems, userData),
+            icon: isRunning ? 'loading' : handleFnProps(icon, actionItems, userData),
             label: handleFnProps(label, actionItems, userData),
             level: handleFnProps(level, actionItems, userData),
             redirectOnSuccess: handleFnProps(redirectOnSuccess, actionItems, userData),

--- a/packages/xo-web/src/common/sorted-table/index.js
+++ b/packages/xo-web/src/common/sorted-table/index.js
@@ -193,12 +193,11 @@ const CollapsedActions = decorate([
       },
     },
     computed: {
-      wrappedActions: ({ runningActions }, { actions }) => {
-        actions.forEach((action, index) => {
-          actions[index].isRunning = runningActions.includes(action.label)
-        })
-        return [...actions]
-      },
+      wrappedActions: ({ runningActions }, { actions }) =>
+        actions.map(action => {
+          action.isRunning = runningActions.includes(action.label)
+          return action
+        }),
       dropdownId: generateId,
       actions: ({ wrappedActions: actions }, { items, userData }) =>
         actions.map(({ disabled, grouped, handler, icon, isRunning, label, level, redirectOnSuccess }) => {


### PR DESCRIPTION
### GIF

![Peek 12-05-2023 05-08](https://github.com/vatesfr/xen-orchestra/assets/70369997/a10fd10c-7585-4582-9e58-bc8af96aaf56)


### Description

Disable running actions to avoid unwanted repetitions of actions.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
