### PR TITLE
fix(xo-web/home): fix 'isHostTimeConsistentWithXoaTime.then is not a function'

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Home/Host] Fix "isHostTimeConsistentWithXoaTime.then is not a function" (PR [#6896](https://github.com/vatesfr/xen-orchestra/pull/6896))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/packages/xo-web/src/xo-app/home/host-item.js
+++ b/packages/xo-web/src/xo-app/home/host-item.js
@@ -59,7 +59,7 @@ export default class HostItem extends Component {
   }
 
   componentWillMount() {
-    isHostTimeConsistentWithXoaTime(this.props.item).then(value =>
+    Promise.resolve(isHostTimeConsistentWithXoaTime(this.props.item)).then(value =>
       this.setState({
         isHostTimeConsistentWithXoaTime: value,
       })


### PR DESCRIPTION
### Description

See xoa-support#15250
Introduced by [132b1](https://github.com/vatesfr/xen-orchestra/commit/132b1a41dbdc5f3716d24c604e18f5a422a30a5a)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
