### PR TITLE
fix(vmware-explorer): better handling of VM import without any storage

### DIFF
--- a/@xen-orchestra/vmware-explorer/esxi.mjs
+++ b/@xen-orchestra/vmware-explorer/esxi.mjs
@@ -235,6 +235,9 @@ export default class Esxi extends EventEmitter {
 
     return Object.keys(datas).map(id => {
       const { config, storage, runtime } = datas[id]
+      if (storage === undefined) {
+        throw new Error(`source VM ${id} don't have any storage`)
+      }
       const perDatastoreUsage = Array.isArray(storage.perDatastoreUsage)
         ? storage.perDatastoreUsage
         : [storage.perDatastoreUsage]

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Backup/Restore] In case of snapshot with memory, create the suspend VDI on the correct SR instead of the default one
+- [Import/Esxi] Handle `Cannot read properties of undefined (reading 'perDatastoreUsage')` error whe importing a VM without any storage (PR [#7168](https://github.com/vatesfr/xen-orchestra/pull/7168))
 
 ### Packages to release
 
@@ -32,6 +33,7 @@
 <!--packages-start-->
 
 - @xen-orchestra/backups patch
+- @xen-orchestra/vmware-explorer patch
 - xo-server minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Backup/Restore] In case of snapshot with memory, create the suspend VDI on the correct SR instead of the default one
-- [Import/Esxi] Handle `Cannot read properties of undefined (reading 'perDatastoreUsage')` error whe importing a VM without any storage (PR [#7168](https://github.com/vatesfr/xen-orchestra/pull/7168))
+- [Import/ESXi] Handle `Cannot read properties of undefined (reading 'perDatastoreUsage')` error when importing VM without storage (PR [#7168](https://github.com/vatesfr/xen-orchestra/pull/7168))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

from support  18963 , log : 

```
esxi.listVms
{
  "host": "* obfuscated *",
  "user": "* obfuscated *",
  "password": "* obfuscated *",
  "sslVerify": false
}
{
  "message": "Cannot read properties of undefined (reading 'perDatastoreUsage')",
  "name": "TypeError",
  "stack": "TypeError: Cannot read properties of undefined (reading 'perDatastoreUsage')
    at file:///usr/local/lib/node_modules/xo-server/node_modules/@xen-orchestra/vmware-explorer/esxi.mjs:238:55
    at Array.map (<anonymous>)
    at Esxi.getAllVmMetadata (file:///usr/local/lib/node_modules/xo-server/node_modules/@xen-orchestra/vmware-explorer/esxi.mjs:236:31)
    at Api.#callApiMethod (file:///usr/local/lib/node_modules/xo-server/src/xo-mixins/api.mjs:445:20)"
}
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
