### PR TITLE
fix(xo-server): missing data in mirror backup job

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -6,11 +6,14 @@
 ### Enhancements
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
+
 - [SR] show an icon on SR during VDI coalescing (with XCP-ng 8.3+) (PR [#7241](https://github.com/vatesfr/xen-orchestra/pull/7241))
 
 - [VDI/Export] Expose NBD settings in the XO and REST APIs api (PR [#7251](https://github.com/vatesfr/xen-orchestra/pull/7251))
 
 ### Bug fixes
+
+- [Backup/Report] Missing report for Mirror Backup (PR [#7254](https://github.com/vatesfr/xen-orchestra/pull/7254))
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 

--- a/packages/xo-server/src/xo-mixins/jobs/index.mjs
+++ b/packages/xo-server/src/xo-mixins/jobs/index.mjs
@@ -171,7 +171,7 @@ export default class Jobs {
 
     const runJobId = logger.notice(`Starting execution of ${id}.`, {
       data:
-        type === 'backup' || type === 'metadataBackup'
+        type === 'backup' || type === 'metadataBackup' || type === 'mirrorBackup'
           ? {
               mode: job.mode,
               reportWhen: job.settings['']?.reportWhen ?? 'failure',


### PR DESCRIPTION
Mirror Backup jobs weren't storing all the data necessary for sending the report

![image](https://github.com/vatesfr/xen-orchestra/assets/50174/84d29751-c0cb-4a3d-b268-678c40bfa089)


### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
