### PR TITLE
fix(lite/composable): useSubscriber is disabled by default

### DIFF
--- a/@xen-orchestra/lite/src/composables/subscriber.composable.ts
+++ b/@xen-orchestra/lite/src/composables/subscriber.composable.ts
@@ -15,7 +15,7 @@ export type SubscriberOptions = {
 export const useSubscriber = ({
   onSubscriptionStart,
   onSubscriptionEnd,
-  enabled,
+  enabled = true,
   dependencies,
 }: SubscriberOptions = {}) => {
   const subscribers = ref(new Set<symbol>());


### PR DESCRIPTION
### Description

This PR fix the `useSubscribe` composable to be enabled by default

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
