### PR TITLE
chore(netbox): remove null-indexed entries from keyed-by collections

### DIFF
--- a/packages/xo-server-netbox/src/index.js
+++ b/packages/xo-server-netbox/src/index.js
@@ -261,6 +261,7 @@ class Netbox {
       await this.#request(`/virtualization/clusters/?type_id=${nbClusterType.id}`),
       'custom_fields.uuid'
     )
+    delete allNbClusters.null
     const nbClusters = pick(allNbClusters, xoPools)
 
     const clustersToCreate = []
@@ -421,7 +422,9 @@ class Netbox {
     // Then make them objects to map the Netbox VMs to their XO VMs
     // { VM UUID → Netbox VM }
     const allNbVms = keyBy(allNbVmsList, 'custom_fields.uuid')
+    delete allNbVms.null
     const nbVms = keyBy(nbVmsList, 'custom_fields.uuid')
+    delete nbVms.null
 
     // Used for name deduplication
     // Start by storing the names of the VMs that have been created manually in
@@ -539,6 +542,7 @@ class Netbox {
     const nbIfsList = await this.#request(`/virtualization/interfaces/?${clusterFilter}`)
     // { ID → Interface }
     const nbIfs = keyBy(nbIfsList, 'custom_fields.uuid')
+    delete nbIfs.null
 
     const ifsToDelete = []
     const ifsToUpdate = []
@@ -780,7 +784,10 @@ class Netbox {
       }
     }
 
-    Object.assign(nbVms, keyBy(await this.#request('/virtualization/virtual-machines/', 'PATCH', vmsToUpdate2)))
+    Object.assign(
+      nbVms,
+      keyBy(await this.#request('/virtualization/virtual-machines/', 'PATCH', vmsToUpdate2), 'custom_fields.uuid')
+    )
 
     log.info(`Done synchronizing ${xoPools.length} pools with Netbox`, { pools: xoPools })
   }


### PR DESCRIPTION
### Description

When we use lodash's keyBy to map UUIDs to Netbox objects, there can be an entry with a `null` key since some objects may not have a UUID. That entry is never used, can be unexpected and is bug prone so it's safer to remove it.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
