### PR TITLE
fix(xo-web/metadata-restore-modal): add check to hide pool select when restoring xo config backup

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@
 - [Jobs] Reset parameters when editing method to avoid invalid parameters on execution [Forum#69299](https://xcp-ng.org/forum/post/69299)
 - [Metadata Backup] Fix `ENOENT` error when restoring an _XO Config_ backup [Forum#68999](https://xcp-ng.org/forum/post/68999)
 - [REST API] Fix `/backup/log/<id>` which was broken by the `/backups` to `/backup` renaming [Forum#69426](https://xcp-ng.org/forum/post/69426)
+- [Backup/Restore] Fix unnecessary pool selector in XO config backup restore modal [Forum#8130](https://xcp-ng.org/forum/topic/8130/xo-configbackup-restore) (PR [#7287](https://github.com/vatesfr/xen-orchestra/pull/7287))
 
 ### Packages to release
 

--- a/packages/xo-web/src/xo-app/backup/restore/restore-metadata-backups-modal-body.js
+++ b/packages/xo-web/src/xo-app/backup/restore/restore-metadata-backups-modal-body.js
@@ -55,9 +55,11 @@ export default class RestoreMetadataBackupModalBody extends Component {
             />
           </Col>
         </Row>
-        <Row className='mt-1'>
-          <SelectPool onChange={this.linkState('pool')} required value={this.state.pool} />
-        </Row>
+        {this.props.type !== 'XO' && (
+          <Row className='mt-1'>
+            <SelectPool onChange={this.linkState('pool')} required value={this.state.pool} />
+          </Row>
+        )}
         {this.props.type !== 'XO' && <SingleLineRow>{restorationWarning}</SingleLineRow>}
       </Container>
     )

--- a/packages/xo-web/src/xo-app/backup/restore/restore-metadata-backups-modal-body.js
+++ b/packages/xo-web/src/xo-app/backup/restore/restore-metadata-backups-modal-body.js
@@ -55,12 +55,12 @@ export default class RestoreMetadataBackupModalBody extends Component {
             />
           </Col>
         </Row>
-        {this.props.type !== 'XO' && (
-          <Row className='mt-1'>
+        {this.props.type !== 'XO' && [
+          <Row className='mt-1' key='select'>
             <SelectPool onChange={this.linkState('pool')} required value={this.state.pool} />
-          </Row>
-        )}
-        {this.props.type !== 'XO' && <SingleLineRow>{restorationWarning}</SingleLineRow>}
+          </Row>,
+          <SingleLineRow key='message'>{restorationWarning}</SingleLineRow>,
+        ]}
       </Container>
     )
   }


### PR DESCRIPTION
### Description

Don't show pool selector when restoring XO config backup

Fixes forum [#8130](https://xcp-ng.org/forum/topic/8130/xo-configbackup-restore)

### Screenshots

- before
![image](https://github.com/vatesfr/xen-orchestra/assets/66562640/6b7ad2c0-4b08-499f-8b82-3aa5d0e76ea9)

- after
![image](https://github.com/vatesfr/xen-orchestra/assets/66562640/43ae1a72-0690-42e7-a000-2a91008c773e)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
