### PR TITLE
fix(xo-web/new-vm): list VIFs ordered by device

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [New VM] Order interfaces by device as done on a VM Network tab (PR [#6944](https://github.com/vatesfr/xen-orchestra/pull/6944))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -26,5 +28,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-web/src/xo-app/new-vm/index.js
+++ b/packages/xo-web/src/xo-app/new-vm/index.js
@@ -549,9 +549,12 @@ export default class NewVm extends BaseComponent {
     forEach(template.VIFs, vifId => {
       const vif = getObject(storeState, vifId, resourceSet)
       VIFs.push({
+        device: vif.device,
         network: pool || isInResourceSet(vif.$network) ? vif.$network : defaultNetworkIds[0],
       })
     })
+    // sort the array so it corresponds to the order chosen by the user when creating the VM
+    VIFs.sort((a, b) => Number(a.device) - Number(b.device))
     if (VIFs.length === 0) {
       VIFs = defaultNetworkIds.map(id => ({ network: id }))
     }


### PR DESCRIPTION
Use splice function to insert VIF according to the device parameter number.

See zammad#15920

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
