### PR TITLE
fix(xo-server-perf-alert): add conditional statement on entry

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,6 +37,7 @@
 - @vates/nbd-client patch
 - @vates/task minor
 - xo-server-auth-oidc minor
+- xo-server-perf-alert patch
 - xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-server-perf-alert/src/index.js
+++ b/packages/xo-server-perf-alert/src/index.js
@@ -589,12 +589,13 @@ ${monitorBodies.join('\n')}`
 
       const entriesWithMissingStats = []
       for (const entry of snapshot) {
-        // Ignore special SRs (e.g. *XCP-ng Tools*, *DVD drives*, etc) as their usage is always 100%
-        if (entry.object.physical_size <= 0 && entry.object.content_type === 'iso') continue
+        if (entry.object === null) continue
         if (entry.value === undefined) {
           entriesWithMissingStats.push(entry)
           continue
         }
+        // Ignore special SRs (e.g. *XCP-ng Tools*, *DVD drives*, etc) as their usage is always 100%
+        if (entry.object.physical_size <= 0 && entry.object.content_type === 'iso') continue
 
         const raiseAlarm = _alarmId => {
           // sample XenCenter message (linebreaks are meaningful):

--- a/packages/xo-server-perf-alert/src/index.js
+++ b/packages/xo-server-perf-alert/src/index.js
@@ -589,6 +589,7 @@ ${monitorBodies.join('\n')}`
 
       const entriesWithMissingStats = []
       for (const entry of snapshot) {
+        //  can happen when the user forgets to remove an element that doesn't exist anymore from the list of the monitored machines
         if (entry.object === null) continue
         if (entry.value === undefined) {
           entriesWithMissingStats.push(entry)


### PR DESCRIPTION
Test if the entry is null to handle the case where the object cannot be found, which can happen when the user forgets to remove an element that doesn't exist anymore from the list of the monitored machines.

Fixes: https://team.vates.fr/vates/pl/u1f9c755tjnc8k4ftdwz8y5uro

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
