### PR TITLE
docs(patches): update URLs that need to be accessible from XOA

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,9 +94,9 @@ uri = 'tcp://db:password@hostname:port'
 
 ## Proxy for updates and patches
 
-To check if your hosts are up-to-date, we need to access `http://updates.xensource.com/XenServer/updates.xml`.
+To check if your hosts are up-to-date, we need to access `https://updates.ops.xenserver.com/xenserver/updates.xml`.
 
-And to download the patches, we need access to `http://support.citrix.com/supportkc/filedownload?`.
+And to download the patches, we need access to `https://fileservice.citrix.com/direct/v2/download/secured/support/article/*/downloads/*.zip`.
 
 To do that behind a corporate proxy, just add the `httpProxy` variable to match your current proxy configuration.
 

--- a/packages/xo-server/src/xapi/mixins/patching.mjs
+++ b/packages/xo-server/src/xapi/mixins/patching.mjs
@@ -59,7 +59,7 @@ const listMissingPatches = debounceWithKey(_listMissingPatches, LISTING_DEBOUNCE
 // =============================================================================
 
 export default {
-  // raw { uuid: patch } map translated from updates.xensource.com/XenServer/updates.xml
+  // raw { uuid: patch } map translated from updates.ops.xenserver.com/xenserver/updates.xml
   // FIXME: should be static
   @decorateWith(debounceWithKey, 24 * 60 * 60 * 1000, function () {
     return this


### PR DESCRIPTION
### Description

Old URL: http://updates.xensource.com/XenServer/updates.xml
New URL: https://updates.ops.xenserver.com/xenserver/updates.xml

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
