### PR TITLE
fix(xo-web/host/advanced): fix if smartctl plugin not installed

### DIFF
--- a/packages/xo-server/src/api/host.mjs
+++ b/packages/xo-server/src/api/host.mjs
@@ -479,7 +479,7 @@ setControlDomainMemory.resolve = {
 /**
  *
  * @param {{host:HOST}} params
- * @returns null if plugin is not installed or don't have the method
+ * @returns null if plugin don't have the method
  *          an object device: status on success
  */
 export function getSmartctlHealth({ host }) {
@@ -499,7 +499,7 @@ getSmartctlHealth.resolve = {
 /**
  *
  * @param {{host:HOST}} params
- * @returns null if plugin is not installed or don't have the method
+ * @returns null if plugin don't have the method
  *          an object device: full device information on success
  */
 export function getSmartctlInformation({ host, deviceNames }) {

--- a/packages/xo-web/src/xo-app/host/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/host/tab-advanced.js
@@ -174,8 +174,11 @@ export default class extends Component {
       })
     }
 
-    const smartctlHealth = await getSmartctlHealth(host)
-    const isSmartctlHealthEnabled = smartctlHealth !== null
+    let smartctlHealth
+    try {
+      smartctlHealth = await getSmartctlHealth(host)
+    } catch (error) {}
+    const isSmartctlHealthEnabled = smartctlHealth != null
     const smartctlUnhealthyDevices = isSmartctlHealthEnabled
       ? Object.keys(smartctlHealth).filter(deviceName => smartctlHealth[deviceName] !== 'PASSED')
       : undefined


### PR DESCRIPTION
### Description

If the smartctl plugin is not installed, it can throw. See [Forum#7853](https://xcp-ng.org/forum/topic/7853/q-why-is-xcp-complaining-to-miss-smartctl-py?_=1697443745992).
No changelog entries have been added, as the bug is not really visible to users. The link to the [Forum#7853](https://xcp-ng.org/forum/topic/7853/q-why-is-xcp-complaining-to-miss-smartctl-py?_=1697443745992) helped to resolve the bug, but does not report this bug.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
