### PR TITLE
feat(esxi): improve vmware import reliability

### DIFF
--- a/@xen-orchestra/vmware-explorer/VhdEsxiCowd.mjs
+++ b/@xen-orchestra/vmware-explorer/VhdEsxiCowd.mjs
@@ -48,7 +48,7 @@ export default class VhdEsxiCowd extends VhdAbstract {
 
     // depending on the paramters we also look into the parent data
     return (
-      this.#grainDirectory.readInt32LE(blockId * 4) !== 0 ||
+      this.#grainDirectory.readUInt32LE(blockId * 4) !== 0 ||
       (this.#lookMissingBlockInParent && this.#parentVhd.containsBlock(blockId))
     )
   }
@@ -61,14 +61,14 @@ export default class VhdEsxiCowd extends VhdAbstract {
     const buffer = await this.#read(0, 2048)
 
     strictEqual(buffer.slice(0, 4).toString('ascii'), 'COWD')
-    strictEqual(buffer.readInt32LE(4), 1) // version
-    strictEqual(buffer.readInt32LE(8), 3) // flags
-    const numSectors = buffer.readInt32LE(12)
-    const grainSize = buffer.readInt32LE(16)
+    strictEqual(buffer.readUInt32LE(4), 1) // version
+    strictEqual(buffer.readUInt32LE(8), 3) // flags
+    const numSectors = buffer.readUInt32LE(12)
+    const grainSize = buffer.readUInt32LE(16)
     strictEqual(grainSize, 1) // 1 grain should be 1 sector long
-    strictEqual(buffer.readInt32LE(20), 4) // grain directory position in sectors
+    strictEqual(buffer.readUInt32LE(20), 4) // grain directory position in sectors
 
-    const nbGrainDirectoryEntries = buffer.readInt32LE(24)
+    const nbGrainDirectoryEntries = buffer.readUInt32LE(24)
     strictEqual(nbGrainDirectoryEntries, Math.ceil(numSectors / 4096))
     const size = numSectors * 512
     // a grain directory entry contains the address of a grain table
@@ -90,7 +90,7 @@ export default class VhdEsxiCowd extends VhdAbstract {
   // we're lucky : a grain address can address exacty a full block
   async readBlock(blockId) {
     notEqual(this.#grainDirectory, undefined, 'grainDirectory is not loaded')
-    const sectorOffset = this.#grainDirectory.readInt32LE(blockId * 4)
+    const sectorOffset = this.#grainDirectory.readUInt32LE(blockId * 4)
 
     const buffer = (await this.#parentVhd.readBlock(blockId)).buffer
 
@@ -137,7 +137,7 @@ export default class VhdEsxiCowd extends VhdAbstract {
     }
 
     for (let i = 0; i < graintable.length / 4; i++) {
-      const grainOffset = graintable.readInt32LE(i * 4)
+      const grainOffset = graintable.readUInt32LE(i * 4)
       if (grainOffset === 0) {
         // the content from parent : it is already in buffer
         await changeRange()

--- a/@xen-orchestra/vmware-explorer/VhdEsxiRaw.mjs
+++ b/@xen-orchestra/vmware-explorer/VhdEsxiRaw.mjs
@@ -199,6 +199,14 @@ export default class VhdEsxiRaw extends VhdAbstract {
     )
     clearInterval(progress)
   }
+
+  rawContent() {
+    return this.#esxi.download(this.#datastore, this.#path).then(res => {
+      const stream = res.body
+      stream.length = this.footer.currentSize
+      return stream
+    })
+  }
 }
 
 /* eslint-enable no-console */

--- a/@xen-orchestra/vmware-explorer/VhdEsxiRaw.mjs
+++ b/@xen-orchestra/vmware-explorer/VhdEsxiRaw.mjs
@@ -1,7 +1,7 @@
 import _computeGeometryForSize from 'vhd-lib/_computeGeometryForSize.js'
 import { createFooter, createHeader } from 'vhd-lib/_createFooterHeader.js'
 import { DISK_TYPES, FOOTER_SIZE } from 'vhd-lib/_constants.js'
-import { readChunk } from '@vates/read-chunk'
+import { readChunkStrict, skipStrict } from '@vates/read-chunk'
 import { Task } from '@vates/task'
 import { unpackFooter, unpackHeader } from 'vhd-lib/Vhd/_utils.js'
 import { VhdAbstract } from 'vhd-lib'
@@ -20,6 +20,10 @@ export default class VhdEsxiRaw extends VhdAbstract {
   #bat
   #header
   #footer
+
+  #streamOffset = 0
+  #stream
+  #reading = false
 
   static async open(esxi, datastore, path, opts) {
     const vhd = new VhdEsxiRaw(esxi, datastore, path, opts)
@@ -64,12 +68,65 @@ export default class VhdEsxiRaw extends VhdAbstract {
     return this.#bat.has(blockId)
   }
 
-  async readBlock(blockId) {
+  async #readChunk(start, length) {
+    if (this.#reading) {
+      throw new Error('reading must be done sequentially')
+    }
+    try {
+      this.#reading = true
+      if (this.#stream !== undefined) {
+        // stream is too far ahead or to far behind
+        if (this.#streamOffset > start || this.#streamOffset + VHD_BLOCK_LENGTH < start) {
+          this.#stream.destroy()
+          this.#stream = undefined
+          this.#streamOffset = 0
+        }
+      }
+      // no stream
+      if (this.#stream === undefined) {
+        const end = this.footer.currentSize - 1
+        const res = await this.#esxi.download(this.#datastore, this.#path, `${start}-${end}`)
+        this.#stream = res.body
+        this.#streamOffset = start
+      }
+
+      // stream a little behind
+      if (this.#streamOffset < start) {
+        await skipStrict(this.#stream, start - this.#streamOffset)
+        this.#streamOffset = start
+      }
+
+      // really read data
+      this.#streamOffset += length
+      const data = await readChunkStrict(this.#stream, length)
+      return data
+    } catch (error) {
+      error.start = start
+      error.length = length
+      error.streamLength = this.footer.currentSize
+      this.#stream?.destroy()
+      this.#stream = undefined
+      this.#streamOffset = 0
+      throw error
+    } finally {
+      this.#reading = false
+    }
+  }
+
+  async #readBlock(blockId) {
     const start = blockId * VHD_BLOCK_LENGTH
-    const end = (blockId + 1) * VHD_BLOCK_LENGTH - 1
+    let length = VHD_BLOCK_LENGTH
+    let partial = false
+    if (start + length > this.footer.currentSize) {
+      length = this.footer.currentSize - start
+      partial = true
+    }
 
-    const data = await (await this.#esxi.download(this.#datastore, this.#path, `${start}-${end}`)).buffer()
+    let data = await this.#readChunk(start, length)
 
+    if (partial) {
+      data = Buffer.concat([data, Buffer.alloc(VHD_BLOCK_LENGTH - data.length)])
+    }
     const bitmap = Buffer.alloc(512, 255)
     return {
       id: blockId,
@@ -79,28 +136,44 @@ export default class VhdEsxiRaw extends VhdAbstract {
     }
   }
 
+  async readBlock(blockId) {
+    let tries = 5
+    let lastError
+    while (tries > 0) {
+      try {
+        const res = await this.#readBlock(blockId)
+        return res
+      } catch (error) {
+        lastError = error
+        lastError.blockId = blockId
+        console.warn('got error , will retry in 2seconds', lastError)
+      }
+      await new Promise(resolve => setTimeout(() => resolve(), 2000))
+      tries--
+    }
+
+    throw lastError
+  }
+
   // this will read all the disk once to check which block contains data, it can take a long time to execute depending on the network speed
   async readBlockAllocationTable() {
     if (!this.#thin) {
       // fast path : is we do not use thin mode, the BAT is full
       return
     }
-    const res = await this.#esxi.download(this.#datastore, this.#path)
-    const length = res.headers.get('content-length')
-    const stream = res.body
     const empty = Buffer.alloc(VHD_BLOCK_LENGTH, 0)
     let pos = 0
     this.#bat = new Set()
-    let nextChunkLength = Math.min(VHD_BLOCK_LENGTH, length)
-    Task.set('total', length / VHD_BLOCK_LENGTH)
+    let nextChunkLength = Math.min(VHD_BLOCK_LENGTH, this.footer.currentSize)
+    Task.set('total', this.footer.currentSize / VHD_BLOCK_LENGTH)
     const progress = setInterval(() => {
-      Task.set('progress', Math.round((pos * 100) / length))
-      console.log('reading blocks', pos / VHD_BLOCK_LENGTH, '/', length / VHD_BLOCK_LENGTH)
+      Task.set('progress', Math.round((pos * 100) / this.footer.currentSize))
+      console.log('reading blocks', pos / VHD_BLOCK_LENGTH, '/', this.footer.currentSize / VHD_BLOCK_LENGTH)
     }, 30 * 1000)
 
     while (nextChunkLength > 0) {
       try {
-        const chunk = await readChunk(stream, nextChunkLength)
+        const chunk = await this.#readChunk(pos, nextChunkLength)
         let isEmpty
         if (nextChunkLength === VHD_BLOCK_LENGTH) {
           isEmpty = empty.equals(chunk)
@@ -112,13 +185,18 @@ export default class VhdEsxiRaw extends VhdAbstract {
           this.#bat.add(pos / VHD_BLOCK_LENGTH)
         }
         pos += VHD_BLOCK_LENGTH
-        nextChunkLength = Math.min(VHD_BLOCK_LENGTH, length - pos)
+        nextChunkLength = Math.min(VHD_BLOCK_LENGTH, this.footer.currentSize - pos)
       } catch (error) {
         clearInterval(progress)
         throw error
       }
     }
-    console.log('BAT reading done, remaining  ', this.#bat.size, '/', Math.ceil(length / VHD_BLOCK_LENGTH))
+    console.log(
+      'BAT reading done, remaining  ',
+      this.#bat.size,
+      '/',
+      Math.ceil(this.footer.currentSize / VHD_BLOCK_LENGTH)
+    )
     clearInterval(progress)
   }
 }

--- a/@xen-orchestra/vmware-explorer/VhdEsxiRaw.mjs
+++ b/@xen-orchestra/vmware-explorer/VhdEsxiRaw.mjs
@@ -49,10 +49,10 @@ export default class VhdEsxiRaw extends VhdAbstract {
 
     this.#header = unpackHeader(createHeader(length / VHD_BLOCK_LENGTH))
     const geometry = _computeGeometryForSize(length)
-    const actualSize = geometry.actualSize
 
     this.#footer = unpackFooter(
-      createFooter(actualSize, Math.floor(Date.now() / 1000), geometry, FOOTER_SIZE, DISK_TYPES.DYNAMIC)
+      // length can be smaller than disk capacity due to alignment to head/cylinder/sector
+      createFooter(length, Math.floor(Date.now() / 1000), geometry, FOOTER_SIZE, DISK_TYPES.DYNAMIC)
     )
   }
 

--- a/@xen-orchestra/vmware-explorer/package.json
+++ b/@xen-orchestra/vmware-explorer/package.json
@@ -4,11 +4,12 @@
   "version": "0.2.3",
   "name": "@xen-orchestra/vmware-explorer",
   "dependencies": {
-    "@vates/task": "^0.2.0",
+    "@vates/node-vsphere-soap": "^1.0.0",
     "@vates/read-chunk": "^1.1.1",
+    "@vates/task": "^0.2.0",
+    "@xen-orchestra/log": "^0.6.0",
     "lodash": "^4.17.21",
     "node-fetch": "^3.3.0",
-    "@vates/node-vsphere-soap": "^1.0.0",
     "vhd-lib": "^4.5.0"
   },
   "engines": {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -38,6 +38,7 @@
 - @vates/nbd-client major
 - @vates/node-vsphere-soap major
 - @xen-orchestra/backups minor
+- @xen-orchestra/vmware-explorer minor
 - @xen-orchestra/xapi major
 - complex-matcher patch
 - xen-api patch


### PR DESCRIPTION
### Description

- retry downloading on failure
- handle unaligned last block 
- keep original size instead of geometry size
- reuse stream when possible on vhdesxiraw
- add a fast path when importing a  vm without snapshot in thick mode

fixes https://help.vates.fr/#ticket/zoom/14561

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
