### PR TITLE
feat(@xen-orchestra/backups): store more detailled sizes

### DIFF
--- a/@xen-orchestra/backups/RemoteAdapter.js
+++ b/@xen-orchestra/backups/RemoteAdapter.js
@@ -669,7 +669,7 @@ class RemoteAdapter {
     const handler = this._handler
     if (this.useVhdDirectory()) {
       const dataPath = `${dirname(path)}/data/${uuidv4()}.vhd`
-      const size = await createVhdDirectoryFromStream(handler, dataPath, input, {
+      const sizes = await createVhdDirectoryFromStream(handler, dataPath, input, {
         concurrency: writeBlockConcurrency,
         compression: this.#getCompressionType(),
         async validator() {
@@ -678,9 +678,14 @@ class RemoteAdapter {
         },
       })
       await VhdAbstract.createAlias(handler, path, dataPath)
-      return size
+      return sizes
     } else {
-      return this.outputStream(path, input, { checksum, validator })
+      const size = this.outputStream(path, input, { checksum, validator })
+      return {
+        compressedSize: size,
+        sourceSize: size,
+        writtenSize: size,
+      }
     }
   }
 

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.js
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.js
@@ -205,7 +205,7 @@ class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrementalWrite
             // TODO remove when this has been done before the export
             await checkVhd(handler, parentPath)
           }
-
+          // @todo : sum per property
           transferSize += await adapter.writeVhd(path, deltaExport.streams[`${id}.vhd`], {
             // no checksum for VHDs, because they will be invalidated by
             // merges and chainings
@@ -232,7 +232,7 @@ class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrementalWrite
 
       return { size: transferSize }
     })
-    metadataContent.size = size
+    metadataContent.size = size // @todo: transferSize
     this._metadataFileName = await adapter.writeVmBackupMetadata(vm.uuid, metadataContent)
 
     // TODO: run cleanup?

--- a/packages/vhd-lib/Vhd/VhdFile.js
+++ b/packages/vhd-lib/Vhd/VhdFile.js
@@ -463,7 +463,7 @@ exports.VhdFile = class VhdFile extends VhdAbstract {
     }
   }
 
-  async getSize() {
+  async streamSize() {
     return await this._handler.getSize(this._path)
   }
 }

--- a/packages/xo-web/src/xo-app/logs/backup-ng/index.js
+++ b/packages/xo-web/src/xo-app/logs/backup-ng/index.js
@@ -142,9 +142,11 @@ const COLUMNS = [
               return
             }
             if (operationTask.message === 'transfer' && vmTransferSize === undefined) {
+              // @todo handle if size is an object
               vmTransferSize = operationTask.result?.size
             }
             if (operationTask.message === 'merge' && vmMergeSize === undefined) {
+              // @todo handle if size is an object
               vmMergeSize = operationTask.result?.size
             }
 

--- a/packages/xo-web/src/xo-app/logs/backup-ng/log-alert-body.js
+++ b/packages/xo-web/src/xo-app/logs/backup-ng/log-alert-body.js
@@ -330,6 +330,7 @@ const SrTask = ({ children, className, task }) => (
 )
 
 const TransferMergeTask = ({ className, task }) => {
+  // @todo : handle case when size is an object
   const size = defined(() => task.result.size, 0)
   if (task.status === 'success' && size === 0 && task.warnings?.length === 0) {
     return null


### PR DESCRIPTION
### Description

size is only one value, we want to be able to store dthe difference between size read from host, size written on disk and details the various improvement ( compression, dedupication,  delta, ...)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
