### PR TITLE
feat(netbox): don't delete VMs and interfaces that don't have a UUID

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Netbox] Don't delete VMs that have been created manually in XO-synced cluster (PR [#7008](https://github.com/vatesfr/xen-orchestra/pull/7008))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -26,5 +28,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- xo-server-netbox minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,7 +7,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [Netbox] Don't delete VMs that have been created manually in XO-synced cluster (PR [#7008](https://github.com/vatesfr/xen-orchestra/pull/7008))
+- [Netbox] Don't delete VMs that have been created manually in XO-synced cluster [Forum#7639](https://xcp-ng.org/forum/topic/7639) (PR [#7008](https://github.com/vatesfr/xen-orchestra/pull/7008))
 
 ### Bug fixes
 

--- a/packages/xo-server-netbox/src/index.js
+++ b/packages/xo-server-netbox/src/index.js
@@ -261,11 +261,6 @@ class Netbox {
     )
     const nbClusters = pick(allNbClusters, xoPools)
 
-    if (allNbClusters[undefined] !== undefined) {
-      // Show a warning but never delete clusters automatically
-      log.warn('Found some clusters with missing UUID custom field', allNbClusters[undefined])
-    }
-
     const clustersToCreate = []
     const clustersToUpdate = []
     for (const xoPoolId of xoPools) {
@@ -418,9 +413,12 @@ class Netbox {
     const allNbVms = keyBy(allNbVmsList, 'custom_fields.uuid')
     const nbVms = keyBy(nbVmsList, 'custom_fields.uuid')
 
-    const usedNames = [] // Used for name deduplication
+    // Used for name deduplication
+    // Start by storing the names of the VMs that have been created manually in
+    // Netbox as we'll need to avoid name conflicts with those too
+    const usedNames = nbVmsList.filter(nbVm => nbVm.custom_fields.uuid == null).map(nbVm => nbVm.name)
     // Build the 3 collections of VMs and perform all the API calls at the end
-    const vmsToDelete = nbVmsList.filter(nbVm => nbVm.custom_fields.uuid == null).map(nbVm => ({ id: nbVm.id }))
+    const vmsToDelete = []
     const vmsToUpdate = []
     const vmsToCreate = []
     for (const xoPoolId of xoPools) {
@@ -532,7 +530,7 @@ class Netbox {
     // { ID → Interface }
     const nbIfs = keyBy(nbIfsList, 'custom_fields.uuid')
 
-    const ifsToDelete = nbIfsList.filter(nbIf => nbIf.custom_fields.uuid == null).map(nbIf => ({ id: nbIf.id }))
+    const ifsToDelete = []
     const ifsToUpdate = []
     const ifsToCreate = []
     for (const nbVm of Object.values(nbVms)) {


### PR DESCRIPTION
See https://xcp-ng.org/forum/topic/7639

### Description

In an effort of not deleting or overwriting useful data that has been added manually by the user, this reverts the feature of deleting VMs and interfaces that are not bound to an XO object via their custom field UUID. Such objects:
- shouldn't exist in normal use cases anyway
- aren't an issue for the Netbox sync
- are easy to clean manually

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
