### PR TITLE
feat(backups): deduplication

### DIFF
--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -681,13 +681,14 @@ export class RemoteAdapter {
     return path
   }
 
-  async writeVhd(path, input, { checksum = true, validator = noop, writeBlockConcurrency } = {}) {
+  async writeVhd(path, input, { checksum = true, validator = noop, writeBlockConcurrency, dedup = false } = {}) {
     const handler = this._handler
     if (this.useVhdDirectory()) {
       const dataPath = `${dirname(path)}/data/${uuidv4()}.vhd`
       const size = await createVhdDirectoryFromStream(handler, dataPath, input, {
         concurrency: writeBlockConcurrency,
         compression: this.#getCompressionType(),
+        dedup,
         async validator() {
           await input.task
           return validator.apply(this, arguments)

--- a/@xen-orchestra/backups/_cleanVm.mjs
+++ b/@xen-orchestra/backups/_cleanVm.mjs
@@ -146,6 +146,17 @@ export async function checkAliases(
     }
 
     try {
+      target = await resolveVhdAlias(handler, alias)
+  
+      if (!isVhdFile(target)) {
+        logWarn('alias references non VHD target', { alias, target })
+        if (remove) {
+          logInfo('removing alias and non VHD target', { alias, target })
+          await handler.unlink(target)
+          await handler.unlink(alias)
+        }
+        continue
+      }
       const { dispose } = await openVhd(handler, target)
       try {
         await dispose()

--- a/@xen-orchestra/backups/_runners/VmsXapi.mjs
+++ b/@xen-orchestra/backups/_runners/VmsXapi.mjs
@@ -20,6 +20,7 @@ const DEFAULT_XAPI_VM_SETTINGS = {
   concurrency: 2,
   copyRetention: 0,
   deleteFirst: false,
+  dedup: false,
   diskPerVmConcurrency: 0, // not limited by default
   exportRetention: 0,
   fullInterval: 0,

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
@@ -235,6 +235,7 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
             // no checksum for VHDs, because they will be invalidated by
             // merges and chainings
             checksum: false,
+            dedup: settings.dedup,
             validator: tmpPath => checkVhd(handler, tmpPath),
             writeBlockConcurrency: this._config.writeBlockConcurrency,
           })

--- a/@xen-orchestra/backups/docs/VM backups/README.md
+++ b/@xen-orchestra/backups/docs/VM backups/README.md
@@ -45,6 +45,34 @@ When `useVhdDirectory` is enabled on the remote, the directory containing the VH
     └─ <uuid>.vhd
 ```
 
+#### vhd directory with deduplication
+
+the difference with non dedup mode is that a hash is computed of each vhd block. The hash is splited in 4 chars token and the data are stored  in xo-block-store/{token1}/.../{token7}/{token8}.source.
+Then a hard link is made from this source to the destination folder in <vdis>/<job UUID>/<VDI UUID>/blocks/{number}/{number}
+
+
+```
+<remote>
+└─ xo-block-store
+  └─ {4 char}
+    └─  ...
+        └─ {char.source} 
+└─ xo-vm-backups
+  ├─ index.json // TODO
+  └─ <VM UUID>
+     ├─ cache.json.gz
+     ├─ vdis
+     │  └─ <job UUID>
+     │     └─ <VDI UUID>
+     │        ├─ index.json // TODO
+     │        ├─ <YYYYMMDD>T<HHmmss>.alias.vhd // contains the relative path to a VHD directory
+     |        └─ data
+     |          ├─ <uuid>.vhd // VHD directory format is described in vhd-lib/Vhd/VhdDirectory.js
+     ├─ <YYYYMMDD>T<HHmmss>.json // backup metadata
+     ├─ <YYYYMMDD>T<HHmmss>.xva
+     └─ <YYYYMMDD>T<HHmmss>.xva.checksum
+```
+
 ## Cache for a VM
 
 In a VM directory, if the file `cache.json.gz` exists, it contains the metadata for all the backups for this VM.

--- a/@xen-orchestra/backups/docs/dedup.md
+++ b/@xen-orchestra/backups/docs/dedup.md
@@ -1,0 +1,23 @@
+# Deduplication
+
+- This this use a additionnal inode (or equivalent on the FS), for each different block in the xo-block-store`sub folder`
+- This will not work well with immutabilty/object lock
+- only dedup blocks of vhd directory
+- prerequisite are : the fs must support hard link and extended attributes
+- a key (full backup) does not take more space on te remote than a delta. It will take more inodes , and more time since we'll have to read all the blocks. T
+
+When a new block is written to the remote, a hash is computed. If a file with this hash doesn't exists in xo-block-store` create it, then add the has as an extended attributes.
+A link hard link, sharing data and extended attributes is then create to the destination
+
+When deleting a block which has a hash extended attributes, a check is done on the xo-block-store. If there are no other link, then the block is deleted . The directory containing it stays
+
+When merging block : the unlink method is called before overwriting an existing block
+
+### troubleshooting
+
+Since all the blocks are hard linked, you can convert a deduplicated remote to a non deduplicated one by deleting the xo-block-store directory
+
+two new method has been added to the local fs handler :
+
+- deduplicationGarbageCollector(), which should be called from the root of the FS : it will clean any block without other links, and any empty directory
+- deduplicationStats() that will compute the number of blocks in store and how many times they are used

--- a/@xen-orchestra/backups/formatVmBackups.mjs
+++ b/@xen-orchestra/backups/formatVmBackups.mjs
@@ -32,6 +32,7 @@ function formatVmBackup(backup) {
 
     id: backup.id,
     isImmutable: backup.isImmutable,
+    dedup: backup.dedup,
     jobId: backup.jobId,
     mode: backup.mode,
     scheduleId: backup.scheduleId,

--- a/@xen-orchestra/fs/package.json
+++ b/@xen-orchestra/fs/package.json
@@ -33,6 +33,7 @@
     "bind-property-descriptor": "^2.0.0",
     "decorator-synchronized": "^0.6.0",
     "execa": "^5.0.0",
+    "fs-extended-attributes": "^1.0.1",
     "fs-extra": "^11.1.0",
     "get-stream": "^6.0.0",
     "limit-concurrency-decorator": "^0.6.0",

--- a/@xen-orchestra/fs/src/index.js
+++ b/@xen-orchestra/fs/src/index.js
@@ -19,7 +19,8 @@ try {
 } catch (_) {}
 
 export const getHandler = (remote, ...rest) => {
-  const Handler = HANDLERS[parse(remote.url).type]
+  const { type  }  = parse(remote.url)
+  const Handler = HANDLERS[type]
   if (!Handler) {
     throw new Error('Unhandled remote type')
   }

--- a/@xen-orchestra/fs/src/local.js
+++ b/@xen-orchestra/fs/src/local.js
@@ -1,12 +1,17 @@
 import assert from 'node:assert/strict'
-import fromCallback from 'promise-toolbox/fromCallback'
 import fs from 'fs-extra'
+import fsx from 'fs-extended-attributes'
 import lockfile from 'proper-lockfile'
 import { createLogger } from '@xen-orchestra/log'
 import { execFile } from 'node:child_process'
-import { fromEvent, retry } from 'promise-toolbox'
-
+import { asyncEach } from '@vates/async-each'
+import { fromEvent, fromCallback, ignoreErrors, retry } from 'promise-toolbox'
+import { synchronized } from 'decorator-synchronized'
+ 
 import RemoteHandlerAbstract from './abstract'
+import { normalize as normalizePath } from './path'
+
+import { createHash, randomBytes } from 'node:crypto'
 
 const { info, warn } = createLogger('xo:fs:local')
 
@@ -55,6 +60,10 @@ export default class LocalHandler extends RemoteHandlerAbstract {
   #addSyncStackTrace
   #retriesOnEagain
 
+  #supportDedup
+  #dedupDirectory = '/xo-block-store'
+  #hashMethod = 'sha256'
+  #attributeKey = `user.hash.${this.#hashMethod}`
   constructor(remote, opts = {}) {
     super(remote)
 
@@ -217,16 +226,242 @@ export default class LocalHandler extends RemoteHandlerAbstract {
     return this.#addSyncStackTrace(fs.truncate, this.getFilePath(file), len)
   }
 
-  async _unlink(file) {
-    const filePath = this.getFilePath(file)
+  async #localUnlink(filePath) {
     return await this.#addSyncStackTrace(retry, () => fs.unlink(filePath), this.#retriesOnEagain)
+  }
+  async _unlink(file, { dedup } = {}) {
+    const filePath = this.getFilePath(file)
+    let hash
+    // only try to read dedup source if we try to delete something deduplicated
+    if (dedup === true) {
+      try {
+        // get hash before deleting the file
+        hash = await this.#getExtendedAttribute(file, this.#attributeKey)
+      } catch (err) {
+        // whatever : fall back to normal delete
+      }
+    }
+
+    // delete file in place
+    await this.#localUnlink(filePath)
+
+    // implies we are on a deduplicated file
+    if (hash !== undefined) {
+      const dedupPath = this.getFilePath(this.#computeDeduplicationPath(hash))
+      try {
+        const { nlink } = await fs.stat(dedupPath)
+        // get the number of copy still using these data
+        // delete source if it's alone
+        if (nlink === 1) {
+          await this.#localUnlink(dedupPath)
+        }
+      } catch (error) {
+        // no problem if another process deleted the source or if we unlink directly the source file
+        if (error.code !== 'ENOENT') {
+          throw error
+        }
+      }
+    }
   }
 
   _writeFd(file, buffer, position) {
     return this.#addSyncStackTrace(fs.write, file.fd, buffer, 0, buffer.length, position)
   }
 
-  _writeFile(file, data, { flags }) {
+  #localWriteFile(file, data, { flags }) {
     return this.#addSyncStackTrace(fs.writeFile, this.getFilePath(file), data, { flag: flags })
+  }
+
+  async _writeFile(file, data, { flags, dedup }) {
+    if (dedup === true) {
+      // only compute support once , and only if needed
+      if (this.#supportDedup === undefined) {
+        const supported = await this.checkSupport()
+        this.#supportDedup = supported.hardLink === true && supported.extendedAttributes === true
+      }
+      if (this.#supportDedup) {
+        const hash = this.#hash(data)
+        // create the file (if not already present) in the store
+        const dedupPath = await this.#writeDeduplicationSource(hash, data)
+        // hard link to the target place
+        // this linked file will have the same extended attributes
+        // (used for unlink)
+        return this.#link(dedupPath, file)
+      }
+    }
+    // fallback
+    return this.#localWriteFile(file, data, { flags })
+  }
+
+  #hash(data) {
+    return createHash(this.#hashMethod).update(data).digest('hex')
+  }
+
+  async #getExtendedAttribute(file, attributeName) {
+    return new Promise((resolve, reject) => {
+      fsx.get(this.getFilePath(file), attributeName, (err, res) => {
+        if (err) {
+          reject(err)
+        } else {
+          // res is a buffer
+          // it is null if the file doesn't have this attribute
+          if (res !== null) {
+            resolve(res.toString('utf-8'))
+          }
+          resolve(undefined)
+        }
+      })
+    })
+  }
+  async #setExtendedAttribute(file, attributeName, value) {
+    return new Promise((resolve, reject) => {
+      fsx.set(this.getFilePath(file), attributeName, value, (err, res) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(res)
+        }
+      })
+    })
+  }
+
+  // create a hard link between to files
+  #link(source, dest) {
+    return fs.link(this.getFilePath(source), this.getFilePath(dest))
+  }
+
+  // split path to keep a sane number of file per directory
+  #computeDeduplicationPath(hash) {
+    assert.equal(hash.length % 4, 0)
+    let path = this.#dedupDirectory
+    for (let i = 0; i < hash.length; i++) {
+      if (i % 4 === 0) {
+        path += '/'
+      }
+      path += hash[i]
+    }
+    path += '.source'
+    return path
+  }
+
+  async #writeDeduplicationSource(hash, data) {
+    const path = this.#computeDeduplicationPath(hash)
+    try {
+      // flags ensures it fails if it already exists
+      // _outputfile will create the directory tree
+      await this._outputFile(path, data, { flags: 'wx' })
+    } catch (error) {
+      // if it is alread present : not a problem
+      if (error.code === 'EEXIST') {
+        // it should already have the extended attributes, nothing more to do
+        return path
+      }
+      throw error
+    }
+
+    try {
+      await this.#setExtendedAttribute(path, this.#attributeKey, hash)
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        throw error
+      }
+      // if a concurrent process deleted the dedup : recreate it
+      return this.#writeDeduplicationSource(path, hash)
+    }
+    return path
+  }
+
+  /**
+   * delete empty dirs
+   * delete file source thath don't have any more links
+   *
+   * @returns Promise
+   */
+
+  async deduplicationGarbageCollector(dir = this.#dedupDirectory, alreadyVisited = false) {
+    try {
+      await this._rmdir(dir)
+      return
+    } catch (error) {
+      if (error.code !== 'ENOTEMPTY') {
+        throw error
+      }
+    }
+    // the directory may not be empty after a first visit
+    if (alreadyVisited) {
+      return
+    }
+
+    const files = await this._list(dir)
+    await asyncEach(
+      files,
+      async file => {
+        const stat = await fs.stat(this.getFilePath(`${dir}/${file}`))
+        // have to check the stat to ensure we don't try to delete
+        // the directories : they don't have links
+        if (stat.isDirectory()) {
+          return this.deduplicationGarbageCollector(`${dir}/${file}`)
+        }
+        if (stat.nlink === 1) {
+          return fs.unlink(this.getFilePath(`${dir}/${file}`))
+        }
+      },
+      { concurrency: 2 }
+    ) // since we do a recursive traveral with a deep tree)
+    return this.deduplicationGarbageCollector(dir, true)
+  }
+
+  async deduplicationStats(dir = this.#dedupDirectory) {
+    let nbSourceBlocks = 0
+    let nbBlocks = 0
+    try {
+      const files = await this._list(dir)
+      await asyncEach(
+        files,
+        async file => {
+          const stat = await fs.stat(this.getFilePath(`${dir}/${file}`))
+          if (stat.isDirectory()) {
+            const { nbSourceBlocks: nbSourceInChild, nbBlocks: nbBlockInChild } = await this.deduplicationStats(
+              `${dir}/${file}`
+            )
+            nbSourceBlocks += nbSourceInChild
+            nbBlocks += nbBlockInChild
+          } else {
+            nbSourceBlocks++
+            nbBlocks += stat.nlink - 1 // ignore current
+          }
+        },
+        { concurrency: 2 }
+      )
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        throw err
+      }
+    }
+    return { nbSourceBlocks, nbBlocks }
+  }
+
+  @synchronized()
+  async checkSupport() {
+    const supported = await super.checkSupport()
+    const sourceFileName = normalizePath(`${Date.now()}.sourcededup`)
+    const destFileName = normalizePath(`${Date.now()}.destdedup`)
+    try {
+      const SIZE = 1024 * 1024
+      const data = await fromCallback(randomBytes, SIZE)
+      const hash = this.#hash(data)
+      await this._outputFile(sourceFileName, data, { flags: 'wx', dedup: false })
+      await this.#setExtendedAttribute(sourceFileName, this.#attributeKey, hash)
+      await this.#link(sourceFileName, destFileName)
+      const linkedData = await this._readFile(destFileName)
+      supported.hardLink = linkedData.equals(data)
+      supported.extendedAttributes = hash === (await this.#getExtendedAttribute(sourceFileName, this.#attributeKey))
+    } catch (error) {
+      warn(`error while testing the dedup`, { error })
+    } finally {
+      ignoreErrors.call(this._unlink(sourceFileName))
+      ignoreErrors.call(this._unlink(destFileName))
+    }
+    return supported
   }
 }

--- a/@xen-orchestra/fs/src/local.test.js
+++ b/@xen-orchestra/fs/src/local.test.js
@@ -1,0 +1,107 @@
+import { after, beforeEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import fs from 'node:fs/promises'
+import { getSyncedHandler } from './index.js'
+import { Disposable, pFromCallback } from 'promise-toolbox'
+import tmp from 'tmp'
+import execa from 'execa'
+import { rimraf } from 'rimraf'
+import { randomBytes } from 'node:crypto'
+
+// https://xkcd.com/221/
+const data =
+  'H2GbLa0F2J4LHFLRwLP9zN4dGWJpdx1T6eGWra8BRlV9fBpRGtWIOSKXjU8y7fnxAWVGWpbYPYCwRigvxRSTcuaQsCtwvDNKMmFwYpsGMS14akgBD3EpOMPpKIRRySOsOeknpr48oopO1n9eq0PxGbOcY4Q9aojRu9rn1SMNyjq7YGzwVQEm6twA3etKGSYGvPJVTs2riXm7u6BhBh9VZtQDxQEy5ttkHiZUpgLi6QshSpMjL7dHco8k6gzGcxfpoyS5IzaQeXqDOeRjE6HNn27oUXpze5xRYolQhxA7IqdfzcYwWTqlaZb7UBUZoFCiFs5Y6vPlQVZ2Aw5YganLV1ZcIz78j6TAtXJAfXrDhksm9UteQul8RYT0Ur8AJRYgiGXOsXrWWBKm3CzZci6paLZ2jBmGfgVuBJHlvgFIjOHiVozjulGD4SwKQ2MNqUOylv89NTP1BsJuZ7MC6YCm5yix7FswoE7Y2NhDFqzEQvseRQFyz52AsfuqRY7NruKHlO7LOSI932che2WzxBAwy78Sk1eRHQLsZ37dLB4UkFFIq6TvyjJKznTMAcx9HDOSrFeke6KfsDB1A4W3BAxJk40oAcFMeM72Lg97sJExMJRz1m1nGQJEiGCcnll9G6PqEfHjoOhdDLgN2xewUyvbuRuKEXXxD1H6Tz1iWReyRGSagQNLXvqkKoHoxu3bvSi8nWrbtEY6K2eHLeF5bYubYGXc5VsfiCQNPEzQV4ECzaPdolRtbpRFMcB5aWK70Oew3HJkEcN7IkcXI9vlJKnFvFMqGOHKujd4Tyjhvru2UFh0dAkEwojNzz7W0XlASiXRneea9FgiJNLcrXNtBkvIgw6kRrgbXI6DPJdWDpm3fmWS8EpOICH3aTiXRLQUDZsReAaOsfau1FNtP4JKTQpG3b9rKkO5G7vZEWqTi69mtPGWmyOU47WL1ifJtlzGiFbZ30pcHMc0u4uopHwEQq6ZwM5S6NHvioxihhHQHO8JU2xvcjg5OcTEsXtMwIapD3re'
+const hash = '09a3cd9e135114cb870a0b5cf0dfd3f4be994662d0c715b65bcfc5e3b635dd40'
+const dataPath = 'xo-block-store/09a3/cd9e/1351/14cb/870a/0b5c/f0df/d3f4/be99/4662/d0c7/15b6/5bcf/c5e3/b635/dd40.source'
+
+let dir
+describe('dedup tests', () => {
+  beforeEach(async () => {
+    dir = await pFromCallback(cb => tmp.dir(cb))
+  })
+  after(async () => {
+    await rimraf(dir)
+  })
+
+  it('works in general case ', async () => {
+    await Disposable.use(getSyncedHandler({ url: `file://${dir}` }, { dedup: true }), async handler => {
+      await handler.outputFile('in/a/sub/folder/file', data, { dedup: true })
+      assert.doesNotReject(handler.list('xo-block-store'))
+      assert.strictEqual((await handler.list('xo-block-store')).length, 1)
+      assert.strictEqual((await handler.list('in/a/sub/folder')).length, 1)
+      assert.strictEqual((await handler.readFile('in/a/sub/folder/file')).toString('utf-8'), data)
+      const value = (await execa('getfattr', ['-n', 'user.hash.sha256', '--only-value', dir + '/in/a/sub/folder/file']))
+        .stdout
+      assert.strictEqual(value, hash)
+      // the source file is created
+      assert.strictEqual((await handler.readFile(dataPath)).toString('utf-8'), data)
+
+      await handler.outputFile('in/anotherfolder/file', data, { dedup: true })
+      assert.strictEqual((await handler.list('in/anotherfolder')).length, 1)
+      assert.strictEqual((await handler.readFile('in/anotherfolder/file')).toString('utf-8'), data)
+
+      await handler.unlink('in/a/sub/folder/file', { dedup: true })
+      // source is still here
+      assert.strictEqual((await handler.readFile(dataPath)).toString('utf-8'), data)
+      assert.strictEqual((await handler.readFile('in/anotherfolder/file')).toString('utf-8'), data)
+
+      await handler.unlink('in/anotherfolder/file', { dedup: true })
+      // source should have been deleted
+      assert.strictEqual(
+        (
+          await handler.list(
+            'xo-block-store/09a3/cd9e/1351/14cb/870a/0b5c/f0df/d3f4/be99/4662/d0c7/15b6/5bcf/c5e3/b635'
+          )
+        ).length,
+        0
+      )
+      assert.strictEqual((await handler.list('in/anotherfolder')).length, 0)
+    })
+  })
+
+  it('garbage collector an stats ', async () => {
+    await Disposable.use(getSyncedHandler({ url: `file://${dir}` }, { dedup: true }), async handler => {
+      await handler.outputFile('in/anotherfolder/file', data, { dedup: true })
+      await handler.outputFile('in/anotherfolder/same', data, { dedup: true })
+      await handler.outputFile('in/a/sub/folder/file', randomBytes(1024), { dedup: true })
+
+      let stats = await handler.deduplicationStats()
+      assert.strictEqual(stats.nbBlocks, 3)
+      assert.strictEqual(stats.nbSourceBlocks, 2)
+
+      await fs.unlink(`${dir}/in/a/sub/folder/file`, { dedup: true })
+      assert.strictEqual((await handler.list('xo-block-store')).length, 2)
+
+      await handler.deduplicationGarbageCollector()
+      stats = await handler.deduplicationStats()
+      assert.strictEqual(stats.nbBlocks, 2)
+      assert.strictEqual(stats.nbSourceBlocks, 1)
+
+      assert.strictEqual((await handler.list('xo-block-store')).length, 1)
+    })
+  })
+
+  it('compute support', async () => {
+    await Disposable.use(getSyncedHandler({ url: `file://${dir}` }, { dedup: true }), async handler => {
+      const supported = await handler.checkSupport()
+      assert.strictEqual(supported.hardLink, true, 'support hard link is not present in local fs')
+      assert.strictEqual(supported.extendedAttributes, true, 'support extended attributes is not present in local fs')
+    })
+  })
+
+  it('handles edge cases : source deleted', async () => {
+    await Disposable.use(getSyncedHandler({ url: `file://${dir}` }, { dedup: true }), async handler => {
+      await handler.outputFile('in/a/sub/folder/edge', data, { dedup: true })
+      await handler.unlink(dataPath, { dedup: true })
+      // no error if source si already deleted
+      await assert.doesNotReject(() => handler.unlink('in/a/sub/folder/edge', { dedup: true }))
+    })
+  })
+  it('handles edge cases : non deduplicated file ', async () => {
+    await Disposable.use(getSyncedHandler({ url: `file://${dir}` }, { dedup: true }), async handler => {
+      await handler.outputFile('in/a/sub/folder/edge', data, { dedup: false })
+      // no error if deleting a non dedup file with dedup flags
+      await assert.doesNotReject(() => handler.unlink('in/a/sub/folder/edge', { dedup: true }))
+    })
+  })
+})

--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -276,6 +276,11 @@ export default class S3Handler extends RemoteHandlerAbstract {
   }
 
   async _writeFile(file, data, options) {
+    if (options?.dedup ?? false) {
+      throw new Error(
+        "S3 remotes don't support deduplication from XO, please use the deduplication of your S3 provider if any"
+      )
+    }
     return this.#s3.send(
       new PutObjectCommand({
         ...this.#createParams(file),

--- a/packages/vhd-lib/Vhd/VhdAbstract.integ.js
+++ b/packages/vhd-lib/Vhd/VhdAbstract.integ.js
@@ -104,7 +104,7 @@ describe('VhdAbstract', async () => {
   it('renames and unlink a VhdDirectory', async () => {
     const initalSize = 4
     const vhdDirectory = `${tempDir}/randomfile.dir`
-    await createRandomVhdDirectory(vhdDirectory, initalSize)
+    await createRandomVhdDirectory(vhdDirectory, initalSize, { dedup: true })
 
     await Disposable.use(async function* () {
       const handler = yield getSyncedHandler({ url: 'file:///' })
@@ -116,8 +116,21 @@ describe('VhdAbstract', async () => {
       // it should clean an existing directory
       await fs.mkdir(targetFileName)
       await fs.writeFile(`${targetFileName}/dummy`, 'I exists')
-      await VhdAbstract.unlink(handler, `${targetFileName}/dummy`)
+      await VhdAbstract.unlink(handler, `${targetFileName}`)
       assert.equal(await fs.exists(`${targetFileName}/dummy`), false)
+    })
+  })
+
+  it('unlinks a deduplicated VhdDirectory', async () => {
+    const initalSize = 4
+    const vhdDirectory = `${tempDir}/random.vhd`
+    await createRandomVhdDirectory(vhdDirectory, initalSize, { dedup: true })
+
+    await Disposable.use(async function* () {
+      const handler = yield getSyncedHandler({ url: 'file:///' })
+
+      await VhdAbstract.unlink(handler, vhdDirectory)
+      assert.equal(await fs.exists(vhdDirectory), false)
     })
   })
 

--- a/packages/vhd-lib/Vhd/VhdAbstract.js
+++ b/packages/vhd-lib/Vhd/VhdAbstract.js
@@ -206,7 +206,14 @@ exports.VhdAbstract = class VhdAbstract {
       await handler.unlink(resolved)
     } catch (err) {
       if (err.code === 'EISDIR') {
-        await handler.rmtree(resolved)
+        // @todo : should we open it ?
+        const chunkFilters = await handler.readFile(path + '/chunk-filters.json').then(JSON.parse, error => {
+          if (error.code === 'ENOENT') {
+            return []
+          }
+          throw error
+        })
+        await handler.rmtree(resolved, { dedup: chunkFilters[1] === true })
       } else {
         throw err
       }

--- a/packages/vhd-lib/Vhd/VhdAbstract.js
+++ b/packages/vhd-lib/Vhd/VhdAbstract.js
@@ -207,7 +207,7 @@ exports.VhdAbstract = class VhdAbstract {
     } catch (err) {
       if (err.code === 'EISDIR') {
         // @todo : should we open it ?
-        const chunkFilters = await handler.readFile(path + '/chunk-filters.json').then(JSON.parse, error => {
+        const chunkFilters = await handler.readFile(resolved + '/chunk-filters.json').then(JSON.parse, error => {
           if (error.code === 'ENOENT') {
             return []
           }

--- a/packages/vhd-lib/createVhdDirectoryFromStream.js
+++ b/packages/vhd-lib/createVhdDirectoryFromStream.js
@@ -8,8 +8,8 @@ const { asyncEach } = require('@vates/async-each')
 
 const { warn } = createLogger('vhd-lib:createVhdDirectoryFromStream')
 
-const buildVhd = Disposable.wrap(async function* (handler, path, inputStream, { concurrency, compression }) {
-  const vhd = yield VhdDirectory.create(handler, path, { compression })
+const buildVhd = Disposable.wrap(async function* (handler, path, inputStream, { concurrency, compression, dedup }) {
+  const vhd = yield VhdDirectory.create(handler, path, { compression, dedup })
   await asyncEach(
     parseVhdStream(inputStream),
     async function (item) {
@@ -45,10 +45,10 @@ exports.createVhdDirectoryFromStream = async function createVhdDirectoryFromStre
   handler,
   path,
   inputStream,
-  { validator, concurrency = 16, compression } = {}
+  { validator, concurrency = 16, compression, dedup } = {}
 ) {
   try {
-    const size = await buildVhd(handler, path, inputStream, { concurrency, compression })
+    const size = await buildVhd(handler, path, inputStream, { concurrency, compression, dedup })
     if (validator !== undefined) {
       await validator.call(this, path)
     }

--- a/packages/vhd-lib/tests/utils.js
+++ b/packages/vhd-lib/tests/utils.js
@@ -70,7 +70,7 @@ exports.recoverRawContent = async function recoverRawContent(vhdName, rawName, o
 }
 
 // @ todo how can I call vhd-cli copy from here
-async function convertToVhdDirectory(rawFileName, vhdFileName, path) {
+async function convertToVhdDirectory(rawFileName, vhdFileName, path, { dedup = false } = {}) {
   fs.mkdirp(path)
 
   const srcVhd = await fs.open(vhdFileName, 'r')
@@ -103,15 +103,17 @@ async function convertToVhdDirectory(rawFileName, vhdFileName, path) {
     await fs.read(srcRaw, blockData, 0, blockData.length, offset)
     await fs.writeFile(path + '/blocks/0/' + i, Buffer.concat([bitmap, blockData]))
   }
+
+  await fs.writeFile(path + '/chunk-filters.json', JSON.stringify(['none', dedup]))
   await fs.close(srcRaw)
 }
 exports.convertToVhdDirectory = convertToVhdDirectory
 
-exports.createRandomVhdDirectory = async function createRandomVhdDirectory(path, sizeMB) {
+exports.createRandomVhdDirectory = async function createRandomVhdDirectory(path, sizeMB, { dedup = false } = {}) {
   fs.mkdirp(path)
   const rawFileName = `${path}/temp.raw`
   await createRandomFile(rawFileName, sizeMB)
   const vhdFileName = `${path}/temp.vhd`
   await convertFromRawToVhd(rawFileName, vhdFileName)
-  await convertToVhdDirectory(rawFileName, vhdFileName, path)
+  await convertToVhdDirectory(rawFileName, vhdFileName, path, { dedup })
 }

--- a/packages/xo-web/src/common/render-xo-item.js
+++ b/packages/xo-web/src/common/render-xo-item.js
@@ -745,6 +745,7 @@ const xoItemToRender = {
       {backup.withMemory && <span className='tag tag-info'>{_('withMemory')} </span>}
       {backup.size !== undefined && <span className='tag tag-info'>{formatSize(backup.size)}</span>}{' '}
       <NumericDate timestamp={backup.timestamp} />
+      {backup.dedup === true && <span className='tag tag-info'>deduplicated</span>}{' '}
     </span>
   ),
 


### PR DESCRIPTION
### Description

* works only with local backup 
  * hard link works on NFS ( as long as they stay inside the mount)
  * extended attributes works from NFS 4.2 https://stackoverflow.com/questions/24629459/how-to-use-extended-file-attributes-on-nfs
> All that is needed is Linux kernel version 5.9 or newer on both the server and client, then mount with NFS version 4.2 or newer. Support for extended attributes is enabled automatically when both server and client support nfs 4.2. 
* only dedup blocks of vhd directory
* compatible with encryption/compression
* not compatile with dedup #6928 
* write block in <remote>/xo-block-store
* hard link block in the vhd/block directory
* on delete, remove block from store if there are no other link( the FS count them for us)
* on merge : check if there is an overwrite => trigger delete before rename 
* differenciate by name vhd with dedup enabled : alias point to a uuid.dedup.vhd instead of uuid.vhd
* only check if you need to dedup on unlink / rename in theses identified VHD
* @todo : show gain
* @todo : ui for dedup remote
* @todo: test on windows / non ext fs

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
