### PR TITLE
fix(backups): fix vm is undefined error

### DIFF
--- a/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.js
+++ b/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.js
@@ -70,7 +70,7 @@ exports.MixinRemoteWriter = (BaseClass = Object) =>
           // add a random suffix to avoid collision in case multiple tasks are created at the same second
           Math.random().toString(36).slice(2)
 
-        await handler.outputFile(taskFile, this._backup.vm.uuid)
+        await handler.outputFile(taskFile, this._vmUuid)
         const remotePath = handler.getRealPath()
         await MergeWorker.run(remotePath)
       }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,4 +27,6 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
+
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Backup] Fix `Cannot read properties of undefined (reading 'vm')` (PR [#6873](https://github.com/vatesfr/xen-orchestra/pull/6873))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.


### PR DESCRIPTION
### Description

fix Error after the transfer of an incremental backup, when using merge workers

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
