### PR TITLE
feat(lite): added tooltip on CPU provisioning warning icon

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [VM/Action] Ability to migrate a VM from its view (PR [#7164](https://github.com/vatesfr/xen-orchestra/pull/7164))
 - Ability to override host address with `master` URL query param (PR [#7187](https://github.com/vatesfr/xen-orchestra/pull/7187))
+- Added tooltip on CPU provisioning warning icon (PR [#7223](https://github.com/vatesfr/xen-orchestra/pull/7223))
 
 ## **0.1.6** (2023-11-30)
 

--- a/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardCpuProvisioning.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardCpuProvisioning.vue
@@ -3,8 +3,14 @@
     <UiCardTitle>
       {{ $t("cpu-provisioning") }}
       <template v-if="!hasError" #right>
-        <!-- TODO: add a tooltip for the warning icon -->
-        <UiStatusIcon v-if="state !== 'success'" :state="state" />
+        <UiStatusIcon
+          v-if="state !== 'success'"
+          v-tooltip="{
+            content: $t('cpu-provisioning-warning-tooltip'),
+            placement: 'left',
+          }"
+          :state="state"
+        />
       </template>
     </UiCardTitle>
     <NoDataError v-if="hasError" />
@@ -37,11 +43,12 @@ import UiCard from "@/components/ui/UiCard.vue";
 import UiCardFooter from "@/components/ui/UiCardFooter.vue";
 import UiCardSpinner from "@/components/ui/UiCardSpinner.vue";
 import UiCardTitle from "@/components/ui/UiCardTitle.vue";
-import { useHostCollection } from "@/stores/xen-api/host.store";
-import { useVmCollection } from "@/stores/xen-api/vm.store";
-import { useVmMetricsCollection } from "@/stores/xen-api/vm-metrics.store";
+import { vTooltip } from "@/directives/tooltip.directive";
 import { percent } from "@/libs/utils";
 import { VM_POWER_STATE } from "@/libs/xen-api/xen-api.enums";
+import { useHostCollection } from "@/stores/xen-api/host.store";
+import { useVmMetricsCollection } from "@/stores/xen-api/vm-metrics.store";
+import { useVmCollection } from "@/stores/xen-api/vm.store";
 import { logicAnd } from "@vueuse/math";
 import { computed } from "vue";
 

--- a/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardCpuProvisioning.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardCpuProvisioning.vue
@@ -6,7 +6,7 @@
         <UiStatusIcon
           v-if="state !== 'success'"
           v-tooltip="{
-            content: $t('cpu-provisioning-warning-tooltip'),
+            content: $t('cpu-provisioning-warning'),
             placement: 'left',
           }"
           :state="state"

--- a/@xen-orchestra/lite/src/locales/en.json
+++ b/@xen-orchestra/lite/src/locales/en.json
@@ -38,6 +38,7 @@
   "console-unavailable": "Console unavailable",
   "copy": "Copy",
   "cpu-provisioning": "CPU provisioning",
+  "cpu-provisioning-warning-tooltip": "The number of vCPUs allocated exceeds the number of physical CPUs available. System performance could be affected",
   "cpu-usage": "CPU usage",
   "dashboard": "Dashboard",
   "delete": "Delete",

--- a/@xen-orchestra/lite/src/locales/en.json
+++ b/@xen-orchestra/lite/src/locales/en.json
@@ -38,7 +38,7 @@
   "console-unavailable": "Console unavailable",
   "copy": "Copy",
   "cpu-provisioning": "CPU provisioning",
-  "cpu-provisioning-warning-tooltip": "The number of vCPUs allocated exceeds the number of physical CPUs available. System performance could be affected",
+  "cpu-provisioning-warning": "The number of vCPUs allocated exceeds the number of physical CPUs available. System performance could be affected",
   "cpu-usage": "CPU usage",
   "dashboard": "Dashboard",
   "delete": "Delete",

--- a/@xen-orchestra/lite/src/locales/fr.json
+++ b/@xen-orchestra/lite/src/locales/fr.json
@@ -38,6 +38,7 @@
   "console-unavailable": "Console indisponible",
   "copy": "Copier",
   "cpu-provisioning": "Provisionnement CPU",
+  "cpu-provisioning-warning-tooltip": "Le nombre de vCPU alloués dépasse le nombre de CPU physique disponible. Les performances du système pourraient être affectées",
   "cpu-usage": "Utilisation CPU",
   "dashboard": "Tableau de bord",
   "delete": "Supprimer",

--- a/@xen-orchestra/lite/src/locales/fr.json
+++ b/@xen-orchestra/lite/src/locales/fr.json
@@ -38,7 +38,7 @@
   "console-unavailable": "Console indisponible",
   "copy": "Copier",
   "cpu-provisioning": "Provisionnement CPU",
-  "cpu-provisioning-warning-tooltip": "Le nombre de vCPU alloués dépasse le nombre de CPU physique disponible. Les performances du système pourraient être affectées",
+  "cpu-provisioning-warning": "Le nombre de vCPU alloués dépasse le nombre de CPU physique disponible. Les performances du système pourraient être affectées",
   "cpu-usage": "Utilisation CPU",
   "dashboard": "Tableau de bord",
   "delete": "Supprimer",


### PR DESCRIPTION
### Description

Added tooltip on CPU provisioning warning icon, to inform that system performances could be affected

### Screenshot

![image](https://github.com/vatesfr/xen-orchestra/assets/66562640/696ebd2b-7b43-493b-a868-9dbf4b1bbab9)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
