### PR TITLE
feat(xo-web/task): action to open task REST API URL

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,5 +27,6 @@
 
 <!--packages-start-->
 
-- xo-web patch
+- xo-web minor
+
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Tasks] New type of tasks created by XO ("XO Tasks" section) (PRs [#6861](https://github.com/vatesfr/xen-orchestra/pull/6861) [#6869](https://github.com/vatesfr/xen-orchestra/pull/6869))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -459,7 +459,7 @@ const messages = {
   taskError: 'Error',
   taskEstimatedEnd: 'Estimated end',
   taskReason: 'Reason',
-  taskOpenApi: "Open task's REST API URL",
+  taskOpenRawLog: 'Open raw log',
   saveBackupJob: 'Save',
   deleteBackupSchedule: 'Remove backup job',
   deleteBackupScheduleQuestion: 'Are you sure you want to delete this backup job?',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -459,6 +459,7 @@ const messages = {
   taskError: 'Error',
   taskEstimatedEnd: 'Estimated end',
   taskReason: 'Reason',
+  taskOpenApi: "Open task's REST API URL",
   saveBackupJob: 'Save',
   deleteBackupSchedule: 'Remove backup job',
   deleteBackupScheduleQuestion: 'Are you sure you want to delete this backup job?',

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -580,7 +580,7 @@ export const subscribeXoTasks = createSubscription(async previousTasks => {
   }
 
   // Fetch new and updated tasks
-  const response = await fetch('./rest/v0/tasks?fields=end,id,name,objectId,properties,start,status,updatedAt' + filter)
+  const response = await fetch('./rest/v0/tasks?fields=end,id,name,objectId,properties,start,status,updatedAt,href' + filter)
   for (const task of await response.json()) {
     tasks.set(task.id, task)
   }

--- a/packages/xo-web/src/icons.scss
+++ b/packages/xo-web/src/icons.scss
@@ -350,6 +350,10 @@
     @extend .fa;
     @extend .fa-circle-thin;
   }
+  &-api {
+    @extend .fa;
+    @extend .fa-code;
+  }
 
   // Backups
   &-backup {

--- a/packages/xo-web/src/xo-app/tasks/index.js
+++ b/packages/xo-web/src/xo-app/tasks/index.js
@@ -220,6 +220,14 @@ const INDIVIDUAL_ACTIONS = [
   },
 ]
 
+const XO_TASKS_INDIVIDUAL_ACTIONS = [
+  {
+    handler: task => window.open(task.href),
+    icon: 'api',
+    label: _('taskOpenApi'),
+  },
+]
+
 const GROUPED_ACTIONS = [
   {
     disabled: tasks => some(tasks, isNotCancelable),
@@ -339,7 +347,12 @@ export default class Tasks extends Component {
         <Container>
           <Row>
             <Col>
-              <SortedTable collection={props.xoTasks} columns={XO_TASKS_COLUMNS} stateUrlParam='s_xo' />
+              <SortedTable
+                collection={props.xoTasks}
+                columns={XO_TASKS_COLUMNS}
+                individualActions={XO_TASKS_INDIVIDUAL_ACTIONS}
+                stateUrlParam='s_xo'
+              />
             </Col>
           </Row>
         </Container>

--- a/packages/xo-web/src/xo-app/tasks/index.js
+++ b/packages/xo-web/src/xo-app/tasks/index.js
@@ -224,7 +224,7 @@ const XO_TASKS_INDIVIDUAL_ACTIONS = [
   {
     handler: task => window.open(task.href),
     icon: 'api',
-    label: _('taskOpenApi'),
+    label: _('taskOpenRawLog'),
   },
 ]
 


### PR DESCRIPTION
### Screenshots

![Capture_2023-05-30_10:46:39](https://github.com/vatesfr/xen-orchestra/assets/10992860/c3527dad-425e-4087-b32c-96d0d531e453)

### Description

Add an "individual action" to XO Tasks to open the REST API URL.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
