### PR TITLE
fix(backups): handles task end in CR without health check

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.js
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.js
@@ -79,9 +79,17 @@ exports.Abstract = class AbstractVmBackupRunner {
     const intersect = settings.healthCheckVmsWithTags.some(t => tags.includes(t))
 
     if (settings.healthCheckVmsWithTags.length !== 0 && !intersect) {
-      return
+      // create a task to have an info in the logs and reports
+      return Task.run(
+        {
+          name: 'health check',
+        },
+        () => {
+          Task.info(`This VM doesn't match the healthcheck's tags for this schedule`)
+        }
+      )
     }
 
-    await this._callWriters(writer => writer.healthCheck(this._healthCheckSr), 'writer.healthCheck()')
+    await this._callWriters(writer => writer.healthCheck(), 'writer.healthCheck()')
   }
 }

--- a/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.js
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.js
@@ -85,7 +85,7 @@ exports.Abstract = class AbstractVmBackupRunner {
           name: 'health check',
         },
         () => {
-          Task.info(`This VM doesn't match the healthcheck's tags for this schedule`)
+          Task.info(`This VM doesn't match the health check's tags for this schedule`)
         }
       )
     }

--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractRemote.js
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractRemote.js
@@ -39,7 +39,7 @@ exports.AbstractRemote = class AbstractRemoteVmBackupRunner extends Abstract {
         ...settings,
         ...allSettings[remoteId],
       }
-      writers.add(new RemoteWriter({ adapter, config, job, vmUuid, remoteId, settings: targetSettings }))
+      writers.add(new RemoteWriter({ adapter, config, healthCheckSr, job, vmUuid, remoteId, settings: targetSettings }))
     })
   }
 

--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.js
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.js
@@ -78,20 +78,18 @@ class AbstractXapiVmBackupRunner extends Abstract {
         const targetSettings = {
           ...settings,
           ...allSettings[remoteId],
-          healthCheckSr,
         }
         if (targetSettings.exportRetention !== 0) {
-          writers.add(new BackupWriter({ adapter, config, job, vmUuid: vm.uuid, remoteId, settings: targetSettings }))
+          writers.add(new BackupWriter({ adapter, config, healthCheckSr, job, vmUuid: vm.uuid, remoteId, settings: targetSettings }))
         }
       })
       srs.forEach(sr => {
         const targetSettings = {
           ...settings,
           ...allSettings[sr.uuid],
-          healthCheckSr,
         }
         if (targetSettings.copyRetention !== 0) {
-          writers.add(new ReplicationWriter({ config, job, vmUuid: vm.uuid, sr, settings: targetSettings }))
+          writers.add(new ReplicationWriter({  config, healthCheckSr, job, vmUuid: vm.uuid, sr, settings: targetSettings}))
         }
       })
     }

--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.js
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.js
@@ -78,6 +78,7 @@ class AbstractXapiVmBackupRunner extends Abstract {
         const targetSettings = {
           ...settings,
           ...allSettings[remoteId],
+          healthCheckSr,
         }
         if (targetSettings.exportRetention !== 0) {
           writers.add(new BackupWriter({ adapter, config, job, vmUuid: vm.uuid, remoteId, settings: targetSettings }))
@@ -87,6 +88,7 @@ class AbstractXapiVmBackupRunner extends Abstract {
         const targetSettings = {
           ...settings,
           ...allSettings[sr.uuid],
+          healthCheckSr,
         }
         if (targetSettings.copyRetention !== 0) {
           writers.add(new ReplicationWriter({ config, job, vmUuid: vm.uuid, sr, settings: targetSettings }))

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.js
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.js
@@ -49,9 +49,10 @@ exports.IncrementalXapiWriter = class IncrementalXapiWriter extends MixinXapiWri
         type: 'SR',
       },
     })
+    const hasHealthCheckSr = this._settings.healthCheckSr !== undefined
     this.transfer = task.wrapFn(this.transfer)
-    this.cleanup = task.wrapFn(this.cleanup)
-    this.healthCheck = task.wrapFn(this.healthCheck, true)
+    this.cleanup = task.wrapFn(this.cleanup, !hasHealthCheckSr)
+    this.healthCheck = task.wrapFn(this.healthCheck, hasHealthCheckSr)
 
     return task.run(() => this._prepare())
   }

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.js
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.js
@@ -49,7 +49,7 @@ exports.IncrementalXapiWriter = class IncrementalXapiWriter extends MixinXapiWri
         type: 'SR',
       },
     })
-    const hasHealthCheckSr = this._settings.healthCheckSr !== undefined
+    const hasHealthCheckSr = this._healthCheckSr !== undefined
     this.transfer = task.wrapFn(this.transfer)
     this.cleanup = task.wrapFn(this.cleanup, !hasHealthCheckSr)
     this.healthCheck = task.wrapFn(this.healthCheck, hasHealthCheckSr)

