### PR TITLE
fix(xo-server/snapshot): allow self user that is member of a group to snapshot

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,7 +30,7 @@
 - [Usage report] Fix "Converting circular structure to JSON" error (PR [#7096](https://github.com/vatesfr/xen-orchestra/pull/7096))
 - [Usage report] Fix "Cannot convert undefined or null to object" error (PR [#7092](https://github.com/vatesfr/xen-orchestra/pull/7092))
 - [Plugin/transport-xmpp] Fix plugin load
-- [Self Service] Fix Self users not being able to snapshot VMs when they're members of a user group
+- [Self Service] Fix Self users not being able to snapshot VMs when they're members of a user group (PR [#7129](https://github.com/vatesfr/xen-orchestra/pull/7129))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,6 +30,7 @@
 - [Usage report] Fix "Converting circular structure to JSON" error (PR [#7096](https://github.com/vatesfr/xen-orchestra/pull/7096))
 - [Usage report] Fix "Cannot convert undefined or null to object" error (PR [#7092](https://github.com/vatesfr/xen-orchestra/pull/7092))
 - [Plugin/transport-xmpp] Fix plugin load
+- [Self Service] Fix Self users not being able to snapshot VMs when they're members of a user group
 
 ### Packages to release
 

--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -973,7 +973,12 @@ export const snapshot = defer(async function (
     }
   }
 
-  if (resourceSet === undefined || !resourceSet.subjects.includes(user.id)) {
+  // Workaround: allow Resource Set members to snapshot a VM even though they
+  // don't have operate permissions on the SR(s)
+  if (
+    resourceSet === undefined ||
+    (!resourceSet.subjects.includes(user.id) && !user.groups.some(groupId => resourceSet.subjects.includes(groupId)))
+  ) {
     await checkPermissionOnSrs.call(this, vm)
   }
 


### PR DESCRIPTION
See Zammad#18478

### Description

VM snapshot: when the VM belongs to a Resource Set, we explicitly bypass SR
permission check for users that are members of that Resource Set to allow them
to snapshot their VMs. But we only checked if the user is in the `subjects` list
of the Resource Set and forgot to also check the groups the user belongs to.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
