### PR TITLE
feat(xo-server): http.useForwardedHeaders

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,7 @@
 - [REST API] _XO config & Pool metadata Backup_ jobs are available at `/backup/jobs/metadata`
 - [REST API] _Mirror Backup_ jobs are available at `/backup/jobs/metadata`
 - [Plugin/auth-saml] Add _Force re-authentication_ setting [Forum#67764](https://xcp-ng.org/forum/post/67764) (PR [#7232](https://github.com/vatesfr/xen-orchestra/pull/7232))
+- [HTTP] `http.useForwardedHeaders` setting can be unabled when XO is behind a reverse proxy to fetch clients IP addresses from `X-Forwarded-*` headers [Forum#67625](https://xcp-ng.org/forum/post/67625) (PR [#7233](https://github.com/vatesfr/xen-orchestra/pull/7233))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 - [REST API] _XO config & Pool metadata Backup_ jobs are available at `/backup/jobs/metadata`
 - [REST API] _Mirror Backup_ jobs are available at `/backup/jobs/metadata`
 - [Plugin/auth-saml] Add _Force re-authentication_ setting [Forum#67764](https://xcp-ng.org/forum/post/67764) (PR [#7232](https://github.com/vatesfr/xen-orchestra/pull/7232))
-- [HTTP] `http.useForwardedHeaders` setting can be unabled when XO is behind a reverse proxy to fetch clients IP addresses from `X-Forwarded-*` headers [Forum#67625](https://xcp-ng.org/forum/post/67625) (PR [#7233](https://github.com/vatesfr/xen-orchestra/pull/7233))
+- [HTTP] `http.useForwardedHeaders` setting can be enabled when XO is behind a reverse proxy to fetch clients IP addresses from `X-Forwarded-*` headers [Forum#67625](https://xcp-ng.org/forum/post/67625) (PR [#7233](https://github.com/vatesfr/xen-orchestra/pull/7233))
 
 ### Bug fixes
 

--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -107,6 +107,9 @@ writeBlockConcurrency = 16
 enabled = false
 threshold = 1000
 
+[http]
+useForwardedHeaders = false
+
 # Helmet handles HTTP security via headers
 #
 # https://helmetjs.github.io/docs/

--- a/packages/xo-server/package.json
+++ b/packages/xo-server/package.json
@@ -107,6 +107,7 @@
     "passport": "^0.6.0",
     "passport-local": "^1.0.0",
     "promise-toolbox": "^0.21.0",
+    "proxy-addr": "^2.0.7",
     "proxy-agent": "^5.0.0",
     "pug": "^3.0.0",
     "pumpify": "^2.0.0",

--- a/packages/xo-server/sample.config.toml
+++ b/packages/xo-server/sample.config.toml
@@ -79,7 +79,7 @@
 # - false (default): do not use the headers
 # - true: always use the headers
 # - a list of trusted addresses: the headers will be used only if the connection
-#   is coming from of these addresses
+#   is coming from one of these addresses
 #
 # More info about the accepted values: https://www.npmjs.com/package/proxy-addr?activeTab=readme#proxyaddrreq-trust
 #

--- a/packages/xo-server/sample.config.toml
+++ b/packages/xo-server/sample.config.toml
@@ -72,6 +72,12 @@
 # good enough (e.g. a domain name must be used or there is a reverse proxy).
 #publicUrl = 'https://xoa.company.lan'
 
+# Uncomment this if xo-server is behind a reverse proxy to make xo-server use
+# X-Forwarded-* headers to determine the IP address of clients.
+#
+# > Note: X-Forwarded-* headers are easily spoofed and the detected IP addresses are unreliable.
+useForwardedHeaders = true
+
 # Settings applied to cookies created by xo-server's embedded HTTP server.
 #
 # See https://www.npmjs.com/package/cookie#options-1

--- a/packages/xo-server/sample.config.toml
+++ b/packages/xo-server/sample.config.toml
@@ -75,8 +75,16 @@
 # Uncomment this if xo-server is behind a reverse proxy to make xo-server use
 # X-Forwarded-* headers to determine the IP address of clients.
 #
+# Accepted values for this setting:
+# - false (default): do not use the headers
+# - true: always use the headers
+# - a list of trusted addresses: the headers will be used only if the connection
+#   is coming from of these addresses
+#
+# More info about the accepted values: https://www.npmjs.com/package/proxy-addr?activeTab=readme#proxyaddrreq-trust
+#
 # > Note: X-Forwarded-* headers are easily spoofed and the detected IP addresses are unreliable.
-useForwardedHeaders = true
+#useForwardedHeaders = true
 
 # Settings applied to cookies created by xo-server's embedded HTTP server.
 #

--- a/packages/xo-server/src/index.mjs
+++ b/packages/xo-server/src/index.mjs
@@ -837,7 +837,15 @@ export default async function main(args) {
   // Trigger a clean job.
   await xo.hooks.clean()
 
-  const useForwardedHeaders = () => xo.config.get('http.useForwardedHeaders')
+  const useForwardedHeaders = (() => {
+    // recompile the fonction when the setting change
+    let useForwardedHeaders
+    xo.config.watch('http.useForwardedHeaders', val => {
+      useForwardedHeaders = typeof val === 'boolean' ? () => val : proxyAddr.compile(val)
+    })
+
+    return (...args) => useForwardedHeaders(...args)
+  })()
 
   express.set('trust proxy', useForwardedHeaders)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17225,7 +17225,7 @@ protocol-buffers-encodings@^1.1.0:
     signed-varint "^2.0.1"
     varint "5.0.0"
 
-proxy-addr@~2.0.7:
+proxy-addr@^2.0.7, proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
   integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==


### PR DESCRIPTION
### Description

Fixes https://xcp-ng.org/forum/post/67625

This setting can be enabled when XO is behind a reverse proxy to fetch clients IP addresses from `X-Forwarded-*` headers.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
