### PR TITLE
fix(xo-server): replacing wrong param name

### DIFF
--- a/@vates/task/.USAGE.md
+++ b/@vates/task/.USAGE.md
@@ -123,7 +123,7 @@ const onProgress = makeOnProgress({
   onTaskUpdate(taskLog) {},
 })
 
-Task.run({ data: { name: 'my task' }, onProgress }, asyncFn)
+Task.run({ properties: { name: 'my task' }, onProgress }, asyncFn)
 ```
 
 It can also be fed event logs directly:

--- a/@vates/task/README.md
+++ b/@vates/task/README.md
@@ -139,7 +139,7 @@ const onProgress = makeOnProgress({
   onTaskUpdate(taskLog) {},
 })
 
-Task.run({ data: { name: 'my task' }, onProgress }, asyncFn)
+Task.run({ properties: { name: 'my task' }, onProgress }, asyncFn)
 ```
 
 It can also be fed event logs directly:

--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -1400,7 +1400,7 @@ export async function importMultipleFromEsxi({
       await asyncEach(
         vms,
         async vm => {
-          await Task.run({ data: { name: `importing vm ${vm}` } }, async () => {
+          await Task.run({ properties: { name: `importing vm ${vm}` } }, async () => {
             try {
               const vmUuid = await this.migrationfromEsxi({
                 host,


### PR DESCRIPTION
### Description

When the `Task` class is imported from `@vates/tasks`, Task.run parameter uses `properties` key instead of `data` . This is corrected in this PR. Introduced by https://github.com/vatesfr/xen-orchestra/commit/1da05e239d61147d6253c9aac08b7fdf63c96d47

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
