### PR TITLE
fix(xo-server-auth-google): bad argument passed to registerUser2

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Backup/Restore] Fix `Cannot read properties of undefined (reading 'id')` error when restoring via an XO Proxy (PR [#7026](https://github.com/vatesfr/xen-orchestra/pull/7026))
-- [Google Auth] Fix `Internal Server Error` (xo-server: `Cannot read properties of undefined (reading 'id')`) when logging in with Google [Forum#7729](https://xcp-ng.org/forum/topic/7729)
+- [Google Auth] Fix `Internal Server Error` (xo-server: `Cannot read properties of undefined (reading 'id')`) when logging in with Google [Forum#7729](https://xcp-ng.org/forum/topic/7729) (PR [#7031](https://github.com/vatesfr/xen-orchestra/pull/7031))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Backup/Restore] Fix `Cannot read properties of undefined (reading 'id')` error when restoring via an XO Proxy (PR [#7026](https://github.com/vatesfr/xen-orchestra/pull/7026))
+- [Google Auth] Fix `Internal Server Error` (xo-server: `Cannot read properties of undefined (reading 'id')`) when logging in with Google [Forum#7729](https://xcp-ng.org/forum/topic/7729)
 
 ### Packages to release
 
@@ -32,6 +33,7 @@
 <!--packages-start-->
 
 - xo-server patch
+- xo-server-auth-google patch
 - xo-server-netbox minor
 
 <!--packages-end-->

--- a/packages/xo-server-auth-google/src/index.js
+++ b/packages/xo-server-auth-google/src/index.js
@@ -53,8 +53,10 @@ class AuthGoogleXoPlugin {
           done(
             null,
             await xo.registerUser2('google', {
-              id: profile.id,
-              name: conf.scope === 'email' ? profile.emails[0].value : profile.displayName,
+              user: {
+                id: profile.id,
+                name: conf.scope === 'email' ? profile.emails[0].value : profile.displayName,
+              },
             })
           )
         } catch (error) {


### PR DESCRIPTION
Introduced by 91b19d9bc4b782d318112972c998e87d75f586af
See https://xcp-ng.org/forum/topic/7729

### Description

`registerUser2` expects `{ user: { id, name }, data }` instead of `{ id, name }` as 2nd argument.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
