### PR TITLE
feat(xo-web/pool): ability to do a rolling pool reboot

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,7 +20,7 @@
 - [Tags] Admin can create colored tags (PR [#7262](https://github.com/vatesfr/xen-orchestra/pull/7262))
 - [Tags] Add tooltips on `xo:no-bak` and `xo:notify-on-snapshot` tags (PR [#7335](https://github.com/vatesfr/xen-orchestra/pull/7335))
 - [VM] Custom notes [#5792](https://github.com/vatesfr/xen-orchestra/issues/5792) (PR [#7322](https://github.com/vatesfr/xen-orchestra/pull/7322))
-- [Pool/Advanced] Ability to do a `Rolling Pool Reboot` (Enterprise plans)
+- [Pool/Advanced] Ability to do a `Rolling Pool Reboot` (Enterprise plans) [#6885](https://github.com/vatesfr/xen-orchestra/issues/6885) (PRs [#7243](https://github.com/vatesfr/xen-orchestra/pull/7243), [#7242](https://github.com/vatesfr/xen-orchestra/pull/7242))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@
 - [Tags] Admin can create colored tags (PR [#7262](https://github.com/vatesfr/xen-orchestra/pull/7262))
 - [Tags] Add tooltips on `xo:no-bak` and `xo:notify-on-snapshot` tags (PR [#7335](https://github.com/vatesfr/xen-orchestra/pull/7335))
 - [VM] Custom notes [#5792](https://github.com/vatesfr/xen-orchestra/issues/5792) (PR [#7322](https://github.com/vatesfr/xen-orchestra/pull/7322))
+- [Pool/Advanced] Ability to do a `Rolling Pool Reboot` (Enterprise plans)
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -912,6 +912,13 @@ const messages = {
   poolSupportSourceUsers: 'XCP-ng Pro Support not available for source users',
   poolSupportXcpngOnly: 'Only available for pool of XCP-ng hosts',
   poolLicenseAlreadyFullySupported: 'The pool is already fully supported',
+  rollingPoolReboot: 'Rolling pool reboot',
+  rollingPoolRebootHaWarning: 'High Availability is enabled. This will automatically disable it during the reboot.',
+  rollingPoolRebootLoadBalancerWarning:
+    'Load Balancer plugin is running. This will automatically pause it during the reboot.',
+  rollingPoolRebootMessage:
+    'Are you sure you want to start a rolling pool reboot? Running VMs will be migrated back and forth and this can take a while. Scheduled backups that may concern this pool will be disabled.',
+
   setpoolMaster: 'Master',
   syslogRemoteHost: 'Remote syslog host',
   defaultMigrationNetwork: 'Default migration network',
@@ -2683,6 +2690,9 @@ const messages = {
   trialLicenseInfo: 'You are currently in a {edition} trial period that will end on {date, date, medium}',
   proxyMultipleLicenses: 'This proxy has more than 1 license!',
   proxyUnknownVm: 'Unknown proxy VM.',
+
+  // ----- plan -----
+  onlyAvailableToEnterprise: 'Only available to enterprise users',
 
   // ----- proxies -----
   forgetProxyApplianceTitle: 'Forget prox{n, plural, one {y} other {ies}}',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -912,7 +912,7 @@ const messages = {
   poolSupportSourceUsers: 'XCP-ng Pro Support not available for source users',
   poolSupportXcpngOnly: 'Only available for pool of XCP-ng hosts',
   poolLicenseAlreadyFullySupported: 'The pool is already fully supported',
-  rollingPoolReboot: 'Rolling pool reboot',
+  rollingPoolReboot: 'Rolling Pool Reboot',
   rollingPoolRebootHaWarning: 'High Availability is enabled. This will automatically disable it during the reboot.',
   rollingPoolRebootLoadBalancerWarning:
     'Load Balancer plugin is running. This will automatically pause it during the reboot.',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -917,7 +917,7 @@ const messages = {
   rollingPoolRebootLoadBalancerWarning:
     'Load Balancer plugin is running. This will automatically pause it during the reboot.',
   rollingPoolRebootMessage:
-    'Are you sure you want to start a rolling pool reboot? Running VMs will be migrated back and forth and this can take a while. Scheduled backups that may concern this pool will be disabled.',
+    'Are you sure you want to start a Rolling Pool Reboot? Running VMs will be migrated back and forth and this can take a while. Scheduled backups that may concern this pool will be disabled.',
 
   setpoolMaster: 'Master',
   syslogRemoteHost: 'Remote syslog host',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2692,7 +2692,7 @@ const messages = {
   proxyUnknownVm: 'Unknown proxy VM.',
 
   // ----- plan -----
-  onlyAvailableToEnterprise: 'Only available to enterprise users',
+  onlyAvailableToEnterprise: 'Only available to Enterprise users',
 
   // ----- proxies -----
   forgetProxyApplianceTitle: 'Forget prox{n, plural, one {y} other {ies}}',

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -48,6 +48,7 @@ import {
 } from '../store/actions'
 
 import parseNdJson from './_parseNdJson'
+import RollingPoolRebootModal from './rolling-pool-reboot-modal'
 
 // ===================================================================
 
@@ -815,6 +816,32 @@ export const setPoolMaster = host =>
       host: <strong>{host.name_label}</strong>,
     }),
   }).then(() => _call('pool.setPoolMaster', { host: resolveId(host) }), noop)
+
+export const rollingPoolReboot = async pool => {
+  const poolId = resolveId(pool)
+  await confirm({
+    body: <RollingPoolRebootModal pool={poolId} />,
+    title: _('rollingPoolReboot'),
+    icon: 'pool-rolling-reboot',
+  })
+  try {
+    return await _call('pool.rollingReboot', { pool: poolId })
+  } catch (error) {
+    if (!forbiddenOperation.is(error)) {
+      throw error
+    }
+    await confirm({
+      body: (
+        <p className='text-warning'>
+          <Icon icon='alarm' /> {_('bypassBackupPoolModalMessage')}
+        </p>
+      ),
+      title: _('rollingPoolReboot'),
+      icon: 'pool-rolling-reboot',
+    })
+    return _call('pool.rollingReboot', { pool: poolId, bypassBackupCheck: true })
+  }
+}
 
 // Host --------------------------------------------------------------
 

--- a/packages/xo-web/src/common/xo/rolling-pool-reboot-modal/index.js
+++ b/packages/xo-web/src/common/xo/rolling-pool-reboot-modal/index.js
@@ -1,0 +1,46 @@
+import _ from 'intl'
+import addSubscriptions from 'add-subscriptions'
+import BaseComponent from 'base-component'
+import Icon from 'icon'
+import React from 'react'
+import { connectStore } from 'utils'
+import { createGetObjectsOfType } from 'selectors'
+
+import { subscribePlugins } from '../'
+
+@addSubscriptions(() => ({
+  plugins: subscribePlugins,
+}))
+@connectStore(
+  {
+    pools: createGetObjectsOfType('pool'),
+  },
+  { withRef: true }
+)
+export default class RollingPoolRebootModal extends BaseComponent {
+  render() {
+    const pool = this.props.pools[this.props.pool]
+    const loadBalancerPlugin =
+      this.props.plugins !== undefined && this.props.plugins.find(plugin => plugin.name === 'load-balancer')
+
+    return (
+      <div>
+        <p>{_('rollingPoolRebootMessage')}</p>
+        {pool.HA_enabled && (
+          <p>
+            <em className='text-warning'>
+              <Icon icon='alarm' /> {_('rollingPoolRebootHaWarning')}
+            </em>
+          </p>
+        )}
+        {loadBalancerPlugin !== undefined && loadBalancerPlugin.loaded && (
+          <p>
+            <em className='text-warning'>
+              <Icon icon='alarm' /> {_('rollingPoolRebootLoadBalancerWarning')}
+            </em>
+          </p>
+        )}
+      </div>
+    )
+  }
+}

--- a/packages/xo-web/src/icons.scss
+++ b/packages/xo-web/src/icons.scss
@@ -695,6 +695,10 @@
       @extend .fa;
       @extend .fa-angle-double-down;
     }
+    &-rolling-reboot {
+      @extend .fa;
+      @extend .fa-circle-o-notch;
+    }
   }
 
   &-vif {

--- a/packages/xo-web/src/xo-app/pool/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/pool/tab-advanced.js
@@ -267,35 +267,33 @@ export default class TabAdvanced extends Component {
     const { enabled: hostsEnabledMultipathing, disabled: hostsDisabledMultipathing } = hostsByMultipathing
     const { crashDumpSr } = pool
     const crashDumpSrPredicate = this._getCrashDumpSrPredicate()
-    const isEnterprisePlan = getXoaPlan() === ENTERPRISE
+    const isEnterprisePlan = getXoaPlan().value >= ENTERPRISE.value
 
     return (
       <div>
         <Container>
-          <div>
-            <Row>
-              <Col className='text-xs-right'>
+          <Row>
+            <Col className='text-xs-right'>
+              <TabButton
+                btnStyle='warning'
+                handler={rollingPoolReboot}
+                handlerParam={pool}
+                icon='pool-rolling-reboot'
+                labelId='rollingPoolReboot'
+                disabled={!isEnterprisePlan}
+                tooltip={!isEnterprisePlan ? _('onlyAvailableToEnterprise') : undefined}
+              />
+              {this._isNetboxPluginLoaded() && (
                 <TabButton
-                  btnStyle='warning'
-                  handler={rollingPoolReboot}
-                  handlerParam={pool}
-                  icon='pool-rolling-reboot'
-                  labelId='rollingPoolReboot'
-                  disabled={!isEnterprisePlan}
-                  tooltip={!isEnterprisePlan ? _('onlyAvailableToEnterprise') : undefined}
+                  btnStyle='primary'
+                  handler={synchronizeNetbox}
+                  handlerParam={[pool]}
+                  icon='refresh'
+                  labelId='syncNetbox'
                 />
-                {this._isNetboxPluginLoaded() && (
-                  <TabButton
-                    btnStyle='primary'
-                    handler={synchronizeNetbox}
-                    handlerParam={[pool]}
-                    icon='refresh'
-                    labelId='syncNetbox'
-                  />
-                )}
-              </Col>
-            </Row>
-          </div>
+              )}
+            </Col>
+          </Row>
           <Row>
             <Col>
               <h3>{_('xenSettingsLabel')}</h3>

--- a/packages/xo-web/src/xo-app/pool/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/pool/tab-advanced.js
@@ -281,7 +281,7 @@ export default class TabAdvanced extends Component {
                   handlerParam={pool}
                   icon='pool-rolling-reboot'
                   labelId='rollingPoolReboot'
-                  // disabled={!isEnterprisePlan}
+                  disabled={!isEnterprisePlan}
                   tooltip={!isEnterprisePlan ? _('onlyAvailableToEnterprise') : undefined}
                 />
                 {this._isNetboxPluginLoaded() && (

--- a/packages/xo-web/src/xo-app/pool/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/pool/tab-advanced.js
@@ -26,6 +26,7 @@ import {
   editPool,
   installSupplementalPackOnAllHosts,
   isSrWritable,
+  rollingPoolReboot,
   setHostsMultipathing,
   setPoolMaster,
   setRemoteSyslogHost,
@@ -45,7 +46,7 @@ import { confirm } from '../../common/modal'
 import { error } from '../../common/notification'
 import { Host, Pool } from '../../common/render-xo-item'
 import { isAdmin } from '../../common/selectors'
-import { SOURCES, getXoaPlan } from '../../common/xoa-plans'
+import { ENTERPRISE, SOURCES, getXoaPlan } from '../../common/xoa-plans'
 
 const BindLicensesButton = decorate([
   addSubscriptions({
@@ -266,22 +267,35 @@ export default class TabAdvanced extends Component {
     const { enabled: hostsEnabledMultipathing, disabled: hostsDisabledMultipathing } = hostsByMultipathing
     const { crashDumpSr } = pool
     const crashDumpSrPredicate = this._getCrashDumpSrPredicate()
+    const isEnterprisePlan = getXoaPlan() === ENTERPRISE
+
     return (
       <div>
         <Container>
-          {this._isNetboxPluginLoaded() && (
+          <div>
             <Row>
               <Col className='text-xs-right'>
                 <TabButton
-                  btnStyle='primary'
-                  handler={synchronizeNetbox}
-                  handlerParam={[pool]}
-                  icon='refresh'
-                  labelId='syncNetbox'
+                  btnStyle='warning'
+                  handler={rollingPoolReboot}
+                  handlerParam={pool}
+                  icon='pool-rolling-reboot'
+                  labelId='rollingPoolReboot'
+                  // disabled={!isEnterprisePlan}
+                  tooltip={!isEnterprisePlan ? _('onlyAvailableToEnterprise') : undefined}
                 />
+                {this._isNetboxPluginLoaded() && (
+                  <TabButton
+                    btnStyle='primary'
+                    handler={synchronizeNetbox}
+                    handlerParam={[pool]}
+                    icon='refresh'
+                    labelId='syncNetbox'
+                  />
+                )}
               </Col>
             </Row>
-          )}
+          </div>
           <Row>
             <Col>
               <h3>{_('xenSettingsLabel')}</h3>


### PR DESCRIPTION
### Screenshots

![Capture d’écran de 2024-01-11 16-40-23](https://github.com/vatesfr/xen-orchestra/assets/70369997/404922ac-2769-4875-a080-a58ec84bde56)
![Capture d’écran de 2024-01-11 16-39-33](https://github.com/vatesfr/xen-orchestra/assets/70369997/d58df9c4-3e4b-4808-859e-26f714e71012)

### Description

wait for the PR #7242 
Fixes #6885 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
