### PR TITLE
fix(s3): enable content md5 header even if user can't check it

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -39,6 +39,7 @@
 - @vates/nbd-client patch
 - @xen-orchestra/backups minor
 - @xen-orchestra/cr-seed-cli major
+- @xen-orchestra/fs patch
 - @xen-orchestra/vmware-explorer patch
 - xen-api major
 - xo-server patch


### PR DESCRIPTION
### Description

enable content md5 header, required by object lock in case user don't have enough authorization to check if object lock is enable or not

from 
https://xcp-ng.org/forum/topic/7939/unable-to-connect-to-backblaze-b2/7?_=1700572613725
following : 796e2ab674826e06bf76e91220c769296c9d2b8a 

user report it fixes the issue : https://xcp-ng.org/forum/post/67633 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
