### PR TITLE
feat(backups): don't backup VM created by health check

### DIFF
--- a/@xen-orchestra/backups/ImportVmBackup.mjs
+++ b/@xen-orchestra/backups/ImportVmBackup.mjs
@@ -16,20 +16,29 @@ async function resolveUuid(xapi, cache, uuid, type) {
   return cache.get(uuid)
 }
 export class ImportVmBackup {
-  constructor({ adapter, metadata, srUuid, xapi, settings: { newMacAddresses, mapVdisSrs = {} } = {} }) {
+  constructor({
+    adapter,
+    metadata,
+    srUuid,
+    xapi,
+    settings: { additionnalVmTag, newMacAddresses, mapVdisSrs = {} } = {},
+  }) {
     this._adapter = adapter
-    this._importIncrementalVmSettings = { newMacAddresses, mapVdisSrs }
+    this._importIncrementalVmSettings = { additionnalVmTag, newMacAddresses, mapVdisSrs }
     this._metadata = metadata
     this._srUuid = srUuid
     this._xapi = xapi
   }
 
   async #decorateIncrementalVmMetadata(backup) {
-    const { mapVdisSrs } = this._importIncrementalVmSettings
+    const { additionnalVmTag, mapVdisSrs } = this._importIncrementalVmSettings
     const xapi = this._xapi
 
     const cache = new Map()
     const mapVdisSrRefs = {}
+    if (additionnalVmTag !== undefined) {
+      backup.vm.tags.push(additionnalVmTag)
+    }
     for (const [vdiUuid, srUuid] of Object.entries(mapVdisSrs)) {
       mapVdisSrRefs[vdiUuid] = await resolveUuid(xapi, cache, srUuid, 'SR')
     }

--- a/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.mjs
@@ -96,6 +96,9 @@ export const MixinRemoteWriter = (BaseClass = Object) =>
             metadata,
             srUuid,
             xapi,
+            settings: {
+              additionnalVmTag: 'xo:no-bak=Health Check',
+            },
           }).run()
           const restoredVm = xapi.getObject(restoredId)
           try {

--- a/@xen-orchestra/backups/_runners/_writers/_MixinXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/_MixinXapiWriter.mjs
@@ -58,7 +58,7 @@ export const MixinXapiWriter = (BaseClass = Object) =>
               )
             }
             const healthCheckVm = xapi.getObject(healthCheckVmRef) ?? (await xapi.waitObject(healthCheckVmRef))
-
+            await healthCheckVm.add_tag('xo:no-bak=Health Check')
             await new HealthCheckVmBackup({
               restoredVm: healthCheckVm,
               xapi,

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -10,6 +10,7 @@
 - [VM/Disks] Display task information when importing VDIs (PR [#7197](https://github.com/vatesfr/xen-orchestra/pull/7197))
 - [REST API] Support VM import using the XVA format
 - [Task] Show the related SR on the Garbage Collector Task ( vdi coalescing) (PR [#7189](https://github.com/vatesfr/xen-orchestra/pull/7189))
+- [Backup] Don't backup VM with tag xo:no-bak (PR [#7173](https://github.com/vatesfr/xen-orchestra/pull/7173))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Backup/HealthCheck] Don't backup VM created by health check when using smart mode (PR [#7173](https://github.com/vatesfr/xen-orchestra/pull/7173))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
@@ -129,7 +129,9 @@ export default class BackupNg {
                     isMatchingVm(obj) &&
                     // don't match replicated VMs created by this very job otherwise
                     // they will be replicated again and again
-                    !('start' in obj.blockedOperations && obj.other['xo:backup:job'] === job.id)
+                    !('start' in obj.blockedOperations && obj.other['xo:backup:job'] === job.id) &&
+                    // handle xo:no-bak and xo:no-bak=reason tags. For example : VMs from Health Check
+                    !obj.tags.some(t => t.split('=', 1)[0] === 'xo:no-bak')
                 })(),
               })
             )

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
@@ -626,7 +626,10 @@ export default class BackupNg {
       .run(async () => {
         const app = this._app
         const xapi = app.getXapi(srId)
-        const restoredId = await this.importVmBackupNg(backupId, srId, settings)
+        const restoredId = await this.importVmBackupNg(backupId, srId, {
+          ...settings,
+          additionnalVmTag: 'xo:no-bak=Health Check',
+        })
 
         const restoredVm = xapi.getObject(restoredId)
         try {

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -572,6 +572,8 @@ const messages = {
   editBackupSmartNotResidentOn: 'Not resident on',
   editBackupSmartPools: 'Pools',
   editBackupSmartTags: 'Tags',
+  editBackupSmartTagsInfo:
+    "VMs with tags in the form of <b>xo:no-bak</b> or <b>xo:no-bak=Reason</b>won't be included in any backup.For example, ephemeral VMs created by health check have this tag",
   sampleOfMatchingVms: 'Sample of matching VMs',
   backupReplicatedVmsInfo:
     'Replicated VMs (VMs with Continuous Replication or Disaster Recovery tag) must be excluded!',

--- a/packages/xo-web/src/xo-app/backup/new/smart-backup.js
+++ b/packages/xo-web/src/xo-app/backup/new/smart-backup.js
@@ -97,7 +97,12 @@ const SmartBackup = decorate([
         </label>
         <SelectPool multi onChange={effects.setPoolNotValues} value={state.pools.notValues} />
       </FormGroup>
-      <h3>{_('editBackupSmartTags')}</h3>
+      <h3>
+        {_('editBackupSmartTags')}
+        <Tooltip content={_('editBackupSmartTagsInfo')}>
+          <Icon icon='info' />
+        </Tooltip>{' '}
+      </h3>
       <hr />
       <FormGroup>
         <label>


### PR DESCRIPTION
### Description

from [796e2ab674826e06bf76e91220c769296c9d2b8a](https://xcp-ng.org/forum/topic/7837/overlapping-backup-schedules-healthcheck-vms-lead-to-uuid_invalid/3?_=1697010971756) 

add a tag to the VM during the health check , exclude this tag from backups 

do not squash 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
