### PR TITLE
Add client information to authentication tokens

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,6 +29,7 @@
 
 <!--packages-start-->
 
+- xo-cli minor
 - xo-server-netbox patch
 - xo-web patch
 

--- a/packages/xo-cli/index.mjs
+++ b/packages/xo-cli/index.mjs
@@ -13,6 +13,7 @@ import humanFormat from 'human-format'
 import identity from 'lodash/identity.js'
 import isObject from 'lodash/isObject.js'
 import micromatch from 'micromatch'
+import os from 'os'
 import pairs from 'lodash/toPairs.js'
 import pick from 'lodash/pick.js'
 import prettyMs from 'pretty-ms'
@@ -47,7 +48,7 @@ async function connect() {
   return xo
 }
 
-async function parseRegisterArgs(args, tokenDescription, acceptToken = false) {
+async function parseRegisterArgs(args, tokenDescription, client, acceptToken = false) {
   const {
     allowUnauthorized,
     expiresIn,
@@ -84,21 +85,21 @@ async function parseRegisterArgs(args, tokenDescription, acceptToken = false) {
         pw(resolve)
       }),
     ] = opts
-    result.token = await _createToken({ ...result, description: tokenDescription, email, password })
+    result.token = await _createToken({ ...result, client, description: tokenDescription, email, password })
   }
 
   return result
 }
 
-async function _createToken({ allowUnauthorized, description, email, expiresIn, password, url }) {
+async function _createToken({ allowUnauthorized, client, description, email, expiresIn, password, url }) {
   const xo = new Xo({ rejectUnauthorized: !allowUnauthorized, url })
   await xo.open()
   try {
     await xo.signIn({ email, password })
     console.warn('Successfully logged with', xo.user.email)
 
-    return await xo.call('token.create', { description, expiresIn }).catch(error => {
-      // if invalid parameter error, retry without description for backward compatibility
+    return await xo.call('token.create', { client, description, expiresIn }).catch(error => {
+      // if invalid parameter error, retry without client and description for backward compatibility
       if (error.code === 10) {
         return xo.call('token.create', { expiresIn })
       }
@@ -218,6 +219,8 @@ function wrap(val) {
 }
 
 // ===================================================================
+
+const PACKAGE_JSON = JSON.parse(readFileSync(new URL('package.json', import.meta.url)))
 
 const help = wrap(
   (function (pkg) {
@@ -355,7 +358,7 @@ $name v$version`.replace(/<([^>]+)>|\$(\w+)/g, function (_, arg, key) {
 
       return pkg[key]
     })
-  })(JSON.parse(readFileSync(new URL('package.json', import.meta.url))))
+  })(PACKAGE_JSON)
 )
 
 // -------------------------------------------------------------------
@@ -422,9 +425,18 @@ async function createToken(args) {
 COMMANDS.createToken = createToken
 
 async function register(args) {
-  const opts = await parseRegisterArgs(args, 'xo-cli --register', true)
+  let { clientId } = await config.load()
+  if (clientId === undefined) {
+    clientId = Math.random().toString(36).slice(2)
+  }
+
+  const { name, version } = PACKAGE_JSON
+  const label = `${name}@${version} - ${os.hostname()} - ${os.type()} ${os.machine()}`
+
+  const opts = await parseRegisterArgs(args, label, { id: clientId }, true)
   await config.set({
     allowUnauthorized: opts.allowUnauthorized,
+    clientId,
     server: opts.url,
     token: opts.token,
   })

--- a/packages/xo-server/src/api/token.mjs
+++ b/packages/xo-server/src/api/token.mjs
@@ -1,8 +1,9 @@
 // TODO: Prevent token connections from creating tokens.
 // TODO: Token permission.
-export async function create({ description, expiresIn }) {
+export async function create({ client, description, expiresIn }) {
   return (
     await this.createAuthenticationToken({
+      client,
       description,
       expiresIn,
       userId: this.apiContext.user.id,
@@ -16,6 +17,15 @@ create.params = {
   description: {
     optional: true,
     type: 'string',
+  },
+  client: {
+    description:
+      'client this authentication token belongs to, if a previous token exists, it will be updated and returned',
+    optional: true,
+    type: 'object',
+    properties: {
+      id: { description: 'unique identifier of this client', type: 'string' },
+    },
   },
   expiresIn: {
     optional: true,

--- a/packages/xo-server/src/models/token.mjs
+++ b/packages/xo-server/src/models/token.mjs
@@ -3,7 +3,25 @@ import Collection from '../collection/redis.mjs'
 // ===================================================================
 
 export class Tokens extends Collection {
+  _serialize(token) {
+    const { client } = token
+    if (client !== undefined) {
+      const { id, ...rest } = client
+      token.client_id = id
+      token.client = JSON.stringify(rest)
+    }
+  }
+
   _unserialize(token) {
+    const { client, client_id } = token
+    if (client !== undefined) {
+      token.client = {
+        ...JSON.parse(client),
+        id: client_id,
+      }
+      delete token.client_id
+    }
+
     if (token.created_at !== undefined) {
       token.created_at = +token.created_at
     }


### PR DESCRIPTION
### Description

A client should reuse its previous token instead of creating a new one.

An authentication token should contain information about its client (web vs CLI, platform, etc).

~~An authentication token should contain information about its last use (date, IP address).~~ (in another PR)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
