### PR TITLE
feat(lite/stories): identify models with an icon and tooltip

### DIFF
--- a/@xen-orchestra/lite/src/components/component-story/StoryPropParams.vue
+++ b/@xen-orchestra/lite/src/components/component-story/StoryPropParams.vue
@@ -29,6 +29,13 @@
       >
         <th class="name">
           {{ param.getFullName() }}
+          <sup
+            v-if="param.isVModel()"
+            v-tooltip="`[Model] Can be used with ${param.getVModelDirective()}`"
+            class="v-model-indicator"
+          >
+            <UiIcon :icon="faRepeat" />
+          </sup>
         </th>
         <td>
           <CodeHighlight :code="param.getTypeLabel()" />
@@ -86,8 +93,9 @@ import UiIcon from "@/components/ui/icon/UiIcon.vue";
 import UiModal from "@/components/ui/UiModal.vue";
 import useModal from "@/composables/modal.composable";
 import useSortedCollection from "@/composables/sorted-collection.composable";
+import { vTooltip } from "@/directives/tooltip.directive";
 import type { PropParam } from "@/libs/story/story-param";
-import { faClose } from "@fortawesome/free-solid-svg-icons";
+import { faClose, faRepeat } from "@fortawesome/free-solid-svg-icons";
 import { useVModel } from "@vueuse/core";
 import { toRef } from "vue";
 
@@ -172,5 +180,9 @@ const {
     opacity: 1;
     color: var(--color-green-infra-base);
   }
+}
+
+.v-model-indicator {
+  color: var(--color-green-infra-base);
 }
 </style>

--- a/@xen-orchestra/lite/src/libs/story/story-param.ts
+++ b/@xen-orchestra/lite/src/libs/story/story-param.ts
@@ -101,9 +101,23 @@ abstract class BaseParam {
 export class PropParam extends mixin(BaseParam, WithWidget, WithType) {
   #isRequired = false;
   #defaultValue: any;
+  #isVModel: boolean;
+
+  constructor(name: string, isVModel = false) {
+    super(name);
+    this.#isVModel = isVModel;
+  }
 
   isRequired() {
     return this.#isRequired;
+  }
+
+  isVModel() {
+    return this.#isVModel;
+  }
+
+  getVModelDirective() {
+    return this.name === "modelValue" ? "v-model" : `v-model:${this.name}`;
   }
 
   getNamePrefix() {
@@ -337,7 +351,7 @@ export class ModelParam extends BaseParam {
 
   constructor(name: string) {
     super(name);
-    this.#prop = new PropParam(name);
+    this.#prop = new PropParam(name, true);
     this.#event = new EventParam(name, true).args({
       value: "unknown",
     });


### PR DESCRIPTION
### Description

When a prop is a model, add an indicator (icon + tooltip) to identify it as such.

### Screenshot

![Story model identification](https://github.com/vatesfr/xen-orchestra/assets/19408/fe5c68dd-cd24-45dd-be52-4abaf5ef804d)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
