### PR TITLE
feat(backup): make remote immutable

### DIFF
--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -35,6 +35,8 @@ export const DIR_XO_CONFIG_BACKUPS = 'xo-config-backups'
 
 export const DIR_XO_POOL_METADATA_BACKUPS = 'xo-pool-metadata-backups'
 
+const IMMUTABILTY_METADATA_FILENAME = '/immutability.json'
+
 const { debug, warn } = createLogger('xo:backups:RemoteAdapter')
 
 const compareTimestamp = (a, b) => a.timestamp - b.timestamp
@@ -749,10 +751,37 @@ export class RemoteAdapter {
   }
 
   async readVmBackupMetadata(path) {
+    let json
+    let isImmutable = false
+    let remoteIsImmutable = false
+    // if the remote is immutable, check if this metadatas are also immutables
+    try {
+      // this file is not encrypted
+      await this._handler._readFile(IMMUTABILTY_METADATA_FILENAME)
+      remoteIsImmutable = true
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        throw error
+      }
+    }
+
+    try {
+      // this will trigger an EPERM error if the file is immutable
+      json = await this.handler.readFile(path, { flag: 'r+' })
+      // s3 handler don't respect flags
+    } catch (err) {
+      // retry without triggerring immutbaility check ,only on immutable remote
+      if (err.code === 'EPERM' && remoteIsImmutable) {
+        isImmutable = true
+        json = await this._handler.readFile(path, { flag: 'r' })
+      } else {
+        throw err
+      }
+    }
     // _filename is a private field used to compute the backup id
     //
     // it's enumerable to make it cacheable
-    const metadata = { ...JSON.parse(await this._handler.readFile(path)), _filename: path }
+    const metadata = { ...JSON.parse(json), _filename: path, isImmutable }
 
     // backups created on XenServer < 7.1 via JSON in XML-RPC transports have boolean values encoded as integers, which make them unusable with more recent XAPIs
     if (typeof metadata.vm.is_a_template === 'number') {

--- a/@xen-orchestra/backups/formatVmBackups.mjs
+++ b/@xen-orchestra/backups/formatVmBackups.mjs
@@ -31,6 +31,7 @@ function formatVmBackup(backup) {
           }),
 
     id: backup.id,
+    isImmutable: backup.isImmutable,
     jobId: backup.jobId,
     mode: backup.mode,
     scheduleId: backup.scheduleId,

--- a/@xen-orchestra/immutable-backups/.USAGE.md
+++ b/@xen-orchestra/immutable-backups/.USAGE.md
@@ -1,0 +1,10 @@
+### make a remote immutable
+
+launch the `xo-immutable-remote` command. The configuration is stored in the config file.
+This script must be kept running to make file immutable reliably.
+
+### make file mutable
+
+launch the `xo-lift-remote-immutability` cli. The configuration is stored in the config file .
+
+If the config file have a `liftEvery`, this script will contiue to run and check regularly if there are files to update.

--- a/@xen-orchestra/immutable-backups/.npmignore
+++ b/@xen-orchestra/immutable-backups/.npmignore
@@ -1,0 +1,1 @@
+../../scripts/npmignore

--- a/@xen-orchestra/immutable-backups/README.md
+++ b/@xen-orchestra/immutable-backups/README.md
@@ -1,0 +1,31 @@
+<!-- DO NOT EDIT MANUALLY, THIS FILE HAS BEEN GENERATED -->
+
+# @xen-orchestra/immutable-backups
+
+## Usage
+
+### make a remote immutable
+
+launch the `xo-immutable-remote` command. The configuration is stored in the config file.
+This script must be kept running to make file immutable reliably.
+
+### make file mutable
+
+launch the `xo-lift-remote-immutability` cli. The configuration is stored in the config file .
+
+If the config file have a `liftEvery`, this script will contiue to run and check regularly if there are files to update.
+
+## Contributions
+
+Contributions are _very_ welcomed, either on the documentation or on
+the code.
+
+You may:
+
+- report any [issue](https://github.com/vatesfr/xen-orchestra/issues)
+  you've encountered;
+- fork and create a pull request.
+
+## License
+
+[AGPL-3.0-or-later](https://spdx.org/licenses/AGPL-3.0-or-later) © [Vates SAS](https://vates.fr)

--- a/@xen-orchestra/immutable-backups/_cleanXoCache.mjs
+++ b/@xen-orchestra/immutable-backups/_cleanXoCache.mjs
@@ -1,0 +1,10 @@
+import fs from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import isBackupMetadata from './isBackupMetadata.mjs'
+
+export default async path => {
+  if (isBackupMetadata(path)) {
+    // snipe vm metadata cache to force XO to update it
+    await fs.unlink(join(dirname(path), 'cache.json.gz'))
+  }
+}

--- a/@xen-orchestra/immutable-backups/_isInVhdDirectory.mjs
+++ b/@xen-orchestra/immutable-backups/_isInVhdDirectory.mjs
@@ -1,0 +1,4 @@
+import { dirname } from 'node:path'
+
+// check if we are handling file directly under a vhd directory ( bat, headr, footer,..)
+export default path => dirname(path).endsWith('.vhd')

--- a/@xen-orchestra/immutable-backups/_loadConfig.mjs
+++ b/@xen-orchestra/immutable-backups/_loadConfig.mjs
@@ -1,0 +1,46 @@
+import { load } from 'app-conf'
+import { homedir } from 'os'
+import { join } from 'node:path'
+import ms from 'ms'
+
+const APP_NAME = 'xo-immutable-backups'
+const APP_DIR = new URL('.', import.meta.url).pathname
+
+export default async function loadConfig() {
+  const config = await load(APP_NAME, {
+    appDir: APP_DIR,
+    ignoreUnknownFormats: true,
+  })
+  if (config.remotes === undefined || config.remotes?.length < 1) {
+    throw new Error(
+      'No remotes are configured in the config file, please add at least one [remotes.<remoteid>]  with a root property pointing to the absolute path of the remote to watch'
+    )
+  }
+  if (config.liftEvery) {
+    config.liftEvery = ms(config.liftEvery)
+  }
+  for (const [remoteId, { indexPath, immutabilityDuration, root }] of Object.entries(config.remotes)) {
+    if (!root) {
+      throw new Error(
+        `Remote ${remoteId} don't have a root property,containing the absolute path to the root of a backup repository `
+      )
+    }
+    if (!immutabilityDuration) {
+      throw new Error(
+        `Remote ${remoteId} don't have a immutabilityDuration property to indicate the minimal duration the backups should be  protected by immutability `
+      )
+    }
+    if (ms(immutabilityDuration) < ms('1d')) {
+      throw new Error(
+        `Remote ${remoteId} immutability duration is smaller than the minimum allowed (1d), current : ${immutabilityDuration}`
+      )
+    }
+    if (!indexPath) {
+      const basePath = indexPath ?? process.env.XDG_DATA_HOME ?? join(homedir(), '.local', 'share')
+      const immutabilityIndexPath = join(basePath, APP_NAME, remoteId)
+      config.remotes[remoteId].indexPath = immutabilityIndexPath
+    }
+    config.remotes[remoteId].immutabilityDuration = ms(immutabilityDuration)
+  }
+  return config
+}

--- a/@xen-orchestra/immutable-backups/config.toml
+++ b/@xen-orchestra/immutable-backups/config.toml
@@ -1,0 +1,14 @@
+
+# how often does the lift immutability script will run to check if 
+# some files need to be made mutable 
+liftEvery =  1h
+
+# you can add as many remote as you want, if you change the id ( here : remote1)
+#[remotes.remote1]
+#root = "/mnt/ssd/vhdblock/" # the absolute path of the root of the backup repository
+#immutabilityDuration = 7d # mandatory
+# optional, default value is false will scan and update the index on start, can be expensive
+#rebuildIndexOnStart = true 
+
+# the index path is optional, default in XDG_DATA_HOME, or if this is not set, in ~/.local/share
+#indexPath = "/var/lib/" # will add automatically the application name immutable-backup 

--- a/@xen-orchestra/immutable-backups/directory.mjs
+++ b/@xen-orchestra/immutable-backups/directory.mjs
@@ -1,0 +1,21 @@
+import execa from 'execa'
+import { unindexFile, indexFile } from './fileIndex.mjs'
+
+export async function makeImmutable(dirPath, immutabilityCachePath) {
+  if (immutabilityCachePath) {
+    await indexFile(dirPath, immutabilityCachePath)
+  }
+  await execa('chattr', ['+i', '-R', dirPath])
+}
+
+export async function liftImmutability(dirPath, immutabilityCachePath) {
+  if (immutabilityCachePath) {
+    await unindexFile(dirPath, immutabilityCachePath)
+  }
+  await execa('chattr', ['-i', '-R', dirPath])
+}
+
+export async function isImmutable(path) {
+  const { stdout } = await execa('lsattr', ['-d', path])
+  return stdout[4] === 'i'
+}

--- a/@xen-orchestra/immutable-backups/directory.spec.mjs
+++ b/@xen-orchestra/immutable-backups/directory.spec.mjs
@@ -1,0 +1,31 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { tmpdir } from 'node:os'
+import * as Directory from './directory.mjs'
+import { rimraf } from 'rimraf'
+
+describe('immutable-backups/file', async () => {
+  it('really lock a directory', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'immutable-backups-tests'))
+    const dataDir = path.join(dir, 'data')
+    await fs.mkdir(dataDir)
+    const immutDir = path.join(dir, '.immutable')
+    const filePath = path.join(dataDir, 'test')
+    await fs.writeFile(filePath, 'data')
+    await Directory.makeImmutable(dataDir, immutDir)
+    await assert.rejects(() => fs.writeFile(filePath, 'data'))
+    await assert.rejects(() => fs.appendFile(filePath, 'data'))
+    await assert.rejects(() => fs.unlink(filePath))
+    await assert.rejects(() => fs.rename(filePath, filePath + 'copy'))
+    await assert.rejects(() => fs.writeFile(path.join(dataDir, 'test2'), 'data'))
+    await assert.rejects(() => fs.rename(dataDir, dataDir + 'copy'))
+    await Directory.liftImmutability(dataDir, immutDir)
+    await fs.writeFile(filePath, 'data')
+    await fs.appendFile(filePath, 'data')
+    await fs.unlink(filePath)
+    await fs.rename(dataDir, dataDir + 'copy')
+    await rimraf(dir)
+  })
+})

--- a/@xen-orchestra/immutable-backups/doc.md
+++ b/@xen-orchestra/immutable-backups/doc.md
@@ -1,0 +1,114 @@
+# Imutability
+
+the goal is to make a remote that XO can write, but not modify during the immutability duration set on the remote. That way, it's not possible for XO to delete or encrypt any backup during this period. It protects your backup agains ransomware, at least as long as the attacker does not have a root access to the remote server.
+
+We target `governance` type of immutability, **the local root account of the remote server will be able to lift immutability**.
+
+We use the file system capabilities, they are tested on the protection process start.
+
+It is compatible with encryption at rest made by XO.
+
+## Prerequisites
+
+The commands must be run as root on the remote, or by a user with the `CAP_LINUX_IMMUTABLE` capability . On start, the protect process writes into the remote `imutability.json` file its status and the immutability duration.
+
+the `chattr` and `lsattr` should be installed on the system
+
+## Configuring
+
+this package uses app-conf to store its config. The application name is `xo-immutable-backup`. A sample config file is provided in this package.
+
+## Making a file immutable
+
+when marking a file or a folder immutable, it create an alias file in the `<indexPath>/<DayOfFileCreation>/<sha256(fullpath)>`.
+
+`indexPath` can be defined in the config file, otherwise `XDG_HOME` is used. If not available it goes to `~/.local/share`
+
+This index is used when lifting the immutability of the remote, it will only look at the old enough `<indexPath>/<DayOfFileCreation>/` folders.
+
+## Real time protecting
+
+On start, the watcher will create the index if it does not exists.
+It will also do a checkup to ensure immutability could work on this remote and handle the easiest issues.
+
+The watching process depends on the backup type, since we don't want to make temporary files and cache immutable.
+
+It won't protect files during upload, only when the files have been completly written on disk. Real time, in this case, means "protecting critical files as soon as possible after they are uploaded"
+
+This can be alleviated by :
+
+- Coupling immutability with encryption to ensure the file is not modified
+- Making health check to ensure the data are exactly as the snapshot data
+
+List of protected files :
+
+```js
+const PATHS = [
+  // xo configuration backupq
+  'xo-config-backups/*/*/data',
+  'xo-config-backups/*/*/data.json',
+  'xo-config-backups/*/*/metadata.json',
+  // pool backupq
+  'xo-pool-metadata-backups/*/metadata.json',
+  'xo-pool-metadata-backups/*/data',
+  // vm backups , xo-vm-backups/<vmuuid>/
+  'xo-vm-backups/*/*.json',
+  'xo-vm-backups/*/*.xva',
+  'xo-vm-backups/*/*.xva.checksum',
+  // xo-vm-backups/<vmuuid>/vdis/<jobid>/<vdiUuid>
+  'xo-vm-backups/*/vdis/*/*/*.vhd', // can be an alias or a vhd file
+  // for vhd directory :
+  'xo-vm-backups/*/vdis/*/*/data/*.vhd/bat',
+  'xo-vm-backups/*/vdis/*/*/data/*.vhd/header',
+  'xo-vm-backups/*/vdis/*/*/data/*.vhd/footer',
+]
+```
+
+## Releasing protection on old enough files on a remote
+
+the watcher will periodically check if some file must by unlocked
+
+## Troubleshooting
+
+### some files are still locked
+
+add the `rebuildIndexOnStart` option to the config file
+
+### make remote fully mutable again
+
+- Update the immutability setting with a 0 duration
+- launch the `liftProtection` cli.
+- remove the `protectRemotes` service
+
+### increasing the immutability duration
+
+this will prolong immutable file, but won't protect files that are already out of immutability
+
+### reducing the immutability duration
+
+change the setting, and launch the `liftProtection` cli , or wait for next planed execution
+
+### why are my incremental backups not marked as protected in XO ?
+
+are not marked as protected in XO ?
+
+For incremental backups to be marked as protected in XO, the entire chain must be under protection. To ensure at least 7 days of backups are protected, you need to set the immutability duration and retention at 14 days, the full backup interval at 7 days
+
+That means that if the last backup chain is complete ( 7 backup ) it is completely under protection, and if not, the precedent chain is also under protection. K are key backups, and are delta
+
+```
+Kd Kdddddd Kdddddd K #  8 backups protected, 2 chains
+K Kdddddd Kdddddd Kd #  9 backups protected, 2 chains
+ Kdddddd Kdddddd Kdd # 10 backups protected, 2 chains
+ Kddddd Kdddddd Kddd # 11 backups protected, 2 chains
+ Kdddd Kdddddd Kdddd # 12 backups protected, 2 chains
+ Kddd Kdddddd Kddddd # 13 backups protected, 2 chains
+ Kdd Kdddddd Kdddddd #  7 backups protected, 1 chain since precedent full is now mutable
+Kd Kdddddd Kdddddd K #  8 backups protected, 2 chains
+```
+
+### Why doesn't the protect process start ?
+
+- it should be run as root or by a user with the `CAP_LINUX_IMMUTABLE` capability
+- the underlying file system should support immutability, especially the `chattr` and `lsattr` command
+- logs are in journalctl

