### PR TITLE
feat(backups): show more detail on restored VM

### DIFF
--- a/@xen-orchestra/backups/ImportVmBackup.mjs
+++ b/@xen-orchestra/backups/ImportVmBackup.mjs
@@ -84,6 +84,13 @@ export class ImportVmBackup {
             vmRef,
             `${metadata.vm.name_label} (${formatFilenameDate(metadata.timestamp)})`
           ),
+          xapi.call(
+            'VM.set_name_description',
+            vmRef,
+            `${metadata.vm.name_description}
+            Restored on ${formatFilenameDate(+new Date())} from ${adapter._handler._remote.name}
+            `
+          ),
         ])
 
         return {

--- a/@xen-orchestra/backups/ImportVmBackup.mjs
+++ b/@xen-orchestra/backups/ImportVmBackup.mjs
@@ -87,8 +87,8 @@ export class ImportVmBackup {
           xapi.call(
             'VM.set_name_description',
             vmRef,
-            `${metadata.vm.name_description}
-            Restored on ${formatFilenameDate(+new Date())} from ${adapter._handler._remote.name}
+            `Restored on ${formatFilenameDate(+new Date())} from ${adapter._handler._remote.name} -
+             ${metadata.vm.name_description}
             `
           ),
         ])

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -9,6 +9,7 @@
 
 - [Netbox] Ability to synchronize XO users as Netbox tenants (PR [#7158](https://github.com/vatesfr/xen-orchestra/pull/7158))
 - [VM/Console] Add a message to indicate that the console view has been [disabled](https://support.citrix.com/article/CTX217766/how-to-disable-the-console-for-the-vm-in-xencenter) for this VM [#6319](https://github.com/vatesfr/xen-orchestra/issues/6319) (PR [#7161](https://github.com/vatesfr/xen-orchestra/pull/7161))
+- [Restore] Show source remote and restoration time on a restored VM (PR [#7186](https://github.com/vatesfr/xen-orchestra/pull/7186))
 
 ### Bug fixes
 
@@ -36,7 +37,7 @@
 <!--packages-start-->
 
 - @vates/nbd-client patch
-- @xen-orchestra/backups patch
+- @xen-orchestra/backups minor
 - @xen-orchestra/cr-seed-cli major
 - @xen-orchestra/vmware-explorer patch
 - xen-api major


### PR DESCRIPTION
### Description

this will help identify restoration information, especially when testing multiple restoration / health check in parallel

the `name_label` still contains the backup time
the `name_description` contains the original description + the restoration time and the source backup repository 

![image](https://github.com/vatesfr/xen-orchestra/assets/50174/07f83b10-fd1f-4b95-80d3-b14b0a8343cb)



### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
