### PR TITLE
feat(vhd-lib): slim down key backup when using block based backup

### DIFF
--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.js
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.js
@@ -211,6 +211,7 @@ class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrementalWrite
             checksum: false,
             validator: tmpPath => checkVhd(handler, tmpPath),
             writeBlockConcurrency: this._config.writeBlockConcurrency,
+            isDelta,
           })
 
           if (isDelta) {


### PR DESCRIPTION
### Description

backing up thick vhd (iscsi based for example) lead to a lot of wasted space used

in this PR , we'll only write on remote the block that are not empty (hoping that an empty block contains only 0 )
If this works well, we'll be able to rework vhdfile based backup to get this optimization

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
