### PR TITLE
fix(vmware-explorer): handle self signed certificate during download

### DIFF
--- a/@xen-orchestra/vmware-explorer/esxi.mjs
+++ b/@xen-orchestra/vmware-explorer/esxi.mjs
@@ -3,6 +3,7 @@ import { dirname } from 'node:path'
 import { EventEmitter } from 'node:events'
 import { strictEqual, notStrictEqual } from 'node:assert'
 import fetch from 'node-fetch'
+import https from 'https'
 
 import parseVmdk from './parsers/vmdk.mjs'
 import parseVmsd from './parsers/vmsd.mjs'
@@ -13,6 +14,7 @@ export default class Esxi extends EventEmitter {
   #cookies
   #dcPath
   #host
+  #httpsAgent
   #user
   #password
   #ready = false
@@ -22,9 +24,12 @@ export default class Esxi extends EventEmitter {
     this.#host = host
     this.#user = user
     this.#password = password
-    // @FIXME this module inject NODE_TLS_REJECT_UNAUTHORIZED into the process env, which is problematic because it disables globally SSL certificate verification
-    //
-    // we need to find a fix for this, maybe forking the library
+    if (!sslVerify) {
+      this.#httpsAgent = new https.Agent({
+        rejectUnauthorized: false,
+      })
+    }
+
     this.#client = new Client(host, user, password, sslVerify)
     this.#client.once('ready', async () => {
       try {
@@ -78,6 +83,7 @@ export default class Esxi extends EventEmitter {
       headers.Range = 'bytes=' + range
     }
     const res = await fetch(url, {
+      agent: this.#httpsAgent,
       method: 'GET',
       headers,
       highWaterMark: 10 * 1024 * 1024,


### PR DESCRIPTION
### Description

following  #6859

also handle self signed certificate when downloading disk data 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
