### PR TITLE
fix(xo-web/menu): do not subscribe to unhealthy vdi chains if no permissions

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Proxies] Fix `this.getObject` is not a function during deployment
+- [Menu] Don't subscribe to unhealthy VDI chains if user has not enough permissions (PR [#7265](https://github.com/vatesfr/xen-orchestra/pull/7265))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Proxies] Fix `this.getObject` is not a function during deployment
-- [Menu] Don't subscribe to unhealthy VDI chains if user has not enough permissions (PR [#7265](https://github.com/vatesfr/xen-orchestra/pull/7265))
+- [Settings/Logs] Fix `sr.getAllUnhealthyVdiChainsLength: not enough permissions` error with non-admin users (PR [#7265](https://github.com/vatesfr/xen-orchestra/pull/7265))
 
 ### Packages to release
 

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -564,10 +564,10 @@ subscribeVolumeInfo.forceRefresh = (() => {
   }
 })()
 
-export const subscribeSrsUnhealthyVdiChainsLength = createSubscription(async () => {
+export const subscribeSrsUnhealthyVdiChainsLength = createSubscription(() => {
   const _isAdmin = isAdmin(store.getState())
 
-  return _isAdmin ? await _call('sr.getAllUnhealthyVdiChainsLength') : undefined
+  return _isAdmin ? _call('sr.getAllUnhealthyVdiChainsLength') : undefined
 })
 
 const unhealthyVdiChainsLengthSubscriptionsBySr = {}

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -34,7 +34,7 @@ import store from 'store'
 import WarmMigrationModal from './warm-migration-modal'
 import { alert, chooseAction, confirm } from '../modal'
 import { error, info, success } from '../notification'
-import { getObject } from 'selectors'
+import { getObject, isAdmin } from 'selectors'
 import { getXoaPlan, SOURCES } from '../xoa-plans'
 import { noop, resolveId, resolveIds } from '../utils'
 import {
@@ -564,7 +564,11 @@ subscribeVolumeInfo.forceRefresh = (() => {
   }
 })()
 
-export const subscribeSrsUnhealthyVdiChainsLength = createSubscription(() => _call('sr.getAllUnhealthyVdiChainsLength'))
+export const subscribeSrsUnhealthyVdiChainsLength = createSubscription(async () => {
+  const _isAdmin = isAdmin(store.getState())
+
+  return _isAdmin ? await _call('sr.getAllUnhealthyVdiChainsLength') : undefined
+})
 
 const unhealthyVdiChainsLengthSubscriptionsBySr = {}
 export const createSrUnhealthyVdiChainsLengthSubscription = sr => {


### PR DESCRIPTION
### Description

Menu : don't subscribe to unhealthy VDI chains if user has not enough permissions

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
