### PR TITLE
feat(xo-web/menu): add warning icon in proxies menu

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -10,6 +10,7 @@
 - [SR] show an icon on SR during VDI coalescing (with XCP-ng 8.3+) (PR [#7241](https://github.com/vatesfr/xen-orchestra/pull/7241))
 
 - [VDI/Export] Expose NBD settings in the XO and REST APIs api (PR [#7251](https://github.com/vatesfr/xen-orchestra/pull/7251))
+- [Menu/Proxies] Added a warning icon if unable to check proxies upgrade (PR [#7237](https://github.com/vatesfr/xen-orchestra/pull/7237))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2703,6 +2703,7 @@ const messages = {
   proxiesNeedUpgrade: 'Some proxies need to be upgraded.',
   upgradeNeededForProxies: 'Some proxies need to be upgraded. Click here to get more information.',
   xoProxyConcreteGuide: 'XO Proxy: a concrete guide',
+  someProxiesHaveErrors: 'Some proxies have errors',
 
   // ----- Utils -----
   secondsFormat: '{seconds, plural, one {# second} other {# seconds}}',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2703,7 +2703,8 @@ const messages = {
   proxiesNeedUpgrade: 'Some proxies need to be upgraded.',
   upgradeNeededForProxies: 'Some proxies need to be upgraded. Click here to get more information.',
   xoProxyConcreteGuide: 'XO Proxy: a concrete guide',
-  someProxiesHaveErrors: 'Some proxies have errors',
+  someProxiesHaveErrors:
+    '{n, number} prox{n, plural, one {y} other {ies}} ha{n, plural, one {s} other {ve}} error{n, plural, one {} other {s}}',
 
   // ----- Utils -----
   secondsFormat: '{seconds, plural, one {# second} other {# seconds}}',

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -512,7 +512,14 @@ subscribeHostMissingPatches.forceRefresh = host => {
 const proxiesApplianceUpdaterState = {}
 export const subscribeProxiesApplianceUpdaterState = (proxyId, cb) => {
   if (proxiesApplianceUpdaterState[proxyId] === undefined) {
-    proxiesApplianceUpdaterState[proxyId] = createSubscription(() => getProxyApplianceUpdaterState(proxyId))
+    proxiesApplianceUpdaterState[proxyId] = createSubscription(async () => {
+      try {
+        return await getProxyApplianceUpdaterState(proxyId)
+      } catch (error) {
+        console.error(error)
+        return { state: 'error' }
+      }
+    })
   }
   return proxiesApplianceUpdaterState[proxyId](cb)
 }

--- a/packages/xo-web/src/xo-app/menu/index.js
+++ b/packages/xo-web/src/xo-app/menu/index.js
@@ -32,7 +32,7 @@ import {
   getXoaState,
   isAdmin,
 } from 'selectors'
-import { countBy, every, forEach, identity, isEmpty, isEqual, map, pick, size, some } from "lodash";
+import { countBy, every, forEach, identity, isEmpty, isEqual, map, pick, size, some } from 'lodash'
 
 import styles from './index.css'
 

--- a/packages/xo-web/src/xo-app/menu/index.js
+++ b/packages/xo-web/src/xo-app/menu/index.js
@@ -111,9 +111,19 @@ export default class Menu extends Component {
     () => this.state.proxyStates,
     proxyStates => some(proxyStates, state => state.endsWith('-upgrade-needed'))
   )
-  _areProxiesErrors = createSelector(
+  _getNProxiesErrors = createSelector(
     () => this.state.proxyStates,
-    proxyStates => some(proxyStates, state => state === 'error')
+    (proxyStates) => {
+      let count = 0
+
+      forEach(proxyStates, proxyState => {
+        if (proxyState === 'error') {
+          count++
+        }
+      })
+
+      return count
+    }
   )
   _checkPermissions = createSelector(
     () => this.props.isAdmin,
@@ -216,6 +226,7 @@ export default class Menu extends Component {
     const noOperatablePools = this._getNoOperatablePools()
     const noResourceSets = this._getNoResourceSets()
     const noNotifications = this._getNoNotifications()
+    const nProxiesErrors = this._getNProxiesErrors()
 
     const missingPatchesWarning = this._hasMissingPatches() ? (
       <Tooltip content={_('homeMissingPatches')}>
@@ -471,11 +482,9 @@ export default class Menu extends Component {
                 ]}
               />
             </Tooltip>
-          ) : this._areProxiesErrors() ? (
-            <Tooltip content={_('someProxiesHaveErrors')}>
-              <span className='text-warning'>
-                <Icon icon='alarm' />
-              </span>
+          ) : nProxiesErrors > 0 ? (
+            <Tooltip content={_('someProxiesHaveErrors', { n: nProxiesErrors })}>
+              <span className='tag tag-pill tag-warning'>{nProxiesErrors}</span>
             </Tooltip>
           ) : null,
         ],

--- a/packages/xo-web/src/xo-app/menu/index.js
+++ b/packages/xo-web/src/xo-app/menu/index.js
@@ -32,7 +32,7 @@ import {
   getXoaState,
   isAdmin,
 } from 'selectors'
-import { every, forEach, identity, isEmpty, isEqual, map, pick, size, some } from 'lodash'
+import { countBy, every, forEach, identity, isEmpty, isEqual, map, pick, size, some } from "lodash";
 
 import styles from './index.css'
 
@@ -113,17 +113,7 @@ export default class Menu extends Component {
   )
   _getNProxiesErrors = createSelector(
     () => this.state.proxyStates,
-    (proxyStates) => {
-      let count = 0
-
-      forEach(proxyStates, proxyState => {
-        if (proxyState === 'error') {
-          count++
-        }
-      })
-
-      return count
-    }
+    proxyStates => countBy(proxyStates).error
   )
   _checkPermissions = createSelector(
     () => this.props.isAdmin,
@@ -484,7 +474,7 @@ export default class Menu extends Component {
             </Tooltip>
           ) : nProxiesErrors > 0 ? (
             <Tooltip content={_('someProxiesHaveErrors', { n: nProxiesErrors })}>
-              <span className='tag tag-pill tag-warning'>{nProxiesErrors}</span>
+              <span className='tag tag-pill tag-danger'>{nProxiesErrors}</span>
             </Tooltip>
           ) : null,
         ],

--- a/packages/xo-web/src/xo-app/menu/index.js
+++ b/packages/xo-web/src/xo-app/menu/index.js
@@ -111,7 +111,10 @@ export default class Menu extends Component {
     () => this.state.proxyStates,
     proxyStates => some(proxyStates, state => state.endsWith('-upgrade-needed'))
   )
-
+  _areProxiesErrors = createSelector(
+    () => this.state.proxyStates,
+    proxyStates => some(proxyStates, state => state === 'error')
+  )
   _checkPermissions = createSelector(
     () => this.props.isAdmin,
     () => this.props.permissions,
@@ -467,6 +470,12 @@ export default class Menu extends Component {
                   { icon: 'menu-update', size: 1 },
                 ]}
               />
+            </Tooltip>
+          ) : this._areProxiesErrors() ? (
+            <Tooltip content={_('someProxiesHaveErrors')}>
+              <span className='text-warning'>
+                <Icon icon='alarm' />
+              </span>
             </Tooltip>
           ) : null,
         ],


### PR DESCRIPTION
See Zammad#19126

### Description

Add a warning icon in Proxies menu if unable to check proxy upgrade

### Screenshot

![image](https://github.com/vatesfr/xen-orchestra/assets/66562640/a8e146c5-8530-49e0-87f4-b468d5fc40bf)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
