### PR TITLE
feat(xo-web/dashboard/health): display number of VDIs to coalesce

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 - [PIF] Show network name in PIF selectors (PR [#7081](https://github.com/vatesfr/xen-orchestra/pull/7081))
 - [VM/Advanced] Possibility to create/delete VTPM [#7066](https://github.com/vatesfr/xen-orchestra/issues/7066) [Forum#6578](https://xcp-ng.org/forum/topic/6578/xcp-ng-8-3-public-alpha/109) (PR [#7085](https://github.com/vatesfr/xen-orchestra/pull/7085))
 - [VM/New] Possibility to create and attach a _VTPM_ to a VM [#7066](https://github.com/vatesfr/xen-orchestra/issues/7066) [Forum#6578](https://xcp-ng.org/forum/topic/6578/xcp-ng-8-3-public-alpha/109) (PR [#7077](https://github.com/vatesfr/xen-orchestra/pull/7077))
+- [Dashboard/Health] Displays number of VDIs to coalesce (PR [#7111](https://github.com/vatesfr/xen-orchestra/pull/7111))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1574,6 +1574,7 @@ const messages = {
   spaceLeftTooltip: '{used}% used ({free} left)',
   unhealthyVdis: 'Unhealthy VDIs',
   vdisToCoalesce: 'VDIs to coalesce',
+  nVdis: '{nVdis, number} VDI{nVdis, plural, one {} other {s}}:',
   vdisWithInvalidVhdParent: 'VDIs with invalid parent VHD',
   srVdisToCoalesceWarning: 'This SR has more than {limitVdis, number} VDIs to coalesce',
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1370,7 +1370,8 @@ const messages = {
   // ----- VM advanced tab -----
   createVtpm: 'Create a VTPM',
   deleteVtpm: 'Delete the VTPM',
-  deleteVtpmWarning: 'If the VTPM is in use, removing it will result in a dangerous data loss. Are you sure you want to remove the VTPM?',
+  deleteVtpmWarning:
+    'If the VTPM is in use, removing it will result in a dangerous data loss. Are you sure you want to remove the VTPM?',
   vmRemoveButton: 'Remove',
   vmConvertToTemplateButton: 'Convert to template',
   vmSwitchVirtualizationMode: 'Convert to {mode}',
@@ -1574,9 +1575,8 @@ const messages = {
   spaceLeftTooltip: '{used}% used ({free} left)',
   unhealthyVdis: 'Unhealthy VDIs',
   vdisToCoalesce: 'VDIs to coalesce',
-  nVdis: '{nVdis, number} VDI{nVdis, plural, one {} other {s}}:',
   vdisWithInvalidVhdParent: 'VDIs with invalid parent VHD',
-  srVdisToCoalesceWarning: 'This SR has more than {limitVdis, number} VDIs to coalesce',
+  srVdisToCoalesceWarning: 'This SR has {nVdis, number} VDI{nVdis, plural, one {} other {s}} to coalesce',
 
   // ----- New VM -----
   createVmModalTitle: 'Create VM',

--- a/packages/xo-web/src/xo-app/dashboard/health/unhealthyVdis.js
+++ b/packages/xo-web/src/xo-app/dashboard/health/unhealthyVdis.js
@@ -11,7 +11,7 @@ import { connectStore } from 'utils'
 import { Col, Row } from 'grid'
 import { createGetObjectsOfType } from 'selectors'
 import { injectState, provideState } from 'reaclette'
-import { forEach, isEmpty, map, size } from 'lodash'
+import { forEach, isEmpty, map } from 'lodash'
 import { Sr, Vdi } from 'render-xo-item'
 import { subscribeSrsUnhealthyVdiChainsLength, VDIS_TO_COALESCE_LIMIT } from 'xo'
 
@@ -20,8 +20,8 @@ const COLUMNS = [
     itemRenderer: (srId, { vdisHealthBySr }) => (
       <div>
         <Sr id={srId} link />{' '}
-        {size(vdisHealthBySr[srId].unhealthyVdis) >= VDIS_TO_COALESCE_LIMIT && (
-          <Tooltip content={_('srVdisToCoalesceWarning', { limitVdis: VDIS_TO_COALESCE_LIMIT })}>
+        {vdisHealthBySr[srId].nUnhealthyVdis >= VDIS_TO_COALESCE_LIMIT && (
+          <Tooltip content={_('srVdisToCoalesceWarning', { nVdis: vdisHealthBySr[srId].nUnhealthyVdis })}>
             <span className='text-warning'>
               <Icon icon='alarm' />
             </span>
@@ -35,11 +35,6 @@ const COLUMNS = [
   {
     itemRenderer: (srId, { vdisHealthBySr }) => (
       <div>
-        <SingleLineRow>
-          <Col>
-            <em>{_('nVdis', { nVdis: size(vdisHealthBySr[srId].unhealthyVdis) })}</em>
-          </Col>
-        </SingleLineRow>
         {map(vdisHealthBySr[srId].unhealthyVdis, (unhealthyVdiLength, vdiId) => (
           <SingleLineRow key={vdiId}>
             <Col>

--- a/packages/xo-web/src/xo-app/dashboard/health/unhealthyVdis.js
+++ b/packages/xo-web/src/xo-app/dashboard/health/unhealthyVdis.js
@@ -35,6 +35,11 @@ const COLUMNS = [
   {
     itemRenderer: (srId, { vdisHealthBySr }) => (
       <div>
+        <SingleLineRow>
+          <Col>
+            <em>{_('nVdis', { nVdis: size(vdisHealthBySr[srId].unhealthyVdis) })}</em>
+          </Col>
+        </SingleLineRow>
         {map(vdisHealthBySr[srId].unhealthyVdis, (unhealthyVdiLength, vdiId) => (
           <SingleLineRow key={vdiId}>
             <Col>


### PR DESCRIPTION
Fixes Zammad#17577

### Description

In dashboard/health view, displays number of VDIs to coalesce :
![Screenshot from 2023-10-20 13-25-33](https://github.com/vatesfr/xen-orchestra/assets/119158464/f48fe294-25d2-46cf-8a18-353126e8e8d5)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as 
_Draft_
