### PR TITLE
feat(xo-web/self): show # of VMs that belong to each Resource Set

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 - [PIF] Show network name in PIF selectors (PR [#7081](https://github.com/vatesfr/xen-orchestra/pull/7081))
 - [VM/Advanced] Possibility to create/delete VTPM [#7066](https://github.com/vatesfr/xen-orchestra/issues/7066) [Forum#6578](https://xcp-ng.org/forum/topic/6578/xcp-ng-8-3-public-alpha/109) (PR [#7085](https://github.com/vatesfr/xen-orchestra/pull/7085))
 - [VM/New] Possibility to create and attach a _VTPM_ to a VM [#7066](https://github.com/vatesfr/xen-orchestra/issues/7066) [Forum#6578](https://xcp-ng.org/forum/topic/6578/xcp-ng-8-3-public-alpha/109) (PR [#7077](https://github.com/vatesfr/xen-orchestra/pull/7077))
-- [Self] Show number of VMs that belong to each Resource Set
+- [Self] Show number of VMs that belong to each Resource Set (PR [#7114](https://github.com/vatesfr/xen-orchestra/pull/7114))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 - [PIF] Show network name in PIF selectors (PR [#7081](https://github.com/vatesfr/xen-orchestra/pull/7081))
 - [VM/Advanced] Possibility to create/delete VTPM [#7066](https://github.com/vatesfr/xen-orchestra/issues/7066) [Forum#6578](https://xcp-ng.org/forum/topic/6578/xcp-ng-8-3-public-alpha/109) (PR [#7085](https://github.com/vatesfr/xen-orchestra/pull/7085))
 - [VM/New] Possibility to create and attach a _VTPM_ to a VM [#7066](https://github.com/vatesfr/xen-orchestra/issues/7066) [Forum#6578](https://xcp-ng.org/forum/topic/6578/xcp-ng-8-3-public-alpha/109) (PR [#7077](https://github.com/vatesfr/xen-orchestra/pull/7077))
+- [Self] Show number of VMs that belong to each Resource Set
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1370,7 +1370,8 @@ const messages = {
   // ----- VM advanced tab -----
   createVtpm: 'Create a VTPM',
   deleteVtpm: 'Delete the VTPM',
-  deleteVtpmWarning: 'If the VTPM is in use, removing it will result in a dangerous data loss. Are you sure you want to remove the VTPM?',
+  deleteVtpmWarning:
+    'If the VTPM is in use, removing it will result in a dangerous data loss. Are you sure you want to remove the VTPM?',
   vmRemoveButton: 'Remove',
   vmConvertToTemplateButton: 'Convert to template',
   vmSwitchVirtualizationMode: 'Convert to {mode}',
@@ -1691,6 +1692,8 @@ const messages = {
   resourceSetQuota: 'Used: {usage} (Total: {total})',
   resourceSetNew: 'New',
   shareVmsByDefault: 'Share VMs by default',
+  nVmsInResourceSet:
+    '{nVms, number} VM{nVms, plural, one {} other {s}} belong{nVms, plural, one {s} other {}} to this Resource Set',
 
   // ---- VM import ---
   fileType: 'File type:',

--- a/packages/xo-web/src/xo-app/self/index.js
+++ b/packages/xo-web/src/xo-app/self/index.js
@@ -13,6 +13,7 @@ import intersection from 'lodash/intersection'
 import isEmpty from 'lodash/isEmpty'
 import keyBy from 'lodash/keyBy'
 import keys from 'lodash/keys'
+import Link from 'link'
 import map from 'lodash/map'
 import mapKeys from 'lodash/mapKeys'
 import PropTypes from 'prop-types'
@@ -20,6 +21,7 @@ import React from 'react'
 import remove from 'lodash/remove'
 import renderXoItem from 'render-xo-item'
 import ResourceSetQuotas from 'resource-set-quotas'
+import size from 'lodash/size'
 import some from 'lodash/some'
 import Tags from 'tags'
 import Upgrade from 'xoa-upgrade'
@@ -570,10 +572,13 @@ export class Edit extends Component {
 @addSubscriptions({
   ipPools: subscribeIpPools,
 })
+@connectStore({
+  vms: createGetObjectsOfType('VM').filter((state, props) => vm => vm.resourceSet === props.resourceSet.id),
+})
 @injectIntl
 class ResourceSet extends Component {
   _renderDisplay = () => {
-    const { resourceSet } = this.props
+    const { resourceSet, vms } = this.props
     const resolvedIpPools = mapKeys(this.props.ipPools, 'id')
     const { limits, ipPools, subjects, objectsByType, tags } = resourceSet
 
@@ -615,6 +620,9 @@ class ResourceSet extends Component {
       </li>,
       <li key='graphs' className='list-group-item'>
         <ResourceSetQuotas limits={limits} />
+        <Link to={`/home?s=resourceSet:${resourceSet.id}&t=VM`}>
+          <Icon icon='preview' /> {_('nVmsInResourceSet', { nVms: size(vms) })}
+        </Link>
       </li>,
       <li key='actions' className='list-group-item text-xs-center'>
         <div className='btn-toolbar'>


### PR DESCRIPTION
See Zammad#17568

### Screenshots

![Capture_2023-10-20_14:35:41](https://github.com/vatesfr/xen-orchestra/assets/10992860/22536698-a4ee-45f2-b7be-285380c6ac04)
![Capture_2023-10-20_14:36:12](https://github.com/vatesfr/xen-orchestra/assets/10992860/0b72c85b-2d9b-4ae6-9080-bfd6ccfa85a0)
![Capture_2023-10-20_14:37:02](https://github.com/vatesfr/xen-orchestra/assets/10992860/1c1a676b-a39b-45ac-839d-212a047d9239)

### Description

In Self Service dashboard, for each Resource Set:
- show how many VMs belong to that Resource Set
- link to the Home view with the proper filter to show the list of those VMs

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
