### PR TITLE
feat(xo-web): scoped tags

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Tags] Implement scoped tags (PR [#7270](https://github.com/vatesfr/xen-orchestra/pull/7270))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -26,5 +28,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-web/package.json
+++ b/packages/xo-web/package.json
@@ -120,6 +120,7 @@
     "readable-stream": "^3.0.2",
     "redux": "^4.0.0",
     "redux-thunk": "^2.0.1",
+    "relative-luminance": "^2.0.1",
     "reselect": "^2.5.4",
     "rimraf": "^5.0.1",
     "sass": "^1.38.1",

--- a/packages/xo-web/src/common/tags.js
+++ b/packages/xo-web/src/common/tags.js
@@ -154,7 +154,7 @@ export const Tag = ({ type, label, onDelete, onClick }) => {
   // must be in format #rrggbb for luminance parsing
   const color = '#2598d9'
 
-  const borderSize = '0.1em'
+  const borderSize = '0.2em'
   const padding = '0.2em'
 
   const isLight =

--- a/packages/xo-web/src/common/tags.js
+++ b/packages/xo-web/src/common/tags.js
@@ -218,6 +218,11 @@ export const Tag = ({ type, label, onDelete, onClick }) => {
             cursor: 'pointer',
             display: 'inline-block',
             padding,
+
+            // if isScoped, the display is a bit different
+            background: isScoped && color2,
+            color: isScoped && color,
+            borderLeft: isScoped && borderSize + ' solid ' + color,
           }}
         >
           <Icon icon='remove-tag' />

--- a/packages/xo-web/src/common/tags.js
+++ b/packages/xo-web/src/common/tags.js
@@ -5,6 +5,7 @@ import map from 'lodash/map'
 import pFinally from 'promise-toolbox/finally'
 import PropTypes from 'prop-types'
 import React from 'react'
+import relativeLuminance from 'relative-luminance'
 
 import ActionButton from './action-button'
 import Component from './base-component'
@@ -16,26 +17,12 @@ import { SelectTag } from './select-objects'
 const INPUT_STYLE = {
   maxWidth: '8em',
 }
-const TAG_STYLE = {
-  backgroundColor: '#2598d9',
-  borderRadius: '0.5em',
-  color: 'white',
-  fontSize: '0.6em',
-  margin: '0.2em',
-  marginTop: '-0.1em',
-  padding: '0.3em',
-  verticalAlign: 'middle',
-}
-const LINK_STYLE = {
-  cursor: 'pointer',
-}
 const ADD_TAG_STYLE = {
   cursor: 'pointer',
+  display: 'inline-block',
   fontSize: '0.8em',
   marginLeft: '0.2em',
-}
-const REMOVE_TAG_STYLE = {
-  cursor: 'pointer',
+  verticalAlign: 'middle',
 }
 
 class SelectExistingTag extends Component {
@@ -128,19 +115,26 @@ export default class Tags extends Component {
     const deleteTag = (onDelete || onChange) && this._deleteTag
 
     return (
-      <span className='form-group' style={{ color: '#999' }}>
-        <Icon icon='tags' />{' '}
-        <span>
+      <div style={{ color: '#999', display: 'inline-block' }}>
+        <div style={{ display: 'inline-block', verticalAlign: 'middle' }}>
+          <Icon icon='tags' />
+        </div>
+        <div style={{ display: 'inline-block', fontSize: '0.6em', verticalAlign: 'middle' }}>
           {map(labels.sort(), (label, index) => (
             <Tag label={label} onDelete={deleteTag} key={index} onClick={onClick} />
           ))}
-        </span>
+        </div>
         {(onAdd || onChange) && !this.state.editing ? (
-          <span onClick={this._startEdit} style={ADD_TAG_STYLE}>
+          <div onClick={this._startEdit} style={ADD_TAG_STYLE}>
             <Icon icon='add-tag' />
-          </span>
+          </div>
         ) : (
-          <span className='form-inline' onBlur={this._closeEditionIfUnfocused} onFocus={this._focus}>
+          <div
+            style={{ display: 'inline-block', verticalAlign: 'middle' }}
+            className='form-inline'
+            onBlur={this._closeEditionIfUnfocused}
+            onFocus={this._focus}
+          >
             <span className='input-group'>
               <input autoFocus className='form-control' onKeyDown={this._onKeyDown} style={INPUT_STYLE} type='text' />
               <span className='input-group-btn'>
@@ -149,27 +143,89 @@ export default class Tags extends Component {
                 </Tooltip>
               </span>
             </span>
-          </span>
+          </div>
         )}
-      </span>
+      </div>
     )
   }
 }
 
-export const Tag = ({ type, label, onDelete, onClick }) => (
-  <span style={TAG_STYLE}>
-    <span onClick={onClick && (() => onClick(label))} style={onClick && LINK_STYLE}>
-      {label}
-    </span>{' '}
-    {onDelete ? (
-      <span onClick={onDelete && (() => onDelete(label))} style={REMOVE_TAG_STYLE}>
-        <Icon icon='remove-tag' />
-      </span>
-    ) : (
-      []
-    )}
-  </span>
-)
+export const Tag = ({ type, label, onDelete, onClick }) => {
+  // must be in format #rrggbb for luminance parsing
+  const color = '#2598d9'
+
+  const borderSize = '0.1em'
+  const padding = '0.2em'
+
+  const isLight =
+    relativeLuminance(
+      Array.from({ length: 3 }, (_, i) => {
+        const j = i * 2 + 1
+        return parseInt(color.slice(j, j + 2), 16)
+      })
+    ) > 0.5
+  const color2 = isLight ? '#000' : '#fff'
+
+  const i = label.indexOf('=')
+  const isScoped = i !== -1
+
+  return (
+    <div
+      style={{
+        background: color,
+        border: borderSize + ' solid ' + color,
+        borderRadius: '0.5em',
+        color: color2,
+        display: 'inline-block',
+        margin: '0.2em',
+
+        // prevent value background from breaking border radius
+        overflow: 'clip',
+      }}
+    >
+      <div
+        onClick={onClick && (() => onClick(label))}
+        style={{
+          cursor: onClick && 'pointer',
+          display: 'inline-block',
+        }}
+      >
+        <div
+          style={{
+            display: 'inline-block',
+            padding,
+          }}
+        >
+          {isScoped ? label.slice(0, i) : label}
+        </div>
+        {isScoped && (
+          <div
+            style={{
+              background: color2,
+              color,
+              display: 'inline-block',
+              padding,
+            }}
+          >
+            {label.slice(i + 1) || <i>N/A</i>}
+          </div>
+        )}
+      </div>
+      {onDelete && (
+        <div
+          onClick={onDelete && (() => onDelete(label))}
+          style={{
+            cursor: 'pointer',
+            display: 'inline-block',
+            padding,
+          }}
+        >
+          <Icon icon='remove-tag' />
+        </div>
+      )}
+    </div>
+  )
+}
 Tag.propTypes = {
   label: PropTypes.string.isRequired,
 }

--- a/packages/xo-web/src/common/tags.js
+++ b/packages/xo-web/src/common/tags.js
@@ -150,10 +150,15 @@ export default class Tags extends Component {
   }
 }
 
-export const Tag = ({ type, label, onDelete, onClick }) => {
-  // must be in format #rrggbb for luminance parsing
-  const color = '#2598d9'
+export const Tag = ({
+  type,
+  label,
+  onDelete,
+  onClick,
 
+  // must be in format #rrggbb for luminance parsing
+  color = '#2598d9',
+}) => {
   const borderSize = '0.2em'
   const padding = '0.2em'
 
@@ -164,7 +169,6 @@ export const Tag = ({ type, label, onDelete, onClick }) => {
         return parseInt(color.slice(j, j + 2), 16)
       })
     ) > 0.5
-  const color2 = isLight ? '#000' : '#fff'
 
   const i = label.indexOf('=')
   const isScoped = i !== -1
@@ -175,7 +179,7 @@ export const Tag = ({ type, label, onDelete, onClick }) => {
         background: color,
         border: borderSize + ' solid ' + color,
         borderRadius: '0.5em',
-        color: color2,
+        color: isLight ? '#000' : '#fff',
         display: 'inline-block',
         margin: '0.2em',
 
@@ -201,8 +205,8 @@ export const Tag = ({ type, label, onDelete, onClick }) => {
         {isScoped && (
           <div
             style={{
-              background: color2,
-              color,
+              background: '#fff',
+              color: '#000',
               display: 'inline-block',
               padding,
             }}
@@ -220,9 +224,8 @@ export const Tag = ({ type, label, onDelete, onClick }) => {
             padding,
 
             // if isScoped, the display is a bit different
-            background: isScoped && color2,
-            color: isScoped && color,
-            borderLeft: isScoped && borderSize + ' solid ' + color,
+            background: isScoped && '#fff',
+            color: isScoped && (isLight ? '#000' : color),
           }}
         >
           <Icon icon='remove-tag' />

--- a/packages/xo-web/src/xo-app/home/host-item.js
+++ b/packages/xo-web/src/xo-app/home/host-item.js
@@ -335,9 +335,9 @@ export default class HostItem extends Component {
               {host.productBrand} {host.version}
             </Col>
             <Col mediumSize={3} className={styles.itemExpanded}>
-              <span style={{ fontSize: '1.4em' }}>
+              <div style={{ fontSize: '1.4em' }}>
                 <HomeTags type='host' labels={host.tags} onDelete={this._removeTag} onAdd={this._addTag} />
-              </span>
+              </div>
             </Col>
             <Col mediumSize={6} className={styles.itemExpanded}>
               <MiniStats fetch={this._fetchStats} />

--- a/packages/xo-web/src/xo-app/home/pool-item.js
+++ b/packages/xo-web/src/xo-app/home/pool-item.js
@@ -265,9 +265,9 @@ export default class PoolItem extends Component {
               {master.productBrand} {master.version}
             </Col>
             <Col mediumSize={5}>
-              <span style={{ fontSize: '1.4em' }}>
+              <div style={{ fontSize: '1.4em' }}>
                 <HomeTags type='pool' labels={pool.tags} onDelete={this._removeTag} onAdd={this._addTag} />
-              </span>
+              </div>
             </Col>
             <Col mediumSize={3} className={styles.itemExpanded}>
               <span>

--- a/packages/xo-web/src/xo-app/home/sr-item.js
+++ b/packages/xo-web/src/xo-app/home/sr-item.js
@@ -192,9 +192,9 @@ export default class SrItem extends Component {
               {sr.VDIs.length}x <Icon icon='disk' />
             </Col>
             <Col mediumSize={4}>
-              <span style={{ fontSize: '1.4em' }}>
+              <div style={{ fontSize: '1.4em' }}>
                 <HomeTags type='SR' labels={sr.tags} onDelete={this._removeTag} onAdd={this._addTag} />
-              </span>
+              </div>
             </Col>
           </SingleLineRow>
         )}

--- a/packages/xo-web/src/xo-app/home/template-item.js
+++ b/packages/xo-web/src/xo-app/home/template-item.js
@@ -87,9 +87,9 @@ export default class TemplateItem extends Component {
               ))}
             </Col>
             <Col mediumSize={4}>
-              <span style={{ fontSize: '1.4em' }}>
+              <div style={{ fontSize: '1.4em' }}>
                 <HomeTags type='VM-template' labels={vm.tags} onDelete={this._removeTag} onAdd={this._addTag} />
-              </span>
+              </div>
             </Col>
           </Row>
         )}

--- a/packages/xo-web/src/xo-app/home/vm-item.js
+++ b/packages/xo-web/src/xo-app/home/vm-item.js
@@ -209,9 +209,9 @@ export default class VmItem extends Component {
               ))}
             </Col>
             <Col mediumSize={6}>
