### PR TITLE
feat(lite/dev): add keyboard shortcut to toggle language

### DIFF
--- a/@xen-orchestra/lite/src/App.vue
+++ b/@xen-orchestra/lite/src/App.vue
@@ -29,6 +29,7 @@ import { useXenApiStore } from "@/stores/xen-api.store";
 import { useActiveElement, useMagicKeys, whenever } from "@vueuse/core";
 import { logicAnd } from "@vueuse/math";
 import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 
 let link = document.querySelector(
   "link[rel~='icon']"
@@ -48,10 +49,11 @@ useChartTheme();
 const uiStore = useUiStore();
 
 if (import.meta.env.DEV) {
+  const { locale } = useI18n();
   const activeElement = useActiveElement();
-  const { D } = useMagicKeys();
+  const { D, L } = useMagicKeys();
 
-  const canToggleDarkMode = computed(() => {
+  const canToggle = computed(() => {
     if (activeElement.value == null) {
       return true;
     }
@@ -60,8 +62,13 @@ if (import.meta.env.DEV) {
   });
 
   whenever(
-    logicAnd(D, canToggleDarkMode),
+    logicAnd(D, canToggle),
     () => (uiStore.colorMode = uiStore.colorMode === "dark" ? "light" : "dark")
+  );
+
+  whenever(
+    logicAnd(L, canToggle),
+    () => (locale.value = locale.value === "en" ? "fr" : "en")
   );
 }
 


### PR DESCRIPTION
### Description

To make development easier, add the ability to toggle language between FR and EN while in development mode by pressing the `L` key (the same way we can toggle light/dark theme with `D` key).

### Screenshot

![Language Toggle](https://github.com/vatesfr/xen-orchestra/assets/19408/5a0f09a7-38cf-41fd-9ec6-38a18525639d)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
