### PR TITLE
feat(lite/component): add support for nested modals

### DIFF
--- a/@xen-orchestra/lite/src/stories/ui-modal.story.vue
+++ b/@xen-orchestra/lite/src/stories/ui-modal.story.vue
@@ -1,5 +1,6 @@
 <template>
   <ComponentStory
+    v-slot="{ properties, settings }"
     :params="[
       colorProp(),
       iconProp(),
@@ -11,16 +12,30 @@
       slot('buttons').help('Meant to receive UiButton components'),
       setting('title').preset('Modal Title').widget(),
       setting('subtitle').preset('Modal Subtitle').widget(),
+      setting('nested_modal').widget(boolean()),
     ]"
-    v-slot="{ properties, settings }"
   >
     <UiButton type="button" @click="open">Open Modal</UiButton>
 
-    <UiModal v-bind="properties" v-if="isOpen">
+    <UiModal v-if="isOpen" v-bind="properties">
       <template #title>{{ settings.title }}</template>
       <template #subtitle>{{ settings.subtitle }}</template>
       <template #buttons>
         <UiButton @click="close">Discard</UiButton>
+      </template>
+      <template v-if="settings.nested_modal">
+        <UiModal :icon="faWarning" color="warning">
+          <template #title>Warning</template>
+          <template #subtitle> This is a warning "nested" modal.</template>
+          <UiModal :icon="faInfoCircle" color="info">
+            <template #title>Info</template>
+            <template #subtitle> This is an info "nested" modal.</template>
+          </UiModal>
+        </UiModal>
+        <UiModal :icon="faCheck" color="success">
+          <template #title>Success</template>
+          <template #subtitle> This is a success "deep nested" modal.</template>
+        </UiModal>
       </template>
     </UiModal>
   </ComponentStory>
@@ -38,6 +53,12 @@ import {
   setting,
   slot,
 } from "@/libs/story/story-param";
+import {
+  faCheck,
+  faInfoCircle,
+  faWarning,
+} from "@fortawesome/free-solid-svg-icons";
+import { boolean } from "@/libs/story/story-widget";
 
 const { open, close, isOpen } = useModal();
 </script>

--- a/@xen-orchestra/lite/src/types/injection-keys.ts
+++ b/@xen-orchestra/lite/src/types/injection-keys.ts
@@ -1,3 +1,4 @@
 import type { InjectionKey } from "vue";
 
 export const IK_MENU_TELEPORTED = Symbol() as InjectionKey<boolean>;
+export const IK_MODAL_NESTED = Symbol() as InjectionKey<boolean>;


### PR DESCRIPTION
### Description

Modals now allow to be nested

### Usage example

```html
<UiModal color="error" :icon="faTimes">
  <template #title>Error</template>
  <template #subtitle>This is an error</template>
  <UiModal color="warning" :icon="faExclamation">
    <template #title>Warning</template>
    <template #subtitle>This is a warning</template>
  </UiModal>
</UiModal>
```

### Screenshot

![Nested modals](https://github.com/vatesfr/xen-orchestra/assets/19408/b21bb6ca-db52-4355-9fa9-dff327c1fbe5)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
