### PR TITLE
feat(lite/components): rewrite FormInputWrapper

### DIFF
--- a/@xen-orchestra/lite/src/components/component-story/StoryWidget.vue
+++ b/@xen-orchestra/lite/src/components/component-story/StoryWidget.vue
@@ -81,4 +81,10 @@ const model = useVModel(props, "modelValue", emit);
   display: flex;
   gap: 1rem;
 }
+
+.form-select,
+.form-input,
+.form-json {
+  font-size: 1.4rem;
+}
 </style>

--- a/@xen-orchestra/lite/src/components/form/FormInput.vue
+++ b/@xen-orchestra/lite/src/components/form/FormInput.vue
@@ -1,13 +1,14 @@
 <template>
-  <span :class="wrapperClass" v-bind="wrapperAttrs">
+  <span :class="wrapperClass" class="container" v-bind="wrapperAttrs">
     <template v-if="inputType === 'select'">
       <select
+        :id="id"
+        ref="inputElement"
         v-model="value"
         :class="inputClass"
         :disabled="disabled || isLabelDisabled"
         :required="required"
         class="select"
-        ref="inputElement"
         v-bind="$attrs"
       >
         <slot />
@@ -18,6 +19,7 @@
     </template>
     <textarea
       v-else-if="inputType === 'textarea'"
+      :id="id"
       ref="textarea"
       v-model="value"
       :class="inputClass"
@@ -28,12 +30,13 @@
     />
     <input
       v-else
+      :id="id"
+      ref="inputElement"
       v-model="value"
       :class="inputClass"
       :disabled="disabled || isLabelDisabled"
       :required="required"
       class="input"
-      ref="inputElement"
       v-bind="$attrs"
     />
     <span v-if="before !== undefined" class="before">
@@ -53,6 +56,7 @@ import type { Color } from "@/types";
 import {
   IK_FORM_INPUT_COLOR,
   IK_FORM_LABEL_DISABLED,
+  IK_INPUT_ID,
   IK_INPUT_TYPE,
 } from "@/types/injection-keys";
 import type { IconDefinition } from "@fortawesome/fontawesome-common-types";
