### PR TITLE
Task abortion

### DIFF
--- a/@vates/task/.USAGE.md
+++ b/@vates/task/.USAGE.md
@@ -21,6 +21,8 @@ const task = new Task({
       const { data, message } = event
     } else if (type === 'property') {
       const { name, value } = event
+    } else if (type === 'abortionRequested') {
+      const { reason } = event
     }
   },
 })
@@ -34,7 +36,6 @@ task.id
 // - pending
 // - success
 // - failure
-// - aborted
 task.status
 
 // Triggers the abort signal associated to the task.

--- a/@vates/task/.USAGE.md
+++ b/@vates/task/.USAGE.md
@@ -88,6 +88,30 @@ const onProgress = makeOnProgress({
   onRootTaskStart(taskLog) {
     // `taskLog` is an object reflecting the state of this task and all its subtasks,
     // and will be mutated in real-time to reflect the changes of the task.
+
+    // timestamp at which the task started
+    taskLog.start
+
+    // current status of the task as described in the previous section
+    taskLog.status
+
+    // undefined or a dictionary of properties attached to the task
+    taskLog.properties
+
+    // timestamp at which the abortion was requested, undefined otherwise
+    taskLog.abortionRequestedAt
+
+    // undefined or an array of infos emitted on the task
+    taskLog.infos
+
+    // undefined or an array of warnings emitted on the task
+    taskLog.warnings
+
+    // timestamp at which the task ended, undefined otherwise
+    taskLog.end
+
+    // undefined or the result value of the task
+    taskLog.result
   },
 
   // This function is called each time a root task ends.

--- a/@vates/task/README.md
+++ b/@vates/task/README.md
@@ -37,6 +37,8 @@ const task = new Task({
       const { data, message } = event
     } else if (type === 'property') {
       const { name, value } = event
+    } else if (type === 'abortionRequested') {
+      const { reason } = event
     }
   },
 })
@@ -50,7 +52,6 @@ task.id
 // - pending
 // - success
 // - failure
-// - aborted
 task.status
 
 // Triggers the abort signal associated to the task.

