### PR TITLE
feat(xo-web/New network): don't show PIFs that belong to a bond

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [About] For source users, display if their XO is up to date [#5934](https://github.com/vatesfr/xen-orchestra/issues/5934) (PR [#7091](https://github.com/vatesfr/xen-orchestra/pull/7091))
 - [Proxy] Ability to open support tunnel on XO Proxy (PRs [#7126](https://github.com/vatesfr/xen-orchestra/pull/7126) [#7127](https://github.com/vatesfr/xen-orchestra/pull/7127))
 - [XOSTOR] Ability to create a XOSTOR storage (PR [#6983](https://github.com/vatesfr/xen-orchestra/pull/6983))
-- [XO-WEB] Don't show PIFs that belong to a bond (PR [#7136](https://github.com/vatesfr/xen-orchestra/pull/7136))
+- [New network] Remove bonded PIFs from selector when creating bonded network (PR [#7136](https://github.com/vatesfr/xen-orchestra/pull/7136))
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [About] For source users, display if their XO is up to date [#5934](https://github.com/vatesfr/xen-orchestra/issues/5934) (PR [#7091](https://github.com/vatesfr/xen-orchestra/pull/7091))
 - [Proxy] Ability to open support tunnel on XO Proxy (PRs [#7126](https://github.com/vatesfr/xen-orchestra/pull/7126) [#7127](https://github.com/vatesfr/xen-orchestra/pull/7127))
 - [XOSTOR] Ability to create a XOSTOR storage (PR [#6983](https://github.com/vatesfr/xen-orchestra/pull/6983))
-- [New network] Remove bonded PIFs from selector when creating bonded network (PR [#7136](https://github.com/vatesfr/xen-orchestra/pull/7136))
+- [New network] Remove bonded PIFs from selector when creating network (PR [#7136](https://github.com/vatesfr/xen-orchestra/pull/7136))
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [About] For source users, display if their XO is up to date [#5934](https://github.com/vatesfr/xen-orchestra/issues/5934) (PR [#7091](https://github.com/vatesfr/xen-orchestra/pull/7091))
 - [Proxy] Ability to open support tunnel on XO Proxy (PRs [#7126](https://github.com/vatesfr/xen-orchestra/pull/7126) [#7127](https://github.com/vatesfr/xen-orchestra/pull/7127))
 - [XOSTOR] Ability to create a XOSTOR storage (PR [#6983](https://github.com/vatesfr/xen-orchestra/pull/6983))
+- [XO-WEB] Don't show PIFs that belong to a bond (PR [#7136](https://github.com/vatesfr/xen-orchestra/pull/7136))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/xo-app/new/network/index.js
+++ b/packages/xo-web/src/xo-app/new/network/index.js
@@ -156,7 +156,7 @@ const NewNetwork = decorate([
       pifPredicate:
         (_, { pool }) =>
         pif =>
-          !pif.isBondSlave && pif.vlan === -1 && pif.$host === (pool && pool.master),
+          !pif.isBondSlave && !pif.isBondMaster && pif.vlan === -1 && pif.$host === (pool && pool.master),
       pifPredicateSdnController:
         (_, { pool }) =>
         pif =>


### PR DESCRIPTION
### Description

Condition added to check if PIF is a bond slave or a bond master

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
