### PR TITLE
fix(signin): try to preserve current page across reauthentication

### DIFF
--- a/packages/xo-server/signin.pug
+++ b/packages/xo-server/signin.pug
@@ -7,6 +7,14 @@ html
     title Xen Orchestra
     meta(name = 'author' content = 'Vates SAS')
     link(rel = 'stylesheet' href = 'index.css')
+    script.
+      function add_hash(id, attr, uri) {
+        var elt = document.getElementById(id);
+        if (elt) {
+          elt.setAttribute(attr, uri + document.location.hash);
+        }
+        return true;
+      }
   body(style = 'display: flex; height: 100vh;')
     div(style = 'margin: auto; width: 20em;')
       div.mb-2(style = 'display: flex;')
@@ -35,8 +43,17 @@ html
       else
         div.mb-2
         each label, id in strategies
-          div: a(href = 'signin/' + id).btn.btn-block.btn-primary.mb-1 Sign in with #{label}
-        form(action = 'signin/local' method = 'post')
+          div: a(
+            id = 'signin_btn_' + id
+            href = 'signin/' + id
+            onclick = 'return add_hash("signin_btn_' + id + '", "href", "signin/' + id + '")'
+          ).btn.btn-block.btn-primary.mb-1 Sign in with #{label}
+        form(
+          id = 'signin_frm_local'
+          action = 'signin/local'
+          method = 'post'
+          onsubmit = 'return add_hash("signin_frm_local", "action", "signin/local")'
+        )
           fieldset
             .input-group.mb-1
               span.input-group-addon

--- a/packages/xo-server/signin.pug
+++ b/packages/xo-server/signin.pug
@@ -7,14 +7,6 @@ html
     title Xen Orchestra
     meta(name = 'author' content = 'Vates SAS')
     link(rel = 'stylesheet' href = 'index.css')
-    script.
-      function add_hash(id, attr, uri) {
-        var elt = document.getElementById(id);
-        if (elt) {
-          elt.setAttribute(attr, uri + document.location.hash);
-        }
-        return true;
-      }
   body(style = 'display: flex; height: 100vh;')
     div(style = 'margin: auto; width: 20em;')
       div.mb-2(style = 'display: flex;')
@@ -43,17 +35,8 @@ html
       else
         div.mb-2
         each label, id in strategies
-          div: a(
-            id = 'signin_btn_' + id
-            href = 'signin/' + id
-            onclick = 'return add_hash("signin_btn_' + id + '", "href", "signin/' + id + '")'
-          ).btn.btn-block.btn-primary.mb-1 Sign in with #{label}
-        form(
-          id = 'signin_frm_local'
-          action = 'signin/local'
-          method = 'post'
-          onsubmit = 'return add_hash("signin_frm_local", "action", "signin/local")'
-        )
+          div: a(href = 'signin/' + id).btn.btn-block.btn-primary.mb-1 Sign in with #{label}
+        form(action = 'signin/local' method = 'post')
           fieldset
             .input-group.mb-1
               span.input-group-addon
@@ -86,3 +69,14 @@ html
               button.btn.btn-block.btn-info
                 i.fa.fa-sign-in
                 |  Sign in
+    script.
+      (function () {
+        var d = document
+        var h = d.location.hash
+        d.querySelectorAll('a').forEach(a => {
+            a.href += h
+        })
+        d.querySelectorAll('form').forEach(form => {
+            form.action += h
+        })
+      })()


### PR DESCRIPTION
If an authentication session expires or is lost for whatever reason, XO redirects to `/signin`.  This redirect generally preserves the URL fragment (hash) which contains the page selected prior to reauthentication, i.e. if the user had been in settings/servers just beforehand, they end up at `/signin#settings/servers`.  However, currently when they log back in they end up on the home page; the page they were on is forgotten.

This commit tries to send the user back to the page they were viewing before reauthentication, by preserving the URL fragment in the login form action / by appending it to the links to authentication plugins.  (Not all authentication plugins will necessarily preserve it internally, but we can optimistically try it and see; at worst the old behaviour will remain.)