--- a/@vates/task/README.md
+++ b/@vates/task/README.md
@@ -104,6 +104,30 @@ const onProgress = makeOnProgress({
   onRootTaskStart(taskLog) {
     // `taskLog` is an object reflecting the state of this task and all its subtasks,
     // and will be mutated in real-time to reflect the changes of the task.
+
+    // timestamp at which the task started
+    taskLog.start
+
+    // current status of the task as described in the previous section
+    taskLog.status
+
+    // undefined or a dictionnary of properties attached to the task
+    taskLog.properties
+
+    // timestamp at which the abortion was requested, undefined otherwise
+    taskLog.abortionRequestedAt
+
+    // undefined or an array of infos emitted on the task
+    taskLog.infos
+
+    // undefined or an array of warnings emitted on the task
+    taskLog.warnings
+
+    // timestamp at which the task ended, undefined otherwise
+    taskLog.end
+
+    // undefined or the result value of the task
+    taskLog.result
   },
 
   // This function is called each time a root task ends.

--- a/@vates/task/combineEvents.js
+++ b/@vates/task/combineEvents.js
@@ -47,6 +47,8 @@ exports.makeOnProgress = function ({ onRootTaskEnd = noop, onRootTaskStart = noo
         taskLog.end = event.timestamp
         taskLog.result = event.result
         taskLog.status = event.status
+      } else if (type === 'abortionRequested') {
+        taskLog.abortionRequestedAt = event.timestamp
       }
 
       if (type === 'end' && taskLog.$root === taskLog) {

--- a/@vates/task/combineEvents.test.js
+++ b/@vates/task/combineEvents.test.js
@@ -53,13 +53,18 @@ describe('makeOnProgress()', function () {
       assert.equal(events[i++], 'onTaskUpdate')
       assert.deepEqual(log.infos, [{ data: {}, message: 'foo' }])
 
-      await Task.run({ properties: { name: 'subtask' } }, () => {
+      const subtask = new Task({ properties: { name: 'subtask' } })
+      await subtask.run(() => {
         assert.equal(events[i++], 'onTaskUpdate')
         assert.equal(log.tasks[0].properties.name, 'subtask')
 
         Task.warning('bar', {})
         assert.equal(events[i++], 'onTaskUpdate')
         assert.deepEqual(log.tasks[0].warnings, [{ data: {}, message: 'bar' }])
+
+        subtask.abort()
+        assert.equal(events[i++], 'onTaskUpdate')
+        assert(Math.abs(log.tasks[0].abortionRequestedAt - Date.now()) < 10)
       })
       assert.equal(events[i++], 'onTaskUpdate')
       assert.equal(log.tasks[0].status, 'success')

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [XO Tasks] Abortion can now be requested, note that not all tasks will respond to it
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -29,5 +31,6 @@
 
 - @vates/nbd-client patch
 - @vates/task minor
+- xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-web/src/common/task-status.js
+++ b/packages/xo-web/src/common/task-status.js
@@ -19,10 +19,6 @@ export default {
     icon: 'halted',
     label: 'taskInterrupted',
   },
-  aborted: {
-    icon: 'skipped',
-    label: 'taskAborted',
-  },
   unknown: {
     icon: 'unknown',
     label: 'unknown',

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -580,7 +580,9 @@ export const subscribeXoTasks = createSubscription(async previousTasks => {
   }
 
   // Fetch new and updated tasks
-  const response = await fetch('./rest/v0/tasks?fields=end,id,name,objectId,properties,start,status,updatedAt,href' + filter)
+  const response = await fetch(
+    './rest/v0/tasks?fields=abortionRequestedAt,end,id,name,objectId,properties,start,status,updatedAt,href' + filter
+  )
   for (const task of await response.json()) {
     tasks.set(task.id, task)
   }
@@ -2278,6 +2280,17 @@ export const destroyTasks = tasks =>
     title: _('destroyTasksModalTitle', { nTasks: tasks.length }),
     body: _('destroyTasksModalMessage', { nTasks: tasks.length }),
   }).then(() => Promise.all(map(tasks, task => _call('task.destroy', { id: resolveId(task) }))), noop)
+
+// XO Tasks --------------------------------------------------------------
+
+export const abortXoTask = async task => {
+  const response = await fetch(`./rest/v0/tasks/${task.id}/actions/abort`, { method: 'POST' })
+  if (response.ok) {
+    subscribeXoTasks.forceRefresh()
+  } else {
+    throw new Error(await response.text())
+  }
+}
 
 // Jobs -------------------------------------------------------------
 

--- a/packages/xo-web/src/xo-app/tasks/index.js
+++ b/packages/xo-web/src/xo-app/tasks/index.js
@@ -21,7 +21,15 @@ import {
   getResolvedPendingTasks,
   isAdmin,
 } from 'selectors'
-import { cancelTask, cancelTasks, destroyTask, destroyTasks, subscribePermissions, subscribeXoTasks } from 'xo'
+import {
+  abortXoTask,
+  cancelTask,
+  cancelTasks,
+  destroyTask,
+  destroyTasks,
+  subscribePermissions,
+  subscribeXoTasks,
+} from 'xo'
 
 import Page from '../page'
 
@@ -228,6 +236,13 @@ const XO_TASKS_INDIVIDUAL_ACTIONS = [
     handler: task => window.open(task.href),
     icon: 'api',
     label: _('taskOpenRawLog'),
+  },
+  {
+    disabled: task => !(task.status === 'pending' && task.abortionRequestedAt === undefined),
+    handler: abortXoTask,
+    icon: 'task-cancel',
+    label: _('cancelTask'),
+    level: 'danger',
   },
 ]
 


### PR DESCRIPTION
**[Review by commits](https://github.com/vatesfr/xen-orchestra/pull/6876/commits) and do not squash!**

### Description

Remove `aborted` status in favor of `abortionRequestedAt` property and implement abortion in the UI.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
