### PR TITLE
feat(api/vdi): expose nbd settings in xo api

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,6 +28,7 @@
 
 <!--packages-start-->
 
+- vhd-lib patch
 - xo-server minor
 - xo-web minor
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,6 +8,8 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 - [SR] show an icon on SR during VDI coalescing (with XCP-ng 8.3+) (PR [#7241](https://github.com/vatesfr/xen-orchestra/pull/7241))
 
+- [VDI/Export] Expose NBD settings in the XO and REST APIs api (PR [#7251](https://github.com/vatesfr/xen-orchestra/pull/7251))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,6 +28,7 @@
 
 <!--packages-start-->
 
+- xo-server minor
 - xo-web minor
 
 <!--packages-end-->

--- a/docs/restapi.md
+++ b/docs/restapi.md
@@ -199,6 +199,11 @@ curl \
   > myDisk.vhd
 ```
 
+The following optional query parameters are supported for VDI export:
+
+- `preferNbd`: will use NBD for export if available
+- `nbdConcurrency=<integer>`: set the number of concurrent stream per disk if NBD is enabled, default 1
+
 ## VM Import
 
 A VM can be imported by posting to `/rest/v0/pools/:id/vms`.

--- a/packages/vhd-lib/createStreamNbd.js
+++ b/packages/vhd-lib/createStreamNbd.js
@@ -81,14 +81,14 @@ exports.createNbdVhdStream = async function createVhdStream(
     const entry = streamBat.readUInt32BE(i * 4)
     if (entry !== BLOCK_UNUSED) {
       bat.writeUInt32BE(offsetSector, i * 4)
-      offsetSector += blockSizeInSectors
       entries.push(i)
+      offsetSector += blockSizeInSectors
     } else {
       bat.writeUInt32BE(BLOCK_UNUSED, i * 4)
     }
   }
 
-  const totalLength = (offsetSector + blockSizeInSectors + 1) /* end footer */ * SECTOR_SIZE
+  const totalLength = (offsetSector + 1) /* end footer */ * SECTOR_SIZE
 
   let lengthRead = 0
   let lastUpdate = 0

--- a/packages/xo-server/docs/rest-api.md
+++ b/packages/xo-server/docs/rest-api.md
@@ -210,6 +210,11 @@ curl \
 
 A VDI can be exported in VHD format at `/rest/v0/vdis/<uuid>.vhd` or the raw content at `/rest/v0/vdis/<uuid>.raw`.
 
+The following optional query parameters are supported:
+
+- `preferNbd`: will use NBD for export if available
+- `nbdConcurrency=<integer>`: set the number of concurrent stream per disk if NBD is enabled, default 1
+
 ```sh
 curl \
   -b authenticationToken=KQxQdm2vMiv7jBIK0hgkmgxKzemd8wSJ7ugFGKFkTbs \

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -1104,9 +1104,9 @@ export default class Xapi extends XapiBase {
     return snap
   }
 
-  async exportVdiAsVmdk(vdi, filename, { cancelToken = CancelToken.none, base } = {}) {
+  async exportVdiAsVmdk(vdi, filename, { cancelToken = CancelToken.none, base, nbdConcurrency, preferNbd } = {}) {
     vdi = this.getObject(vdi)
-    const params = { cancelToken, format: VDI_FORMAT_VHD }
+    const params = { cancelToken, format: VDI_FORMAT_VHD, nbdConcurrency, preferNbd }
     if (base !== undefined) {
       params.base = base
     }

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -470,7 +470,9 @@ export default class RestApi {
     api.get(
       '/:collection(vdis|vdi-snapshots)/:object.:format(vhd|raw)',
       wrap(async (req, res) => {
-        const stream = await req.xapiObject.$exportContent({ format: req.params.format })
+        const preferNbd = Object.hasOwn(req.query, 'preferNbd')
+        const nbdConcurrency = req.query.nbdConcurrency && parseInt(req.query.nbdConcurrency)
+        const stream = await req.xapiObject.$exportContent({ format: req.params.format, preferNbd, nbdConcurrency })
 
         // stream can be an HTTP response, in this case, extract interesting data
         const { headers = {}, length, statusCode = 200, statusMessage = 'OK' } = stream


### PR DESCRIPTION
### Description

`xo-cli disk.exportContent id=<ID> @=/dev/null preferNbd=true nbdConcurrency=json:8`
or
`<XO base URL>/rest/v0/vdi-snapshots/<VDIis>.vhd?preferNbd=true&nbdConcurrency=3 ` 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
