### PR TITLE
feat(backup): use tcp direct transfer - DO NOT MERGE

### DIFF
--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -98,6 +98,7 @@ export default class RemoteHandlerAbstract {
     const sharedLimit = limitConcurrency(options.maxParallelOperations ?? DEFAULT_MAX_PARALLEL_OPERATIONS)
     this.closeFile = sharedLimit(this.closeFile)
     this.copy = sharedLimit(this.copy)
+    this.exists = sharedLimit(this.exists)
     this.getInfo = sharedLimit(this.getInfo)
     this.getSize = sharedLimit(this.getSize)
     this.list = sharedLimit(this.list)
@@ -321,6 +322,14 @@ export default class RemoteHandlerAbstract {
 
   async rmtree(dir) {
     await this._rmtree(normalizePath(dir))
+  }
+
+  async _exists(file){
+    throw new Error('not implemented')
+  }
+  async exists(file){
+    return this._exists(normalizePath(file))
+
   }
 
   // Asks the handler to sync the state of the effective remote with its'

--- a/@xen-orchestra/fs/src/local.js
+++ b/@xen-orchestra/fs/src/local.js
@@ -206,4 +206,9 @@ export default class LocalHandler extends RemoteHandlerAbstract {
   _writeFile(file, data, { flags }) {
     return this.#addSyncStackTrace(fs.writeFile, this.getFilePath(file), data, { flag: flags })
   }
+
+  async _exists(file){
+    const exists = await  fs.pathExists(this._getFilePath(file))
+    return exists
+  }
 }

--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -421,4 +421,17 @@ export default class S3Handler extends RemoteHandlerAbstract {
   useVhdDirectory() {
     return true
   }
+
+  async _exists(file){
+    try{
+      await this._s3.send(new HeadObjectCommand(this._createParams(file)))
+      return true
+    }catch(error){
+      // normalize this error code
+      if (error.name === 'NoSuchKey') {
+        return false
+      }
+      throw error
+    }
+  }
 }

--- a/@xen-orchestra/xapi/package.json
+++ b/@xen-orchestra/xapi/package.json
@@ -33,6 +33,7 @@
     "http-request-plus": "^1.0.0",
     "json-rpc-protocol": "^0.13.2",
     "lodash": "^4.17.15",
+    "node-ssh": "^13.1.0",
     "promise-toolbox": "^0.21.0",
     "vhd-lib": "^4.5.0",
     "xo-common": "^0.8.0"

--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -38,18 +38,28 @@ async function getTcpStream(host, srUuid, vhdUuid){
     })
   })
   
