### PR TITLE
fix(node-vsphere-soap): don't disable TLS1.2 used by ESXi

### DIFF
--- a/@vates/node-vsphere-soap/lib/client.js
+++ b/@vates/node-vsphere-soap/lib/client.js
@@ -18,7 +18,6 @@ const https = require('node:https')
 const util = require('util')
 const soap = require('soap')
 const Cookie = require('soap-cookie') // required for session persistence
-const constants = require('crypto').constants
 // Client class
 // inherits from EventEmitter
 // possible events: connect, error, ready
@@ -39,8 +38,6 @@ function Client(vCenterHostname, username, password, sslVerify) {
       request: axios.create({
         httpsAgent: new https.Agent({
           rejectUnauthorized: false,
-
-          secureOptions: constants.SSL_OP_NO_TLSv1_2, // likely needed for node >= 10.0
         }),
       }),
     }


### PR DESCRIPTION
### Description
introduced by https://github.com/vatesfr/xen-orchestra/pull/6859 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
