### PR TITLE
fix(xo-server/resource-set): fix error when changing VM resource set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - [Self Service] Fix Self users not being able to snapshot VMs when they're members of a user group (PR [#7129](https://github.com/vatesfr/xen-orchestra/pull/7129))
 - [Netbox] Fix "The selected cluster is not assigned to this site" error [Forum#7887](https://xcp-ng.org/forum/topic/7887) (PR [#7124](https://github.com/vatesfr/xen-orchestra/pull/7124))
 - [Backups] Fix `MESSAGE_METHOD_UNKNOWN` during full backup [Forum#7894](https://xcp-ng.org/forum/topic/7894)(PR [#7139](https://github.com/vatesfr/xen-orchestra/pull/7139))
+- [Resource Set] Fix error displayed after successful VM addition to resource set PR ([#7144](https://github.com/vatesfr/xen-orchestra/pull/7144))
 
 ### Released packages
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@
 - [Self Service] Fix Self users not being able to snapshot VMs when they're members of a user group (PR [#7129](https://github.com/vatesfr/xen-orchestra/pull/7129))
 - [Netbox] Fix "The selected cluster is not assigned to this site" error [Forum#7887](https://xcp-ng.org/forum/topic/7887) (PR [#7124](https://github.com/vatesfr/xen-orchestra/pull/7124))
 - [Backups] Fix `MESSAGE_METHOD_UNKNOWN` during full backup [Forum#7894](https://xcp-ng.org/forum/topic/7894)(PR [#7139](https://github.com/vatesfr/xen-orchestra/pull/7139))
-- [Resource Set] Fix error displayed after successful VM addition to resource set PR ([#7144](https://github.com/vatesfr/xen-orchestra/pull/7144))
+- [Self Service] Fix error displayed after adding a VM to a resource set ([PR #7144](https://github.com/vatesfr/xen-orchestra/pull/7144))
 
 ### Released packages
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,6 @@
 - [Self Service] Fix Self users not being able to snapshot VMs when they're members of a user group (PR [#7129](https://github.com/vatesfr/xen-orchestra/pull/7129))
 - [Netbox] Fix "The selected cluster is not assigned to this site" error [Forum#7887](https://xcp-ng.org/forum/topic/7887) (PR [#7124](https://github.com/vatesfr/xen-orchestra/pull/7124))
 - [Backups] Fix `MESSAGE_METHOD_UNKNOWN` during full backup [Forum#7894](https://xcp-ng.org/forum/topic/7894)(PR [#7139](https://github.com/vatesfr/xen-orchestra/pull/7139))
-- [Self Service] Fix error displayed after adding a VM to a resource set ([PR #7144](https://github.com/vatesfr/xen-orchestra/pull/7144))
 
 ### Released packages
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 - [Backup/Restore] In case of snapshot with memory, create the suspend VDI on the correct SR instead of the default one
 - [Import/ESXi] Handle `Cannot read properties of undefined (reading 'perDatastoreUsage')` error when importing VM without storage (PR [#7168](https://github.com/vatesfr/xen-orchestra/pull/7168))
 - [Export/OVA] Handle export with resulting disk larger than 8.2GB (PR [#7183](https://github.com/vatesfr/xen-orchestra/pull/7183))
+- [Self Service] Fix error displayed after adding a VM to a resource set ([PR #7144](https://github.com/vatesfr/xen-orchestra/pull/7144))
 
 ### Packages to release
 
@@ -37,6 +38,7 @@
 - @xen-orchestra/backups patch
 - @xen-orchestra/cr-seed-cli major
 - @xen-orchestra/vmware-explorer patch
+- xo-server patch
 - xo-server-netbox minor
 - xo-vmdk-to-vhd patch
 - xo-web patch

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,7 @@
 - [Backup/Restore] In case of snapshot with memory, create the suspend VDI on the correct SR instead of the default one
 - [Import/ESXi] Handle `Cannot read properties of undefined (reading 'perDatastoreUsage')` error when importing VM without storage (PR [#7168](https://github.com/vatesfr/xen-orchestra/pull/7168))
 - [Export/OVA] Handle export with resulting disk larger than 8.2GB (PR [#7183](https://github.com/vatesfr/xen-orchestra/pull/7183))
-- [Self Service] Fix error displayed after adding a VM to a resource set ([PR #7144](https://github.com/vatesfr/xen-orchestra/pull/7144))
+- [Self Service] Fix error displayed after adding a VM to a resource set (PR [#7144](https://github.com/vatesfr/xen-orchestra/pull/7144))
 
 ### Packages to release
 

--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -647,11 +647,12 @@ export const set = defer(async function ($defer, params) {
     }
 
     await this.setVmResourceSet(vmId, resourceSetId, true)
-  }
-
-  const share = extract(params, 'share')
-  if (share) {
-    await this.shareVmResourceSet(vmId)
+  } else {
+    // share is implicit in the other branch with `setVmResourceSet`
+    const share = extract(params, 'share')
+    if (share) {
+      await this.shareVmResourceSet(vmId)
+    }
   }
 
   const suspendSr = extract(params, 'suspendSr')

--- a/packages/xo-server/src/xo-mixins/resource-sets.mjs
+++ b/packages/xo-server/src/xo-mixins/resource-sets.mjs
@@ -444,6 +444,7 @@ export default class {
 
   async shareVmResourceSet(vmId) {
     const xapi = this._app.getXapi(vmId)
+    await xapi.barrier(xapi.getObject(vmId).$ref)
     const resourceSetId = xapi.xo.getData(vmId, 'resourceSet')
     if (resourceSetId === undefined) {
       throw new Error('the vm is not in a resource set')

--- a/packages/xo-server/src/xo-mixins/resource-sets.mjs
+++ b/packages/xo-server/src/xo-mixins/resource-sets.mjs
@@ -430,6 +430,10 @@ export default class {
     }
 
     await xapi.xo.setData(vmId, 'resourceSet', resourceSetId === undefined ? null : resourceSetId)
+    await xapi.barrier(xapi.getObject(vmId).$ref)
+    // barrier function is used to ensure completion of previous asynchronous operations
+    // on the vmId object, guaranteeing that all modifications are considered before
+    // retrieving the resourceSetId value.
     $defer.onFailure(() =>
       xapi.xo.setData(vmId, 'resourceSet', previousResourceSetId === undefined ? null : previousResourceSetId)
     )
@@ -444,9 +448,6 @@ export default class {
 
   async shareVmResourceSet(vmId) {
     const xapi = this._app.getXapi(vmId)
-    await xapi.barrier(xapi.getObject(vmId).$ref)
-    // barrier function is used to ensure completion of previous asynchronous operations
-    // on the vmId object, guaranteeing that all modifications are considered before retrieving the resourceSetId value.
     const resourceSetId = xapi.xo.getData(vmId, 'resourceSet')
     if (resourceSetId === undefined) {
       throw new Error('the vm is not in a resource set')

--- a/packages/xo-server/src/xo-mixins/resource-sets.mjs
+++ b/packages/xo-server/src/xo-mixins/resource-sets.mjs
@@ -445,6 +445,8 @@ export default class {
   async shareVmResourceSet(vmId) {
     const xapi = this._app.getXapi(vmId)
     await xapi.barrier(xapi.getObject(vmId).$ref)
+    // barrier function is used to ensure completion of previous asynchronous operations
+    // on the vmId object, guaranteeing that all modifications are considered before retrieving the resourceSetId value.
     const resourceSetId = xapi.xo.getData(vmId, 'resourceSet')
     if (resourceSetId === undefined) {
       throw new Error('the vm is not in a resource set')


### PR DESCRIPTION
### Description

Fixed error displayed after successful VM addition to resource set:
value of "resourceSetId" was not properly retrieved with setData on setVmResourceSet method, so we used the barrier object to ensure that all preceding asynchronous operations are completed before proceeding to the next step.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
