### PR TITLE
fix(XenApi): cannot read properties of undefined (reading 'statusCode')

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@
 - [Home/VMs] Filtering with a UUID will no longer show other VMs on the same host/pool
 - [Jobs] Fixes `invalid parameters` when editing [Forum#64668](https://xcp-ng.org/forum/post/64668)
 - [Smart reboot] Fix cases where VMs remained in a suspended state (PR [#6980](https://github.com/vatesfr/xen-orchestra/pull/6980))
+- [XenApi/stats] Fix `Cannot read properties of undefined (reading 'statusCode')` (PR [#7004](https://github.com/vatesfr/xen-orchestra/pull/7004))
 
 ### Packages to release
 

--- a/packages/xen-api/src/index.js
+++ b/packages/xen-api/src/index.js
@@ -419,7 +419,7 @@ export class Xapi extends EventEmitter {
             signal: $cancelToken,
           }),
         {
-          when: error => error.response !== undefined && error.response.statusCode === 302,
+          when: error => error.response !== undefined && error.response?.statusCode === 302,
           onRetry: async error => {
             const response = error.response
             if (response === undefined) {


### PR DESCRIPTION
### Description

retrying fail when error don't have any response (if there is TLS problem, network proble), it takes longer to investigate the real casue 

from multiple support, like 17007

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
