### PR TITLE
fix(xo-server): ova export with files bigger than 8.2GB

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,7 @@
 - [Backup/Restore] Fix `Cannot read properties of undefined (reading 'id')` error when restoring via an XO Proxy (PR [#7026](https://github.com/vatesfr/xen-orchestra/pull/7026))
 - [Google/GitHub Auth] Fix `Internal Server Error` (xo-server: `Cannot read properties of undefined (reading 'id')`) when logging in with Google or GitHub [Forum#7729](https://xcp-ng.org/forum/topic/7729) (PRs [#7031](https://github.com/vatesfr/xen-orchestra/pull/7031) [#7032](https://github.com/vatesfr/xen-orchestra/pull/7032))
 - [Jobs] Fix schedules not being displayed on first load [#6968](https://github.com/vatesfr/xen-orchestra/issues/6968) (PR [#7034](https://github.com/vatesfr/xen-orchestra/pull/7034))
-- [Export] Fix Ova export with disk content bigger than 8.2GB (PR [#7047](https://github.com/vatesfr/xen-orchestra/pull/7047))
+- [OVA Export] Fix support of disks with more than 8.2GiB of content (PR [#7047](https://github.com/vatesfr/xen-orchestra/pull/7047))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 - [Backup/Restore] Fix `Cannot read properties of undefined (reading 'id')` error when restoring via an XO Proxy (PR [#7026](https://github.com/vatesfr/xen-orchestra/pull/7026))
 - [Google/GitHub Auth] Fix `Internal Server Error` (xo-server: `Cannot read properties of undefined (reading 'id')`) when logging in with Google or GitHub [Forum#7729](https://xcp-ng.org/forum/topic/7729) (PRs [#7031](https://github.com/vatesfr/xen-orchestra/pull/7031) [#7032](https://github.com/vatesfr/xen-orchestra/pull/7032))
 - [Jobs] Fix schedules not being displayed on first load [#6968](https://github.com/vatesfr/xen-orchestra/issues/6968) (PR [#7034](https://github.com/vatesfr/xen-orchestra/pull/7034))
+- [Export] Fix Ova export with disk content bigger than 8.2GB (PR [#7047](https://github.com/vatesfr/xen-orchestra/pull/7047))
 
 ### Packages to release
 

--- a/packages/xo-server/package.json
+++ b/packages/xo-server/package.json
@@ -123,7 +123,7 @@
     "stoppable": "^1.0.5",
     "subleveldown": "^6.0.1",
     "syslog-client": "^1.1.1",
-    "tar-stream": "^2.0.1",
+    "tar-stream": "^3.1.6",
     "tmp": "^0.2.1",
     "unzipper": "^0.10.5",
     "uuid": "^9.0.0",


### PR DESCRIPTION
### Description

test : import still work with this ova : https://xcp-ng.org/forum/topic/7162/error-importing-ova-file-expected-grain-marker-received-object-object/3?lang=fr
export of a file with bigger entries work 

following https://github.com/vatesfr/xen-orchestra/commit/15f69a19f5ae013c0d64f81679ddd3d3851f6553 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
