### PR TITLE
fix(lite/components): app-menu doesn't allow more than 1 submenu

### DIFF
--- a/@xen-orchestra/lite/src/components/menu/AppMenu.vue
+++ b/@xen-orchestra/lite/src/components/menu/AppMenu.vue
@@ -1,8 +1,8 @@
 <template>
   <slot :is-open="isOpen" :open="open" name="trigger" />
-  <Teleport to="body" :disabled="!slots.trigger">
+  <Teleport to="body" :disabled="!shouldTeleport">
     <ul
-      v-if="!$slots.trigger || isOpen"
+      v-if="!hasTrigger || isOpen"
       ref="menu"
       :class="{ horizontal, shadow }"
       class="app-menu"
@@ -14,6 +14,7 @@
 </template>
 
 <script lang="ts" setup>
+import { IK_MENU_TELEPORTED } from "@/types/injection-keys";
 import placementJs, { type Options } from "placement.js";
 import { inject, nextTick, provide, ref, toRef, unref, useSlots } from "vue";
 import { onClickOutside, unrefElement, whenever } from "@vueuse/core";
@@ -36,6 +37,14 @@ const isParentHorizontal = inject("isMenuHorizontal", undefined);
 provide("isMenuHorizontal", toRef(props, "horizontal"));
 provide("isMenuDisabled", toRef(props, "disabled"));
 let clearClickOutsideEvent: (() => void) | undefined;
+
+const hasTrigger = useSlots().trigger !== undefined;
+
+const shouldTeleport = hasTrigger && !inject(IK_MENU_TELEPORTED, false);
+
+if (shouldTeleport) {
+  provide(IK_MENU_TELEPORTED, true);
+}
 
 whenever(
   () => !isOpen.value,

--- a/@xen-orchestra/lite/src/types/injection-keys.ts
+++ b/@xen-orchestra/lite/src/types/injection-keys.ts
@@ -1,0 +1,3 @@
+import type { InjectionKey } from "vue";
+
+export const IK_MENU_TELEPORTED = Symbol() as InjectionKey<boolean>;


### PR DESCRIPTION
### Description

Fix a bug preventing having more that 1 submenu.

### Screenshots

#### Before Fix
![AppMenu Before Fix](https://github.com/vatesfr/xen-orchestra/assets/19408/58cda58c-a442-44b9-bb54-2732cbe6c841)

#### After Fix
![AppMenu After Fix](https://github.com/vatesfr/xen-orchestra/assets/19408/8dc9165f-003d-4442-afb2-41d5a508d86d)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
