### PR TITLE
feat(plugins): auto register all plugins in source use

### DIFF
--- a/packages/xo-server/src/index.mjs
+++ b/packages/xo-server/src/index.mjs
@@ -402,7 +402,11 @@ async function registerPluginsInPath(path, prefix) {
 
 async function registerPlugins(xo) {
   await Promise.all(
-    [new URL('../node_modules', import.meta.url).pathname, '/usr/local/lib/node_modules'].map(path =>
+    [
+      new URL('../...', import.meta.url).pathname,
+      new URL('../node_modules', import.meta.url).pathname,
+      '/usr/local/lib/node_modules',
+    ].map(path =>
       Promise.all([
         registerPluginsInPath.call(xo, path, 'xo-server-'),
         registerPluginsInPath.call(xo, `${path}/@xen-orchestra`, 'server-'),


### PR DESCRIPTION
### Description

when launching for source  the plugins are not registered automatically, the dev will have to regisetr then manually


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
