### PR TITLE
fix(xo-server-auth-github): bad argument passed to registerUser2

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Backup/Restore] Fix `Cannot read properties of undefined (reading 'id')` error when restoring via an XO Proxy (PR [#7026](https://github.com/vatesfr/xen-orchestra/pull/7026))
-- [Google Auth] Fix `Internal Server Error` (xo-server: `Cannot read properties of undefined (reading 'id')`) when logging in with Google [Forum#7729](https://xcp-ng.org/forum/topic/7729) (PR [#7031](https://github.com/vatesfr/xen-orchestra/pull/7031))
+- [Google/GitHub Auth] Fix `Internal Server Error` (xo-server: `Cannot read properties of undefined (reading 'id')`) when logging in with Google or GitHub [Forum#7729](https://xcp-ng.org/forum/topic/7729) (PR [#7031](https://github.com/vatesfr/xen-orchestra/pull/7031))
 
 ### Packages to release
 
@@ -33,6 +33,7 @@
 <!--packages-start-->
 
 - xo-server patch
+- xo-server-auth-github patch
 - xo-server-auth-google patch
 - xo-server-netbox minor
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Backup/Restore] Fix `Cannot read properties of undefined (reading 'id')` error when restoring via an XO Proxy (PR [#7026](https://github.com/vatesfr/xen-orchestra/pull/7026))
-- [Google/GitHub Auth] Fix `Internal Server Error` (xo-server: `Cannot read properties of undefined (reading 'id')`) when logging in with Google or GitHub [Forum#7729](https://xcp-ng.org/forum/topic/7729) (PR [#7031](https://github.com/vatesfr/xen-orchestra/pull/7031))
+- [Google/GitHub Auth] Fix `Internal Server Error` (xo-server: `Cannot read properties of undefined (reading 'id')`) when logging in with Google or GitHub [Forum#7729](https://xcp-ng.org/forum/topic/7729) (PRs [#7031](https://github.com/vatesfr/xen-orchestra/pull/7031) [#7032](https://github.com/vatesfr/xen-orchestra/pull/7032))
 
 ### Packages to release
 

--- a/packages/xo-server-auth-github/src/index.js
+++ b/packages/xo-server-auth-github/src/index.js
@@ -38,7 +38,7 @@ class AuthGitHubXoPlugin {
     this._unregisterPassportStrategy = xo.registerPassportStrategy(
       new Strategy(this._conf, async (accessToken, refreshToken, profile, done) => {
         try {
-          done(null, await xo.registerUser2('github', { id: profile.id, name: profile.username }))
+          done(null, await xo.registerUser2('github', { user: { id: profile.id, name: profile.username } }))
         } catch (error) {
           done(error.message)
         }


### PR DESCRIPTION
Introduced by 562401ebe4e58332d2cce00f610563d14f7a64fe

### Description

`registerUser2` expects `{ user: { id, name }, data }` instead of `{ id, name }` as 2nd argument.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
