### PR TITLE
docs(netbox): remove extra backtick

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -362,7 +362,7 @@ XO will try to find the right prefix for each IP address. If it can't find a pre
   - Assign it to object types:
     - Virtualization > cluster
     - Virtualization > virtual machine
-    - Virtualization > interface`
+    - Virtualization > interface
 
 ![](./assets/customfield.png)
 


### PR DESCRIPTION
Introduced by 3b3f927e4be33e55087665fd2193f82d3d459eb1

### Description

Extra backtick removed at line 365

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
