### PR TITLE
feat(lite): revamp XAPI subscription and add `immediate` option

### DIFF
--- a/@xen-orchestra/lite/README.md
+++ b/@xen-orchestra/lite/README.md
@@ -157,35 +157,6 @@ export const useFoobarStore = defineStore("foobar", () => {
 });
 ```
 
-#### Xen Api Collection Stores
-
-When creating a store for a Xen Api objects collection, use the `createXenApiCollectionStoreContext` helper.
-
-```typescript
-export const useConsoleStore = defineStore("console", () =>
-  createXenApiCollectionStoreContext("console")
-);
-```
-
-##### Extending the base context
-
-Here is how to extend the base context:
-
-```typescript
-import { computed } from "vue";
-
-export const useFoobarStore = defineStore("foobar", () => {
-  const baseContext = createXenApiCollectionStoreContext("foobar");
-
-  const myCustomGetter = computed(() => baseContext.ids.reverse());
-
-  return {
-    ...baseContext,
-    myCustomGetter,
-  };
-});
-```
-
 ### I18n
 
 Internationalization of the app is done with [Vue-i18n](https://vue-i18n.intlify.dev/).

--- a/@xen-orchestra/lite/docs/xen-api-record-stores.md
+++ b/@xen-orchestra/lite/docs/xen-api-record-stores.md
@@ -1,0 +1,144 @@
+# Stores for XenApiRecord collections
+
+All collections of `XenApiRecord` are stored inside the `xapiCollectionStore`.
+
+To retrieve a collection, invoke `useXapiCollectionStore().get(type)`.
+
+## Accessing a collection
+
+In order to use a collection, you'll need to subscribe to it.
+
+```typescript
+const consoleStore = useXapiCollectionStore().get("console");
+const { records, getByUuid /* ... */ } = consoleStore.subscribe();
+```
+
+## Deferred subscription
+
+If you wish to initialize the subscription on demand, you can pass `{ immediate: false }` as options to `subscribe()`.
+
+```typescript
+const consoleStore = useXapiCollectionStore().get("console");
+const { records, start, isStarted /* ... */ } = consoleStore.subscribe({
+  immediate: false,
+});
+
+// Later, you can then use start() to initialize the subscription.
+```
+
+## Create a dedicated store for a collection
+
+To create a dedicated store for a specific `XenApiRecord`, simply return the collection from the XAPI Collection Store:
+
+```typescript
+export const useConsoleStore = defineStore("console", () =>
+  useXapiCollectionStore().get("console")
+);
+```
+
+## Extending the base Subscription
+
+To extend the base Subscription, you'll need to override the `subscribe` method.
+
+For that, you can use the `createSubscribe<XenApiRecord, Extensions>((options) => { /* ... */})` helper.
+
+### Define the extensions
+
+Subscription extensions are defined as `(object | [object, RequiredOptions])[]`.
+
+When using a tuple (`[object, RequiredOptions]`), the corresponding `object` type will be added to the subscription if
+the `RequiredOptions` for that tuple are present in the options passed to `subscribe`.
+
+```typescript
+// Always present extension
+type DefaultExtension = {
+  propA: string;
+  propB: ComputedRef<number>;
+};
+
+// Conditional extension 1
+type FirstConditionalExtension = [
+  { propC: ComputedRef<string> }, // <- This signature will be added
+  { optC: string } // <- if this condition is met
+];
+
+// Conditional extension 2
+type SecondConditionalExtension = [
+  { propD: () => void }, // <- This signature will be added
+  { optD: number } // <- if this condition is met
+];
+
+// Create the extensions array
+type Extensions = [
+  DefaultExtension,
+  FirstConditionalExtension,
+  SecondConditionalExtension
+];
+```
+
+### Define the subscription
+
+```typescript
+export const useConsoleStore = defineStore("console", () => {
+  const consoleCollection = useXapiCollectionStore().get("console");
+
+  const subscribe = createSubscribe<XenApiConsole, Extensions>((options) => {
+    const originalSubscription = consoleCollection.subscribe(options);
+
+    const extendedSubscription = {
+      propA: "Some string",
+      propB: computed(() => 42),
+    };
+
+    const propCSubscription = options?.optC !== undefined && {
+      propC: computed(() => "Some other string"),
+    };
+
+    const propDSubscription = options?.optD !== undefined && {
+      propD: () => console.log("Hello"),
+    };
+
+    return {
+      ...originalSubscription,
+      ...extendedSubscription,
+      ...propCSubscription,
+      ...propDSubscription,
+    };
+  });
+
+  return {
+    ...consoleCollection,
+    subscribe,
+  };
+});
+```
+
+The generated `subscribe` method will then automatically have the following `options` signature:
+
+```typescript
+type Options = {
+  immediate?: false;
+  optC?: string;
+  optD?: number;
+};
+```
+
+### Use the subscription
+
+In each case, all the default properties (`records`, `getByUuid`, etc.) will be present.
+
+```typescript
+const store = useConsoleStore();
+
+// No options (propA and propB will be present)
+const subscription = store.subscribe();
+
+// optC option (propA, propB and propC will be present)
+const subscription = store.subscribe({ optC: "Hello" });
+
+// optD option (propA, propB and propD will be present)
+const subscription = store.subscribe({ optD: 12 });
+
+// optC and optD options (propA, propB, propC and propD will be present)
+const subscription = store.subscribe({ optC: "Hello", optD: 12 });
+```

--- a/@xen-orchestra/lite/src/libs/utils.ts
+++ b/@xen-orchestra/lite/src/libs/utils.ts
@@ -1,5 +1,4 @@
 import type {
-  RawObjectType,
   RawXenApiRecord,
   XenApiHost,
   XenApiHostMetrics,
@@ -7,8 +6,8 @@ import type {
   XenApiVm,
   VM_OPERATION,
 } from "@/libs/xen-api";
-import type { CollectionSubscription } from "@/stores/xapi-collection.store";
 import type { Filter } from "@/types/filter";
+import type { Subscription } from "@/types/xapi-collection";
 import { faSquareCheck } from "@fortawesome/free-regular-svg-icons";
 import { faFont, faHashtag, faList } from "@fortawesome/free-solid-svg-icons";
 import { utcParse } from "d3-time-format";
@@ -117,14 +116,14 @@ export function getStatsLength(stats?: object | any[]) {
 
 export function isHostRunning(
   host: XenApiHost,
-  hostMetricsSubscription: CollectionSubscription<XenApiHostMetrics>
+  hostMetricsSubscription: Subscription<XenApiHostMetrics, object>
 ) {
   return hostMetricsSubscription.getByOpaqueRef(host.metrics)?.live === true;
 }
 
 export function getHostMemory(
   host: XenApiHost,
-  hostMetricsSubscription: CollectionSubscription<XenApiHostMetrics>
+  hostMetricsSubscription: Subscription<XenApiHostMetrics, object>
 ) {
   const hostMetrics = hostMetricsSubscription.getByOpaqueRef(host.metrics);
 
@@ -183,15 +182,6 @@ export function parseRamUsage(
 
 export const getFirst = <T>(value: T | T[]): T | undefined =>
   Array.isArray(value) ? value[0] : value;
-
-export function requireSubscription<T>(
-  subscription: T | undefined,
-  type: RawObjectType
-): asserts subscription is T {
-  if (subscription === undefined) {
-    throw new Error(`You need to provide a ${type} subscription`);
-  }
-}
 
 export const isOperationsPending = (
   obj: XenApiVm,

--- a/@xen-orchestra/lite/src/stores/host.store.ts
+++ b/@xen-orchestra/lite/src/stores/host.store.ts
@@ -1,21 +1,26 @@
-import {
-  isHostRunning,
-  requireSubscription,
-  sortRecordsByNameLabel,
-} from "@/libs/utils";
-import type { GRANULARITY } from "@/libs/xapi-stats";
-import type { XenApiHostMetrics } from "@/libs/xen-api";
-import {
-  type CollectionSubscription,
-  useXapiCollectionStore,
-} from "@/stores/xapi-collection.store";
+import { isHostRunning, sortRecordsByNameLabel } from "@/libs/utils";
+import type { GRANULARITY, XapiStatsResponse } from "@/libs/xapi-stats";
+import type { XenApiHost, XenApiHostMetrics } from "@/libs/xen-api";
+import { useXapiCollectionStore } from "@/stores/xapi-collection.store";
 import { useXenApiStore } from "@/stores/xen-api.store";
+import type { Subscription } from "@/types/xapi-collection";
+import { createSubscribe } from "@/types/xapi-collection";
 import { defineStore } from "pinia";
-import { computed } from "vue";
+import { computed, type ComputedRef } from "vue";
 
-type SubscribeOptions = {
-  hostMetricsSubscription?: CollectionSubscription<XenApiHostMetrics>;
+type GetStatsExtension = {
+  getStats: (
+    hostUuid: string,
+    granularity: GRANULARITY
+  ) => Promise<XapiStatsResponse<any>> | undefined;
 };
+
+type RunningHostsExtension = [
+  { runningHosts: ComputedRef<XenApiHost[]> },
+  { hostMetricsSubscription: Subscription<XenApiHostMetrics, any> }
+];
+
+type Extensions = [GetStatsExtension, RunningHostsExtension];
 
 export const useHostStore = defineStore("host", () => {
   const xenApiStore = useXenApiStore();
@@ -23,19 +28,11 @@ export const useHostStore = defineStore("host", () => {
 
   hostCollection.setSort(sortRecordsByNameLabel);
 
-  const subscribe = ({ hostMetricsSubscription }: SubscribeOptions = {}) => {
-    const hostSubscription = hostCollection.subscribe();
-
-    const runningHosts = computed(() => {
-      requireSubscription(hostMetricsSubscription, "host_metrics");
-
-      return hostSubscription.records.value.filter((host) =>
-        isHostRunning(host, hostMetricsSubscription)
-      );
-    });
+  const subscribe = createSubscribe<XenApiHost, Extensions>((options) => {
+    const originalSubscription = hostCollection.subscribe(options);
 
     const getStats = (hostUuid: string, granularity: GRANULARITY) => {
-      const host = hostSubscription.getByUuid(hostUuid);
+      const host = originalSubscription.getByUuid(hostUuid);
 
       if (host === undefined) {
         throw new Error(`Host ${hostUuid} could not be found.`);
@@ -52,12 +49,25 @@ export const useHostStore = defineStore("host", () => {
       });
     };
 
-    return {
-      ...hostSubscription,
-      runningHosts,
+    const extendedSubscription = {
       getStats,
     };
-  };
+
+    const hostMetricsSubscription = options?.hostMetricsSubscription;
+
+    const runningHostsSubscription = hostMetricsSubscription !== undefined && {
+      runningHosts: computed(() =>
+        originalSubscription.records.value.filter((host) =>
+          isHostRunning(host, hostMetricsSubscription)
+        )
+      ),
+    };
+    return {
+      ...originalSubscription,
+      ...extendedSubscription,
+      ...runningHostsSubscription,
+    };
+  });
 
   return {
     ...hostCollection,

--- a/@xen-orchestra/lite/src/stores/pool.store.ts
+++ b/@xen-orchestra/lite/src/stores/pool.store.ts
@@ -9,12 +9,12 @@ type PoolExtension = {
   pool: ComputedRef<XenApiPool | undefined>;
 };
 
-type Config = [PoolExtension];
+type Extensions = [PoolExtension];
 
 export const usePoolStore = defineStore("pool", () => {
   const poolCollection = useXapiCollectionStore().get("pool");
 
-  const subscribe = createSubscribe<XenApiPool, Config>((options) => {
+  const subscribe = createSubscribe<XenApiPool, Extensions>((options) => {
     const originalSubscription = poolCollection.subscribe(options);
 
     const extendedSubscription = {

--- a/@xen-orchestra/lite/src/stores/pool.store.ts
+++ b/@xen-orchestra/lite/src/stores/pool.store.ts
@@ -1,21 +1,31 @@
 import { getFirst } from "@/libs/utils";
+import type { XenApiPool } from "@/libs/xen-api";
 import { useXapiCollectionStore } from "@/stores/xapi-collection.store";
+import { createSubscribe } from "@/types/xapi-collection";
 import { defineStore } from "pinia";
-import { computed } from "vue";
+import { computed, type ComputedRef } from "vue";
+
+type PoolExtension = {
+  pool: ComputedRef<XenApiPool | undefined>;
+};
+
+type Config = [PoolExtension];
 
 export const usePoolStore = defineStore("pool", () => {
   const poolCollection = useXapiCollectionStore().get("pool");
 
-  const subscribe = () => {
-    const subscription = poolCollection.subscribe();
+  const subscribe = createSubscribe<XenApiPool, Config>((options) => {
+    const originalSubscription = poolCollection.subscribe(options);
 
-    const pool = computed(() => getFirst(subscription.records.value));
+    const extendedSubscription = {
+      pool: computed(() => getFirst(originalSubscription.records.value)),
+    };
 
     return {
-      ...subscription,
-      pool,
+      ...originalSubscription,
+      ...extendedSubscription,
     };
-  };
+  });
 
   return {
     ...poolCollection,

--- a/@xen-orchestra/lite/src/stores/vm.store.ts
+++ b/@xen-orchestra/lite/src/stores/vm.store.ts
@@ -1,18 +1,29 @@
-import { requireSubscription, sortRecordsByNameLabel } from "@/libs/utils";
-import type { GRANULARITY } from "@/libs/xapi-stats";
+import { sortRecordsByNameLabel } from "@/libs/utils";
+import type { GRANULARITY, XapiStatsResponse } from "@/libs/xapi-stats";
 import { POWER_STATE } from "@/libs/xen-api";
 import type { XenApiHost, XenApiVm } from "@/libs/xen-api";
-import {
-  type CollectionSubscription,
-  useXapiCollectionStore,
-} from "@/stores/xapi-collection.store";
+import { useXapiCollectionStore } from "@/stores/xapi-collection.store";
 import { useXenApiStore } from "@/stores/xen-api.store";
+import { createSubscribe, type Subscription } from "@/types/xapi-collection";
 import { defineStore } from "pinia";
-import { computed } from "vue";
+import { computed, type ComputedRef } from "vue";
 
-type SubscribeOptions = {
-  hostSubscription?: CollectionSubscription<XenApiHost>;
+type DefaultExtension = {
+  recordsByHostRef: ComputedRef<Map<string, XenApiVm[]>>;
+  runningVms: ComputedRef<XenApiVm[]>;
 };
+
+type GetStatsExtension = [
+  {
+    getStats: (
+      id: string,
+      granularity: GRANULARITY
+    ) => Promise<XapiStatsResponse<any>>;
+  },
+  { hostSubscription: Subscription<XenApiHost, object> }
+];
+
+type Extensions = [DefaultExtension, GetStatsExtension];
 
 export const useVmStore = defineStore("vm", () => {
   const vmCollection = useXapiCollectionStore().get("VM");
@@ -23,64 +34,66 @@ export const useVmStore = defineStore("vm", () => {
 
   vmCollection.setSort(sortRecordsByNameLabel);
 
-  const subscribe = ({ hostSubscription }: SubscribeOptions = {}) => {
-    const vmSubscription = vmCollection.subscribe();
+  const subscribe = createSubscribe<XenApiVm, Extensions>((options) => {
+    const originalSubscription = vmCollection.subscribe(options);
 
-    const recordsByHostRef = computed(() => {
-      const vmsByHostOpaqueRef = new Map<string, XenApiVm[]>();
+    const extendedSubscription = {
+      recordsByHostRef: computed(() => {
+        const vmsByHostOpaqueRef = new Map<string, XenApiVm[]>();
 
-      vmSubscription.records.value.forEach((vm) => {
-        if (!vmsByHostOpaqueRef.has(vm.resident_on)) {
-          vmsByHostOpaqueRef.set(vm.resident_on, []);
+        originalSubscription.records.value.forEach((vm) => {
+          if (!vmsByHostOpaqueRef.has(vm.resident_on)) {
+            vmsByHostOpaqueRef.set(vm.resident_on, []);
+          }
+
+          vmsByHostOpaqueRef.get(vm.resident_on)?.push(vm);
+        });
+
+        return vmsByHostOpaqueRef;
+      }),
+      runningVms: computed(() =>
+        originalSubscription.records.value.filter(
+          (vm) => vm.power_state === POWER_STATE.RUNNING
+        )
+      ),
+    };
+
+    const hostSubscription = options?.hostSubscription;
+
+    const getStatsSubscription = hostSubscription !== undefined && {
+      getStats: (id: string, granularity: GRANULARITY) => {
+        const xenApiStore = useXenApiStore();
+
+        if (!xenApiStore.isConnected) {
+          return undefined;
         }
 
-        vmsByHostOpaqueRef.get(vm.resident_on)?.push(vm);
-      });
+        const vm = originalSubscription.getByUuid(id);
 
-      return vmsByHostOpaqueRef;
-    });
+        if (vm === undefined) {
+          throw new Error(`VM ${id} could not be found.`);
+        }
 
-    const runningVms = computed(() =>
-      vmSubscription.records.value.filter(
-        (vm) => vm.power_state === POWER_STATE.RUNNING
-      )
-    );
+        const host = hostSubscription.getByOpaqueRef(vm.resident_on);
 
-    const getStats = (id: string, granularity: GRANULARITY) => {
-      requireSubscription(hostSubscription, "host");
+        if (host === undefined) {
+          throw new Error(`VM ${id} is halted or host could not be found.`);
+        }
 
-      const xenApiStore = useXenApiStore();
-
-      if (!xenApiStore.isConnected) {
-        return undefined;
-      }
-
-      const vm = vmSubscription.getByUuid(id);
-
-      if (vm === undefined) {
-        throw new Error(`VM ${id} could not be found.`);
-      }
-
-      const host = hostSubscription.getByOpaqueRef(vm.resident_on);
-
-      if (host === undefined) {
-        throw new Error(`VM ${id} is halted or host could not be found.`);
-      }
-
-      return xenApiStore.getXapiStats()._getAndUpdateStats({
-        host,
-        uuid: vm.uuid,
-        granularity,
-      });
+        return xenApiStore.getXapiStats()._getAndUpdateStats({
+          host,
+          uuid: vm.uuid,
+          granularity,
+        });
+      },
     };
 
     return {
-      ...vmSubscription,
-      recordsByHostRef,
-      getStats,
-      runningVms,
+      ...originalSubscription,
+      ...extendedSubscription,
+      ...getStatsSubscription,
     };
-  };
+  });
 
   return {
     ...vmCollection,

--- a/@xen-orchestra/lite/src/stores/xapi-collection.store.ts
+++ b/@xen-orchestra/lite/src/stores/xapi-collection.store.ts
@@ -1,20 +1,13 @@
-import type {
-  RawObjectType,
-  XenApiConsole,
-  XenApiHost,
-  XenApiHostMetrics,
-  XenApiPool,
-  XenApiRecord,
-  XenApiSr,
-  XenApiTask,
-  XenApiVm,
-  XenApiVmGuestMetrics,
-  XenApiVmMetrics,
-} from "@/libs/xen-api";
+import type { RawObjectType, XenApiRecord } from "@/libs/xen-api";
 import { useXenApiStore } from "@/stores/xen-api.store";
+import type {
+  RawTypeToObject,
+  SubscribeOptions,
+  Subscription,
+} from "@/types/xapi-collection";
 import { tryOnUnmounted, whenever } from "@vueuse/core";
 import { defineStore } from "pinia";
-import { computed, type ComputedRef, readonly, type Ref, ref } from "vue";
+import { computed, readonly, ref } from "vue";
 
 export const useXapiCollectionStore = defineStore("xapiCollection", () => {
   const collections = ref(
@@ -34,18 +27,6 @@ export const useXapiCollectionStore = defineStore("xapiCollection", () => {
 
   return { get };
 });
-
-export interface CollectionSubscription<T extends XenApiRecord> {
-  records: ComputedRef<T[]>;
-  getByOpaqueRef: (opaqueRef: string) => T | undefined;
-  getByUuid: (uuid: string) => T | undefined;
-  hasUuid: (uuid: string) => boolean;
-  isReady: Readonly<Ref<boolean>>;
-  isFetching: Readonly<Ref<boolean>>;
-  isReloading: ComputedRef<boolean>;
-  hasError: ComputedRef<boolean>;
-  lastError: Readonly<Ref<string | undefined>>;
-}
 
 const createXapiCollection = <T extends XenApiRecord>(type: RawObjectType) => {
   const isReady = ref(false);
@@ -123,16 +104,16 @@ const createXapiCollection = <T extends XenApiRecord>(type: RawObjectType) => {
     () => fetchAll()
   );
 
-  const subscribe = () => {
+  function subscribe<O extends SubscribeOptions<any>>(
+    options?: O
+  ): Subscription<T, O> {
     const id = Symbol();
-
-    subscriptions.value.add(id);
 
     tryOnUnmounted(() => {
       unsubscribe(id);
     });
 
-    return {
+    const subscription = {
       records,
       getByOpaqueRef,
       getByUuid,
@@ -143,7 +124,18 @@ const createXapiCollection = <T extends XenApiRecord>(type: RawObjectType) => {
       hasError,
       lastError: readonly(lastError),
     };
-  };
+
+    if (options?.immediate === false) {
+      subscriptions.value.add(id);
+      return subscription as Subscription<T, O>;
+    }
+
+    return {
+      ...subscription,
+      start: () => subscriptions.value.add(id),
+      isStarted: computed(() => subscriptions.value.has(id)),
+    } as unknown as Subscription<T, O>;
+  }
 
   const unsubscribe = (id: symbol) => subscriptions.value.delete(id);
 
@@ -157,60 +149,4 @@ const createXapiCollection = <T extends XenApiRecord>(type: RawObjectType) => {
     setFilter,
     setSort,
   };
-};
-
-type RawTypeToObject = {
-  Bond: never;
-  Certificate: never;
-  Cluster: never;
-  Cluster_host: never;
-  DR_task: never;
-  Feature: never;
-  GPU_group: never;
-  PBD: never;
-  PCI: never;
-  PGPU: never;
-  PIF: never;
-  PIF_metrics: never;
-  PUSB: never;
-  PVS_cache_storage: never;
-  PVS_proxy: never;
-  PVS_server: never;
-  PVS_site: never;
-  SDN_controller: never;
-  SM: never;
-  SR: XenApiSr;
-  USB_group: never;
-  VBD: never;
-  VBD_metrics: never;
-  VDI: never;
-  VGPU: never;
-  VGPU_type: never;
-  VIF: never;
-  VIF_metrics: never;
-  VLAN: never;
-  VM: XenApiVm;
-  VMPP: never;
-  VMSS: never;
-  VM_guest_metrics: XenApiVmGuestMetrics;
-  VM_metrics: XenApiVmMetrics;
-  VUSB: never;
-  blob: never;
-  console: XenApiConsole;
-  crashdump: never;
-  host: XenApiHost;
-  host_cpu: never;
-  host_crashdump: never;
-  host_metrics: XenApiHostMetrics;
-  host_patch: never;
-  network: never;
-  network_sriov: never;
-  pool: XenApiPool;
-  pool_patch: never;
-  pool_update: never;
-  role: never;
-  secret: never;
-  subject: never;
-  task: XenApiTask;
-  tunnel: never;
 };

--- a/@xen-orchestra/lite/src/stores/xapi-collection.store.ts
+++ b/@xen-orchestra/lite/src/stores/xapi-collection.store.ts
@@ -125,14 +125,16 @@ const createXapiCollection = <T extends XenApiRecord>(type: RawObjectType) => {
       lastError: readonly(lastError),
     };
 
-    if (options?.immediate === false) {
-      subscriptions.value.add(id);
+    const start = () => subscriptions.value.add(id);
+
+    if (options?.immediate !== false) {
+      start();
       return subscription as Subscription<T, O>;
     }
 
     return {
       ...subscription,
-      start: () => subscriptions.value.add(id),
+      start,
       isStarted: computed(() => subscriptions.value.has(id)),
     } as unknown as Subscription<T, O>;
   }

--- a/@xen-orchestra/lite/src/types/xapi-collection.ts
+++ b/@xen-orchestra/lite/src/types/xapi-collection.ts
@@ -54,12 +54,12 @@ export type SubscribeOptions<Extensions extends any[]> = Partial<
 type GenerateSubscription<
   Options extends object,
   Extensions extends any[]
-> = Extensions extends [infer FirstConfig, ...infer RestConfig]
-  ? FirstConfig extends [infer FirstObject, infer FirstCondition]
+> = Extensions extends [infer FirstExtension, ...infer RestExtension]
+  ? FirstExtension extends [infer FirstObject, infer FirstCondition]
     ? Options extends FirstCondition
-      ? FirstObject & GenerateSubscription<Options, RestConfig>
-      : GenerateSubscription<Options, RestConfig>
-    : FirstConfig & GenerateSubscription<Options, RestConfig>
+      ? FirstObject & GenerateSubscription<Options, RestExtension>
+      : GenerateSubscription<Options, RestExtension>
+    : FirstExtension & GenerateSubscription<Options, RestExtension>
   : object;
 
 export type Subscription<
@@ -72,9 +72,9 @@ export type Subscription<
 export function createSubscribe<
   T extends XenApiRecord,
   Extensions extends any[],
-  GenOptions extends object = SubscribeOptions<Extensions>
->(builder: (options?: GenOptions) => Subscription<T, GenOptions, Extensions>) {
-  return function subscribe<O extends GenOptions>(
+  Options extends object = SubscribeOptions<Extensions>
+>(builder: (options?: Options) => Subscription<T, Options, Extensions>) {
+  return function subscribe<O extends Options>(
     options?: O
   ): Subscription<T, O, Extensions> {
     return builder(options);

--- a/@xen-orchestra/lite/src/types/xapi-collection.ts
+++ b/@xen-orchestra/lite/src/types/xapi-collection.ts
@@ -1,0 +1,138 @@
+import type {
+  XenApiConsole,
+  XenApiHost,
+  XenApiHostMetrics,
+  XenApiPool,
+  XenApiRecord,
+  XenApiSr,
+  XenApiTask,
+  XenApiVm,
+  XenApiVmGuestMetrics,
+  XenApiVmMetrics,
+} from "@/libs/xen-api";
+import type { ComputedRef, Ref } from "vue";
+
+type DefaultExtension<T extends XenApiRecord> = {
+  records: ComputedRef<T[]>;
+  getByOpaqueRef: (opaqueRef: string) => T | undefined;
+  getByUuid: (uuid: string) => T | undefined;
+  hasUuid: (uuid: string) => boolean;
+  isReady: Readonly<Ref<boolean>>;
+  isFetching: Readonly<Ref<boolean>>;
+  isReloading: ComputedRef<boolean>;
+  hasError: ComputedRef<boolean>;
+  lastError: Readonly<Ref<string | undefined>>;
+};
+
+type DeferExtension = [
+  {
+    start: () => void;
+    isStarted: ComputedRef<boolean>;
+  },
+  { immediate: false }
+];
+
+type DefaultExtensions<T extends XenApiRecord> = [
+  DefaultExtension<T>,
+  DeferExtension
+];
+
+type GenerateSubscribeOptions<Extensions extends any[]> = Extensions extends [
+  infer FirstExtension,
+  ...infer RestExtension
+]
+  ? FirstExtension extends [object, infer FirstCondition]
+    ? FirstCondition & GenerateSubscribeOptions<RestExtension>
+    : GenerateSubscribeOptions<RestExtension>
+  : object;
+
+export type SubscribeOptions<Extensions extends any[]> = Partial<
+  GenerateSubscribeOptions<Extensions> &
+    GenerateSubscribeOptions<DefaultExtensions<any>>
+>;
+
+type GenerateSubscription<
+  Options extends object,
+  Extensions extends any[]
+> = Extensions extends [infer FirstConfig, ...infer RestConfig]
+  ? FirstConfig extends [infer FirstObject, infer FirstCondition]
+    ? Options extends FirstCondition
+      ? FirstObject & GenerateSubscription<Options, RestConfig>
+      : GenerateSubscription<Options, RestConfig>
+    : FirstConfig & GenerateSubscription<Options, RestConfig>
+  : object;
+
+export type Subscription<
+  T extends XenApiRecord,
+  Options extends object,
+  Extensions extends any[] = []
+> = GenerateSubscription<Options, Extensions> &
+  GenerateSubscription<Options, DefaultExtensions<T>>;
+
+export function createSubscribe<
+  T extends XenApiRecord,
+  Extensions extends any[],
+  GenOptions extends object = SubscribeOptions<Extensions>
+>(builder: (options?: GenOptions) => Subscription<T, GenOptions, Extensions>) {
+  return function subscribe<O extends GenOptions>(
+    options?: O
+  ): Subscription<T, O, Extensions> {
+    return builder(options);
+  };
+}
+
+export type RawTypeToObject = {
+  Bond: never;
+  Certificate: never;
+  Cluster: never;
+  Cluster_host: never;
+  DR_task: never;
+  Feature: never;
+  GPU_group: never;
+  PBD: never;
+  PCI: never;
+  PGPU: never;
+  PIF: never;
+  PIF_metrics: never;
+  PUSB: never;
+  PVS_cache_storage: never;
+  PVS_proxy: never;
+  PVS_server: never;
+  PVS_site: never;
+  SDN_controller: never;
+  SM: never;
+  SR: XenApiSr;
+  USB_group: never;
+  VBD: never;
+  VBD_metrics: never;
+  VDI: never;
+  VGPU: never;
+  VGPU_type: never;
+  VIF: never;
+  VIF_metrics: never;
+  VLAN: never;
+  VM: XenApiVm;
+  VMPP: never;
+  VMSS: never;
+  VM_guest_metrics: XenApiVmGuestMetrics;
+  VM_metrics: XenApiVmMetrics;
+  VUSB: never;
+  blob: never;
+  console: XenApiConsole;
+  crashdump: never;
+  host: XenApiHost;
+  host_cpu: never;
+  host_crashdump: never;
+  host_metrics: XenApiHostMetrics;
+  host_patch: never;
+  network: never;
+  network_sriov: never;
+  pool: XenApiPool;
+  pool_patch: never;
+  pool_update: never;
+  role: never;
+  secret: never;
+  subject: never;
+  task: XenApiTask;
+  tunnel: never;
+};


### PR DESCRIPTION
### Description

`subscribe()` now accept an `{ immediate: false }` option.

In this case, the subscription is deferred and can be initialized later with `.start()`.

A `createSubscribe` helper has been added to create an overridden `subscribe` function.

Full documentation has been added to `docs/xen-api-record-stores.md`.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