--- a/@xen-orchestra/immutable-backups/file.mjs
+++ b/@xen-orchestra/immutable-backups/file.mjs
@@ -1,0 +1,24 @@
+import execa from 'execa'
+import { unindexFile, indexFile } from './fileIndex.mjs'
+
+// this work only on linux like systems
+// this could work on windows : https://4sysops.com/archives/set-and-remove-the-read-only-file-attribute-with-powershell/
+
+export async function makeImmutable(path, immutabilityCachePath) {
+  if (immutabilityCachePath) {
+    await indexFile(path, immutabilityCachePath)
+  }
+  await execa('chattr', ['+i', path])
+}
+
+export async function liftImmutability(filePath, immutabilityCachePath) {
+  if (immutabilityCachePath) {
+    await unindexFile(filePath, immutabilityCachePath)
+  }
+  await execa('chattr', ['-i', filePath])
+}
+
+export async function isImmutable(path) {
+  const { stdout } = await execa('lsattr', ['-d', path])
+  return stdout[4] === 'i'
+}

--- a/@xen-orchestra/immutable-backups/file.spec.mjs
+++ b/@xen-orchestra/immutable-backups/file.spec.mjs
@@ -1,0 +1,29 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import * as File from './file.mjs'
+import { tmpdir } from 'node:os'
+import { rimraf } from 'rimraf'
+
+describe('immutable-backups/file', async () => {
+  it('really lock a file', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'immutable-backups-tests'))
+    const immutDir = path.join(dir, '.immutable')
+    const filePath = path.join(dir, 'test.ext')
+    await fs.writeFile(filePath, 'data')
+    assert.strictEqual(await File.isImmutable(filePath), false)
+    await File.makeImmutable(filePath, immutDir)
+    assert.strictEqual(await File.isImmutable(filePath), true)
+    await assert.rejects(() => fs.writeFile(filePath, 'data'))
+    await assert.rejects(() => fs.appendFile(filePath, 'data'))
+    await assert.rejects(() => fs.unlink(filePath))
+    await assert.rejects(() => fs.rename(filePath, filePath + 'copy'))
+    await File.liftImmutability(filePath, immutDir)
+    assert.strictEqual(await File.isImmutable(filePath), false)
+    await fs.writeFile(filePath, 'data')
+    await fs.appendFile(filePath, 'data')
+    await fs.unlink(filePath)
+    await rimraf(dir)
+  })
+})

--- a/@xen-orchestra/immutable-backups/fileIndex.mjs
+++ b/@xen-orchestra/immutable-backups/fileIndex.mjs
@@ -1,0 +1,94 @@
+import { join } from 'node:path'
+import { createHash } from 'node:crypto'
+import fs from 'node:fs/promises'
+import { dirname } from 'path'
+function sha256(content) {
+  return createHash('sha256').update(content).digest('hex')
+}
+
+function formatDate(date) {
+  return date.toISOString().split('T')[0]
+}
+
+async function computeIndexFilePath(path, immutabilityIndexPath) {
+  const stat = await fs.stat(path)
+  const date = new Date(stat.birthtimeMs)
+  const day = formatDate(date)
+  const hash = sha256(path)
+  return join(immutabilityIndexPath, day, hash)
+}
+
+export async function indexFile(path, immutabilityIndexPath) {
+  const indexFilePath = await computeIndexFilePath(path, immutabilityIndexPath)
+  try {
+    await fs.writeFile(indexFilePath, path, { flag: 'wx' })
+  } catch (err) {
+    // missing dir: make it
+    if (err.code === 'ENOENT') {
+      await fs.mkdir(dirname(indexFilePath), { recursive: true })
+      await fs.writeFile(indexFilePath, path)
+    } else if (err.code === 'EPERM') {
+      // an immutable file alreay exist : not a problem if it contains the right target
+      const { size } = await fs.stat(indexFilePath)
+      if (size.length > 1024 * 1024) {
+        throw new Error(`Index file at ${indexFilePath} is too big, ${size} bytes `)
+      }
+      const existingContent = await fs.readFile(indexFilePath, { encoding: 'utf8' })
+      if (existingContent !== path) {
+        throw new Error(`Index file at ${indexFilePath}, should contains ${path}, but contains ${existingContent}`)
+      }
+      throw err
+    } else {
+      throw err
+    }
+  }
+  return indexFilePath
+}
+
+export async function unindexFile(path, immutabilityIndexPath) {
+  try {
+    const cacheFileName = await computeIndexFilePath(path, immutabilityIndexPath)
+    await fs.unlink(cacheFileName)
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw err
+    }
+  }
+}
+
+export async function* listOlderTargets(immutabilityCachePath, immutabilityDuration) {
+  // walk all dir by day until  the limit day
+  const limitDate = new Date(Date.now() - immutabilityDuration)
+
+  const limitDay = formatDate(limitDate)
+  const dir = await fs.opendir(immutabilityCachePath)
+  for await (const dirent of dir) {
+    if (dirent.isFile()) {
+      continue
+    }
+    // ensure we have a valid date
+    if (isNaN(new Date(dirent.name))) {
+      continue
+    }
+    // recent enough to be kept
+    if (dir.name >= limitDay) {
+      continue
+    }
+    const subDirPath = join(immutabilityDuration, dirent.name)
+    const subdir = await fs.opendir(subDirPath)
+    let nb = 0
+    for await (const hashFileEntry of dir) {
+      const entryFullPath = join(subDirPath, hashFileEntry.name)
+      const targetPath = await fs.readFile(entryFullPath, { encoding: 'utf8' })
+      yield {
+        index: entryFullPath,
+        target: targetPath,
+      }
+      nb++
+    }
+    // cleanup older folder
+    if (nb === 0) {
+      await fs.rmdir(subdir)
+    }
+  }
+}

--- a/@xen-orchestra/immutable-backups/isBackupMetadata.mjs
+++ b/@xen-orchestra/immutable-backups/isBackupMetadata.mjs
@@ -1,0 +1,1 @@
+export default path => path.match(/xo-vm-backups\/[^/]+\/[^/]+\.json$/)

--- a/@xen-orchestra/immutable-backups/liftProtection.mjs
+++ b/@xen-orchestra/immutable-backups/liftProtection.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises'
+import * as Directory from './directory.mjs'
+import { createLogger } from '@xen-orchestra/log'
+import { listOlderTargets } from './fileIndex.mjs'
+import cleanXoCache from './_cleanXoCache.mjs'
+import loadConfig from './_loadConfig.mjs'
+
+const { info, warn } = createLogger('xen-orchestra:immutable-backups:liftProtection')
+
+async function liftRemoteImmutability(immutabilityCachePath, immutabilityDuration) {
+  for await (const { index, target } of listOlderTargets(immutabilityCachePath, immutabilityDuration)) {
+    await Directory.liftImmutability(target, immutabilityCachePath)
+    await fs.unlink(index)
+    await cleanXoCache(target)
+  }
+}
+
+async function liftImmutability(remotes) {
+  for (const [remoteId, { indexPath, immutabilityDuration }] of Object.entries(remotes)) {
+    liftRemoteImmutability(indexPath, immutabilityDuration).catch(err =>
+      warn('error during watchRemote', { err, remoteId, indexPath, immutabilityDuration })
+    )
+  }
+}
+
+const { liftEvery, remotes } = await loadConfig()
+
+if (liftEvery > 0) {
+  info('setup watcher for immutability lifting')
+  setInterval(async () => {
+    liftImmutability(remotes)
+  }, liftEvery)
+} else {
+  liftImmutability(remotes)
+}

--- a/@xen-orchestra/immutable-backups/package.json
+++ b/@xen-orchestra/immutable-backups/package.json
@@ -1,0 +1,41 @@
+{
+  "private": true,
+  "name": "@xen-orchestra/immutable-backups",
+  "homepage": "https://github.com/vatesfr/xen-orchestra/tree/master/@xen-orchestra/immutable-backups",
+  "bugs": "https://github.com/vatesfr/xen-orchestra/issues",
+  "repository": {
+    "directory": "@xen-orchestra/immutable-backups",
+    "type": "git",
+    "url": "https://github.com/vatesfr/xen-orchestra.git"
+  },
+  "author": {
+    "name": "Vates SAS",
+    "url": "https://vates.fr"
+  },
+  "bin": {
+    "xo-immutable-remote": "./protectRemotes.mjs",
+    "xo-lift-remote-immutability": "./liftProtection.mjs"
+  },
+  "license": "AGPL-3.0-or-later",
+  "version": "0.0.0",
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "dependencies": {
+    "@vates/async-each": "^1.0.0",
+    "@xen-orchestra/backups": "^0.44.2",
+    "@xen-orchestra/log": "^0.6.0",
+    "app-conf": "^2.3.0",
+    "chokidar": "^3.5.3",
+    "execa": "^5.0.0",
+    "ms": "^2.1.3",
+    "vhd-lib": "^4.7.0"
+  },
+  "devDependencies": {
+    "rimraf": "^5.0.5",
+    "tap": "^18.6.1"
+  },
+  "scripts": {
+    "test-integration": "tap  *.integ.mjs"
+  }
+}

