### PR TITLE
Automatically regen expired automatic certificates

### DIFF
--- a/@xen-orchestra/self-signed/.USAGE.md
+++ b/@xen-orchestra/self-signed/.USAGE.md
@@ -1,3 +1,7 @@
+### `genSelfSigned()`
+
+> Generate a self-signed cert/key pair with OpenSSL.
+
 ```js
 import { genSelfSigned } from '@xen-orchestra/self-signed'
 
@@ -17,4 +21,42 @@ console.log(
 //     // content…
 //     '-----END RSA PRIVATE KEY-----\n'
 // }
+```
+
+### `readCert()`
+
+> Reads a cert/key pair from the filesystem, if missing or invalid, generates a new one and write them to the filesystem.
+
+```js
+import { readCert } from '@xen-orchestra/self-signed/readCert'
+
+const { cert, key } = await readCert('path/to/cert.pem', 'path/to/key.pem', {
+  // if false, do not generate a new one in case of error
+  autoCert: false,
+
+  // this function is called in case a new pair is generated
+  info: console.log,
+
+  // mode used when creating files or directories after generating a new pair
+  mode: 0o400,
+
+  // this function is called when there is a non fatal error (fatal errors are thrown)
+  warn: console.warn.
+})
+
+// unfortunately some cert/key issues are detected only when attempting to use them
+//
+// that's why you can pass a `use` function to `readCert` that will received the pair
+// and in case some specific errors are thrown, it will trigger a new generation
+await readCert('path/to/cert.pem', 'path/to/key.pem', {
+  autoCert: true,
+
+  async use({ cert, key }) {
+    const server = https.createServer({ cert, key })
+
+    await new Promise((resolve, reject) => {
+      server.once('error', reject).listen(443, resolve)
+    })
+  }
+})
 ```

--- a/@xen-orchestra/self-signed/.USAGE.md
+++ b/@xen-orchestra/self-signed/.USAGE.md
@@ -41,7 +41,7 @@ const { cert, key } = await readCert('path/to/cert.pem', 'path/to/key.pem', {
   mode: 0o400,
 
   // this function is called when there is a non fatal error (fatal errors are thrown)
-  warn: console.warn.
+  warn: console.warn,
 })
 
 // unfortunately some cert/key issues are detected only when attempting to use them
@@ -57,6 +57,6 @@ await readCert('path/to/cert.pem', 'path/to/key.pem', {
     await new Promise((resolve, reject) => {
       server.once('error', reject).listen(443, resolve)
     })
-  }
+  },
 })
 ```

--- a/@xen-orchestra/self-signed/README.md
+++ b/@xen-orchestra/self-signed/README.md
@@ -16,6 +16,10 @@ npm install --save @xen-orchestra/self-signed
 
 ## Usage
 
+### `genSelfSigned()`
+
+> Generate a self-signed cert/key pair with OpenSSL.
+
 ```js
 import { genSelfSigned } from '@xen-orchestra/self-signed'
 
@@ -35,6 +39,44 @@ console.log(
 //     // content…
 //     '-----END RSA PRIVATE KEY-----\n'
 // }
+```
+
+### `readCert()`
+
+> Reads a cert/key pair from the filesystem, if missing or invalid, generates a new one and write them to the filesystem.
+
+```js
+import { readCert } from '@xen-orchestra/self-signed/readCert'
+
+const { cert, key } = await readCert('path/to/cert.pem', 'path/to/key.pem', {
+  // if false, do not generate a new one in case of error
+  autoCert: false,
+
+  // this function is called in case a new pair is generated
+  info: console.log,
+
+  // mode used when creating files or directories after generating a new pair
+  mode: 0o400,
+
+  // this function is called when there is a non fatal error (fatal errors are thrown)
+  warn: console.warn.
+})
+
+// unfortunately some cer/key issues are detected only when attempting to use them
+//
+// that's why you can pass a `use` function to `readCert` that will received the pair
+// and in case some specific errors are thrown, it will trigger a new generation
+await readCert('path/to/cert.pem', 'path/to/key.pem', {
+  autoCert: true,
+
+  async use({ cert, key }) {
+    const server = https.createServer({ cert, key })
+
+    await new Promise((resolve, reject) => {
+      server.once('error', reject).listen(443, resolve)
+    })
+  }
+})
 ```
 
 ## Contributions

--- a/@xen-orchestra/self-signed/README.md
+++ b/@xen-orchestra/self-signed/README.md
@@ -59,10 +59,10 @@ const { cert, key } = await readCert('path/to/cert.pem', 'path/to/key.pem', {
   mode: 0o400,
 
   // this function is called when there is a non fatal error (fatal errors are thrown)
-  warn: console.warn.
+  warn: console.warn,
 })
 
-// unfortunately some cer/key issues are detected only when attempting to use them
+// unfortunately some cert/key issues are detected only when attempting to use them
 //
 // that's why you can pass a `use` function to `readCert` that will received the pair
 // and in case some specific errors are thrown, it will trigger a new generation
@@ -75,7 +75,7 @@ await readCert('path/to/cert.pem', 'path/to/key.pem', {
     await new Promise((resolve, reject) => {
       server.once('error', reject).listen(443, resolve)
     })
-  }
+  },
 })
 ```
 

--- a/@xen-orchestra/self-signed/package.json
+++ b/@xen-orchestra/self-signed/package.json
@@ -11,7 +11,7 @@
   },
   "version": "0.1.3",
   "engines": {
-    "node": ">=8.10"
+    "node": ">=15.6"
   },
   "scripts": {
     "postversion": "npm publish --access public"
@@ -20,5 +20,9 @@
   "author": {
     "name": "Vates SAS",
     "url": "https://vates.fr"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./readCert": "./readCert.js"
   }
 }

