### PR TITLE
fix(proxy/backup.importVmBackup): only dispose resources at the end

### DIFF
--- a/@xen-orchestra/proxy/app/mixins/backups.mjs
+++ b/@xen-orchestra/proxy/app/mixins/backups.mjs
@@ -5,7 +5,6 @@ import { compose } from '@vates/compose'
 import { createLogger } from '@xen-orchestra/log'
 import { decorateMethodsWith } from '@vates/decorate-with'
 import { deduped } from '@vates/disposable/deduped.js'
-import { defer } from 'golike-defer'
 import { DurablePartition } from '@xen-orchestra/backups/DurablePartition.mjs'
 import { execFile } from 'child_process'
 import { formatVmBackups } from '@xen-orchestra/backups/formatVmBackups.mjs'
@@ -192,7 +191,7 @@ export default class Backups {
           },
         ],
         importVmBackup: [
-          defer(async ($defer, { backupId, remote, srUuid, settings, streamLogs = false, xapi: xapiOpts }) => {
+          async ({ backupId, remote, srUuid, settings, streamLogs = false, xapi: xapiOpts }) => {
             const {
               dispose,
               value: [adapter, xapi],
@@ -226,7 +225,7 @@ export default class Backups {
             } finally {
               await dispose()
             }
-          }),
+          },
           {
             description: 'create a new VM from a backup',
             params: {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,7 @@
 
 - [Netbox] Fix VMs' `site` property being unnecessarily updated on some versions of Netbox (PR [#7145](https://github.com/vatesfr/xen-orchestra/pull/7145))
 - [Netbox] Fix "400 Bad Request" error (PR [#7153](https://github.com/vatesfr/xen-orchestra/pull/7153))
+- [Backup/Restore] Fix timeout after 5 minutes [#7052](https://github.com/vatesfr/xen-orchestra/issues/7052)
 
 ### Packages to release
 
@@ -30,6 +31,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/proxy patch
 - xo-server-netbox patch
 
 <!--packages-end-->


### PR DESCRIPTION
**DO NOT SQUASH**, [review by commits](https://github.com/vatesfr/xen-orchestra/pull/7152/commits).

### Description

Fixes #7052

Fixes zammad#17383

When a stream is returned, the handler immediately returned a stream which disposed the resource.

Due to the disposable having a 5 mins debounce delay, the problem was only apparent after 5 mins.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
