### PR TITLE
feat(lite): enhance typings for improved type safety

### DIFF
--- a/@xen-orchestra/lite/docs/xen-api-record-stores.md
+++ b/@xen-orchestra/lite/docs/xen-api-record-stores.md
@@ -40,7 +40,7 @@ export const useConsoleStore = defineStore("console", () =>
 
 To extend the base Subscription, you'll need to override the `subscribe` method.
 
-For that, you can use the `createSubscribe<XenApiRecord, Extensions>((options) => { /* ... */})` helper.
+For that, you can use the `createSubscribe<RawObjectType, Extensions>((options) => { /* ... */})` helper.
 
 ### Define the extensions
 
@@ -82,7 +82,7 @@ type Extensions = [
 export const useConsoleStore = defineStore("console", () => {
   const consoleCollection = useXapiCollectionStore().get("console");
 
-  const subscribe = createSubscribe<XenApiConsole, Extensions>((options) => {
+  const subscribe = createSubscribe<"console", Extensions>((options) => {
     const originalSubscription = consoleCollection.subscribe(options);
 
     const extendedSubscription = {

--- a/@xen-orchestra/lite/src/components/ObjectNotFoundWrapper.vue
+++ b/@xen-orchestra/lite/src/components/ObjectNotFoundWrapper.vue
@@ -7,12 +7,12 @@
 </template>
 
 <script
-  generic="T extends XenApiRecord<string>, I extends T['uuid']"
+  generic="T extends XenApiRecord<RawObjectType>, I extends T['uuid']"
   lang="ts"
   setup
 >
 import UiSpinner from "@/components/ui/UiSpinner.vue";
-import type { XenApiRecord } from "@/libs/xen-api";
+import type { RawObjectType, XenApiRecord } from "@/libs/xen-api";
 import ObjectNotFoundView from "@/views/ObjectNotFoundView.vue";
 import { computed } from "vue";
 import { useRouter } from "vue-router";

--- a/@xen-orchestra/lite/src/libs/utils.ts
+++ b/@xen-orchestra/lite/src/libs/utils.ts
@@ -1,10 +1,10 @@
 import type {
   RawXenApiRecord,
   XenApiHost,
-  XenApiHostMetrics,
   XenApiRecord,
   XenApiVm,
   VM_OPERATION,
+  RawObjectType,
 } from "@/libs/xen-api";
 import type { Filter } from "@/types/filter";
 import type { Subscription } from "@/types/xapi-collection";
@@ -116,14 +116,14 @@ export function getStatsLength(stats?: object | any[]) {
 
 export function isHostRunning(
   host: XenApiHost,
-  hostMetricsSubscription: Subscription<XenApiHostMetrics, object>
+  hostMetricsSubscription: Subscription<"host_metrics", object>
 ) {
   return hostMetricsSubscription.getByOpaqueRef(host.metrics)?.live === true;
 }
 
 export function getHostMemory(
   host: XenApiHost,
-  hostMetricsSubscription: Subscription<XenApiHostMetrics, object>
+  hostMetricsSubscription: Subscription<"host_metrics", object>
 ) {
   const hostMetrics = hostMetricsSubscription.getByOpaqueRef(host.metrics);
 
@@ -136,7 +136,7 @@ export function getHostMemory(
   }
 }
 
-export const buildXoObject = <T extends XenApiRecord<string>>(
+export const buildXoObject = <T extends XenApiRecord<RawObjectType>>(
   record: RawXenApiRecord<T>,
   params: { opaqueRef: T["$ref"] }
 ) => {

--- a/@xen-orchestra/lite/src/stores/alarm.store.ts
+++ b/@xen-orchestra/lite/src/stores/alarm.store.ts
@@ -1,4 +1,3 @@
-import type { XenApiMessage } from "@/libs/xen-api";
 import { useXapiCollectionStore } from "@/stores/xapi-collection.store";
 import { createSubscribe } from "@/types/xapi-collection";
 import { defineStore } from "pinia";
@@ -7,7 +6,7 @@ import { computed } from "vue";
 export const useAlarmStore = defineStore("alarm", () => {
   const messageCollection = useXapiCollectionStore().get("message");
 
-  const subscribe = createSubscribe<XenApiMessage, []>((options) => {
+  const subscribe = createSubscribe<"message", []>((options) => {
     const originalSubscription = messageCollection.subscribe(options);
 
     const extendedSubscription = {

--- a/@xen-orchestra/lite/src/stores/host.store.ts
+++ b/@xen-orchestra/lite/src/stores/host.store.ts
@@ -4,7 +4,7 @@ import type {
   HostStats,
   XapiStatsResponse,
 } from "@/libs/xapi-stats";
-import type { XenApiHost, XenApiHostMetrics } from "@/libs/xen-api";
+import type { XenApiHost } from "@/libs/xen-api";
 import { useXapiCollectionStore } from "@/stores/xapi-collection.store";
 import { useXenApiStore } from "@/stores/xen-api.store";
 import type { Subscription } from "@/types/xapi-collection";
@@ -25,7 +25,7 @@ type GetStatsExtension = {
 
 type RunningHostsExtension = [
   { runningHosts: ComputedRef<XenApiHost[]> },
-  { hostMetricsSubscription: Subscription<XenApiHostMetrics, any> }
+  { hostMetricsSubscription: Subscription<"host_metrics", any> }
 ];
 
 type Extensions = [GetStatsExtension, RunningHostsExtension];
@@ -36,7 +36,7 @@ export const useHostStore = defineStore("host", () => {
 
   hostCollection.setSort(sortRecordsByNameLabel);
 
-  const subscribe = createSubscribe<XenApiHost, Extensions>((options) => {
+  const subscribe = createSubscribe<"host", Extensions>((options) => {
     const originalSubscription = hostCollection.subscribe(options);
 
     const getStats: GetStats = (

--- a/@xen-orchestra/lite/src/stores/pool.store.ts
+++ b/@xen-orchestra/lite/src/stores/pool.store.ts
@@ -14,7 +14,7 @@ type Extensions = [PoolExtension];
 export const usePoolStore = defineStore("pool", () => {
   const poolCollection = useXapiCollectionStore().get("pool");
 
-  const subscribe = createSubscribe<XenApiPool, Extensions>((options) => {
+  const subscribe = createSubscribe<"pool", Extensions>((options) => {
     const originalSubscription = poolCollection.subscribe(options);
 
     const extendedSubscription = {

--- a/@xen-orchestra/lite/src/stores/task.store.ts
+++ b/@xen-orchestra/lite/src/stores/task.store.ts
@@ -22,7 +22,7 @@ type Extensions = [PendingTasksExtension, FinishedTasksExtension];
 export const useTaskStore = defineStore("task", () => {
   const tasksCollection = useXapiCollectionStore().get("task");
 
-  const subscribe = createSubscribe<XenApiTask, Extensions>(() => {
+  const subscribe = createSubscribe<"task", Extensions>(() => {
     const subscription = tasksCollection.subscribe();
 
     const { compareFn } = useCollectionSorter<XenApiTask>({

--- a/@xen-orchestra/lite/src/stores/vm.store.ts
+++ b/@xen-orchestra/lite/src/stores/vm.store.ts
@@ -27,7 +27,7 @@ type GetStatsExtension = [
   {
     getStats: GetStats;
   },
-  { hostSubscription: Subscription<XenApiHost, object> }
+  { hostSubscription: Subscription<"host", object> }
 ];
 
 type Extensions = [DefaultExtension, GetStatsExtension];
@@ -41,7 +41,7 @@ export const useVmStore = defineStore("vm", () => {
 
   vmCollection.setSort(sortRecordsByNameLabel);
 
-  const subscribe = createSubscribe<XenApiVm, Extensions>((options) => {
+  const subscribe = createSubscribe<"VM", Extensions>((options) => {
     const originalSubscription = vmCollection.subscribe(options);
 
     const extendedSubscription = {

--- a/@xen-orchestra/lite/src/types/xapi-collection.ts
+++ b/@xen-orchestra/lite/src/types/xapi-collection.ts
@@ -1,10 +1,10 @@
 import type {
+  RawObjectType,
   XenApiConsole,
   XenApiHost,
   XenApiHostMetrics,
   XenApiMessage,
   XenApiPool,
-  XenApiRecord,
   XenApiSr,
   XenApiTask,
   XenApiVm,
@@ -13,11 +13,14 @@ import type {
 } from "@/libs/xen-api";
 import type { ComputedRef, Ref } from "vue";
 
-type DefaultExtension<T extends XenApiRecord<string>> = {
-  records: ComputedRef<T[]>;
-  getByOpaqueRef: (opaqueRef: T["$ref"]) => T | undefined;
-  getByUuid: (uuid: T["uuid"]) => T | undefined;
-  hasUuid: (uuid: T["uuid"]) => boolean;
+type DefaultExtension<
+  T extends RawObjectType,
+  R extends RawTypeToRecord<T> = RawTypeToRecord<T>
+> = {
+  records: ComputedRef<R[]>;
+  getByOpaqueRef: (opaqueRef: R["$ref"]) => R | undefined;
+  getByUuid: (uuid: R["uuid"]) => R | undefined;
+  hasUuid: (uuid: R["uuid"]) => boolean;
   isReady: Readonly<Ref<boolean>>;
   isFetching: Readonly<Ref<boolean>>;
   isReloading: ComputedRef<boolean>;
@@ -33,7 +36,7 @@ type DeferExtension = [
   { immediate: false }
 ];
 
-type DefaultExtensions<T extends XenApiRecord<string>> = [
+type DefaultExtensions<T extends RawObjectType> = [
   DefaultExtension<T>,
   DeferExtension
 ];
@@ -64,14 +67,14 @@ type GenerateSubscription<
   : object;
 
 export type Subscription<
-  T extends XenApiRecord<string>,
+  T extends RawObjectType,
   Options extends object,
   Extensions extends any[] = []
 > = GenerateSubscription<Options, Extensions> &
   GenerateSubscription<Options, DefaultExtensions<T>>;
 
 export function createSubscribe<
-  T extends XenApiRecord<string>,
+  T extends RawObjectType,
   Extensions extends any[],
   Options extends object = SubscribeOptions<Extensions>
 >(builder: (options?: Options) => Subscription<T, Options, Extensions>) {
@@ -82,59 +85,24 @@ export function createSubscribe<
   };
 }
 
-export type RawTypeToObject = {
-  Bond: never;
-  Certificate: never;
-  Cluster: never;
-  Cluster_host: never;
-  DR_task: never;
-  Feature: never;
-  GPU_group: never;
-  PBD: never;
-  PCI: never;
-  PGPU: never;
-  PIF: never;
-  PIF_metrics: never;
-  PUSB: never;
-  PVS_cache_storage: never;
-  PVS_proxy: never;
-  PVS_server: never;
-  PVS_site: never;
-  SDN_controller: never;
-  SM: never;
-  SR: XenApiSr;
-  USB_group: never;
-  VBD: never;
-  VBD_metrics: never;
-  VDI: never;
-  VGPU: never;
-  VGPU_type: never;
-  VIF: never;
-  VIF_metrics: never;
-  VLAN: never;
-  VM: XenApiVm;
-  VMPP: never;
-  VMSS: never;
-  VM_guest_metrics: XenApiVmGuestMetrics;
-  VM_metrics: XenApiVmMetrics;
-  VUSB: never;
-  blob: never;
-  console: XenApiConsole;
-  crashdump: never;
-  host: XenApiHost;
-  host_cpu: never;
-  host_crashdump: never;
-  host_metrics: XenApiHostMetrics;
-  host_patch: never;
-  message: XenApiMessage;
-  network: never;
-  network_sriov: never;
-  pool: XenApiPool;
-  pool_patch: never;
-  pool_update: never;
-  role: never;
-  secret: never;
-  subject: never;
-  task: XenApiTask;
-  tunnel: never;
-};
+export type RawTypeToRecord<T extends RawObjectType> = T extends "SR"
+  ? XenApiSr
+  : T extends "VM"
+  ? XenApiVm
+  : T extends "VM_guest_metrics"
+  ? XenApiVmGuestMetrics
+  : T extends "VM_metrics"
+  ? XenApiVmMetrics
+  : T extends "console"
+  ? XenApiConsole
+  : T extends "host"
+  ? XenApiHost
+  : T extends "host_metrics"
+  ? XenApiHostMetrics
+  : T extends "message"
+  ? XenApiMessage
+  : T extends "pool"
+  ? XenApiPool
+  : T extends "task"
+  ? XenApiTask
+  : never;


### PR DESCRIPTION
### Description

Enhance typings for improved type safety.

More efficient to retrieve a `XenApiRecord` type from its "raw" name (VM_guest_metrics, VM etc.)

This also allows this kind of thing:

```typescript
<script setup generic="T extends RawObjectType">

const props = defineProps<{
  type: T;
  uuid: RawTypeToRecord<T>["uuid"]
}>();

const store = useXapiCollectionStore().get(props.type);

const { getByUuid } = store.subscribe();

const record = computed(() => getByUuid(props.uuid)); // <= No type error

</script>
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
