### PR TITLE
feat(xo-web/proxy): ability to open support tunnel on XO Proxy

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 - [Dashboard/Health] Displays number of VDIs to coalesce (PR [#7111](https://github.com/vatesfr/xen-orchestra/pull/7111))
 - [Self] Show number of VMs that belong to each Resource Set (PR [#7114](https://github.com/vatesfr/xen-orchestra/pull/7114))
 - [About] For source users, display if their XO is up to date [#5934](https://github.com/vatesfr/xen-orchestra/issues/5934) (PR [#7091](https://github.com/vatesfr/xen-orchestra/pull/7091))
+- [Proxy] Ability to open support tunnel on XO Proxy
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
 - [Dashboard/Health] Displays number of VDIs to coalesce (PR [#7111](https://github.com/vatesfr/xen-orchestra/pull/7111))
 - [Self] Show number of VMs that belong to each Resource Set (PR [#7114](https://github.com/vatesfr/xen-orchestra/pull/7114))
 - [About] For source users, display if their XO is up to date [#5934](https://github.com/vatesfr/xen-orchestra/issues/5934) (PR [#7091](https://github.com/vatesfr/xen-orchestra/pull/7091))
-- [Proxy] Ability to open support tunnel on XO Proxy (PRs [#7126](https://github.com/vatesfr/xen-orchestra/pull/7126) [7127](https://github.com/vatesfr/xen-orchestra/pull/7127))
+- [Proxy] Ability to open support tunnel on XO Proxy (PRs [#7126](https://github.com/vatesfr/xen-orchestra/pull/7126) [#7127](https://github.com/vatesfr/xen-orchestra/pull/7127))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
 - [Dashboard/Health] Displays number of VDIs to coalesce (PR [#7111](https://github.com/vatesfr/xen-orchestra/pull/7111))
 - [Self] Show number of VMs that belong to each Resource Set (PR [#7114](https://github.com/vatesfr/xen-orchestra/pull/7114))
 - [About] For source users, display if their XO is up to date [#5934](https://github.com/vatesfr/xen-orchestra/issues/5934) (PR [#7091](https://github.com/vatesfr/xen-orchestra/pull/7091))
-- [Proxy] Ability to open support tunnel on XO Proxy
+- [Proxy] Ability to open support tunnel on XO Proxy (PRs [#7126](https://github.com/vatesfr/xen-orchestra/pull/7126) [7127](https://github.com/vatesfr/xen-orchestra/pull/7127))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -3631,6 +3631,11 @@ export const destroyProxyAppliances = proxies =>
 export const upgradeProxyAppliance = (proxy, props) =>
   _call('proxy.upgradeAppliance', { id: resolveId(proxy), ...props })
 
+export const openTunnelOnProxy = async proxy => {
+  const result = await _call('proxy.openSupportTunnel', { id: resolveId(proxy) }).catch(err => err.message)
+  await alert(_('supportTunnel'), <pre>{result}</pre>)
+}
+
 export const getProxyApplianceUpdaterState = id => _call('proxy.getApplianceUpdaterState', { id })
 
 export const updateProxyApplianceSettings = (id, props) => _call('proxy.updateApplianceSettings', { id, ...props })

--- a/packages/xo-web/src/xo-app/proxies/index.js
+++ b/packages/xo-web/src/xo-app/proxies/index.js
@@ -23,6 +23,7 @@ import {
   forgetProxyAppliances,
   getLicenses,
   getProxyApplianceUpdaterState,
+  openTunnelOnProxy,
   registerProxy,
   subscribeProxies,
   upgradeProxyAppliance,
@@ -110,6 +111,13 @@ const INDIVIDUAL_ACTIONS = [
     handler: (proxy, { upgradeAppliance }) => upgradeAppliance(proxy.id, { ignoreRunningJobs: true }),
     icon: 'upgrade',
     label: _('forceUpgrade'),
+    level: 'primary',
+  },
+  {
+    collapsed: true,
+    handler: proxy => openTunnelOnProxy(proxy),
+    icon: 'open-tunnel',
+    label: _('openTunnel'),
     level: 'primary',
   },
   {


### PR DESCRIPTION
Requires #7126

### Screenshots

![Capture_2023-10-25_15:10:03](https://github.com/vatesfr/xen-orchestra/assets/10992860/c0cdca68-a8d4-45de-9d97-0f4ac033c7cc)
![Capture_2023-10-25_15:10:20](https://github.com/vatesfr/xen-orchestra/assets/10992860/4ca6b306-f11b-479e-910e-fe69929d362a)

### Description

UI for #7126.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
