### PR TITLE
feat(xo-server/api): proxy.openSupportTunnel

### DIFF
--- a/packages/xo-server/src/api/proxy.mjs
+++ b/packages/xo-server/src/api/proxy.mjs
@@ -202,6 +202,26 @@ checkHealth.params = {
   },
 }
 
+export async function openSupportTunnel({ id }) {
+  await this.callProxyMethod(id, 'appliance.supportTunnel.open')
+
+  for (let i = 0; i < 10; ++i) {
+    const { open, stdout } = await this.callProxyMethod(id, 'appliance.supportTunnel.getState')
+    if (open && stdout.length !== 0) {
+      return stdout
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 1e3))
+  }
+
+  throw new Error('could not open support tunnel')
+}
+
+openSupportTunnel.permission = 'admin'
+openSupportTunnel.params = {
+  id: { type: 'string' },
+}
+
 export function updateApplianceSettings({ id, ...props }) {
   return this.updateProxyAppliance(id, props)
 }


### PR DESCRIPTION
### Description

The goal is to provide an easier way for the support team to open a tunnel on a proxy appliance.

This is the server side of this feature.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
