### PR TITLE
feat(xo-web/SR): improve forget SR modal message

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Forget SR] Changed the modal message and added a confirmation text to be sure the action is understood by the user [#7148](https://github.com/vatesfr/xen-orchestra/issues/7148) (PR [#7155](https://github.com/vatesfr/xen-orchestra/pull/7155))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -864,6 +864,7 @@ const messages = {
   srDisconnectAll: 'Disconnect from all hosts',
   srForget: 'Forget this SR',
   srsForget: 'Forget SRs',
+  nSrsForget: 'Forget {nSrs, number} SR{nSrs, plural, one {} other{s}}',
   srRemoveButton: 'Remove this SR',
   srNoVdis: 'No VDIs in this storage',
   srReclaimSpace: 'Reclaim freed space',
@@ -2375,11 +2376,10 @@ const messages = {
   srDisconnectAllModalMessage: 'This will disconnect this SR from all its hosts.',
   srsDisconnectAllModalMessage:
     'This will disconnect each selected SR from its host (local SR) or from every hosts of its pool (shared SR).',
-  srForgetModalTitle: 'Forget SR',
-  srsForgetModalTitle: 'Forget selected SRs',
-  srForgetModalMessage: "Are you sure you want to forget this SR? VDIs on this storage won't be removed.",
-  srsForgetModalMessage:
-    "Are you sure you want to forget all the selected SRs? VDIs on these storages won't be removed.",
+  srForgetModalTitle: 'Forget {nSrs, plural, one {this} other {these}} SR{nSrs, plural, one {} other {s}}',
+  srForgetModalMessage: 'Are you sure you want to forget {nSrs, number} SR{nSrs, plural, one {} other{s}}?',
+  srForgetModalWarning:
+    'You will lose all the metadata for it, meaning all the links between the VDIs (disks) and their respective VMs. This operation cannot be undone.',
   srAllDisconnected: 'Disconnected',
   srSomeConnected: 'Partially connected',
   srAllConnected: 'Connected',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2376,10 +2376,9 @@ const messages = {
   srDisconnectAllModalMessage: 'This will disconnect this SR from all its hosts.',
   srsDisconnectAllModalMessage:
     'This will disconnect each selected SR from its host (local SR) or from every hosts of its pool (shared SR).',
-  srForgetModalTitle: 'Forget {nSrs, plural, one {this} other {these}} SR{nSrs, plural, one {} other {s}}',
-  srForgetModalMessage: 'Are you sure you want to forget {nSrs, number} SR{nSrs, plural, one {} other{s}}?',
+  forgetNSrsModalMessage: 'Are you sure you want to forget {nSrs, number} SR{nSrs, plural, one {} other{s}}?',
   srForgetModalWarning:
-    'You will lose all the metadata for it, meaning all the links between the VDIs (disks) and their respective VMs. This operation cannot be undone.',
+    'You will lose all the metadata, meaning all the links between the VDIs (disks) and their respective VMs. This operation cannot be undone.',
   srAllDisconnected: 'Disconnected',
   srSomeConnected: 'Partially connected',
   srAllConnected: 'Connected',

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -2272,10 +2272,10 @@ export const forgetSr = sr => forgetSrs([sr])
 
 export const forgetSrs = srs =>
   confirm({
-    title: _('srForgetModalTitle', { nSrs: srs.length }),
+    title: _('nSrsForget', { nSrs: srs.length }),
     body: (
       <p className='text-warning font-weight-bold'>
-        {_('srForgetModalMessage', { nSrs: srs.length })} {_('srForgetModalWarning')}
+        {_('forgetNSrsModalMessage', { nSrs: srs.length })} {_('srForgetModalWarning')}
       </p>
     ),
     strongConfirm: {

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -2268,15 +2268,20 @@ export const deleteSr = sr =>
 
 export const fetchSrStats = (sr, granularity) => _call('sr.stats', { id: resolveId(sr), granularity })
 
-export const forgetSr = sr =>
-  confirm({
-    title: _('srForgetModalTitle'),
-    body: _('srForgetModalMessage'),
-  }).then(() => _call('sr.forget', { id: resolveId(sr) }), noop)
+export const forgetSr = sr => forgetSrs([sr])
+
 export const forgetSrs = srs =>
   confirm({
-    title: _('srsForgetModalTitle'),
-    body: _('srsForgetModalMessage'),
+    title: _('srForgetModalTitle', { nSrs: srs.length }),
+    body: (
+      <p className='text-warning font-weight-bold'>
+        {_('srForgetModalMessage', { nSrs: srs.length })} {_('srForgetModalWarning')}
+      </p>
+    ),
+    strongConfirm: {
+      messageId: 'nSrsForget',
+      values: { nSrs: srs.length },
+    },
   }).then(() => Promise.all(map(resolveIds(srs), id => _call('sr.forget', { id }))), noop)
 
 export const reconnectAllHostsSr = sr =>


### PR DESCRIPTION
### Description

Fixes #7148 
Changed the modal message and added a confirmation text to be sure the action is understood by the user:
![Screenshot from 2023-11-03 15-09-15](https://github.com/vatesfr/xen-orchestra/assets/119158464/1ff0fb4c-f64f-4366-9e1d-a07202153a25)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