--- a/@xen-orchestra/self-signed/readCert.js
+++ b/@xen-orchestra/self-signed/readCert.js
@@ -1,0 +1,81 @@
+'use strict'
+
+const { dirname } = require('node:path')
+const { mkdir, readFile, writeFile, unlink } = require('node:fs/promises')
+const { X509Certificate } = require('node:crypto')
+
+const { genSelfSignedCert } = require('./index.js')
+
+const identity = value => value
+
+const noop = Function.prototype
+
+async function outputFile(path, content, mode) {
+  for (let attempt = 0; attempt < 5; ++attempt) {
+    try {
+      return await writeFile(path, content, { mode })
+    } catch (error) {
+      const { code } = error
+      if (code === 'ENOENT') {
+        await mkdir(dirname(path), { mode, recursive: true })
+      } else if (code === 'EACCES') {
+        await unlink(path)
+      } else {
+        throw error
+      }
+    }
+  }
+}
+
+exports.readCert = async function readCert(
+  certPath,
+  keyPath,
+  {
+    autoCert = false,
+    use = identity,
+    info = noop,
+    mode = 0o400,
+    warn = noop,
+
+    ...opts
+  }
+) {
+  let useError = false
+
+  try {
+    const cert = await readFile(certPath)
+
+    if (autoCert) {
+      const x509 = new X509Certificate(cert)
+
+      const now = Date.now()
+      if (now < Date.parse(x509.validFrom) || now > Date.parse(x509.validTo)) {
+        const e = new Error('certificate is not valid')
+
+        // same code used when attempting to connect to a server with an expired certificate
+        e.code = 'CERT_HAS_EXPIRED'
+
+        throw e
+      }
+    }
+
+    const key = await readFile(keyPath)
+
+    useError = true
+    return await use({ cert, key })
+  } catch (error) {
+    // only regen if not a use error or if the use error was ERR_SSL_EE_KEY_TOO_SMALL
+    if (!(autoCert && (!useError || error.code === 'ERR_SSL_EE_KEY_TOO_SMALL'))) {
+      throw error
+    }
+    warn(error)
+
+    const { cert, key } = await genSelfSignedCert(opts)
+
+    info('new certificate generated', { cert, key })
+
+    await Promise.all([outputFile(certPath, cert, mode).catch(warn), outputFile(keyPath, key, mode).catch(warn)])
+
+    return use({ cert, key })
+  }
+}

--- a/@xen-orchestra/self-signed/readCert.js
+++ b/@xen-orchestra/self-signed/readCert.js
@@ -40,7 +40,7 @@ exports.readCert = async function readCert(
     ...opts
   }
 ) {
-  let useError = false
+  let readingDone = false
 
   try {
     const cert = await readFile(certPath)
@@ -61,11 +61,11 @@ exports.readCert = async function readCert(
 
     const key = await readFile(keyPath)
 
-    useError = true
+    readingDone = true
     return await use({ cert, key })
   } catch (error) {
-    // only regen if not a use error or if the use error was ERR_SSL_EE_KEY_TOO_SMALL
-    if (!(autoCert && (!useError || error.code === 'ERR_SSL_EE_KEY_TOO_SMALL'))) {
+    // only regen if a reading error or if the use error was ERR_SSL_EE_KEY_TOO_SMALL
+    if (!(autoCert && (!readingDone || error.code === 'ERR_SSL_EE_KEY_TOO_SMALL'))) {
       throw error
     }
     warn(error)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -42,6 +42,7 @@
 <!--packages-start-->
 
 - @xen-orchestra/backups patch
+- @xen-orchestra/self-signed minor
 - @xen-orchestra/xapi minor
 - xen-api patch
 - xo-server minor


### PR DESCRIPTION
### Description

Expired certificates are not automatically detected, which is not a big deal for user certificates because they can still be used and it's their responsibility to update them.

But automatic certificates must be regenerated in that case which was not the case until now.

This commit unifies certificate/key reading, checking and generation for both xo-server and xo-proxy.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
