### PR TITLE
docs(installation): add findmnt command to sudoers config example

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -336,5 +336,5 @@ useSudo = true
 You need to configure `sudo` to allow the user of your choice to run mount/umount commands without asking for a password. Depending on your operating system / sudo version, the location of this configuration may change. Regardless, you can use:
 
 ```
-username ALL=(root)NOPASSWD: /bin/mount, /bin/umount
+username ALL=(root)NOPASSWD: /bin/mount, /bin/umount, /bin/findmnt
 ```


### PR DESCRIPTION
### Description

`findmnt` command was implemented to fix some random mounting issues with remotes in https://github.com/vatesfr/xen-orchestra/pull/4003. This command will also be ran as root if `useSudo` is set to true in XO configuration. This command is not documented in from sources installation docs sudoers config example. This PR addresses that.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
