### PR TITLE
fix(xo-server): progress for import multiple vm

### DIFF
--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -1392,10 +1392,10 @@ export async function importMultipleFromEsxi({
               result[vm] = vmUuid
             } finally {
               done++
-              Task.set('done', done)
-              Task.set('progress', Math.round((done * 100) / vms.length))
             }
           })
+          Task.set('done', done)
+          Task.set('progress', Math.round((done * 100) / vms.length))
         },
         {
           concurrency,


### PR DESCRIPTION
current miplementation is setting te global progress in the per vm sub task

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
