### PR TITLE
fix(netbox): fix site property null/undefined cases

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,4 +27,6 @@
 
 <!--packages-start-->
 
+- xo-server-netbox patch
+
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Netbox] Fix VMs' `site` property being unnecessarily updated on some versions of Netbox (PR [#7145](https://github.com/vatesfr/xen-orchestra/pull/7145))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/packages/xo-server-netbox/src/index.js
+++ b/packages/xo-server-netbox/src/index.js
@@ -402,7 +402,9 @@ class Netbox {
       cluster: nbVm.cluster?.id ?? null,
       status: nbVm.status?.value ?? null,
       platform: nbVm.platform?.id ?? null,
-      site: nbVm.site?.id,
+      // If site is not supported by Netbox, its value is undefined
+      // If site is supported by Netbox but empty, its value is null
+      site: nbVm.site == null ? nbVm.site : nbVm.site.id,
       // Sort them so that they can be compared by diff()
       tags: nbVm.tags.map(nbTag => ({ id: nbTag.id })).sort(({ id: id1 }, { id: id2 }) => (id1 < id2 ? -1 : 1)),
     })


### PR DESCRIPTION
Introduced by 1d7559ded2c29257285f984c03841646ae70efa8

### Description

When flattening a Netbox VM, the `site` property should be:
- `undefined` if `nbVm.site === undefined` (`site` is not supported)
- `null` if `nbVm.site === null` (`site` is supported and empty)
- `'abc'` if `nbVm.site === 'abc'` (`site` is supported and not empty)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
