### PR TITLE
feat(xo-web/pool/patches): disable rolling pool update button

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,11 @@
 
 - [Proxies] Fix `this.getObject` is not a function during deployment
 - [Settings/Logs] Fix `sr.getAllUnhealthyVdiChainsLength: not enough permissions` error with non-admin users (PR [#7265](https://github.com/vatesfr/xen-orchestra/pull/7265))
-- [Pool/patches] Resolves [#6415] disable Rolling Pool Update button if some powered up VMs are using a non-shared storage (PR [#7294](https://github.com/vatesfr/xen-orchestra/pull/7294))
+- [Settings/Logs] Fix `proxy.getAll: not enough permissions` error with non-admin users (PR [#7249](https://github.com/vatesfr/xen-orchestra/pull/7249))
+- [Replication/Health Check] Fix `healthCheckVm.add_tag is not a function` error [Forum#69156](https://xcp-ng.org/forum/post/69156)
+- [Plugin/load-balancer] Prevent unwanted migrations to hosts with low free memory (PR [#7288](https://github.com/vatesfr/xen-orchestra/pull/7288))
+- Avoid unnecessary `pool.add_to_other_config: Duplicate key` error in XAPI log [Forum#68761](https://xcp-ng.org/forum/post/68761)
+- [Pool/patches] Disable Rolling Pool Update button if some powered up VMs are using a non-shared storage [#6415](https://github.com/vatesfr/xen-orchestra/issues/6415) (PR [#7294](https://github.com/vatesfr/xen-orchestra/pull/7294))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,8 +11,9 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [Pool/Advanced] Show pool backup/migration network even if they no longer exist (PR [#7303](https://github.com/vatesfr/xen-orchestra/pull/7303))
-- [Import/disk] Couldn't update 'name' field when importing from a URL [#7326](https://github.com/vatesfr/xen-orchestra/issues/7326) (PR [#7332](https://github.com/vatesfr/xen-orchestra/pull/7332))
+- [Proxies] Fix `this.getObject` is not a function during deployment
+- [Settings/Logs] Fix `sr.getAllUnhealthyVdiChainsLength: not enough permissions` error with non-admin users (PR [#7265](https://github.com/vatesfr/xen-orchestra/pull/7265))
+- [Pool/patches] Resolves [#6415] disable Rolling Pool Update button if some powered up VMs are using a non-shared storage (PR [#7294](https://github.com/vatesfr/xen-orchestra/pull/7294))
 
 ### Packages to release
 
@@ -30,6 +31,8 @@
 
 <!--packages-start-->
 
+- xo-cli patch
+- xo-server patch
 - xo-web minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,12 +11,6 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [Proxies] Fix `this.getObject` is not a function during deployment
-- [Settings/Logs] Fix `sr.getAllUnhealthyVdiChainsLength: not enough permissions` error with non-admin users (PR [#7265](https://github.com/vatesfr/xen-orchestra/pull/7265))
-- [Settings/Logs] Fix `proxy.getAll: not enough permissions` error with non-admin users (PR [#7249](https://github.com/vatesfr/xen-orchestra/pull/7249))
-- [Replication/Health Check] Fix `healthCheckVm.add_tag is not a function` error [Forum#69156](https://xcp-ng.org/forum/post/69156)
-- [Plugin/load-balancer] Prevent unwanted migrations to hosts with low free memory (PR [#7288](https://github.com/vatesfr/xen-orchestra/pull/7288))
-- Avoid unnecessary `pool.add_to_other_config: Duplicate key` error in XAPI log [Forum#68761](https://xcp-ng.org/forum/post/68761)
 - [Pool/patches] Disable Rolling Pool Update button if some powered up VMs are using a non-shared storage [#6415](https://github.com/vatesfr/xen-orchestra/issues/6415) (PR [#7294](https://github.com/vatesfr/xen-orchestra/pull/7294))
 
 ### Packages to release

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Pool/Advanced] Show pool backup/migration network even if they no longer exist (PR [#7303](https://github.com/vatesfr/xen-orchestra/pull/7303))
 - [Pool/patches] Disable Rolling Pool Update button if some powered up VMs are using a non-shared storage [#6415](https://github.com/vatesfr/xen-orchestra/issues/6415) (PR [#7294](https://github.com/vatesfr/xen-orchestra/pull/7294))
 
 ### Packages to release

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Pool/Advanced] Show pool backup/migration network even if they no longer exist (PR [#7303](https://github.com/vatesfr/xen-orchestra/pull/7303))
+- [Import/disk] Couldn't update 'name' field when importing from a URL [#7326](https://github.com/vatesfr/xen-orchestra/issues/7326) (PR [#7332](https://github.com/vatesfr/xen-orchestra/pull/7332))
 - [Pool/patches] Disable Rolling Pool Update button if some powered up VMs are using a non-shared storage [#6415](https://github.com/vatesfr/xen-orchestra/issues/6415) (PR [#7294](https://github.com/vatesfr/xen-orchestra/pull/7294))
 
 ### Packages to release
@@ -30,8 +31,6 @@
 
 <!--packages-start-->
 
-- xo-cli patch
-- xo-server patch
 - xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -949,6 +949,7 @@ const messages = {
   nbdConnection: 'NBD Connection',
   insecureNbdConnection: 'Insecure NBD Connection (not allowed through XO)',
   // ----- Pool patches tab -----
+  multiHostPoolUpdate: "Rolling pool update can only work when there's multiple hosts in a pool with a shared storage",
   nVmsRunningOnLocalStorage:
     '{nVms, number} VM{nVms, plural, one {} other {s}} {nVms, plural, one {is} other {are}} currently running and using at least one local storage. A shared storage for all your VMs is needed to start a rolling pool update',
   // ----- Pool stats tab -----

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -949,7 +949,9 @@ const messages = {
   nbdConnection: 'NBD Connection',
   insecureNbdConnection: 'Insecure NBD Connection (not allowed through XO)',
   // ----- Pool patches tab -----
-  multiHostPoolUpdate: "Rolling pool update can only work when there's multiple hosts in a pool with a shared storage",
+  isSingleHost: "Rolling pool update can only work when there's multiple hosts in a pool with a shared storage",
+  nVmsRunningOnLocalStorage:
+    '{nVms, number} VM{nVms, plural, one {} other {s}} {nVms, plural, one {is} other {are}} currently running and using at least one local storage. A shared storage for all your VMs is needed to start a rolling pool update',
   // ----- Pool stats tab -----
   poolNoStats: 'No stats',
   poolAllHosts: 'All hosts',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -949,7 +949,6 @@ const messages = {
   nbdConnection: 'NBD Connection',
   insecureNbdConnection: 'Insecure NBD Connection (not allowed through XO)',
   // ----- Pool patches tab -----
-  isSingleHost: "Rolling pool update can only work when there's multiple hosts in a pool with a shared storage",
   nVmsRunningOnLocalStorage:
     '{nVms, number} VM{nVms, plural, one {} other {s}} {nVms, plural, one {is} other {are}} currently running and using at least one local storage. A shared storage for all your VMs is needed to start a rolling pool update',
   // ----- Pool stats tab -----

--- a/packages/xo-web/src/xo-app/pool/tab-patches.js
+++ b/packages/xo-web/src/xo-app/pool/tab-patches.js
@@ -225,7 +225,7 @@ export default class TabPatches extends Component {
               {ROLLING_POOL_UPDATES_AVAILABLE && (
                 <TabButton
                   btnStyle='primary'
-                  disabled={isEmpty(missingPatches) || this.nVmsRunningOnLocalStorage() > 0}
+                  disabled={isEmpty(missingPatches) || this.nVmsRunningOnLocalStorage() > 0 || isSingleHost}
                   handler={rollingPoolUpdate}
                   handlerParam={pool.id}
                   icon='pool-rolling-update'
@@ -235,7 +235,9 @@ export default class TabPatches extends Component {
                       ? _('nVmsRunningOnLocalStorage', {
                           nVms: this.nVmsRunningOnLocalStorage(),
                         })
-                      : undefined
+                      : isSingleHost
+                        ? _('multiHostPoolUpdate')
+                        : undefined
                   }
                 />
               )}

--- a/packages/xo-web/src/xo-app/pool/tab-patches.js
+++ b/packages/xo-web/src/xo-app/pool/tab-patches.js
@@ -188,7 +188,7 @@ const INSTALLED_PATCH_COLUMNS = [
   srs: createGetObjectsOfType('SR'),
 })
 export default class TabPatches extends Component {
-  nVmsRunningOnLocalStorage = createSelector(
+  getNVmsRunningOnLocalStorage = createSelector(
     () => this.props.runningVms,
     () => this.props.vbds,
     () => this.props.vdis,
@@ -217,7 +217,7 @@ export default class TabPatches extends Component {
 
     const isSingleHost = size(poolHosts) < 2
 
-    const hasMultipleVmsRunningOnLocalStorage = size(this.nVmsRunningOnLocalStorage()) > 1
+    const hasMultipleVmsRunningOnLocalStorage = size(this.getNVmsRunningOnLocalStorage()) > 0
 
     return (
       <Upgrade place='poolPatches' required={2}>
@@ -235,7 +235,7 @@ export default class TabPatches extends Component {
                   tooltip={
                     hasMultipleVmsRunningOnLocalStorage
                       ? _('nVmsRunningOnLocalStorage', {
-                          nVms: this.nVmsRunningOnLocalStorage(),
+                          nVms: this.getNVmsRunningOnLocalStorage(),
                         })
                       : isSingleHost
                         ? _('multiHostPoolUpdate')

--- a/packages/xo-web/src/xo-app/pool/tab-patches.js
+++ b/packages/xo-web/src/xo-app/pool/tab-patches.js
@@ -235,7 +235,7 @@ export default class TabPatches extends Component {
                       ? _('nVmsRunningOnLocalStorage', {
                           nVms: this.nVmsRunningOnLocalStorage(),
                         })
-                      : null
+                      : undefined
                   }
                 />
               )}

--- a/packages/xo-web/src/xo-app/pool/tab-patches.js
+++ b/packages/xo-web/src/xo-app/pool/tab-patches.js
@@ -217,6 +217,8 @@ export default class TabPatches extends Component {
 
     const isSingleHost = size(poolHosts) < 2
 
+    const hasMultipleVmsRunningOnLocalStorage = size(this.nVmsRunningOnLocalStorage()) > 1
+
     return (
       <Upgrade place='poolPatches' required={2}>
         <Container>
@@ -225,13 +227,13 @@ export default class TabPatches extends Component {
               {ROLLING_POOL_UPDATES_AVAILABLE && (
                 <TabButton
                   btnStyle='primary'
-                  disabled={isEmpty(missingPatches) || this.nVmsRunningOnLocalStorage() > 0 || isSingleHost}
+                  disabled={isEmpty(missingPatches) || hasMultipleVmsRunningOnLocalStorage || isSingleHost}
                   handler={rollingPoolUpdate}
                   handlerParam={pool.id}
                   icon='pool-rolling-update'
                   labelId='rollingPoolUpdate'
                   tooltip={
-                    this.nVmsRunningOnLocalStorage() > 0
+                    hasMultipleVmsRunningOnLocalStorage
                       ? _('nVmsRunningOnLocalStorage', {
                           nVms: this.nVmsRunningOnLocalStorage(),
                         })

--- a/packages/xo-web/src/xo-app/pool/tab-patches.js
+++ b/packages/xo-web/src/xo-app/pool/tab-patches.js
@@ -217,7 +217,7 @@ export default class TabPatches extends Component {
 
     const isSingleHost = size(poolHosts) < 2
 
-    const hasMultipleVmsRunningOnLocalStorage = size(this.getNVmsRunningOnLocalStorage()) > 0
+    const hasMultipleVmsRunningOnLocalStorage = this.getNVmsRunningOnLocalStorage() > 0
 
     return (
       <Upgrade place='poolPatches' required={2}>


### PR DESCRIPTION
### Description

Fixes https://github.com/vatesfr/xen-orchestra/issues/6415
Disable 'Rolling Pool Update' button  if some powered up VMs are using a non-shared storage
![Screenshot from 2024-01-09 15-59-41](https://github.com/vatesfr/xen-orchestra/assets/119158464/e8abc77b-2e4b-4b6b-8e51-cd01e6f8477c)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
