### PR TITLE
feat:speed up backup by shunting the xapi for transfer

### DIFF
--- a/@vates/nbd-client/bench.mjs
+++ b/@vates/nbd-client/bench.mjs
@@ -1,0 +1,32 @@
+
+import NbdClient from "./index.mjs";
+
+
+
+async function bench(){
+    const client = new NbdClient({
+        address:'172.16.210.14',
+        port: 8077,
+        exportname: 'bench_export'
+    })
+    await client.connect()
+    console.log('connected', client.exportSize)
+
+    for(let chunk_size=16*1024; chunk_size < 16*1024*1024; chunk_size *=2){
+
+
+    let i=0
+    const start = + new Date()
+    for await(const block of client.readBlocks(chunk_size) ){
+        i++
+        if((i*chunk_size) % (16*1024*1024) ===0){
+                process.stdout.write('.')
+        }
+        if(i*chunk_size > 1024*1024*1024) break
+    }
+    console.log(chunk_size,Math.round( (i*chunk_size/1024/1024*1000)/ (new Date() - start)))
+
+    }
+}
+
+bench()

--- a/@vates/nbd-client/index.mjs
+++ b/@vates/nbd-client/index.mjs
@@ -307,11 +307,11 @@ export default class NbdClient {
     })
   }
 
-  async *readBlocks(indexGenerator) {
+  async *readBlocks(indexGenerator = 2*1024*1024) {
     // default : read all blocks
-    if (indexGenerator === undefined) {
+    if (typeof indexGenerator === 'number') {
       const exportSize = this.#exportSize
-      const chunkSize = 2 * 1024 * 1024
+      const chunkSize =  indexGenerator
       indexGenerator = function* () {
         const nbBlocks = Math.ceil(Number(exportSize / BigInt(chunkSize)))
         for (let index = 0; BigInt(index) < nbBlocks; index++) {
@@ -319,6 +319,7 @@ export default class NbdClient {
         }
       }
     }
+
     const readAhead = []
     const readAheadMaxLength = this.#readAhead
     const makeReadBlockPromise = (index, size) => {

--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -64,8 +64,12 @@ class Vdi {
     })
   }
 
-  async _getNbdClient(ref) {
-    const nbdInfos = await this.call('VDI.get_nbd_info', ref)
+  async _getNbdClient(ref) { 
+    const nbdInfos = [{
+      address:'172.16.210.14',
+      port: 8077,
+      exportname: 'bench_export'
+  }]//await this.call('VDI.get_nbd_info', ref)
     if (nbdInfos.length > 0) {
       // a little bit of randomization to spread the load
       const nbdInfo = nbdInfos[Math.floor(Math.random() * nbdInfos.length)]
@@ -94,13 +98,15 @@ class Vdi {
 
       query.base = baseRef
     }
+
+    
     let nbdClient, stream
     try {
-      if (this._preferNbd) {
+      if (this._preferNbd || true) {
         nbdClient = await this._getNbdClient(ref)
       }
       // the raw nbd export does not need to peek ath the vhd source
-      if (nbdClient !== undefined && format === VDI_FORMAT_RAW) {
+      if (nbdClient !== undefined && format === VDI_FORMAT_RAW || true) {
         stream = createNbdRawStream(nbdClient)
       } else {
         // raw export without nbd or vhd exports needs a resource stream

--- a/packages/vhd-lib/createStreamNbd.js
+++ b/packages/vhd-lib/createStreamNbd.js
@@ -15,7 +15,7 @@ const { fuHeader, checksumStruct } = require('./_structs')
 const assert = require('node:assert')
 
 exports.createNbdRawStream = async function createRawStream(nbdClient) {
-  const stream = Readable.from(nbdClient.readBlocks())
+  const stream = Readable.from(nbdClient.readBlocks(524288))
 
   stream.on('error', () => nbdClient.disconnect())
   stream.on('end', () => nbdClient.disconnect())


### PR DESCRIPTION
### Description

Goal : 
backup are slow , speed them up 

bonus: add range to restart transfer

## Preliminary tests

reading from a Vdi in xostore  from a XO on same host allow us to reach 500MB/s , which is a 5-10x gain compared to xapi export/xapi nbd 


## Architecture 2 

direct tcp transfer of files instead of NBD protocol . Test on my hadware : it go as fast as my ssd ( 2-4GB/s with node js createreadstream pipe to a socket, or in rust withio::copy )

piping compression make the performance drop , but can be usefull if transfer is network bound instead of cpu bound. If transfer is disk bound : nothing to do.

```mermaid
sequenceDiagram
	autonumber
	participant XO
	participant TCP server
	participant XAPI
	participant XAPI plugin
	participant XCP host
	XO ->> XAPI plugin: plugin.vdi.export_direct(sessionRef, vdiRef, taskRef, server_url, key)
	XAPI plugin ->> XAPI : sessionRef + vdi uuid
	XAPI ->> XAPI plugin: auth + vdi storage and mode (block/file/..)
	XAPI plugin->> XAPI: create task
	XAPI plugin->> XCP host: echo $key | cat - $sourcefile | nc $host $port -q 0
	XCP host ->> TCP server: key 
	TCP server ->> XO: check key
	XO ->> TCP server: key ok 
	TCP server ->> TCP server : accept content
	loop  while file not completly transferred
		XCP host ->> TCP server: TCP stream 
		TCP server ->> XO: node stream
		XCP host ->> XAPI plugin: update progress
		XAPI plugin->> XAPI: update task ²²²²progress/status
		XAPI ->> XO : update task progress/status
	end
	XCP host ->> XAPI plugin: done + size
	XAPI plugin->> XO: done + size
	XAPI plugin->> XAPI: close task
	XO ->> XO: validate stream with size
```


## Architecture 

limit the security exposure of the host ( no additionnal port to open, don't make it possible to download/upload arbitrary files)

### host side

- add a xapi plugin (if not possible: a standalone server, but that increase security surface a lot)
  - with a method copy_to_nbd(sessionRef, VdiRef, nbdServerUrl)
    - this method compute the real file path of the VDI
    - then launch `nbdcopy` https://libguestfs.org/nbdcopy.1.html  to the remote nbd server and forward the result code 
  - with a method copy_from_nbd(sessionRef, SrRef, nbdServerUrl)
    - this method compute the real file path of the VDI
    - then launch `nbdcopy` from the remote nbd server and forward the created vdiuuid  

### XO side
- implement a NBD readable and writable server with methods : 
  - prepare to receive : create a unique virutal nbd export , and return the exportuuid + a stream that will contains data RAW
  - prepare to send : create a unique nbd export  and return the exportuuid + a promise when transfer is done
- use this server in VDI.importContent and VDI.ExportContent
- must support TLS/noTLS mode 


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
