### PR TITLE
fix(xo-web/licenses/XOSTOR): various fixes on XOSTOR licenses

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,4 +27,6 @@
 
 <!--packages-start-->
 
+- xo-web patch
+
 <!--packages-end-->

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2504,6 +2504,10 @@ const messages = {
   fieldsMissing: 'Some fields are missing',
   hostsNotSameNumberOfDisks: 'Hosts do not have the same number of disks',
   isTapdevsDisk: 'This is "tapdevs" disk',
+  licenseBoundUnknownXostor: 'License attached to an unknown XOSTOR',
+  licenseNotBoundXostor: 'No XOSTOR attached',
+  licenseExpiredXostorWarning:
+    'The license {licenseId} has expired. You can still use the SR but cannot administrate it anymore.',
   networks: 'Networks',
   notXcpPool: 'Not an XCP-ng pool',
   noXostorFound: 'No XOSTOR found',

--- a/packages/xo-web/src/xo-app/xoa/licenses/index.js
+++ b/packages/xo-web/src/xo-app/xoa/licenses/index.js
@@ -128,6 +128,22 @@ const LicenseManager = ({ item, userData }) => {
     }
   }
 
+  if (type === 'xostor') {
+    const { srId } = item
+
+    if (srId === undefined) {
+      return _('licenseNotBoundXostor')
+    }
+
+    const sr = userData.xostorSrs[srId]
+    return (
+      <span>
+        {sr === undefined ? _('licenseBoundUnknownXostor') : <Link to={`srs/${sr.id}`}>{renderXoItem(sr)}</Link>}{' '}
+        <CopyToClipboardButton value={srId} />
+      </span>
+    )
+  }
+
   console.warn('encountered unsupported license type')
   return null
 }
