### PR TITLE
feat(xo-server-netbox): use Netbox version instead of Netbox API version

### DIFF
--- a/packages/xo-server-netbox/src/index.js
+++ b/packages/xo-server-netbox/src/index.js
@@ -216,7 +216,7 @@ class Netbox {
 
   async #fetchNetboxVersion() {
     // Endpoint supported since v2.10. If not supported, Netbox needs to be updated.
-    this.#netboxVersion = (await this.#request('/status/'))['netbox-version']
+    this.#netboxVersion = semver.coerce((await this.#request('/status/'))['netbox-version']).version
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/xo-server-netbox/src/index.js
+++ b/packages/xo-server-netbox/src/index.js
@@ -39,7 +39,7 @@ class Netbox {
   #endpoint
   #intervalToken
   #loaded
-  #netboxApiVersion
+  #netboxVersion
   #xoPools
   #removeApiMethods
   #syncInterval
@@ -103,6 +103,7 @@ class Netbox {
   }
 
   async test() {
+    await this.#fetchNetboxVersion()
     await this.#checkCustomFields()
 
     const randomSuffix = Math.random().toString(36).slice(2, 11)
@@ -185,7 +186,7 @@ class Netbox {
       response = await httpRequest()
     }
 
-    if (method !== 'GET') {
+    if (method !== 'GET' || response.results === undefined) {
       return response
     }
 
@@ -213,9 +214,15 @@ class Netbox {
     }
   }
 
+  async #fetchNetboxVersion() {
+    // Endpoint supported since v2.10. If not supported, Netbox needs to be updated.
+    this.#netboxVersion = (await this.#request('/status/'))['netbox-version']
+  }
+
   // ---------------------------------------------------------------------------
 
   async #synchronize(xoPools = this.#xoPools) {
+    await this.#fetchNetboxVersion()
     await this.#checkCustomFields()
 
     log.info(`Synchronizing ${xoPools.length} pools with Netbox`, { pools: xoPools })
@@ -342,7 +349,7 @@ class Netbox {
       // v3.3.0: "site" is REQUIRED and MUST be the same as cluster's site
       // v3.3.5: "site" is OPTIONAL (auto-assigned in UI, not in API). `null` and cluster's site are accepted.
       // v3.4.8: "site" is OPTIONAL and AUTO-ASSIGNED with cluster's site. If passed: ignored except if site is different from cluster's, then error.
-      if (this.#netboxApiVersion === undefined || semver.satisfies(this.#netboxApiVersion, '3.3.0 - 3.4.7')) {
+      if (this.#netboxVersion === undefined || semver.satisfies(this.#netboxVersion, '3.3.0 - 3.4.7')) {
         nbVm.site = find(nbClusters, { id: nbCluster.id })?.site?.id ?? null
       }
 
@@ -389,7 +396,7 @@ class Netbox {
       nbVm.tags = nbVmTags.sort(({ id: id1 }, { id: id2 }) => (id1 < id2 ? -1 : 1))
 
       // https://netbox.readthedocs.io/en/stable/release-notes/version-2.7/#api-choice-fields-now-use-string-values-3569
-      if (this.#netboxApiVersion !== undefined && !semver.satisfies(this.#netboxApiVersion, '>=2.7.0')) {
+      if (this.#netboxVersion !== undefined && !semver.satisfies(this.#netboxVersion, '>=2.7.0')) {
         nbVm.status = xoVm.power_state === 'Running' ? 1 : 0
       }
 

--- a/packages/xo-server-netbox/src/index.js
+++ b/packages/xo-server-netbox/src/index.js
@@ -145,9 +145,6 @@ class Netbox {
     const httpRequest = async () => {
       try {
         const response = await this.#xo.httpRequest(url, options)
-        // API version only follows minor version, which is less precise and is not semver-valid
-        // See https://github.com/netbox-community/netbox/issues/12879#issuecomment-1589190236
-        this.#netboxApiVersion = semver.coerce(response.headers['api-version'])?.version ?? undefined
         const resBody = await response.text()
         if (resBody.length > 0) {
           return JSON.parse(resBody)


### PR DESCRIPTION
### Description

Netbox version is more precise (X.Y.Z instead of X.Y)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
