### PR TITLE
fix: error stored in remote url

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Remotes] Prevents the "connection failed" alert from continuing to appear after successfull connection
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -28,5 +30,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- xo-remote-parser patch
 
 <!--packages-end-->

--- a/packages/xo-remote-parser/package.json
+++ b/packages/xo-remote-parser/package.json
@@ -21,6 +21,7 @@
     "node": ">=6"
   },
   "dependencies": {
+    "@xen-orchestra/log": "^0.6.0",
     "lodash": "^4.13.1",
     "url-parse": "^1.4.7"
   },

--- a/packages/xo-remote-parser/src/index.js
+++ b/packages/xo-remote-parser/src/index.js
@@ -15,6 +15,11 @@ const parseOptionList = (optionList = '') => {
     optionList = optionList.substring(1)
   }
   const parsed = queryString.parse(optionList)
+
+  // bugfix for persisting error notification
+  delete parsed.error
+  delete parsed.name
+
   Object.keys(parsed).forEach(key => {
     const val = parsed[key]
     // some incorrect values have been saved in users database (introduced by #6270)

--- a/packages/xo-remote-parser/src/index.js
+++ b/packages/xo-remote-parser/src/index.js
@@ -21,11 +21,11 @@ const parseOptionList = (optionList = '') => {
 
   // bugfix for persisting error notification
   if ('error' in parsed) {
-    warn('Deleting "error" value in url query', { error: parsed.error })
+    warn('Deleting "error" value in url query, resave your remote to clear this values', { error: parsed.error })
     delete parsed.error
   }
   if ('name' in parsed) {
-    warn('Deleting "name" value in url query', { name: parsed.name })
+    warn('Deleting "name" value in url query, resave your remote to clear this values', { name: parsed.name })
     delete parsed.name
   }
 

--- a/packages/xo-remote-parser/src/index.js
+++ b/packages/xo-remote-parser/src/index.js
@@ -4,6 +4,9 @@ import trim from 'lodash/trim'
 import trimStart from 'lodash/trimStart'
 import queryString from 'querystring'
 import urlParser from 'url-parse'
+import { createLogger } from '@xen-orchestra/log'
+
+const { warn } = createLogger('xo:xo-remote-parser')
 
 const NFS_RE = /^([^:]+):(?:(\d+):)?([^:?]+)(\?[^?]*)?$/
 const SMB_RE = /^([^:]+):(.+)@([^@]+)\\\\([^\0?]+)(?:\0([^?]*))?(\?[^?]*)?$/
@@ -17,8 +20,14 @@ const parseOptionList = (optionList = '') => {
   const parsed = queryString.parse(optionList)
 
   // bugfix for persisting error notification
-  delete parsed.error
-  delete parsed.name
+  if ('error' in parsed) {
+    warn('Deleting "error" value in url query', { error: parsed.error })
+    delete parsed.error
+  }
+  if ('name' in parsed) {
+    warn('Deleting "name" value in url query', { name: parsed.name })
+    delete parsed.name
+  }
 
   Object.keys(parsed).forEach(key => {
     const val = parsed[key]


### PR DESCRIPTION
### Description

Trying to fix a "Connection failed" alert remaining after connection to remote has been sucessfull

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
