### PR TITLE
feat(backups): expose NBD settings per backup

### DIFF
--- a/@xen-orchestra/backups/_incrementalVm.mjs
+++ b/@xen-orchestra/backups/_incrementalVm.mjs
@@ -41,6 +41,7 @@ export async function exportIncrementalVm(
     fullVdisRequired = new Set(),
 
     disableBaseTags = false,
+    preferNbd,
   } = {}
 ) {
   // refs of VM's VDIs → base's VDIs.
@@ -88,6 +89,7 @@ export async function exportIncrementalVm(
       baseRef: baseVdi?.$ref,
       cancelToken,
       format: 'vhd',
+      preferNbd,
     })
   })
 

--- a/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
@@ -41,6 +41,7 @@ export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends Abstr
 
     const deltaExport = await exportIncrementalVm(exportedVm, baseVm, {
       fullVdisRequired,
+      preferNbd: this._settings.preferNbd,
     })
     // since NBD is network based, if one disk use nbd , all the disk use them
     // except the suspended VDI

--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -83,7 +83,7 @@ class Vdi {
     }
   }
 
-  async exportContent(ref, { baseRef, cancelToken = CancelToken.none, format }) {
+  async exportContent(ref, { baseRef, cancelToken = CancelToken.none, format, preferNbd = this._preferNbd }) {
     const query = {
       format,
       vdi: ref,
@@ -96,7 +96,7 @@ class Vdi {
     }
     let nbdClient, stream
     try {
-      if (this._preferNbd) {
+      if (preferNbd === true) {
         nbdClient = await this._getNbdClient(ref)
       }
       // the raw nbd export does not need to peek ath the vhd source

--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -96,7 +96,7 @@ class Vdi {
     }
     let nbdClient, stream
     try {
-      if (preferNbd === true) {
+      if (preferNbd) {
         nbdClient = await this._getNbdClient(ref)
       }
       // the raw nbd export does not need to peek ath the vhd source

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Backups] Ability to set the NBD mode per backup job in the UI instead of globally in the config file (PR [#6995](https://github.com/vatesfr/xen-orchestra/pull/6995))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -29,6 +31,9 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups minor
+- @xen-orchestra/xapi minor
 - xo-server patch
+- xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -565,6 +565,8 @@ const messages = {
     'Delete old backups before backing up the VMs. If the new backup fails, you will lose your old backups.',
   customTag: 'Custom tag',
   editJobNotFound: "The job you're trying to edit wasn't found",
+  preferNbd: 'Use NBD protocol to transfer disk if available',
+  preferNbdInformation: 'A network accessible by XO or the proxy must have NBD enabled',
 
   // ------ New Remote -----
   newRemote: 'New file system remote',

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -21,7 +21,7 @@ import { generateId, linkState } from 'reaclette-utils'
 import { injectIntl } from 'react-intl'
 import { injectState, provideState } from 'reaclette'
 import { Map } from 'immutable'
-import { Number } from 'form'
+import { Number, Toggle } from 'form'
 import { renderXoItemFromId, Remote } from 'render-xo-item'
 import { SelectRemote, SelectSr, SelectVm } from 'select-objects'
 import {
@@ -148,6 +148,7 @@ const normalizeSettings = ({ copyMode, exportMode, offlineBackupActive, settings
           copyRetention: copyMode ? setting.copyRetention : undefined,
           exportRetention: exportMode ? setting.exportRetention : undefined,
           snapshotRetention: snapshotMode && !offlineBackupActive ? setting.snapshotRetention : undefined,
+          preferNbd: undefined,
         }
       : setting
   )
@@ -187,6 +188,7 @@ const getInitialState = ({ preSelectedVmIds, setHomeVmIdsSelection, suggestedExc
     deltaMode: false,
     drMode: false,
     name: '',
+    preferNbd: false,
     remotes: [],
     schedules: {},
     settings: undefined,
@@ -213,12 +215,11 @@ export const DeleteOldBackupsFirst = ({ handler, handlerParam, value }) => (
 )
 
 const New = decorate([
-  New => props =>
-    (
-      <Upgrade place='newBackup' required={2}>
-        <New {...props} />
-      </Upgrade>
-    ),
+  New => props => (
+    <Upgrade place='newBackup' required={2}>
+      <New {...props} />
+    </Upgrade>
+  ),
   connectStore(() => ({
     hostsById: createGetObjectsOfType('host'),
     poolsById: createGetObjectsOfType('pool'),
@@ -621,6 +622,13 @@ const New = decorate([
             offlineBackup,
           })
         },
+      setPreferNbd:
+        ({ setGlobalSettings }, preferNbd) =>
+        () => {
+          setGlobalSettings({
+            preferNbd,
+          })
+        },
     },
     computed: {
       compressionId: generateId,
@@ -628,6 +636,7 @@ const New = decorate([
       inputConcurrencyId: generateId,
       inputFullIntervalId: generateId,
       inputMaxExportRate: generateId,
+      inputPreferNbd: generateId,
       inputTimeoutId: generateId,
 
       // In order to keep the user preference, the offline backup is kept in the DB
@@ -741,6 +750,7 @@ const New = decorate([
       maxExportRate,
       offlineBackup,
       offlineSnapshot,
+      preferNbd,
       reportRecipients,
       reportWhen = 'failure',
       timeout,
@@ -1010,6 +1020,15 @@ const New = decorate([
                             id={state.inputFullIntervalId}
                             onChange={effects.setFullInterval}
                             value={fullInterval}
+                          />
+                          <label htmlFor={state.inputPreferNbd}>
+                            <strong>Use NBD if available</strong>
+                          </label>
+                          <Toggle
+                            id={state.inputPreferNbd}
+                            name='preferNbd'
+                            value={preferNbd}
+                            onChange={effects.setPreferNbd}
                           />
                         </FormGroup>
                       )}

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -1022,9 +1022,13 @@ const New = decorate([
                             value={fullInterval}
                           />
                           <label htmlFor={state.inputPreferNbd}>
-                            <strong>Use NBD if available</strong>
+                            <strong>{_('preferNbd')}</strong>{' '}
+                            <Tooltip content={_('preferNbdInformation')}>
+                              <Icon icon='info' />
+                            </Tooltip>
                           </label>
                           <Toggle
+                            className='pull-right'
                             id={state.inputPreferNbd}
                             name='preferNbd'
                             value={preferNbd}

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -1021,6 +1021,10 @@ const New = decorate([
                             onChange={effects.setFullInterval}
                             value={fullInterval}
                           />
+                        </FormGroup>
+                      )}
+                      {state.isDelta && (
+                        <FormGroup>
                           <label htmlFor={state.inputPreferNbd}>
                             <strong>{_('preferNbd')}</strong>{' '}
                             <Tooltip content={_('preferNbdInformation')}>


### PR DESCRIPTION
### Description

NBD can only be enabler network wide, and only by modifying the config file. 
This PR add a setting in  the advanced tab of incremental backup to allow the users to set it from the UI


![image](https://github.com/vatesfr/xen-orchestra/assets/50174/c7d7955f-44fc-46bb-a4a2-f5f5126ed3e2)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
