### PR TITLE
fix(xo-web/render-xo-item/PIF): hide parenthesis if no info inside

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,7 @@
 
 - [User] _Forget all connection tokens_ button should not delete other users' tokens, even when current user is an administrator (PR [#7014](https://github.com/vatesfr/xen-orchestra/pull/7014))
 - [Settings/Servers] Fix connection to old XenServer hosts using XML-RPC protocol (broken in XO 5.85.0)
+- [PIF] Remove empty parenthesis "()" when there's no extra info to show next to the PIF's name
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 
 - [User] _Forget all connection tokens_ button should not delete other users' tokens, even when current user is an administrator (PR [#7014](https://github.com/vatesfr/xen-orchestra/pull/7014))
 - [Settings/Servers] Fix connection to old XenServer hosts using XML-RPC protocol (broken in XO 5.85.0)
-- [PIF] Remove empty parenthesis "()" when there's no extra info to show next to the PIF's name
+- [PIF] Remove empty parenthesis "()" when there's no extra info to show next to the PIF's name (PR [#7022](https://github.com/vatesfr/xen-orchestra/pull/7022))
 
 ### Packages to release
 

--- a/packages/xo-web/src/common/render-xo-item.js
+++ b/packages/xo-web/src/common/render-xo-item.js
@@ -563,14 +563,20 @@ const xoItemToRender = {
   // PIF.
   PIF: ({ carrier, device, deviceName, vlan }) => (
     <span>
-      <Icon icon='network' color={carrier ? 'text-success' : 'text-danger'} /> {device} ({deviceName}
-      {deviceName !== '' && vlan !== -1 && ' - '}
-      {vlan !== -1 &&
-        _('keyValue', {
-          key: _('pifVlanLabel'),
-          value: vlan,
-        })}
-      )
+      <Icon icon='network' color={carrier ? 'text-success' : 'text-danger'} /> {device}
+      {(deviceName !== '' || vlan !== -1) && (
+        <span>
+          {' '}
+          ({deviceName}
+          {deviceName !== '' && vlan !== -1 && ' - '}
+          {vlan !== -1 &&
+            _('keyValue', {
+              key: _('pifVlanLabel'),
+              value: vlan,
+            })}
+          )
+        </span>
+      )}
     </span>
   ),
   // Tags.


### PR DESCRIPTION
See Zammad#17381

### Screenshots

Before:
![Capture_2023-09-06_10:36:41](https://github.com/vatesfr/xen-orchestra/assets/10992860/c6939def-e29c-4903-bdd0-684f23b91c03)

After:
![Capture_2023-09-06_10:36:12](https://github.com/vatesfr/xen-orchestra/assets/10992860/0a3781b2-69c0-4c09-935f-16af5a3c0403)

### Description

When a PIF doesn't have a `device_name` and its VLAN is -1, we show empty parenthesis next to the PIF's `device`, which is not necessary and confusing.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
