### PR TITLE
fix(backups): fix CR not deleting older VM

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractRemote.js
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractRemote.js
@@ -39,7 +39,18 @@ exports.AbstractRemote = class AbstractRemoteVmBackupRunner extends Abstract {
         ...settings,
         ...allSettings[remoteId],
       }
-      writers.add(new RemoteWriter({ adapter, config, healthCheckSr, job, vmUuid, remoteId, settings: targetSettings }))
+      writers.add(
+        new RemoteWriter({
+          adapter,
+          config,
+          healthCheckSr,
+          job,
+          scheduleId: schedule.id,
+          vmUuid,
+          remoteId,
+          settings: targetSettings,
+        })
+      )
     })
   }
 

--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.js
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.js
@@ -80,7 +80,18 @@ class AbstractXapiVmBackupRunner extends Abstract {
           ...allSettings[remoteId],
         }
         if (targetSettings.exportRetention !== 0) {
-          writers.add(new BackupWriter({ adapter, config, healthCheckSr, job, vmUuid: vm.uuid, remoteId, settings: targetSettings }))
+          writers.add(
+            new BackupWriter({
+              adapter,
+              config,
+              healthCheckSr,
+              job,
+              scheduleId: schedule.id,
+              vmUuid: vm.uuid,
+              remoteId,
+              settings: targetSettings,
+            })
+          )
         }
       })
       srs.forEach(sr => {
@@ -89,7 +100,17 @@ class AbstractXapiVmBackupRunner extends Abstract {
           ...allSettings[sr.uuid],
         }
         if (targetSettings.copyRetention !== 0) {
-          writers.add(new ReplicationWriter({  config, healthCheckSr, job, vmUuid: vm.uuid, sr, settings: targetSettings}))
+          writers.add(
+            new ReplicationWriter({
+              config,
+              healthCheckSr,
+              job,
+              scheduleId: schedule.id,
+              vmUuid: vm.uuid,
+              sr,
+              settings: targetSettings,
+            })
+          )
         }
       })
     }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [Backup] fix CR not deleting older backups [Forum#62783](https://xcp-ng.org/forum/post/62783) (PR [#6871](https://github.com/vatesfr/xen-orchestra/pull/6871))
+- [Delta Replication] Fix not deleting older replications [Forum#62783](https://xcp-ng.org/forum/post/62783) (PR [#6871](https://github.com/vatesfr/xen-orchestra/pull/6871))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Backup] fix CR not deleting older backups [Forum#62783](https://xcp-ng.org/forum/post/62783) (PR [#6871](https://github.com/vatesfr/xen-orchestra/pull/6871))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -26,5 +28,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- @xen-orchestra/backups patch
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

scheduleId was not passed to the writers constructor. It leads to missing scheduleId in metadata (I think there is no consequence), and a bad filter to detect VM to delete after a successfull replication

Users may need to delete manually the VM created that way 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