--- a/@xen-orchestra/immutable-backups/protectRemotes.mjs
+++ b/@xen-orchestra/immutable-backups/protectRemotes.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises'
+import * as File from './file.mjs'
+import * as Directory from './directory.mjs'
+import assert from 'node:assert'
+import { dirname, join, sep } from 'node:path'
+import { createLogger } from '@xen-orchestra/log'
+import chokidar from 'chokidar'
+import { indexFile } from './fileIndex.mjs'
+import cleanXoCache from './_cleanXoCache.mjs'
+import loadConfig from './_loadConfig.mjs'
+import isInVhdDirectory from './_isInVhdDirectory.mjs'
+const { debug, info, warn } = createLogger('xen-orchestra:immutable-backups:remote')
+
+async function test(remotePath, indexPath) {
+  await fs.readdir(remotePath)
+
+  const testPath = join(remotePath, '.test-immut')
+  // cleanup
+  try {
+    await File.liftImmutability(testPath, indexPath)
+    await fs.unlink(testPath)
+  } catch (err) {}
+  // can create , modify and delete a file
+  await fs.writeFile(testPath, `test immut ${new Date()}`)
+  await fs.writeFile(testPath, `test immut change 1 ${new Date()}`)
+  await fs.unlink(testPath)
+
+  // cannot modify or delete an immutable file
+  await fs.writeFile(testPath, `test immut ${new Date()}`)
+  await File.makeImmutable(testPath, indexPath)
+  await assert.rejects(fs.writeFile(testPath, `test immut change 2  ${new Date()}`), { code: 'EPERM' })
+  await assert.rejects(fs.unlink(testPath), { code: 'EPERM' })
+  // can modify and delete a file after lifting immutability
+  await File.liftImmutability(testPath, indexPath)
+
+  await fs.writeFile(testPath, `test immut change 3 ${new Date()}`)
+  await fs.unlink(testPath)
+}
+async function handleExistingFile(root, indexPath, path) {
+  try {
+    // a vhd block directory is completly immutable
+    if (isInVhdDirectory(path)) {
+      // this will trigger 3 times per vhd blocks
+      const dir = join(root, dirname(path))
+      if (Directory.isImmutable(dir)) {
+        await indexFile(dir, indexPath)
+      }
+    } else {
+      // other files are immutable a file basis
+      const fullPath = join(root, path)
+      if (File.isImmutable(fullPath)) {
+        await indexFile(fullPath, indexPath)
+      }
+    }
+  } catch (err) {
+    if (err.code !== 'EEXIST' && err.code !== 'EPERM') {
+      // there can be a symbolic link in the tree
+      warn('handleExistingFile', err)
+    }
+  }
+}
+
+async function handleNewFile(root, indexPath, pendingVhds, path) {
+  // with awaitWriteFinish we have complete files here
+  // we can make them immutable
+
+  if (isInVhdDirectory(path)) {
+    // watching a vhd block
+    // wait for header/footer and BAT before making this immutable recursively
+    const splitted = path.split(sep)
+    const vmUuid = splitted[1]
+    const vdiUuid = splitted[4]
+    const uniqPath = `${vmUuid}/${vdiUuid}`
+    const { existing } = pendingVhds.get(uniqPath) ?? {}
+    if (existing === undefined) {
+      pendingVhds.set(uniqPath, { existing: 1, lastModified: Date.now() })
+    } else {
+      // already two of the key files,and we got the last one
+      if (existing === 2) {
+        await Directory.makeImmutable(join(root, dirname(path)), indexPath)
+        pendingVhds.delete(uniqPath)
+      } else {
+        // wait for the other
+        pendingVhds.set(uniqPath, { existing: existing + 1, lastModified: Date.now() })
+      }
+    }
+  } else {
+    const fullFilePath = join(root, path)
+    await File.makeImmutable(fullFilePath, indexPath)
+    await cleanXoCache(fullFilePath)
+  }
+}
+export async function watchRemote(remoteId, { root, immutabilityDuration, rebuildIndexOnStart = false, indexPath }) {
+  // create index directory
+  await fs.mkdir(indexPath, { recursive: true })
+
+  // test if fs and index directories are well configured
+  await test(root, indexPath)
+
+  // add duration and watch status in the metadata.json of the remote
+  const settingPath = join(root, 'immutability.json')
+  try {
+    // this file won't be made mutable by liftimmutability
+    await File.liftImmutability(settingPath)
+  } catch (error) {
+    // file may not exists, and it's not really a problem
+    info('lifting immutability on current settings', error)
+  }
+  await fs.writeFile(
+    settingPath,
+    JSON.stringify({
+      since: Date.now(),
+      immutable: true,
+      duration: immutabilityDuration,
+    })
+  )
+  // no index path in makeImmutable(): the immutability won't be lifted
+  File.makeImmutable(settingPath)
+
+  // we wait for footer/header AND BAT to be written before locking a vhd directory
+  // this map allow us to track the vhd with partial metadata
+  const pendingVhds = new Map()
+  // cleanup pending vhd map periodically
+  setInterval(
+    () => {
+      pendingVhds.forEach(({ lastModified, existing }, path) => {
+        if (Date.now() - lastModified > 60 * 60 * 1000) {
+          pendingVhds.delete(path)
+          warn(`vhd at ${path} is incomplete since ${lastModified}`, { existing, lastModified, path })
+        }
+      })
+    },
+    60 * 60 * 1000
+  )
+
+  // watch the remote for any new VM metadata json file
+  const PATHS = [
+    'xo-config-backups/*/*/data',
+    'xo-config-backups/*/*/data.json',
+    'xo-config-backups/*/*/metadata.json',
+    'xo-pool-metadata-backups/*/metadata.json',
+    'xo-pool-metadata-backups/*/data',
+    // xo-vm-backups/<vmuuid>/
+    'xo-vm-backups/*/*.json',
+    'xo-vm-backups/*/*.xva',
+    'xo-vm-backups/*/*.xva.checksum',
+    // xo-vm-backups/<vmuuid>/vdis/<jobid>/<vdiUuid>
+    'xo-vm-backups/*/vdis/*/*/*.vhd', // can be an alias or a vhd file
+    // for vhd directory :
+    'xo-vm-backups/*/vdis/*/*/data/*.vhd/bat',
+    'xo-vm-backups/*/vdis/*/*/data/*.vhd/header',
+    'xo-vm-backups/*/vdis/*/*/data/*.vhd/footer',
+  ]
+
+  let ready = false
+  const watcher = chokidar.watch(PATHS, {
+    ignored: [
+      /(^|[/\\])\../, // ignore dotfiles
+      /\.lock$/,
+    ],
+    cwd: root,
+    recursive: false, // vhd directory can generate a lot of folder, don't let chokidar choke on this
+    ignoreInitial: !rebuildIndexOnStart,
+    depth: 7,
+    awaitWriteFinish: true,
+  })
+
+  // Add event listeners.
+  watcher
+    .on('add', async path => {
+      debug(`File ${path} has been added ${path.split('/').length}`)
+      if (ready) {
+        await handleNewFile(root, indexPath, pendingVhds, path)
+      } else {
+        await handleExistingFile(root, indexPath, path)
+      }
+    })
+    .on('error', error => warn(`Watcher error: ${error}`))
+    .on('ready', () => {
+      ready = true
+      info('Ready for changes')
+    })
+}
+
+const { remotes } = await loadConfig()
+
+for (const [remoteId, remote] of Object.entries(remotes)) {
+  watchRemote(remoteId, remote).catch(err => warn('error during watchRemote', { err, remoteId, remote }))
+}

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,6 +8,7 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - [REST API] New pool action: `create_vm` [#6749](https://github.com/vatesfr/xen-orchestra/issues/6749)
+- [Backup] Implement Backup Repository immutability (PR [#6928](https://github.com/vatesfr/xen-orchestra/pull/6928))
 
 ### Bug fixes
 
@@ -29,8 +30,11 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
 - @xen-orchestra/fs patch
+- @xen-orchestra/immutable-backups major
 - xo-cli minor
 - xo-server minor
+- xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-web/src/common/render-xo-item.js
+++ b/packages/xo-web/src/common/render-xo-item.js
@@ -646,6 +646,11 @@ const xoItemToRender = {
       <span className='tag tag-info' style={{ textTransform: 'capitalize' }}>
         {backup.mode === 'delta' ? _('backupIsIncremental') : backup.mode}
       </span>{' '}
+      {backup.isImmutable && (
+        <span className='tag tag-info'>
+          <Icon icon='lock' />
+        </span>
+      )}{' '}
       <span className='tag tag-warning'>{backup.remote.name}</span>{' '}
       {backup.differencingVhds > 0 && (
         <span className='tag tag-info'>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,14 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
+"@alcalzone/ansi-tokenize@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz#9f89839561325a8e9a0c32360b8d17e48489993f"
+  integrity sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==
+  dependencies:
+    ansi-styles "^6.2.1"
+    is-fullwidth-code-point "^4.0.0"
+
 "@ampproject/remapping@^2.2.0":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630"
@@ -1792,6 +1800,11 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
+"@base2/pretty-print-object@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.1.tgz#371ba8be66d556812dc7fb169ebc3c08378f69d4"
+  integrity sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==
+
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
@@ -1953,6 +1966,13 @@
   integrity sha512-/FykLtodD8gKs3+VNkAUwofu4LBHankclj+I8fB2jTRvG6PV7k/OUt4P+VbM7ip853qS4F0g7Z6hLNa6JeMcAQ==
   dependencies:
     chalk "^4.1.0"
+
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
 
 "@csstools/cascade-layer-name-parser@^1.0.5":
   version "1.0.7"
@@ -2287,6 +2307,23 @@
     resolve-from "^3.0.0"
     rimraf "^3.0.0"
 
+"@isaacs/ts-node-temp-fork-for-pr-2009@^10.9.5":
+  version "10.9.5"
+  resolved "https://registry.yarnpkg.com/@isaacs/ts-node-temp-fork-for-pr-2009/-/ts-node-temp-fork-for-pr-2009-10.9.5.tgz#6e34df6e9ca5f6c9a2c9f864764bc50bb90c0c5f"
+  integrity sha512-hEDlwpHhIabtB+Urku8muNMEkGui0LVGlYLS3KoB9QBDf0Pw3r7q0RrfoQmFuk8CvRpGzErO3/vLQd9Ys+/g4g==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node14" "*"
+    "@tsconfig/node16" "*"
+    "@tsconfig/node18" "*"
+    "@tsconfig/node20" "*"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -2298,7 +2335,7 @@
     js-yaml "^3.13.1"
     resolve-from "^5.0.0"
 
-"@istanbuljs/schema@^0.1.2":
+"@istanbuljs/schema@^0.1.2", "@istanbuljs/schema@^0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
@@ -2504,7 +2541,7 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/resolve-uri@^3.1.0":
+"@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
   integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
@@ -2526,6 +2563,14 @@
   version "1.4.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.22"
@@ -2629,6 +2674,82 @@
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@novnc/novnc/-/novnc-1.4.0.tgz#68adae81a741624142b518323441e852c1f34281"
   integrity sha512-kW6ALMc5BuH08e/ond/I1naYcfjc19JYMN1EdtmgjjjzPGCjW8fMtVM3MwM6q7YLRjPlQ3orEvoKMgSS7RkEVQ==
+
+"@npmcli/agent@^2.0.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@npmcli/agent/-/agent-2.2.0.tgz#e81f00fdb2a670750ff7731bbefb47ecbf0ccf44"
+  integrity sha512-2yThA1Es98orMkpSLVqlDZAMPK3jHJhifP2gnNUdk1754uZ8yI5c+ulCoVG+WlntQA6MzhrURMXjSd9Z7dJ2/Q==
+  dependencies:
+    agent-base "^7.1.0"
+    http-proxy-agent "^7.0.0"
+    https-proxy-agent "^7.0.1"
+    lru-cache "^10.0.1"
+    socks-proxy-agent "^8.0.1"
+
+"@npmcli/fs@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-3.1.0.tgz#233d43a25a91d68c3a863ba0da6a3f00924a173e"
+  integrity sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==
+  dependencies:
+    semver "^7.3.5"
+
+"@npmcli/git@^5.0.0":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@npmcli/git/-/git-5.0.4.tgz#d18c50f99649e6e89e8b427318134f582498700c"
+  integrity sha512-nr6/WezNzuYUppzXRaYu/W4aT5rLxdXqEFupbh6e/ovlYFQ8hpu1UUPV3Ir/YTl+74iXl2ZOMlGzudh9ZPUchQ==
+  dependencies:
+    "@npmcli/promise-spawn" "^7.0.0"
+    lru-cache "^10.0.1"
+    npm-pick-manifest "^9.0.0"
+    proc-log "^3.0.0"
+    promise-inflight "^1.0.1"
+    promise-retry "^2.0.1"
+    semver "^7.3.5"
+    which "^4.0.0"
+
+"@npmcli/installed-package-contents@^2.0.1":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@npmcli/installed-package-contents/-/installed-package-contents-2.0.2.tgz#bfd817eccd9e8df200919e73f57f9e3d9e4f9e33"
+  integrity sha512-xACzLPhnfD51GKvTOOuNX2/V4G4mz9/1I2MfDoye9kBM3RYe5g2YbscsaGoTlaWqkxeiapBWyseULVKpSVHtKQ==
+  dependencies:
+    npm-bundled "^3.0.0"
+    npm-normalize-package-bin "^3.0.0"
+
+"@npmcli/node-gyp@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@npmcli/node-gyp/-/node-gyp-3.0.0.tgz#101b2d0490ef1aa20ed460e4c0813f0db560545a"
+  integrity sha512-gp8pRXC2oOxu0DUE1/M3bYtb1b3/DbJ5aM113+XJBgfXdussRAsX0YOrOhdd8WvnAR6auDBvJomGAkLKA5ydxA==
+
+"@npmcli/package-json@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@npmcli/package-json/-/package-json-5.0.0.tgz#77d0f8b17096763ccbd8af03b7117ba6e34d6e91"
+  integrity sha512-OI2zdYBLhQ7kpNPaJxiflofYIpkNLi+lnGdzqUOfRmCF3r2l1nadcjtCYMJKv/Utm/ZtlffaUuTiAktPHbc17g==
+  dependencies:
+    "@npmcli/git" "^5.0.0"
+    glob "^10.2.2"
+    hosted-git-info "^7.0.0"
+    json-parse-even-better-errors "^3.0.0"
+    normalize-package-data "^6.0.0"
+    proc-log "^3.0.0"
+    semver "^7.5.3"
+
+"@npmcli/promise-spawn@^7.0.0":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@npmcli/promise-spawn/-/promise-spawn-7.0.1.tgz#a836de2f42a2245d629cf6fbb8dd6c74c74c55af"
+  integrity sha512-P4KkF9jX3y+7yFUxgcUdDtLy+t4OlDGuEBLNs57AZsfSfg+uV6MLndqGpnl4831ggaEdXwR50XFoZP4VFtHolg==
+  dependencies:
+    which "^4.0.0"
+
+"@npmcli/run-script@^7.0.0":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@npmcli/run-script/-/run-script-7.0.4.tgz#9f29aaf4bfcf57f7de2a9e28d1ef091d14b2e6eb"
+  integrity sha512-9ApYM/3+rBt9V80aYg6tZfzj3UWdiYyCt7gJUD1VJKvWF5nwKDSICXbYIQbspFTq6TOpbsEtIC0LArB8d9PFmg==
+  dependencies:
+    "@npmcli/node-gyp" "^3.0.0"
+    "@npmcli/package-json" "^5.0.0"
+    "@npmcli/promise-spawn" "^7.0.0"
+    node-gyp "^10.0.0"
+    which "^4.0.0"
 
 "@nraynaud/novnc@0.6.1":
   version "0.6.1"
@@ -2759,6 +2880,50 @@
   version "4.9.6"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.6.tgz#2c1fb69e02a3f1506f52698cfdc3a8b6386df9a6"
   integrity sha512-jqzNLhNDvIZOrt69Ce4UjGRpXJBzhUBzawMwnaDAwyHriki3XollsewxWzOzz+4yOFDkuJHtTsZFwMxhYJWmLQ==
+
+"@sigstore/bundle@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@sigstore/bundle/-/bundle-2.1.1.tgz#7fad9a1728939301607103722ac6f2a083d2f09a"
+  integrity sha512-v3/iS+1nufZdKQ5iAlQKcCsoh0jffQyABvYIxKsZQFWc4ubuGjwZklFHpDgV6O6T7vvV78SW5NHI91HFKEcxKg==
+  dependencies:
+    "@sigstore/protobuf-specs" "^0.2.1"
+
+"@sigstore/core@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@sigstore/core/-/core-0.2.0.tgz#2d8ecae2c38a59a52b1dcbd6110014d88de08a80"
+  integrity sha512-THobAPPZR9pDH2CAvDLpkrYedt7BlZnsyxDe+Isq4ZmGfPy5juOFZq487vCU2EgKD7aHSiTfE/i7sN7aEdzQnA==
+
+"@sigstore/protobuf-specs@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@sigstore/protobuf-specs/-/protobuf-specs-0.2.1.tgz#be9ef4f3c38052c43bd399d3f792c97ff9e2277b"
+  integrity sha512-XTWVxnWJu+c1oCshMLwnKvz8ZQJJDVOlciMfgpJBQbThVjKTCG8dwyhgLngBD2KN0ap9F/gOV8rFDEx8uh7R2A==
+
+"@sigstore/sign@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@sigstore/sign/-/sign-2.2.1.tgz#b37383db1f25ab20cfec980d23ce08e6f99e6caf"
+  integrity sha512-U5sKQEj+faE1MsnLou1f4DQQHeFZay+V9s9768lw48J4pKykPj34rWyI1lsMOGJ3Mae47Ye6q3HAJvgXO21rkQ==
+  dependencies:
+    "@sigstore/bundle" "^2.1.1"
+    "@sigstore/core" "^0.2.0"
+    "@sigstore/protobuf-specs" "^0.2.1"
+    make-fetch-happen "^13.0.0"
+
+"@sigstore/tuf@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@sigstore/tuf/-/tuf-2.3.0.tgz#de64925ea10b16f3a7e77535d91eaf22be4dd904"
+  integrity sha512-S98jo9cpJwO1mtQ+2zY7bOdcYyfVYCUaofCG6wWRzk3pxKHVAkSfshkfecto2+LKsx7Ovtqbgb2LS8zTRhxJ9Q==
+  dependencies:
+    "@sigstore/protobuf-specs" "^0.2.1"
+    tuf-js "^2.2.0"
+
+"@sigstore/verify@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@sigstore/verify/-/verify-0.1.0.tgz#c017aadb1a516ab4a10651cece29463aa9540bfe"
+  integrity sha512-2UzMNYAa/uaz11NhvgRnIQf4gpLTJ59bhb8ESXaoSS5sxedfS+eLak8bsdMc+qpNQfITUTFoSKFx5h8umlRRiA==
+  dependencies:
+    "@sigstore/bundle" "^2.1.1"
+    "@sigstore/core" "^0.2.0"
+    "@sigstore/protobuf-specs" "^0.2.1"
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
@@ -3371,15 +3536,287 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@tapjs/after-each@1.1.18":
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/@tapjs/after-each/-/after-each-1.1.18.tgz#6303e50a9f47e05d2afcb3d79f2e421164b9c9c1"
+  integrity sha512-AuXeD8uUYQ/CUdfhx2jvBhJf3M+T/Kroz5T6ItocZ3jf8H/4x2OKMVbb5YcB7J4ANGtmzXp+8SBseoN1av6y0Q==
+  dependencies:
+    function-loop "^4.0.0"
+
+"@tapjs/after@1.1.18":
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/@tapjs/after/-/after-1.1.18.tgz#f223e5552706149d8a011d7506f36cb85dedfc2d"
+  integrity sha512-r0vMFMfxmO6UR+pB9zGvamaeUI+yhLokYAagsKoM3JdoZgyq0iw1fHn5hPPY8AC1tAzEYG3KtVDpJfpoOr67Iw==
+  dependencies:
+    is-actual-promise "^1.0.0"
+
+"@tapjs/asserts@1.1.18":
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/@tapjs/asserts/-/asserts-1.1.18.tgz#c79ccdcaa00a35d50f24393b66b7ab316cadc3ce"
+  integrity sha512-MwGs/QklLRAsMnB4fO6QFaZ0myR//E21Rek/gGCpTxz7eUwCh24/y7MlBV0W6zDFdnQ1GFbHc/fIBVtcPAWjyw==
+  dependencies:
+    "@tapjs/stack" "1.2.7"
+    is-actual-promise "^1.0.0"
+    tcompare "6.4.5"
+    trivial-deferred "^2.0.0"
+
+"@tapjs/before-each@1.1.18":
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/@tapjs/before-each/-/before-each-1.1.18.tgz#6c374edd7329d30177bf03706b8b0b8076026bfe"
+  integrity sha512-qxBQaOY+IkThP9iauL1tHCxirG9XuKGJvGHY4IGKuk0RswWkXmawSe5hcJ8m569dRXy9yJHEV7N0QueuyWxpBA==
+  dependencies:
+    function-loop "^4.0.0"
+
+"@tapjs/before@1.1.18":
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/@tapjs/before/-/before-1.1.18.tgz#7613403ea4dc3500b2b8d75a345d23be561050ad"
+  integrity sha512-2rkXrAWlkl0+bZ8wSNfEW/7TANs/Dg5SrY2MmdEb0x7Q/zbMoGjrPVKDRF20Me0p+tJBLWSY+FXQ0OhXK0pUjg==
+  dependencies:
+    is-actual-promise "^1.0.0"
+
+"@tapjs/config@2.4.15":
+  version "2.4.15"
+  resolved "https://registry.yarnpkg.com/@tapjs/config/-/config-2.4.15.tgz#38f3f132b59e8eecae3b05aee967297adc0d7bfb"
+  integrity sha512-uU/gfQJh8aSokEBgwAAHD5ctHYbIiZYFaL6IrROcDp7Wr7/fd/dn9K4efpREwKpqKqOgL3XZPOwx7prKxrLHhA==
+  dependencies:
+    "@tapjs/core" "1.5.0"
+    "@tapjs/test" "1.4.0"
+    chalk "^5.2.0"
+    jackspeak "^2.3.6"
+    polite-json "^4.0.1"
+    tap-yaml "2.2.1"
+    walk-up-path "^3.0.1"
+
+"@tapjs/core@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@tapjs/core/-/core-1.5.0.tgz#dfd86bd9fe155861b5b11f9bbfb168cabedcca59"
+  integrity sha512-g+NNI5TGXVJR5G4AZCU0hWu1pdA2qB2OYrY9Ej3mWeg97mvNZBVgNtvx8Vjdwp9BfgbJfyFK7PvoB4nhKgetSQ==
+  dependencies:
+    "@tapjs/processinfo" "^3.1.6"
+    "@tapjs/stack" "1.2.7"
+    "@tapjs/test" "1.4.0"
+    async-hook-domain "^4.0.1"
+    diff "^5.1.0"
+    is-actual-promise "^1.0.0"
+    minipass "^7.0.3"
+    signal-exit "4.1"
+    tap-parser "15.3.1"
+    tap-yaml "2.2.1"
+    tcompare "6.4.5"
+    trivial-deferred "^2.0.0"
+
+"@tapjs/error-serdes@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@tapjs/error-serdes/-/error-serdes-1.2.1.tgz#672370b8436f128e9a24955043fa37c3c101dc1b"
+  integrity sha512-/7eLEcrGo+Qz3eWrjkhDC+VSEOjabkkzr9eRADeU+OLFeZaik8L/GRk0SGhnp4YsQkv0jcNV00A42bEx2HIZcw==
+  dependencies:
+    minipass "^7.0.3"
+
+"@tapjs/filter@1.2.18":
+  version "1.2.18"
+  resolved "https://registry.yarnpkg.com/@tapjs/filter/-/filter-1.2.18.tgz#ff4889e3d81d03bd801f666f3303a99a2ff0e37d"
+  integrity sha512-0yCqaHYLejI/KyxdB5EsrRVu3wxZVl7vPXTwBoyc+ycJWXPapHLhKl67Xk5x3FW/nNelA9TCq/tSHcYlogGN0g==
+
+"@tapjs/fixture@1.2.18":
+  version "1.2.18"
+  resolved "https://registry.yarnpkg.com/@tapjs/fixture/-/fixture-1.2.18.tgz#dba32b930fdd5d11a1453fc07b9ae8b5b07ca80e"
+  integrity sha512-BQIRxydaqjZIG61QhoiQOc9HE3MxSjCn7SUsIfYCzoZoY+3aY6iCdTVg2la86b5ikTbwoWxWWbqICnFWebuHnQ==
+  dependencies:
+    mkdirp "^3.0.0"
+    rimraf "^5.0.5"
+
+"@tapjs/intercept@1.2.18":
+  version "1.2.18"
+  resolved "https://registry.yarnpkg.com/@tapjs/intercept/-/intercept-1.2.18.tgz#c7b35399f850517b60d47041e1e66f63a49e6d0d"
+  integrity sha512-Trcmp64RKD2/nMz7/+NuwjJHfrn8eFofX3s3g0+QGvnTv+5B5ZQs+zWjS7q2d1Qt8LDV8CfS5w3BhYyONsocSw==
+  dependencies:
+    "@tapjs/after" "1.1.18"
+    "@tapjs/stack" "1.2.7"
+
+"@tapjs/mock@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@tapjs/mock/-/mock-1.3.0.tgz#57920a12d318bb7b83af77747a9049543ba4e691"
+  integrity sha512-Uzyikl8SS8Mg7OOr2HuyiaVhYvHNRZnw6A1/qTiJnoZ1MHcLFuwFqIX9ZhfXMil5MIYC/ET096VMDm45q9Tdvw==
+  dependencies:
+    "@tapjs/after" "1.1.18"
+    "@tapjs/stack" "1.2.7"
+    resolve-import "^1.4.5"
+    walk-up-path "^3.0.1"
+
+"@tapjs/node-serialize@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@tapjs/node-serialize/-/node-serialize-1.3.0.tgz#4a62f8d75798c67b97f7da006a6b317fdd3a6207"
+  integrity sha512-52oQKQJMMKrI1cNu8kJ5WTv8YFnbhwfwUs3Jh1vXQb4tOhLW8IHWqXBi5AiNL3HlCMMHaKDFQjW6sbbJuMyJPA==
+  dependencies:
+    "@tapjs/error-serdes" "1.2.1"
+    "@tapjs/stack" "1.2.7"
+    tap-parser "15.3.1"
+
+"@tapjs/processinfo@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@tapjs/processinfo/-/processinfo-3.1.6.tgz#9e9defce887affc60d0642b06f9f934e41ba0132"
+  integrity sha512-ktDsaf79wJsLaoG1Pp+stHSRf6a1k/JydoRAaYVG5iJnd3DooL6yewZsciUi2yiN/WQc5tAXCIFTXL4uXGB8LA==
+  dependencies:
+    pirates "^4.0.5"
+    process-on-spawn "^1.0.0"
+    signal-exit "^4.0.2"
+    uuid "^8.3.2"
+
+"@tapjs/reporter@1.3.16":
+  version "1.3.16"
+  resolved "https://registry.yarnpkg.com/@tapjs/reporter/-/reporter-1.3.16.tgz#b747623737bbb650cc7b6c26b6d16130bfd32d8c"
+  integrity sha512-YoZpBAFGdZyrhIaRCZDuWSeCc10A3YG/4mIdPsKpSbLXPBZ1hwCV8Y/LPCpH5kunZTXYocvQoRHU+oD4pLXC3g==
+  dependencies:
+    "@tapjs/config" "2.4.15"
+    "@tapjs/stack" "1.2.7"
+    chalk "^5.2.0"
+    ink "^4.4.1"
+    minipass "^7.0.3"
+    ms "^2.1.3"
+    patch-console "^2.0.0"
+    prismjs-terminal "^1.2.3"
+    react "^18.2.0"
+    string-length "^6.0.0"
+    tap-parser "15.3.1"
+    tap-yaml "2.2.1"
+    tcompare "6.4.5"
+
+"@tapjs/run@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@tapjs/run/-/run-1.5.0.tgz#bb9b3ae529e679898706b0296e5b733719da93ad"
+  integrity sha512-WrmbHHrhvRvLlTTAGiogF09xiPoorsoG4diAIKifGUyGD/9qRA7pT2mzYIqXvhyxbtuEmaeobHjupSZrak+O4Q==
+  dependencies:
+    "@tapjs/after" "1.1.18"
+    "@tapjs/before" "1.1.18"
+    "@tapjs/config" "2.4.15"
+    "@tapjs/processinfo" "^3.1.6"
+    "@tapjs/reporter" "1.3.16"
+    "@tapjs/spawn" "1.1.18"
+    "@tapjs/stdin" "1.1.18"
+    "@tapjs/test" "1.4.0"
+    c8 "^8.0.1"
+    chalk "^5.3.0"
+    chokidar "^3.5.3"
+    foreground-child "^3.1.1"
+    glob "^10.3.10"
+    minipass "^7.0.3"
+    mkdirp "^3.0.1"
+    opener "^1.5.2"
+    pacote "^17.0.3"
+    resolve-import "^1.4.5"
+    rimraf "^5.0.5"
+    semver "^7.5.4"
+    signal-exit "^4.1.0"
+    tap-parser "15.3.1"
+    tap-yaml "2.2.1"
+    tcompare "6.4.5"
+    trivial-deferred "^2.0.0"
+    which "^4.0.0"
+
+"@tapjs/snapshot@1.2.18":
+  version "1.2.18"
+  resolved "https://registry.yarnpkg.com/@tapjs/snapshot/-/snapshot-1.2.18.tgz#c13b9caa822352e2a03a000d407b99b816757ea8"
+  integrity sha512-fHt4ZgutJ922/YdmXN2d6dkwFTR6KsyD02jcSYBXVDGdFC2YnsjKk/o9s3Yt9tYnYES6Et+6udPlAKcakzR5jQ==
+  dependencies:
+    is-actual-promise "^1.0.0"
+    tcompare "6.4.5"
+    trivial-deferred "^2.0.0"
+
+"@tapjs/spawn@1.1.18":
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/@tapjs/spawn/-/spawn-1.1.18.tgz#d2513fe694f218a695c123339e983e92ca9edc04"
+  integrity sha512-E5H0NTyTZ0FnkPUd5JU3c2KrnjjMDDAuctRd2b0v/M5LB+uAlwwEEJJ6rh+dBsFK/yatfgPli+nbHZVjUz+Usw==
+
+"@tapjs/stack@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@tapjs/stack/-/stack-1.2.7.tgz#09d4cb7da780689f010fdb9a0bd87c3bf78ac0de"
+  integrity sha512-7qUDWDmd+y7ZQ0vTrDTvFlWnJ+ND32NemS5HVuT1ZggHtBwJ62PQHIyCx/B5RopETBb6NvFPfUE21yTiex9Jkw==
+
+"@tapjs/stdin@1.1.18":
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/@tapjs/stdin/-/stdin-1.1.18.tgz#8827740ac7198b35dcbe490868d4c28ed4368875"
+  integrity sha512-UyhK8bRRhQkmBb7N/NFa/11DucHfIzCyyba7uax+dkuXSd6OccTZVxLpRMuaOUV59QCCFAJUJDQnmaWj35fI7Q==
+
+"@tapjs/test@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@tapjs/test/-/test-1.4.0.tgz#3af283c7d7557b07db3929ca4b81711b2323bd55"
+  integrity sha512-t4U11uAUDUeBQTdlqtiDoiuiG3lKLhHa+PxrdIR3GlG+2wDcpqFR8aFFiuq3XTvks0uoWjKx3WkAMyjNsxmikg==
+  dependencies:
+    "@isaacs/ts-node-temp-fork-for-pr-2009" "^10.9.5"
+    "@tapjs/after" "1.1.18"
+    "@tapjs/after-each" "1.1.18"
+    "@tapjs/asserts" "1.1.18"
+    "@tapjs/before" "1.1.18"
+    "@tapjs/before-each" "1.1.18"
+    "@tapjs/filter" "1.2.18"
+    "@tapjs/fixture" "1.2.18"
+    "@tapjs/intercept" "1.2.18"
+    "@tapjs/mock" "1.3.0"
+    "@tapjs/node-serialize" "1.3.0"
+    "@tapjs/snapshot" "1.2.18"
+    "@tapjs/spawn" "1.1.18"
+    "@tapjs/stdin" "1.1.18"
+    "@tapjs/typescript" "1.4.0"
+    "@tapjs/worker" "1.1.18"
+    glob "^10.3.10"
+    jackspeak "^2.3.6"
+    mkdirp "^3.0.0"
+    resolve-import "^1.4.5"
+    rimraf "^5.0.5"
+    sync-content "^1.0.1"
+    tap-parser "15.3.1"
+    tshy "^1.2.2"
+    typescript "5.2"
+
+"@tapjs/typescript@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@tapjs/typescript/-/typescript-1.4.0.tgz#81f3c1eb01a409819a0b075c977300e50e87c958"
+  integrity sha512-3b3pNI20Cf9NRMuT6GE288RESMYMcrwrKuj29Mroiy9MkLEyyPPHqeSRstvakn9/i/nhTlXj2YIftPo80H3OlQ==
+  dependencies:
+    "@isaacs/ts-node-temp-fork-for-pr-2009" "^10.9.5"
+
+"@tapjs/worker@1.1.18":
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/@tapjs/worker/-/worker-1.1.18.tgz#fd1c6e0dc2491bb777d4e1d80d44dbbbbf015bc7"
+  integrity sha512-wxl/dXByMWk9FuYiiSzY/U5QU0oe9EWpf7pJ48feWsTTn42wihUHZT25kbleR4V2l68/SlTPlJkEsKnHjU27Pg==
+
 "@tootallnate/quickjs-emscripten@^0.23.0":
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#db4ecfd499a9765ab24002c3b696d02e6d32a12c"
   integrity sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==
 
-"@tsconfig/node18@^18.2.2":
+"@tsconfig/node14@*":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-14.1.0.tgz#1f8611430002b2a08c68ec1b1e7aa40c03b8fcd2"
+  integrity sha512-VmsCG04YR58ciHBeJKBDNMWWfYbyP8FekWVuTlpstaUPlat1D0x/tXzkWP7yCMU0eSz9V4OZU0LBWTFJ3xZf6w==
+
+"@tsconfig/node16@*":
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-16.1.1.tgz#b9322bcacf7b7a487ab4e078f88455bde47f3780"
+  integrity sha512-+pio93ejHN4nINX4pXqfnR/fPLRtJBaT4ORaa5RH0Oc1zoYmo2B2koG+M328CQhHKn1Wj6FcOxCDFXAot9NhvA==
+
+"@tsconfig/node18@*", "@tsconfig/node18@^18.2.2":
   version "18.2.2"
   resolved "https://registry.yarnpkg.com/@tsconfig/node18/-/node18-18.2.2.tgz#81fb16ecff0d400b1cbadbf76713b50f331029ce"
   integrity sha512-d6McJeGsuoRlwWZmVIeE8CUA27lu6jLjvv1JzqmpsytOYYbVi1tHZEnwCNVOXnj4pyLvneZlFlpXUK+X9wBWyw==
+
+"@tsconfig/node20@*":
+  version "20.1.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node20/-/node20-20.1.2.tgz#b93128c411d38e9507035255195bc8a6718541e3"
+  integrity sha512-madaWq2k+LYMEhmcp0fs+OGaLFk0OenpHa4gmI4VEmCKX4PJntQ6fnnGADVFrVkBj0wIdAlQnK/MrlYTHsa1gQ==
+
+"@tufjs/canonical-json@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz#a52f61a3d7374833fca945b2549bc30a2dd40d0a"
+  integrity sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==
+
+"@tufjs/models@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@tufjs/models/-/models-2.0.0.tgz#c7ab241cf11dd29deb213d6817dabb8c99ce0863"
+  integrity sha512-c8nj8BaOExmZKO2DXhDfegyhSGcG9E/mPN3U13L+/PsoWm1uaGiHHjxqSHQiasDBQwDA3aHuw9+9spYAP1qvvg==
+  dependencies:
+    "@tufjs/canonical-json" "2.0.0"
+    minimatch "^9.0.3"
 
 "@types/asn1@>=0.2.1":
   version "0.2.4"
@@ -4860,6 +5297,11 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abbrev@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz#cf59829b8b4f03f89dda2771cb7f3653828c89bf"
+  integrity sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==
+
 abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
@@ -4923,6 +5365,11 @@ acorn-walk@^7.0.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.1.1:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.2.tgz#7703af9415f1b6db9315d6895503862e231d34aa"
+  integrity sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==
+
 acorn@5.X, acorn@^5.0.3:
   version "5.7.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
@@ -4948,7 +5395,7 @@ acorn@^7.0.0, acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.11.2, acorn@^8.11.3, acorn@^8.5.0, acorn@^8.8.2, acorn@^8.9.0:
+acorn@^8.11.2, acorn@^8.11.3, acorn@^8.4.1, acorn@^8.5.0, acorn@^8.8.2, acorn@^8.9.0:
   version "8.11.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
   integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
@@ -5098,7 +5545,7 @@ ansi-escapes@^4.1.0, ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-escapes@^6.2.0:
+ansi-escapes@^6.0.0, ansi-escapes@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-6.2.0.tgz#8a13ce75286f417f1963487d86ba9f90dccf9947"
   integrity sha512-kzRaCqXnpzWs+3z5ABPQiVke+iq0KXkHo8xiWV4RPTi5Yli0l97BEQuhXV1s7+aSU/fu1kUuxgS4MsQ0fRuygw==
@@ -5271,6 +5718,11 @@ are-we-there-yet@^2.0.0:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argon2@^0.28.5:
   version "0.28.7"
@@ -5642,6 +6094,11 @@ async-hook-domain@^2.0.4:
   resolved "https://registry.yarnpkg.com/async-hook-domain/-/async-hook-domain-2.0.4.tgz#5a24910982c04394ea33dd442860f80cce2d972c"
   integrity sha512-14LjCmlK1PK8eDtTezR6WX8TMaYNIzBIsd2D1sGoGjgx0BuNMMoSdk7i/drlbtamy0AWv9yv2tkB+ASdmeqFIw==
 
+async-hook-domain@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/async-hook-domain/-/async-hook-domain-4.0.1.tgz#e2e359e387dd021a7e16f77a5be8506ebe0ed729"
+  integrity sha512-bSktexGodAjfHWIrSrrqxqWzf1hWBZBpmPNZv+TYUMyWa2eoefFc6q6H1+KtdHYSz35lrhWdmXt/XK9wNEZvww==
+
 async-iterator-to-stream@^1.0.1, async-iterator-to-stream@^1.0.2, async-iterator-to-stream@^1.1.0, async-iterator-to-stream@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/async-iterator-to-stream/-/async-iterator-to-stream-1.2.0.tgz#fd90483e3a308be2b5a1cf2d28d6f62f4f7923e0"
@@ -5696,6 +6153,11 @@ auto-bind@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/auto-bind/-/auto-bind-4.0.0.tgz#e3589fc6c2da8f7ca43ba9f84fa52a744fc997fb"
   integrity sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==
+
+auto-bind@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/auto-bind/-/auto-bind-5.0.1.tgz#50d8e63ea5a1dddcb5e5e36451c1a8266ffbb2ae"
+  integrity sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==
 
 autocomplete.js@0.36.0:
   version "0.36.0"
@@ -6507,7 +6969,7 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==
 
-builtins@^5.0.1:
+builtins@^5.0.0, builtins@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-5.0.1.tgz#87f6db9ab0458be728564fa81d876d8d74552fa9"
   integrity sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==
@@ -6551,6 +7013,24 @@ bytes@3.1.2, bytes@^3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
+c8@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/c8/-/c8-8.0.1.tgz#bafd60be680e66c5530ee69f621e45b1364af9fd"
+  integrity sha512-EINpopxZNH1mETuI0DzRA4MZpAUH+IFiRhnmFD3vFr3vdrgxqi3VfE3KL0AIL+zDq8rC9bZqwM/VDmmoe04y7w==
+  dependencies:
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@istanbuljs/schema" "^0.1.3"
+    find-up "^5.0.0"
+    foreground-child "^2.0.0"
+    istanbul-lib-coverage "^3.2.0"
+    istanbul-lib-report "^3.0.1"
+    istanbul-reports "^3.1.6"
+    rimraf "^3.0.2"
+    test-exclude "^6.0.0"
+    v8-to-istanbul "^9.0.0"
+    yargs "^17.7.2"
+    yargs-parser "^21.1.1"
+
 cac@^6.5.6:
   version "6.7.14"
   resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
@@ -6576,6 +7056,24 @@ cacache@^12.0.2, cacache@^12.0.3:
     ssri "^6.0.1"
     unique-filename "^1.1.1"
     y18n "^4.0.0"
+
+cacache@^18.0.0:
+  version "18.0.2"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-18.0.2.tgz#fd527ea0f03a603be5c0da5805635f8eef00c60c"
+  integrity sha512-r3NU8h/P+4lVUHfeRw1dtgQYar3DZMm4/cm2bZgOvrFC/su7budSOeqh52VJIC4U4iG1WWwV6vRW0znqBvxNuw==
+  dependencies:
+    "@npmcli/fs" "^3.1.0"
+    fs-minipass "^3.0.0"
+    glob "^10.2.2"
+    lru-cache "^10.0.1"
+    minipass "^7.0.3"
+    minipass-collect "^2.0.1"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.4"
+    p-map "^4.0.0"
+    ssri "^10.0.0"
+    tar "^6.1.11"
+    unique-filename "^3.0.0"
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -6787,7 +7285,7 @@ chainsaw@~0.1.0:
   dependencies:
     traverse ">=0.3.0 <0.4"
 
-chalk@5.3.0, chalk@^5.0.1, chalk@^5.2.0:
+chalk@5.3.0, chalk@^5.0.1, chalk@^5.2.0, chalk@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.3.0.tgz#67c20a7ebef70e7f3970a01f90fa210cb6860385"
   integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
@@ -7009,6 +7507,11 @@ cli-boxes@^2.2.0:
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.1.tgz#ddd5035d25094fce220e9cab40a45840a440318f"
   integrity sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==
 
+cli-boxes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-3.0.0.tgz#71a10c716feeba005e4504f36329ef0b17cf3145"
+  integrity sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==
+
 cli-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
@@ -7042,6 +7545,14 @@ cli-truncate@^2.1.0:
   dependencies:
     slice-ansi "^3.0.0"
     string-width "^4.2.0"
+
+cli-truncate@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-3.1.0.tgz#3f23ab12535e3d73e839bb43e73c9de487db1389"
+  integrity sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==
+  dependencies:
+    slice-ansi "^5.0.0"
+    string-width "^5.0.0"
 
 cli-truncate@^4.0.0:
   version "4.0.0"
@@ -7190,6 +7701,13 @@ code-excerpt@^3.0.0:
   integrity sha512-VHNTVhd7KsLGOqfX3SyeO8RyYPMp1GJOg194VITk04WMYCv4plV68YWe6TJZxd9MhobjtpMRnVky01gqZsalaw==
   dependencies:
     convert-to-spaces "^1.0.1"
+
+code-excerpt@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/code-excerpt/-/code-excerpt-4.0.0.tgz#2de7d46e98514385cb01f7b3b741320115f4c95e"
+  integrity sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==
+  dependencies:
+    convert-to-spaces "^2.0.1"
 
 code-point-at@^1.0.0:
   version "1.1.0"
@@ -7526,6 +8044,11 @@ convert-to-spaces@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz#7e3e48bbe6d997b1417ddca2868204b4d3d85715"
   integrity sha512-cj09EBuObp9gZNQCzc7hByQyrs6jVGE+o9kSJmeUoj+GiPiJvi5LYqEH/Hmme4+MTLHM+Ejtq+FChpjjEnsPdQ==
+
+convert-to-spaces@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz#61a6c98f8aa626c16b296b862a91412a33bceb6b"
+  integrity sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==
 
 cookie-parser@^1.4.3:
   version "1.4.6"
@@ -9129,7 +9652,7 @@ encoding-down@^7.1.0:
     level-codec "^10.0.0"
     level-errors "^3.0.0"
 
-encoding@^0.1.11:
+encoding@^0.1.11, encoding@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
   integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
@@ -9179,6 +9702,11 @@ entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
+
+env-paths@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
+  integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
 envify@^4.0.0:
   version "4.1.0"
@@ -9261,6 +9789,11 @@ enzyme@^3.3.0:
     raf "^3.4.1"
     rst-selector-parser "^2.2.3"
     string.prototype.trim "^1.2.1"
+
+err-code@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/err-code/-/err-code-2.0.3.tgz#23c2f3b756ffdfc608d30e27c9a941024807e7f9"
+  integrity sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.8"
@@ -9965,6 +10498,11 @@ events-to-array@^1.0.1:
   resolved "https://registry.yarnpkg.com/events-to-array/-/events-to-array-1.1.2.tgz#2d41f563e1fe400ed4962fe1a4d5c6a7539df7f6"
   integrity sha512-inRWzRY7nG+aXZxBzEqYKB3HPgwflZRopAjDCHv0whhRx+MTUr1ei0ICZUypdyE0HRm4L2d5VEcIqLD6yl+BFA==
 
+events-to-array@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/events-to-array/-/events-to-array-2.0.3.tgz#0cd5ee538baae3ea9ec07539d778a2a6056699bc"
+  integrity sha512-f/qE2gImHRa4Cp2y1stEOSgw8wTFyUdVJX7G//bMwbaV9JqISFxg99NbmVQeP7YLnDUZ2un851jlaDrlpmGehQ==
+
 events@3.3.0, events@^3.0.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
@@ -10142,6 +10680,11 @@ expect@^29.7.0:
     jest-matcher-utils "^29.7.0"
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
+
+exponential-backoff@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
+  integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
 
 express-session@^1.15.6:
   version "1.17.3"
@@ -10703,7 +11246,7 @@ foreground-child@^2.0.0:
     cross-spawn "^7.0.0"
     signal-exit "^3.0.2"
 
-foreground-child@^3.1.0:
+foreground-child@^3.1.0, foreground-child@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.1.1.tgz#1d173e776d75d2772fed08efe4a0de1ea1b12d0d"
   integrity sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==
@@ -10833,6 +11376,13 @@ fs-minipass@^2.0.0:
   dependencies:
     minipass "^3.0.0"
 
+fs-minipass@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-3.0.3.tgz#79a85981c4dc120065e96f62086bf6f9dc26cc54"
+  integrity sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==
+  dependencies:
+    minipass "^7.0.3"
+
 fs-mkdirp-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz#0b7815fc3201c6a69e14db98ce098c16935259eb"
@@ -10893,6 +11443,11 @@ function-loop@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/function-loop/-/function-loop-2.0.1.tgz#799c56ced01698cf12a1b80e4802e9dafc2ebada"
   integrity sha512-ktIR+O6i/4h+j/ZhZJNdzeI4i9lEPeEK6UPR2EVyTVBqOwcU3Za9xYKLH64ZR9HmcROyRrOkizNyjjtWJzDDkQ==
+
+function-loop@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/function-loop/-/function-loop-4.0.0.tgz#12c57cfb9fe08f77532e8b1357242aca2a02c858"
+  integrity sha512-f34iQBedYF3XcI93uewZZOnyscDragxgTK/eTvVB74k3fCD0ZorOi5BV9GS4M8rz/JoNi0Kl3qX5Y9MH3S/CLQ==
 
 function.prototype.name@^1.1.2, function.prototype.name@^1.1.5, function.prototype.name@^1.1.6:
   version "1.1.6"
@@ -11161,7 +11716,7 @@ glob-watcher@^5.0.3:
     normalize-path "^3.0.0"
     object.defaults "^1.1.0"
 
-glob@^10.3.7:
+glob@^10.2.2, glob@^10.2.6, glob@^10.3.10, glob@^10.3.3, glob@^10.3.7:
   version "10.3.10"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.3.10.tgz#0351ebb809fd187fe421ab96af83d3a70715df4b"
   integrity sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==
@@ -11341,7 +11896,7 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@4.X, graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
+graceful-fs@4.X, graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -12002,7 +12557,7 @@ http-assert@^1.3.0:
     deep-equal "~1.0.1"
     http-errors "~1.8.0"
 
-http-cache-semantics@^4.0.0:
+http-cache-semantics@^4.0.0, http-cache-semantics@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
   integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
@@ -12136,7 +12691,7 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-https-proxy-agent@^7.0.2:
+https-proxy-agent@^7.0.1, https-proxy-agent@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz#e2645b846b90e96c6e6f347fb5b2e41f1590b09b"
   integrity sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==
@@ -12214,6 +12769,13 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha512-DUNFN5j7Tln0D+TxzloUjKB+CtVu6myn0JEFak6dG18mNt9YkQ6lzGCdafwofISZ1lLF3xRHJ98VKy9ynkcFaA==
+
+ignore-walk@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-6.0.4.tgz#89950be94b4f522225eb63a13c56badb639190e9"
+  integrity sha512-t7sv42WkwFkyKbivUCglsQW5YWMskWtbEf4MNKX5u/CCWHKSPzN4FtBQGsQZgCLbxOzpVlcbWVK5KB3auIOjSw==
+  dependencies:
+    minimatch "^9.0.0"
 
 ignore@^3.3.5:
   version "3.3.10"
@@ -12301,6 +12863,11 @@ indent-string@^4.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
+indent-string@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-5.0.0.tgz#4fd2980fccaf8622d14c64d694f4cf33c81951a5"
+  integrity sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==
+
 index-modules@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/index-modules/-/index-modules-0.4.3.tgz#35bf9251ac2c1203bdc76ef8e2a8a034bf43f8cb"
@@ -12376,6 +12943,37 @@ ink@^3.2.0:
     wrap-ansi "^6.2.0"
     ws "^7.5.5"
     yoga-layout-prebuilt "^1.9.6"
+
+ink@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/ink/-/ink-4.4.1.tgz#ae684a141e92524af3eccf740c38f03618b48028"
+  integrity sha512-rXckvqPBB0Krifk5rn/5LvQGmyXwCUpBfmTwbkQNBY9JY8RSl3b8OftBNEYxg4+SWUhEKcPifgope28uL9inlA==
+  dependencies:
+    "@alcalzone/ansi-tokenize" "^0.1.3"
+    ansi-escapes "^6.0.0"
+    auto-bind "^5.0.1"
+    chalk "^5.2.0"
+    cli-boxes "^3.0.0"
+    cli-cursor "^4.0.0"
+    cli-truncate "^3.1.0"
+    code-excerpt "^4.0.0"
+    indent-string "^5.0.0"
+    is-ci "^3.0.1"
+    is-lower-case "^2.0.2"
+    is-upper-case "^2.0.2"
+    lodash "^4.17.21"
+    patch-console "^2.0.0"
+    react-reconciler "^0.29.0"
+    scheduler "^0.23.0"
+    signal-exit "^3.0.7"
+    slice-ansi "^6.0.0"
+    stack-utils "^2.0.6"
+    string-width "^5.1.2"
+    type-fest "^0.12.0"
+    widest-line "^4.0.1"
+    wrap-ansi "^8.1.0"
+    ws "^8.12.0"
+    yoga-wasm-web "~0.3.3"
 
 inline-source-map@~0.6.0:
   version "0.6.2"
@@ -12544,6 +13142,13 @@ is-accessor-descriptor@^1.0.1:
   dependencies:
     hasown "^2.0.0"
 
+is-actual-promise@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-actual-promise/-/is-actual-promise-1.0.1.tgz#69ddeb85d9007d0b778c089845436891ba49c93c"
+  integrity sha512-PlsL4tNv62lx5yN2HSqaRSTgIpUAPW7U6+crVB8HfWm5161rZpeqWbl0ZSqH2MAfRKXWSZVPRNbE/r8qPcb13g==
+  dependencies:
+    tshy "^1.7.0"
+
 is-arguments@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
@@ -12635,6 +13240,13 @@ is-ci@^2.0.0:
   integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
   dependencies:
     ci-info "^2.0.0"
+
+is-ci@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
+  integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
+  dependencies:
+    ci-info "^3.2.0"
 
 is-color-stop@^1.0.0:
   version "1.1.0"
@@ -12829,6 +13441,18 @@ is-ip@^3.1.0:
   dependencies:
     ip-regex "^4.0.0"
 
+is-lambda@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5"
+  integrity sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==
+
+is-lower-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-lower-case/-/is-lower-case-2.0.2.tgz#1c0884d3012c841556243483aa5d522f47396d2a"
+  integrity sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==
+  dependencies:
+    tslib "^2.0.3"
+
 is-map@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
@@ -12919,17 +13543,17 @@ is-plain-obj@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
   integrity sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==
 
+is-plain-object@5.0.0, is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
+
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
-
-is-plain-object@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
-  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
@@ -13043,6 +13667,13 @@ is-unicode-supported@^0.1.0:
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
+is-upper-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-upper-case/-/is-upper-case-2.0.2.tgz#f1105ced1fe4de906a5f39553e7d3803fd804649"
+  integrity sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==
+  dependencies:
+    tslib "^2.0.3"
+
 is-utf8@^0.2.0, is-utf8@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
@@ -13107,6 +13738,11 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+isexe@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-3.1.1.tgz#4a407e2bd78ddfb14bea0c27c6f7072dde775f0d"
+  integrity sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -13194,7 +13830,7 @@ istanbul-lib-processinfo@^2.0.2, istanbul-lib-processinfo@^2.0.3:
     rimraf "^3.0.0"
     uuid "^8.3.2"
 
-istanbul-lib-report@^3.0.0:
+istanbul-lib-report@^3.0.0, istanbul-lib-report@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
   integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
@@ -13212,7 +13848,7 @@ istanbul-lib-source-maps@^4.0.0:
     istanbul-lib-coverage "^3.0.0"
     source-map "^0.6.1"
 
-istanbul-reports@^3.0.2, istanbul-reports@^3.1.3:
+istanbul-reports@^3.0.2, istanbul-reports@^3.1.3, istanbul-reports@^3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.1.6.tgz#2544bcab4768154281a2f0870471902704ccaa1a"
   integrity sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==
@@ -13248,7 +13884,7 @@ jackspeak@^1.4.2:
   dependencies:
     cliui "^7.0.4"
 
-jackspeak@^2.3.5:
+jackspeak@^2.3.5, jackspeak@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-2.3.6.tgz#647ecc472238aee4b06ac0e461acc21a8c505ca8"
   integrity sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==
@@ -13816,7 +14452,7 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978"
   integrity sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==
 
-jsonparse@^1.2.0:
+jsonparse@^1.2.0, jsonparse@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
@@ -14800,10 +15436,27 @@ make-dir@^4.0.0:
   dependencies:
     semver "^7.5.3"
 
-make-error@^1, make-error@^1.0.2, make-error@^1.0.4, make-error@^1.2.1, make-error@^1.3.0, make-error@^1.3.2, make-error@^1.3.5, make-error@^1.3.6:
+make-error@^1, make-error@^1.0.2, make-error@^1.0.4, make-error@^1.1.1, make-error@^1.2.1, make-error@^1.3.0, make-error@^1.3.2, make-error@^1.3.5, make-error@^1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
+make-fetch-happen@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-13.0.0.tgz#705d6f6cbd7faecb8eac2432f551e49475bfedf0"
+  integrity sha512-7ThobcL8brtGo9CavByQrQi+23aIfgYU++wg4B87AIS8Rb2ZBt/MEaDqzA00Xwv/jUjAjYkLHjVolYuTLKda2A==
+  dependencies:
+    "@npmcli/agent" "^2.0.0"
+    cacache "^18.0.0"
+    http-cache-semantics "^4.1.1"
+    is-lambda "^1.0.1"
+    minipass "^7.0.2"
+    minipass-fetch "^3.0.0"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.4"
+    negotiator "^0.6.3"
+    promise-retry "^2.0.1"
+    ssri "^10.0.0"
 
 make-iterator@^1.0.0:
   version "1.0.1"
@@ -15208,6 +15861,53 @@ minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
+minipass-collect@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/minipass-collect/-/minipass-collect-2.0.1.tgz#1621bc77e12258a12c60d34e2276ec5c20680863"
+  integrity sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==
+  dependencies:
+    minipass "^7.0.3"
+
+minipass-fetch@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-3.0.4.tgz#4d4d9b9f34053af6c6e597a64be8e66e42bf45b7"
+  integrity sha512-jHAqnA728uUpIaFm7NWsCnqKT6UqZz7GcI/bDpPATuwYyKwJwW0remxSCxUlKiEty+eopHGa3oc8WxgQ1FFJqg==
+  dependencies:
+    minipass "^7.0.3"
+    minipass-sized "^1.0.3"
+    minizlib "^2.1.2"
+  optionalDependencies:
+    encoding "^0.1.13"
+
+minipass-flush@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/minipass-flush/-/minipass-flush-1.0.5.tgz#82e7135d7e89a50ffe64610a787953c4c4cbb373"
+  integrity sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-json-stream@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minipass-json-stream/-/minipass-json-stream-1.0.1.tgz#7edbb92588fbfc2ff1db2fc10397acb7b6b44aa7"
+  integrity sha512-ODqY18UZt/I8k+b7rl2AENgbWE8IDYam+undIJONvigAz8KR5GWblsFTEfQs0WODsjbSXWlm+JHEv8Gr6Tfdbg==
+  dependencies:
+    jsonparse "^1.3.1"
+    minipass "^3.0.0"
+
+minipass-pipeline@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz#68472f79711c084657c067c5c6ad93cddea8214c"
+  integrity sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-sized@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/minipass-sized/-/minipass-sized-1.0.3.tgz#70ee5a7c5052070afacfbc22977ea79def353b70"
+  integrity sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==
+  dependencies:
+    minipass "^3.0.0"
+
 minipass@^3.0.0, minipass@^3.1.5, minipass@^3.1.6, minipass@^3.3.4:
   version "3.3.6"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.3.6.tgz#7bba384db3a1520d18c9c0e5251c3444e95dd94a"
@@ -15220,12 +15920,12 @@ minipass@^5.0.0:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
   integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0":
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.2, minipass@^7.0.3:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.0.4.tgz#dbce03740f50a4786ba994c1fb908844d27b038c"
   integrity sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==
 
-minizlib@^2.1.1:
+minizlib@^2.1.1, minizlib@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
   integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
@@ -15278,6 +15978,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4, mkdirp@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+mkdirp@^3.0.0, mkdirp@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-3.0.1.tgz#e44e4c5607fb279c168241713cc6e0fea9adcb50"
+  integrity sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==
 
 mlly@^1.2.0, mlly@^1.4.2:
   version "1.5.0"
@@ -15387,7 +16092,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.1.1, ms@^2.1.2:
+ms@2.1.3, ms@^2.1.1, ms@^2.1.2, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -15529,7 +16234,7 @@ nearley@^2.7.10:
     railroad-diagrams "^1.0.0"
     randexp "0.4.6"
 
-negotiator@0.6.3:
+negotiator@0.6.3, negotiator@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
@@ -15643,6 +16348,22 @@ node-gyp-build@^4.2.0, node-gyp-build@^4.3.0:
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.0.tgz#3fee9c1731df4581a3f9ead74664369ff00d26dd"
   integrity sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==
 
+node-gyp@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-10.0.1.tgz#205514fc19e5830fa991e4a689f9e81af377a966"
+  integrity sha512-gg3/bHehQfZivQVfqIyy8wTdSymF9yTyP4CJifK73imyNMU8AIGQE2pUa7dNWfmMeG9cDVF2eehiRMv0LC1iAg==
+  dependencies:
+    env-paths "^2.2.0"
+    exponential-backoff "^3.1.1"
+    glob "^10.3.10"
+    graceful-fs "^4.2.6"
+    make-fetch-happen "^13.0.0"
+    nopt "^7.0.0"
+    proc-log "^3.0.0"
+    semver "^7.3.5"
+    tar "^6.1.2"
+    which "^4.0.0"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -15727,6 +16448,13 @@ nopt@^5.0.0:
   dependencies:
     abbrev "1"
 
+nopt@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-7.2.0.tgz#067378c68116f602f552876194fd11f1292503d7"
+  integrity sha512-CVDtwCdhYIvnAzFoJ6NJ6dX3oga9/HyciQDnG1vQDjSLMeKLJ4A93ZqYKDrgYSr1FBY5/hMYC+2VCi24pgpkGA==
+  dependencies:
+    abbrev "^2.0.0"
+
 normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -15804,6 +16532,65 @@ now-and-later@^2.0.0:
   integrity sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==
   dependencies:
     once "^1.3.2"
+
+npm-bundled@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-3.0.0.tgz#7e8e2f8bb26b794265028491be60321a25a39db7"
+  integrity sha512-Vq0eyEQy+elFpzsKjMss9kxqb9tG3YHg4dsyWuUENuzvSUWe1TCnW/vV9FkhvBk/brEDoDiVd+M1Btosa6ImdQ==
+  dependencies:
+    npm-normalize-package-bin "^3.0.0"
+
+npm-install-checks@^6.0.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/npm-install-checks/-/npm-install-checks-6.3.0.tgz#046552d8920e801fa9f919cad569545d60e826fe"
+  integrity sha512-W29RiK/xtpCGqn6f3ixfRYGk+zRyr+Ew9F2E20BfXxT5/euLdA/Nm7fO7OeTGuAmTs30cpgInyJ0cYe708YTZw==
+  dependencies:
+    semver "^7.1.1"
+
+npm-normalize-package-bin@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz#25447e32a9a7de1f51362c61a559233b89947832"
+  integrity sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==
+
+npm-package-arg@^11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-11.0.1.tgz#f208b0022c29240a1c532a449bdde3f0a4708ebc"
+  integrity sha512-M7s1BD4NxdAvBKUPqqRW957Xwcl/4Zvo8Aj+ANrzvIPzGJZElrH7Z//rSaec2ORcND6FHHLnZeY8qgTpXDMFQQ==
+  dependencies:
+    hosted-git-info "^7.0.0"
+    proc-log "^3.0.0"
+    semver "^7.3.5"
+    validate-npm-package-name "^5.0.0"
+
+npm-packlist@^8.0.0:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-8.0.2.tgz#5b8d1d906d96d21c85ebbeed2cf54147477c8478"
+  integrity sha512-shYrPFIS/JLP4oQmAwDyk5HcyysKW8/JLTEA32S0Z5TzvpaeeX2yMFfoK1fjEBnCBvVyIB/Jj/GBFdm0wsgzbA==
+  dependencies:
+    ignore-walk "^6.0.4"
+
+npm-pick-manifest@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/npm-pick-manifest/-/npm-pick-manifest-9.0.0.tgz#f87a4c134504a2c7931f2bb8733126e3c3bb7e8f"
+  integrity sha512-VfvRSs/b6n9ol4Qb+bDwNGUXutpy76x6MARw/XssevE0TnctIKcmklJZM5Z7nqs5z5aW+0S63pgCNbpkUNNXBg==
+  dependencies:
+    npm-install-checks "^6.0.0"
+    npm-normalize-package-bin "^3.0.0"
+    npm-package-arg "^11.0.0"
+    semver "^7.3.5"
+
+npm-registry-fetch@^16.0.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/npm-registry-fetch/-/npm-registry-fetch-16.1.0.tgz#10227b7b36c97bc1cf2902a24e4f710cfe62803c"
+  integrity sha512-PQCELXKt8Azvxnt5Y85GseQDJJlglTFM9L9U9gkv2y4e9s0k3GVDdOx3YoB6gm2Do0hlkzC39iCGXby+Wve1Bw==
+  dependencies:
+    make-fetch-happen "^13.0.0"
+    minipass "^7.0.2"
+    minipass-fetch "^3.0.0"
+    minipass-json-stream "^1.0.1"
+    minizlib "^2.1.2"
+    npm-package-arg "^11.0.0"
+    proc-log "^3.0.0"
 
 npm-run-all2@^6.1.1:
   version "6.1.1"
@@ -16164,7 +16951,7 @@ opencollective-postinstall@^2.0.2:
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
   integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
-opener@^1.5.1:
+opener@^1.5.1, opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
@@ -16337,6 +17124,13 @@ p-map@^3.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
+p-map@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
+  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
+  dependencies:
+    aggregate-error "^3.0.0"
+
 p-reduce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
@@ -16396,6 +17190,30 @@ package-json@^6.3.0:
     registry-auth-token "^4.0.0"
     registry-url "^5.0.0"
     semver "^6.2.0"
+
+pacote@^17.0.3:
+  version "17.0.6"
+  resolved "https://registry.yarnpkg.com/pacote/-/pacote-17.0.6.tgz#874bb59cda5d44ab784d0b6530fcb4a7d9b76a60"
+  integrity sha512-cJKrW21VRE8vVTRskJo78c/RCvwJCn1f4qgfxL4w77SOWrTCRcmfkYHlHtS0gqpgjv3zhXflRtgsrUCX5xwNnQ==
+  dependencies:
+    "@npmcli/git" "^5.0.0"
+    "@npmcli/installed-package-contents" "^2.0.1"
+    "@npmcli/promise-spawn" "^7.0.0"
+    "@npmcli/run-script" "^7.0.0"
+    cacache "^18.0.0"
+    fs-minipass "^3.0.0"
+    minipass "^7.0.2"
+    npm-package-arg "^11.0.0"
+    npm-packlist "^8.0.0"
+    npm-pick-manifest "^9.0.0"
+    npm-registry-fetch "^16.0.0"
+    proc-log "^3.0.0"
+    promise-retry "^2.0.1"
+    read-package-json "^7.0.0"
+    read-package-json-fast "^3.0.0"
+    sigstore "^2.2.0"
+    ssri "^10.0.0"
+    tar "^6.1.11"
 
 pako@^1.0.3, pako@~1.0.5:
   version "1.0.11"
@@ -16638,6 +17456,11 @@ patch-console@^1.0.0:
   resolved "https://registry.yarnpkg.com/patch-console/-/patch-console-1.0.0.tgz#19b9f028713feb8a3c023702a8cc8cb9f7466f9d"
   integrity sha512-nxl9nrnLQmh64iTzMfyylSlRozL7kAXIaxw1fVcLYdyhNkJCRUzirRZTikXGJsg+hc4fqpneTK6iU2H1Q8THSA==
 
+patch-console@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/patch-console/-/patch-console-2.0.0.tgz#9023f4665840e66f40e9ce774f904a63167433bb"
+  integrity sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==
+
 path-browserify@0.0.1, path-browserify@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
@@ -16717,7 +17540,7 @@ path-root@^0.1.1:
   dependencies:
     path-root-regex "^0.1.0"
 
-path-scurry@^1.10.1:
+path-scurry@^1.10.1, path-scurry@^1.9.2:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.10.1.tgz#9ba6bf5aa8500fe9fd67df4f0d9483b2b0bfc698"
   integrity sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==
@@ -16849,7 +17672,7 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==
 
-pirates@^4.0.4, pirates@^4.0.6:
+pirates@^4.0.4, pirates@^4.0.5, pirates@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
   integrity sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==
@@ -16912,6 +17735,11 @@ pngjs@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-5.0.0.tgz#e79dd2b215767fd9c04561c01236df960bce7fbb"
   integrity sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==
+
+polite-json@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/polite-json/-/polite-json-4.0.1.tgz#57580c8576b1f8c24350be8dcdef5582bb7d75e7"
+  integrity sha512-8LI5ZeCPBEb4uBbcYKNVwk4jgqNx1yHReWoW4H4uUihWlSqZsUDfSITrRhjliuPgxsNPFhNSudGO2Zu4cbWinQ==
 
 portfinder@^1.0.13, portfinder@^1.0.26:
   version "1.0.32"
@@ -17399,10 +18227,24 @@ pretty-time@^1.1.0:
   resolved "https://registry.yarnpkg.com/pretty-time/-/pretty-time-1.1.0.tgz#ffb7429afabb8535c346a34e41873adf3d74dd0e"
   integrity sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA==
 
-prismjs@^1.13.0:
+prismjs-terminal@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/prismjs-terminal/-/prismjs-terminal-1.2.3.tgz#ece78c1c19fe73694ca609a7aee2b3d4de926d4c"
+  integrity sha512-xc0zuJ5FMqvW+DpiRkvxURlz98DdfDsZcFHdO699+oL+ykbFfgI7O4VDEgUyc07BSL2NHl3zdb8m/tZ/aaqUrw==
+  dependencies:
+    chalk "^5.2.0"
+    prismjs "^1.29.0"
+    string-length "^6.0.0"
+
+prismjs@^1.13.0, prismjs@^1.29.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
   integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
+
+proc-log@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/proc-log/-/proc-log-3.0.0.tgz#fb05ef83ccd64fd7b20bbe9c8c1070fc08338dd8"
+  integrity sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==
 
 process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -17438,6 +18280,14 @@ promise-polyfill@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-6.1.0.tgz#dfa96943ea9c121fca4de9b5868cb39d3472e057"
   integrity sha512-g0LWaH0gFsxovsU7R5LrrhHhWAWiHRnh1GPrhXnPgYsDkIqjRYUYSZEsej/wtleDrz5xVSIDbeKfidztp2XHFQ==
+
+promise-retry@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-2.0.1.tgz#ff747a13620ab57ba688f5fc67855410c370da22"
+  integrity sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==
+  dependencies:
+    err-code "^2.0.2"
+    retry "^0.12.0"
 
 promise-toolbox@^0.19.0:
   version "0.19.2"
@@ -18141,6 +18991,15 @@ react-dropzone@^4.2.3:
     attr-accept "^1.1.3"
     prop-types "^15.5.7"
 
+react-element-to-jsx-string@^15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-15.0.0.tgz#1cafd5b6ad41946ffc8755e254da3fc752a01ac6"
+  integrity sha512-UDg4lXB6BzlobN60P8fHWVPX3Kyw8ORrTeBtClmIlGdkOOE+GYQSFvmEU5iLLpwp/6v42DINwNcwOhOLfQ//FQ==
+  dependencies:
+    "@base2/pretty-print-object" "1.0.1"
+    is-plain-object "5.0.0"
+    react-is "18.1.0"
+
 react-input-autosize@^2.1.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.2.tgz#fcaa7020568ec206bc04be36f4eb68e647c4d8c2"
@@ -18158,6 +19017,11 @@ react-intl@^2.4.0:
     intl-messageformat "^2.1.0"
     intl-relativeformat "^2.1.0"
     invariant "^2.1.1"
+
+react-is@18.1.0:
+  version "18.1.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.1.0.tgz#61aaed3096d30eacf2a2127118b5b41387d32a67"
+  integrity sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==
 
 react-is@^16.12.0, react-is@^16.13.0, react-is@^16.13.1, react-is@^16.3.1, react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0:
   version "16.13.1"
@@ -18236,6 +19100,14 @@ react-reconciler@^0.26.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
+
+react-reconciler@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.29.0.tgz#ee769bd362915076753f3845822f2d1046603de7"
+  integrity sha512-wa0fGj7Zht1EYMRhKWwoo1H9GApxYLBuhoAuXN0TlltESAjDssB+Apf0T/DngVqaMyPypDmabL37vw/2aRM98Q==
+  dependencies:
+    loose-envify "^1.1.0"
+    scheduler "^0.23.0"
 
 react-redux@^5.0.6:
   version "5.1.2"
@@ -18348,12 +19220,37 @@ react@^17.0.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+react@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
+  dependencies:
+    loose-envify "^1.1.0"
+
 read-only-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/read-only-stream/-/read-only-stream-2.0.0.tgz#2724fd6a8113d73764ac288d4386270c1dbf17f0"
   integrity sha512-3ALe0bjBVZtkdWKIcThYpQCLbBMd/+Tbh2CDSrAIDO3UsZ4Xs+tnyjv2MjCOMMgBG+AsUOeuP1cgtY1INISc8w==
   dependencies:
     readable-stream "^2.0.2"
+
+read-package-json-fast@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/read-package-json-fast/-/read-package-json-fast-3.0.2.tgz#394908a9725dc7a5f14e70c8e7556dff1d2b1049"
+  integrity sha512-0J+Msgym3vrLOUB3hzQCuZHII0xkNGCtz/HJH9xZshwv9DbDwkw1KaE3gx/e2J5rpEY5rtOy6cyhKOPrkP7FZw==
+  dependencies:
+    json-parse-even-better-errors "^3.0.0"
+    npm-normalize-package-bin "^3.0.0"
+
+read-package-json@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/read-package-json/-/read-package-json-7.0.0.tgz#d605c9dcf6bc5856da24204aa4e9518ee9714be0"
+  integrity sha512-uL4Z10OKV4p6vbdvIXB+OzhInYtIozl/VxUBPgNkBuUi2DeRonnuspmaVAMcrkmfjKGNmRndyQAbE7/AmzGwFg==
+  dependencies:
+    glob "^10.2.2"
+    json-parse-even-better-errors "^3.0.0"
+    normalize-package-data "^6.0.0"
+    npm-normalize-package-bin "^3.0.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -18841,6 +19738,14 @@ resolve-global@1.0.0, resolve-global@^1.0.0:
   dependencies:
     global-dirs "^0.1.1"
 
+resolve-import@^1.4.4, resolve-import@^1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/resolve-import/-/resolve-import-1.4.5.tgz#d6f74648ef53ca0e8f2d5cab95322573de9737a4"
+  integrity sha512-HXb4YqODuuXT7Icq1Z++0g2JmhgbUHSs3VT2xR83gqvAPUikYT2Xk+562KHQgiaNkbBOlPddYrDLsC44qQggzw==
+  dependencies:
+    glob "^10.3.3"
+    walk-up-path "^3.0.1"
+
 resolve-options@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/resolve-options/-/resolve-options-1.1.0.tgz#32bb9e39c06d67338dc9378c0d6d6074566ad131"
@@ -18965,7 +19870,7 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^5.0.1:
+rimraf@^5.0.1, rimraf@^5.0.5:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-5.0.5.tgz#9be65d2d6e683447d2e9013da2bf451139a61ccf"
   integrity sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==
@@ -19153,6 +20058,13 @@ scheduler@^0.20.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
+  dependencies:
+    loose-envify "^1.1.0"
+
 schema-utils@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"
@@ -19215,7 +20127,7 @@ semver-greatest-satisfied-range@^1.1.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
-semver@7.5.4, semver@^7.0.0, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.6, semver@^7.5.3, semver@^7.5.4:
+semver@7.5.4, semver@^7.0.0, semver@^7.1.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.6, semver@^7.5.3, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
@@ -19411,15 +20323,15 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
+signal-exit@4.1, signal-exit@^4.0.1, signal-exit@^4.0.2, signal-exit@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
 signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.4, signal-exit@^3.0.6, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
-
-signal-exit@^4.0.1, signal-exit@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
-  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
 signed-varint@^2.0.1:
   version "2.0.1"
@@ -19427,6 +20339,18 @@ signed-varint@^2.0.1:
   integrity sha512-abgDPg1106vuZZOvw7cFwdCABddfJRz5akcCcchzTbhyhYnsG31y4AlZEgp315T7W3nQq5P4xeOm186ZiPVFzw==
   dependencies:
     varint "~5.0.0"
+
+sigstore@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/sigstore/-/sigstore-2.2.0.tgz#acba5f73ca2158d2b0507bc52d3592149c3ed20e"
+  integrity sha512-fcU9clHwEss2/M/11FFM8Jwc4PjBgbhXoNskoK5guoK0qGQBSeUbQZRJ+B2fDFIvhyf0gqCaPrel9mszbhAxug==
+  dependencies:
+    "@sigstore/bundle" "^2.1.1"
+    "@sigstore/core" "^0.2.0"
+    "@sigstore/protobuf-specs" "^0.2.1"
+    "@sigstore/sign" "^2.2.1"
+    "@sigstore/tuf" "^2.3.0"
+    "@sigstore/verify" "^0.1.0"
 
 simple-concat@^1.0.0:
   version "1.0.1"
@@ -19505,6 +20429,14 @@ slice-ansi@^5.0.0:
   integrity sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==
   dependencies:
     ansi-styles "^6.0.0"
+    is-fullwidth-code-point "^4.0.0"
+
+slice-ansi@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-6.0.0.tgz#f08a1e6703e3598256b667f015ccef9f12c59f7c"
+  integrity sha512-6bn4hRfkTvDfUoEQYkERg0BVF1D0vrX9HEkMl08uDiNWvVvjylLHvZFZWkDo6wjT8tUctbYl1nCOuE66ZTaUtA==
+  dependencies:
+    ansi-styles "^6.2.1"
     is-fullwidth-code-point "^4.0.0"
 
 slice-ansi@^7.0.0:
@@ -19596,7 +20528,7 @@ sockjs@^0.3.21:
     uuid "^8.3.2"
     websocket-driver "^0.7.4"
 
-socks-proxy-agent@^8.0.2:
+socks-proxy-agent@^8.0.1, socks-proxy-agent@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz#5acbd7be7baf18c46a3f293a840109a430a640ad"
   integrity sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==
@@ -19816,6 +20748,13 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
+ssri@^10.0.0:
+  version "10.0.5"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-10.0.5.tgz#e49efcd6e36385196cb515d3a2ad6c3f0265ef8c"
+  integrity sha512-bSf16tAFkGeRlUNDjXu8FzaMQt6g2HZJrun7mtMbIPOddxt3GLMSz5VWUWcqTJUPfLEaDIepGxv+bYQW49596A==
+  dependencies:
+    minipass "^7.0.3"
+
 ssri@^6.0.1:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.2.tgz#157939134f20464e7301ddba3e90ffa8f7728ac5"
@@ -19840,7 +20779,7 @@ stack-utils@^1.0.1:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-stack-utils@^2.0.2, stack-utils@^2.0.3, stack-utils@^2.0.4:
+stack-utils@^2.0.2, stack-utils@^2.0.3, stack-utils@^2.0.4, stack-utils@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.6.tgz#aaf0748169c02fc33c8232abccf933f54a1cc34f"
   integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
@@ -19994,6 +20933,13 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
+string-length@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-6.0.0.tgz#1c7342bbf032129b2f80003e69f889c70231d791"
+  integrity sha512-1U361pxZHEQ+FeSjzqRpV+cu2vTzYeWeafXFLykiFlv4Vc0n3njgU8HrMbyik5uwm77naWMuVG8fhEF+Ovb1Kg==
+  dependencies:
+    strip-ansi "^7.1.0"
+
 "string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -20021,7 +20967,7 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^5.0.1, string-width@^5.1.2:
+string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
   integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
@@ -20391,6 +21337,16 @@ symbol-observable@^1.0.3:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
+sync-content@^1.0.1, sync-content@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/sync-content/-/sync-content-1.0.2.tgz#c76bca03e7d4c5a1ec3e5024f85144a7b592640d"
+  integrity sha512-znd3rYiiSxU3WteWyS9a6FXkTA/Wjk8WQsOyzHbineeL837dLn3DA4MRhsIX3qGcxDMH6+uuFV4axztssk7wEQ==
+  dependencies:
+    glob "^10.2.6"
+    mkdirp "^3.0.1"
+    path-scurry "^1.9.2"
+    rimraf "^5.0.1"
+
 synckit@^0.8.6:
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.8.tgz#fe7fe446518e3d3d49f5e429f443cf08b6edfcd7"
@@ -20425,6 +21381,14 @@ tap-mocha-reporter@^5.0.3:
     tap-yaml "^1.0.0"
     unicode-length "^2.0.2"
 
+tap-parser@15.3.1:
+  version "15.3.1"
+  resolved "https://registry.yarnpkg.com/tap-parser/-/tap-parser-15.3.1.tgz#2d18027340eb357396df5758bcb42df946a7e4aa"
+  integrity sha512-hwAtXX5TBGt2MJeYvASc7DjP48PUzA7P8RTbLxQcgKCEH7ICD5IsRco7l5YvkzjHlZbUbeI9wzO8B4hw2sKgnQ==
+  dependencies:
+    events-to-array "^2.0.3"
+    tap-yaml "2.2.1"
+
 tap-parser@^11.0.0, tap-parser@^11.0.2:
   version "11.0.2"
   resolved "https://registry.yarnpkg.com/tap-parser/-/tap-parser-11.0.2.tgz#5d3e76e2cc521e23a8c50201487b273ca0fba800"
@@ -20433,6 +21397,14 @@ tap-parser@^11.0.0, tap-parser@^11.0.2:
     events-to-array "^1.0.1"
     minipass "^3.1.6"
     tap-yaml "^1.0.0"
+
+tap-yaml@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tap-yaml/-/tap-yaml-2.2.1.tgz#dcc2e901533a9c053630d070e8a1603ef2831f40"
+  integrity sha512-ovZuUMLAIH59jnFHXKEGJ+WyDYl6Cuduwg9qpvnqkZOUA1nU84q02Sry1HT0KXcdv2uB91bEKKxnIybBgrb6oA==
+  dependencies:
+    yaml "^2.3.0"
+    yaml-types "^0.3.0"
 
 tap-yaml@^1.0.0, tap-yaml@^1.0.2:
   version "1.0.2"
@@ -20473,6 +21445,31 @@ tap@^16.0.1, tap@^16.1.0, tap@^16.2.0, tap@^16.3.0:
     treport "^3.0.4"
     which "^2.0.2"
 
+tap@^18.6.1:
+  version "18.7.0"
+  resolved "https://registry.yarnpkg.com/tap/-/tap-18.7.0.tgz#11ed2cb9af29bec8734f73af91bb26925dd6ca63"
+  integrity sha512-bL/0krlx8k3fY9mjI9CMfVoAGclZegl+vm5pEJpF/USxam5eNhp5wLk5UH0ST3gWEJkW0PDdFHTOStE+mYurrQ==
+  dependencies:
+    "@tapjs/after" "1.1.18"
+    "@tapjs/after-each" "1.1.18"
+    "@tapjs/asserts" "1.1.18"
+    "@tapjs/before" "1.1.18"
+    "@tapjs/before-each" "1.1.18"
+    "@tapjs/core" "1.5.0"
+    "@tapjs/filter" "1.2.18"
+    "@tapjs/fixture" "1.2.18"
+    "@tapjs/intercept" "1.2.18"
+    "@tapjs/mock" "1.3.0"
+    "@tapjs/node-serialize" "1.3.0"
+    "@tapjs/run" "1.5.0"
+    "@tapjs/snapshot" "1.2.18"
+    "@tapjs/spawn" "1.1.18"
+    "@tapjs/stdin" "1.1.18"
+    "@tapjs/test" "1.4.0"
+    "@tapjs/typescript" "1.4.0"
+    "@tapjs/worker" "1.1.18"
+    resolve-import "^1.4.5"
+
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
@@ -20492,7 +21489,7 @@ tar-stream@^3.1.6:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
-tar@^6.1.11, tar@^6.1.15:
+tar@^6.1.11, tar@^6.1.15, tar@^6.1.2:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.0.tgz#b14ce49a79cb1cd23bc9b016302dea5474493f73"
   integrity sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==
@@ -20503,6 +21500,14 @@ tar@^6.1.11, tar@^6.1.15:
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
+
+tcompare@6.4.5:
+  version "6.4.5"
+  resolved "https://registry.yarnpkg.com/tcompare/-/tcompare-6.4.5.tgz#68a8786309050e645099a0eff34941ef75fb241c"
+  integrity sha512-Whuz9xlKKI2XXICKDSDRKjXdBuC6gBNOgmEUtH7UFyQeYzfUMQ19DyjZULarGKDGFhgOg3CJ+IQUEfpkOPg0Uw==
+  dependencies:
+    diff "^5.1.0"
+    react-element-to-jsx-string "^15.0.0"
 
 tcompare@^5.0.6, tcompare@^5.0.7:
   version "5.0.7"
@@ -20832,6 +21837,11 @@ trivial-deferred@^1.0.1:
   resolved "https://registry.yarnpkg.com/trivial-deferred/-/trivial-deferred-1.1.2.tgz#6b07aa1eb045f6128b8b30673b040f99bfe64a2e"
   integrity sha512-vDPiDBC3hyP6O4JrJYMImW3nl3c03Tsj9fEXc7Qc/XKa1O7gf5ZtFfIR/E0dun9SnDHdwjna1Z2rSzYgqpxh/g==
 
+trivial-deferred@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/trivial-deferred/-/trivial-deferred-2.0.0.tgz#06b6ffa7655916fbe5956203b5e06842fa969dd1"
+  integrity sha512-iGbM7X2slv9ORDVj2y2FFUq3cP/ypbtu2nQ8S38ufjL0glBABvmR9pTdsib1XtS2LUhhLMbelaBUaf/s5J3dSw==
+
 "true-case-path@^1.0.2":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-1.0.3.tgz#f813b5a8c86b40da59606722b144e3225799f47d"
@@ -20854,6 +21864,21 @@ tsconfig-paths@^3.11.0, tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
+tshy@^1.2.2, tshy@^1.7.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/tshy/-/tshy-1.11.0.tgz#411a0271c878e989f5b0b1005c7df0db1d2ee7d0"
+  integrity sha512-5T5PVyuYQKTcOKz5a2lpwx4WKi8yEzQGO0Q5l+9clJMYupMaTI7ONEwKggGAZDQQGIgCOyUCfBWnSkG0XdJc+A==
+  dependencies:
+    chalk "^5.3.0"
+    chokidar "^3.5.3"
+    foreground-child "^3.1.1"
+    mkdirp "^3.0.1"
+    resolve-import "^1.4.4"
+    rimraf "^5.0.1"
+    sync-content "^1.0.2"
+    typescript "5.2 || 5.3"
+    walk-up-path "^3.0.1"
+
 tslib@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
@@ -20864,7 +21889,7 @@ tslib@^1.11.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.1, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.5.0, tslib@^2.6.2:
+tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.5.0, tslib@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
@@ -20883,6 +21908,15 @@ tty-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.1.tgz#3f05251ee17904dfd0677546670db9651682b811"
   integrity sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==
+
+tuf-js@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tuf-js/-/tuf-js-2.2.0.tgz#4daaa8620ba7545501d04dfa933c98abbcc959b9"
+  integrity sha512-ZSDngmP1z6zw+FIkIBjvOp/II/mIub/O7Pp12j1WNsiCpg5R5wAc//i555bBQsE44O94btLt0xM/Zr2LQjwdCg==
+  dependencies:
+    "@tufjs/models" "2.0.0"
+    debug "^4.3.4"
+    make-fetch-happen "^13.0.0"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -21064,7 +22098,12 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^5.0.3, typescript@~5.3.3:
+typescript@5.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+
+"typescript@5.2 || 5.3", typescript@^5.0.3, typescript@~5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
@@ -21250,10 +22289,24 @@ unique-filename@^1.1.1:
   dependencies:
     unique-slug "^2.0.0"
 
+unique-filename@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-3.0.0.tgz#48ba7a5a16849f5080d26c760c86cf5cf05770ea"
+  integrity sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==
+  dependencies:
+    unique-slug "^4.0.0"
+
 unique-slug@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.2.tgz#baabce91083fc64e945b0f3ad613e264f7cd4e6c"
   integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
+  dependencies:
+    imurmurhash "^0.1.4"
+
+unique-slug@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-4.0.0.tgz#6bae6bb16be91351badd24cdce741f892a6532e3"
+  integrity sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==
   dependencies:
     imurmurhash "^0.1.4"
 
@@ -21493,7 +22546,12 @@ uuid@^9.0.0, uuid@~9.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
-v8-to-istanbul@^9.0.1:
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
+
+v8-to-istanbul@^9.0.0, v8-to-istanbul@^9.0.1:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz#2ed7644a245cddd83d4e087b9b33b3e62dfd10ad"
   integrity sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==
@@ -21516,6 +22574,13 @@ validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validate-npm-package-name@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz#f16afd48318e6f90a1ec101377fa0384cfc8c713"
+  integrity sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==
+  dependencies:
+    builtins "^5.0.0"
 
 value-or-function@^3.0.0:
   version "3.0.0"
@@ -21833,6 +22898,11 @@ vuepress@^1.4.1:
     envinfo "^7.2.0"
     opencollective-postinstall "^2.0.2"
     update-notifier "^4.0.0"
+
+walk-up-path@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/walk-up-path/-/walk-up-path-3.0.1.tgz#c8d78d5375b4966c717eb17ada73dbd41490e886"
+  integrity sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA==
 
 walker@^1.0.8:
   version "1.0.8"
@@ -22182,6 +23252,13 @@ which@^3.0.0:
   dependencies:
     isexe "^2.0.0"
 
+which@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-4.0.0.tgz#cd60b5e74503a3fbcfbf6cd6b4138a8bae644c1a"
+  integrity sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==
+  dependencies:
+    isexe "^3.1.1"
+
 wide-align@^1.1.2:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
@@ -22195,6 +23272,13 @@ widest-line@^3.1.0:
   integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
   dependencies:
     string-width "^4.0.0"
+
+widest-line@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-4.0.1.tgz#a0fc673aaba1ea6f0a0d35b3c2795c9a9cc2ebf2"
+  integrity sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==
+  dependencies:
+    string-width "^5.0.1"
 
 window-size@0.1.0:
   version "0.1.0"
@@ -22324,7 +23408,7 @@ ws@^7, ws@^7.5.5:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
-ws@^8.2.3, ws@^8.3.0, ws@^8.4.0, ws@^8.5.0:
+ws@^8.12.0, ws@^8.2.3, ws@^8.3.0, ws@^8.4.0, ws@^8.5.0:
   version "8.16.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.16.0.tgz#d1cd774f36fbc07165066a60e40323eab6446fd4"
   integrity sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==
@@ -22480,7 +23564,12 @@ yaml-eslint-parser@^1.2.2:
     lodash "^4.17.21"
     yaml "^2.0.0"
 
-yaml@2.3.4, yaml@^2.0.0, yaml@^2.2.2, yaml@^2.3.2:
+yaml-types@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/yaml-types/-/yaml-types-0.3.0.tgz#b077f34496e12dc709d97f2c3bad3fff11089680"
+  integrity sha512-i9RxAO/LZBiE0NJUy9pbN5jFz5EasYDImzRkj8Y81kkInTi1laia3P3K/wlMKzOxFQutZip8TejvQP/DwgbU7A==
+
+yaml@2.3.4, yaml@^2.0.0, yaml@^2.2.2, yaml@^2.3.0, yaml@^2.3.2:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.4.tgz#53fc1d514be80aabf386dc6001eb29bf3b7523b2"
   integrity sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==
@@ -22570,7 +23659,7 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.0.0, yargs@^17.3.1:
+yargs@^17.0.0, yargs@^17.3.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
@@ -22635,6 +23724,11 @@ yoga-layout-prebuilt@^1.9.6:
   integrity sha512-YnOmtSbv4MTf7RGJMK0FvZ+KD8OEe/J5BNnR0GHhD8J/XcG/Qvxgszm0Un6FTHWW4uHlTgP0IztiXQnGyIR45g==
   dependencies:
     "@types/yoga-layout" "1.9.2"
+
+yoga-wasm-web@~0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/yoga-wasm-web/-/yoga-wasm-web-0.3.3.tgz#eb8e9fcb18e5e651994732f19a220cb885d932ba"
+  integrity sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==
 
 zepto@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
### Description
in the doc folder of the new package


one watcher per vm should not overload the remote, even with a few thousands VMs saved ( default inotify allow 8192 watcher )

review by commit 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
