### PR TITLE
feat(lite/component): created UiResources + UiResource

### DIFF
--- a/@xen-orchestra/lite/src/components/component-story/ComponentStory.vue
+++ b/@xen-orchestra/lite/src/components/component-story/ComponentStory.vue
@@ -33,7 +33,7 @@
     </AppMenu>
   </UiTabBar>
 
-  <div class="tabs">
+  <div :class="{ 'full-width': fullWidthComponent }" class="tabs">
     <UiCard v-if="selectedTab === TAB.NONE" class="tab-content">
       <i>No configuration defined</i>
     </UiCard>
@@ -102,11 +102,11 @@ import StorySettingParams from "@/components/component-story/StorySettingParams.
 import StorySlotParams from "@/components/component-story/StorySlotParams.vue";
 import AppMenu from "@/components/menu/AppMenu.vue";
 import MenuItem from "@/components/menu/MenuItem.vue";
+import UiIcon from "@/components/ui/icon/UiIcon.vue";
 import UiButton from "@/components/ui/UiButton.vue";
 import UiCard from "@/components/ui/UiCard.vue";
 import UiCardTitle from "@/components/ui/UiCardTitle.vue";
 import UiCounter from "@/components/ui/UiCounter.vue";
-import UiIcon from "@/components/ui/icon/UiIcon.vue";
 import UiTab from "@/components/ui/UiTab.vue";
 import UiTabBar from "@/components/ui/UiTabBar.vue";
 import {
@@ -140,6 +140,7 @@ const props = defineProps<{
       settings?: Record<string, any>;
     }
   >;
+  fullWidthComponent?: boolean;
 }>();
 
 enum TAB {
@@ -332,6 +333,10 @@ const applyPreset = (preset: {
   display: flex;
   padding: 1rem;
   gap: 1rem;
+
+  &.full-width {
+    flex-direction: column;
+  }
 
   .tab-content {
     flex: 1;

--- a/@xen-orchestra/lite/src/components/ui/resources/UiResource.vue
+++ b/@xen-orchestra/lite/src/components/ui/resources/UiResource.vue
@@ -1,0 +1,50 @@
+<template>
+  <li class="ui-resource">
+    <UiIcon :icon="icon" class="icon" />
+    <div class="separator" />
+    <div class="label">{{ label }}</div>
+    <div class="count">{{ count }}</div>
+  </li>
+</template>
+
+<script lang="ts" setup>
+import UiIcon from "@/components/ui/icon/UiIcon.vue";
+import type { IconDefinition } from "@fortawesome/fontawesome-common-types";
+
+defineProps<{
+  icon: IconDefinition;
+  label: string;
+  count: string | number;
+}>();
+</script>
+
+<style lang="postcss" scoped>
+.ui-resource {
+  display: flex;
+  align-items: center;
+}
+
+.icon {
+  color: var(--color-extra-blue-base);
+  font-size: 3.2rem;
+}
+
+.separator {
+  height: 4.5rem;
+  width: 0;
+  border-left: 0.1rem solid var(--color-extra-blue-base);
+  background-color: var(--color-extra-blue-base);
+  margin: 0 1.5rem;
+}
+
+.label {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.count {
+  font-size: 1.4rem;
+  font-weight: 400;
+  margin-left: 2rem;
+}
+</style>

--- a/@xen-orchestra/lite/src/components/ui/resources/UiResources.vue
+++ b/@xen-orchestra/lite/src/components/ui/resources/UiResources.vue
@@ -1,0 +1,13 @@
+<template>
+  <ul class="ui-resources">
+    <slot />
+  </ul>
+</template>
+
+<style lang="postcss" scoped>
+.ui-resources {
+  display: flex;
+  gap: 1rem 5.4rem;
+  flex-wrap: wrap;
+}
+</style>

--- a/@xen-orchestra/lite/src/stories/ui-resource.story.vue
+++ b/@xen-orchestra/lite/src/stories/ui-resource.story.vue
@@ -1,0 +1,70 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties }"
+    :params="[
+      iconProp().preset(faRocket),
+      prop('label').required().str().widget().preset('Rockets'),
+      prop('count')
+        .required()
+        .type('string | number')
+        .widget(text())
+        .preset('175'),
+    ]"
+    :presets="presets"
+  >
+    <UiResource v-bind="properties" />
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from "@/components/component-story/ComponentStory.vue";
+import UiResource from "@/components/ui/resources/UiResource.vue";
+import { iconProp, prop } from "@/libs/story/story-param";
+import { text } from "@/libs/story/story-widget";
+import {
+  faDatabase,
+  faDisplay,
+  faMemory,
+  faMicrochip,
+  faNetworkWired,
+  faRocket,
+} from "@fortawesome/free-solid-svg-icons";
+
+const presets = {
+  VMs: {
+    props: {
+      icon: faDisplay,
+      count: 1,
+      label: "VMs",
+    },
+  },
+  vCPUs: {
+    props: {
+      icon: faMicrochip,
+      count: 4,
+      label: "vCPUs",
+    },
+  },
+  RAM: {
+    props: {
+      icon: faMemory,
+      count: 2,
+      label: "RAM",
+    },
+  },
+  SR: {
+    props: {
+      icon: faDatabase,
+      count: 1,
+      label: "SR",
+    },
+  },
+  Interfaces: {
+    props: {
+      icon: faNetworkWired,
+      count: 2,
+      label: "Interfaces",
+    },
+  },
+};
+</script>

--- a/@xen-orchestra/lite/src/stories/ui-resources.story.md
+++ b/@xen-orchestra/lite/src/stories/ui-resources.story.md
@@ -1,0 +1,11 @@
+# Example
+
+```vue-template
+<UiResources>
+  <UiResource :icon="faDisplay" count="1" label="VMs" />
+  <UiResource :icon="faMicrochip" count="4" label="vCPUs" />
+  <UiResource :icon="faMemory" count="2" label="RAM" />
+  <UiResource :icon="faDatabase" count="1" label="SR" />
+  <UiResource :icon="faNetworkWired" count="2" label="Interfaces" />
+</UiResources>
+```

--- a/@xen-orchestra/lite/src/stories/ui-resources.story.vue
+++ b/@xen-orchestra/lite/src/stories/ui-resources.story.vue
@@ -1,0 +1,28 @@
+<template>
+  <ComponentStory
+    :params="[slot().help('One or multiple `UiResource`')]"
+    full-width-component
+  >
+    <UiResources>
+      <UiResource :icon="faDisplay" count="1" label="VMs" />
+      <UiResource :icon="faMicrochip" count="4" label="vCPUs" />
+      <UiResource :icon="faMemory" count="2" label="RAM" />
+      <UiResource :icon="faDatabase" count="1" label="SR" />
+      <UiResource :icon="faNetworkWired" count="2" label="Interfaces" />
+    </UiResources>
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from "@/components/component-story/ComponentStory.vue";
+import UiResource from "@/components/ui/resources/UiResource.vue";
+import UiResources from "@/components/ui/resources/UiResources.vue";
+import { slot } from "@/libs/story/story-param";
+import {
+  faDatabase,
+  faDisplay,
+  faMemory,
+  faMicrochip,
+  faNetworkWired,
+} from "@fortawesome/free-solid-svg-icons";
+</script>


### PR DESCRIPTION
### Description

Created a new component to summarize resources allocation.

### Screenshots

![UiResources](https://github.com/vatesfr/xen-orchestra/assets/19408/b35b0898-c996-48f0-ad6b-0a2b4b297fbd)

![UiResources Dark](https://github.com/vatesfr/xen-orchestra/assets/19408/967fb579-181e-4a8f-b43a-001002130ec9)

### Usage example

```html
<UiResources>
  <UiResource :icon="faDisplay" count="1" label="VMs" />
  <UiResource :icon="faMicrochip" count="4" label="vCPUs" />
  <UiResource :icon="faMemory" count="2" label="RAM" />
  <UiResource :icon="faDatabase" count="1" label="SR" />
  <UiResource :icon="faNetworkWired" count="2" label="Interfaces" />
</UiResources>
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
