### PR TITLE
fix(xo-web): fix naming conflict for duplicate variables

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,11 +30,8 @@
 
 <!--packages-start-->
 
-<<<<<<< HEAD
 - xen-api patch
 - xo-server minor
-=======
->>>>>>> 1d6153027 (changelog)
 - xo-web patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,8 +30,11 @@
 
 <!--packages-start-->
 
+<<<<<<< HEAD
 - xen-api patch
 - xo-server minor
+=======
+>>>>>>> 1d6153027 (changelog)
 - xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -659,8 +659,8 @@ export const editServer = (server, props) =>
 
 export const enableServer = server =>
   _call('server.enable', { id: resolveId(server) })
-    ::tapCatch(error => {
-      if (error.message === 'Invalid XML-RPC message') {
+    ::tapCatch(err => {
+      if (err.message === 'Invalid XML-RPC message') {
         error(_('enableServerErrorTitle'), _('enableServerErrorMessage'))
       }
     })


### PR DESCRIPTION
Introduced by https://github.com/vatesfr/xen-orchestra/commit/c9244b2b137db357d31c17ba732a06b93f656ace

### Description

Fix naming conflict for duplicate variables

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
