### PR TITLE
feat(s3): upload file bigger than 50GB

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/FullRemote.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/FullRemote.mjs
@@ -29,6 +29,8 @@ export const FullRemote = class FullRemoteVmBackupRunner extends AbstractRemote 
           writer =>
             writer.run({
               stream: forkStreamUnpipe(stream),
+              // stream is copied and transformed, it's not safe to attach additionnal properties to it
+              streamLength: stream.length,
               timestamp: metadata.timestamp,
               vm: metadata.vm,
               vmSnapshot: metadata.vmSnapshot,

--- a/@xen-orchestra/backups/_runners/_vmRunners/FullXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/FullXapi.mjs
@@ -35,13 +35,22 @@ export const FullXapi = class FullXapiVmBackupRunner extends AbstractXapi {
         useSnapshot: false,
       })
     )
+
+    const vdis = await exportedVm.$getDisks()
+    let maxStreamLength = 1024 * 1024 // Ovf file and tar headers are a few KB, let's stay safe
+    vdis.forEach(vdiRef => {
+      const vdi = this._xapi.getObject(vdiRef)
+      maxStreamLength += vdi.physical_utilisation ?? 0 // at most the xva will take the physical usage of the disk
+      // it can be smaller due to the smaller block size for xva than vhd, and compression of xcp-ng
+    })
+
     const sizeContainer = watchStreamSize(stream)
 
     const timestamp = Date.now()
