### PR TITLE
feat(xo-server/xostor): server implementation

### DIFF
--- a/packages/xo-server/src/api/sr.mjs
+++ b/packages/xo-server/src/api/sr.mjs
@@ -6,6 +6,7 @@ import some from 'lodash/some.js'
 import ensureArray from '../_ensureArray.mjs'
 import { asInteger } from '../xapi/utils.mjs'
 import { debounceWithKey } from '../_pDebounceWithKey.mjs'
+import { destroy as destroyXostor } from './xostor.mjs'
 import { forEach, parseXml } from '../utils.mjs'
 
 // ===================================================================
@@ -56,6 +57,10 @@ const srIsBackingHa = sr => sr.$pool.ha_enabled && some(sr.$pool.$ha_statefiles,
 // TODO: find a way to call this "delete" and not destroy
 export async function destroy({ sr }) {
   const xapi = this.getXapi(sr)
+  if (sr.SR_type === 'linstor') {
+    await destroyXostor.call(this, { sr })
+    return
+  }
   if (sr.SR_type !== 'xosan') {
     await xapi.destroySr(sr._xapiId)
     return

--- a/packages/xo-server/src/api/xostor.mjs
+++ b/packages/xo-server/src/api/xostor.mjs
@@ -45,10 +45,10 @@ export function installDependencies({ host }) {
 installDependencies.description = 'Install XOSTOR dependencies'
 installDependencies.permission = 'admin'
 installDependencies.params = {
-  hostId: { type: 'string' },
+  host: { type: 'string' },
 }
 installDependencies.resolve = {
-  host: ['hostId', 'host', 'administrate'],
+  host: ['host', 'host', 'administrate'],
 }
 
 export function updateDependencies({ host }) {
@@ -57,10 +57,10 @@ export function updateDependencies({ host }) {
 updateDependencies.description = 'Update XOSTOR dependencies'
 updateDependencies.permission = 'admin'
 updateDependencies.params = {
-  hostId: { type: 'string' },
+  host: { type: 'string' },
 }
 updateDependencies.resolve = {
-  host: ['hostId', 'host', 'administrate'],
+  host: ['host', 'host', 'administrate'],
 }
 
 export async function formatDisks({ disks, force, host, ignoreFileSystems, provisioning }) {
@@ -96,12 +96,12 @@ formatDisks.permission = 'admin'
 formatDisks.params = {
   disks: { type: 'array', items: { type: 'string' } },
   force: { type: 'boolean', optional: true, default: false },
-  hostId: { type: 'string' },
+  host: { type: 'string' },
   ignoreFileSystems: { type: 'boolean', optional: true, default: false },
   provisioning: { enum: PROVISIONING },
 }
 formatDisks.resolve = {
-  host: ['hostId', 'host', 'administrate'],
+  host: ['host', 'host', 'administrate'],
 }
 
 export async function create({ description, disksByHosts, force, ignoreFileSystems, name, provisioning, replication }) {
@@ -121,7 +121,7 @@ export async function create({ description, disksByHosts, force, ignoreFileSyste
     host => boundFormatDisks({ disks: disksByHosts[host.id], host, force, ignoreFileSystems, provisioning }),
     {
       stopOnError: false,
-    }
+    },
   )
 
   const host = hosts[0]
@@ -166,8 +166,8 @@ export async function destroy({ sr }) {
 destroy.description = 'Destroy a XOSTOR storage'
 destroy.permission = 'admin'
 destroy.params = {
-  srId: { type: 'string' },
+  sr: { type: 'string' },
 }
 destroy.resolve = {
-  sr: ['srId', 'SR', 'administrate'],
+  sr: ['sr', 'SR', 'administrate'],
 }

--- a/packages/xo-server/src/api/xostor.mjs
+++ b/packages/xo-server/src/api/xostor.mjs
@@ -1,0 +1,184 @@
+import { asyncEach } from '@vates/async-each'
+import { createLogger } from '@xen-orchestra/log'
+
+const ENUM_PROVISIONING = {
+  Thin: 'thin',
+  Thick: 'thick',
+}
+const LV_NAME = 'thin_device'
+const PROVISIONING = Object.values(ENUM_PROVISIONING)
+const VG_NAME = 'linstor_group'
+const _XOSTOR_DEPENDENCIES = ['xcp-ng-release-linstor', 'xcp-ng-linstor']
+const XOSTOR_DEPENDENCIES = _XOSTOR_DEPENDENCIES.join(',')
+
+const log = createLogger('xo:api:pool')
+
+function pluginCall(xapi, host, plugin, fnName, args) {
+  return xapi.call('host.call_plugin', host._xapiRef, plugin, fnName, args)
+}
+
+async function destroyVolumeGroup(xapi, host, force) {
+  const isVgAlreadyExist =
+    Object.keys(
+      JSON.parse(
+        await pluginCall(xapi, host, 'lvm.py', 'list_volume_groups', {
+          vg_name: VG_NAME,
+        })
+      )
+    ).length > 0
+  if (isVgAlreadyExist) {
+    log.info(`Trying to delete the ${VG_NAME} volume group.`, { hostId: host.id })
+    return pluginCall(xapi, host, 'lvm.py', 'destroy_volume_group', {
+      vg_name: VG_NAME,
+      force: String(force),
+    })
+  }
+}
+
+async function installOrUpdateDependencies(host, method = 'install') {
+  if (method !== 'install' && method !== 'update') {
+    throw new Error('Invalid method')
+  }
+
+  const xapi = this.getXapi(host)
+  log.info(`Trying to ${method} XOSTOR dependencies (${XOSTOR_DEPENDENCIES})`, { hostId: host.id })
+  for (const _package of _XOSTOR_DEPENDENCIES) {
+    await xapi.call('host.call_plugin', host._xapiRef, 'updater.py', method, {
+      packages: _package,
+    })
+  }
+}
+
+export function installDependencies({ host }) {
+  return installOrUpdateDependencies.call(this, host)
+}
+installDependencies.description = 'Install XOSTOR dependencies'
+installDependencies.permission = 'admin'
+installDependencies.params = {
+  hostId: { type: 'string' },
+}
+installDependencies.resolve = {
+  host: ['hostId', 'host', 'administrate'],
+}
+
+export function updateDependencies({ host }) {
+  return installOrUpdateDependencies.call(this, host, 'update')
+}
+updateDependencies.description = 'Update XOSTOR dependencies'
+updateDependencies.permission = 'admin'
+updateDependencies.params = {
+  hostId: { type: 'string' },
+}
+updateDependencies.resolve = {
+  host: ['hostId', 'host', 'administrate'],
+}
+
+export async function formatDisks({ disks, force, host, ignoreFileSystems, provisioning }) {
+  const rawDisks = disks.join(',')
+  const xapi = this.getXapi(host)
+
+  const lvmPlugin = (fnName, args) => pluginCall(xapi, host, 'lvm.py', fnName, args)
+  log.info(`Format disks (${rawDisks}) with force: ${force}`, { hostId: host.id })
+
+  if (force) {
+    await destroyVolumeGroup(xapi, host, force)
+  }
+  await lvmPlugin('create_physical_volume', {
+    devices: rawDisks,
+    ignore_existing_filesystems: String(ignoreFileSystems),
+    force: String(force),
+  })
+
+  await lvmPlugin('create_volume_group', {
+    devices: rawDisks,
+    vg_name: VG_NAME,
+  })
+
+  if (provisioning === ENUM_PROVISIONING.Thin) {
+    await lvmPlugin('create_thin_pool', {
+      lv_name: LV_NAME,
+      vg_name: VG_NAME,
+    })
+  }
+}
+formatDisks.description = 'Format disks for a XOSTOR use'
+formatDisks.permission = 'admin'
+formatDisks.params = {
+  disks: { type: 'array', items: { type: 'string' } },
+  force: { type: 'boolean', optional: true, default: false },
+  hostId: { type: 'string' },
+  ignoreFileSystems: { type: 'boolean', optional: true, default: false },
+  provisioning: { enum: PROVISIONING },
+}
+formatDisks.resolve = {
+  host: ['hostId', 'host', 'administrate'],
+}
+
+export async function create({ description, disksByHosts, force, ignoreFileSystems, name, provisioning, replication }) {
+  const hostIds = Object.keys(disksByHosts)
+  const hosts = hostIds.map(hostId => this.getObject(hostId, 'host'))
+
+  if (!hosts.every(host => host.$pool === hosts[0].$pool)) {
+    throw new Error('All hosts must be in the same pool')
+  }
+
+  const boundInstallDependencies = installDependencies.bind(this)
+  await asyncEach(hosts, host => boundInstallDependencies({ host }), { stopOnError: false })
+
+  const boundFormatDisks = formatDisks.bind(this)
+  await asyncEach(
+    hosts,
+    host => boundFormatDisks({ disks: disksByHosts[host.id], host, force, ignoreFileSystems, provisioning }),
+    {
+      stopOnError: false,
+    }
+  )
+
+  const pool = this.getObject(hosts[0].$pool, 'pool')
+  const master = hosts.find(host => host.id === pool.master)
+
+  log.info(`Create XOSTOR (${name}) with provisioning: ${provisioning}`)
+  return this.getXapi(master).SR_create({
+    device_config: {
+      'group-name': 'linstor_group/' + LV_NAME,
+      redundancy: String(replication),
+      provisioning,
+    },
+    host: master.id,
+    name_description: description,
+    name_label: name,
+    shared: true,
+    type: 'linstor',
+  })
+}
+create.description = 'Create a XOSTOR storage'
+create.permission = 'admin'
+create.params = {
+  description: { type: 'string', optional: true, default: 'From XO-server' },
+  disksByHosts: { type: 'object' },
+  force: { type: 'boolean', optional: true, default: false },
+  ignoreFileSystems: { type: 'boolean', optional: true, default: false },
+  name: { type: 'string' },
+  provisioning: { enum: PROVISIONING },
+  replication: { type: 'number' },
+}
+
+// Also called by sr.destroy if sr.SR_type === 'linstor'
+export async function destroy({ sr }) {
+  if (sr.SR_type !== 'linstor') {
+    throw new Error('SR is not of linstor type')
+  }
+  const xapi = this.getXapi(sr)
+  const hosts = Object.values(xapi.objects.indexes.type.host).map(host => this.getObject(host.uuid, 'host'))
+
+  await xapi.destroySr(sr._xapiId)
+  return asyncEach(hosts, host => destroyVolumeGroup(xapi, host, true), { stopOnError: false })
+}
+destroy.description = 'Destroy a XOSTOR storage'
+destroy.permission = 'admin'
+destroy.params = {
+  srId: { type: 'string' },
+}
+destroy.resolve = {
+  sr: ['srId', 'SR', 'administrate'],
+}


### PR DESCRIPTION
### FIXME

- Only PBD of the master host is connected. (I can't reproduce it anymore)

### Test

A test pool is available at: 172.16.210.83.

If a XOSTOR storage has already been created, please delete it.

Use the following xo-cli command:

```
xo-cli xostor.create \
    provisioning=thin \
    disksByHosts=json:'{
        "8b9d5b00-9839-40c2-aff0-3710f05e093b": ["/dev/sdb", "/dev/sdc"],
        "3c093a7a-33a8-4823-88dd-028466328098": ["/dev/sdb", "/dev/sdc"],
        "cea28d8f-ae1c-4cde-86be-bd49153c1057": ["/dev/sdb", "/dev/sdc"]
    }' \
    name="XOSTOR test" \
    replication=json:3
```

If the `linstor_group` `Virtual Group` or `Physical Volume` already exists, add `force=true`.

### Screenshot

![Capture d’écran de 2023-08-02 15-29-44](https://github.com/vatesfr/xen-orchestra/assets/70369997/c7ff2f79-ace1-497a-961f-656f238505df)

### Description

[Spec](https://kanban.vates.fr/b/jnfjuip4eBARBNuv9/xo-releases/57aQ5t9rd2JeMN2N5)

- [x] Tested on XCP-ng 8.3 thin
- [x] Tested on XCP-ng 8.3 thick
- [x] Tested with more than one disk per host
- [x] Tested without using the entire pool hosts
- XCP-ng 8.2 cannot be tested at this time.
- [ ] Tested on XCP-ng 8.2 thick
- [ ] Tested on XCP-ng 8.2 thin

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
