### PR TITLE
fix(xapi/VDI_importContent): other_config entries must be strings

### DIFF
--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -140,7 +140,7 @@ class Vdi {
     try {
       const taskRef = await this.task_create(`Importing content into VDI ${vdi.name_label} on SR ${sr.name_label}`)
       const uuid = await this.getField('task', taskRef, 'uuid')
-      await vdi.update_other_config({ 'xo:import:task': uuid, 'xo:import:length': stream.length })
+      await vdi.update_other_config({ 'xo:import:task': uuid, 'xo:import:length': stream.length.toString() })
       await this.putResource(cancelToken, stream, '/import_raw_vdi/', {
         query: {
           format,


### PR DESCRIPTION
### Description

introduced  by ffd523679de80b36b2eacd30cc98de3c588a2b77

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
