### PR TITLE
feat(xo-web/host-item): display warning when HVM disabled

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Home/Host] Displays a warning for hosts with HVM disabled [#6823](https://github.com/vatesfr/xen-orchestra/issues/6823) (PR [#6834](https://github.com/vatesfr/xen-orchestra/pull/6834))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -26,5 +28,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -917,6 +917,7 @@ const messages = {
 
   // ----- Host item ------
   host: 'Host',
+  hostHvmDisabled: 'Hardware assisted virtualization is not enabled on this host',
   hostNoLicensePartialProSupport:
     'This host does not have an active license, even though it is in a pool with licensed hosts. In order for XCP-ng Pro Support to be enabled on a pool, all hosts within the pool must have an active license',
   hostNoSupport: 'No XCP-ng Pro Support enabled on this host',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -917,7 +917,7 @@ const messages = {
 
   // ----- Host item ------
   host: 'Host',
-  hostHvmDisabled: 'Hardware assisted virtualization is not enabled on this host',
+  hostHvmDisabled: 'Hardware-assisted virtualization is not enabled on this host',
   hostNoLicensePartialProSupport:
     'This host does not have an active license, even though it is in a pool with licensed hosts. In order for XCP-ng Pro Support to be enabled on a pool, all hosts within the pool must have an active license',
   hostNoSupport: 'No XCP-ng Pro Support enabled on this host',

--- a/packages/xo-web/src/xo-app/home/host-item.js
+++ b/packages/xo-web/src/xo-app/home/host-item.js
@@ -177,6 +177,17 @@ export default class HostItem extends Component {
           ),
         })
       }
+
+      if (!host.hvmCapable) {
+        alerts.push({
+          level: 'warning',
+          render: (
+            <span>
+              <Icon icon='alarm' /> {_('hostHvmDisabled')}
+            </span>
+          ),
+        })
+      }
       return alerts
     }
   )


### PR DESCRIPTION
Fixes #6823

### Screenshot

![Capture d’écran de 2023-05-15 16-08-42](https://github.com/vatesfr/xen-orchestra/assets/70369997/f33a8e47-7f68-4150-b606-c3952822e135)

### Description

Displays a warning in the Home/Host view for hosts with HVM disabled.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
