### PR TITLE
docs(backups): fix restore process

### DIFF
--- a/docs/backups.md
+++ b/docs/backups.md
@@ -192,9 +192,9 @@ Any Debian Linux mount point could be supported this way, until we add further o
 
 All your scheduled backups are acccessible in the "Restore" view in the backup section of Xen Orchestra.
 
-1. Select your remote and click on the eye icon to see the VMs available
+1. Search the VM Name and click on the blue button with a white arrow
 2. Choose the backup you want to restore
-3. Select the SR where you want to restore it
+3. Select the SR where you want to restore it and click "OK"
 
 :::tip
 You can restore your backup even on a brand new host/pool and on brand new hardware.


### PR DESCRIPTION
### Description

This change follows a discussion with Marc Pezin and Yannick on Mattermost. As Yannick pointed out, the [doc](https://xen-orchestra.com/docs/backups.html#restore-a-backup) refers to a remote while there is no such option in XO GUI:

![Capture d’écran du 2024-01-05 14-05-41](https://github.com/vatesfr/xen-orchestra/assets/93598082/9dc90774-87db-46cf-a077-67362b86a6c3)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
