### PR TITLE
docs(installation): Fedora & CentOS wrong package "libvhdi-utils"

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -112,7 +112,7 @@ apt-get install build-essential redis-server libpng-dev git python3-minimal libv
 On Fedora/CentOS like:
 
 ```sh
-dnf install redis libpng-devel git libvhdi-utils lvm2 cifs-utils make automake gcc gcc-c++
+dnf install redis libpng-devel git libvhdi-tools lvm2 cifs-utils make automake gcc gcc-c++
 ```
 
 ### Make sure Redis is running


### PR DESCRIPTION

### Description
Under Packages the installation of package "libvhdi-utils" is incorrect for Fedora/CentOS. This should be replaced by "libvhdi-tools" instead.


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