-  console.log('tcp server up')
-  
-  const result = await ssh.execCommand(`python /tmp/uploadVhd.py /run/sr-mount/${srUuid}/${vhdUuid}.vhd ${XO_ADDRESS}  ${server.address().port}  key > /tmp/log.flo & `)
+  console.log('tcp server up',server.address().port)
+  console.log( `python /tmp/uploadVhd.py /run/sr-mount/${srUuid}/${vhdUuid}.vhd ${XO_ADDRESS}  ${server.address().port} ` )
+  ssh.execCommand(`python /tmp/uploadVhd.py /run/sr-mount/${srUuid}/${vhdUuid}.vhd ${XO_ADDRESS}  ${server.address().port}   `)
+    .then(result=>{
+      console.log('command done', result)
+      if(result.code  !== 0){
+        throw new Error(result.stderr)
+      }
+    })
+    .catch(err => {
+      console.error('command errored', err)
+      throw err
+    })
 
   console.log('python script launched')
   return new Promise((resolve, reject) =>{
     server.on('connection', clientSocket=>{
-      console.log('client connecetd')
+      console.log('client connected')
       resolve(clientSocket)
     });
     server.on('end', () => {
-      console.log('client disconnected', result);
+      console.log('client disconnected');
       ssh.disconnect()
     });
     server.on('error', err=>{

--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -55,17 +55,17 @@ async function getTcpStream(host, srUuid, vhdUuid){
   console.log('python script launched')
   return new Promise((resolve, reject) =>{
     server.on('connection', clientSocket=>{
-      console.log('client connected')
-      resolve(clientSocket)
+      console.log('client connected') 
+     // clientSocket.pipe(stream)
+      resolve(clientSocket)  
+      clientSocket.on('end', () => {
+        console.log('client disconnected'); 
+
+      });
+      clientSocket.on('error', err=>{
+        console.log('client error') 
+      })
     });
-    server.on('end', () => {
-      console.log('client disconnected');
-      ssh.disconnect()
-    });
-    server.on('error', err=>{
-      console.log('client error')
-      reject(err)
-    })
   })
 }
 class Vdi {
@@ -152,10 +152,11 @@ class Vdi {
     }
     const vdi = this.getObject(ref)
     console.log('GOT VDI ')
+    this._preferNbd = false
     const sr = this.getObject(vdi.SR)
     const pbds = sr.PBDs.map(pbdUuid => this.getObject(pbdUuid))
     const hosts = pbds.map(pbd => this.getObject(pbd.host))
-    console.log({vdi,sr, pbds, hosts})
+    // console.log({vdi,sr, pbds, hosts})
     return getTcpStream(hosts[0], sr.uuid, vdi.uuid)
     let nbdClient, stream
     try {

--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -63,7 +63,7 @@ async function getTcpStream(host, srUuid, vhdUuid){
 
       });
       clientSocket.on('error', err=>{
-        console.log('client error') 
+        console.log('client error', err) 
       })
     });
   })

--- a/packages/vhd-cli/commands/check.js
+++ b/packages/vhd-cli/commands/check.js
@@ -39,7 +39,6 @@ module.exports = async function check(rawArgs) {
     }
     if(blocks){
       for await(const _ of vhd.blocks()){
-
       }
       console.log('Blocks check done')
     }

--- a/packages/vhd-lib/Vhd/VhdAbstract.js
+++ b/packages/vhd-lib/Vhd/VhdAbstract.js
@@ -407,4 +407,14 @@ exports.VhdAbstract = class VhdAbstract {
     assert.strictEqual(copied, length, 'invalid length')
     return copied
   }
+
+  _checkBlock() {
+    throw new Error('not implemented')
+  }
+
+  // check if a block is ok without reading it
+  // there still can be error when reading the block later (if it's deleted, if right are incorrects,...)
+  async checkBlock(blockId) {
+    return this._checkBlock(blockId)
+  }
 }

--- a/packages/vhd-lib/Vhd/VhdDirectory.js
+++ b/packages/vhd-lib/Vhd/VhdDirectory.js
@@ -317,4 +317,9 @@ exports.VhdDirectory = class VhdDirectory extends VhdAbstract {
     })
     this.#compressor = getCompressor(chunkFilters[0])
   }
+
+  async _checkBlock(blockId){
+    const path = this._getFullBlockPath(blockId)
+    return this._handler.exists(path)
+  }
 }

--- a/packages/vhd-lib/Vhd/VhdFile.js
+++ b/packages/vhd-lib/Vhd/VhdFile.js
@@ -469,4 +469,8 @@ exports.VhdFile = class VhdFile extends VhdAbstract {
   async getSize() {
     return await this._handler.getSize(this._path)
   }
+
+  _checkBlock(blockId){
+    return true
+  }
 }

--- a/packages/vhd-lib/Vhd/VhdSynthetic.js
+++ b/packages/vhd-lib/Vhd/VhdSynthetic.js
@@ -113,6 +113,10 @@ const VhdSynthetic = class VhdSynthetic extends VhdAbstract {
     return vhd?._getFullBlockPath(blockId)
   }
 
