### PR TITLE
fix(xo-server/RPU): do not migrate VM back if already on host

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Rolling Pool Update] After the update, when migrating VMs back to their host, do not migrate VMs that are already on the right host [Forum#7802](https://xcp-ng.org/forum/topic/7802) (PR [#7071](https://github.com/vatesfr/xen-orchestra/pull/7071))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/packages/xo-server/src/xapi/mixins/patching.mjs
+++ b/packages/xo-server/src/xapi/mixins/patching.mjs
@@ -629,7 +629,13 @@ export default {
         continue
       }
 
+      const residentVms = host.$resident_VMs.map(vm => vm.uuid)
+
       for (const vmId of vmIds) {
+        if (residentVms.includes(vmId)) {
+          continue
+        }
+
         try {
           await this.migrateVm(vmId, this, hostId)
         } catch (err) {


### PR DESCRIPTION
See https://xcp-ng.org/forum/topic/7802

### Description

[Rolling Pool Update](https://xen-orchestra.com/blog/xen-orchestra-5-54/#rollingpoolupdates): after the update, when migrating VMs back to their host, do not migrate VMs that are already on the right host.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
