### PR TITLE
fix(xapi/host_smartReboot): resume VMs after enabling host

### DIFF
--- a/@xen-orchestra/xapi/host.mjs
+++ b/@xen-orchestra/xapi/host.mjs
@@ -32,9 +32,13 @@ class Host {
    * @param {string} ref - Opaque reference of the host
    */
   async smartReboot($defer, ref) {
+    const suspendedVms = []
     if (await this.getField('host', ref, 'enabled')) {
       await this.callAsync('host.disable', ref)
-      $defer(() => this.callAsync('host.enable', ref))
+      $defer(async () => {
+        await this.callAsync('host.enable', ref)
+        return asyncEach(suspendedVms, vmRef => this.callAsync('VM.resume', vmRef, false, false))
+      })
     }
 
     let currentVmRef
@@ -51,7 +55,7 @@ class Host {
 
         try {
           await this.callAsync('VM.suspend', vmRef)
-          $defer(() => this.callAsync('VM.resume', vmRef, false, false))
+          suspendedVms.push(vmRef)
         } catch (error) {
           const { code } = error
 

--- a/@xen-orchestra/xapi/host.mjs
+++ b/@xen-orchestra/xapi/host.mjs
@@ -37,6 +37,7 @@ class Host {
       await this.callAsync('host.disable', ref)
       $defer(async () => {
         await this.callAsync('host.enable', ref)
+        // Resuming VMs should occur after host enabling to avoid triggering a 'NO_HOSTS_AVAILABLE' error
         return asyncEach(suspendedVms, vmRef => this.callAsync('VM.resume', vmRef, false, false))
       })
     }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
 - [File Restore] Increase timeout from one to ten minutes when restoring through XO Proxy
 - [Home/VMs] Filtering with a UUID will no longer show other VMs on the same host/pool
 - [Jobs] Fixes `invalid parameters` when editing [Forum#64668](https://xcp-ng.org/forum/post/64668)
+- [Smart reboot] Fix cases where VMs remained in a suspended state (PR [#6980](https://github.com/vatesfr/xen-orchestra/pull/6980))
 
 ### Packages to release
 
@@ -38,6 +39,7 @@
 
 - @xen-orchestra/backups patch
 - @xen-orchestra/mixins minor
+- @xen-orchestra/xapi patch
 - xen-api patch
 - xo-server minor
 - xo-server-auth-ldap patch


### PR DESCRIPTION
### Description

`VM.resume` was called before `host.enable`, leaving the VMs in a suspended state in case `smartReboot` throws an error.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
