### PR TITLE
feat(lite/xapi): update XenApi types and enums

### DIFF
--- a/@xen-orchestra/lite/src/components/PowerStateIcon.vue
+++ b/@xen-orchestra/lite/src/components/PowerStateIcon.vue
@@ -4,7 +4,7 @@
 
 <script lang="ts" setup>
 import UiIcon from "@/components/ui/icon/UiIcon.vue";
-import { POWER_STATE } from "@/libs/xen-api/xen-api.utils";
+import { VM_POWER_STATE } from "@/libs/xen-api/xen-api.enums";
 import {
   faMoon,
   faPause,
@@ -15,14 +15,14 @@ import {
 import { computed } from "vue";
 
 const props = defineProps<{
-  state: POWER_STATE;
+  state: VM_POWER_STATE;
 }>();
 
 const icons = {
-  [POWER_STATE.RUNNING]: faPlay,
-  [POWER_STATE.PAUSED]: faPause,
-  [POWER_STATE.SUSPENDED]: faMoon,
-  [POWER_STATE.HALTED]: faStop,
+  [VM_POWER_STATE.RUNNING]: faPlay,
+  [VM_POWER_STATE.PAUSED]: faPause,
+  [VM_POWER_STATE.SUSPENDED]: faMoon,
+  [VM_POWER_STATE.HALTED]: faStop,
 };
 
 const icon = computed(() => icons[props.state] ?? faQuestion);

--- a/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardCpuProvisioning.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardCpuProvisioning.vue
@@ -41,11 +41,11 @@ import { useHostCollection } from "@/stores/xen-api/host.store";
 import { useVmCollection } from "@/stores/xen-api/vm.store";
 import { useVmMetricsCollection } from "@/stores/xen-api/vm-metrics.store";
 import { percent } from "@/libs/utils";
-import { POWER_STATE } from "@/libs/xen-api/xen-api.utils";
+import { VM_POWER_STATE } from "@/libs/xen-api/xen-api.enums";
 import { logicAnd } from "@vueuse/math";
 import { computed } from "vue";
 
-const ACTIVE_STATES = new Set([POWER_STATE.RUNNING, POWER_STATE.PAUSED]);
+const ACTIVE_STATES = new Set([VM_POWER_STATE.RUNNING, VM_POWER_STATE.PAUSED]);
 
 const {
   hasError: hostStoreHasError,

--- a/@xen-orchestra/lite/src/components/vm/VmActionItems/VmActionCopyItem.vue
+++ b/@xen-orchestra/lite/src/components/vm/VmActionItems/VmActionCopyItem.vue
@@ -14,7 +14,7 @@
 import MenuItem from "@/components/menu/MenuItem.vue";
 import { useVmCollection } from "@/stores/xen-api/vm.store";
 import { vTooltip } from "@/directives/tooltip.directive";
-import { POWER_STATE, VM_OPERATION } from "@/libs/xen-api/xen-api.utils";
+import { VM_POWER_STATE, VM_OPERATION } from "@/libs/xen-api/xen-api.enums";
 import type { XenApiVm } from "@/libs/xen-api/xen-api.types";
 import { useXenApiStore } from "@/stores/xen-api.store";
 import { faCopy } from "@fortawesome/free-solid-svg-icons";
@@ -36,7 +36,7 @@ const areAllSelectedVmsHalted = computed(
   () =>
     selectedVms.value.length > 0 &&
     selectedVms.value.every(
-      (selectedVm) => selectedVm.power_state === POWER_STATE.HALTED
+      (selectedVm) => selectedVm.power_state === VM_POWER_STATE.HALTED
     )
 );
 

--- a/@xen-orchestra/lite/src/components/vm/VmActionItems/VmActionDeleteItem.vue
+++ b/@xen-orchestra/lite/src/components/vm/VmActionItems/VmActionDeleteItem.vue
@@ -42,7 +42,7 @@ import useModal from "@/composables/modal.composable";
 import { ColorContext } from "@/context";
 import { vTooltip } from "@/directives/tooltip.directive";
 import type { XenApiVm } from "@/libs/xen-api/xen-api.types";
-import { POWER_STATE } from "@/libs/xen-api/xen-api.utils";
+import { VM_POWER_STATE } from "@/libs/xen-api/xen-api.enums";
 import { useXenApiStore } from "@/stores/xen-api.store";
 import { useVmCollection } from "@/stores/xen-api/vm.store";
 import { faSatellite, faTrashCan } from "@fortawesome/free-solid-svg-icons";
@@ -65,7 +65,7 @@ const vms = computed<XenApiVm[]>(() =>
 );
 
 const areSomeVmsInExecution = computed(() =>
-  vms.value.some((vm) => vm.power_state !== POWER_STATE.HALTED)
+  vms.value.some((vm) => vm.power_state !== VM_POWER_STATE.HALTED)
 );
 
 const deleteVms = async () => {

--- a/@xen-orchestra/lite/src/components/vm/VmActionItems/VmActionPowerStateItems.vue
+++ b/@xen-orchestra/lite/src/components/vm/VmActionItems/VmActionPowerStateItems.vue
@@ -100,7 +100,7 @@ import { useHostMetricsCollection } from "@/stores/xen-api/host-metrics.store";
 import { usePoolCollection } from "@/stores/xen-api/pool.store";
 import { useVmCollection } from "@/stores/xen-api/vm.store";
 import type { XenApiHost, XenApiVm } from "@/libs/xen-api/xen-api.types";
-import { POWER_STATE, VM_OPERATION } from "@/libs/xen-api/xen-api.utils";
+import { VM_POWER_STATE, VM_OPERATION } from "@/libs/xen-api/xen-api.enums";
 import { useXenApiStore } from "@/stores/xen-api.store";
 import {
   faCirclePlay,
@@ -136,16 +136,16 @@ const vmRefsWithPowerState = computed(() =>
 const xenApi = useXenApiStore().getXapi();
 
 const areVmsRunning = computed(() =>
-  vms.value.every((vm) => vm.power_state === POWER_STATE.RUNNING)
+  vms.value.every((vm) => vm.power_state === VM_POWER_STATE.RUNNING)
 );
 const areVmsHalted = computed(() =>
-  vms.value.every((vm) => vm.power_state === POWER_STATE.HALTED)
+  vms.value.every((vm) => vm.power_state === VM_POWER_STATE.HALTED)
 );
 const areVmsSuspended = computed(() =>
-  vms.value.every((vm) => vm.power_state === POWER_STATE.SUSPENDED)
+  vms.value.every((vm) => vm.power_state === VM_POWER_STATE.SUSPENDED)
 );
 const areVmsPaused = computed(() =>
-  vms.value.every((vm) => vm.power_state === POWER_STATE.PAUSED)
+  vms.value.every((vm) => vm.power_state === VM_POWER_STATE.PAUSED)
 );
 
 const areOperationsPending = (operation: VM_OPERATION | VM_OPERATION[]) =>
@@ -179,7 +179,7 @@ const areVmsBusyToForceShutdown = computed(() =>
   areOperationsPending(VM_OPERATION.HARD_SHUTDOWN)
 );
 const getHostState = (host: XenApiHost) =>
-  isHostRunning(host) ? POWER_STATE.RUNNING : POWER_STATE.HALTED;
+  isHostRunning(host) ? VM_POWER_STATE.RUNNING : VM_POWER_STATE.HALTED;
 </script>
 
 <style lang="postcss" scoped>

--- a/@xen-orchestra/lite/src/libs/xen-api/xen-api.enums.ts
+++ b/@xen-orchestra/lite/src/libs/xen-api/xen-api.enums.ts
@@ -1,0 +1,493 @@
+export enum TASK_ALLOWED_OPERATION {
+  CANCEL = "cancel",
+  DESTROY = "destroy",
+}
+
+export enum TASK_STATUS_TYPE {
+  CANCELLED = "cancelled",
+  CANCELLING = "cancelling",
+  FAILURE = "failure",
+  PENDING = "pending",
+  SUCCESS = "success",
+}
+
+export enum EVENT_OPERATION {
+  ADD = "add",
+  DEL = "del",
+  MOD = "mod",
+}
+
+export enum POOL_ALLOWED_OPERATION {
+  APPLY_UPDATES = "apply_updates",
+  CERT_REFRESH = "cert_refresh",
+  CLUSTER_CREATE = "cluster_create",
+  CONFIGURE_REPOSITORIES = "configure_repositories",
+  COPY_PRIMARY_HOST_CERTS = "copy_primary_host_certs",
+  DESIGNATE_NEW_MASTER = "designate_new_master",
+  EXCHANGE_CA_CERTIFICATES_ON_JOIN = "exchange_ca_certificates_on_join",
+  EXCHANGE_CERTIFICATES_ON_JOIN = "exchange_certificates_on_join",
+  GET_UPDATES = "get_updates",
+  HA_DISABLE = "ha_disable",
+  HA_ENABLE = "ha_enable",
+  SYNC_UPDATES = "sync_updates",
+  TLS_VERIFICATION_ENABLE = "tls_verification_enable",
+}
+
+export enum TELEMETRY_FREQUENCY {
+  DAILY = "daily",
+  MONTHLY = "monthly",
+  WEEKLY = "weekly",
+}
+
+export enum UPDATE_SYNC_FREQUENCY {
+  DAILY = "daily",
+  WEEKLY = "weekly",
+}
+
+export enum AFTER_APPLY_GUIDANCE {
+  RESTART_HOST = "restartHost",
+  RESTART_HVM = "restartHVM",
+  RESTART_PV = "restartPV",
+  RESTART_XAPI = "restartXAPI",
+}
+
+export enum UPDATE_AFTER_APPLY_GUIDANCE {
+  RESTART_HOST = "restartHost",
+  RESTART_HVM = "restartHVM",
+  RESTART_PV = "restartPV",
+  RESTART_XAPI = "restartXAPI",
+}
+
+export enum LIVEPATCH_STATUS {
+  OK = "ok",
+  OK_LIVEPATCH_COMPLETE = "ok_livepatch_complete",
+  OK_LIVEPATCH_INCOMPLETE = "ok_livepatch_incomplete",
+}
+
+export enum VM_POWER_STATE {
+  HALTED = "Halted",
+  PAUSED = "Paused",
+  RUNNING = "Running",
+  SUSPENDED = "Suspended",
+}
+
+export enum UPDATE_GUIDANCE {
+  REBOOT_HOST = "reboot_host",
+  REBOOT_HOST_ON_LIVEPATCH_FAILURE = "reboot_host_on_livepatch_failure",
+  RESTART_DEVICE_MODEL = "restart_device_model",
+  RESTART_TOOLSTACK = "restart_toolstack",
+}
+
+export enum ON_SOFTREBOOT_BEHAVIOR {
+  DESTROY = "destroy",
+  PRESERVE = "preserve",
+  RESTART = "restart",
+  SOFT_REBOOT = "soft_reboot",
+}
+
+export enum ON_NORMAL_EXIT {
+  DESTROY = "destroy",
+  RESTART = "restart",
+}
+
+export enum VM_OPERATION {
+  ASSERT_OPERATION_VALID = "assert_operation_valid",
+  AWAITING_MEMORY_LIVE = "awaiting_memory_live",
+  CALL_PLUGIN = "call_plugin",
+  CHANGING_DYNAMIC_RANGE = "changing_dynamic_range",
+  CHANGING_MEMORY_LIMITS = "changing_memory_limits",
+  CHANGING_MEMORY_LIVE = "changing_memory_live",
+  CHANGING_NVRAM = "changing_NVRAM",
+  CHANGING_SHADOW_MEMORY = "changing_shadow_memory",
+  CHANGING_SHADOW_MEMORY_LIVE = "changing_shadow_memory_live",
+  CHANGING_STATIC_RANGE = "changing_static_range",
+  CHANGING_VCPUS = "changing_VCPUs",
+  CHANGING_VCPUS_LIVE = "changing_VCPUs_live",
+  CHECKPOINT = "checkpoint",
+  CLEAN_REBOOT = "clean_reboot",
+  CLEAN_SHUTDOWN = "clean_shutdown",
+  CLONE = "clone",
+  COPY = "copy",
+  CREATE_TEMPLATE = "create_template",
+  CREATE_VTPM = "create_vtpm",
+  CSVM = "csvm",
+  DATA_SOURCE_OP = "data_source_op",
+  DESTROY = "destroy",
+  EXPORT = "export",
+  GET_BOOT_RECORD = "get_boot_record",
+  HARD_REBOOT = "hard_reboot",
+  HARD_SHUTDOWN = "hard_shutdown",
+  IMPORT = "import",
+  MAKE_INTO_TEMPLATE = "make_into_template",
+  METADATA_EXPORT = "metadata_export",
+  MIGRATE_SEND = "migrate_send",
+  PAUSE = "pause",
+  POOL_MIGRATE = "pool_migrate",
+  POWER_STATE_RESET = "power_state_reset",
+  PROVISION = "provision",
+  QUERY_SERVICES = "query_services",
+  RESUME = "resume",
+  RESUME_ON = "resume_on",
+  REVERT = "revert",
+  REVERTING = "reverting",
+  SEND_SYSRQ = "send_sysrq",
+  SEND_TRIGGER = "send_trigger",
+  SHUTDOWN = "shutdown",
+  SNAPSHOT = "snapshot",
+  SNAPSHOT_WITH_QUIESCE = "snapshot_with_quiesce",
+  START = "start",
+  START_ON = "start_on",
+  SUSPEND = "suspend",
+  UNPAUSE = "unpause",
+  UPDATE_ALLOWED_OPERATIONS = "update_allowed_operations",
+}
+
+export enum ON_CRASH_BEHAVIOUR {
+  COREDUMP_AND_DESTROY = "coredump_and_destroy",
+  COREDUMP_AND_RESTART = "coredump_and_restart",
+  DESTROY = "destroy",
+  PRESERVE = "preserve",
+  RENAME_RESTART = "rename_restart",
+  RESTART = "restart",
+}
+
+export enum DOMAIN_TYPE {
+  HVM = "hvm",
+  PV = "pv",
+  PVH = "pvh",
+  PV_IN_PVH = "pv_in_pvh",
+  UNSPECIFIED = "unspecified",
+}
+
+export enum TRISTATE_TYPE {
+  NO = "no",
+  UNSPECIFIED = "unspecified",
+  YES = "yes",
+}
+
+export enum VMPP_BACKUP_TYPE {
+  CHECKPOINT = "checkpoint",
+  SNAPSHOT = "snapshot",
+}
+
+export enum VMPP_BACKUP_FREQUENCY {
+  DAILY = "daily",
+  HOURLY = "hourly",
+  WEEKLY = "weekly",
+}
+
+export enum VMPP_ARCHIVE_FREQUENCY {
+  ALWAYS_AFTER_BACKUP = "always_after_backup",
+  DAILY = "daily",
+  NEVER = "never",
+  WEEKLY = "weekly",
+}
+
+export enum VMPP_ARCHIVE_TARGET_TYPE {
+  CIFS = "cifs",
+  NFS = "nfs",
+  NONE = "none",
+}
+
+export enum VMSS_FREQUENCY {
+  DAILY = "daily",
+  HOURLY = "hourly",
+  WEEKLY = "weekly",
+}
+
+export enum VMSS_TYPE {
+  CHECKPOINT = "checkpoint",
+  SNAPSHOT = "snapshot",
+  SNAPSHOT_WITH_QUIESCE = "snapshot_with_quiesce",
+}
+
+export enum VM_APPLIANCE_OPERATION {
+  CLEAN_SHUTDOWN = "clean_shutdown",
+  HARD_SHUTDOWN = "hard_shutdown",
+  SHUTDOWN = "shutdown",
+  START = "start",
+}
+
+export enum HOST_ALLOWED_OPERATION {
+  APPLY_UPDATES = "apply_updates",
+  EVACUATE = "evacuate",
+  POWER_ON = "power_on",
+  PROVISION = "provision",
+  REBOOT = "reboot",
+  SHUTDOWN = "shutdown",
+  VM_MIGRATE = "vm_migrate",
+  VM_RESUME = "vm_resume",
+  VM_START = "vm_start",
+}
+
+export enum LATEST_SYNCED_UPDATES_APPLIED_STATE {
+  NO = "no",
+  UNKNOWN = "unknown",
+  YES = "yes",
+}
+
+export enum HOST_DISPLAY {
+  DISABLED = "disabled",
+  DISABLE_ON_REBOOT = "disable_on_reboot",
+  ENABLED = "enabled",
+  ENABLE_ON_REBOOT = "enable_on_reboot",
+}
+
+export enum HOST_SCHED_GRAN {
+  CORE = "core",
+  CPU = "cpu",
+  SOCKET = "socket",
+}
+
+export enum NETWORK_OPERATION {
+  ATTACHING = "attaching",
+}
+
+export enum NETWORK_DEFAULT_LOCKING_MODE {
+  DISABLED = "disabled",
+  UNLOCKED = "unlocked",
+}
+
+export enum NETWORK_PURPOSE {
+  INSECURE_NBD = "insecure_nbd",
+  NBD = "nbd",
+}
+
+export enum VIF_OPERATION {
+  ATTACH = "attach",
+  PLUG = "plug",
+  UNPLUG = "unplug",
+}
+
+export enum VIF_LOCKING_MODE {
+  DISABLED = "disabled",
+  LOCKED = "locked",
+  NETWORK_DEFAULT = "network_default",
+  UNLOCKED = "unlocked",
+}
+
+export enum VIF_IPV4_CONFIGURATION_MODE {
+  NONE = "None",
+  STATIC = "Static",
+}
+
+export enum VIF_IPV6_CONFIGURATION_MODE {
+  NONE = "None",
+  STATIC = "Static",
+}
+
+export enum PIF_IGMP_STATUS {
+  DISABLED = "disabled",
+  ENABLED = "enabled",
+  UNKNOWN = "unknown",
+}
+
+export enum IP_CONFIGURATION_MODE {
+  DHCP = "DHCP",
+  NONE = "None",
+  STATIC = "Static",
+}
+
+export enum IPV6_CONFIGURATION_MODE {
+  AUTOCONF = "Autoconf",
+  DHCP = "DHCP",
+  NONE = "None",
+  STATIC = "Static",
+}
+
+export enum PRIMARY_ADDRESS_TYPE {
+  IPV4 = "IPv4",
+  IPV6 = "IPv6",
+}
+
+export enum BOND_MODE {
+  ACTIVE_BACKUP = "active-backup",
+  BALANCE_SLB = "balance-slb",
+  LACP = "lacp",
+}
+
+export enum STORAGE_OPERATION {
+  DESTROY = "destroy",
+  FORGET = "forget",
+  PBD_CREATE = "pbd_create",
+  PBD_DESTROY = "pbd_destroy",
+  PLUG = "plug",
+  SCAN = "scan",
+  UNPLUG = "unplug",
+  UPDATE = "update",
+  VDI_CLONE = "vdi_clone",
+  VDI_CREATE = "vdi_create",
+  VDI_DATA_DESTROY = "vdi_data_destroy",
+  VDI_DESTROY = "vdi_destroy",
+  VDI_DISABLE_CBT = "vdi_disable_cbt",
+  VDI_ENABLE_CBT = "vdi_enable_cbt",
+  VDI_INTRODUCE = "vdi_introduce",
+  VDI_LIST_CHANGED_BLOCKS = "vdi_list_changed_blocks",
+  VDI_MIRROR = "vdi_mirror",
+  VDI_RESIZE = "vdi_resize",
+  VDI_SET_ON_BOOT = "vdi_set_on_boot",
+  VDI_SNAPSHOT = "vdi_snapshot",
+}
+
+export enum SR_HEALTH {
+  HEALTHY = "healthy",
+  RECOVERING = "recovering",
+}
+
+export enum VDI_OPERATION {
+  BLOCKED = "blocked",
+  CLONE = "clone",
+  COPY = "copy",
+  DATA_DESTROY = "data_destroy",
+  DESTROY = "destroy",
+  DISABLE_CBT = "disable_cbt",
+  ENABLE_CBT = "enable_cbt",
+  FORCE_UNLOCK = "force_unlock",
+  FORGET = "forget",
+  GENERATE_CONFIG = "generate_config",
+  LIST_CHANGED_BLOCKS = "list_changed_blocks",
+  MIRROR = "mirror",
+  RESIZE = "resize",
+  RESIZE_ONLINE = "resize_online",
+  SET_ON_BOOT = "set_on_boot",
+  SNAPSHOT = "snapshot",
+  UPDATE = "update",
+}
+
+export enum VDI_TYPE {
+  CBT_METADATA = "cbt_metadata",
+  CRASHDUMP = "crashdump",
+  EPHEMERAL = "ephemeral",
+  HA_STATEFILE = "ha_statefile",
+  METADATA = "metadata",
+  PVS_CACHE = "pvs_cache",
+  REDO_LOG = "redo_log",
+  RRD = "rrd",
+  SUSPEND = "suspend",
+  SYSTEM = "system",
+  USER = "user",
+}
+
+export enum ON_BOOT {
+  PERSIST = "persist",
+  RESET = "reset",
+}
+
+export enum VBD_OPERATION {
+  ATTACH = "attach",
+  EJECT = "eject",
+  INSERT = "insert",
+  PAUSE = "pause",
+  PLUG = "plug",
+  UNPAUSE = "unpause",
+  UNPLUG = "unplug",
+  UNPLUG_FORCE = "unplug_force",
+}
+
+export enum VBD_TYPE {
+  CD = "CD",
+  DISK = "Disk",
+  FLOPPY = "Floppy",
+}
+
+export enum VBD_MODE {
+  RO = "RO",
+  RW = "RW",
+}
+
+export enum VTPM_OPERATION {
+  DESTROY = "destroy",
+}
+
+export enum PERSISTENCE_BACKEND {
+  XAPI = "xapi",
+}
+
+export enum CONSOLE_PROTOCOL {
+  RDP = "rdp",
+  RFB = "rfb",
+  VT100 = "vt100",
+}
+
+export enum CLS {
+  CERTIFICATE = "Certificate",
+  HOST = "Host",
+  POOL = "Pool",
+  PVS_PROXY = "PVS_proxy",
+  SR = "SR",
+  VDI = "VDI",
+  VM = "VM",
+  VMPP = "VMPP",
+  VMSS = "VMSS",
+}
+
+export enum TUNNEL_PROTOCOL {
+  GRE = "gre",
+  VXLAN = "vxlan",
+}
+
+export enum SRIOV_CONFIGURATION_MODE {
+  MANUAL = "manual",
+  MODPROBE = "modprobe",
+  SYSFS = "sysfs",
+  UNKNOWN = "unknown",
+}
+
+export enum PGPU_DOM0_ACCESS {
+  DISABLED = "disabled",
+  DISABLE_ON_REBOOT = "disable_on_reboot",
+  ENABLED = "enabled",
+  ENABLE_ON_REBOOT = "enable_on_reboot",
+}
+
+export enum ALLOCATION_ALGORITHM {
+  BREADTH_FIRST = "breadth_first",
+  DEPTH_FIRST = "depth_first",
+}
+
+export enum VGPU_TYPE_IMPLEMENTATION {
+  GVT_G = "gvt_g",
+  MXGPU = "mxgpu",
+  NVIDIA = "nvidia",
+  NVIDIA_SRIOV = "nvidia_sriov",
+  PASSTHROUGH = "passthrough",
+}
+
+export enum PVS_PROXY_STATUS {
+  CACHING = "caching",
+  INCOMPATIBLE_PROTOCOL_VERSION = "incompatible_protocol_version",
+  INCOMPATIBLE_WRITE_CACHE_MODE = "incompatible_write_cache_mode",
+  INITIALISED = "initialised",
+  STOPPED = "stopped",
+}
+
+export enum SDN_CONTROLLER_PROTOCOL {
+  PSSL = "pssl",
+  SSL = "ssl",
+}
+
+export enum VUSB_OPERATION {
+  ATTACH = "attach",
+  PLUG = "plug",
+  UNPLUG = "unplug",
+}
+
+export enum CLUSTER_OPERATION {
+  ADD = "add",
+  DESTROY = "destroy",
+  DISABLE = "disable",
+  ENABLE = "enable",
+  REMOVE = "remove",
+}
+
+export enum CLUSTER_HOST_OPERATION {
+  DESTROY = "destroy",
+  DISABLE = "disable",
+  ENABLE = "enable",
+}
+
+export enum CERTIFICATE_TYPE {
+  CA = "ca",
+  HOST = "host",
+  HOST_INTERNAL = "host_internal",
+}

--- a/@xen-orchestra/lite/src/libs/xen-api/xen-api.types.ts
+++ b/@xen-orchestra/lite/src/libs/xen-api/xen-api.types.ts
@@ -1,8 +1,46 @@
 import type {
-  XEN_API_OBJECT_TYPES,
-  POWER_STATE,
+  ALLOCATION_ALGORITHM,
+  BOND_MODE,
+  DOMAIN_TYPE,
+  IP_CONFIGURATION_MODE,
+  IPV6_CONFIGURATION_MODE,
+  NETWORK_DEFAULT_LOCKING_MODE,
+  NETWORK_OPERATION,
+  NETWORK_PURPOSE,
+  ON_BOOT,
+  ON_CRASH_BEHAVIOUR,
+  ON_NORMAL_EXIT,
+  ON_SOFTREBOOT_BEHAVIOR,
+  PERSISTENCE_BACKEND,
+  PGPU_DOM0_ACCESS,
+  PIF_IGMP_STATUS,
+  PRIMARY_ADDRESS_TYPE,
+  SRIOV_CONFIGURATION_MODE,
+  TUNNEL_PROTOCOL,
+  UPDATE_GUIDANCE,
+  VBD_MODE,
+  VBD_OPERATION,
+  VBD_TYPE,
+  VDI_OPERATION,
+  VDI_TYPE,
+  VGPU_TYPE_IMPLEMENTATION,
+  VIF_IPV4_CONFIGURATION_MODE,
+  VIF_IPV6_CONFIGURATION_MODE,
+  VIF_LOCKING_MODE,
+  VIF_OPERATION,
+  VM_APPLIANCE_OPERATION,
   VM_OPERATION,
-} from "@/libs/xen-api/xen-api.utils";
+  VM_POWER_STATE,
+  VMPP_ARCHIVE_FREQUENCY,
+  VMPP_ARCHIVE_TARGET_TYPE,
+  VMPP_BACKUP_FREQUENCY,
+  VMPP_BACKUP_TYPE,
+  VMSS_FREQUENCY,
+  VMSS_TYPE,
+  VTPM_OPERATION,
+  VUSB_OPERATION,
+} from "@/libs/xen-api/xen-api.enums";
+import type { XEN_API_OBJECT_TYPES } from "@/libs/xen-api/xen-api.utils";
 
 type TypeMapping = typeof XEN_API_OBJECT_TYPES;
 export type ObjectType = keyof TypeMapping;
@@ -81,18 +119,236 @@ export interface XenApiSr extends XenApiRecord<"sr"> {
 }
 
 export interface XenApiVm extends XenApiRecord<"vm"> {
-  current_operations: Record<string, VM_OPERATION>;
-  guest_metrics: string;
-  metrics: XenApiVmMetrics["$ref"];
-  name_label: string;
-  name_description: string;
-  power_state: POWER_STATE;
-  resident_on: XenApiHost["$ref"];
+  HVM_boot_params: Record<string, string>;
+  HVM_boot_policy: string;
+  HVM_shadow_multiplier: number;
+  NVRAM: Record<string, string>;
+  PCI_bus: string;
+  PV_args: string;
+  PV_bootloader: string;
+  PV_bootloader_args: string;
+  PV_kernel: string;
+  PV_legacy_args: string;
+  PV_ramdisk: string;
+  VBDs: XenApiVbd["$ref"][];
+  VCPUs_at_startup: number;
+  VCPUs_max: number;
+  VCPUs_params: Record<string, string>;
+  VGPUs: XenApiVgpu["$ref"][];
+  VIFs: XenApiVif["$ref"][];
+  VTPMs: XenApiVtpm["$ref"][];
+  VUSBs: XenApiVusb["$ref"][];
+  actions_after_crash: ON_CRASH_BEHAVIOUR;
+  actions_after_reboot: ON_NORMAL_EXIT;
+  actions_after_shutdown: ON_NORMAL_EXIT;
+  actions_after_softreboot: ON_SOFTREBOOT_BEHAVIOR;
+  affinity: XenApiHost["$ref"];
+  allowed_operations: VM_OPERATION[];
+  appliance: XenApiVmAppliance["$ref"];
+  attached_PCIs: XenApiPci["$ref"][];
+  bios_strings: Record<string, string>;
+  blobs: Record<string, XenApiBlob["$ref"]>;
+  blocked_operations: Record<VM_OPERATION, string>;
+  children: XenApiVm["$ref"][];
   consoles: XenApiConsole["$ref"][];
-  is_control_domain: boolean;
+  crash_dumps: XenApiCrashdump["$ref"][];
+  current_operations: Record<string, VM_OPERATION>;
+  domain_type: DOMAIN_TYPE;
+  domarch: string;
+  domid: number;
+  generation_id: string;
+  guest_metrics: XenApiVmGuestMetrics["$ref"];
+  ha_always_run: boolean;
+  ha_restart_priority: string;
+  hardware_platform_version: number;
+  has_vendor_device: boolean;
   is_a_snapshot: boolean;
   is_a_template: boolean;
-  VCPUs_at_startup: number;
+  is_control_domain: boolean;
+  is_default_template: boolean;
+  is_snapshot_from_vmpp: boolean;
+  is_vmss_snapshot: boolean;
+  last_boot_CPU_flags: Record<string, string>;
+  last_booted_record: string;
+  memory_dynamic_max: number;
+  memory_dynamic_min: number;
+  memory_overhead: number;
+  memory_static_max: number;
+  memory_static_min: number;
+  memory_target: number;
+  metrics: XenApiVmMetrics["$ref"];
+  name_description: string;
+  name_label: string;
+  order: number;
+  other_config: Record<string, string>;
+  parent: XenApiVm["$ref"];
+  pending_guidances: UPDATE_GUIDANCE[];
+  platform: Record<string, string>;
+  power_state: VM_POWER_STATE;
+  protection_policy: XenApiVmpp["$ref"];
+  recommendations: string;
+  reference_label: string;
+  requires_reboot: boolean;
+  resident_on: XenApiHost["$ref"];
+  scheduled_to_be_resident_on: XenApiHost["$ref"];
+  shutdown_delay: number;
+  snapshot_info: Record<string, string>;
+  snapshot_metadata: string;
+  snapshot_of: XenApiVm["$ref"];
+  snapshot_schedule: XenApiVmss["$ref"];
+  snapshot_time: string;
+  snapshots: XenApiVm["$ref"][];
+  start_delay: number;
+  suspend_SR: XenApiSr["$ref"];
+  suspend_VDI: XenApiVdi["$ref"];
+  tags: string[];
+  transportable_snapshot_id: string;
+  user_version: number;
+  version: number;
+  xenstore_data: Record<string, string>;
+}
+
+export interface XenApiVtpm extends XenApiRecord<"vtpm"> {
+  VM: XenApiVm["$ref"];
+  allowed_operations: VTPM_OPERATION[];
+  backend: XenApiVm["$ref"];
+  current_operations: Record<string, VTPM_OPERATION>;
+  is_protected: boolean;
+  is_unique: boolean;
+  persistence_backend: PERSISTENCE_BACKEND;
+}
+
+export interface XenApiVusb extends XenApiRecord<"vusb"> {
+  USB_group: XenApiUsbGroup["$ref"];
+  VM: XenApiVm["$ref"];
+  allowed_operations: VUSB_OPERATION[];
+  current_operations: Record<string, VUSB_OPERATION>;
+  currently_attached: boolean;
+  other_config: Record<string, string>;
+}
+
+export interface XenApiUsbGroup extends XenApiRecord<"usb_group"> {
+  PUSBs: XenApiPusb["$ref"][];
+  VUSBs: XenApiVusb["$ref"][];
+  name_description: string;
+  name_label: string;
+  other_config: Record<string, string>;
+}
+
+export interface XenApiPusb extends XenApiRecord<"pusb"> {
+  USB_group: XenApiUsbGroup["$ref"];
+  description: string;
+  host: XenApiHost["$ref"];
+  other_config: Record<string, string>;
+  passthrough_enabled: boolean;
+  path: string;
+  product_desc: string;
+  product_id: string;
+  serial: string;
+  speed: number;
+  vendor_desc: string;
+  vendor_id: string;
+  version: string;
+}
+
+export interface XenApiVgpu extends XenApiRecord<"vgpu"> {
+  GPU_group: XenApiGpuGroup["$ref"];
+  PCI: XenApiPci["$ref"];
+  VM: XenApiVm["$ref"];
+  compatibility_metadata: Record<string, string>;
+  currently_attached: boolean;
+  device: string;
+  extra_args: string;
+  other_config: Record<string, string>;
+  resident_on: XenApiPgpu["$ref"];
+  scheduled_to_be_resident_on: XenApiPgpu["$ref"];
+  type: XenApiVgpuType["$ref"];
+}
+
+export interface XenApiGpuGroup extends XenApiRecord<"gpu_group"> {
+  GPU_types: string[];
+  PGPUs: XenApiPgpu["$ref"][];
+  VGPUs: XenApiVgpu["$ref"][];
+  allocation_algorithm: ALLOCATION_ALGORITHM;
+  enabled_VGPU_types: XenApiVgpuType["$ref"][];
+  name_description: string;
+  name_label: string;
+  other_config: Record<string, string>;
+  supported_VGPU_types: XenApiVgpuType["$ref"][];
+}
+
+export interface XenApiPgpu extends XenApiRecord<"pgpu"> {
+  GPU_group: XenApiGpuGroup["$ref"];
+  PCI: XenApiPci["$ref"];
+  compatibility_metadata: Record<string, string>;
+  dom0_access: PGPU_DOM0_ACCESS;
+  enabled_VGPU_types: XenApiVgpuType["$ref"][];
+  host: XenApiHost["$ref"];
+  is_system_display_device: boolean;
+  other_config: Record<string, string>;
+  resident_VGPUs: XenApiVgpu["$ref"][];
+  supported_VGPU_max_capacities: Record<XenApiVgpuType["$ref"], number>;
+  supported_VGPU_types: XenApiVgpuType["$ref"][];
+}
+
+export interface XenApiVgpuType extends XenApiRecord<"vgpu_type"> {
+  VGPUs: XenApiVgpu["$ref"][];
+  compatible_types_in_vm: XenApiVgpuType["$ref"][];
+  enabled_on_GPU_groups: XenApiGpuGroup["$ref"][];
+  enabled_on_PGPUs: XenApiPgpu["$ref"][];
+  experimental: boolean;
+  framebuffer_size: number;
+  identifier: string;
+  implementation: VGPU_TYPE_IMPLEMENTATION;
+  max_heads: number;
+  max_resolution_x: number;
+  max_resolution_y: number;
+  model_name: string;
+  supported_on_GPU_groups: XenApiGpuGroup["$ref"][];
+  supported_on_PGPUs: XenApiPgpu["$ref"][];
+  vendor_name: string;
+}
+
+export interface XenApiVmAppliance extends XenApiRecord<"vm_appliance"> {
+  VMs: XenApiVm["$ref"][];
+  allowed_operations: VM_APPLIANCE_OPERATION[];
+  current_operations: Record<string, VM_APPLIANCE_OPERATION>;
+  name_description: string;
+  name_label: string;
+}
+
+export interface XenApiVmpp extends XenApiRecord<"vmpp"> {
+  VMs: XenApiVm["$ref"][];
+  alarm_config: Record<string, string>;
+  archive_frequency: VMPP_ARCHIVE_FREQUENCY;
+  archive_last_run_time: string;
+  archive_schedule: Record<string, string>;
+  archive_target_config: Record<string, string>;
+  archive_target_type: VMPP_ARCHIVE_TARGET_TYPE;
+  backup_frequency: VMPP_BACKUP_FREQUENCY;
+  backup_last_run_time: string;
+  backup_retention_value: number;
+  backup_schedule: Record<string, string>;
+  backup_type: VMPP_BACKUP_TYPE;
+  is_alarm_enabled: boolean;
+  is_archive_running: boolean;
+  is_backup_running: boolean;
+  is_policy_enabled: boolean;
+  name_description: string;
+  name_label: string;
+  recent_alerts: string[];
+}
+
+export interface XenApiVmss extends XenApiRecord<"vmss"> {
+  VMs: XenApiVm["$ref"][];
+  enabled: boolean;
+  frequency: VMSS_FREQUENCY;
+  last_run_time: string;
+  name_description: string;
+  name_label: string;
+  retained_snapshots: number;
+  schedule: Record<string, string>;
+  type: VMSS_TYPE;
 }
 
 export interface XenApiConsole extends XenApiRecord<"console"> {
@@ -131,9 +387,241 @@ export interface XenApiMessage<RelationType extends RawObjectType>
   timestamp: string;
 }
 
+export interface XenApiVbd extends XenApiRecord<"vbd"> {
+  VDI: XenApiVdi["$ref"];
+  VM: XenApiVm["$ref"];
+  allowed_operations: VBD_OPERATION[];
+  bootable: boolean;
+  current_operations: Record<string, VBD_OPERATION>;
+  currently_attached: boolean;
+  device: string;
+  empty: boolean;
+  metrics: XenApiVbdMetrics["$ref"];
+  mode: VBD_MODE;
+  other_config: Record<string, string>;
+  qos_algorithm_params: Record<string, string>;
+  qos_algorithm_type: string;
+  qos_supported_algorithms: string[];
+  runtime_properties: Record<string, string>;
+  status_code: number;
+  status_detail: string;
+  storage_lock: boolean;
+  type: VBD_TYPE;
+  unpluggable: boolean;
+  userdevice: string;
+}
+
+export interface XenApiVbdMetrics extends XenApiRecord<"vbd_metrics"> {
+  io_read_kbs: number;
+  io_write_kbs: number;
+  last_updated: string;
+  other_config: Record<string, string>;
+}
+
+export interface XenApiVdi extends XenApiRecord<"vdi"> {
+  SR: XenApiSr["$ref"];
+  VBDs: XenApiVbd["$ref"][];
+  allow_caching: boolean;
+  allowed_operations: VDI_OPERATION[];
+  cbt_enabled: boolean;
+  crash_dumps: XenApiCrashdump["$ref"][];
+  current_operations: Record<string, VDI_OPERATION>;
+  is_a_snapshot: boolean;
+  is_tools_iso: boolean;
+  location: string;
+  managed: boolean;
+  metadata_latest: boolean;
+  metadata_of_pool: XenApiPool["$ref"];
+  missing: boolean;
+  name_description: string;
+  name_label: string;
+  on_boot: ON_BOOT;
+  other_config: Record<string, string>;
+  parent: XenApiVdi["$ref"];
+  physical_utilisation: number;
+  read_only: boolean;
+  sharable: boolean;
+  sm_config: Record<string, string>;
+  snapshot_of: XenApiVdi["$ref"];
+  snapshot_time: string;
+  snapshots: XenApiVdi["$ref"][];
+  storage_lock: boolean;
+  tags: string[];
+  type: VDI_TYPE;
+  virtual_size: number;
+  xenstore_data: Record<string, string>;
+}
+
+export interface XenApiCrashdump extends XenApiRecord<"crashdump"> {
+  VDI: XenApiVdi["$ref"];
+  VM: XenApiVm["$ref"];
+  other_config: Record<string, string>;
+}
+
+export interface XenApiNetwork extends XenApiRecord<"network"> {
+  MTU: number;
+  PIFs: XenApiPif["$ref"][];
+  VIFs: XenApiVif["$ref"][];
+  allowed_operations: NETWORK_OPERATION[];
+  assigned_ips: Record<XenApiVif["$ref"], string>;
+  blobs: Record<string, XenApiBlob["$ref"]>;
+  bridge: string;
+  current_operations: Record<string, NETWORK_OPERATION>;
+  default_locking_mode: NETWORK_DEFAULT_LOCKING_MODE;
+  managed: boolean;
+  name_description: string;
+  name_label: string;
+  other_config: Record<string, string>;
+  purpose: NETWORK_PURPOSE[];
+  tags: string[];
+}
+
+export interface XenApiBlob extends XenApiRecord<"blob"> {
+  last_updated: string;
+  mime_type: string;
+  name_description: string;
+  name_label: string;
+  public: boolean;
+  size: number;
+}
+
+export interface XenApiVif extends XenApiRecord<"vif"> {
+  MAC: string;
+  MAC_autogenerated: boolean;
+  MTU: number;
+  VM: XenApiVm["$ref"];
+  allowed_operations: VIF_OPERATION[];
+  current_operations: Record<string, VIF_OPERATION>;
+  currently_attached: boolean;
+  device: string;
+  ipv4_addresses: string[];
+  ipv4_allowed: string[];
+  ipv4_configuration_mode: VIF_IPV4_CONFIGURATION_MODE;
+  ipv4_gateway: string;
+  ipv6_addresses: string[];
+  ipv6_allowed: string[];
+  ipv6_configuration_mode: VIF_IPV6_CONFIGURATION_MODE;
+  ipv6_gateway: string;
+  locking_mode: VIF_LOCKING_MODE;
+  metrics: XenApiVifMetrics["$ref"];
+  network: XenApiNetwork["$ref"];
+  other_config: Record<string, string>;
+  qos_algorithm_params: Record<string, string>;
+  qos_algorithm_type: string;
+  qos_supported_algorithms: string[];
+  runtime_properties: Record<string, string>;
+  status_code: number;
+  status_detail: string;
+}
+
+export interface XenApiVifMetrics extends XenApiRecord<"vif_metrics"> {
+  io_read_kbs: number;
+  io_write_kbs: number;
+  last_updated: string;
+  other_config: Record<string, string>;
+}
+
+export interface XenApiPif extends XenApiRecord<"pif"> {
+  DNS: string;
+  IP: string;
+  IPv6: string[];
+  MAC: string;
+  MTU: number;
+  PCI: XenApiPci["$ref"];
+  VLAN: number;
+  VLAN_master_of: XenApiVlan["$ref"];
+  VLAN_slave_of: XenApiVlan["$ref"][];
+  bond_master_of: XenApiBond["$ref"][];
+  bond_slave_of: XenApiBond["$ref"];
+  capabilities: string[];
+  currently_attached: boolean;
+  device: string;
+  disallow_unplug: boolean;
+  gateway: string;
+  host: XenApiHost["$ref"];
+  igmp_snooping_status: PIF_IGMP_STATUS;
+  ip_configuration_mode: IP_CONFIGURATION_MODE;
+  ipv6_configuration_mode: IPV6_CONFIGURATION_MODE;
+  ipv6_gateway: string;
+  managed: boolean;
+  management: boolean;
+  metrics: XenApiPifMetrics["$ref"];
+  netmask: string;
+  network: XenApiNetwork["$ref"];
+  other_config: Record<string, string>;
+  physical: boolean;
+  primary_address_type: PRIMARY_ADDRESS_TYPE;
+  properties: Record<string, string>;
+  sriov_logical_PIF_of: XenApiNetworkSriov["$ref"][];
+  sriov_physical_PIF_of: XenApiNetworkSriov["$ref"][];
+  tunnel_access_PIF_of: XenApiTunnel["$ref"][];
+  tunnel_transport_PIF_of: XenApiTunnel["$ref"][];
+}
+
+export interface XenApiNetworkSriov extends XenApiRecord<"network_sriov"> {
+  configuration_mode: SRIOV_CONFIGURATION_MODE;
+  logical_PIF: XenApiPif["$ref"];
+  physical_PIF: XenApiPif["$ref"];
+  requires_reboot: boolean;
+}
+
+export interface XenApiVlan extends XenApiRecord<"vlan"> {
+  other_config: Record<string, string>;
+  tag: number;
+  tagged_PIF: XenApiPif["$ref"];
+  untagged_PIF: XenApiPif["$ref"];
+}
+
+export interface XenApiTunnel extends XenApiRecord<"tunnel"> {
+  access_PIF: XenApiPif["$ref"];
+  other_config: Record<string, string>;
+  protocol: TUNNEL_PROTOCOL;
+  status: Record<string, string>;
+  transport_PIF: XenApiPif["$ref"];
+}
+
+export interface XenApiPci extends XenApiRecord<"pci"> {
+  class_name: string;
+  dependencies: XenApiPci["$ref"][];
+  device_name: string;
+  driver_name: string;
+  host: XenApiHost["$ref"];
+  other_config: Record<string, string>;
+  pci_id: string;
+  subsystem_device_name: string;
+  subsystem_vendor_name: string;
+  vendor_name: string;
+}
+
+export interface XenApiPifMetrics extends XenApiRecord<"pif_metrics"> {
+  carrier: boolean;
+  device_id: string;
+  device_name: string;
+  duplex: boolean;
+  io_read_kbs: number;
+  io_write_kbs: number;
+  last_updated: string;
+  other_config: Record<string, string>;
+  pci_bus_path: string;
+  speed: number;
+  vendor_id: string;
+  vendor_name: string;
+}
+
+export interface XenApiBond extends XenApiRecord<"bond"> {
+  auto_update_mac: boolean;
+  links_up: number;
+  master: XenApiPif["$ref"];
+  mode: BOND_MODE;
+  other_config: Record<string, string>;
+  primary_slave: XenApiPif["$ref"];
+  properties: Record<string, string>;
+  slaves: XenApiPif["$ref"][];
+}
+
 export type XenApiEvent<
   RelationType extends ObjectType,
-  XRecord extends ObjectTypeToRecord<RelationType>,
+  XRecord extends ObjectTypeToRecord<RelationType>
 > = {
   id: string;
   class: RelationType;

--- a/@xen-orchestra/lite/src/libs/xen-api/xen-api.utils.ts
+++ b/@xen-orchestra/lite/src/libs/xen-api/xen-api.utils.ts
@@ -40,6 +40,7 @@ export const XEN_API_OBJECT_TYPES = {
   vm: "VM",
   vmpp: "VMPP",
   vmss: "VMSS",
+  vm_appliance: "VM_appliance",
   vm_guest_metrics: "VM_guest_metrics",
   vm_metrics: "VM_metrics",
   vusb: "VUSB",
@@ -62,6 +63,7 @@ export const XEN_API_OBJECT_TYPES = {
   subject: "subject",
   task: "task",
   tunnel: "tunnel",
+  vtpm: "VTPM",
 } as const;
 
 export const rawTypeToType = <RawType extends RawObjectType>(
@@ -71,28 +73,6 @@ export const rawTypeToType = <RawType extends RawObjectType>(
 export const typeToRawType = <Type extends ObjectType>(
   type: Type
 ): TypeToRawType<Type> => XEN_API_OBJECT_TYPES[type];
-
-export enum POWER_STATE {
-  RUNNING = "Running",
-  PAUSED = "Paused",
-  HALTED = "Halted",
-  SUSPENDED = "Suspended",
-}
-
-export enum VM_OPERATION {
-  START = "start",
-  START_ON = "start_on",
-  RESUME = "resume",
-  UNPAUSE = "unpause",
-  CLONE = "clone",
-  SHUTDOWN = "shutdown",
-  CLEAN_SHUTDOWN = "clean_shutdown",
-  HARD_SHUTDOWN = "hard_shutdown",
-  CLEAN_REBOOT = "clean_reboot",
-  HARD_REBOOT = "hard_reboot",
-  PAUSE = "pause",
-  SUSPEND = "suspend",
-}
 
 export const buildXoObject = <T extends XenApiRecord<ObjectType>>(
   record: RawXenApiRecord<T>,

--- a/@xen-orchestra/lite/src/stores/xen-api/vm.store.ts
+++ b/@xen-orchestra/lite/src/stores/xen-api/vm.store.ts
@@ -3,8 +3,10 @@ import { useXenApiStoreSubscribableContext } from "@/composables/xen-api-store-s
 import { sortRecordsByNameLabel } from "@/libs/utils";
 import type { VmStats } from "@/libs/xapi-stats";
 import type { XenApiHost, XenApiVm } from "@/libs/xen-api/xen-api.types";
-import type { VM_OPERATION } from "@/libs/xen-api/xen-api.utils";
-import { POWER_STATE } from "@/libs/xen-api/xen-api.utils";
+import {
+  type VM_OPERATION,
+  VM_POWER_STATE,
+} from "@/libs/xen-api/xen-api.enums";
 import { useXenApiStore } from "@/stores/xen-api.store";
 import { createUseCollection } from "@/stores/xen-api/create-use-collection";
 import { useHostStore } from "@/stores/xen-api/host.store";
@@ -35,7 +37,7 @@ export const useVmStore = defineStore("xen-api-vm", () => {
   };
 
   const runningVms = computed(() =>
-    records.value.filter((vm) => vm.power_state === POWER_STATE.RUNNING)
+    records.value.filter((vm) => vm.power_state === VM_POWER_STATE.RUNNING)
   );
 
   const recordsByHostRef = computed(() => {

--- a/@xen-orchestra/lite/src/stories/power-state-icon.story.vue
+++ b/@xen-orchestra/lite/src/stories/power-state-icon.story.vue
@@ -2,9 +2,9 @@
   <ComponentStory
     :params="[
       prop('state')
-        .enum(...Object.values(POWER_STATE))
+        .enum(...Object.values(VM_POWER_STATE))
         .required()
-        .preset(POWER_STATE.RUNNING)
+        .preset(VM_POWER_STATE.RUNNING)
         .widget(),
     ]"
     v-slot="{ properties }"
@@ -17,7 +17,7 @@
 import PowerStateIcon from "@/components/PowerStateIcon.vue";
 import ComponentStory from "@/components/component-story/ComponentStory.vue";
 import { prop } from "@/libs/story/story-param";
-import { POWER_STATE } from "@/libs/xen-api/xen-api.utils";
+import { VM_POWER_STATE } from "@/libs/xen-api/xen-api.enums";
 </script>
 
 <style lang="postcss" scoped></style>

--- a/@xen-orchestra/lite/src/views/pool/PoolVmsView.vue
+++ b/@xen-orchestra/lite/src/views/pool/PoolVmsView.vue
@@ -38,7 +38,7 @@ import UiCard from "@/components/ui/UiCard.vue";
 import UiCardTitle from "@/components/ui/UiCardTitle.vue";
 import VmsActionsBar from "@/components/vm/VmsActionsBar.vue";
 import { useVmCollection } from "@/stores/xen-api/vm.store";
-import { POWER_STATE } from "@/libs/xen-api/xen-api.utils";
+import { VM_POWER_STATE } from "@/libs/xen-api/xen-api.enums";
 import { usePageTitleStore } from "@/stores/page-title.store";
 import { useUiStore } from "@/stores/ui.store";
 import type { Filters } from "@/types/filter";
@@ -62,7 +62,7 @@ const filters: Filters = {
     label: t("power-state"),
     icon: faPowerOff,
     type: "enum",
-    choices: Object.values(POWER_STATE),
+    choices: Object.values(VM_POWER_STATE),
   },
 };
 

--- a/@xen-orchestra/lite/src/views/vm/VmConsoleView.vue
+++ b/@xen-orchestra/lite/src/views/vm/VmConsoleView.vue
@@ -34,7 +34,7 @@ import UiSpinner from "@/components/ui/UiSpinner.vue";
 import { useConsoleCollection } from "@/stores/xen-api/console.store";
 import { useVmCollection } from "@/stores/xen-api/vm.store";
 import type { XenApiVm } from "@/libs/xen-api/xen-api.types";
-import { POWER_STATE, VM_OPERATION } from "@/libs/xen-api/xen-api.utils";
+import { VM_POWER_STATE, VM_OPERATION } from "@/libs/xen-api/xen-api.enums";
 import { usePageTitleStore } from "@/stores/page-title.store";
 import { useUiStore } from "@/stores/ui.store";
 import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
@@ -77,7 +77,7 @@ const hasError = computed(() => hasVmError.value || hasConsoleError.value);
 const vm = computed(() => getVmByUuid(route.params.uuid as XenApiVm["uuid"]));
 
 const isVmRunning = computed(
-  () => vm.value?.power_state === POWER_STATE.RUNNING
+  () => vm.value?.power_state === VM_POWER_STATE.RUNNING
 );
 
 const vmConsole = computed(() => {


### PR DESCRIPTION
### Description

New XenApi types and enums, generated from the xapi-project JSON file.

Enums have been moved from `xen-api.utils.ts` to `xen-api.enums.ts`.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
