### PR TITLE
fix(xen-api): don't fail silently when a getResource query fail without response

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,6 +29,7 @@
 
 <!--packages-start-->
 
+- xen-api patch
 - xo-server patch
 - xo-server-auth-ldap patch
 - xo-web patch

--- a/packages/xen-api/src/index.js
+++ b/packages/xen-api/src/index.js
@@ -419,7 +419,7 @@ export class Xapi extends EventEmitter {
             signal: $cancelToken,
           }),
         {
-          when: error => error.response.statusCode === 302,
+          when: error => error.response !== undefined && error.response.statusCode === 302,
           onRetry: async error => {
             const response = error.response
             if (response === undefined) {


### PR DESCRIPTION
### Description

error without response can happen with TLS certificates problems, and the onRetry already handle this case

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
