### PR TITLE
feat(xo-web,xo-server/xostor): ability to create XOSTOR SR from the UI

### DIFF
--- a/packages/xo-server/src/api/xostor.mjs
+++ b/packages/xo-server/src/api/xostor.mjs
@@ -1,5 +1,6 @@
 import { asyncEach } from '@vates/async-each'
 import { createLogger } from '@xen-orchestra/log'
+import { operationFailed } from 'xo-common/api-errors.js'
 
 const ENUM_PROVISIONING = {
   Thin: 'thin',
@@ -104,8 +105,8 @@ formatDisks.resolve = {
   host: ['host', 'host', 'administrate'],
 }
 
-export async function create({ description, disksByHosts, force, ignoreFileSystems, name, provisioning, replication }) {
-  const hostIds = Object.keys(disksByHosts)
+export async function create({ description, disksByHost, force, ignoreFileSystems, name, provisioning, replication }) {
+  const hostIds = Object.keys(disksByHost)
   const hosts = hostIds.map(hostId => this.getObject(hostId, 'host'))
 
   if (!hosts.every(host => host.$pool === hosts[0].$pool)) {
@@ -116,18 +117,30 @@ export async function create({ description, disksByHosts, force, ignoreFileSyste
   const boundInstallDependencies = installDependencies.bind(this)
   await asyncEach(hosts, host => boundInstallDependencies({ host }), { stopOnError: false })
   const boundFormatDisks = formatDisks.bind(this)
-  await asyncEach(
-    hosts,
-    host => boundFormatDisks({ disks: disksByHosts[host.id], host, force, ignoreFileSystems, provisioning }),
-    {
-      stopOnError: false,
-    },
-  )
+  try {
+    await asyncEach(
+      hosts,
+      host => boundFormatDisks({ disks: disksByHost[host.id], host, force, ignoreFileSystems, provisioning }),
+      {
+        stopOnError: false,
+      }
+    )
+  } catch (error) {
+    log.error(error.errors[0])
+    const isForceRequired = error.errors.every(error => error.code === 'LVM_ERROR(5)')
+
+    if (isForceRequired) {
+      throw operationFailed({ objectId: hostIds, code: 'VG_GROUP_ALREADY_EXIST' })
+    }
+
+    throw error
+  }
 
   const host = hosts[0]
+  const xapi = this.getXapi(host)
 
   log.info(`Create XOSTOR (${name}) with provisioning: ${provisioning}`)
-  return this.getXapi(host).SR_create({
+  const srRef = await this.getXapi(host).SR_create({
     device_config: {
       'group-name': 'linstor_group/' + LV_NAME,
       redundancy: String(replication),
@@ -139,12 +152,14 @@ export async function create({ description, disksByHosts, force, ignoreFileSyste
     shared: true,
     type: 'linstor',
   })
+
+  return xapi.getObject(srRef).uuid
 }
 create.description = 'Create a XOSTOR storage'
 create.permission = 'admin'
 create.params = {
   description: { type: 'string', optional: true, default: 'From XO-server' },
-  disksByHosts: { type: 'object' },
+  disksByHost: { type: 'object' },
   force: { type: 'boolean', optional: true, default: false },
   ignoreFileSystems: { type: 'boolean', optional: true, default: false },
   name: { type: 'string' },

--- a/packages/xo-server/src/api/xostor.mjs
+++ b/packages/xo-server/src/api/xostor.mjs
@@ -130,7 +130,7 @@ export async function create({ description, disksByHost, force, ignoreFileSystem
     const isForceRequired = error.errors.every(error => error.code === 'LVM_ERROR(5)')
 
     if (isForceRequired) {
-      throw operationFailed({ objectId: hostIds, code: 'VG_GROUP_ALREADY_EXIST' })
+      throw operationFailed({ objectId: hostIds, code: 'VG_GROUP_ALREADY_EXISTS' })
     }
 
     throw error

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2475,6 +2475,8 @@ const messages = {
   xostor: 'XOSTOR',
   xostorDiskRequired: 'At least one disk is required',
   xostorDisksDropdownLabel: '({nDisks, number} disk{nDisks, plural, one {} other {s}}) {hostname}',
+  xostorFailedVgAlreadyExist:
+    'Failed to format disks due to a VG group "linstor_group" already present on the hosts. Do you want to delete these VG groups?',
   xostorPackagesWillBeInstalled: '"xcp-ng-release-linstor" and "xcp-ng-linstor" will be installed on each host',
   xostorReplicationWarning: 'If a disk dies, you will lose data',
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2475,8 +2475,8 @@ const messages = {
   xostor: 'XOSTOR',
   xostorDiskRequired: 'At least one disk is required',
   xostorDisksDropdownLabel: '({nDisks, number} disk{nDisks, plural, one {} other {s}}) {hostname}',
-  xostorFailedVgAlreadyExist:
-    'Failed to format disks due to a VG group "linstor_group" already present on the hosts. Do you want to delete these VG groups?',
+  xostorFailedVgAlreadyExists:
+    "Formatting disks failed because a VG group named 'linstor_group' already exists on the hosts. Do you want to delete these VG groups?",
   xostorPackagesWillBeInstalled: '"xcp-ng-release-linstor" and "xcp-ng-linstor" will be installed on each host',
   xostorReplicationWarning: 'If a disk dies, you will lose data',
 

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -3373,13 +3373,12 @@ export const updateXosanPacks = pool =>
 
 // XOSTOR   --------------------------------------------------------------------
 
-export const createXostorSr = (xostorParams, opts = {}) => {
-  const params = { ...xostorParams, ...opts }
+export const createXostorSr = params => {
   return _call('xostor.create', params).catch(async error => {
-    if (operationFailed.is(error, { code: 'VG_GROUP_ALREADY_EXIST' })) {
+    if (operationFailed.is(error, { code: 'VG_GROUP_ALREADY_EXISTS' })) {
       await confirm({
         title: _('xostor'),
-        body: _('xostorFailedVgAlreadyExist'),
+        body: _('xostorFailedVgAlreadyExists'),
         icon: 'error',
       })
 

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -16,6 +16,7 @@ import {
   incorrectState,
   noHostsAvailable,
   operationBlocked,
+  operationFailed,
   vmLacksFeature,
 } from 'xo-common/api-errors'
 
@@ -3369,6 +3370,25 @@ export const updateXosanPacks = pool =>
 
     return downloadAndInstallXosanPack(pack, pool, { version: pack.version })
   })
+
+// XOSTOR   --------------------------------------------------------------------
+
+export const createXostorSr = (xostorParams, opts = {}) => {
+  const params = { ...xostorParams, ...opts }
+  return _call('xostor.create', params).catch(async error => {
+    if (operationFailed.is(error, { code: 'VG_GROUP_ALREADY_EXIST' })) {
+      await confirm({
+        title: _('xostor'),
+        body: _('xostorFailedVgAlreadyExist'),
+        icon: 'error',
+      })
+
+      params.force = true
+      return _call('xostor.create', params)
+    }
+    throw error
+  })
+}
 
 // Licenses --------------------------------------------------------------------
 

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -3373,8 +3373,10 @@ export const updateXosanPacks = pool =>
 
 // XOSTOR   --------------------------------------------------------------------
 
-export const createXostorSr = params => {
-  return _call('xostor.create', params).catch(async error => {
+export const createXostorSr = async params => {
+  try {
+    return await _call('xostor.create', params)
+  } catch (error) {
     if (operationFailed.is(error, { code: 'VG_GROUP_ALREADY_EXISTS' })) {
       await confirm({
         title: _('xostor'),
@@ -3386,7 +3388,7 @@ export const createXostorSr = params => {
       return _call('xostor.create', params)
     }
     throw error
-  })
+  }
 }
 
 // Licenses --------------------------------------------------------------------

--- a/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
+++ b/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
@@ -496,13 +496,14 @@ const NewXostorForm = decorate([
       async createXostorSr() {
         const { disksByHost, srDescription, srName, provisioning, replication } = this.state
 
+        const _disksByHost = { ...disksByHost }
         for (const [hostId, disks] of Object.entries(disksByHost)) {
-          disksByHost[hostId] = disks.map(disk => formatDiskName(disk.name))
+          _disksByHost[hostId] = disks.map(disk => formatDiskName(disk.name))
         }
 
         this.state._createdSrUuid = await createXostorSr({
           description: srDescription.trim() === '' ? undefined : srDescription.trim(),
-          disksByHost,
+          disksByHost: _disksByHost,
           name: srName.trim() === '' ? undefined : srName.trim(),
           provisioning: provisioning.value,
           replication: replication.value,
@@ -560,7 +561,7 @@ const NewXostorForm = decorate([
         <Row>
           <ActionButton
             btnStyle='primary'
-            disabled={false}
+            disabled={state.isFormInvalid}
             handler={effects.createXostorSr}
             icon='add'
             redirectOnSuccess={getSrPath}

--- a/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
+++ b/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
@@ -423,6 +423,7 @@ const SummaryCard = decorate([
               </Row>
               <Row>
                 <Col size={12}>{_('keyValue', { key: _('pool'), value: <PoolRenderItem id={state.poolId} /> })}</Col>
+                {/* FIXME: XOSTOR network management is not yet implemented at XOSTOR level */}
                 {/* <Col size={6}>
                   {_('keyValue', { key: _('network'), value: <NetworkRenderItem id={state.networkId} /> })}
                 </Col> */}
@@ -526,14 +527,13 @@ const NewXostorForm = decorate([
       isFormInvalid: state =>
         state.isReplicationMissing || state.isProvisioningMissing || state.isNameMissing || state.isDisksMissing,
       isXcpngHost: state => isXcpngHost(first(state.poolHosts)),
+      getSrPath: state => () => `/srs/${state._createdSrUuid}`,
       // State ============
       networkId: state => (state._networkId === undefined ? state._defaultNetworkId : state._networkId),
     },
   }),
   injectState,
   ({ effects, resetState, state, hostsByPoolId, networks, pifs }) => {
-    const getSrPath = () => `/srs/${state._createdSrUuid}`
-
     return (
       <Container>
         <Row>
@@ -564,7 +564,7 @@ const NewXostorForm = decorate([
             disabled={state.isFormInvalid}
             handler={effects.createXostorSr}
             icon='add'
-            redirectOnSuccess={getSrPath}
+            redirectOnSuccess={state.getSrPath}
           >
             {_('create')}
           </ActionButton>

--- a/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
+++ b/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
@@ -9,7 +9,7 @@ import { Card, CardBlock, CardHeader } from 'card'
 import { connectStore, formatSize } from 'utils'
 import { Container, Col, Row } from 'grid'
 import { createGetObjectsOfType } from 'selectors'
-import { find, first, map, remove, size, some } from 'lodash'
+import { find, first, map, mapValues, remove, size, some } from 'lodash'
 import { createXostorSr, getBlockdevices } from 'xo'
 import { injectState, provideState } from 'reaclette'
 import { Input as DebounceInput } from 'debounce-input-decorator'
@@ -497,14 +497,9 @@ const NewXostorForm = decorate([
       async createXostorSr() {
         const { disksByHost, srDescription, srName, provisioning, replication } = this.state
 
-        const _disksByHost = { ...disksByHost }
-        for (const [hostId, disks] of Object.entries(disksByHost)) {
-          _disksByHost[hostId] = disks.map(disk => formatDiskName(disk.name))
-        }
-
         this.state._createdSrUuid = await createXostorSr({
           description: srDescription.trim() === '' ? undefined : srDescription.trim(),
-          disksByHost: _disksByHost,
+          disksByHost: mapValues(disksByHost, disks => disks.map(disk => formatDiskName(disk.name))),
           name: srName.trim() === '' ? undefined : srName.trim(),
           provisioning: provisioning.value,
           replication: replication.value,
@@ -533,48 +528,47 @@ const NewXostorForm = decorate([
     },
   }),
   injectState,
-  ({ effects, resetState, state, hostsByPoolId, networks, pifs }) => {
-    return (
-      <Container>
-        <Row>
-          <Col size={6}>
-            <StorageCard />
-          </Col>
-          <Col size={6}>
-            <SettingsCard />
-          </Col>
-        </Row>
-        <Row>
-          <Col size={12}>
-            <PoolCard hostsByPoolId={hostsByPoolId} />
-          </Col>
-          {/* <Col size={6}>
+  ({ effects, resetState, state, hostsByPoolId, networks, pifs }) => (
+    <Container>
+      <Row>
+        <Col size={6}>
+          <StorageCard />
+        </Col>
+        <Col size={6}>
+          <SettingsCard />
+        </Col>
+      </Row>
+      <Row>
+        <Col size={12}>
+          <PoolCard hostsByPoolId={hostsByPoolId} />
+        </Col>
+        {/* FIXME: XOSTOR network management is not yet implemented at XOSTOR level */}
+        {/* <Col size={6}>
             <NetworkCard networks={networks} pifs={pifs} />
           </Col> */}
-        </Row>
-        <Row>
-          <DisksCard />
-        </Row>
-        <Row>
-          <SummaryCard />
-        </Row>
-        <Row>
-          <ActionButton
-            btnStyle='primary'
-            disabled={state.isFormInvalid}
-            handler={effects.createXostorSr}
-            icon='add'
-            redirectOnSuccess={state.getSrPath}
-          >
-            {_('create')}
-          </ActionButton>
-          <ActionButton className='ml-1' handler={resetState} icon='reset'>
-            {_('formReset')}
-          </ActionButton>
-        </Row>
-      </Container>
-    )
-  },
+      </Row>
+      <Row>
+        <DisksCard />
+      </Row>
+      <Row>
+        <SummaryCard />
+      </Row>
+      <Row>
+        <ActionButton
+          btnStyle='primary'
+          disabled={state.isFormInvalid}
+          handler={effects.createXostorSr}
+          icon='add'
+          redirectOnSuccess={state.getSrPath}
+        >
+          {_('create')}
+        </ActionButton>
+        <ActionButton className='ml-1' handler={resetState} icon='reset'>
+          {_('formReset')}
+        </ActionButton>
+      </Row>
+    </Container>
+  ),
 ])
 
 export default NewXostorForm


### PR DESCRIPTION
### Description

A test pool is available at: 172.16.210.83.
If you'd like to test the scenario where the `VG_GROUP_ALREADY_EXISTS` error occurs, follow these steps:
- If there's already an XOSTOR storage, delete it using XOA
- SSH into the pool master. `ssh root@172.16.210.83`
- Create a new Volume Group called 'linstor_group' `vgcreate linstor_group /dev/sdb`
- Make sure the VG group was created successfully. `vgs`
- Now, try creating a new XOSTOR storage, and don't forget to select at least one disk on the pool master to make the error happen.

The Network section has been commented out, as it is not yet implemented at the XCP-ng level.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
