### PR TITLE
feat(xo-web/sr): show coalescing status

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -6,6 +6,7 @@
 ### Enhancements
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
+- [SR] show an icon on SR during VDI coalescing (with XCP-ng 8.3+) (PR [#7241](https://github.com/vatesfr/xen-orchestra/pull/7241))
 
 ### Bug fixes
 
@@ -26,5 +27,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-web/src/icons.scss
+++ b/packages/xo-web/src/icons.scss
@@ -136,6 +136,10 @@
     @extend .fa;
     @extend .fa-caret-up;
   }
+  &-coalesce {
+    @extend .fa;
+    @extend .fa-cog;
+  }
   &-loading {
     @extend .fa;
     @extend .fa-spinner;

--- a/packages/xo-web/src/xo-app/home/sr-item.js
+++ b/packages/xo-web/src/xo-app/home/sr-item.js
@@ -17,6 +17,11 @@ import { connectStore, formatSizeShort, getIscsiPaths } from 'utils'
 import styles from './index.css'
 
 @connectStore({
+  coalesceTask: createSelector(
+    (_, props) => props.item,
+    createGetObjectsOfType('task').groupBy('applies_to'),
+    (sr, tasks) => tasks[sr.uuid]?.[0]
+  ),
   container: createGetObject((_, props) => props.item.$container),
   isHa: createSelector(
     (_, props) => props.item,
@@ -102,7 +107,7 @@ export default class SrItem extends Component {
   }
 
   render() {
-    const { container, expandAll, isDefaultSr, isHa, isShared, item: sr, selected } = this.props
+    const { coalesceTask, container, expandAll, isDefaultSr, isHa, isShared, item: sr, selected } = this.props
 
     return (
       <div className={styles.item}>
@@ -121,6 +126,11 @@ export default class SrItem extends Component {
                 {isHa && (
                   <Tooltip content={_('srHaTooltip')}>
                     <span className='tag tag-pill tag-info ml-1'>{_('ha')}</span>
+                  </Tooltip>
+                )}
+                {coalesceTask !== undefined && (
+                  <Tooltip content={`${coalesceTask.name_label} ${Math.round(coalesceTask.progress * 100)}%`}>
+                    <Icon icon='coalesce' fixedWidth />
                   </Tooltip>
                 )}
                 {sr.inMaintenanceMode && <span className='tag tag-pill tag-warning ml-1'>{_('maintenanceMode')}</span>}

--- a/packages/xo-web/src/xo-app/host/tab-storage.js
+++ b/packages/xo-web/src/xo-app/host/tab-storage.js
@@ -1,4 +1,5 @@
 import _ from 'intl'
+import Icon from 'icon'
 import Link from 'link'
 import map from 'lodash/map'
 import React from 'react'
@@ -29,9 +30,14 @@ const forgetSrs = pbds =>
 const SR_COLUMNS = [
   {
     name: _('srName'),
-    itemRenderer: storage => (
-      <Link to={`/srs/${storage.id}`}>
-        <Text onChange={nameLabel => editSr(storage.id, { nameLabel })} useLongClick value={storage.nameLabel} />
+    itemRenderer: ({ id, nameLabel, coalesceTask }) => (
+      <Link to={`/srs/${id}`}>
+        <Text onChange={nameLabel => editSr(id, { nameLabel })} useLongClick value={nameLabel} />
+        {coalesceTask !== undefined && (
+          <Tooltip content={`${coalesceTask.name_label} ${Math.round(coalesceTask.progress * 100)}%`}>
+            <Icon icon='coalesce' />
+          </Tooltip>
+        )}
       </Link>
     ),
     sortCriteria: 'nameLabel',
@@ -113,14 +119,13 @@ const SR_ACTIONS = [
 export default connectStore(() => {
   const pbds = createGetObjectsOfType('PBD').pick((_, props) => props.host.$PBDs)
   const srs = createGetObjectsOfType('SR').pick(createSelector(pbds, pbds => map(pbds, pbd => pbd.SR)))
-
-  const storages = createSelector(pbds, srs, (pbds, srs) =>
+  const coalesceTasks = createGetObjectsOfType('task').groupBy('applies_to')
+  const storages = createSelector(pbds, srs, coalesceTasks, (pbds, srs, coalesceTasks) =>
     map(
       filter(pbds, pbd => srs[pbd.SR] !== undefined),
       pbd => {
         const sr = srs[pbd.SR]
         const { physical_usage: usage, size } = sr
-
         return {
           attached: pbd.attached,
           pbdDeviceConfig: pbd.device_config,
@@ -132,6 +137,7 @@ export default connectStore(() => {
           shared: isSrShared(sr),
           size: size > 0 ? size : 0,
           usagePercentage: size > 0 && Math.round((100 * usage) / size),
+          coalesceTask: coalesceTasks[pbd.SR]?.[0], // there can be only one coalesce task by SR
         }
       }
     )


### PR DESCRIPTION
### Description

review by commit

show the coalscing status of a SR ( require xcp-ng 8.3+)
in home/SR:
![Capture d’écran du 2023-12-18 17-18-55](https://github.com/vatesfr/xen-orchestra/assets/50174/c402f9e8-a991-4b90-9d6d-1728771576b5)


in host/SR : 
![image](https://github.com/vatesfr/xen-orchestra/assets/50174/017d1802-6ba2-4a94-9b4c-e619a0753da1)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
