### PR TITLE
feat(xo-server): implement disk status check

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,7 +34,7 @@
 - @xen-orchestra/xapi minor
 - vhd-lib patch
 - xo-server-backup-reports patch
-- xo-server patch
+- xo-server minor
 - xo-web patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Host/Advanced] Display system disks health based on the _smartctl_ plugin. [#4458](https://github.com/vatesfr/xen-orchestra/issues/4458) (PR [#7060](https://github.com/vatesfr/xen-orchestra/pull/7060))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -35,6 +37,6 @@
 - vhd-lib patch
 - xo-server-backup-reports patch
 - xo-server minor
-- xo-web patch
+- xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-server/src/api/host.mjs
+++ b/packages/xo-server/src/api/host.mjs
@@ -456,3 +456,52 @@ setControlDomainMemory.params = {
 setControlDomainMemory.resolve = {
   host: ['id', 'host', 'administrate'],
 }
+
+// -------------------------------------------------------------------
+/**
+ *
+ * @param {{host:HOST}} params
+ * @returns null if plugin is not installed or don't have the method
+ *          an object device: status on success
+ */
+export function getSmartctlHealth({ host }) {
+  return this.getXapi(host).getSmartctlHealth(host._xapiId)
+}
+
+getSmartctlHealth.description = 'get smartctl health status'
+
+getSmartctlHealth.params = {
+  id: { type: 'string' },
+}
+
+getSmartctlHealth.resolve = {
+  host: ['id', 'host', 'view'],
+}
+
+/**
+ *
+ * @param {{host:HOST}} params
+ * @returns null if plugin is not installed or don't have the method
+ *          an object device: full device information on success
+ */
+export function getSmartctlInformation({ host, deviceNames }) {
+  return this.getXapi(host).getSmartctlInformation(host._xapiId, deviceNames)
+}
+
+getSmartctlInformation.description = 'get smartctl information'
+
+getSmartctlInformation.params = {
+  id: { type: 'string' },
+
+  deviceNames: {
+    type: 'array',
+    items: {
+      type: 'string',
+    },
+    optional: true,
+  },
+}
+
+getSmartctlInformation.resolve = {
+  host: ['id', 'host', 'view'],
+}

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -12,6 +12,7 @@ import mixin from '@xen-orchestra/mixin/legacy.js'
 import ms from 'ms'
 import noop from 'lodash/noop.js'
 import once from 'lodash/once.js'
+import pick from 'lodash/pick.js'
 import tarStream from 'tar-stream'
 import uniq from 'lodash/uniq.js'
 import { asyncMap } from '@xen-orchestra/async-map'
@@ -1420,6 +1421,36 @@ export default class Xapi extends XapiBase {
           {}
         )) !== 'false'
       )
+    } catch (error) {
+      if (error.code === 'XENAPI_MISSING_PLUGIN' || error.code === 'UNKNOWN_XENAPI_PLUGIN_FUNCTION') {
+        return null
+      } else {
+        throw error
+      }
+    }
+  }
+
+  async getSmartctlHealth(hostId) {
+    try {
+      return JSON.parse(await this.call('host.call_plugin', this.getObject(hostId).$ref, 'smartctl.py', 'health', {}))
+    } catch (error) {
+      if (error.code === 'XENAPI_MISSING_PLUGIN' || error.code === 'UNKNOWN_XENAPI_PLUGIN_FUNCTION') {
+        return null
+      } else {
+        throw error
+      }
+    }
+  }
+
+  async getSmartctlInformation(hostId, deviceNames) {
+    try {
+      const informations = JSON.parse(
+        await this.call('host.call_plugin', this.getObject(hostId).$ref, 'smartctl.py', 'information', {})
+      )
+      if (deviceNames === undefined) {
+        return informations
+      }
+      return pick(informations, deviceNames)
     } catch (error) {
       if (error.code === 'XENAPI_MISSING_PLUGIN' || error.code === 'UNKNOWN_XENAPI_PLUGIN_FUNCTION') {
         return null

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -981,6 +981,7 @@ const messages = {
   // ----- host stat tab -----
   statLoad: 'Load average',
   // ----- host advanced tab -----
+  disksSystemHealthy: 'All disks are healthy ✅',
   editHostIscsiIqnTitle: 'Edit iSCSI IQN',
   editHostIscsiIqnMessage:
     'Are you sure you want to edit the iSCSI IQN? This may result in failures connecting to existing SRs if the host is attached to iSCSI SRs.',
@@ -1031,6 +1032,7 @@ const messages = {
   hostRemoteSyslog: 'Remote syslog',
   hostIommu: 'IOMMU',
   hostNoCertificateInstalled: 'No certificates installed on this host',
+  smartctlPluginNotInstalled: 'Smartctl plugin not installed',
   supplementalPacks: 'Installed supplemental packs',
   supplementalPackNew: 'Install new supplemental pack',
   supplementalPackPoolNew: 'Install supplemental pack on every host',
@@ -1041,6 +1043,7 @@ const messages = {
   supplementalPackInstallErrorMessage: 'The installation of the supplemental pack failed.',
   supplementalPackInstallSuccessTitle: 'Installation success',
   supplementalPackInstallSuccessMessage: 'Supplemental pack successfully installed.',
+  systemDisksHealth: 'System disks health',
   uniqueHostIscsiIqnInfo: 'The iSCSI IQN must be unique. ',
   // ----- Host net tabs -----
   networkCreateButton: 'Add a network',

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -1024,6 +1024,11 @@ export const isHyperThreadingEnabledHost = host =>
     id: resolveId(host),
   })
 
+export const getSmartctlHealth = host => _call('host.getSmartctlHealth', { id: resolveId(host) })
+
+export const getSmartctlInformation = (host, deviceNames) =>
+  _call('host.getSmartctlInformation', { id: resolveId(host), deviceNames })
+
 export const installCertificateOnHost = (id, props) => _call('host.installCertificate', { id, ...props })
 
 export const setControlDomainMemory = (id, memory) => _call('host.setControlDomainMemory', { id, memory })

--- a/packages/xo-web/src/xo-app/host/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/host/tab-advanced.js
@@ -171,7 +171,7 @@ export default class extends Component {
     }
 
     this.setState({
-      isHtEnabled: await isHyperThreadingEnabledHost(this.props.host),
+      isHtEnabled: await isHyperThreadingEnabledHost(this.props.host).catch(() => null),
     })
   }
 


### PR DESCRIPTION
### Screenshot

![Capture d’écran de 2023-09-28 16-59-04](https://github.com/vatesfr/xen-orchestra/assets/70369997/aea3c985-4fea-4c04-8c8f-bd561c1c4e5d)
![Capture d’écran de 2023-09-28 10-49-08](https://github.com/vatesfr/xen-orchestra/assets/70369997/40612f6e-15f1-4acc-a594-9786b92a07c7)
![Capture d’écran de 2023-09-28 10-55-57](https://github.com/vatesfr/xen-orchestra/assets/70369997/e27c00fe-824a-4017-b103-a0fa8c770151)

### Description

See [#4458](https://github.com/vatesfr/xen-orchestra/issues/4458)

expose disk status check from plugin https://github.com/xcp-ng/xcp-ng-xapi-plugins#smartctl-parser by @AtaxyaNetwork 


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
