### PR TITLE
fix(@xen-orchestra/backups): fix METHOD_NOT_ALLOWED when doing full backup

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/FullXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/FullXapi.mjs
@@ -41,9 +41,10 @@ export const FullXapi = class FullXapiVmBackupRunner extends AbstractXapi {
     for (const vdiRef of vdis) {
       const vdi = await this._xapi.getRecord('VDI', vdiRef)
 
-      // at most the xva will take the physical usage of the disk
-      // the resulting stream can be smaller due to the smaller block size for xva than vhd, and compression of xcp-ng
-      maxStreamLength += vdi.physical_utilisation
+      // the size a of fully allocated vdi will be virtual_size  exaclty, it's a gross over evaluation
+      // of the real stream size in general, since a disk is never completly full
+      // vdi.physical_size seems to underevaluate a lot the real disk usage of a VDI, as of 2023-10-30
+      maxStreamLength += vdi.virtual_size
     }
 
     const sizeContainer = watchStreamSize(stream)

--- a/@xen-orchestra/backups/_runners/_vmRunners/FullXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/FullXapi.mjs
@@ -39,7 +39,8 @@ export const FullXapi = class FullXapiVmBackupRunner extends AbstractXapi {
     const vdis = await exportedVm.$getDisks()
     let maxStreamLength = 1024 * 1024 // Ovf file and tar headers are a few KB, let's stay safe
     for (const vdiRef of vdis) {
-      const vdi = await this._xapi.getRecord(vdiRef)
+      const vdi = await this._xapi.getRecord('VDI', vdiRef)
+
       // at most the xva will take the physical usage of the disk
       // the resulting stream can be smaller due to the smaller block size for xva than vhd, and compression of xcp-ng
       maxStreamLength += vdi.physical_utilisation

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Netbox] Fix "The selected cluster is not assigned to this site" error [Forum#7887](https://xcp-ng.org/forum/topic/7887) (PR [#7124](https://github.com/vatesfr/xen-orchestra/pull/7124))
+- [Backups] Fix `MESSAGE_METHOD_UNKNOWN` during full backup [Forum#7894](https://xcp-ng.org/forum/topic/7894)(PR [#7139](https://github.com/vatesfr/xen-orchestra/pull/7139))
 
 ### Packages to release
 
@@ -29,6 +30,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
 - xo-cli minor
 - xo-server-netbox patch
 - xo-web patch


### PR DESCRIPTION
introduced by #7086

### Description

review by commit , do not squash 

physical_size return 5120 and 12800 for a VM which produce a 229MB export 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