+  _checkBlock(blockId) {
+    const vhd = this.#getVhdWithBlock(blockId)
+    return vhd?._checkBlock(blockId) ?? false
+  }
   // return true if all the vhds ar an instance of cls
   checkVhdsClass(cls) {
     return this.#vhds.every(vhd => vhd instanceof cls)

--- a/packages/xo-server/uploadVhd.py
+++ b/packages/xo-server/uploadVhd.py
@@ -8,6 +8,19 @@ import math
 
 # inspired from https://github.com/imcleod/pyvhd/blob/master/pyvhd.py
 
+class FakeSocket:
+
+    def __init__(self):
+        self.sent = 0
+    
+    def connect(self, host):
+        #nothin to do 
+        print('connected')
+
+    def send(self, data):
+        # nothing to be done
+        self.sent += len(data)
+
 
 def divro(num, den):
     # Divide always rounding up and returning an integer
@@ -155,15 +168,17 @@ class Vhd:
 
         batOffset = self.parsedHeader[2]
         print('batOffset',batOffset)
-        self.file.seek(batOffset)
-        batLength = self.parsedHeader[4]
+        self.parentLocator = self.file.read(batOffset - self.parsedFooter[3] - 1024)
+        print('parentLocator', len(self.parentLocator))
+        batLength = self.parsedHeader[4] * 4
         print('batlnght',batLength)
-        
-        self.file.seek(batOffset)
+
         bat = self.file.read(batLength*4)
+        # realign to 512 bytes sectors
+        self.file.seek(math.ceil((batLength + batOffset)/512)*512)
         self.bat= []
 
-        for blockIndex in range(0,batLength) :
+        for blockIndex in range(0,batLength/4) :
             offset = struct.unpack_from('>I', bat, blockIndex * 4)[0]
             self.bat.append(offset)
 
@@ -181,6 +196,7 @@ class Vhd:
         else:
             print('found root')
             self.parent = None
+
     
     def containsBlocks(self, index):
         return self.bat[index] != 0xffffffff or ( self.parent and self.parent.containsBlocks(index) )
@@ -219,37 +235,44 @@ class Vhd:
         struct.pack_into(">I", footer, 64, 0 )
         struct.pack_into('>I', footer, 64, (vhd_checksum(footer)))
         sent = 0
+        print('will send footer', len(footer), sent)
         socket.send(footer)
         sent += len(footer)
 
         # write child header but with root parentTimestamp,parentUnicodeName,parentUuid
-        header = header[0:40] +  root.header[40: 558] + header[558:]
+        header = header[0:40] +  root.header[40:] 
         # todo checksum 
         struct.pack_into(">I", header, 36, 0 ) 
         struct.pack_into('>I', header, 36, (vhd_checksum(header)))
+        print('will send header', len(header), sent)
         socket.send(header)
         sent += len(header)
 
+        # parent locator : ignore for now 
+        print('will send PL', len(root.parentLocator), sent)
+        socket.send(root.parentLocator)
+        sent += len(root.parentLocator)
+
         # write BAT aligned with 512bytes sector
 
-        offset = 1024 + 512  + len(self.bat) * 4 
-        offsetSector = math.ceil(offset/512)
+        offset = sent  + len(self.bat)*4
+        offsetSector = int(math.ceil(offset/512))
         bat = ""
+        print("start", offsetSector, sent, len(self.bat))*4
         for blockIndex in range(0, len(self.bat), 1):
             if self.containsBlocks(blockIndex) :
-                #print('got block', blockIndex)
-                bat += struct.pack(">I", ( offsetSector ) )
+                bat += struct.pack("I", ( offsetSector ) )
                 offsetSector += 4*1024 + 1
             else:
                 bat += struct.pack(">I", 0xffffffff )
 
 #        add padding to align to 512 bytes
         while len(bat) % 512 !=0:
+            print("pad", len(bat))
             bat += struct.pack(">I", ( 0 ) )
+        print('will send BAT', len(bat), sent)
         socket.send(bat)
-        print('bat len', len(bat))
         sent += len(bat)
-        
         # todo : parent locator 
 
         # write blocks
@@ -257,7 +280,6 @@ class Vhd:
             data = self.getBlockData(blockIndex)
             # print('will send ', len(data), blockIndex, len(self.bat))
             if data:
-                # print(' got data for block ', blockIndex) 
                 socket.send(data)
                 sent += len(data)
 
@@ -313,6 +335,7 @@ def main():
     vhd = Vhd(args.file_path)
 
     client_socket = socket.socket()
+#    client_socket = FakeSocket()
     client_socket.connect((args.host, int(args.port)))
     vhd.writeTo(client_socket)
 #    send(args.host, args.port, args.key, root_path)

--- a/packages/xo-server/uploadVhd.py
+++ b/packages/xo-server/uploadVhd.py
@@ -1,0 +1,55 @@
+
+import argparse
+import os
+import socket
+import subprocess
+import time
+
+def send(host, port, key, path):
+    client_socket = socket.socket()
+    client_socket.connect((host, int(port)))
+    print("Connected to server.")
+    #client_socket.send(key)
+    #data = client_socket.recv(1024)  # Adjust buffer size as needed
+    with open(path, 'rb') as file:
+        data = file.read(1024*1024)
+        while data:
+            client_socket.send(data)
+            data = file.read(1024*1024)
+    client_socket.close()
+    print("File sent.")
+
+
+def execute_command(file_path):
+    result = subprocess.Popen(['vhd-tool', 'get', file_path,'parent-unicode-name'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = result.communicate()
+    if result.returncode == 0:
+        output = stdout.strip()
+        if output:
+            print(output)
+            return execute_command(os.path.join(os.path.dirname(file_path), output))
+        else:
+            print("Command produced an empty result.")
+            print(file_path)
+            return file_path
+    else:
+	    print("Command failed with exit code {}.".format(result.returncode))
+
+def main():
+    parser = argparse.ArgumentParser(description="look for the root file of a vhd chain and send it to a tcp server")
+    parser.add_argument("file_path", help="Path to the file to be processed.")
+    parser.add_argument("host", help="host with the TCP server.")
+    parser.add_argument("port", help="port of the tcp server")
+    parser.add_argument("key", help="authent key")
+    args = parser.parse_args()
+
+    root_path = execute_command(args.file_path)
+    print(root_path)
+    send(args.host, args.port, args.key, root_path)
+
+if __name__ == "__main__":
+    main()
+
+
+
+

--- a/packages/xo-server/uploadVhd.py
+++ b/packages/xo-server/uploadVhd.py
@@ -231,7 +231,7 @@ class Vhd:
 
         # write BAT aligned with 512bytes sector
 
-        offset = 1024 + 512  + len(bat) * 4
+        offset = 1024 + 512  + len(bat) * 4 + 5120
         offsetSector = offset/512
         bat = ""
         for blockIndex in range(0, len(self.bat), 1):

--- a/packages/xo-server/uploadVhd.py
+++ b/packages/xo-server/uploadVhd.py
@@ -1,9 +1,269 @@
-
 import argparse
 import os
 import socket
 import subprocess
 import time
+import struct
+import math
+
+# inspired from https://github.com/imcleod/pyvhd/blob/master/pyvhd.py
+
+
+def divro(num, den):
+    # Divide always rounding up and returning an integer
+    # Is there some nicer way to do this?
+    return int(math.ceil((1.0*num)/(1.0*den)))
+
+def vhd_checksum(buf):
+    # This is the checksum defined in the MS spec
+    # sum up all bytes in the checked structure then take the ones compliment
+    checksum = 0
+    for byte in buf:
+        checksum += byte
+    return ((~checksum) & 0xFFFFFFFF)
+
+def vhd_chs(size):
+    # CHS calculation as defined by the VHD spec
+    sectors = divro(size, SECTORSIZE)
+
+    if sectors > (65535 * 16 * 255):
+        sectors = 65535 * 16 * 255
+
+    if sectors >= 65535 * 16 * 63:
+        spt = 255
+        cth = sectors / spt
+        heads = 16
+    else:
+        spt = 17
+        cth = sectors / spt
+        heads = (cth + 1023) / 1024
+
+        if heads < 4:
+            heads = 4
+
+        if (cth >= (heads * 1024)) or (heads > 16):
+            spt = 31
+            cth = sectors / spt
+            heads = 16
+
+        if cth >= (heads * 1024):
+            spt = 63
+            cth = sectors / spt
+            heads = 16
+
+    cylinders = cth / heads
+
+    return (cylinders, heads, spt)
+
+def zerostring(len):
+    zs = ""
+    for i in range(1, len):
+        zs += '\0'
+    return zs
+
+# Header/Footer - From MS doc
+# 512 bytes - early versions had a 511 byte footer for no obvious reason
+
+#Cookie 8
+#Features 4
+#File Format Version 4
+#Data Offset 8
+#Time Stamp 4
+#Creator Application 4
+#Creator Version 4
+#Creator Host OS 4
+#Original Size 8
+#Current Size 8
+#Disk Geometry 4
+# Disk Cylinders 2
+# Disk Heads 1
+# Disk Sectors 1
+#Disk Type 4
+#Checksum 4
+#Unique Id 16
+#Saved State 1
+#Reserved 427
+
+HEADER_FMT = ">8sIIQI4sIIQQHBBII16sB427s"
+
+# Dynamic header
+# 1024 bytes
+
+#Cookie 8
+#Data Offset 8
+#Table Offset 8
+#Header Version 4
+#Max Table Entries 4
+#Block Size 4
+#Checksum 4
+#Parent Unique ID 16
+#Parent Time Stamp 4
+#Reserved 4
+#Parent Unicode Name 512
+#Parent Locator Entry 1 24
+#Parent Locator Entry 2 24
+#Parent Locator Entry 3 24
+#Parent Locator Entry 4 24
+#Parent Locator Entry 5 24
+#Parent Locator Entry 6 24
+#Parent Locator Entry 7 24
+#Parent Locator Entry 8 24
+#Reserved 256
+
+DYNAMIC_FMT = ">8sQQIIII16sII512s192s256s"
+
+# BAT header 
+# This is not in the Microsoft spec but is present in the Xen code
+# This is a bitmap of the BAT where "1" indicates the BAT entry is valid
+# and "0" indicates that it is unallocated.
+#
+# Cookie 8 - 'tdbatmap'
+# batmap_offset 8 - byte offset to the BAT map
+# batmap_size 4 - batmap size in sectors rounded up
+# batmap_version 4 - 0x00010002 in vhd-util
+# batmap_checksum 4 - 1's compliment of batmap itself
+
+BAT_HDR_FMT = ">8sQIII"
+
+VHD_BLOCKSIZE = 2 * 1024 * 1024 # Default blocksize 2 MB
+SECTORSIZE = 512
+VHD_BLOCKSIZE_SECTORS = VHD_BLOCKSIZE/SECTORSIZE
+VHD_HEADER_SIZE = struct.calcsize(HEADER_FMT)
+VHD_DYN_HEADER_SIZE = struct.calcsize(DYNAMIC_FMT)
+SECTOR_BITMAP_SIZE = VHD_BLOCKSIZE / SECTORSIZE / 8
+FULL_SECTOR_BITMAP = ""
+for i in range(0,SECTOR_BITMAP_SIZE):
+    FULL_SECTOR_BITMAP += chr(0xFF)
+SECTOR_BITMAP_SECTORS = divro(SECTOR_BITMAP_SIZE, SECTORSIZE)
+# vhd-util has a bug that pads an additional 7 sectors on to each bloc
+# at the end.  I suspect this is due to miscalculating the size of the
+# bitmap.  Specifically, forgetting to divide the number of bits by 8.
+BLOCK_PAD_SECTORS = 7 # Bug for bug compat with vhd-util
+
+
+class Vhd:
+    def __init__(self, path):
+        print ('new VHD', path)
+        self.path = path
+        print(path, self.path)
+        self.file = open(self.path, 'rb')
+        self.footer = self.file.read(512)
+        self.parsedFooter = struct.unpack(">8sIIQI4sIIQQHBBII16sB427s", self.footer)
+        self.file.seek(self.parsedFooter[3])
+        self.header  = self.file.read(1024)
+        self.parsedHeader = struct.unpack(">8sQQIIII16sII512s192s256s", self.header)
+
+        batOffset = self.parsedHeader[2]
+        print('batOffset',batOffset)
+        self.file.seek(batOffset)
+        batLength = self.parsedHeader[4]
+        print('batlnght',batLength)
+        
+        self.file.seek(batOffset)
+        bat = self.file.read(batLength*4)
+        self.bat= []
+
+        for blockIndex in range(0,batLength) :
+            offset = struct.unpack_from('>I', bat, blockIndex * 4)[0]
+            self.bat.append(offset)
+
+
+        #result = subprocess.Popen(['vhd-tool', 'get', path,'parent-unicode-name'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        #stdout, stderr = result.communicate()
+        #parentUnicodeName = stdout.strip()    
+        parentUnicodeName = self.parsedHeader[10].decode("utf-16-be").rstrip('\x00').encode('utf-8')
+        print('parentUnicodeName',parentUnicodeName)
+        if parentUnicodeName:
+            parentPath = os.path.join(os.path.dirname(path), parentUnicodeName)
+            print('got parent', parentUnicodeName, parentPath)
+            print(parentUnicodeName)
+            self.parent = Vhd(parentPath)
+        else:
+            print('found root')
+            self.parent = None
+    
+    def containsBlocks(self, index):
+        return self.bat[index] != 0xffffffff or ( self.parent and self.parent.containsBlocks(index) )
+
+    def getBlockData(self, index):
+        offset = self.bat[index]
+        if offset == 0xffffffff:
+            #print('empty in this vhd')
+            if self.parent:
+                #print('check in parent')
+                return self.parent.getBlockData(index)
+            else:
+                #print('empty in root')
+                return None
+        else:
+            #print('found in', os.path.basename(self.path), index, "at", offset*512)
+            self.file.seek(offset*512)
+            return self.file.read(2*1024 *1024 + 512)
+
+    def getRoot(self):
+        if self.parent:
+           return self.parent.getRoot() 
+        return self
+
+
+    def writeTo(self, socket):
+        root = self.getRoot()
+        print('writeTo', root)   
+        
+        footer = bytearray(self.footer[:])
+        header = bytearray(self.header[:])
+        bat = self.bat[:]
+        # write child  footer but with root diskType
+        
+        struct.pack_into(">I", footer, 60, struct.unpack_from(">I",root.footer, 60)[0])
+        # todo : checksum 
+        struct.pack_into(">I", footer, 64, 0 )
+        struct.pack_into('>I', footer, 64, (vhd_checksum(footer)))
+        socket.send(footer)
+
+
+        # write child header but with root parentTimestamp,parentUnicodeName,parentUuid
+        header = header[0:40] +  root.header[40: 558] + header[558:]
+        # todo checksum 
+        struct.pack_into(">I", header, 36, 0 ) 
+        struct.pack_into('>I', header, 36, (vhd_checksum(header)))
+        socket.send(header)
+
+        # write BAT aligned with 512bytes sector
+
+        offset = 1024 + 512  + len(bat) * 4
+        offsetSector = offset/512
+        bat = ""
+        for blockIndex in range(0, len(self.bat), 1):
+            if self.containsBlocks(blockIndex) :
+                #print('got block', blockIndex)
+                bat += struct.pack(">I", ( offsetSector ) )
+                offsetSector += 4*1024 + 1
+            else:
+                bat += struct.pack(">I", 0xffffffff )
+
+#        add padding to align to 512 bytes
+        while len(bat) % 512 !=0:
+            bat += struct.pack(">I", ( 0 ) )
+        socket.send(bat)
+        
+        # todo : parent locator 
+
+        # write blocks
+        for blockIndex in range(0, len(self.bat), 1):
+            data = self.getBlockData(blockIndex)
+            # print('will send ', len(data), blockIndex, len(self.bat))
+            if data:
+                # print(' got data for block ', blockIndex) 
+                socket.send(data)
+
+        # write footer again 
+        socket.send(footer)
+        print('done')
+
+
+
+
 
 def send(host, port, key, path):
     client_socket = socket.socket()
@@ -33,23 +293,25 @@ def execute_command(file_path):
             print(file_path)
             return file_path
     else:
-	    print("Command failed with exit code {}.".format(result.returncode))
+        print("Command failed with exit code {}.".format(result.returncode))
 
 def main():
     parser = argparse.ArgumentParser(description="look for the root file of a vhd chain and send it to a tcp server")
     parser.add_argument("file_path", help="Path to the file to be processed.")
     parser.add_argument("host", help="host with the TCP server.")
     parser.add_argument("port", help="port of the tcp server")
-    parser.add_argument("key", help="authent key")
+#    parser.add_argument("key", help="authent key")
     args = parser.parse_args()
 
-    root_path = execute_command(args.file_path)
-    print(root_path)
-    send(args.host, args.port, args.key, root_path)
+#    root_path = execute_command(args.file_path)
+   
+    vhd = Vhd(args.file_path)
+
+    client_socket = socket.socket()
+    client_socket.connect((args.host, int(args.port)))
+    vhd.writeTo(client_socket)
+#    send(args.host, args.port, args.key, root_path)
 
 if __name__ == "__main__":
     main()
-
-
-
 


### PR DESCRIPTION
### Description

#### Current workflow

- current method replace completely vdi.exportContent
```mermaid
sequenceDiagram
	autonumber
	participant XO
	participant TCP server
	participant XCP host
	XO ->> XO: create TCP server on random free port
	XO ->> XCP host: upload `uploadVhd.py` to /tmp via ssh
	XO ->> XCP host: launch `uploadVhd.py` with path to vhd, and XOA ip/port of TCP server
	XCP host ->> XCP host: build full vhd chain
	XCP host ->> TCP server: upload synthetic vhd built from vhd chain
	TCP server ->> XO: stream content
	XO ->> XO: write backup
	XO ->> XO: validate vhd 
```

#### target workflow  (minimal)


```mermaid
sequenceDiagram
	autonumber
	participant Backup reporitory
	participant XO
	participant TCP server
	participant XAPI
	participant plugin XAPI
	XO ->> XO: create TCP server on random free port
	XO ->> plugin XAPI: export(vdiUUid, host, port, taskRef (optional))
	plugin XAPI ->> plugin XAPI: locate / mount vhd chain
	plugin XAPI ->> TCP server: upload synthetic vhd built from vhd chain
	loop  while file not completly transferred
		plugin XAPI ->> TCP server: send data 
		TCP server ->> XO: node stream
		XO ->> Backup reporitory: write backup
	end
	XO ->> Backup reporitory:: validate vhd 
```
 

#### target workflow  (full)
also pass the `baseRef` to handle delta vhd exports

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
