### PR TITLE
feat(xo-web/XOA/Support): button to restart xo-server service

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,11 +8,12 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - [Netbox] Don't delete VMs that have been created manually in XO-synced cluster [Forum#7639](https://xcp-ng.org/forum/topic/7639) (PR [#7008](https://github.com/vatesfr/xen-orchestra/pull/7008))
-- [Kubernetes] *Search domains* field is now optional [#7028](https://github.com/vatesfr/xen-orchestra/pull/7028)
+- [Kubernetes] _Search domains_ field is now optional [#7028](https://github.com/vatesfr/xen-orchestra/pull/7028)
 - [Patches] Support new XenServer Updates system. See [our documentation](https://xen-orchestra.com/docs/updater.html#xenserver-updates). (PR [#7044](https://github.com/vatesfr/xen-orchestra/pull/7044))
 - [REST API] Hosts' audit and system logs can be downloaded [#3968](https://github.com/vatesfr/xen-orchestra/issues/3968) (PR [#7048](https://github.com/vatesfr/xen-orchestra/pull/7048))
 - [Host/Advanced] New button to download system logs [#3968](https://github.com/vatesfr/xen-orchestra/issues/3968) (PR [#7048](https://github.com/vatesfr/xen-orchestra/pull/7048))
 - [Home/Hosts, Pools] Display host brand and version (PR [#7027](https://github.com/vatesfr/xen-orchestra/pull/7027))
+- [XOA] New button to restart XO Server directly from the UI
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 - [REST API] Hosts' audit and system logs can be downloaded [#3968](https://github.com/vatesfr/xen-orchestra/issues/3968) (PR [#7048](https://github.com/vatesfr/xen-orchestra/pull/7048))
 - [Host/Advanced] New button to download system logs [#3968](https://github.com/vatesfr/xen-orchestra/issues/3968) (PR [#7048](https://github.com/vatesfr/xen-orchestra/pull/7048))
 - [Home/Hosts, Pools] Display host brand and version (PR [#7027](https://github.com/vatesfr/xen-orchestra/pull/7027))
-- [XOA] New button to restart XO Server directly from the UI
+- [XOA] New button to restart XO Server directly from the UI (PR [#7056](https://github.com/vatesfr/xen-orchestra/pull/7056))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -240,6 +240,8 @@ const messages = {
   xoaCheck: 'XOA check',
   closeTunnel: 'Close tunnel',
   createSupportTicket: 'Create a support ticket',
+  restartXoServer: 'Restart XO Server',
+  restartXoServerConfirm: 'Restarting XO Server will interrupt any backup job or XO task that is currently running. Xen Orchestra will also be unavailable for a few seconds. Are you sure you want to restart XO Server?',
   openTunnel: 'Open tunnel',
   supportCommunity: 'The XOA check and the support tunnel are available in XOA.',
   supportTunnel: 'Support tunnel',

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -3436,6 +3436,19 @@ export const getApplianceInfo = () => _call('xoa.getApplianceInfo')
 
 export const getApiApplianceInfo = () => fetch('./rest/v0/appliance').then(resp => resp.json())
 
+export const restartXoServer = async () => {
+  await confirm({
+    icon: 'restart',
+    title: _('restartXoServer'),
+    body: _('restartXoServerConfirm'),
+    strongConfirm: {
+      messageId: 'restartXoServer',
+    },
+  })
+
+  await _call('xoa.restartXoServer')
+}
+
 // Proxy --------------------------------------------------------------------
 
 export const getAllProxies = () => _call('proxy.getAll')

--- a/packages/xo-web/src/icons.scss
+++ b/packages/xo-web/src/icons.scss
@@ -1235,6 +1235,10 @@
     @extend .fa;
     @extend .fa-cloud-upload;
   }
+  &-restart {
+    @extend .fa;
+    @extend .fa-refresh;
+  }
 
   // XOSAN related
 

--- a/packages/xo-web/src/xo-app/xoa/support/index.js
+++ b/packages/xo-web/src/xo-app/xoa/support/index.js
@@ -7,7 +7,7 @@ import { addSubscriptions, adminOnly, getXoaPlan } from 'utils'
 import { Card, CardBlock, CardHeader } from 'card'
 import { Container, Row, Col } from 'grid'
 import { injectState, provideState } from 'reaclette'
-import { closeTunnel, openTunnel, subscribeTunnelState } from 'xo'
+import { closeTunnel, openTunnel, restartXoServer, subscribeTunnelState } from 'xo'
 import { reportOnSupportPanel } from 'report-bug-button'
 
 const ansiUp = new AnsiUp()
@@ -42,6 +42,9 @@ const Support = decorate([
         <Col>
           <ActionButton btnStyle='primary' disabled={COMMUNITY} handler={reportOnSupportPanel} icon='ticket'>
             {_('createSupportTicket')}
+          </ActionButton>
+          <ActionButton btnStyle='danger' disabled={COMMUNITY} handler={restartXoServer} icon='restart' className='ml-1'>
+            {_('restartXoServer')}
           </ActionButton>
         </Col>
       </Row>


### PR DESCRIPTION
### Screenshots

![Capture_2023-09-26_12:32:52](https://github.com/vatesfr/xen-orchestra/assets/10992860/e3f0c331-00a0-48db-8dab-b9a9dd399ae7)
![Capture_2023-09-26_12:32:25](https://github.com/vatesfr/xen-orchestra/assets/10992860/f5d36680-2adc-4884-9881-3c598524f287)

### Description

Call `xoa.restartXoServer` to restart xo-server service.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
