### PR TITLE
fix(xo-server/normalizeVmNetworks): always assume multiple space-delimited IPs

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,7 +23,7 @@
 - [Jobs] Fixes `invalid parameters` when editing [Forum#64668](https://xcp-ng.org/forum/post/64668)
 - [Smart reboot] Fix cases where VMs remained in a suspended state (PR [#6980](https://github.com/vatesfr/xen-orchestra/pull/6980))
 - [Backup/Health dashboard] Don't show mirrored VMs as detached backups (PR [#7000](https://github.com/vatesfr/xen-orchestra/pull/7000))
-- [Netbox] Fix `the address has neither IPv6 nor IPv4 format` error [Forum#7625](https://xcp-ng.org/forum/topic/7625)
+- [Netbox] Fix `the address has neither IPv6 nor IPv4 format` error [Forum#7625](https://xcp-ng.org/forum/topic/7625) (PR [#6990](https://github.com/vatesfr/xen-orchestra/pull/6990))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@
 - [Jobs] Fixes `invalid parameters` when editing [Forum#64668](https://xcp-ng.org/forum/post/64668)
 - [Smart reboot] Fix cases where VMs remained in a suspended state (PR [#6980](https://github.com/vatesfr/xen-orchestra/pull/6980))
 - [Backup/Health dashboard] Don't show mirrored VMs as detached backups (PR [#7000](https://github.com/vatesfr/xen-orchestra/pull/7000))
+- [Netbox] Fix `the address has neither IPv6 nor IPv4 format` error [Forum#7625](https://xcp-ng.org/forum/topic/7625)
 
 ### Packages to release
 

--- a/packages/xo-server/src/_normalizeVmNetworks.spec.mjs
+++ b/packages/xo-server/src/_normalizeVmNetworks.spec.mjs
@@ -19,10 +19,10 @@ tap.test('normalizeVmNetworks', async t => {
       '0/ipv4/1': '127.0.0.5',
 
       // any key are allowed
-      '0/ipv4/foo bar': '127.0.0.3',
+      '0/ipv4/foo bar': '127.0.0.3 127.0.0.6',
 
       // ipv6 protocol is supported as well
-      '0/ipv6/0': '::1',
+      '0/ipv6/0': '::1 ::2',
 
       // empty addresses are ignored
       '0/ipv4/3': '   ',
@@ -36,7 +36,9 @@ tap.test('normalizeVmNetworks', async t => {
       '0/ipv4/2': '127.0.0.5',
       '0/ipv4/3': '127.0.0.4',
       '0/ipv4/4': '127.0.0.3',
+      '0/ipv4/5': '127.0.0.6',
       '0/ipv6/0': '::1',
+      '0/ipv6/1': '::2',
       '1/ipv4/0': '127.0.0.1',
     }
   )


### PR DESCRIPTION
See https://xcp-ng.org/forum/topic/7625

### Description

The previous code assumed that only legacy `x/ip` fields could contain multiple space-delimited IPs but it turns out that it can also happen in `x/ipvx/x` fields (see link).
When it happened, the IPs weren't flattened and it could break the Netbox synchronization, which assumes that the IPs are properly flattened.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