-              <span style={{ fontSize: '1.4em' }}>
+              <div style={{ fontSize: '1.4em' }}>
                 <HomeTags type='VM' labels={vm.tags} onDelete={this._removeTag} onAdd={this._addTag} />
-              </span>
+              </div>
             </Col>
             <Col mediumSize={6} className={styles.itemExpanded}>
               {this._isRunning && <MiniStats fetch={this._fetchStats} />}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9654,6 +9654,11 @@ eslint@^8.7.0:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
+esm@^3.0.84:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
+
 espree@^9.0.0, espree@^9.3.1, espree@^9.6.0, espree@^9.6.1:
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz#a2a17b8e434690a5432f2f8018ce71d331a48c6f"
@@ -18393,6 +18398,13 @@ relateurl@0.2.x, relateurl@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==
+
+relative-luminance@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/relative-luminance/-/relative-luminance-2.0.1.tgz#2babddf3a5a59673227d6f02e0f68e13989e3d13"
+  integrity sha512-wFuITNthJilFPwkK7gNJcULxXBcfFZvZORsvdvxeOdO44wCeZnuQkf3nFFzOR/dpJNxYsdRZJLsepWbyKhnMww==
+  dependencies:
+    esm "^3.0.84"
 
 release-zalgo@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### Description

Based on #7258 developed by @fbeauchamp.

- use inline blocks to respect all paddings/margins
- main settings are in easily modifiable variables
- text color is either black or white based on the background color luminance
- make sure tags and surrounding action buttons are aligned

Home view:
![image](https://github.com/vatesfr/xen-orchestra/assets/298721/c5d3aa80-0950-49e1-a90a-126546b2b0e9)

VM view:
![image](https://github.com/vatesfr/xen-orchestra/assets/298721/51bba790-071a-45a7-930b-87e472ef4236)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
