### PR TITLE
fix(xo-server/patching): always pass xsCredentials to installPatches on XS

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Rolling Pool Update] After the update, when migrating VMs back to their host, do not migrate VMs that are already on the right host [Forum#7802](https://xcp-ng.org/forum/topic/7802) (PR [#7071](https://github.com/vatesfr/xen-orchestra/pull/7071))
+- [RPU] Fix "XenServer credentials not found" when running a Rolling Pool Update on a XenServer pool
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Rolling Pool Update] After the update, when migrating VMs back to their host, do not migrate VMs that are already on the right host [Forum#7802](https://xcp-ng.org/forum/topic/7802) (PR [#7071](https://github.com/vatesfr/xen-orchestra/pull/7071))
-- [RPU] Fix "XenServer credentials not found" when running a Rolling Pool Update on a XenServer pool
+- [RPU] Fix "XenServer credentials not found" when running a Rolling Pool Update on a XenServer pool (PR [#7089](https://github.com/vatesfr/xen-orchestra/pull/7089))
 
 ### Packages to release
 

--- a/packages/xo-server/src/xapi/mixins/patching.mjs
+++ b/packages/xo-server/src/xapi/mixins/patching.mjs
@@ -493,7 +493,7 @@ export default {
   },
 
   @decorateWith(deferrable)
-  async rollingPoolUpdate($defer) {
+  async rollingPoolUpdate($defer, { xsCredentials } = {}) {
     const isXcp = _isXcp(this.pool.$master)
 
     if (this.pool.ha_enabled) {
@@ -530,7 +530,7 @@ export default {
     // On XS/CH, start by installing patches on all hosts
     if (!isXcp) {
       log.debug('Install patches')
-      await this.installPatches()
+      await this.installPatches({ xsCredentials })
     }
 
     // Remember on which hosts the running VMs are

--- a/packages/xo-server/src/xo-mixins/pool.mjs
+++ b/packages/xo-server/src/xo-mixins/pool.mjs
@@ -62,11 +62,14 @@ export default class Pools {
       }
       const patchesName = await Promise.all([targetXapi.findPatches(targetRequiredPatches), ...findPatchesPromises])
 
+      const { xsCredentials } = _app.apiContext.user.preferences
+
       // Install patches in parallel.
       const installPatchesPromises = []
       installPatchesPromises.push(
         targetXapi.installPatches({
           patches: patchesName[0],
+          xsCredentials,
         })
       )
       let i = 1
@@ -74,6 +77,7 @@ export default class Pools {
         installPatchesPromises.push(
           sourceXapis[sourceId].installPatches({
             patches: patchesName[i++],
+            xsCredentials,
           })
         )
       }

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -686,7 +686,7 @@ export default class XenServers {
       $defer(() => app.loadPlugin('load-balancer'))
     }
 
-    await this.getXapi(pool).rollingPoolUpdate()
+    await this.getXapi(pool).rollingPoolUpdate({ xsCredentials: app.apiContext.user.preferences.xsCredentials })
   }
 }
 


### PR DESCRIPTION
Fixes Zammad#18284
Introduced by a30d962b1de60ee7c78ca553de54d68c33354b42

### Description

Since #7044, `installPatches` expects `xsCredentials` to be passed when it's called on a XenServer pool, which was properly done for a `pool.installPatches` API call but not when the call was coming from anywhere else.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
