### PR TITLE
feat(@xen-orchestra/backups): use parallel reading whith NBD + blocks  to only one remote

### DIFF
--- a/@xen-orchestra/backups/_VmBackup.js
+++ b/@xen-orchestra/backups/_VmBackup.js
@@ -267,7 +267,7 @@ class VmBackup {
     await this._callWriters(
       writer =>
         writer.transfer({
-          deltaExport: forkDeltaExport(deltaExport),
+          deltaExport: this._writers.size > 1 ? forkDeltaExport(deltaExport) : deltaExport,
           sizeContainers,
           timestamp,
         }),

--- a/packages/vhd-lib/parseVhdStream.js
+++ b/packages/vhd-lib/parseVhdStream.js
@@ -160,7 +160,12 @@ class StreamParser {
     yield* this.blocks()
   }
 }
+
 exports.parseVhdStream = async function* parseVhdStream(stream) {
-  const parser = new StreamParser(stream)
-  yield* parser.parse()
+  if (stream._iterator) {
+    yield* stream._iterator()
+  } else {
+    const parser = new StreamParser(stream)
+    yield* parser.parse()
+  }
 }


### PR DESCRIPTION
### Description

PR #6716 removed the parallel reading in favor a widespread use of NBD and unique reading 

this PR make it possible to use parallel reading given theses prequisites : 

* delta backup job
* only one remote AND it is store vhd in block
* no replication 
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
