### PR TITLE
fix(lite): host patches list is broken if `changelog` property is empty

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Explicit error if users attempt to connect from a slave host (PR [#7110](https://github.com/vatesfr/xen-orchestra/pull/7110))
 - More compact UI (PR [#7159](https://github.com/vatesfr/xen-orchestra/pull/7159))
+- Fix dashboard host patches list (PR [#7169](https://github.com/vatesfr/xen-orchestra/pull/7169))
 
 ## **0.1.5** (2023-11-07)
 

--- a/@xen-orchestra/lite/src/components/HostPatchesTable.vue
+++ b/@xen-orchestra/lite/src/components/HostPatchesTable.vue
@@ -44,9 +44,13 @@ const props = defineProps<{
 }>();
 
 const sortedPatches = computed(() =>
-  [...props.patches].sort(
-    (patch1, patch2) => patch1.changelog.date - patch2.changelog.date
-  )
+  [...props.patches].sort((patch1, patch2) => {
+    if (patch1.changelog == null || patch2.changelog == null) {
+      return 0;
+    }
+
+    return patch1.changelog.date - patch2.changelog.date;
+  })
 );
 
 const { isDesktop } = useUiStore();

--- a/@xen-orchestra/lite/src/components/HostPatchesTable.vue
+++ b/@xen-orchestra/lite/src/components/HostPatchesTable.vue
@@ -45,8 +45,10 @@ const props = defineProps<{
 
 const sortedPatches = computed(() =>
   [...props.patches].sort((patch1, patch2) => {
-    if (patch1.changelog == null || patch2.changelog == null) {
-      return 0;
+    if (patch1.changelog == null) {
+      return 1;
+    } else if (patch2.changelog == null) {
+      return -1;
     }
 
     return patch1.changelog.date - patch2.changelog.date;

--- a/@xen-orchestra/lite/src/types/xen-api.ts
+++ b/@xen-orchestra/lite/src/types/xen-api.ts
@@ -31,9 +31,12 @@ export type XenApiPatch = {
   size: number;
   url: string;
   version: string;
-  changelog: {
-    date: number;
-    description: string;
-    author: string;
-  };
+  changelog:
+    | null
+    | undefined
+    | {
+        date: number;
+        description: string;
+        author: string;
+      };
 };


### PR DESCRIPTION
### Description

On pool dashboard, the host patches list is broken if the `changelog` property of the patch is empty (`null` or `undefined`)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
