### PR TITLE
fix(xo-server/PIF): IPv4 reconfiguration only worked when mode was updated

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,6 +36,7 @@
 - [Modal] Fix opened modal not closing when navigating to another route/URL (PR [#7301](https://github.com/vatesfr/xen-orchestra/pull/7301))
 - [Backup/Restore] Don't count memory as a key (i.e. complete) disk [Forum#8212](https://xcp-ng.org/forum/post/69591) (PR [#7315](https://github.com/vatesfr/xen-orchestra/pull/7315))
 - [Pool/patches] Disable Rolling Pool Update button if host is alone in its pool [#6415](https://github.com/vatesfr/xen-orchestra/issues/6415) (PR [#7286](https://github.com/vatesfr/xen-orchestra/pull/7286))
+- [PIF] Fix PIF reconfiguration is only triggered if IPv6 has been updated (PR [#7324](https://github.com/vatesfr/xen-orchestra/pull/7324))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,7 +36,7 @@
 - [Modal] Fix opened modal not closing when navigating to another route/URL (PR [#7301](https://github.com/vatesfr/xen-orchestra/pull/7301))
 - [Backup/Restore] Don't count memory as a key (i.e. complete) disk [Forum#8212](https://xcp-ng.org/forum/post/69591) (PR [#7315](https://github.com/vatesfr/xen-orchestra/pull/7315))
 - [Pool/patches] Disable Rolling Pool Update button if host is alone in its pool [#6415](https://github.com/vatesfr/xen-orchestra/issues/6415) (PR [#7286](https://github.com/vatesfr/xen-orchestra/pull/7286))
-- [PIF] Fix PIF reconfiguration is only triggered if IPv6 has been updated (PR [#7324](https://github.com/vatesfr/xen-orchestra/pull/7324))
+- [PIF] Fix IPv4 reconfiguration only worked when the IPv4 mode was updated (PR [#7324](https://github.com/vatesfr/xen-orchestra/pull/7324))
 
 ### Packages to release
 

--- a/packages/xo-server/src/api/pif.mjs
+++ b/packages/xo-server/src/api/pif.mjs
@@ -90,7 +90,13 @@ export async function reconfigureIp({ pif, mode, ip = '', netmask = '', gateway 
       )
     }
 
-    if (mode !== undefined && mode !== pif.mode) {
+    if (
+      (mode !== undefined && mode !== pif.mode) ||
+      ip !== pif.ip ||
+      netmask !== pif.netmask ||
+      gateway !== pif.gateway ||
+      dns !== pif.dns
+    ) {
       await Task.run(
         { properties: { name: 'reconfigure IPv4', mode, ip, netmask, gateway, dns, objectId: pif.uuid } },
         () => xapi.call('PIF.reconfigure_ip', pif._xapiRef, mode, ip, netmask, gateway, dns)


### PR DESCRIPTION
### Description

`PIF.reconfigure_ip` was only called if `mode !== pif.mode` 

Introduced by [4c8e4](https://github.com/vatesfr/xen-orchestra/pull/7218/commits/4c8e402c11ec60cad34e020dc56a03a62af87630)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