@@ -174,11 +190,15 @@ const PRODUCTS_COLUMNS = [
 // -----------------------------------------------------------------------------
 
 @adminOnly
-@connectStore({
-  xosanSrs: createGetObjectsOfType('SR').filter([
-    ({ SR_type }) => SR_type === 'xosan', // eslint-disable-line camelcase
-  ]),
-  xoaRegistration: state => state.xoaRegisterState,
+@connectStore(() => {
+  const getSrs = createGetObjectsOfType('SR')
+  return {
+    xosanSrs: getSrs.filter([
+      ({ SR_type }) => SR_type === 'xosan', // eslint-disable-line camelcase
+    ]),
+    xoaRegistration: state => state.xoaRegisterState,
+    xostorSrs: getSrs.filter([({ SR_type }) => SR_type === 'linstor']),
+  }
 })
 @addSubscriptions(() => ({
   plugins: subscribePlugins,
@@ -363,7 +383,7 @@ export default class Licenses extends Component {
       return <em>{_('statusLoading')}</em>
     }
 
-    const { xoaRegistration, selfLicenses, xosanSrs } = this.props
+    const { xoaRegistration, selfLicenses, xosanSrs, xostorSrs } = this.props
 
     return (
       <Container>
@@ -390,6 +410,7 @@ export default class Licenses extends Component {
               data-registeredEmail={xoaRegistration.email}
               data-selfLicenses={selfLicenses}
               data-xosanSrs={xosanSrs}
+              data-xostorSrs={xostorSrs}
               stateUrlParam='s'
             />
           </Col>

--- a/packages/xo-web/src/xo-app/xoa/licenses/xostor.js
+++ b/packages/xo-web/src/xo-app/xoa/licenses/xostor.js
@@ -6,13 +6,14 @@ import Icon from 'icon'
 import React from 'react'
 import SelectLicense from 'select-license'
 import SortedTable from 'sorted-table'
-import Tooltip from 'tooltip'
 import { bindLicense } from 'xo'
 import { connectStore } from 'utils'
-import { createGetObjectsOfType } from 'selectors'
+import { createGetObjectsOfType, createSelector } from 'selectors'
 import { groupBy } from 'lodash'
 import { injectState, provideState } from 'reaclette'
 import { Pool, Sr } from 'render-xo-item'
+
+import BulkIcons from '../../../common/bulk-icons'
 
 class XostorLicensesForm extends Component {
   state = {
@@ -24,40 +25,74 @@ class XostorLicensesForm extends Component {
     return bindLicense(this.state.licenseId, item.uuid).then(userData.updateLicenses)
   }
 
+  getAlerts = createSelector(
+    () => this.props.item,
+    () => this.props.userData,
+    (sr, userData) => {
+      const alerts = []
+      const licenses = userData.licensesByXostorUuid[sr.id]
+
+      // Xostor bound to multiple licenses
+      if (licenses?.length > 1) {
+        alerts.push({
+          level: 'danger',
+          render: (
+            <p>
+              {licenses.map(license => license.id.slice(-4)).join(',')} {_('xostorMultipleLicenses')}
+            </p>
+          ),
+        })
+      }
+
+      const license = licenses?.[0]
+      const slicedLicenseId = license?.id.slice(-4)
+      if (license?.expires < Date.now()) {
+        alerts.push({
+          level: 'danger',
+          render: _('licenseExpiredXostorWarning', { licenseId: slicedLicenseId }),
+        })
+      }
+      return alerts
+    }
+  )
+
   render() {
     const { item, userData } = this.props
     const { licenseId } = this.state
     const licenses = userData.licensesByXostorUuid[item.id]
 
-    // Xostor bound to multiple licenses
-    if (licenses?.length > 1) {
-      return (
-        <div>
-          <span>{licenses.map(license => license.id.slice(-4)).join(',')}</span>{' '}
-          <Tooltip content={_('xostorMultipleLicenses')}>
-            <Icon color='text-danger' icon='alarm' />
-          </Tooltip>
-        </div>
-      )
+    const license = licenses?.[0]
+    const slicedLicenseId = license?.id.slice(-4)
+
+    const alerts = this.getAlerts()
+
+    if (alerts.length > 0) {
+      return <BulkIcons alerts={alerts} />
     }
 
-    const license = licenses?.[0]
     return license !== undefined ? (
-      <span>{license.id.slice(-4)}</span>
+      <span>{slicedLicenseId}</span>
     ) : (
-      <form className='form-inline'>
-        <SelectLicense onChange={this.linkState('licenseId')} productType='xostor' />
-        <ActionButton
-          btnStyle='primary'
-          className='ml-1'
-          disabled={licenseId === 'none'}
-          handler={this.bind}
-          handlerParam={licenseId}
-          icon='connect'
-        >
-          {_('bindLicense')}
-        </ActionButton>
-      </form>
+      <div>
+        {license !== undefined && (
+          <div className='text-danger mb-1'>
+            <Icon icon='alarm' /> {_('licenseHasExpired')}
+          </div>
+        )}
+        <form className='form-inline'>
+          <SelectLicense onChange={this.linkState('licenseId')} productType='xostor' />
+          <ActionButton
+            btnStyle='primary'
+            className='ml-1'
+            disabled={licenseId === 'none'}
+            handler={this.bind}
+            handlerParam={licenseId}
+            icon='connect'
+          >
+            {_('bindLicense')}
+          </ActionButton>
+        </form>
+      </div>
     )
   }
 }

--- a/packages/xo-web/src/xo-app/xoa/licenses/xostor.js
+++ b/packages/xo-web/src/xo-app/xoa/licenses/xostor.js
@@ -57,21 +57,18 @@ class XostorLicensesForm extends Component {
   )
 
   render() {
-    const { item, userData } = this.props
-    const { licenseId } = this.state
-    const licenses = userData.licensesByXostorUuid[item.id]
-
-    const license = licenses?.[0]
-    const slicedLicenseId = license?.id.slice(-4)
-
     const alerts = this.getAlerts()
-
     if (alerts.length > 0) {
       return <BulkIcons alerts={alerts} />
     }
 
+    const { item, userData } = this.props
+    const { licenseId } = this.state
+    const licenses = userData.licensesByXostorUuid[item.id]
+    const license = licenses?.[0]
+
     return license !== undefined ? (
-      <span>{slicedLicenseId}</span>
+      <span>{license?.id.slice(-4)}</span>
     ) : (
       <div>
         {license !== undefined && (

--- a/packages/xo-web/src/xo-app/xoa/licenses/xostor.js
+++ b/packages/xo-web/src/xo-app/xoa/licenses/xostor.js
@@ -38,18 +38,19 @@ class XostorLicensesForm extends Component {
           level: 'danger',
           render: (
             <p>
-              {licenses.map(license => license.id.slice(-4)).join(',')} {_('xostorMultipleLicenses')}
+              {_('xostorMultipleLicenses')}
+              <br />
+              {licenses.map(license => license.id.slice(-4)).join(',')}
             </p>
           ),
         })
       }
 
       const license = licenses?.[0]
-      const slicedLicenseId = license?.id.slice(-4)
       if (license?.expires < Date.now()) {
         alerts.push({
           level: 'danger',
-          render: _('licenseExpiredXostorWarning', { licenseId: slicedLicenseId }),
+          render: _('licenseExpiredXostorWarning', { licenseId: license?.id.slice(-4) }),
         })
       }
       return alerts


### PR DESCRIPTION
introduced by #6983

### Screenshots

![Capture d’écran de 2023-10-30 10-23-11](https://github.com/vatesfr/xen-orchestra/assets/70369997/557d21d7-c145-4078-86c6-6a1ab1da2dc7)
![Capture d’écran de 2023-10-30 11-06-49](https://github.com/vatesfr/xen-orchestra/assets/70369997/90627ea3-0855-4344-9d08-34ad89ce196a)
![Capture d’écran de 2023-10-30 11-07-06](https://github.com/vatesfr/xen-orchestra/assets/70369997/556d6a3a-9198-4260-beaa-a4b5cbe6a285)


### Description

- Handle XOSTOR licenses on `LicenseManager` function.
- Display error if licenses are expired
-  BulkIcons instead Tooltips

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
