### PR TITLE
feat(lite): set color-scheme CSS property to "dark" in dark mode

### DIFF
--- a/@xen-orchestra/lite/src/assets/theme.css
+++ b/@xen-orchestra/lite/src/assets/theme.css
@@ -59,6 +59,8 @@
 }
 
 :root.dark {
+  color-scheme: dark;
+
   --color-blue-scale-000: #ffffff;
   --color-blue-scale-100: #e5e5e7;
   --color-blue-scale-200: #9899a5;


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme

### Screenshots

Before:
![Capture_2023-10-16_16:15:18](https://github.com/vatesfr/xen-orchestra/assets/10992860/6676220a-949b-4b7e-98bb-8be3f246b248)

After:
![Capture_2023-10-16_16:15:35](https://github.com/vatesfr/xen-orchestra/assets/10992860/8e633a1a-6453-4f94-88c2-1912c70d50d7)

![color-scheme](https://github.com/vatesfr/xen-orchestra/assets/10992860/3dce804a-1605-404f-8b1e-ffafc61723e0)

### Description

Visible change: scrollbars in Chrome become dark in dark mode

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
