### PR TITLE
fix(xo-web/dashboard): empty VDIs shouldn't be flagged as orphan

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Netbox] Fix VMs' `site` property being unnecessarily updated on some versions of Netbox (PR [#7145](https://github.com/vatesfr/xen-orchestra/pull/7145))
+- [Dashboard] Empty Vdis aren(t flagged as orphan) (PR [#7090](https://github.com/vatesfr/xen-orchestra/pull/7090)
 
 ### Packages to release
 
@@ -30,5 +31,5 @@
 <!--packages-start-->
 
 - xo-server-netbox patch
-
+- xo-web patch
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Netbox] Fix VMs' `site` property being unnecessarily updated on some versions of Netbox (PR [#7145](https://github.com/vatesfr/xen-orchestra/pull/7145))
-- [Dashboard] Empty Vdis aren(t flagged as orphan) (PR [#7090](https://github.com/vatesfr/xen-orchestra/pull/7090)
+- [Dashboard/Health] Empty VDIs are no longer considered orphans (PR [#7102](https://github.com/vatesfr/xen-orchestra/pull/7102))
 
 ### Packages to release
 

--- a/packages/xo-web/src/xo-app/dashboard/health/index.js
+++ b/packages/xo-web/src/xo-app/dashboard/health/index.js
@@ -525,7 +525,11 @@ const HANDLED_VDI_TYPES = new Set(['system', 'user', 'ephemeral'])
         Object.assign({}, vdis, snapshotVdis)
       ),
       createSelector(getSrs, srs => vdi => {
-        if (vdi.$VBDs.length !== 0 || !HANDLED_VDI_TYPES.has(vdi.VDI_type)) {
+        if (
+          vdi.$VBDs.length !== 0 || // vdi with a vbd aren't orphans
+          !HANDLED_VDI_TYPES.has(vdi.VDI_type) || // only for vdi with handled types
+          vdi.size === 0 // empty vdi aren't considered as orphans
+        ) {
           return false
         }
 


### PR DESCRIPTION
### Description

![Orphaned VDIs](https://github.com/vatesfr/xen-orchestra/assets/50174/a61a57c9-6c89-4e7d-9b05-f475c2a5d01e)

Fixes zammad#15524 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
