### PR TITLE
feat(xo-web,xo-server): restart VM to change memory setting

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,6 +8,7 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - [Host/Network/PIF] Display and ability to edit IPv6 field [#5400](https://github.com/vatesfr/xen-orchestra/issues/5400) (PR [#7218](https://github.com/vatesfr/xen-orchestra/pull/7218))
+- [VM] Trying to increase the memory of a running VM will now propose the option to automatically restart it and increasing its memory (PR [#7244](https://github.com/vatesfr/xen-orchestra/pull/7244))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,7 +8,7 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - [Host/Network/PIF] Display and ability to edit IPv6 field [#5400](https://github.com/vatesfr/xen-orchestra/issues/5400) (PR [#7218](https://github.com/vatesfr/xen-orchestra/pull/7218))
-- [VM] Trying to increase the memory of a running VM will now propose the option to automatically restart it and increasing its memory (PR [#7244](https://github.com/vatesfr/xen-orchestra/pull/7244))
+- [VM] Trying to increase the memory of a running VM will now propose the option to automatically restart it and increasing its memory [#7069](https://github.com/vatesfr/xen-orchestra/issues/7069) (PR [#7244](https://github.com/vatesfr/xen-orchestra/pull/7244))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -774,6 +774,29 @@ set.resolve = {
 
 // -------------------------------------------------------------------
 
+export const setAndRestart = defer(async function ($defer, params) {
+  const vm = params.VM
+  const force = extract(params, 'force')
+
+  await stop.bind(this)({ vm, force })
+
+  $defer(start.bind(this), { vm, force })
+
+  return set.bind(this)(params)
+})
+
+setAndRestart.params = {
+  // Restart options
+  force: { type: 'boolean', optional: true },
+
+  // Set params
+  ...set.params,
+}
+
+setAndRestart.resolve = set.resolve
+
+// -------------------------------------------------------------------
+
 export const restart = defer(async function ($defer, { vm, force = false, bypassBlockedOperation = force }) {
   const xapi = this.getXapi(vm)
   if (bypassBlockedOperation) {

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1456,6 +1456,10 @@ const messages = {
   vmDefaultBootFirmwareLabel: 'default (bios)',
   vmBootFirmwareWarningMessage:
     "You're about to change your boot firmware. This is still experimental in CH/XCP-ng 8.0. Are you sure you want to continue?",
+  setAndRestartVmFailed: 'Error on restarting and setting the VM: {vm}',
+  vmEditAndRestartModalTitle: 'VM is currently running',
+  vmEditAndRestartModalMessage:
+    'This VM is currently running, and needs to be stopped to modify this value. Restart VM and modify this value?',
 
   // ----- VM placeholders -----
 

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -1825,11 +1825,10 @@ export const editVm = async (vm, props) => {
             icon: 'vm-reboot',
             title: _('vmEditAndRestartModalTitle'),
           })
-          return _call('vm.setAndRestart', { ...props, id: resolveId(vm), force }).then(noop, err => {
-            error(_('setAndRestartVmFailed', { vm: renderXoItemFromId(resolveId(vm)) }), err.message)
-          })
+          await _call('vm.setAndRestart', { ...props, id: resolveId(vm), force })
         } catch (err) {
           if (err !== undefined) {
+            error(_('setAndRestartVmFailed', { vm: renderXoItemFromId(resolveId(vm)) }), err.message)
             throw err
           }
         }

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -17,6 +17,7 @@ import {
   noHostsAvailable,
   operationBlocked,
   operationFailed,
+  vmBadPowerState,
   vmLacksFeature,
 } from 'xo-common/api-errors'
 
@@ -1812,8 +1813,29 @@ export const editVm = async (vm, props) => {
     }
   }
   await _call('vm.set', { ...props, id: resolveId(vm) })
-    .catch(err => {
-      error(_('setVmFailed', { vm: renderXoItemFromId(resolveId(vm)) }), err.message)
+    .catch(async err => {
+      if (vmBadPowerState.is(err, { actual: 'running' }) || err.message === 'Cannot change memory on running VM') {
+        try {
+          const force = await chooseAction({
+            body: <p>{_('vmEditAndRestartModalMessage')}</p>,
+            buttons: [
+              { label: _('rebootVmLabel'), value: false, btnStyle: 'success' },
+              { label: _('forceRebootVmLabel'), value: true, btnStyle: 'danger' },
+            ],
+            icon: 'vm-reboot',
+            title: _('vmEditAndRestartModalTitle'),
+          })
+          return _call('vm.setAndRestart', { ...props, id: resolveId(vm), force }).then(noop, err => {
+            error(_('setAndRestartVmFailed', { vm: renderXoItemFromId(resolveId(vm)) }), err.message)
+          })
+        } catch (err) {
+          if (err !== undefined) {
+            throw err
+          }
+        }
+      } else {
+        error(_('setVmFailed', { vm: renderXoItemFromId(resolveId(vm)) }), err.message)
+      }
     })
     ::tap(subscribeResourceSets.forceRefresh)
 }
@@ -2600,7 +2622,7 @@ export const listVmBackups = remotes => _call('backupNg.listVmBackups', { remote
 export const restoreBackup = (
   backup,
   sr,
-  { generateNewMacAddresses = false, mapVdisSrs = {}, startOnRestore = false, useDifferentialRestore= false } = {}
+  { generateNewMacAddresses = false, mapVdisSrs = {}, startOnRestore = false, useDifferentialRestore = false } = {}
 ) => {
   const promise = _call('backupNg.importVmBackup', {
     id: resolveId(backup),


### PR DESCRIPTION
### Description

Add modal to restart VM to increase memory. See #7069

![image](https://github.com/vatesfr/xen-orchestra/assets/50174/72145078-c94a-4fd9-940b-617ba6fe2bc8)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
