### PR TITLE
fix(vhd-lib/createStreamNbd): skip original table offset before overwriting

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,6 +29,7 @@
 
 <!--packages-start-->
 
+- vhd-lib minor
 - xo-server minor
 - xo-web minor
 

--- a/packages/vhd-lib/createStreamNbd.js
+++ b/packages/vhd-lib/createStreamNbd.js
@@ -45,10 +45,12 @@ exports.createNbdVhdStream = async function createVhdStream(
   const bufFooter = await readChunkStrict(sourceStream, FOOTER_SIZE)
 
   const header = unpackHeader(await readChunkStrict(sourceStream, HEADER_SIZE))
-  header.tableOffset = FOOTER_SIZE + HEADER_SIZE
   // compute BAT in order
   const batSize = Math.ceil((header.maxTableEntries * 4) / SECTOR_SIZE) * SECTOR_SIZE
+  // skip space between header and beginning of the table
   await skipStrict(sourceStream, header.tableOffset - (FOOTER_SIZE + HEADER_SIZE))
+  // new table offset
+  header.tableOffset = FOOTER_SIZE + HEADER_SIZE
   const streamBat = await readChunkStrict(sourceStream, batSize)
   let offset = FOOTER_SIZE + HEADER_SIZE + batSize
   // check if parentlocator are ordered


### PR DESCRIPTION
### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
