### PR TITLE
Faster ZIP and tar+gzip support

### DIFF
--- a/@xen-orchestra/backups/package.json
+++ b/@xen-orchestra/backups/package.json
@@ -40,6 +40,7 @@
     "parse-pairs": "^2.0.0",
     "promise-toolbox": "^0.21.0",
     "proper-lockfile": "^4.1.2",
+    "tar": "^6.1.15",
     "uuid": "^9.0.0",
     "vhd-lib": "^4.5.0",
     "xen-api": "^1.3.3",

--- a/@xen-orchestra/proxy/app/mixins/api.mjs
+++ b/@xen-orchestra/proxy/app/mixins/api.mjs
@@ -58,7 +58,7 @@ const ndJsonStream = asyncIteratorToStream(async function* (responseId, iterable
 
 export default class Api {
   constructor(app, { appVersion, httpServer }) {
-    this._ajv = new Ajv({ allErrors: true })
+    this._ajv = new Ajv({ allErrors: true, useDefaults: true })
     this._methods = { __proto__: null }
     const PREFIX = '/api/v1'
     const router = new Router({ prefix: PREFIX }).post('/', async ctx => {

--- a/@xen-orchestra/proxy/app/mixins/backups.mjs
+++ b/@xen-orchestra/proxy/app/mixins/backups.mjs
@@ -174,12 +174,15 @@ export default class Backups {
           },
         ],
         fetchPartitionFiles: [
-          ({ disk: diskId, remote, partition: partitionId, paths }) =>
-            Disposable.use(this.getAdapter(remote), adapter => adapter.fetchPartitionFiles(diskId, partitionId, paths)),
+          ({ disk: diskId, format, remote, partition: partitionId, paths }) =>
+            Disposable.use(this.getAdapter(remote), adapter =>
+              adapter.fetchPartitionFiles(diskId, partitionId, paths, format)
+            ),
           {
             description: 'fetch files from partition',
             params: {
               disk: { type: 'string' },
+              format: { type: 'string', default: 'zip' },
               partition: { type: 'string', optional: true },
               paths: { type: 'array', items: { type: 'string' } },
               remote: { type: 'object' },

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@
   - Fix synchronization not working if some pools are unavailable
   - Better error messages
 - [RPU] Avoid migration of VMs on hosts without missing patches (PR [#6943](https://github.com/vatesfr/xen-orchestra/pull/6943))
+- [Backup/File restore] Faster and more robust ZIP export
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
   - Better error messages
 - [RPU] Avoid migration of VMs on hosts without missing patches (PR [#6943](https://github.com/vatesfr/xen-orchestra/pull/6943))
 - [Backup/File restore] Faster and more robust ZIP export
+- [Backup/File restore] Add faster tar+gzip (`.tgz`) export
 
 ### Bug fixes
 

--- a/packages/xo-server/src/api/backup-ng.mjs
+++ b/packages/xo-server/src/api/backup-ng.mjs
@@ -336,21 +336,21 @@ listFiles.params = {
   },
 }
 
-async function handleFetchFiles(req, res, { remote, disk, partition, paths }) {
-  const zipStream = await this.fetchBackupNgPartitionFiles(remote, disk, partition, paths)
+async function handleFetchFiles(req, res, { remote, disk, format, partition, paths }) {
+  const stream = await this.fetchBackupNgPartitionFiles(remote, disk, partition, paths, format)
 
   res.setHeader('content-disposition', 'attachment')
   res.setHeader('content-type', 'application/octet-stream')
-  return zipStream
+  return stream
 }
 
 export async function fetchFiles(params) {
-  const { paths } = params
+  const { format, paths } = params
   let filename = `restore_${safeDateFormat(new Date())}`
   if (paths.length === 1) {
     filename += `_${basename(paths[0])}`
   }
-  filename += '.zip'
+  filename += '.' + format
 
   return this.registerHttpRequest(handleFetchFiles, params, {
     suffix: '/' + encodeURIComponent(filename),
@@ -362,6 +362,10 @@ fetchFiles.permission = 'admin'
 fetchFiles.params = {
   disk: {
     type: 'string',
+  },
+  format: {
+    type: 'string',
+    default: 'tgz',
   },
   partition: {
     optional: true,

--- a/packages/xo-server/src/xo-mixins/file-restore-ng.mjs
+++ b/packages/xo-server/src/xo-mixins/file-restore-ng.mjs
@@ -33,7 +33,7 @@ export default class BackupNgFileRestore {
     })
   }
 
-  async fetchBackupNgPartitionFiles(remoteId, diskId, partitionId, paths) {
+  async fetchBackupNgPartitionFiles(remoteId, diskId, partitionId, paths, format) {
     const app = this._app
     const remote = await app.getRemoteWithCredentials(remoteId)
     return remote.proxy !== undefined
@@ -48,11 +48,14 @@ export default class BackupNgFileRestore {
             },
             partition: partitionId,
             paths,
+
+            // don't send the legacy default format to keep compatibility with old proxies
+            format: format === 'zip' ? undefined : format,
           },
           { assertType: 'stream' }
         )
       : Disposable.use(app.getBackupsRemoteAdapter(remote), adapter =>
-          adapter.fetchPartitionFiles(diskId, partitionId, paths)
+          adapter.fetchPartitionFiles(diskId, partitionId, paths, format)
         )
   }
 

--- a/packages/xo-server/src/xo.mjs
+++ b/packages/xo-server/src/xo.mjs
@@ -17,6 +17,7 @@ import { createLogger } from '@xen-orchestra/log'
 import { EventEmitter } from 'events'
 import { noSuchObject } from 'xo-common/api-errors.js'
 import { parseDuration } from '@vates/parse-duration'
+import { pipeline } from 'node:stream'
 import { UniqueIndex as XoUniqueIndex } from 'xo-collection/unique-index.js'
 
 import mixins from './xo-mixins/index.mjs'
@@ -143,7 +144,7 @@ export default class Xo extends EventEmitter {
           if (typeof result === 'string' || Buffer.isBuffer(result)) {
             res.end(result)
           } else if (typeof result.pipe === 'function') {
-            result.pipe(res)
+            pipeline(result, res, noop)
           } else {
             res.end(JSON.stringify(result))
           }

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1782,6 +1782,7 @@ const messages = {
   // ----- Restore files view -----
   restoreFiles: 'Restore backup files',
   restoreFilesError: 'Invalid options',
+  restoreFilesExportFormat: 'Export format:',
   restoreFilesFromBackup: 'Restore file from {name}',
   restoreFilesSelectBackup: 'Select a backup…',
   restoreFilesSelectDisk: 'Select a disk…',
@@ -1792,7 +1793,9 @@ const messages = {
   restoreFilesDiskError: 'Error while scanning disk',
   restoreFilesSelectAllFiles: "Select all this folder's files",
   restoreFilesSelectFolder: 'Select this folder',
+  restoreFilesTgz: 'tar+gzip (.tgz)',
   restoreFilesUnselectAll: 'Unselect all files',
+  restoreFilesZip: 'ZIP (slow)',
 
   // ----- Modals -----
   bypassBackupHostModalMessage: 'There may be ongoing backups on the host. Are you sure you want to continue?',

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -2686,8 +2686,8 @@ export const listPartitions = (remote, disk) => _call('backupNg.listPartitions',
 export const listFiles = (remote, disk, path, partition) =>
   _call('backupNg.listFiles', resolveIds({ remote, disk, path, partition }))
 
-export const fetchFiles = (remote, disk, partition, paths) =>
-  _call('backupNg.fetchFiles', resolveIds({ remote, disk, partition, paths })).then(({ $getFrom: url }) => {
+export const fetchFiles = (remote, disk, partition, paths, format) =>
+  _call('backupNg.fetchFiles', resolveIds({ remote, disk, format, partition, paths })).then(({ $getFrom: url }) => {
     window.open(`.${url}`)
   })
 

--- a/packages/xo-web/src/xo-app/backup/file-restore/index.js
+++ b/packages/xo-web/src/xo-app/backup/file-restore/index.js
@@ -142,11 +142,11 @@ export default class Restore extends Component {
     confirm({
       title: _('restoreFilesFromBackup', { name: last.vm.name_label }),
       body: <RestoreFileModalBody vmName={last.vm.name_label} backups={backups} />,
-    }).then(({ remote, disk, partition, paths }) => {
+    }).then(({ remote, disk, format, partition, paths }) => {
       if (remote === undefined || disk === undefined || paths.length === 0) {
         return error(_('restoreFiles'), _('restoreFilesError'))
       }
-      return fetchFiles(remote, disk, partition, paths)
+      return fetchFiles(remote, disk, partition, paths, format)
     }, noop)
 
   _delete = data =>

--- a/packages/xo-web/src/xo-app/backup/file-restore/restore-file-modal.js
+++ b/packages/xo-web/src/xo-app/backup/file-restore/restore-file-modal.js
@@ -75,15 +75,17 @@ const formatFilesOptions = (rawFiles, path) => {
 
 export default class RestoreFileModalBody extends Component {
   state = {
+    format: 'tgz',
     selectedFiles: [],
   }
 
   get value() {
-    const { disk, partition, selectedFiles, backup } = this.state
+    const { disk, format, partition, selectedFiles, backup } = this.state
     const redundantFiles = this._getRedundantFiles()
 
     return {
       disk,
+      format,
       partition,
       paths: map(
         selectedFiles.filter(({ path }) => !redundantFiles[path]),
@@ -260,12 +262,26 @@ export default class RestoreFileModalBody extends Component {
     }
   )
 
+  _linkState = ({ target }) => {
+    this.setState({ [target.name]: target.value })
+  }
+
   // ---------------------------------------------------------------------------
 
   render() {
     const { backups } = this.props
-    const { backup, disk, partition, partitions, path, scanDiskError, listFilesError, scanningFiles, selectedFiles } =
-      this.state
+    const {
+      backup,
+      disk,
+      format,
+      partition,
+      partitions,
+      path,
+      scanDiskError,
+      listFilesError,
+      scanningFiles,
+      selectedFiles,
+    } = this.state
     const noPartitions = isEmpty(partitions)
     const redundantFiles = this._getRedundantFiles()
 
@@ -390,6 +406,25 @@ export default class RestoreFileModalBody extends Component {
             <em>{_('restoreFilesNoFilesSelected')}</em>
           ),
         ]}
+        <Container className='mt-1'>
+          <Row>
+            <Col>{_('restoreFilesExportFormat')}</Col>
+          </Row>
+          <Row>
+            <Col size={6}>
+              <label>
+                <input checked={format === 'tgz'} name='format' onChange={this._linkState} type='radio' value='tgz' />{' '}
+                {_('restoreFilesTgz')}
+              </label>
+            </Col>
+            <Col size={6}>
+              <label>
+                <input checked={format === 'zip'} name='format' onChange={this._linkState} type='radio' value='zip' />{' '}
+                {_('restoreFilesZip')}
+              </label>
+            </Col>
+          </Row>
+        </Container>
       </div>
     )
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19770,7 +19770,7 @@ tar-stream@^2.0.1, tar-stream@^2.2.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^6.1.11:
+tar@^6.1.11, tar@^6.1.15:
   version "6.1.15"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.15.tgz#c9738b0b98845a3b344d334b8fa3041aaba53a69"
   integrity sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==


### PR DESCRIPTION
**DO NOT SQUASH.**

### Description

More robust and faster ZIP export.

tar+gzip export is now also possible (~6 times faster than ZIP).

This PR provides the format tar+gzip by default and keep ZIP as an alternative.

![image](https://github.com/vatesfr/xen-orchestra/assets/298721/34e189f2-3a31-45dd-aad1-2f57fd93ee50)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
