### PR TITLE
chore(xen-api): http-request-plus → undici (except putResource)

### DIFF
--- a/@xen-orchestra/backups/_runners/_PoolMetadataBackup.mjs
+++ b/@xen-orchestra/backups/_runners/_PoolMetadataBackup.mjs
@@ -31,7 +31,7 @@ export class PoolMetadataBackup {
     const poolDir = `${DIR_XO_POOL_METADATA_BACKUPS}/${schedule.id}/${pool.$id}`
     const dir = `${poolDir}/${formatFilenameDate(timestamp)}`
 
-    const stream = await this._exportPoolMetadata()
+    const stream = (await this._exportPoolMetadata()).body
     const fileName = `${dir}/data`
 
     const metadata = JSON.stringify(

--- a/@xen-orchestra/backups/_runners/_vmRunners/FullXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/FullXapi.mjs
@@ -30,10 +30,12 @@ export const FullXapi = class FullXapiVmBackupRunner extends AbstractXapi {
     const vm = this._vm
     const exportedVm = this._exportedVm
     const stream = this._throttleStream(
-      await this._xapi.VM_export(exportedVm.$ref, {
-        compress: Boolean(compression) && (compression === 'native' ? 'gzip' : 'zstd'),
-        useSnapshot: false,
-      })
+      (
+        await this._xapi.VM_export(exportedVm.$ref, {
+          compress: Boolean(compression) && (compression === 'native' ? 'gzip' : 'zstd'),
+          useSnapshot: false,
+        })
+      ).body
     )
 
     const vdis = await exportedVm.$getDisks()

--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -108,10 +108,12 @@ class Vdi {
       } else {
         // raw export without nbd or vhd exports needs a resource stream
         const vdiName = await this.getField('VDI', ref, 'name_label')
-        stream = await this.getResource(cancelToken, '/export_raw_vdi/', {
-          query,
-          task: await this.task_create(`Exporting content of VDI ${vdiName}`),
-        })
+        stream = (
+          await this.getResource(cancelToken, '/export_raw_vdi/', {
+            query,
+            task: await this.task_create(`Exporting content of VDI ${vdiName}`),
+          })
+        ).body
         if (nbdClient !== undefined && format === VDI_FORMAT_VHD) {
           const taskRef = await this.task_create(`Exporting content of VDI ${vdiName} using NBD`)
           stream = await createNbdVhdStream(nbdClient, stream)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,6 +36,9 @@
 <!--packages-start-->
 
 - @vates/otp minor
+- @xen-orchestra/backups patch
+- @xen-orchestra/xapi patch
+- xen-api major
 - xo-server minor
 - xo-web patch
 

--- a/packages/xen-api/examples/export-vdi.mjs
+++ b/packages/xen-api/examples/export-vdi.mjs
@@ -44,14 +44,14 @@ defer(async ($defer, rawArgs) => {
   const vdi = await resolveRecord(xapi, 'VDI', args[1])
 
   // https://xapi-project.github.io/xen-api/snapshots.html#downloading-a-disk-or-snapshot
-  const exportStream = await xapi.getResource(token, '/export_raw_vdi/', {
+  const response = await xapi.getResource(token, '/export_raw_vdi/', {
     query: {
       format: raw ? 'raw' : 'vhd',
       vdi: vdi.$ref,
     },
   })
 
-  console.warn('Export task:', exportStream.headers['task-id'])
+  console.warn('Export task:', response.headers['task-id'])
 
   const top = createTop()
   const progressStream = createProgress()
@@ -63,5 +63,5 @@ defer(async ($defer, rawArgs) => {
     }, 1e3)
   )
 
-  await pipeline(exportStream, progressStream, throttle(bps), createOutputStream(args[2]))
+  await pipeline(response.body, progressStream, throttle(bps), createOutputStream(args[2]))
 })(process.argv.slice(2)).catch(console.error.bind(console, 'error'))

--- a/packages/xen-api/examples/export-vm.mjs
+++ b/packages/xen-api/examples/export-vm.mjs
@@ -37,17 +37,17 @@ defer(async ($defer, rawArgs) => {
   process.on('SIGINT', cancel)
 
   // https://xapi-project.github.io/xen-api/importexport.html
-  const exportStream = await xapi.getResource(token, '/export/', {
+  const response = await xapi.getResource(token, '/export/', {
     query: {
       ref: (await resolveRecord(xapi, 'VM', args[1])).$ref,
       use_compression: zstd ? 'zstd' : gzip ? 'true' : 'false',
     },
   })
 
-  console.warn('Export task:', exportStream.headers['task-id'])
+  console.warn('Export task:', response.headers['task-id'])
 
   await pipeline(
-    exportStream,
+    response.body,
     createProgress({ time: 1e3 }, p => console.warn(formatProgress(p))),
     createOutputStream(args[2])
   )

--- a/packages/xen-api/index.mjs
+++ b/packages/xen-api/index.mjs
@@ -5,6 +5,7 @@ import ms from 'ms'
 import httpRequest from 'http-request-plus'
 import map from 'lodash/map.js'
 import noop from 'lodash/noop.js'
+import { Client } from 'undici'
 import { coalesceCalls } from '@vates/coalesce-calls'
 import { Collection } from 'xo-collection'
 import { EventEmitter } from 'events'
@@ -402,37 +403,54 @@ export class Xapi extends EventEmitter {
     }
 
     let url = new URL('http://localhost')
-    url.protocol = this._url.protocol
-    url.pathname = pathname
-    url.search = new URLSearchParams(query)
     await this._setHostAddressInUrl(url, host)
 
     const response = await this._addSyncStackTrace(
       pRetry(
-        async () =>
-          httpRequest(url, {
-            rejectUnauthorized: !this._allowUnauthorized,
+        async () => {
+          const client = new Client(url, {
+            connect: {
+              rejectUnauthorized: !this._allowUnauthorized,
+              // Support XS <= 6.5 with Node => 12
+              minVersion: 'TLSv1',
+            },
+          })
 
-            // this is an inactivity timeout (unclear in Node doc)
-            timeout: this._httpInactivityTimeout,
+          return client
+            .request({
+              method: 'GET',
+              path: pathname,
+              query,
+              maxRedirections: 0,
+              headersTimeout: this._httpInactivityTimeout,
+              bodyTimeout: this._httpInactivityTimeout,
+              agent: this.httpAgent,
 
-            maxRedirects: 0,
-
-            // Support XS <= 6.5 with Node => 12
-            minVersion: 'TLSv1',
-            agent: this.httpAgent,
-
-            signal: $cancelToken,
-          }),
+              signal: $cancelToken,
+            })
+            .then(response => {
+              const { statusCode } = response
+              if (((statusCode / 100) | 0) === 2) {
+                return response
+              }
+              const error = new Error(`${response.statusCode} ${response.statusMessage}`)
+              Object.defineProperty(error, 'response', { value: response })
+              throw error
+            })
+        },
         {
           when: error => error.response !== undefined && error.response.statusCode === 302,
           onRetry: async error => {
             const response = error.response
-            if (response === undefined) {
+            if (response === undefined || response.body === undefined) {
               throw error
             }
-            response.destroy()
+            response.body.on('error', noop)
+            response.body.destroy()
             url = await this._replaceHostAddressInUrl(new URL(response.headers.location, url))
+            query = Object.fromEntries(url.searchParams.entries())
+            pathname = url.pathname
+            url.pathname = url.search = ''
           },
         }
       )
@@ -953,14 +971,18 @@ export class Xapi extends EventEmitter {
     const { hostname } = url
     url.hostnameRaw = hostname[0] === '[' ? hostname.slice(1, -1) : hostname
 
-    this._humanId = `${this._auth.user ?? 'unknown'}@${url.hostname}`
-    this._transport = this._createTransport({
-      secureOptions: {
+    const client = new Client(url, {
+      connect: {
         minVersion: 'TLSv1',
         rejectUnauthorized: !this._allowUnauthorized,
       },
-      url,
+    })
+
+    this._humanId = `${this._auth.user ?? 'unknown'}@${url.hostname}`
+    this._transport = this._createTransport({
       agent: this.httpAgent,
+      client,
+      url,
     })
     this._url = url
   }

--- a/packages/xen-api/package.json
+++ b/packages/xen-api/package.json
@@ -28,7 +28,7 @@
     "xen-api": "./cli.mjs"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "dependencies": {
     "@vates/coalesce-calls": "^0.1.0",
@@ -48,7 +48,8 @@
     "promise-toolbox": "^0.21.0",
     "proxy-agent": "^6.3.1",
     "pw": "0.0.4",
-    "xmlrpc": "^1.3.2",
+    "undici": "^6.2.1",
+    "xmlrpc-parser": "^1.0.3",
     "xo-collection": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/xo-server-perf-alert/src/index.js
+++ b/packages/xo-server-perf-alert/src/index.js
@@ -693,7 +693,7 @@ ${entriesWithMissingStats.map(({ listItem }) => listItem).join('\n')}`
       payload.vm_uuid = xapiObject.uuid
     }
     // JSON is not well formed, can't use the default node parser
-    return JSON5.parse(await (await xapi.getResource('/rrd_updates', payload)).text())
+    return JSON5.parse(await (await xapi.getResource('/rrd_updates', payload)).body.text())
   }
 }
 

--- a/packages/xo-server/src/api/test.mjs
+++ b/packages/xo-server/src/api/test.mjs
@@ -60,7 +60,7 @@ export async function copyVm({ vm, sr }) {
   {
     // eslint-disable-next-line no-console
     console.log('export full VM...')
-    const input = await srcXapi.VM_export(vm._xapiRef)
+    const input = (await srcXapi.VM_export(vm._xapiRef)).body
     // eslint-disable-next-line no-console
     console.log('import full VM...')
     await tgtXapi.VM_destroy(await tgtXapi.VM_import(input, sr._xapiRef))

--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -1212,7 +1212,7 @@ revert.resolve = {
 async function handleExport(req, res, { xapi, vmRef, compress, format = 'xva' }) {
   // @todo : should we put back the handleExportFAIL_ON_QUEUE ?
   const stream =
-    format === 'ova' ? await xapi.exportVmOva(vmRef) : await xapi.VM_export(FAIL_ON_QUEUE, vmRef, { compress })
+    format === 'ova' ? await xapi.exportVmOva(vmRef) : (await xapi.VM_export(FAIL_ON_QUEUE, vmRef, { compress })).body
 
   res.on('close', () => stream.destroy())
   // Remove the filename as it is already part of the URL.

--- a/packages/xo-server/src/xapi-stats.mjs
+++ b/packages/xo-server/src/xapi-stats.mjs
@@ -255,7 +255,7 @@ export default class XapiStats {
           start: timestamp,
         },
       })
-      .then(response => response.text())
+      .then(response => response.body.text())
       .then(data => {
         try {
           // starting from XAPI 23.31, the response is valid JSON

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -385,9 +385,11 @@ export default class Xapi extends XapiBase {
     }
 
     const sr = targetXapi.getObject(targetSrId)
-    const stream = await this.VM_export(this.getObject(vmId).$ref, {
-      compress,
-    })
+    const stream = (
+      await this.VM_export(this.getObject(vmId).$ref, {
+        compress,
+      })
+    ).body
 
     const onVmCreation = nameLabel !== undefined ? vm => vm.set_name_label(nameLabel) : null
 

--- a/packages/xo-server/src/xapi/mixins/pool.mjs
+++ b/packages/xo-server/src/xapi/mixins/pool.mjs
@@ -16,7 +16,7 @@ const methods = {
   exportPoolMetadata($cancelToken) {
     return this.getResource($cancelToken, PATH_DB_DUMP, {
       task: this.task_create('Export pool metadata'),
-    })
+    }).then(response => response.body)
   },
 
   // Restore the XAPI database from an XML backup

--- a/yarn.lock
+++ b/yarn.lock
@@ -19819,15 +19819,20 @@ sass@^1.38.1:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
-sax@1.2.x, sax@~1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
-  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+sax-parser@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/sax-parser/-/sax-parser-2.0.2.tgz#7b3b4a25fc69bf4e729ad5f0f98430205d461689"
+  integrity sha512-EjLxlFjZdmv/cpOwV+klYEeOYjR2Dc9C495d2Ruk+N6xknrOnIfjSum2a63hfi9Vox2fCsjYc3NuDVo0YkGpjg==
 
 sax@>=0.6, sax@>=0.6.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.3.0.tgz#a5dbe77db3be05c9d1ee7785dbd3ea9de51593d0"
   integrity sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==
+
+sax@~1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 scheduler@^0.23.0:
   version "0.23.0"
@@ -21911,6 +21916,11 @@ undici-types@~5.26.4:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
+undici@^6.2.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.7.1.tgz#3cb27222fd5d72c1b2058f4e18bf9b53dd933af8"
+  integrity sha512-+Wtb9bAQw6HYWzCnxrPTMVEV3Q1QjYanI0E4q02ehReMuquQdLTEFEYbfs7hcImVYKcQkWSwT6buEmSVIiDDtQ==
+
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz#301acdc525631670d39f6146e0e77ff6bbdebddc"
@@ -22155,6 +22165,11 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+utf8-base64@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/utf8-base64/-/utf8-base64-0.1.2.tgz#555806c458f9ba3f089c3ebe0c5f6198348bb57b"
+  integrity sha512-DNeEx/I7HruiVsfk/DbEl4bpdRR/mv5p6FGDFZVyA8wqdMOqYp0CeCgW4/DzsPIW/skOq5Bxv49/eYfvAYJTWg==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
@@ -23133,11 +23148,6 @@ xml2js@^0.4.19, xml2js@^0.4.23:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"
 
-xmlbuilder@8.2.x:
-  version "8.2.2"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-8.2.2.tgz#69248673410b4ba42e1a6136551d2922335aa773"
-  integrity sha512-eKRAFz04jghooy8muekqzo8uCSVNeyRedbuJrp0fovbLIi7wlsYtdUn3vBAAPq2Y3/0xMz2WMEUQ8yhVVO9Stw==
-
 xmlbuilder@^15.1.1:
   version "15.1.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
@@ -23148,13 +23158,13 @@ xmlbuilder@~11.0.0:
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
   integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
-xmlrpc@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/xmlrpc/-/xmlrpc-1.3.2.tgz#26b2ea347848d028aac7e7514b5351976de3e83d"
-  integrity sha512-jQf5gbrP6wvzN71fgkcPPkF4bF/Wyovd7Xdff8d6/ihxYmgETQYSuTc+Hl+tsh/jmgPLro/Aro48LMFlIyEKKQ==
+xmlrpc-parser@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/xmlrpc-parser/-/xmlrpc-parser-1.0.3.tgz#94f21bb74daaa2290a51471635c73f8b6dc1f3d9"
+  integrity sha512-0197DF6MrKFoiaccl2GuB5mcc3F0jSebPLHIqsahpau4yyztg34bVZDhc6HGzs5hji801prnytCKTo4Kdpa7Rw==
   dependencies:
-    sax "1.2.x"
-    xmlbuilder "8.2.x"
+    sax-parser "^2.0.2"
+    utf8-base64 "^0.1.2"
 
 xok@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### Description

Replace http-request-plus by undici in xen-api

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_