### PR TITLE
feat(xo-server): add xenStoreData to XO VM objects

### DIFF
--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -319,6 +319,7 @@ const TRANSFORMS = {
     // { taskRef → operation } map directly
     const currentOperations = {}
     const { $xapi } = obj
+    const { xenstore_data } = obj
     forEach(obj.current_operations, (operation, ref) => {
       const task = $xapi.getObjectByRef(ref, undefined)
       if (task !== undefined) {
@@ -429,6 +430,7 @@ const TRANSFORMS = {
       VGPUs: link(obj, 'VGPUs'),
       $VGPUs: link(obj, 'VGPUs'),
       nicType: obj.platform.nic_type,
+      xenStoreData: xenstore_data,
     }
 
     if (isHvm) {

--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -319,7 +319,6 @@ const TRANSFORMS = {
     // { taskRef → operation } map directly
     const currentOperations = {}
     const { $xapi } = obj
-    const { xenstore_data } = obj
     forEach(obj.current_operations, (operation, ref) => {
       const task = $xapi.getObjectByRef(ref, undefined)
       if (task !== undefined) {
@@ -430,7 +429,7 @@ const TRANSFORMS = {
       VGPUs: link(obj, 'VGPUs'),
       $VGPUs: link(obj, 'VGPUs'),
       nicType: obj.platform.nic_type,
-      xenStoreData: xenstore_data,
+      xenStoreData: obj.xenstore_data,
     }
 
     if (isHvm) {


### PR DESCRIPTION
### Description

The initial support added in #7055 to support terraform resource support doesn't provide read access to a VM's state. Since terraform's model requires read and write access to the resource it's managing, this PR implements the missing piece for https://github.com/terra-farm/terraform-provider-xenorchestra/issues/261. 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - [x] Update "Packages to release" in `CHANGELOG.unreleased.md` -- **xo-server already listed in CHANGELOG.unreleased.md**
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Testing done

Updated my personal XOA with the change and saw the correct response from `xo-cli xo.getAllObjects` for a VM object.

```
$ xo-cli xo.getAllObjects filter='json:{"id": "067e8eee-6950-411c-ac67-65c3397c76b2"}'

[ .. ]
    virtualizationMode: 'hvm',
    xenStoreData: {
      'vm-data': '',
      'vm-data/mmio-hole-size': '268435456',
      'vm-data/test': 'value'
    },

```