### PR TITLE
fix(load-balancer): bad comparison to evaluate migration in perf plan

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 - [Settings/Logs] Fix `sr.getAllUnhealthyVdiChainsLength: not enough permissions` error with non-admin users (PR [#7265](https://github.com/vatesfr/xen-orchestra/pull/7265))
 - [Settings/Logs] Fix `proxy.getAll: not enough permissions` error with non-admin users (PR [#7249](https://github.com/vatesfr/xen-orchestra/pull/7249))
 - [Replication/Health Check] Fix `healthCheckVm.add_tag is not a function` error [Forum#69156](https://xcp-ng.org/forum/post/69156)
+- [Plugin/load-balancer] Prevent unwanted migrations to hosts with low free memory (PR [#7288](https://github.com/vatesfr/xen-orchestra/pull/7288))
 
 ### Packages to release
 
@@ -35,6 +36,7 @@
 <!--packages-start-->
 
 - @xen-orchestra/backups patch
+- xo-server-load-balancer patch
 - xo-cli patch
 - xo-server patch
 - xo-web minor

--- a/packages/xo-server-load-balancer/src/performance-plan.js
+++ b/packages/xo-server-load-balancer/src/performance-plan.js
@@ -178,7 +178,7 @@ export default class PerformancePlan extends Plan {
       const state = this._getThresholdState(exceededAverages)
       if (
         destinationAverages.cpu + vmAverages.cpu >= this._thresholds.cpu.low ||
-        destinationAverages.memoryFree - vmAverages.memory <= this._thresholds.cpu.high ||
+        destinationAverages.memoryFree - vmAverages.memory <= this._thresholds.memory.high ||
         (!state.cpu &&
           !state.memory &&
           (exceededAverages.cpu - vmAverages.cpu < destinationAverages.cpu + vmAverages.cpu ||


### PR DESCRIPTION
### Description

Memory is compared to CPU usage to migrate VM in performance plan context.
This condition can cause unwanted migrations.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
