### PR TITLE
feat(xo-web/xostor): call to action for source users

### DIFF
--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2501,7 +2501,7 @@ const messages = {
   summary: 'Summary',
   wrongNumberOfHosts: 'Wrong number of hosts',
   xostor: 'XOSTOR',
-  xostorCommunity: 'XOSTOR is available in XOA',
+  xostorAvailableInXoa: 'XOSTOR is available in XOA',
   xostorDiskRequired: 'At least one disk is required',
   xostorDisksDropdownLabel: '({nDisks, number} disk{nDisks, plural, one {} other {s}}) {hostname}',
   xostorFailedVgAlreadyExists:

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2501,6 +2501,7 @@ const messages = {
   summary: 'Summary',
   wrongNumberOfHosts: 'Wrong number of hosts',
   xostor: 'XOSTOR',
+  xostorCommunity: 'XOSTOR is available in XOA',
   xostorDiskRequired: 'At least one disk is required',
   xostorDisksDropdownLabel: '({nDisks, number} disk{nDisks, plural, one {} other {s}}) {hostname}',
   xostorFailedVgAlreadyExists:

--- a/packages/xo-web/src/xo-app/xostor/index.js
+++ b/packages/xo-web/src/xo-app/xostor/index.js
@@ -6,6 +6,7 @@ import React from 'react'
 import { injectState, provideState } from 'reaclette'
 import { Container, Col, Row } from 'grid'
 import { TryXoa } from 'utils'
+import { getXoaPlan, SOURCES } from 'xoa-plans'
 
 import NewXostorForm from './new-xostor-form'
 import XostorList from './xostor-list'
@@ -32,7 +33,14 @@ const Xostor = decorate([
   injectState,
   ({ effects, state }) => (
     <Page header={HEADER}>
-      {process.env.XOA_PLAN < 5 ? (
+      {getXoaPlan() === SOURCES ? (
+        <Container>
+          <h2 className='text-info'>{_('xostorCommunity')}</h2>
+          <p>
+            <TryXoa page='xosan' />
+          </p>
+        </Container>
+      ) : (
         <Container>
           <XostorList />
           <Row className='mb-1'>
@@ -47,13 +55,6 @@ const Xostor = decorate([
             </Col>
           </Row>
           {state.showNewXostorForm && <NewXostorForm />}
-        </Container>
-      ) : (
-        <Container>
-          <h2 className='text-info'>{_('xostorCommunity')}</h2>
-          <p>
-            <TryXoa page='xosan' />
-          </p>
         </Container>
       )}
     </Page>

--- a/packages/xo-web/src/xo-app/xostor/index.js
+++ b/packages/xo-web/src/xo-app/xostor/index.js
@@ -35,7 +35,7 @@ const Xostor = decorate([
     <Page header={HEADER}>
       {getXoaPlan() === SOURCES ? (
         <Container>
-          <h2 className='text-info'>{_('xostorCommunity')}</h2>
+          <h2 className='text-info'>{_('xostorAvailableInXoa')}</h2>
           <p>
             <TryXoa page='xosan' />
           </p>

--- a/packages/xo-web/src/xo-app/xostor/index.js
+++ b/packages/xo-web/src/xo-app/xostor/index.js
@@ -5,6 +5,7 @@ import Icon from 'icon'
 import React from 'react'
 import { injectState, provideState } from 'reaclette'
 import { Container, Col, Row } from 'grid'
+import { TryXoa } from 'utils'
 
 import NewXostorForm from './new-xostor-form'
 import XostorList from './xostor-list'
@@ -31,19 +32,30 @@ const Xostor = decorate([
   injectState,
   ({ effects, state }) => (
     <Page header={HEADER}>
-      <XostorList />
-      <Row className='mb-1'>
-        <Col>
-          <ActionButton
-            btnStyle='primary'
-            handler={effects._toggleShowNewXostorForm}
-            icon={state.showNewXostorForm ? 'minus' : 'plus'}
-          >
-            {_('new')}
-          </ActionButton>
-        </Col>
-      </Row>
-      {state.showNewXostorForm && <NewXostorForm />}
+      {process.env.XOA_PLAN < 5 ? (
+        <Container>
+          <XostorList />
+          <Row className='mb-1'>
+            <Col>
+              <ActionButton
+                btnStyle='primary'
+                handler={effects._toggleShowNewXostorForm}
+                icon={state.showNewXostorForm ? 'minus' : 'plus'}
+              >
+                {_('new')}
+              </ActionButton>
+            </Col>
+          </Row>
+          {state.showNewXostorForm && <NewXostorForm />}
+        </Container>
+      ) : (
+        <Container>
+          <h2 className='text-info'>{_('xostorCommunity')}</h2>
+          <p>
+            <TryXoa page='xosan' />
+          </p>
+        </Container>
+      )}
     </Page>
   ),
 ])


### PR DESCRIPTION
### Screenshot

![Capture d’écran de 2023-10-23 16-00-59](https://github.com/vatesfr/xen-orchestra/assets/70369997/f075758b-0c70-490a-b609-6fb0e24ec505)

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
