### PR TITLE
Log failed auth

### DIFF
--- a/@xen-orchestra/mixins/Tasks.mjs
+++ b/@xen-orchestra/mixins/Tasks.mjs
@@ -135,10 +135,10 @@ export default class Tasks extends EventEmitter {
    *
    * @returns {Task}
    */
-  create({ name, objectId, userId = this.#app.apiContext?.user?.id, type }) {
+  create({ name, objectId, userId = this.#app.apiContext?.user?.id, type, ...props }) {
     const tasks = this.#tasks
 
-    const task = new Task({ properties: { name, objectId, userId, type }, onProgress: this.#onProgress })
+    const task = new Task({ properties: { ...props, name, objectId, userId, type }, onProgress: this.#onProgress })
 
     // Use a compact, sortable, string representation of the creation date
     //

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,6 +33,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/mixins minor
 - @xen-orchestra/xapi minor
 - vhd-lib patch
 - xo-server-backup-reports patch

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,6 +8,7 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - [Host/Advanced] Display system disks health based on the _smartctl_ plugin. [#4458](https://github.com/vatesfr/xen-orchestra/issues/4458) (PR [#7060](https://github.com/vatesfr/xen-orchestra/pull/7060))
+- [Authentication] Failed attempts are now logged as XO tasks (PR [#7061](https://github.com/vatesfr/xen-orchestra/pull/7061))
 
 ### Bug fixes
 


### PR DESCRIPTION
[Review by commits and ignore white spaces](https://github.com/vatesfr/xen-orchestra/pull/7061/commits/fe85831f2f6e19ae82cd3213bad775c0ec9051c6?w=1), **DO NOT SQUASH**.

### Description

![Screenshot from 2023-09-28 15-04-11](https://github.com/vatesfr/xen-orchestra/assets/298721/40b0cfdc-eac5-4110-9108-d33bba241900)

Clicking on the `</>` button show the raw log which provide more info:

```json
{
  "id": "0ln36jhbq",
  "properties": {
    "credentials": {
      "username": "john.smith"
    },
    "userData": {
      "ip": "93.184.216.34"
    },
    "name": "XO user authentication",
    "type": "xo:authentication:authenticateUser"
  },
  "start": 1695905824888,
  "status": "failure",
  "updatedAt": 1695905824897,
  "end": 1695905824897,
  "result": {
    "code": 3,
    "message": "invalid credentials",
    "name": "XoError",
    "stack": "XoError: invalid credentials\n    at invalidCredentials (/usr/local/lib/node_modules/xo-server/node_modules/packages/xo-common/api-errors.js:26:11)\n    at file:///usr/local/lib/node_modules/xo-server/src/xo-mixins/authentication.mjs:169:17\n    at Task.runInside (/usr/local/lib/node_modules/xo-server/node_modules/@vates/task/index.js:158:22)\n    at Task.run (/usr/local/lib/node_modules/xo-server/node_modules/@vates/task/index.js:141:20)\n    at Strategy._verify (file:///usr/local/lib/node_modules/xo-server/src/index.mjs:283:26)"
  }
}
```

But this view should be improved in the future to make task properties more directly accessible.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
