### PR TITLE
Fix token deletion

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,4 +27,6 @@
 
 <!--packages-start-->
 
+- xo-server minor
+
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [User] _Forget all connection tokens_ button should not delete other users' tokens, even when current user is an administrator (PR [#7014](https://github.com/vatesfr/xen-orchestra/pull/7014))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -28,5 +30,6 @@
 <!--packages-start-->
 
 - xo-server minor
+- xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-server/src/api/token.mjs
+++ b/packages/xo-server/src/api/token.mjs
@@ -31,9 +31,33 @@ async function delete_({ pattern, tokens }) {
 
 export { delete_ as delete }
 
-delete_.description = 'delete an existing authentication token'
+delete_.description = 'delete matching authentication tokens for all users'
 
 delete_.params = {
+  tokens: { type: 'array', optional: true, items: { type: 'string' } },
+  pattern: { type: 'object', optional: true },
+}
+
+delete_.permission = 'admin'
+
+// -------------------------------------------------------------------
+
+export async function deleteOwn({ pattern, tokens }) {
+  await this.deleteAuthenticationTokens({
+    filter: {
+      __and: [
+        {
+          user_id: this.apiContext.user.id,
+        },
+        pattern ?? { id: { __or: tokens } },
+      ],
+    },
+  })
+}
+
+deleteOwn.description = 'delete matching authentication tokens for the current user'
+
+deleteOwn.params = {
   tokens: { type: 'array', optional: true, items: { type: 'string' } },
   pattern: { type: 'object', optional: true },
 }

--- a/packages/xo-server/src/xo-mixins/authentication.mjs
+++ b/packages/xo-server/src/xo-mixins/authentication.mjs
@@ -210,14 +210,8 @@ export default class {
   }
 
   async deleteAuthenticationTokens({ filter }) {
-    let predicate
-    const { apiContext } = this._app
-    if (apiContext !== undefined && apiContext.permission !== 'admin') {
-      predicate = { user_id: apiContext.user.id }
-    }
-
     const db = this._tokens
-    return db.remove((await db.get(predicate)).filter(createPredicate(filter)).map(({ id }) => id))
+    await db.remove((await db.get()).filter(createPredicate(filter)).map(({ id }) => id))
   }
 
   async _getAuthenticationToken(id, properties) {

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -2973,7 +2973,7 @@ export const removeUserAuthProvider = ({ userId, authProviderId }) => {
 }
 
 const _signOutFromEverywhereElse = () =>
-  _call('token.delete', {
+  _call('token.deleteOwn', {
     pattern: {
       id: {
         __not: cookies.get('token'),
@@ -3111,7 +3111,7 @@ export const deleteAuthToken = async ({ id }) => {
     icon: 'user',
     title: _('deleteAuthTokenConfirm'),
   })
-  return _call('token.delete', { tokens: [id] })::tap(subscribeUserAuthTokens.forceRefresh)
+  return _call('token.deleteOwn', { tokens: [id] })::tap(subscribeUserAuthTokens.forceRefresh)
 }
 
 export const deleteAuthTokens = async tokens => {
@@ -3122,7 +3122,7 @@ export const deleteAuthTokens = async tokens => {
     icon: 'user',
     title: _('deleteAuthTokensConfirm', { nTokens: tokens.length }),
   })
-  return _call('token.delete', { tokens: tokens.map(token => token.id) })::tap(subscribeUserAuthTokens.forceRefresh)
+  return _call('token.deleteOwn', { tokens: tokens.map(token => token.id) })::tap(subscribeUserAuthTokens.forceRefresh)
 }
 
 export const editAuthToken = ({ description, id }) =>


### PR DESCRIPTION
**DO NOT SQUASH**

### Description

_Forget all connection tokens_ button should not delete other users' tokens, even when current user is and administrator

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
