### PR TITLE
fix(xo-server-netbox): properly delete all interfaces that don't have a UUID

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Netbox] Fix VMs' `site` property being unnecessarily updated on some versions of Netbox (PR [#7145](https://github.com/vatesfr/xen-orchestra/pull/7145))
-- [Netbox] Fix "400 Bad Request" error
+- [Netbox] Fix "400 Bad Request" error (PR [#7153](https://github.com/vatesfr/xen-orchestra/pull/7153))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Netbox] Fix VMs' `site` property being unnecessarily updated on some versions of Netbox (PR [#7145](https://github.com/vatesfr/xen-orchestra/pull/7145))
+- [Netbox] Fix "400 Bad Request" error
 
 ### Packages to release
 

--- a/packages/xo-server-netbox/src/index.js
+++ b/packages/xo-server-netbox/src/index.js
@@ -550,10 +550,11 @@ class Netbox {
         continue
       }
       // Start by deleting old interfaces attached to this Netbox VM
-      Object.entries(nbIfs).forEach(([id, nbIf]) => {
-        if (nbIf.virtual_machine.id === nbVm.id && !xoVm.VIFs.includes(nbIf.custom_fields.uuid)) {
+      nbIfsList.forEach(nbIf => {
+        const xoVifId = nbIf.custom_fields.uuid
+        if (nbIf.virtual_machine.id === nbVm.id && !xoVm.VIFs.includes(xoVifId)) {
           ifsToDelete.push({ id: nbIf.id })
-          delete nbIfs[id]
+          delete nbIfs[xoVifId]
         }
       })
 

--- a/packages/xo-server-netbox/src/index.js
+++ b/packages/xo-server-netbox/src/index.js
@@ -550,6 +550,7 @@ class Netbox {
         continue
       }
       // Start by deleting old interfaces attached to this Netbox VM
+      // Loop over the array to make sure interfaces with a `null` UUID also get deleted
       nbIfsList.forEach(nbIf => {
         const xoVifId = nbIf.custom_fields.uuid
         if (nbIf.virtual_machine.id === nbVm.id && !xoVm.VIFs.includes(xoVifId)) {


### PR DESCRIPTION
Fixes Zammad#18812
Introduced by 3b1bcc67ae91dcfd124aab042dd9687d0de54533

### Description

The first step of synchronizing VIFs with Netbox interfaces is to clean up any interface attached to the Netbox VM that isn't found on the XO VM, *based on their UUID*, including the interfaces that don't have a UUID at all (`uuid` is `null`).
But by looping over the keyed-by-UUID collection, we could only ever delete at most *one* null-UUID interface, the other ones being dropped by `keyBy`.

Using the flat-array collection instead makes sure all the interfaces are handled.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
