### PR TITLE
Fix lock integrity of reconnect-core

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 - [REST API] Fix VDI export when NBD is enabled
 - [XO Config Cloud Backup] Improve wording about passphrase (PR [#6938](https://github.com/vatesfr/xen-orchestra/pull/6938))
 - [Pool] Fix IPv6 handling when adding hosts
+- [Build] Fix yarn.lock integrity issue
 
 ### Packages to release
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17567,6 +17567,7 @@ rechoir@^0.6.2:
 "reconnect-core@https://github.com/dodo/reconnect-core/tarball/merged":
   version "0.0.1"
   resolved "https://github.com/dodo/reconnect-core/tarball/merged#b9daf2adc45b19a6cc5fd2f048f8d9406cece498"
+  integrity sha512-z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/SpIdNs6c5H0NE8XYXysP+DGNKHfuwvY7kxvUdBeoGlODJ6+SfaPg==
   dependencies:
     backoff "~2.3.0"
 


### PR DESCRIPTION
### Description

_fix: yarn.lock missing integrity of reconnect-core_

Not sure why it was missing, probably a bug with yarn. It's needed for certain build tools to work properly. 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

