### PR TITLE
feat(lite/component): new component FormSection

### DIFF
--- a/@xen-orchestra/lite/src/components/form/FormSection.vue
+++ b/@xen-orchestra/lite/src/components/form/FormSection.vue
@@ -1,0 +1,92 @@
+<template>
+  <div :class="{ collapsible }" class="form-section">
+    <fieldset class="fieldset">
+      <legend class="legend" @click="toggleCollapse">
+        {{ label }}
+        <UiIcon :icon="icon" class="collapse-icon" />
+      </legend>
+      <div v-if="!isCollapsed" class="content">
+        <slot />
+      </div>
+    </fieldset>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import UiIcon from "@/components/ui/icon/UiIcon.vue";
+import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
+import { useVModel, whenever } from "@vueuse/core";
+import { computed } from "vue";
+
+const props = defineProps<{
+  label: string;
+  collapsible?: boolean;
+  collapsed?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (event: "update:collapsed", value: boolean): void;
+}>();
+
+const isCollapsed = useVModel(props, "collapsed", emit);
+
+const toggleCollapse = () => {
+  if (props.collapsible) {
+    isCollapsed.value = !isCollapsed.value;
+  }
+};
+
+const icon = computed(() => {
+  if (!props.collapsible) {
+    return undefined;
+  }
+
+  return isCollapsed.value ? faChevronDown : faChevronUp;
+});
+
+whenever(
+  () => !props.collapsible,
+  () => (isCollapsed.value = false)
+);
+</script>
+
+<style lang="postcss" scoped>
+.collapsible {
+  padding: 1rem 1.5rem;
+  background-color: var(--background-color-extra-blue);
+  border-radius: 0.8rem;
+}
+
+.fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.legend {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--color-extra-blue-base);
+  border: none;
+  border-bottom: 1px solid var(--color-extra-blue-base);
+  width: 100%;
+  font-size: 2rem;
+  font-weight: 500;
+  padding-bottom: 1rem;
+
+  .collapsible & {
+    color: var(--color-blue-scale-100);
+    padding-bottom: 0;
+    cursor: pointer;
+  }
+}
+
+.content {
+  padding: 1.5rem 0;
+}
+
+.collapse-icon {
+  color: var(--color-extra-blue-base);
+}
+</style>

--- a/@xen-orchestra/lite/src/stories/form-section.story.vue
+++ b/@xen-orchestra/lite/src/stories/form-section.story.vue
@@ -1,0 +1,24 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties }"
+    :params="[
+      prop('label').required().str().preset('Install settings').widget(),
+      prop('collapsible').bool().widget(),
+      model('collapsed').prop((p) => p.bool()),
+      slot(),
+    ]"
+  >
+    <FormSection v-bind="properties">
+      <FormInput />
+    </FormSection>
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from "@/components/component-story/ComponentStory.vue";
+import FormInput from "@/components/form/FormInput.vue";
+import FormSection from "@/components/form/FormSection.vue";
+import { model, prop, slot } from "@/libs/story/story-param";
+</script>
+
+<style lang="postcss" scoped></style>


### PR DESCRIPTION
### Description

Created new component: `FormSection`

Can take a `collapsible` prop in conjunction of a `collapsed` prop.

If `collapsible` is set to `true`, the style is changed and clicking the section header will toggle the content visibility.

Collapse status updates are sent via the `update:collapsed` event.

This allows to use `collapsed` as a _model_ (ie. `<FormSection collapsible v-model:collapsed="collapsed">`)

### Screenshot

![Form Section](https://github.com/vatesfr/xen-orchestra/assets/19408/c89e2e98-e93a-426f-9513-81886b1c8645)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
