### PR TITLE
fix(xo-vmdk-to-vhd): improve compatibilty of ova with disk bigger than 8.2GB

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,11 +33,11 @@
 
 <!--packages-start-->
 
-- xo-vmdk-to-vhd patch
 - @vates/nbd-client patch
 - @xen-orchestra/backups patch
 - @xen-orchestra/vmware-explorer patch
 - xo-server-netbox minor
+- xo-vmdk-to-vhd patch
 - xo-web patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
 
 - [Backup/Restore] In case of snapshot with memory, create the suspend VDI on the correct SR instead of the default one
 - [Import/ESXi] Handle `Cannot read properties of undefined (reading 'perDatastoreUsage')` error when importing VM without storage (PR [#7168](https://github.com/vatesfr/xen-orchestra/pull/7168))
-- [Export/Ova] Handle ova export with resulting disk greater than 8.2GB (PR [#7183](https://github.com/vatesfr/xen-orchestra/pull/7183))
+- [Export/OVA] Handle export with resulting disk larger than 8.2GB (PR [#7183](https://github.com/vatesfr/xen-orchestra/pull/7183))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 
 - [Backup/Restore] In case of snapshot with memory, create the suspend VDI on the correct SR instead of the default one
 - [Import/ESXi] Handle `Cannot read properties of undefined (reading 'perDatastoreUsage')` error when importing VM without storage (PR [#7168](https://github.com/vatesfr/xen-orchestra/pull/7168))
+- [Export/Ova] Handle ova export with resulting disk greater than 8.2GB (PR [#7183](https://github.com/vatesfr/xen-orchestra/pull/7183))
 
 ### Packages to release
 
@@ -32,6 +33,7 @@
 
 <!--packages-start-->
 
+- xo-vmdk-to-vhd patch
 - @vates/nbd-client patch
 - @xen-orchestra/backups patch
 - @xen-orchestra/vmware-explorer patch

--- a/packages/xo-vmdk-to-vhd/package.json
+++ b/packages/xo-vmdk-to-vhd/package.json
@@ -18,14 +18,14 @@
   "preferGlobal": false,
   "main": "dist/",
   "engines": {
-    "node": ">=12"
+    "node": ">=12.3"
   },
   "dependencies": {
     "child-process-promise": "^2.0.3",
     "lodash": "^4.17.15",
     "pako": "^2.0.4",
     "promise-toolbox": "^0.21.0",
-    "tar-stream": "^2.2.0",
+    "tar-stream": "^3.1.6",
     "vhd-lib": "^4.6.1",
     "xml2js": "^0.4.23"
   },


### PR DESCRIPTION
### Description

following #7047, from https://xcp-ng.org/forum/topic/7946/ova-export-not-functional?_=1700051758755

ova exported from xo with more than 8.2G data per disk can't be imported in virtual box 

tar-stream@3 pack and entry are now streams

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
