### PR TITLE
fix(xo-vmdk-to-vhd): handle ova with disk position collision

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
 - [OVA Export] Fix support of disks with more than 8.2GiB of content (PR [#7047](https://github.com/vatesfr/xen-orchestra/pull/7047))
 - [Backup] Fix `VHDFile implementation is not compatible with encrypted remote` when using VHD directory with encryption (PR [#7045](https://github.com/vatesfr/xen-orchestra/pull/7045))
 - [Backup/Mirror] Fix `xo:fs:local WARN lock compromised` when mirroring a Backup Repository to a local/NFS/SMB repository ([#7043](https://github.com/vatesfr/xen-orchestra/pull/7043))
+- [Ova import] Fix importing VM with collision in disk position (PR [#7051](https://github.com/vatesfr/xen-orchestra/pull/7051)) (issue [7046](https://github.com/vatesfr/xen-orchestra/issues/7046))
 
 ### Packages to release
 
@@ -38,6 +39,7 @@
 
 - @xen-orchestra/backups patch
 - vhd-lib minor
+- xo-vmdk-to-vhd patch
 - xo-server patch
 - xo-server-auth-github patch
 - xo-server-auth-google patch

--- a/packages/xo-vmdk-to-vhd/src/ova-read.js
+++ b/packages/xo-vmdk-to-vhd/src/ova-read.js
@@ -132,7 +132,7 @@ const allocationUnitsToFactor = unit => {
 }
 
 const cleanDisks = disks => {
-  const usedPositions = []
+  const usedPositions = new Set()
   let nextPosition = Object.keys(disks).length
   for (const diskId in disks) {
     let position = disks[diskId].position
@@ -141,14 +141,14 @@ const cleanDisks = disks => {
       console.error(`No position specified for '${diskId}'.`)
       delete disks[diskId]
     } else {
-      if (usedPositions.includes(position)) {
+      if (usedPositions.has(position)) {
         console.warn(
           `There is at least two disks with position ${position}, we're changing the second one to ${nextPosition}`
         )
         disks[diskId].position = position = nextPosition
         nextPosition++
       }
-      usedPositions.push(position)
+      usedPositions.add(position)
     }
   }
 }


### PR DESCRIPTION
### Description

some ova have multiple disks with the same position 

this may lead to unbootable VM in case the renumeroted disk was the bootable one ( VMware-VirtualSAN-Witness-7.0.0-15843807.ova for example )  

from #7046 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