-
     await this._callWriters(
       writer =>
         writer.run({
+          maxStreamLength,
           sizeContainer,
           stream: forkStreamUnpipe(stream),
           timestamp,

--- a/@xen-orchestra/backups/_runners/_writers/FullRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/FullRemoteWriter.mjs
@@ -24,7 +24,7 @@ export class FullRemoteWriter extends MixinRemoteWriter(AbstractFullWriter) {
     )
   }
 
-  async _run({ timestamp, sizeContainer, stream, vm, vmSnapshot }) {
+  async _run({ maxStreamLength, timestamp, sizeContainer, stream, streamLength, vm, vmSnapshot }) {
     const settings = this._settings
     const job = this._job
     const scheduleId = this._scheduleId
@@ -65,6 +65,8 @@ export class FullRemoteWriter extends MixinRemoteWriter(AbstractFullWriter) {
 
     await Task.run({ name: 'transfer' }, async () => {
       await adapter.outputStream(dataFilename, stream, {
+        maxStreamLength,
+        streamLength,
         validator: tmpPath => adapter.isValidXva(tmpPath),
       })
       return { size: sizeContainer.size }

--- a/@xen-orchestra/backups/_runners/_writers/_AbstractFullWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/_AbstractFullWriter.mjs
@@ -1,9 +1,9 @@
 import { AbstractWriter } from './_AbstractWriter.mjs'
 
 export class AbstractFullWriter extends AbstractWriter {
-  async run({ timestamp, sizeContainer, stream, vm, vmSnapshot }) {
+  async run({ maxStreamLength, timestamp, sizeContainer, stream, streamLength, vm, vmSnapshot }) {
     try {
-      return await this._run({ timestamp, sizeContainer, stream, vm, vmSnapshot })
+      return await this._run({ maxStreamLength, timestamp, sizeContainer, stream, streamLength, vm, vmSnapshot })
     } finally {
       // ensure stream is properly closed
       stream.destroy()

--- a/@xen-orchestra/fs/package.json
+++ b/@xen-orchestra/fs/package.json
@@ -25,6 +25,7 @@
     "@aws-sdk/lib-storage": "^3.54.0",
     "@aws-sdk/middleware-apply-body-checksum": "^3.58.0",
     "@aws-sdk/node-http-handler": "^3.54.0",
+    "@aws-sdk/s3-request-presigner": "^3.421.0",
     "@sindresorhus/df": "^3.1.1",
     "@vates/async-each": "^1.0.0",
     "@vates/coalesce-calls": "^0.1.0",

--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -189,7 +189,7 @@ export default class RemoteHandlerAbstract {
    * @param {number} [options.dirMode]
    * @param {(this: RemoteHandlerAbstract, path: string) => Promise<undefined>} [options.validator] Function that will be called before the data is commited to the remote, if it fails, file should not exist
    */
-  async outputStream(path, input, { checksum = true, dirMode, validator } = {}) {
+  async outputStream(path, input, { checksum = true, dirMode, maxStreamLength, streamLength, validator } = {}) {
     path = normalizePath(path)
     let checksumStream
 
@@ -201,6 +201,8 @@ export default class RemoteHandlerAbstract {
     }
     await this._outputStream(path, input, {
       dirMode,
+      maxStreamLength,
+      streamLength,
       validator,
     })
     if (checksum) {

--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -5,6 +5,7 @@ import {
   CreateMultipartUploadCommand,
   DeleteObjectCommand,
   GetObjectCommand,
+  GetObjectLockConfigurationCommand,
   HeadObjectCommand,
   ListObjectsV2Command,
   PutObjectCommand,
@@ -439,5 +440,10 @@ export default class S3Handler extends RemoteHandlerAbstract {
 
   useVhdDirectory() {
     return true
+  }
+
+  async #hasObjectLock(){
+    const res = await this.#s3.send(new GetObjectLockConfigurationCommand({Bucket: bucket}))
+    return res.ObjectLockConfiguration?.ObjectLockEnabled === 'Enabled'
   }
 }

--- a/@xen-orchestra/fs/testupload.mjs
+++ b/@xen-orchestra/fs/testupload.mjs
@@ -1,0 +1,152 @@
+import fs from 'fs/promises'
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner"
+import {
+    CompleteMultipartUploadCommand,
+    CreateMultipartUploadCommand,
+    S3Client,
+    UploadPartCommand,
+  } from '@aws-sdk/client-s3'
+
+  import { NodeHttpHandler } from '@aws-sdk/node-http-handler'
+import { Agent as HttpAgent } from 'http'
+import { Agent as HttpsAgent } from 'https'
+import { parse } from 'xo-remote-parser'
+import { join, split } from './dist/path.js'
+
+import guessAwsRegion from './dist/_guessAwsRegion.js'
+import { PassThrough } from 'stream'
+import { readChunk } from '@vates/read-chunk'
+import { pFromCallback } from 'promise-toolbox'
+
+async function v2(url, inputStream){
+    const {
+        allowUnauthorized,
+        host,
+        path,
+        username,
+        password,
+        protocol,
+        region = guessAwsRegion(host),
+      } = parse(url)
+    const client = new S3Client({
+        apiVersion: '2006-03-01',
+        endpoint: `${protocol}://s3.us-east-2.amazonaws.com`,
+        forcePathStyle: true,
+        credentials: {
+          accessKeyId: username,
+          secretAccessKey: password,
+        },
+        region,
+        requestHandler: new NodeHttpHandler({
+          socketTimeout: 600000,
+          httpAgent: new HttpAgent({
+            keepAlive: true,
+          }),
+          httpsAgent: new HttpsAgent({
+            rejectUnauthorized: !allowUnauthorized,
+            keepAlive: true,
+          }),
+        }),
+      })
+      
+    const pathParts = split(path)
+    const bucket = pathParts.shift()
+    const dir = join(...pathParts)
+
+    const command = new CreateMultipartUploadCommand({
+        Bucket: bucket, Key: join(dir, 'flov2')
+    })
+    const multipart = await client.send(command)
+    console.log({multipart})
+
+    const parts = []
+    // monitor memory usage
+    const intervalMonitorMemoryUsage = setInterval(()=>console.log(Math.round(process.memoryUsage().rss/1024/1024)), 2000)
+
+    const CHUNK_SIZE = Math.ceil(5*1024*1024*1024*1024/10000) // smallest chunk allowing 5TB upload
+
+    function read(inputStream, maxReadSize){
+        if(maxReadSize === 0){
+            return null
+        }
+        return readChunk(inputStream, maxReadSize)
+    }
+
+    async function write(data, chunkStream, remainingBytes){
+        const ready = chunkStream.write(data)
+        if(!ready){
+            await pFromCallback(cb=> chunkStream.once('drain', cb))
+        }
+        remainingBytes -= data.length
+        process.stdout.write('.')
+        return remainingBytes
+    }
+
+    
+    async function uploadChunk(inputStream){
+        const PartNumber = parts.length +1
+        let done = false
+        let remainingBytes = CHUNK_SIZE
+        const maxChunkPartSize = Math.round(CHUNK_SIZE / 100)
+        const chunkStream = new PassThrough()
+        console.log({maxChunkPartSize,CHUNK_SIZE})
+        const command = new UploadPartCommand({
+            ...multipart,
+            PartNumber,
+        })
+        const presignedUrl = await getSignedUrl(client, command,{ expiresIn: 3600 });
+
+        const promise =  fetch(presignedUrl, {
+            method: 'PUT',
+            body:chunkStream,
+            duplex: "half",
+            headers:{
+                "content-length": CHUNK_SIZE
+            } 
+        })
+
+
+        let data
+        try{
+            while((data = await read(inputStream, Math.min(remainingBytes, maxChunkPartSize))) !== null){
+                remainingBytes  = await write(data, chunkStream, remainingBytes)
+            }
+            const fullBuffer = Buffer.alloc(maxChunkPartSize,0)
+            done = remainingBytes > 0
+            // add padding at the end of the file (not a problem for tar like : xva/ova)
+            while(remainingBytes > maxChunkPartSize){
+                remainingBytes  = await write(fullBuffer,chunkStream, remainingBytes)
+            }
+            await write(Buffer.alloc(remainingBytes,0))
+            // wait for the end of the upload
+            const res = await promise
+
+            parts.push({ ETag: res.headers.get('etag'), PartNumber })
+        }catch(err){
+            console.error(err)
+            throw err
+        }
+        return done
+    }
+
+    while(!await uploadChunk(inputStream)){
+        console.log('uploaded one chunk', parts.length)
+    }
+
+    // mark the upload as complete and ask s3 to glue the chunk together
+    const completRes = await client.send(
+        new CompleteMultipartUploadCommand({
+          ...multipart,
+          MultipartUpload: { Parts: parts },
+        })
+      )
+      console.log({completRes})
+    clearInterval(intervalMonitorMemoryUsage)
+
+}
+
+const input = await fs.open('/tmp/60G') // big ass file 
+const inputStream = input.createReadStream()
+const remoteUrl = ""
+
+v2(remoteUrl,inputStream)

--- a/@xen-orchestra/fs/testupload.mjs
+++ b/@xen-orchestra/fs/testupload.mjs
@@ -1,8 +1,11 @@
 import fs from 'fs/promises'
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner"
+import { createHash } from "crypto";
 import {
     CompleteMultipartUploadCommand,
     CreateMultipartUploadCommand,
+    GetObjectLockConfigurationCommand,
+    PutObjectCommand,
     S3Client,
     UploadPartCommand,
   } from '@aws-sdk/client-s3'
@@ -65,20 +68,25 @@ async function v2(url, inputStream){
 
     const CHUNK_SIZE = Math.ceil(5*1024*1024*1024*1024/10000) // smallest chunk allowing 5TB upload
 
-    function read(inputStream, maxReadSize){
+    async function read(inputStream, maxReadSize){
         if(maxReadSize === 0){
             return null
         }
-        return readChunk(inputStream, maxReadSize)
+        process.stdout.write('+')
+        const chunk = await readChunk(inputStream, maxReadSize)
+        process.stdout.write('@')
+        return chunk
     }
 
     async function write(data, chunkStream, remainingBytes){
         const ready = chunkStream.write(data)
         if(!ready){
+            process.stdout.write('.')
             await pFromCallback(cb=> chunkStream.once('drain', cb))
+            process.stdout.write('@')
         }
         remainingBytes -= data.length
-        process.stdout.write('.')
+        process.stdout.write(remainingBytes+' ')
         return remainingBytes
     }
 
@@ -87,41 +95,57 @@ async function v2(url, inputStream){
         const PartNumber = parts.length +1
         let done = false
         let remainingBytes = CHUNK_SIZE
-        const maxChunkPartSize = Math.round(CHUNK_SIZE / 100)
+        const maxChunkPartSize = Math.round(CHUNK_SIZE / 1000)
         const chunkStream = new PassThrough()
         console.log({maxChunkPartSize,CHUNK_SIZE})
-        const command = new UploadPartCommand({
-            ...multipart,
-            PartNumber,
-        })
-        const presignedUrl = await getSignedUrl(client, command,{ expiresIn: 3600 });
-
-        const promise =  fetch(presignedUrl, {
-            method: 'PUT',
-            body:chunkStream,
-            duplex: "half",
-            headers:{
-                "content-length": CHUNK_SIZE
-            } 
-        })
+        
 
 
         let data
+        let chunkBuffer = []
+        const hash = createHash('md5');
         try{
             while((data = await read(inputStream, Math.min(remainingBytes, maxChunkPartSize))) !== null){
-                remainingBytes  = await write(data, chunkStream, remainingBytes)
+                chunkBuffer.push(data)
+                hash.update(data)
+                remainingBytes -= data.length
+                //remainingBytes  = await write(data, chunkStream, remainingBytes)
             }
+            console.log('data put')
             const fullBuffer = Buffer.alloc(maxChunkPartSize,0)
             done = remainingBytes > 0
             // add padding at the end of the file (not a problem for tar like : xva/ova)
+            // if not content length will not match and we'll have UND_ERR_REQ_CONTENT_LENGTH_MISMATCH error
+            console.log('full padding')
             while(remainingBytes > maxChunkPartSize){
-                remainingBytes  = await write(fullBuffer,chunkStream, remainingBytes)
+                chunkBuffer.push(fullBuffer)
+                hash.update(fullBuffer)
+                remainingBytes -= maxChunkPartSize
+                //remainingBytes  = await write(fullBuffer,chunkStream, remainingBytes)
             }
-            await write(Buffer.alloc(remainingBytes,0))
+            console.log('full padding done ')
+            chunkBuffer.push(Buffer.alloc(remainingBytes,0))
+            hash.update(Buffer.alloc(remainingBytes,0))
+            console.log('md5 ok ')
+            //await write(Buffer.alloc(remainingBytes,0),chunkStream, remainingBytes)
             // wait for the end of the upload
-            const res = await promise
 
-            parts.push({ ETag: res.headers.get('etag'), PartNumber })
+            const command = new UploadPartCommand({
+                ...multipart,
+                PartNumber,
+                ContentLength:CHUNK_SIZE,
+                Body: chunkStream,
+                ContentMD5 : hash.digest('base64')
+            })
+            const promise = client.send(command)
+            for (const buffer of chunkBuffer){
+                await write(buffer, chunkStream, remainingBytes)
+            }
+            chunkStream.on('error', err => console.error(err))
+            const res = await  promise
+
+            console.log({res, headers : res.headers })
+            parts.push({ ETag:/*res.headers.get('etag')  */res.ETag, PartNumber })
         }catch(err){
             console.error(err)
             throw err
@@ -145,8 +169,90 @@ async function v2(url, inputStream){
 
 }
 
-const input = await fs.open('/tmp/60G') // big ass file 
+async function simplePut(url , inputStream){
+    const {
+        allowUnauthorized,
+        host,
+        path,
+        username,
+        password,
+        protocol,
+        region = guessAwsRegion(host),
+      } = parse(url)
+    const client = new S3Client({
+        apiVersion: '2006-03-01',
+        endpoint: `${protocol}://s3.us-east-2.amazonaws.com`,
+        forcePathStyle: true,
+        credentials: {
+          accessKeyId: username,
+          secretAccessKey: password,
+        },
+        region,
+        requestHandler: new NodeHttpHandler({
+          socketTimeout: 600000,
+          httpAgent: new HttpAgent({
+            keepAlive: true,
+          }),
+          httpsAgent: new HttpsAgent({
+            rejectUnauthorized: !allowUnauthorized,
+            keepAlive: true,
+          }),
+        }),
+      })
+      
+    const pathParts = split(path)
+    const bucket = pathParts.shift()
+    const dir = join(...pathParts)
+
+    //const hasObjectLock = await client.send(new GetObjectLockConfigurationCommand({Bucket: bucket}))
+    //console.log(hasObjectLock.ObjectLockConfiguration?.ObjectLockEnabled === 'Enabled')
+
+
+    const md5 = await createMD5('/tmp/1g')
+    console.log({md5})
+    const command = new PutObjectCommand({
+        Bucket: bucket, Key: join(dir, 'simple'),
+        ContentMD5: md5,
+        ContentLength: 1024*1024*1024,
+        Body: inputStream
+    })
+    const intervalMonitorMemoryUsage = setInterval(()=>console.log(Math.round(process.memoryUsage().rss/1024/1024)), 2000)
+
+    const res = await client.send(command)
+    /*
+    const presignedUrl = await getSignedUrl(client,  command,{ expiresIn: 3600 });
+    const res = await fetch(presignedUrl, {
+        method: 'PUT',
+        body:inputStream,
+        duplex: "half",
+        headers:{
+            "x-amz-decoded-content-length": 1024*1024*1024,
+            "content-md5" : md5
+        } 
+    })*/
+    clearInterval(intervalMonitorMemoryUsage)
+
+    console.log(res)
+}
+
+async function createMD5(filePath) {
+    const input = await fs.open(filePath) // big ass file 
+    return new Promise((res, rej) => {
+      const hash = createHash('md5');
+      
+      const rStream = input.createReadStream(filePath);
+      rStream.on('data', (data) => {
+        hash.update(data);
+      });
+      rStream.on('end', () => {
+        res(hash.digest('base64'));
+      });
+    })
+  }
+const input = await fs.open('/tmp/1g') // big ass file 
 const inputStream = input.createReadStream()
 const remoteUrl = ""
 
 v2(remoteUrl,inputStream)
+
+//simplePut(remoteUrl,inputStream)


### PR DESCRIPTION
### Description

#### chunk size computation
Chunk size is (length ?? maxLength ) / 10 000 . (min 5MB, max 500MB). 

can be computed from disk utilization (for an xva export) or disk size (for a mirror backup)

#### Transfer strategy 

1. direct transfer : non buffering, only for tar like format , only for bucket without object lock  : memory consumption is constant ( not related to file size). Will use at most one chunk in additional  size on disk
2. direct transfer to temporary file : same as precedent + an additional copy step that truncate the padding. memory consumption is constant . Does not work with backup repository encryption (can't truncate file easily)
3. buffering : use 1 chunk of additional memory ,read one chunk, md5 it,  then transfer it => slower than precedent, no temporary file 
4. double buffering : use 2 chunk ; read 1 chunk , start transfering and reading the next chunk => faster than precedent
5. default mode of `lib-storage` 

I think we should use 2 on non object locked, non encrypted  backup repository, and 5 in other. A file configuration should be present to force the fallback to lib-storage

#### To do 

- [ ] implement sensible maxLenght/lengh computation
- [ ] use it to compute PartSize, throw an error if stream is bigger than 10K PartSize
- [ ] use md5 middleware only if Backup repository has object lock 
- [ ] use direct transfer as a fast path  it BR is not encrypted AND not object locked

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