@@ -71,6 +75,7 @@ defineOptions({ inheritAttrs: false });
 
 const props = withDefaults(
   defineProps<{
+    id?: string;
     modelValue?: any;
     color?: Color;
     before?: IconDefinition | string;
@@ -122,6 +127,10 @@ const inputClass = computed(() => [
   },
 ]);
 
+const parentId = inject(IK_INPUT_ID, undefined);
+
+const id = computed(() => props.id ?? parentId?.value);
+
 const { textarea, triggerResize } = useTextareaAutosize();
 
 watch(value, () => nextTick(() => triggerResize()), {
@@ -136,11 +145,16 @@ defineExpose({
 </script>
 
 <style lang="postcss" scoped>
+.container {
+  font-size: 2rem;
+}
+
 .form-input,
 .form-select,
 .form-textarea {
-  display: inline-grid;
+  display: grid;
   align-items: stretch;
+  max-width: 30em;
 
   --before-width: v-bind('beforeWidth || "1.75em"');
   --after-width: v-bind('afterWidth || "1.625em"');
@@ -175,11 +189,11 @@ defineExpose({
 .select {
   font-size: 1em;
   width: 100%;
-  height: 2em;
+  height: 3em;
   margin: 0;
   color: var(--text-color);
-  border: 0.0625em solid var(--border-color);
-  border-radius: 0.5em;
+  border: 0.05em solid var(--border-color);
+  border-radius: 0.4em;
   outline: none;
   background-color: var(--background-color);
   box-shadow: var(--shadow-100);

--- a/@xen-orchestra/lite/src/components/form/FormInputWrapper.vue
+++ b/@xen-orchestra/lite/src/components/form/FormInputWrapper.vue
@@ -1,38 +1,83 @@
 <template>
-  <div class="wrapper">
-    <label
-      v-if="$slots.label"
-      class="form-label"
-      :class="{ disabled, ...formInputWrapperClass }"
+  <div class="form-input-wrapper">
+    <div
+      v-if="label !== undefined || learnMoreUrl !== undefined"
+      class="label-container"
     >
+      <label :for="id" class="label">
+        <UiIcon :icon="icon" />
+        {{ label }}
+      </label>
+      <a
+        v-if="learnMoreUrl !== undefined"
+        :href="learnMoreUrl"
+        class="learn-more-url"
+        target="_blank"
+      >
+        <UiIcon :icon="faInfoCircle" />
+        <span>Learn more</span>
+      </a>
+    </div>
+    <div class="input-container">
       <slot />
-    </label>
-    <slot />
-    <p v-if="hasError || hasWarning" :class="formInputWrapperClass">
-      <UiIcon :icon="faCircleExclamation" v-if="hasError" />{{
-        error ?? warning
-      }}
-    </p>
+    </div>
+    <div class="messages-container">
+      <div v-if="warning !== undefined" class="warning">
+        {{ warning }}
+      </div>
+      <div v-if="error !== undefined" class="error">
+        {{ error }}
+      </div>
+      <div v-if="help !== undefined" class="help">
+        {{ help }}
+      </div>
+    </div>
   </div>
 </template>
 
 <script lang="ts" setup>
 import UiIcon from "@/components/ui/icon/UiIcon.vue";
+import type { Color } from "@/types";
 import {
   IK_FORM_HAS_LABEL,
   IK_FORM_INPUT_COLOR,
   IK_FORM_LABEL_DISABLED,
+  IK_INPUT_ID,
 } from "@/types/injection-keys";
-import { faCircleExclamation } from "@fortawesome/free-solid-svg-icons";
+import type { IconDefinition } from "@fortawesome/fontawesome-common-types";
+import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+import { uniqueId } from "lodash-es";
 import { computed, provide, useSlots } from "vue";
 
 const slots = useSlots();
 
 const props = defineProps<{
-  disabled?: boolean;
-  error?: string;
+  label?: string;
+  id?: string;
+  icon?: IconDefinition;
+  learnMoreUrl?: string;
   warning?: string;
+  error?: string;
+  help?: string;
+  disabled?: boolean;
 }>();
+
+const id = computed(() => props.id ?? uniqueId("form-input-"));
+provide(IK_INPUT_ID, id);
+
+const color = computed<Color | undefined>(() => {
+  if (props.error !== undefined && props.error.trim() !== "") {
+    return "error";
+  }
+
+  if (props.warning !== undefined && props.warning.trim() !== "") {
+    return "warning";
+  }
+
+  return undefined;
+});
+
+provide(IK_FORM_INPUT_COLOR, color);
 
 provide(
   IK_FORM_HAS_LABEL,
@@ -43,63 +88,61 @@ provide(
   IK_FORM_LABEL_DISABLED,
   computed(() => props.disabled ?? false)
 );
-
-const hasError = computed(
-  () => props.error !== undefined && props.error.trim() !== ""
-);
-const hasWarning = computed(
-  () => props.warning !== undefined && props.warning.trim() !== ""
-);
-
-provide(
-  IK_FORM_INPUT_COLOR,
-  computed(() =>
-    hasError.value ? "error" : hasWarning.value ? "warning" : undefined
-  )
-);
-
-const formInputWrapperClass = computed(() => ({
-  error: hasError.value,
-  warning: !hasError.value && hasWarning.value,
-}));
 </script>
 
 <style lang="postcss" scoped>
-.wrapper {
+.form-input-wrapper {
+  max-width: 60rem;
+}
+
+.label-container {
   display: flex;
-  flex-direction: column;
-}
-
-.wrapper :deep(.input) {
-  margin-bottom: 1rem;
-}
-
-.form-label {
-  font-size: 1.6rem;
-  display: inline-flex;
+  justify-content: space-between;
   align-items: center;
-  gap: 0.625em;
+}
 
-  &.disabled {
-    cursor: not-allowed;
-    color: var(--color-blue-scale-300);
+.label {
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--color-blue-scale-100);
+  font-size: 1.4rem;
+  padding: 1rem 0;
+}
+
+.messages-container {
+  margin-top: 1rem;
+}
+
+.warning,
+.error,
+.help,
+.learn-more-url {
+  font-size: 1.3rem;
+  line-height: 150%;
+  margin: 0.5rem 0;
+}
+
+.learn-more-url {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+  color: var(--color-extra-blue-base);
+
+  & > span {
+    text-decoration: underline;
   }
-}
-p.error,
-p.warning {
-  font-size: 0.65em;
-  margin-bottom: 1rem;
-}
-
-.error {
-  color: var(--color-red-vates-base);
 }
 
 .warning {
   color: var(--color-orange-world-base);
 }
 
-p svg {
-  margin-right: 0.4em;
+.error {
+  color: var(--color-red-vates-base);
+}
+
+.help {
+  color: var(--color-blue-scale-300);
 }
 </style>

--- a/@xen-orchestra/lite/src/components/form/FormInputWrapper.vue
+++ b/@xen-orchestra/lite/src/components/form/FormInputWrapper.vue
@@ -15,7 +15,7 @@
         target="_blank"
       >
         <UiIcon :icon="faInfoCircle" />
-        <span>Learn more</span>
+        <span>{{ $t("learn-more") }}</span>
       </a>
     </div>
     <div class="input-container">

--- a/@xen-orchestra/lite/src/locales/en.json
+++ b/@xen-orchestra/lite/src/locales/en.json
@@ -62,6 +62,7 @@
   "hosts": "Hosts",
   "language": "Language",
   "last-week": "Last week",
+  "learn-more": "Learn more",
   "loading-hosts": "Loading hosts…",
   "log-out": "Log out",
   "login": "Login",

--- a/@xen-orchestra/lite/src/locales/fr.json
+++ b/@xen-orchestra/lite/src/locales/fr.json
@@ -62,6 +62,7 @@
   "hosts": "Hôtes",
   "language": "Langue",
   "last-week": "Semaine dernière",
+  "learn-more": "En savoir plus",
   "loading-hosts": "Chargement des hôtes…",
   "log-out": "Se déconnecter",
   "login": "Connexion",

--- a/@xen-orchestra/lite/src/stories/form-input-wrapper.story.vue
+++ b/@xen-orchestra/lite/src/stories/form-input-wrapper.story.vue
@@ -1,0 +1,29 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties }"
+    :params="[
+      prop('label').type('string').widget().preset('My input'),
+      iconProp(),
+      prop('learnMoreUrl').type('string').widget().preset('https://google.com'),
+      prop('warning').type('string').widget(),
+      prop('error').type('string').widget(),
+      prop('help').type('string').widget().preset('256 by default'),
+      prop('disabled').type('boolean').widget(),
+      slot().help('Contains the input'),
+    ]"
+  >
+    <FormInputWrapper v-bind="properties">
+      <FormInput v-model="modelValue" />
+    </FormInputWrapper>
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from "@/components/component-story/ComponentStory.vue";
+import FormInput from "@/components/form/FormInput.vue";
+import FormInputWrapper from "@/components/form/FormInputWrapper.vue";
+import { iconProp, prop, slot } from "@/libs/story/story-param";
+import { ref } from "vue";
+
+const modelValue = ref("");
+</script>

--- a/@xen-orchestra/lite/src/types/injection-keys.ts
+++ b/@xen-orchestra/lite/src/types/injection-keys.ts
@@ -5,6 +5,7 @@ import type { ValueFormatter } from "@/types/chart";
 import type { ComputedRef, InjectionKey } from "vue";
 
 export const IK_MENU_TELEPORTED = Symbol() as InjectionKey<boolean>;
+
 export const IK_TAB_BAR_DISABLED = Symbol() as InjectionKey<
   ComputedRef<boolean>
 >;
@@ -70,3 +71,5 @@ export const IK_BUTTON_GROUP_COLOR = Symbol() as InjectionKey<
 >;
 
 export const IK_CARD_GROUP_VERTICAL = Symbol() as InjectionKey<boolean>;
+
+export const IK_INPUT_ID = Symbol() as InjectionKey<ComputedRef<string>>;

--- a/@xen-orchestra/lite/src/views/settings/SettingsView.vue
+++ b/@xen-orchestra/lite/src/views/settings/SettingsView.vue
@@ -135,21 +135,19 @@
     </UiCard>
     <UiCard class="group">
       <UiCardTitle>{{ $t("language") }}</UiCardTitle>
-      <UiKeyValueList>
+      <UiKeyValueList class="full-length">
         <UiKeyValueRow>
           <template #value>
-            <FormWidget class="full-length" :before="faEarthAmericas">
-              <select v-model="$i18n.locale">
-                <option
-                  :value="locale"
-                  v-for="locale in $i18n.availableLocales"
-                  :key="locale"
-                >
-                  {{ locales[locale].name ?? locale }}
-                </option>
-              </select>
-            </FormWidget></template
-          >
+            <FormSelect v-model="$i18n.locale" :before="faEarthAmericas">
+              <option
+                :value="locale"
+                v-for="locale in $i18n.availableLocales"
+                :key="locale"
+              >
+                {{ locales[locale].name ?? locale }}
+              </option>
+            </FormSelect>
+          </template>
         </UiKeyValueRow>
       </UiKeyValueList>
     </UiCard>
@@ -178,6 +176,7 @@ import TitleBar from "@/components/TitleBar.vue";
 import UiCard from "@/components/ui/UiCard.vue";
 import UiKeyValueList from "@/components/ui/UiKeyValueList.vue";
 import UiKeyValueRow from "@/components/ui/UiKeyValueRow.vue";
+import FormSelect from "@/components/form/FormSelect.vue";
 
 const xoLiteVersion = XO_LITE_VERSION;
 const xoLiteGitHead = XO_LITE_GIT_HEAD;

--- a/@xen-orchestra/lite/src/views/settings/SettingsView.vue
+++ b/@xen-orchestra/lite/src/views/settings/SettingsView.vue
@@ -135,18 +135,20 @@
     </UiCard>
     <UiCard class="group">
       <UiCardTitle>{{ $t("language") }}</UiCardTitle>
-      <UiKeyValueList class="full-length">
+      <UiKeyValueList>
         <UiKeyValueRow>
           <template #value>
-            <FormSelect v-model="$i18n.locale" :before="faEarthAmericas">
-              <option
-                :value="locale"
-                v-for="locale in $i18n.availableLocales"
-                :key="locale"
-              >
-                {{ locales[locale].name ?? locale }}
-              </option>
-            </FormSelect>
+            <FormWidget class="full-length" :before="faEarthAmericas">
+              <select v-model="$i18n.locale">
+                <option
+                  :value="locale"
+                  v-for="locale in $i18n.availableLocales"
+                  :key="locale"
+                >
+                  {{ locales[locale].name ?? locale }}
+                </option>
+              </select>
+            </FormWidget>
           </template>
         </UiKeyValueRow>
       </UiKeyValueList>
@@ -176,7 +178,6 @@ import TitleBar from "@/components/TitleBar.vue";
 import UiCard from "@/components/ui/UiCard.vue";
 import UiKeyValueList from "@/components/ui/UiKeyValueList.vue";
 import UiKeyValueRow from "@/components/ui/UiKeyValueRow.vue";
-import FormSelect from "@/components/form/FormSelect.vue";
 
 const xoLiteVersion = XO_LITE_VERSION;
 const xoLiteGitHead = XO_LITE_GIT_HEAD;


### PR DESCRIPTION
### Description

Rewrite `FormInputWrapper` and update `FormInput` to match Figma design.

Slotted input will change color according to passed `warning` and/or `error` message.

### Screenshot

![FormInputWrapper](https://github.com/vatesfr/xen-orchestra/assets/19408/f0509074-a230-44b4-abc6-3e96f1decaca)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
