### PR TITLE
Fix host_smartReboot when VMs have a suspended operation block

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Host/Advanced] Allow to force _Smart reboot_ if some resident VMs have the suspend operation blocked [Forum#7136](https://xcp-ng.org/forum/topic/7136/suspending-vms-during-host-reboot/23) (PR [#7025](https://github.com/vatesfr/xen-orchestra/pull/7025))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -29,5 +31,6 @@
 
 - @xen-orchestra/xapi minor
 - xo-server minor
+- xo-web minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,4 +27,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/xapi minor
+- xo-server minor
+
 <!--packages-end-->

--- a/packages/xo-server/src/api/host.mjs
+++ b/packages/xo-server/src/api/host.mjs
@@ -119,7 +119,15 @@ set.resolve = {
 
 // FIXME: set force to false per default when correctly implemented in
 // UI.
-export async function restart({ bypassBackupCheck = false, host, force = false, suspendResidentVms }) {
+export async function restart({
+  bypassBackupCheck = false,
+  host,
+  force = false,
+  suspendResidentVms,
+
+  bypassBlockedSuspend = force,
+  bypassCurrentVmCheck = force,
+}) {
   if (bypassBackupCheck) {
     log.warn('host.restart with argument "bypassBackupCheck" set to true', { hostId: host.id })
   } else {
@@ -127,13 +135,23 @@ export async function restart({ bypassBackupCheck = false, host, force = false, 
   }
 
   const xapi = this.getXapi(host)
-  return suspendResidentVms ? xapi.host_smartReboot(host._xapiRef) : xapi.rebootHost(host._xapiId, force)
+  return suspendResidentVms
+    ? xapi.host_smartReboot(host._xapiRef, bypassBlockedSuspend, bypassCurrentVmCheck)
+    : xapi.rebootHost(host._xapiId, force)
 }
 
 restart.description = 'restart the host'
 
 restart.params = {
   bypassBackupCheck: {
+    type: 'boolean',
+    optional: true,
+  },
+  bypassBlockedSuspend: {
+    type: 'boolean',
+    optional: true,
+  },
+  bypassCurrentVmCheck: {
     type: 'boolean',
     optional: true,
   },

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -963,9 +963,13 @@ const messages = {
   enableHostLabel: 'Enable',
   disableHostLabel: 'Disable',
   restartHostAgent: 'Restart toolstack',
+  smartRebootBypassCurrentVmCheck:
+    'As the XOA is hosted on the host that is scheduled for a reboot, it will also be restarted. Consequently, XO won\'t be able to resume VMs, and VMs with the "Protect from accidental shutdown" option enabled will not have this option reactivated automatically.',
   smartRebootHostLabel: 'Smart reboot',
   smartRebootHostTooltip: 'Suspend resident VMs, reboot host and resume VMs automatically',
   forceRebootHostLabel: 'Force reboot',
+  forceSmartRebootHost:
+    'Smart Reboot failed because {nVms, number} VM{nVms, plural, one {} other {s}} ha{nVms, plural, one {s} other {ve}} {nVms, plural, one {its} other {their}} Suspend operation blocked. Would you like to force?',
   rebootHostLabel: 'Reboot',
   noHostsAvailableErrorTitle: 'Error while restarting host',
   noHostsAvailableErrorMessage:

--- a/packages/xo-web/src/xo-app/host/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/host/tab-advanced.js
@@ -76,7 +76,7 @@ const downloadLogs = async uuid => {
 const forceReboot = host => restartHost(host, true)
 
 const smartReboot = ALLOW_SMART_REBOOT
-  ? host => restartHost(host, false, true) // don't force, suspend resident VMs
+  ? host => restartHost(host, false, true, false, false) // don't force, suspend resident VMs, don't bypass blocked suspend, don't bypass current VM check
   : () => {}
 
 const formatPack = ({ name, author, description, version }, key) => (


### PR DESCRIPTION
### Screenshot

![Capture d’écran de 2023-09-29 15-00-09](https://github.com/vatesfr/xen-orchestra/assets/70369997/71461d6e-4ceb-4c48-9c4d-df141c6d6c47)
![Capture d’écran de 2023-10-03 16-22-23](https://github.com/vatesfr/xen-orchestra/assets/70369997/e0d9496d-b9c4-4eba-97d1-d27b12a4468d)

### Description

Do not squash

See [XCP-ng forum#7136](https://xcp-ng.org/forum/topic/7136/suspending-vms-during-host-reboot/23)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
