### PR TITLE
fix(xo-web/New network): only hide bond-PIFs when creating a bonded n…

### DIFF
--- a/packages/xo-web/src/xo-app/new/network/index.js
+++ b/packages/xo-web/src/xo-app/new/network/index.js
@@ -154,9 +154,9 @@ const NewNetwork = decorate([
         host =>
           host.$pool === pool.id || networks.some(({ pool }) => pool !== undefined && pool.id === host.$pool),
       pifPredicate:
-        (_, { pool }) =>
+        ({ bonded }, { pool }) =>
         pif =>
-          !pif.isBondSlave && !pif.isBondMaster && pif.vlan === -1 && pif.$host === (pool && pool.master),
+          !pif.isBondSlave && !(bonded && pif.isBondMaster) && pif.vlan === -1 && pif.$host === (pool && pool.master),
       pifPredicateSdnController:
         (_, { pool }) =>
         pif =>


### PR DESCRIPTION
Fixes #7150
See https://xcp-ng.org/forum/topic/7918
Introduced by dbdc5f3e3befae75c29ba501886ea7555c8d480e

### Description

A bond should not be used to create *another bond* so we decided to filter out bond-PIFs from the PIF selector in PR #7136. But we forgot to check that the user toggled "Bonded network"!

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
