### PR TITLE
fix(xo-web/home): don't search in linked objects

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 - [LDAP] Mark the _Id attribute_ setting as required
 - [Incremental Replication] Fix `TypeError: Cannot read properties of undefined (reading 'uuid') at #isAlreadyOnHealthCheckSr` [Forum#7492](https://xcp-ng.org/forum/topic/7492) (PR [#6969](https://github.com/vatesfr/xen-orchestra/pull/6969))
 - [File Restore] Increase timeout from one to ten minutes when restoring through XO Proxy
+- [Home/VMs] Filtering with a UUID will no longer show other VMs on the same host/pool
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

Introduced by 59289840697eedd39429246d856201261865dc4a

For instance, Searching the UUID of a running VM was showing all other VMs on the same host due to the UUID being present in their `container.residentVms`.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
