### PR TITLE
feat(backups): store vhd path of a backup unencrypted

### DIFF
--- a/@xen-orchestra/backups/_backupType.mjs
+++ b/@xen-orchestra/backups/_backupType.mjs
@@ -1,4 +1,5 @@
 export const isMetadataFile = filename => filename.endsWith('.json')
+export const isMetadataPlainTextFile = filename => filename.endsWith('.json.plaintext')
 export const isVhdFile = filename => filename.endsWith('.vhd')
 export const isXvaFile = filename => filename.endsWith('.xva')
 export const isXvaSumFile = filename => filename.endsWith('.xva.checksum')

--- a/packages/vhd-lib/Vhd/VhdAbstract.integ.js
+++ b/packages/vhd-lib/Vhd/VhdAbstract.integ.js
@@ -66,6 +66,20 @@ describe('VhdAbstract', async () => {
     })
   })
 
+  it('Creates alias unencrypted in encrypted remote', async () => {
+    await Disposable.use(async function* () {
+      const handler = yield getSyncedHandler({
+        url: `file://${tempDir}/?encryptionKey="85704F498279D6FCD2B2AA7B793944DF"`,
+      })
+      const aliasPath = `alias.alias.vhd`
+      const aliasFsPath = `${tempDir}/${aliasPath}`
+      await VhdAbstract.createAlias(handler, aliasPath, 'target.vhd')
+      assert.equal(await fs.exists(aliasFsPath), true)
+      const content = await fs.readFile(aliasFsPath, 'utf-8')
+      assert.equal(content, 'target.vhd')
+    })
+  })
+
   it('has *.alias.vhd extension', async () => {
     await Disposable.use(async function* () {
       const handler = yield getSyncedHandler({ url: 'file:///' })

--- a/packages/vhd-lib/Vhd/VhdAbstract.js
+++ b/packages/vhd-lib/Vhd/VhdAbstract.js
@@ -236,7 +236,8 @@ exports.VhdAbstract = class VhdAbstract {
         `Alias relative path ${relativePathToTarget} is too long : ${relativePathToTarget.length} chars, max is ${ALIAS_MAX_PATH_LENGTH}`
       )
     }
-    await handler.writeFile(aliasPath, relativePathToTarget)
+    // using _outputFile means the checksum will NOT be encrypted
+    await handler._outputFile(path.resolve('/', aliasPath), relativePathToTarget, { flags: 'wx' })
   }
 
   streamSize() {


### PR DESCRIPTION
### Description

we need to be able to link a backup with its files to handle immutability, even with an encrypted backup 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
