### PR TITLE
feat(backups): differential restore

### DIFF
--- a/@xen-orchestra/backups/ImportVmBackup.mjs
+++ b/@xen-orchestra/backups/ImportVmBackup.mjs
@@ -4,7 +4,14 @@ import { formatFilenameDate } from './_filenameDate.mjs'
 import { importIncrementalVm } from './_incrementalVm.mjs'
 import { Task } from './Task.mjs'
 import { watchStreamSize } from './_watchStreamSize.mjs'
+import { VhdNegative, VhdSynthetic } from 'vhd-lib'
+import { decorateClass } from '@vates/decorate-with'
+import { createLogger } from '@xen-orchestra/log'
+import { dirname, join } from 'node:path'
+import pickBy from 'lodash/pickBy.js'
+import { defer } from 'golike-defer'
 
+const { debug, info, warn } = createLogger('xo:backups:importVmBackup')
 async function resolveUuid(xapi, cache, uuid, type) {
   if (uuid == null) {
     return uuid
@@ -30,8 +37,168 @@ export class ImportVmBackup {
     this._xapi = xapi
   }
 
-  async #decorateIncrementalVmMetadata(backup) {
+  async #getPathOfVdiSnapshot(snapshotUuid) {
+    const metadata = this._metadata
+    if (this._pathToVdis === undefined) {
+      const backups = await this._adapter.listVmBackups(
+        this._metadata.vm.uuid,
+        ({ mode, timestamp }) => mode === 'delta' && timestamp >= metadata.timestamp
+      )
+      const map = new Map()
+      for (const backup of backups) {
+        for (const [vdiRef, vdi] of Object.entries(backup.vdis)) {
+          map.set(vdi.uuid, backup.vhds[vdiRef])
+        }
+      }
+      this._pathToVdis = map
+    }
+    return this._pathToVdis.get(snapshotUuid)
+  }
+
+  async _reuseNearestSnapshot($defer, ignoredVdis) {
+    const metadata = this._metadata
+    const { mapVdisSrs } = this._importIncrementalVmSettings
+    const { vbds, vhds, vifs, vm, vmSnapshot } = metadata
+    const streams = {}
+    const metdataDir = dirname(metadata._filename)
+    const vdis = ignoredVdis === undefined ? metadata.vdis : pickBy(metadata.vdis, vdi => !ignoredVdis.has(vdi.uuid))
+
+    for (const [vdiRef, vdi] of Object.entries(vdis)) {
+      const vhdPath = join(metdataDir, vhds[vdiRef])
+
+      let xapiDisk
+      try {
+        xapiDisk = await this._xapi.getRecordByUuid('VDI', vdi.$snapshot_of$uuid)
+      } catch (err) {
+        // if this disk is not present anymore, fall back to default restore
+        warn(err)
+      }
+
+      let snapshotCandidate, backupCandidate
+      if (xapiDisk !== undefined) {
+        debug('found disks, wlll search its snapshots', { snapshots: xapiDisk.snapshots })
+        for (const snapshotRef of xapiDisk.snapshots) {
+          const snapshot = await this._xapi.getRecord('VDI', snapshotRef)
+          debug('handling snapshot', { snapshot })
+
+          // take only the first snapshot
+          if (snapshotCandidate && snapshotCandidate.snapshot_time < snapshot.snapshot_time) {
+            debug('already got a better candidate')
+            continue
+          }
+
+          // have a corresponding backup more recent than metadata ?
+          const pathToSnapshotData = await this.#getPathOfVdiSnapshot(snapshot.uuid)
+          if (pathToSnapshotData === undefined) {
+            debug('no backup linked to this snaphot')
+            continue
+          }
+          if (snapshot.$SR.uuid !== (mapVdisSrs[vdi.$snapshot_of$uuid] ?? this._srUuid)) {
+            debug('not restored on the same SR', { snapshotSr: snapshot.$SR.uuid, mapVdisSrs, srUuid: this._srUuid })
+            continue
+          }
+
+          debug('got a candidate', pathToSnapshotData)
+
+          snapshotCandidate = snapshot
+          backupCandidate = pathToSnapshotData
+        }
+      }
+
+      let stream
+      const backupWithSnapshotPath = join(metdataDir, backupCandidate ?? '')
+      if (vhdPath === backupWithSnapshotPath) {
+        // all the data are already on the host
+        debug('direct reuse of a snapshot')
+        stream = null
+        vdis[vdiRef].baseVdi = snapshotCandidate
+        // go next disk , we won't use this stream
+        continue
+      }
+
+      let disposableDescendants
+
+      const disposableSynthetic = await VhdSynthetic.fromVhdChain(this._adapter._handler, vhdPath)
+
+      // this will also clean if another disk of this VM backup fails
+      // if user really only need to restore non failing disks he can retry with ignoredVdis
+      let disposed = false
+      const disposeOnce = async () => {
+        if (!disposed) {
+          disposed = true
+          try {
+            await disposableDescendants?.dispose()
+            await disposableSynthetic?.dispose()
+          } catch (error) {
+            warn('openVhd: failed to dispose VHDs', { error })
+          }
+        }
+      }
+      $defer.onFailure(() => disposeOnce())
+
+      const parentVhd = disposableSynthetic.value
+      await parentVhd.readBlockAllocationTable()
+      debug('got vhd synthetic of parents', parentVhd.length)
+
+      if (snapshotCandidate !== undefined) {
+        try {
+          debug('will try to use differential restore', {
+            backupWithSnapshotPath,
+            vhdPath,
+            vdiRef,
+          })
+
+          disposableDescendants = await VhdSynthetic.fromVhdChain(this._adapter._handler, backupWithSnapshotPath, {
+            until: vhdPath,
+          })
+          const descendantsVhd = disposableDescendants.value
+          await descendantsVhd.readBlockAllocationTable()
+          debug('got vhd synthetic of descendants')
+          const negativeVhd = new VhdNegative(parentVhd, descendantsVhd)
+          debug('got vhd negative')
+
+          // update the stream with the negative vhd stream
+          stream = await negativeVhd.stream()
+          vdis[vdiRef].baseVdi = snapshotCandidate
+        } catch (err) {
+          // can be a broken VHD chain, a vhd chain with a key backup, ....
+          // not an irrecuperable error, don't dispose parentVhd, and fallback to full restore
+          warn(`can't use differential restore`, err)
+          disposableDescendants?.dispose()
+        }
+      }
+      // didn't make a negative stream : fallback to classic stream
+      if (stream === undefined) {
+        debug('use legacy restore')
+        stream = await parentVhd.stream()
+      }
+
+      stream.on('end', disposeOnce)
+      stream.on('close', disposeOnce)
+      stream.on('error', disposeOnce)
+      info('everything is ready, will transfer', stream.length)
+      streams[`${vdiRef}.vhd`] = stream
+    }
+    return {
+      streams,
+      vbds,
+      vdis,
+      version: '1.0.0',
+      vifs,
+      vm: { ...vm, suspend_VDI: vmSnapshot.suspend_VDI },
+    }
+  }
+
+  async #decorateIncrementalVmMetadata() {
     const { additionnalVmTag, mapVdisSrs } = this._importIncrementalVmSettings
+    
+    const ignoredVdis = new Set(
+      Object.entries(mapVdisSrs)
+        .filter(([_, srUuid]) => srUuid === null)
+        .map(([vdiUuid]) => vdiUuid)
+    )
+    const backup = await this._reuseNearestSnapshot(ignoredVdis)
+
     const xapi = this._xapi
 
     const cache = new Map()
@@ -55,7 +222,7 @@ export class ImportVmBackup {
     const isFull = metadata.mode === 'full'
 
     const sizeContainer = { size: 0 }
-    const { mapVdisSrs, newMacAddresses } = this._importIncrementalVmSettings
+    const { newMacAddresses } = this._importIncrementalVmSettings
     let backup
     if (isFull) {
       backup = await adapter.readFullVmBackup(metadata)
@@ -63,12 +230,7 @@ export class ImportVmBackup {
     } else {
       assert.strictEqual(metadata.mode, 'delta')
 
-      const ignoredVdis = new Set(
-        Object.entries(mapVdisSrs)
-          .filter(([_, srUuid]) => srUuid === null)
-          .map(([vdiUuid]) => vdiUuid)
-      )
-      backup = await this.#decorateIncrementalVmMetadata(await adapter.readIncrementalVmBackup(metadata, ignoredVdis))
+      backup = await this.#decorateIncrementalVmMetadata()
       Object.values(backup.streams).forEach(stream => watchStreamSize(stream, sizeContainer))
     }
 
@@ -110,3 +272,5 @@ export class ImportVmBackup {
     )
   }
 }
+
+decorateClass(ImportVmBackup, { _reuseNearestSnapshot: defer })

--- a/@xen-orchestra/backups/_incrementalVm.mjs
+++ b/@xen-orchestra/backups/_incrementalVm.mjs
@@ -250,6 +250,10 @@ export const importIncrementalVm = defer(async function importIncrementalVm(
     // Import VDI contents.
     cancelableMap(cancelToken, Object.entries(newVdis), async (cancelToken, [id, vdi]) => {
       for (let stream of ensureArray(streams[`${id}.vhd`])) {
+        if (stream === null) {
+          // we restore a backup and reuse completly a local snapshot
+          continue
+        }
         if (typeof stream === 'function') {
           stream = await stream()
         }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,10 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [VM/Disks] Display task information when importing VDIs (PR [#7197](https://github.com/vatesfr/xen-orchestra/pull/7197))
+- [REST API] Support VM import using the XVA format
+- [Backup] Implement differential restore (PR [#7202](https://github.com/vatesfr/xen-orchestra/pull/7202))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,4 +27,9 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
+- vhd-lib minor
+- xo-server minor
+- xo-web minor
+
 <!--packages-end-->

--- a/packages/vhd-lib/Vhd/VhdNegative.integ.js
+++ b/packages/vhd-lib/Vhd/VhdNegative.integ.js
@@ -1,0 +1,184 @@
+'use strict'
+
+const { VhdAbstract, VhdNegative } = require('..')
+
+const { describe, it } = require('test')
+const assert = require('assert/strict')
+const { unpackHeader, unpackFooter } = require('./_utils')
+const { createHeader, createFooter } = require('../_createFooterHeader')
+const _computeGeometryForSize = require('../_computeGeometryForSize')
+const { FOOTER_SIZE, DISK_TYPES } = require('../_constants')
+
+const VHD_BLOCK_LENGTH = 2 * 1024 * 1024
+class VhdMock extends VhdAbstract {
+  #blockUsed
+  #header
+  #footer
+  get header() {
+    return this.#header
+  }
+  get footer() {
+    return this.#footer
+  }
+
+  constructor(header, footer, blockUsed = new Set()) {
+    super()
+    this.#header = header
+    this.#footer = footer
+    this.#blockUsed = blockUsed
+  }
+  containsBlock(blockId) {
+    return this.#blockUsed.has(blockId)
+  }
+  readBlock(blockId, onlyBitmap = false) {
+    const bitmap = Buffer.alloc(512, 255) // bitmap are full of bit 1
+
+    const data = Buffer.alloc(2 * 1024 * 1024, 0) // empty are full of bit 0
+    data.writeUint8(blockId)
+    return {
+      id: blockId,
+      bitmap,
+      data,
+      buffer: Buffer.concat([bitmap, data]),
+    }
+  }
+
+  readBlockAllocationTable() {}
+  readHeaderAndFooter() {}
+  _readParentLocatorData(id) {}
+}
+
+describe('vhd negative', async () => {
+  it(`throws when uid aren't chained `, () => {
+    const length = 10e8
+
+    let header = unpackHeader(createHeader(length / VHD_BLOCK_LENGTH))
+    const geometry = _computeGeometryForSize(length)
+    let footer = unpackFooter(
+      createFooter(length, Math.floor(Date.now() / 1000), geometry, FOOTER_SIZE, DISK_TYPES.DIFFERENCING)
+    )
+    const parent = new VhdMock(header, footer)
+
+    header = unpackHeader(createHeader(length / VHD_BLOCK_LENGTH))
+    footer = unpackFooter(
+      createFooter(length, Math.floor(Date.now() / 1000), geometry, FOOTER_SIZE, DISK_TYPES.DIFFERENCING)
+    )
+
+    const child = new VhdMock(header, footer)
+    assert.throws(() => new VhdNegative(parent, child), { message: 'NOT_CHAINED' })
+  })
+
+  it('throws when size changed', () => {
+    const childLength = 10e8
+    const parentLength = 10e8 + 1
+
+    let header = unpackHeader(createHeader(parentLength / VHD_BLOCK_LENGTH))
+    let geometry = _computeGeometryForSize(parentLength)
+    let footer = unpackFooter(
+      createFooter(parentLength, Math.floor(Date.now() / 1000), geometry, FOOTER_SIZE, DISK_TYPES.DIFFERENCING)
+    )
+    const parent = new VhdMock(header, footer)
+
+    header = unpackHeader(createHeader(childLength / VHD_BLOCK_LENGTH))
+    geometry = _computeGeometryForSize(childLength)
+    header.parentUuid = footer.uuid
+    footer = unpackFooter(
+      createFooter(childLength, Math.floor(Date.now() / 1000), geometry, FOOTER_SIZE, DISK_TYPES.DIFFERENCING)
+    )
+    const child = new VhdMock(header, footer)
+    assert.throws(() => new VhdNegative(parent, child), { message: 'GEOMETRY_CHANGED' })
+  })
+  it('throws when child is not differencing', () => {
+    const length = 10e8
+
+    let header = unpackHeader(createHeader(length / VHD_BLOCK_LENGTH))
+    const geometry = _computeGeometryForSize(length)
+    let footer = unpackFooter(
+      createFooter(length, Math.floor(Date.now() / 1000), geometry, FOOTER_SIZE, DISK_TYPES.DIFFERENCING)
+    )
+    const parent = new VhdMock(header, footer)
+
+    header = unpackHeader(createHeader(length / VHD_BLOCK_LENGTH))
+    header.parentUuid = footer.uuid
+    footer = unpackFooter(
+      createFooter(length, Math.floor(Date.now() / 1000), geometry, FOOTER_SIZE, DISK_TYPES.DYNAMIC)
+    )
+
+    const child = new VhdMock(header, footer)
+    assert.throws(() => new VhdNegative(parent, child), { message: 'CHILD_NOT_DIFFERENCING' })
+  })
+
+  it(`throws when writing into vhd negative `, async () => {
+    const length = 10e8
+
+    let header = unpackHeader(createHeader(length / VHD_BLOCK_LENGTH))
+    const geometry = _computeGeometryForSize(length)
+    let footer = unpackFooter(
+      createFooter(length, Math.floor(Date.now() / 1000), geometry, FOOTER_SIZE, DISK_TYPES.DIFFERENCING)
+    )
+    const parent = new VhdMock(header, footer)
+    const parentUuid = footer.uuid
+    header = unpackHeader(createHeader(length / VHD_BLOCK_LENGTH))
+    header.parentUuid = parentUuid
+    footer = unpackFooter(
+      createFooter(length, Math.floor(Date.now() / 1000), geometry, FOOTER_SIZE, DISK_TYPES.DIFFERENCING)
+    )
+
+    const child = new VhdMock(header, footer)
+
+    const vhd = new VhdNegative(parent, child)
+
+    // await assert.rejects( ()=> vhd.writeFooter())
+    assert.throws(() => vhd.writeHeader())
+    assert.throws(() => vhd.writeBlockAllocationTable())
+    assert.throws(() => vhd.writeEntireBlock())
+    assert.throws(() => vhd.mergeBlock(), { message: `can't coalesce block into a vhd negative` })
+  })
+
+  it('normal case', async () => {
+    const length = 10e8
+
+    let header = unpackHeader(createHeader(length / VHD_BLOCK_LENGTH))
+    let geometry = _computeGeometryForSize(length)
+    let footer = unpackFooter(
+      createFooter(length, Math.floor(Date.now() / 1000), geometry, FOOTER_SIZE, DISK_TYPES.DYNAMIC)
+    )
+    const parent = new VhdMock(header, footer, new Set([1, 3]))
+    const parentUuid = footer.uuid
+    header = unpackHeader(createHeader(length / VHD_BLOCK_LENGTH))
+    header.parentUuid = parentUuid
+    geometry = _computeGeometryForSize(length)
+    footer = unpackFooter(
+      createFooter(length, Math.floor(Date.now() / 1000), geometry, FOOTER_SIZE, DISK_TYPES.DIFFERENCING)
+    )
+
+    const childUuid = footer.uuid
+    const child = new VhdMock(header, footer, new Set([2, 3]))
+
+    const vhd = new VhdNegative(parent, child)
+    assert.equal(vhd.header.parentUuid.equals(childUuid), true)
+    assert.equal(vhd.footer.diskType, DISK_TYPES.DIFFERENCING)
+    await vhd.readBlockAllocationTable()
+    await vhd.readHeaderAndFooter()
+    await vhd.readParentLocator(0)
+    assert.equal(vhd.header.parentUuid, childUuid)
+    assert.equal(vhd.footer.diskType, DISK_TYPES.DIFFERENCING)
+    assert.equal(vhd.containsBlock(1), false)
+    assert.equal(vhd.containsBlock(2), true)
+    assert.equal(vhd.containsBlock(3), true)
+    assert.equal(vhd.containsBlock(4), false)
+
+    const expected = [0, 1, 0, 3, 0]
+    const expectedBitmap = Buffer.alloc(512, 255) // bitmap must always be full of bit 1
+    for (let index = 0; index < 5; index++) {
+      if (vhd.containsBlock(index)) {
+        const { id, data, bitmap } = await vhd.readBlock(index)
+        assert.equal(index, id)
+        assert.equal(expectedBitmap.equals(bitmap), true)
+        assert.equal(data.readUInt8(0), expected[index])
+      } else {
+        assert.equal([2, 3].includes(index), false)
+      }
+    }
+  })
+})

--- a/packages/vhd-lib/Vhd/VhdNegative.js
+++ b/packages/vhd-lib/Vhd/VhdNegative.js
@@ -1,0 +1,84 @@
+'use strict'
+
+const UUID = require('uuid')
+const { DISK_TYPES } = require('../_constants')
+const { VhdAbstract } = require('./VhdAbstract')
+const { computeBlockBitmapSize } = require('./_utils')
+const assert = require('node:assert')
+/**
+ * Build an incremental VHD which can be applied to a child to revert to the state of its parent.
+ * @param {*} parent
+ * @param {*} descendant
+ */
+
+class VhdNegative extends VhdAbstract {
+  #parent
+  #child
+
+  get header() {
+    // we want to have parent => child => negative
+    // where => means " is the parent of "
+    return {
+      ...this.#parent.header,
+      parentUuid: this.#child.footer.uuid,
+    }
+  }
+
+  get footer() {
+    // by construct a negative vhd is differencing disk
+    return {
+      ...this.#parent.footer,
+      diskType: DISK_TYPES.DIFFERENCING,
+    }
+  }
+
+  constructor(parent, child) {
+    super()
+    this.#parent = parent
+    this.#child = child
+
+    assert.strictEqual(UUID.stringify(child.header.parentUuid), UUID.stringify(parent.footer.uuid), 'NOT_CHAINED')
+    assert.strictEqual(child.footer.diskType, DISK_TYPES.DIFFERENCING, 'CHILD_NOT_DIFFERENCING')
+    // we don't want to handle alignment and missing block for now
+    // last block may contains partly empty data when changing size
+    assert.strictEqual(child.footer.currentSize, parent.footer.currentSize, 'GEOMETRY_CHANGED')
+  }
+
+  async readBlockAllocationTable() {
+    return Promise.all([this.#parent.readBlockAllocationTable(), this.#child.readBlockAllocationTable()])
+  }
+
+  containsBlock(blockId) {
+    return this.#child.containsBlock(blockId)
+  }
+
+  async readHeaderAndFooter() {
+    return Promise.all([this.#parent.readHeaderAndFooter(), this.#child.readHeaderAndFooter()])
+  }
+
+  async readBlock(blockId, onlyBitmap = false) {
+    // only read the content of the first vhd containing this block
+    if (this.#parent.containsBlock(blockId)) {
+      return this.#parent.readBlock(blockId, onlyBitmap)
+    }
+
+    const bitmap = Buffer.alloc(computeBlockBitmapSize(this.header.blockSize), 255) // bitmap are full of bit 1
+    const data = Buffer.alloc(this.header.blockSize, 0) // empty are full of bit 0
+    return {
+      id: blockId,
+      bitmap,
+      data,
+      buffer: Buffer.concat([bitmap, data]),
+    }
+  }
+
+  mergeBlock(child, blockId) {
+    throw new Error(`can't coalesce block into a vhd negative`)
+  }
+
+  _readParentLocatorData(id) {
+    return this.#parent._readParentLocatorData(id)
+  }
+}
+
+exports.VhdNegative = VhdNegative

--- a/packages/vhd-lib/_resolveRelativeFromFile.js
+++ b/packages/vhd-lib/_resolveRelativeFromFile.js
@@ -2,6 +2,10 @@
 
 const { dirname, resolve } = require('path')
 
-const resolveRelativeFromFile = (file, path) => resolve('/', dirname(file), path).slice(1)
-
+const resolveRelativeFromFile = (file, path) => {
+  if (file.startsWith('/')) {
+    return resolve(dirname(file), path)
+  }
+  return resolve('/', dirname(file), path).slice(1)
+}
 module.exports = resolveRelativeFromFile

--- a/packages/vhd-lib/index.js
+++ b/packages/vhd-lib/index.js
@@ -13,4 +13,5 @@ exports.VhdAbstract = require('./Vhd/VhdAbstract').VhdAbstract
 exports.VhdDirectory = require('./Vhd/VhdDirectory').VhdDirectory
 exports.VhdFile = require('./Vhd/VhdFile').VhdFile
 exports.VhdSynthetic = require('./Vhd/VhdSynthetic').VhdSynthetic
+exports.VhdNegative = require('./Vhd/VhdNegative').VhdNegative
 exports.Constants = require('./_constants')

--- a/packages/xo-server/src/api/backup-ng.mjs
+++ b/packages/xo-server/src/api/backup-ng.mjs
@@ -277,6 +277,10 @@ importVmBackup.params = {
   sr: {
     type: 'string',
   },
+  useDifferentialRestore: {
+    type: 'boolean',
+    optional: true
+  }
 }
 
 export function checkBackup({ id, settings, sr }) {

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1802,6 +1802,7 @@ const messages = {
   latest: 'latest',
   restoreVmBackupsStart: 'Start VM{nVms, plural, one {} other {s}} after restore',
   restoreVmBackupsBulkErrorTitle: 'Multi-restore error',
+  restoreVmUseDifferentialRestore: 'Use differential restore',
   restoreMetadataBackupTitle: 'Restore {item}',
   bulkRestoreMetadataBackupTitle:
     'Restore {nMetadataBackups, number} metadata backup{nMetadataBackups, plural, one {} other {s}}',

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -2584,11 +2584,11 @@ export const listVmBackups = remotes => _call('backupNg.listVmBackups', { remote
 export const restoreBackup = (
   backup,
   sr,
-  { generateNewMacAddresses = false, mapVdisSrs = {}, startOnRestore = false } = {}
+  { generateNewMacAddresses = false, mapVdisSrs = {}, startOnRestore = false, useDifferentialRestore= false } = {}
 ) => {
   const promise = _call('backupNg.importVmBackup', {
     id: resolveId(backup),
-    settings: { mapVdisSrs: resolveIds(mapVdisSrs), newMacAddresses: generateNewMacAddresses },
+    settings: { mapVdisSrs: resolveIds(mapVdisSrs), newMacAddresses: generateNewMacAddresses, useDifferentialRestore },
     sr: resolveId(sr),
   })
 

--- a/packages/xo-web/src/xo-app/backup/restore/index.js
+++ b/packages/xo-web/src/xo-app/backup/restore/index.js
@@ -184,16 +184,16 @@ export default class Restore extends Component {
       body: <RestoreBackupsModalBody data={data} />,
       icon: 'restore',
     })
-      .then(({ backup, generateNewMacAddresses, targetSrs: { mainSr, mapVdisSrs }, start }) => {
+      .then(({ backup, generateNewMacAddresses, targetSrs: { mainSr, mapVdisSrs }, start, useDifferentialRestore }) => {
         if (backup == null || mainSr == null) {
           error(_('backupRestoreErrorTitle'), _('backupRestoreErrorMessage'))
           return
         }
-
         return restoreBackup(backup, mainSr, {
           generateNewMacAddresses,
           mapVdisSrs,
           startOnRestore: start,
+          useDifferentialRestore,
         })
       }, noop)
       .then(() => this._refreshBackupList())

--- a/packages/xo-web/src/xo-app/backup/restore/restore-backups-modal-body.js
+++ b/packages/xo-web/src/xo-app/backup/restore/restore-backups-modal-body.js
@@ -12,7 +12,11 @@ import { SelectSr } from 'select-objects'
 const BACKUP_RENDERER = getRenderXoItemOfType('backup')
 
 export default class RestoreBackupsModalBody extends Component {
-  state = { generateNewMacAddresses: false, targetSrs: { mainSr: undefined, mapVdisSrs: undefined } }
+  state = {
+    generateNewMacAddresses: false,
+    targetSrs: { mainSr: undefined, mapVdisSrs: undefined },
+    useDifferentialRestore: false,
+  }
 
   get value() {
     return this.state
@@ -77,6 +81,17 @@ export default class RestoreBackupsModalBody extends Component {
                   onChange={this.toggleState('generateNewMacAddresses')}
                 />{' '}
                 {_('generateNewMacAddress')}
+              </div>
+            )}
+
+            {this.state.backup.mode === 'delta' && (
+              <div>
+                <Toggle
+                  iconSize={1}
+                  value={this.state.useDifferentialRestore}
+                  onChange={this.toggleState('useDifferentialRestore')}
+                />{' '}
+                {_('restoreVmUseDifferentialRestore')}
               </div>
             )}
           </div>


### PR DESCRIPTION
### Description
review by commit, do not squash 

When restoring a backup, try to reuse data from an existing snapshot. We use this snasphot and apply a reverse differential of the changes between the backup and the snapshot

Prerequisite : a uninterrupted delta chain from the backup being restored to a backup that still have its snapshot on the host

That means restore on the same host, without moving VDIs from their SR, no key backup in this chain, and the snapshots are still here 
![image](https://github.com/vatesfr/xen-orchestra/assets/50174/52f63009-01df-447c-befa-dd4e0b8b9906)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
