### PR TITLE
fix(xo-server): add mbr for cloud-init only for windows VM

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Backup/Mirror] Fix backup report not being sent (PR [#7049](https://github.com/vatesfr/xen-orchestra/pull/7049))
-- [Cloudinit] Fix Kaleos VM not bootable (PR [#7050](https://github.com/vatesfr/xen-orchestra/pull/7050))
+- [New VM] Only add MBR to cloud-init drive on Windows VMs to avoid booting issues (e.g. with Talos) (PR [#7050](https://github.com/vatesfr/xen-orchestra/pull/7050))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Backup/Mirror] Fix backup report not being sent (PR [#7049](https://github.com/vatesfr/xen-orchestra/pull/7049))
+- [Cloudinit] Fix Kaleos VM not bootable (PR [#7050](https://github.com/vatesfr/xen-orchestra/pull/7050))
 
 ### Packages to release
 
@@ -30,5 +31,6 @@
 <!--packages-start-->
 
 - xo-server-backup-reports patch
+- xo-server patch
 
 <!--packages-end-->

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -1328,7 +1328,10 @@ export default class Xapi extends XapiBase {
         )
       ),
     ])
-    buffer = addMbr(buffer)
+    // only add the MBR for windows VM
+    if (vm.platform?.virdian === true) {
+      buffer = addMbr(buffer)
+    }
     const vdi = await this._getOrWaitObject(
       await this.VDI_create({
         name_label: 'XO CloudConfigDrive',

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -1329,7 +1329,7 @@ export default class Xapi extends XapiBase {
       ),
     ])
     // only add the MBR for windows VM
-    if (vm.platform?.virdian === true) {
+    if (vm.platform.viridian === 'true') {
       buffer = addMbr(buffer)
     }
     const vdi = await this._getOrWaitObject(


### PR DESCRIPTION
### Description

Kaleos use a minimal boot loader that don't like he MBR introduced by #6889 

This PR try to add MBR only for windows template, by using the viridian flag in the platform property

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
