### PR TITLE
fix(lite/markdown): vue code fence are no longer detected

### DIFF
--- a/@xen-orchestra/lite/src/libs/markdown.ts
+++ b/@xen-orchestra/lite/src/libs/markdown.ts
@@ -1,10 +1,22 @@
 import HLJS from "highlight.js";
 import { marked } from "marked";
 
+enum VUE_TAG {
+  TEMPLATE = "vue-template",
+  SCRIPT = "vue-script",
+  STYLE = "vue-style",
+}
+
 marked.use({
   renderer: {
     code(str: string, lang: string) {
-      const code = highlight(str, HLJS.getLanguage(lang) ? lang : "plaintext");
+      const code = highlight(
+        str,
+        Object.values(VUE_TAG).includes(lang as VUE_TAG) ||
+          HLJS.getLanguage(lang)
+          ? lang
+          : "plaintext"
+      );
       return `<pre class="hljs"><button class="copy-button" type="button">Copy</button><code class="hljs-code">${code}</code></pre>`;
     },
   },
@@ -12,45 +24,48 @@ marked.use({
 
 function highlight(str: string, lang: string) {
   switch (lang) {
-    case "vue-template": {
+    case VUE_TAG.TEMPLATE: {
       const indented = str
         .trim()
         .split("\n")
         .map((s) => `  ${s}`)
         .join("\n");
-      return wrap(indented, "template");
+      return wrap(indented, lang);
     }
-    case "vue-script":
-      return wrap(str.trim(), "script");
-    case "vue-style":
-      return wrap(str.trim(), "style");
+    case VUE_TAG.SCRIPT:
+    case VUE_TAG.STYLE:
+      return wrap(str.trim(), lang);
     default: {
       return copyable(HLJS.highlight(str, { language: lang }).value);
     }
   }
 }
 
-function wrap(str: string, tag: "template" | "script" | "style") {
+function wrap(str: string, lang: VUE_TAG) {
   let openTag;
+  let closeTag;
   let code;
 
-  switch (tag) {
-    case "template":
+  switch (lang) {
+    case VUE_TAG.TEMPLATE:
       openTag = "<template>";
+      closeTag = "</template>";
       code = HLJS.highlight(str, { language: "xml" }).value;
       break;
-    case "script":
+    case VUE_TAG.SCRIPT:
       openTag = '<script lang="ts" setup>';
+      closeTag = "</script>";
       code = HLJS.highlight(str, { language: "typescript" }).value;
       break;
-    case "style":
+    case VUE_TAG.STYLE:
       openTag = '<style lang="postcss" scoped>';
+      closeTag = "</style>";
       code = HLJS.highlight(str, { language: "scss" }).value;
       break;
   }
 
   const openTagHtml = HLJS.highlight(openTag, { language: "xml" }).value;
-  const closeTagHtml = HLJS.highlight(`</${tag}>`, { language: "xml" }).value;
+  const closeTagHtml = HLJS.highlight(closeTag, { language: "xml" }).value;
 
   return `${openTagHtml}${copyable(code)}${closeTagHtml}`;
 }


### PR DESCRIPTION
### Description

The `vue-template`, `vue-script`, and `vue-style` code fences were no longer detected, and thus were no longer highlighted.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
