### PR TITLE
feat(xo-web/SelectPif): show network name

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -9,6 +9,7 @@
 
 - [Host/Advanced] Allow to force _Smart reboot_ if some resident VMs have the suspend operation blocked [Forum#7136](https://xcp-ng.org/forum/topic/7136/suspending-vms-during-host-reboot/23) (PR [#7025](https://github.com/vatesfr/xen-orchestra/pull/7025))
 - [Plugin/backup-report] Errors are now listed in XO tasks
+- [PIF] Show network name in PIF selectors
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -9,7 +9,7 @@
 
 - [Host/Advanced] Allow to force _Smart reboot_ if some resident VMs have the suspend operation blocked [Forum#7136](https://xcp-ng.org/forum/topic/7136/suspending-vms-during-host-reboot/23) (PR [#7025](https://github.com/vatesfr/xen-orchestra/pull/7025))
 - [Plugin/backup-report] Errors are now listed in XO tasks
-- [PIF] Show network name in PIF selectors
+- [PIF] Show network name in PIF selectors (PR [#7081](https://github.com/vatesfr/xen-orchestra/pull/7081))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/render-xo-item.js
+++ b/packages/xo-web/src/common/render-xo-item.js
@@ -299,6 +299,56 @@ Vdi.defaultProps = {
 
 // ===================================================================
 
+export const Pif = decorate([
+  connectStore(() => {
+    const getObject = createGetObject()
+    const getNetwork = createGetObject(createSelector(getObject, pif => get(() => pif.$network)))
+
+    // FIXME: props.self ugly workaround to get object as a self user
+    return (state, props) => ({
+      pif: getObject(state, props, props.self),
+      network: getNetwork(state, props),
+    })
+  }),
+  ({ id, showNetwork, pif, network }) => {
+    if (pif === undefined) {
+      return unknowItem(id, 'PIF')
+    }
+
+    const { carrier, device, deviceName, vlan } = pif
+
+    return (
+      <span>
+        <Icon icon='network' color={carrier ? 'text-success' : 'text-danger'} /> {device} ({deviceName}
+        {vlan !== -1 && (
+          <span>
+            {' '}
+            -{' '}
+            {_('keyValue', {
+              key: _('pifVlanLabel'),
+              value: vlan,
+            })}
+          </span>
+        )}
+        {showNetwork && network !== undefined && <span> - {network.name_label}</span>})
+      </span>
+    )
+  },
+])
+
+Pif.propTypes = {
+  id: PropTypes.string.isRequired,
+  self: PropTypes.bool,
+  showNetwork: PropTypes.bool,
+}
+
+Pif.defaultProps = {
+  self: false,
+  showNetwork: false,
+}
+
+// ===================================================================
+
 export const Network = decorate([
   connectStore(() => {
     const getObject = createGetObject()
@@ -561,24 +611,8 @@ const xoItemToRender = {
   ),
 
   // PIF.
-  PIF: ({ carrier, device, deviceName, vlan }) => (
-    <span>
-      <Icon icon='network' color={carrier ? 'text-success' : 'text-danger'} /> {device}
-      {(deviceName !== '' || vlan !== -1) && (
-        <span>
-          {' '}
-          ({deviceName}
-          {deviceName !== '' && vlan !== -1 && ' - '}
-          {vlan !== -1 &&
-            _('keyValue', {
-              key: _('pifVlanLabel'),
-              value: vlan,
-            })}
-          )
-        </span>
-      )}
-    </span>
-  ),
+  PIF: props => <Pif {...props} />,
+
   // Tags.
   tag: tag => (
     <span>

--- a/packages/xo-web/src/common/render-xo-item.js
+++ b/packages/xo-web/src/common/render-xo-item.js
@@ -316,21 +316,28 @@ export const Pif = decorate([
     }
 
     const { carrier, device, deviceName, vlan } = pif
+    const showExtraInfo = deviceName || vlan !== -1 || (showNetwork && network !== undefined)
 
     return (
       <span>
-        <Icon icon='network' color={carrier ? 'text-success' : 'text-danger'} /> {device} ({deviceName}
-        {vlan !== -1 && (
+        <Icon icon='network' color={carrier ? 'text-success' : 'text-danger'} /> {device}
+        {showExtraInfo && (
           <span>
             {' '}
-            -{' '}
-            {_('keyValue', {
-              key: _('pifVlanLabel'),
-              value: vlan,
-            })}
+            ({deviceName}
+            {vlan !== -1 && (
+              <span>
+                {' '}
+                -{' '}
+                {_('keyValue', {
+                  key: _('pifVlanLabel'),
+                  value: vlan,
+                })}
+              </span>
+            )}
+            {showNetwork && network !== undefined && <span> - {network.name_label}</span>})
           </span>
         )}
-        {showNetwork && network !== undefined && <span> - {network.name_label}</span>})
       </span>
     )
   },

--- a/packages/xo-web/src/common/select-objects.js
+++ b/packages/xo-web/src/common/select-objects.js
@@ -251,6 +251,7 @@ class GenericSelect extends React.Component {
             ? `${option.xoItem.type}-resourceSet`
             : undefined,
         memoryFree: option.xoItem.type === 'host' || undefined,
+        showNetwork: true,
       })}
     </span>
   )


### PR DESCRIPTION
See Zammad#17381

### Description

Show network name in PIF selectors as it can help differentiate PIFs that have the same device/deviceName.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
