### PR TITLE
fix(xo-server): don't require `start` for Redis collections

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,5 +30,6 @@
 <!--packages-start-->
 
 - @xen-orchestra/backups patch
+- xo-server patch
 
 <!--packages-end-->

--- a/packages/xo-server/src/xo-mixins/acls.mjs
+++ b/packages/xo-server/src/xo-mixins/acls.mjs
@@ -12,7 +12,7 @@ export default class {
   constructor(app) {
     this._app = app
 
-    app.hooks.on('start', () => {
+    app.hooks.on('core started', () => {
       const aclsDb = (this._acls = new Acls({
         connection: app._redis,
         namespace: 'acl',

--- a/packages/xo-server/src/xo-mixins/authentication.mjs
+++ b/packages/xo-server/src/xo-mixins/authentication.mjs
@@ -80,7 +80,7 @@ export default class {
       return tokensDb.rebuildIndexes()
     })
 
-    app.hooks.on('start', () => {
+    app.hooks.on('core started', () => {
       // Creates persistent collections.
       const tokensDb = (this._tokens = new Tokens({
         connection: app._redis,

--- a/packages/xo-server/src/xo-mixins/cloud-configs.mjs
+++ b/packages/xo-server/src/xo-mixins/cloud-configs.mjs
@@ -14,7 +14,7 @@ export default class {
     this._app = app
 
     app.hooks.on('clean', () => this._db.rebuildIndexes())
-    app.hooks.on('start', () => {
+    app.hooks.on('core started', () => {
       const db = (this._db = new CloudConfigs({
         connection: app._redis,
         namespace: 'cloudConfig',

--- a/packages/xo-server/src/xo-mixins/jobs/index.mjs
+++ b/packages/xo-server/src/xo-mixins/jobs/index.mjs
@@ -80,14 +80,12 @@ export default class Jobs {
     executors.call = executeCall
 
     app.hooks.on('clean', () => this._jobs.rebuildIndexes())
-    app.hooks.on('start', async () => {
+    app.hooks.on('core started', () => {
       const jobsDb = (this._jobs = new JobsDb({
         connection: app._redis,
         namespace: 'job',
         indexes: ['user_id', 'key'],
       }))
-
-      this._logger = await app.getLogger('jobs')
 
       app.addConfigManager(
         'jobs',
@@ -95,6 +93,9 @@ export default class Jobs {
         jobs => Promise.all(jobs.map(job => jobsDb.save(job))),
         ['users']
       )
+    })
+    app.hooks.on('start', async () => {
+      this._logger = await app.getLogger('jobs')
     })
     // it sends a report for the interrupted backup jobs
     app.on('plugins:registered', () =>

--- a/packages/xo-server/src/xo-mixins/plugins.mjs
+++ b/packages/xo-server/src/xo-mixins/plugins.mjs
@@ -20,7 +20,7 @@ export default class {
     }).addVocabulary(['$multiline', '$type', 'enumNames'])
     this._plugins = { __proto__: null }
 
-    app.hooks.on('start', () => {
+    app.hooks.on('core started', () => {
       this._pluginsMetadata = new PluginsMetadata({
         connection: app._redis,
         namespace: 'plugin-metadata',

--- a/packages/xo-server/src/xo-mixins/proxies.mjs
+++ b/packages/xo-server/src/xo-mixins/proxies.mjs
@@ -70,7 +70,7 @@ export default class Proxy {
     })
 
     app.hooks.on('clean', () => this._db.rebuildIndexes())
-    app.hooks.on('start', () => {
+    app.hooks.on('core started', () => {
       const db = (this._db = new Collection({
         connection: app._redis,
         indexes: ['address', 'vmUuid'],

--- a/packages/xo-server/src/xo-mixins/remotes.mjs
+++ b/packages/xo-server/src/xo-mixins/remotes.mjs
@@ -37,7 +37,7 @@ export default class {
     this._app = app
 
     app.hooks.on('clean', () => this._remotes.rebuildIndexes())
-    app.hooks.on('start', async () => {
+    app.hooks.on('core started', () => {
       this._remotes = new Remotes({
         connection: app._redis,
         namespace: 'remote',
@@ -49,7 +49,8 @@ export default class {
         () => this._remotes.get(),
         remotes => Promise.all(remotes.map(remote => this._remotes.update(remote)))
       )
-
+    })
+    app.hooks.on('start', async () => {
       const remotes = await this._remotes.get()
       remotes.forEach(remote => {
         ignoreErrors.call(this.updateRemote(remote.id, {}))


### PR DESCRIPTION
### Description

Introduced by 9f3b02036

Redis connection is usable right after starting the core, therefore collections can be created on the `core started` event and does not require for the (much heavier) `start` hook to run.

This change fixes `xo-server-recover-account`.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