--- a/@xen-orchestra/backups/_runners/_writers/_AbstractWriter.js
+++ b/@xen-orchestra/backups/_runners/_writers/_AbstractWriter.js
@@ -4,8 +4,9 @@ const { formatFilenameDate } = require('../../_filenameDate')
 const { getVmBackupDir } = require('../../_getVmBackupDir')
 
 exports.AbstractWriter = class AbstractWriter {
-  constructor({ config, job, vmUuid, scheduleId, settings }) {
+  constructor({ config, healthCheckSr, job, vmUuid, scheduleId, settings }) {
     this._config = config
+    this._healthCheckSr = healthCheckSr
     this._job = job
     this._scheduleId = scheduleId
     this._settings = settings

--- a/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.js
+++ b/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.js
@@ -76,7 +76,9 @@ exports.MixinRemoteWriter = (BaseClass = Object) =>
       }
     }
 
-    healthCheck(sr) {
+    healthCheck() {
+      const sr = this._settings.healthCheckSr
+      assert.notStrictEqual(sr, undefined, 'SR should be defined before making a health check')
       assert.notStrictEqual(
         this._metadataFileName,
         undefined,

--- a/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.js
+++ b/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.js
@@ -77,7 +77,7 @@ exports.MixinRemoteWriter = (BaseClass = Object) =>
     }
 
     healthCheck() {
-      const sr = this._settings.healthCheckSr
+      const sr = this._healthCheckSr
       assert.notStrictEqual(sr, undefined, 'SR should be defined before making a health check')
       assert.notStrictEqual(
         this._metadataFileName,

--- a/@xen-orchestra/backups/_runners/_writers/_MixinXapiWriter.js
+++ b/@xen-orchestra/backups/_runners/_writers/_MixinXapiWriter.js
@@ -15,7 +15,7 @@ exports.MixinXapiWriter = (BaseClass = Object) =>
     }
 
     healthCheck() {
-      const sr = this._settings.healthCheckSr
+      const sr = this._healthCheckSr
       assert.notStrictEqual(sr, undefined, 'SR should be defined before making a health check')
       assert.notEqual(this._targetVmRef, undefined, 'A vm should have been transfered to be health checked')
       // copy VM

--- a/@xen-orchestra/backups/_runners/_writers/_MixinXapiWriter.js
+++ b/@xen-orchestra/backups/_runners/_writers/_MixinXapiWriter.js
@@ -14,7 +14,9 @@ exports.MixinXapiWriter = (BaseClass = Object) =>
       this._sr = sr
     }
 
-    healthCheck(sr) {
+    healthCheck() {
+      const sr = this._settings.healthCheckSr
+      assert.notStrictEqual(sr, undefined, 'SR should be defined before making a health check')
       assert.notEqual(this._targetVmRef, undefined, 'A vm should have been transfered to be health checked')
       // copy VM
       return Task.run(

--- a/@xen-orchestra/backups/docs/VM backups/README.md
+++ b/@xen-orchestra/backups/docs/VM backups/README.md
@@ -228,7 +228,7 @@ Settings are described in [`@xen-orchestra/backups/Backup.js](https://github.com
     - `prepare({ isFull })`
     - `transfer({ timestamp, deltaExport, sizeContainers })`
     - `cleanup()`
-    - `healthCheck(sr)`
+    - `healthCheck()` // may not be executed if no health check sr or tag doesn't match
   - **Full**
     - `run({ timestamp, sizeContainer, stream })`
 - `afterBackup()`

--- a/@xen-orchestra/backups/docs/VM backups/README.md
+++ b/@xen-orchestra/backups/docs/VM backups/README.md
@@ -228,7 +228,7 @@ Settings are described in [`@xen-orchestra/backups/Backup.js](https://github.com
     - `prepare({ isFull })`
     - `transfer({ timestamp, deltaExport, sizeContainers })`
     - `cleanup()`
-    - `healthCheck()` // may not be executed if no health check sr or tag doesn't match
+    - `healthCheck()` // is not executed if no health check sr or tag doesn't match
   - **Full**
     - `run({ timestamp, sizeContainer, stream })`
 - `afterBackup()`

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [Incremental Replication] was shown as interrupted if there wasn't a health check after [Forum#62669](https://xcp-ng.org/forum/post/62669) (PR [#6866](https://github.com/vatesfr/xen-orchestra/pull/6866))
+- [Incremental Replication] Fix task showing as *interrupted* when running without health check [Forum#62669](https://xcp-ng.org/forum/post/62669) (PR [#6866](https://github.com/vatesfr/xen-orchestra/pull/6866))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Incremental Replication] was shown as interrupted if there wasn't a health check after [Forum#62669](https://xcp-ng.org/forum/post/62669) (PR [#6866](https://github.com/vatesfr/xen-orchestra/pull/6866))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.


### PR DESCRIPTION
### Description

from https://xcp-ng.org/forum/topic/7376/continuous-replication-storage-issue/8 

should be reworked/rechecked after merging mirror backups

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
