### PR TITLE
feat(xo-web,xo-server/XOSTOR): display existing XOSTORs

### DIFF
--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -509,7 +509,8 @@ const TRANSFORMS = {
       // TODO: Should it replace usage?
       physical_usage: +obj.physical_utilisation,
 
-      allocationStrategy: ALLOCATION_BY_TYPE[srType],
+      allocationStrategy:
+        srType === 'linstor' ? obj.$PBDs[0]?.device_config.provisioning ?? 'unknown' : ALLOCATION_BY_TYPE[srType],
       current_operations: obj.current_operations,
       inMaintenanceMode: obj.other_config['xo:maintenanceState'] !== undefined,
       name_description: obj.name_description,

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2461,6 +2461,7 @@ const messages = {
   hostsNotSameNumberOfDisks: 'Hosts do not have the same number of disks',
   networks: 'Networks',
   notXcpPool: 'Not an XCP-ng pool',
+  noXostorFound: 'No XOSTOR found',
   numberOfHosts: 'Number of hosts',
   objectDoesNotMeetXostorRequirements: '{object} does not meet XOSTOR requirements. Refer to the documentation.',
   onlyShowXostorRequirements: 'Only show {type} that meet XOSTOR requirements',

--- a/packages/xo-web/src/icons.scss
+++ b/packages/xo-web/src/icons.scss
@@ -1019,6 +1019,10 @@
     @extend .fa;
     @extend .fa-database;
   }
+  &-menu-xostor {
+    @extend .fa;
+    @extend .fa-database;
+  }
   &-menu-hub {
     @extend .fa;
     @extend .fa-cubes;

--- a/packages/xo-web/src/xo-app/xostor/index.js
+++ b/packages/xo-web/src/xo-app/xostor/index.js
@@ -7,6 +7,8 @@ import { injectState, provideState } from 'reaclette'
 import { Container, Col, Row } from 'grid'
 
 import NewXostorForm from './new-xostor-form'
+import XostorList from './xostor-list'
+
 import Page from '../page'
 
 const HEADER = (
@@ -29,6 +31,7 @@ const Xostor = decorate([
   injectState,
   ({ effects, state }) => (
     <Page header={HEADER}>
+      <XostorList />
       <Row className='mb-1'>
         <Col>
           <ActionButton

--- a/packages/xo-web/src/xo-app/xostor/xostor-list.js
+++ b/packages/xo-web/src/xo-app/xostor/xostor-list.js
@@ -1,0 +1,97 @@
+import _ from 'intl'
+import decorate from 'apply-decorators'
+import React from 'react'
+import { connectStore, formatSize } from 'utils'
+import { createGetObjectsOfType, createSelector } from 'selectors'
+import { find, map, isEmpty } from 'lodash'
+import { injectState, provideState } from 'reaclette'
+import { Pool } from 'render-xo-item'
+import SortedTable from 'sorted-table'
+import Tooltip from 'tooltip'
+
+import { deleteSr } from 'xo'
+
+const COLUMNS = [
+  {
+    name: _('srPool'),
+    itemRenderer: sr => <Pool id={sr.pool.id} link />,
+    sortCriteria: sr => sr.pool.name_label,
+  },
+  {
+    name: _('name'),
+    itemRenderer: sr => sr.name_label,
+    sortCriteria: sr => sr.name_label,
+  },
+  {
+    name: 'Provisioning',
+    itemRenderer: sr => sr.allocationStrategy,
+    sortCriteria: sr => sr.allocationStrategy,
+  },
+  {
+    name: 'Size',
+    itemRenderer: sr => formatSize(sr.size),
+    sortCriteria: sr => sr.size,
+  },
+  {
+    name: 'Used space',
+    itemRenderer: sr => {
+      const used = (sr.physical_usage * 100) / sr.size
+      return (
+        <Tooltip
+          content={_('spaceLeftTooltip', {
+            used: String(Math.round(used)),
+            free: formatSize(sr.size - sr.physical_usage),
+          })}
+        >
+          <progress className='progress' max='100' value={used} />
+        </Tooltip>
+      )
+    },
+    sortCriteria: sr => (sr.physical_usage * 100) / sr.size,
+  },
+]
+
+const INDIVIDUAL_ACTIONS = [
+  {
+    handler: deleteSr,
+    icon: 'delete',
+    label: 'delete',
+    level: 'danger'
+  }
+]
+
+
+const XostorList = decorate([
+  connectStore(() => ({
+      xostorSrs: createSelector(
+        createGetObjectsOfType('SR').filter([sr => sr.SR_type === 'linstor']),
+        createGetObjectsOfType('pool'),
+        (srs, pools) =>
+          map(srs, sr => ({
+            ...sr,
+            pool: find(pools, { id: sr.$pool }),
+          })),
+      ),
+    })
+  ),
+  provideState({
+    initialState: () => ({ showNewXostorForm: false }),
+  }),
+  injectState,
+  ({ effects, state, xostorSrs }) =>  (
+      <div>
+        {isEmpty(xostorSrs) ? (
+          _('noXostorFound')
+        ) : (
+          <SortedTable
+            collection={xostorSrs}
+            columns={COLUMNS}
+            individualActions={INDIVIDUAL_ACTIONS}
+            stateUrlParam='s'
+          />
+        )}
+      </div>
+    )
+])
+
+export default XostorList

--- a/packages/xo-web/src/xo-app/xostor/xostor-list.js
+++ b/packages/xo-web/src/xo-app/xostor/xostor-list.js
@@ -1,15 +1,14 @@
 import _ from 'intl'
 import decorate from 'apply-decorators'
 import React from 'react'
+import SortedTable from 'sorted-table'
+import Tooltip from 'tooltip'
 import { connectStore, formatSize } from 'utils'
 import { createGetObjectsOfType, createSelector } from 'selectors'
+import { deleteSr } from 'xo'
 import { find, map, isEmpty } from 'lodash'
 import { injectState, provideState } from 'reaclette'
 import { Pool } from 'render-xo-item'
-import SortedTable from 'sorted-table'
-import Tooltip from 'tooltip'
-
-import { deleteSr } from 'xo'
 
 const COLUMNS = [
   {
@@ -56,42 +55,40 @@ const INDIVIDUAL_ACTIONS = [
     handler: deleteSr,
     icon: 'delete',
     label: 'delete',
-    level: 'danger'
-  }
+    level: 'danger',
+  },
 ]
-
 
 const XostorList = decorate([
   connectStore(() => ({
-      xostorSrs: createSelector(
-        createGetObjectsOfType('SR').filter([sr => sr.SR_type === 'linstor']),
-        createGetObjectsOfType('pool'),
-        (srs, pools) =>
-          map(srs, sr => ({
-            ...sr,
-            pool: find(pools, { id: sr.$pool }),
-          })),
-      ),
-    })
-  ),
+    xostorSrs: createSelector(
+      createGetObjectsOfType('SR').filter([sr => sr.SR_type === 'linstor']),
+      createGetObjectsOfType('pool'),
+      (srs, pools) =>
+        map(srs, sr => ({
+          ...sr,
+          pool: find(pools, { id: sr.$pool }),
+        }))
+    ),
+  })),
   provideState({
     initialState: () => ({ showNewXostorForm: false }),
   }),
   injectState,
-  ({ effects, state, xostorSrs }) =>  (
-      <div>
-        {isEmpty(xostorSrs) ? (
-          _('noXostorFound')
-        ) : (
-          <SortedTable
-            collection={xostorSrs}
-            columns={COLUMNS}
-            individualActions={INDIVIDUAL_ACTIONS}
-            stateUrlParam='s'
-          />
-        )}
-      </div>
-    )
+  ({ effects, state, xostorSrs }) => (
+    <div>
+      {isEmpty(xostorSrs) ? (
+        _('noXostorFound')
+      ) : (
+        <SortedTable
+          collection={xostorSrs}
+          columns={COLUMNS}
+          individualActions={INDIVIDUAL_ACTIONS}
+          stateUrlParam='s'
+        />
+      )}
+    </div>
+  ),
 ])
 
 export default XostorList

--- a/packages/xo-web/src/xo-app/xostor/xostor-list.js
+++ b/packages/xo-web/src/xo-app/xostor/xostor-list.js
@@ -6,7 +6,7 @@ import Tooltip from 'tooltip'
 import { connectStore, formatSize } from 'utils'
 import { createGetObjectsOfType, createSelector } from 'selectors'
 import { deleteSr } from 'xo'
-import { find, map } from 'lodash'
+import { map } from 'lodash'
 import { Pool } from 'render-xo-item'
 
 const COLUMNS = [
@@ -62,12 +62,13 @@ const XostorList = decorate([
   connectStore(() => ({
     xostorSrs: createSelector(
       createGetObjectsOfType('SR').filter([sr => sr.SR_type === 'linstor']),
-      createGetObjectsOfType('pool'),
-      (srs, pools) =>
-        map(srs, sr => ({
+      createGetObjectsOfType('pool').groupBy('id'),
+      (srs, poolByIds) => {
+        return map(srs, sr => ({
           ...sr,
-          pool: find(pools, { id: sr.$pool }),
+          pool: poolByIds[sr.$pool][0],
         }))
+      }
     ),
   })),
   ({ xostorSrs }) => (

--- a/packages/xo-web/src/xo-app/xostor/xostor-list.js
+++ b/packages/xo-web/src/xo-app/xostor/xostor-list.js
@@ -6,33 +6,32 @@ import Tooltip from 'tooltip'
 import { connectStore, formatSize } from 'utils'
 import { createGetObjectsOfType, createSelector } from 'selectors'
 import { deleteSr } from 'xo'
-import { find, map, isEmpty } from 'lodash'
-import { injectState, provideState } from 'reaclette'
+import { find, map } from 'lodash'
 import { Pool } from 'render-xo-item'
 
 const COLUMNS = [
   {
     name: _('srPool'),
     itemRenderer: sr => <Pool id={sr.pool.id} link />,
-    sortCriteria: sr => sr.pool.name_label,
+    sortCriteria: 'pool.name_label',
   },
   {
     name: _('name'),
     itemRenderer: sr => sr.name_label,
-    sortCriteria: sr => sr.name_label,
+    sortCriteria: 'name_label',
   },
   {
-    name: 'Provisioning',
+    name: _('provisioning'),
     itemRenderer: sr => sr.allocationStrategy,
-    sortCriteria: sr => sr.allocationStrategy,
+    sortCriteria: 'allocationStrategy',
   },
   {
-    name: 'Size',
+    name: _('size'),
     itemRenderer: sr => formatSize(sr.size),
-    sortCriteria: sr => sr.size,
+    sortCriteria: 'size',
   },
   {
-    name: 'Used space',
+    name: _('usedSpace'),
     itemRenderer: sr => {
       const used = (sr.physical_usage * 100) / sr.size
       return (
@@ -54,7 +53,7 @@ const INDIVIDUAL_ACTIONS = [
   {
     handler: deleteSr,
     icon: 'delete',
-    label: 'delete',
+    label: _('delete'),
     level: 'danger',
   },
 ]
@@ -71,23 +70,8 @@ const XostorList = decorate([
         }))
     ),
   })),
-  provideState({
-    initialState: () => ({ showNewXostorForm: false }),
-  }),
-  injectState,
-  ({ effects, state, xostorSrs }) => (
-    <div>
-      {isEmpty(xostorSrs) ? (
-        _('noXostorFound')
-      ) : (
-        <SortedTable
-          collection={xostorSrs}
-          columns={COLUMNS}
-          individualActions={INDIVIDUAL_ACTIONS}
-          stateUrlParam='s'
-        />
-      )}
-    </div>
+  ({ xostorSrs }) => (
+    <SortedTable collection={xostorSrs} columns={COLUMNS} individualActions={INDIVIDUAL_ACTIONS} stateUrlParam='s' />
   ),
 ])
 


### PR DESCRIPTION
### Screenshot

![Capture d’écran de 2023-08-17 10-15-52](https://github.com/vatesfr/xen-orchestra/assets/70369997/ec220ef0-c2d7-401e-acda-b913a73200cb)

### Description

TODO: Add Network column when implemented

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
