### PR TITLE
fix(lite/console): fix console not updating when changing VM

### DIFF
--- a/@xen-orchestra/lite/src/components/RemoteConsole.vue
+++ b/@xen-orchestra/lite/src/components/RemoteConsole.vue
@@ -4,7 +4,7 @@
 
 <script lang="ts" setup>
 import { fibonacci } from "iterable-backoff";
-import { computed, onBeforeUnmount, ref, watch, watchEffect } from "vue";
+import { computed, onBeforeUnmount, ref, watchEffect } from "vue";
 import VncClient from "@novnc/novnc/core/rfb";
 import { useXenApiStore } from "@/stores/xen-api.store";
 import { promiseTimeout } from "@vueuse/shared";

--- a/@xen-orchestra/lite/src/components/RemoteConsole.vue
+++ b/@xen-orchestra/lite/src/components/RemoteConsole.vue
@@ -87,7 +87,6 @@ const createVncConnection = async () => {
   vncClient.addEventListener("connect", handleConnectionEvent);
 };
 
-watch(url, clearVncClient);
 watchEffect(() => {
   if (
     url.value === undefined ||
@@ -98,6 +97,8 @@ watchEffect(() => {
   }
 
   nConnectionAttempts = 0;
+
+  clearVncClient();
   createVncConnection();
 });
 


### PR DESCRIPTION
### Description

Introduced by [5237f](https://github.com/vatesfr/xen-orchestra/commit/5237fdd3873e0eed5994d60a61daf4472f061cd5)
`WatchEffect` is called before `Watch`. So the connection was "created" then "cleaned"

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
