### PR TITLE
Update index.html

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## **next**
 
+- Fix link to manifest in the html file location (PR [#7319](https://github.com/vatesfr/xen-orchestra/pull/7319))
 - Fix Typescript typings errors when running `yarn type-check` command (PR [#7278](https://github.com/vatesfr/xen-orchestra/pull/7278))
 - Introduce PWA Json Manifest (PR [#7291](https://github.com/vatesfr/xen-orchestra/pull/7291))
 

--- a/@xen-orchestra/lite/index.html
+++ b/@xen-orchestra/lite/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
-    <link rel="manifest" href="/manifest.webmanifest">
+    <link rel="manifest" href="public/manifest.webmanifest">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>XO Lite</title>
   </head>


### PR DESCRIPTION
Fixes a typo in regards to the path to the manifest in the head reference.

### Description

When the html file was merged I later noticed that there was a typo in the path to where the pwa manifest file was saved following the relocation to the public folder.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
