### PR TITLE
fix(backups): import on non default SR

### DIFF
--- a/@xen-orchestra/backups/ImportVmBackup.mjs
+++ b/@xen-orchestra/backups/ImportVmBackup.mjs
@@ -33,9 +33,9 @@ export class ImportVmBackup {
     for (const [vdiUuid, srUuid] of Object.entries(mapVdisSrs)) {
       mapVdisSrRefs[vdiUuid] = await resolveUuid(xapi, cache, srUuid, 'SR')
     }
-    const sr = await resolveUuid(xapi, cache, this._srUuid, 'SR')
+    const srRef = await resolveUuid(xapi, cache, this._srUuid, 'SR')
     Object.values(backup.vdis).forEach(vdi => {
-      vdi.SR = mapVdisSrRefs[vdi.uuid] ?? sr.$ref
+      vdi.SR = mapVdisSrRefs[vdi.uuid] ?? srRef
     })
     return backup
   }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,4 +27,5 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
 <!--packages-end-->


### PR DESCRIPTION
### Description

restore was only done on the default SR 
introduced by https://github.com/vatesfr/xen-orchestra/commit/4504141cbfab5beffd62b82a08446763e9ba6734


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
