### PR TITLE
feat(xo-server-load-balancer): balance vCPUs option

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,7 @@
 - [OTP] Accepts (ignores) whitespaces in the one-time password (some OTP applications add them for nicer display)
 - [VM/General] Show current VM tags without the need to search them in advanced creation tag selector [#7351](https://github.com/vatesfr/xen-orchestra/issues/7351) (PR [#7434](https://github.com/vatesfr/xen-orchestra/pull/7434))
 - [xo-cli] Supports signing in with one-time password (PR [#7459](https://github.com/vatesfr/xen-orchestra/pull/7459))
+- [Plugin/load-balancer] A parameter was added in performance mode to balance VMs on hosts depending on their number of vCPU, when it does not cause performance issues. [#5389](https://github.com/vatesfr/xen-orchestra/issues/5389) (PR [#7333](https://github.com/vatesfr/xen-orchestra/pull/7333))
 
 ### Bug fixes
 
@@ -47,6 +48,7 @@
 - xen-api major
 - xo-cli minor
 - xo-server minor
+- xo-server-load-balancer minor
 - xo-web minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 - [OTP] Accepts (ignores) whitespaces in the one-time password (some OTP applications add them for nicer display)
 - [VM/General] Show current VM tags without the need to search them in advanced creation tag selector [#7351](https://github.com/vatesfr/xen-orchestra/issues/7351) (PR [#7434](https://github.com/vatesfr/xen-orchestra/pull/7434))
 - [xo-cli] Supports signing in with one-time password (PR [#7459](https://github.com/vatesfr/xen-orchestra/pull/7459))
-- [Plugin/load-balancer] A parameter was added in performance mode to balance VMs on hosts depending on their number of vCPU, when it does not cause performance issues. [#5389](https://github.com/vatesfr/xen-orchestra/issues/5389) (PR [#7333](https://github.com/vatesfr/xen-orchestra/pull/7333))
+- [Plugin/load-balancer] A parameter was added in performance mode to balance VMs on hosts depending on their number of vCPUs, when it does not cause performance issues [#5389](https://github.com/vatesfr/xen-orchestra/issues/5389) (PR [#7333](https://github.com/vatesfr/xen-orchestra/pull/7333))
 
 ### Bug fixes
 

--- a/packages/xo-server-load-balancer/package.json
+++ b/packages/xo-server-load-balancer/package.json
@@ -24,7 +24,7 @@
   "preferGlobal": false,
   "main": "dist/",
   "engines": {
-    "node": ">=7"
+    "node": ">=12.9"
   },
   "dependencies": {
     "@xen-orchestra/cron": "^1.0.6",

--- a/packages/xo-server-load-balancer/src/index.js
+++ b/packages/xo-server-load-balancer/src/index.js
@@ -90,6 +90,12 @@ export const configurationSchema = {
               $type: 'Tag',
             },
           },
+
+          balanceVcpu: {
+            type: 'boolean',
+            title: 'Balance VCPUs',
+            description: 'pre-position VMs on hosts to balance VCPU/CPU ratio (performance plan only)',
+          },
         },
 
         required: ['name', 'mode', 'pools'],

--- a/packages/xo-server-load-balancer/src/index.js
+++ b/packages/xo-server-load-balancer/src/index.js
@@ -91,14 +91,19 @@ export const configurationSchema = {
             },
           },
 
-          balanceVcpu: {
+          balanceVcpus: {
             type: 'boolean',
-            title: 'Balance VCPUs',
-            description: 'pre-position VMs on hosts to balance VCPU/CPU ratio (performance plan only)',
+            title: 'Balance vCPUs',
+            description: 'pre-position VMs on hosts to balance vCPU/CPU ratio (performance plan only)',
           },
         },
 
         required: ['name', 'mode', 'pools'],
+        // when UI will allow it, remove this anyOf and hide balanceVcpu option outside performance mode
+        anyOf: [
+          { properties: { mode: { const: 'Performance mode' } } },
+          { properties: { balanceVcpus: { const: false } } },
+        ],
       },
 
       minItems: 1,

--- a/packages/xo-server-load-balancer/src/performance-plan.js
+++ b/packages/xo-server-load-balancer/src/performance-plan.js
@@ -64,7 +64,7 @@ export default class PerformancePlan extends Plan {
       }
     }
 
-    if (this._balanceVcpu) {
+    if (this._balanceVcpus) {
       await this._processVcpuPrepositionning()
     }
   }

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -322,10 +322,10 @@ export default class Plan {
     debugVcpuBalancing(`Average vCPUs per CPU: ${idealVcpuPerCpuRatio}`)
 
     // execute prepositionning only if vCPU/CPU ratios are different enough, to prevent executing too often
-    // TODO : maybe we should apply a more complex function than just a ratio, to have more coherent values on both small and big architectures
+    // TODO: maybe we should apply a more complex function than just a ratio, to have more coherent values on both small and big architectures
     const ratio = vcpuPerCpuRatio(minBy(hostList, vcpuPerCpuRatio)) / vcpuPerCpuRatio(maxBy(hostList, vcpuPerCpuRatio))
     if (ratio > THRESHOLD_VCPU_RATIO) {
-      debugVcpuBalancing(`vCPU ratios not different enough : ${ratio}`)
+      debugVcpuBalancing(`vCPU ratios not different enough: ${ratio}`)
       return
     }
 
@@ -333,14 +333,14 @@ export default class Plan {
     const { averages: hostsAverages } = await this._getHostStatsAverages({ hosts: allHosts })
     const poolAverageCpu = computePoolAverageCpu(hostsAverages)
     if (poolAverageCpu > THRESHOLD_POOL_CPU) {
-      debugVcpuBalancing(`Pool too much loaded for vCPU prepositionning : ${poolAverageCpu}% CPU used`)
+      debugVcpuBalancing(`Pool too much loaded for vCPU prepositionning: ${poolAverageCpu}% CPU used`)
       return
     }
     const vmsAverages = await this._getVmsAverages(allVms, idToHost)
 
     // 1. Find source host from which to migrate.
     const sources = sortBy(
-      // filter to only get host for which removing vCPUs is meaningful
+      // filter to only get hosts for which removing vCPUs is meaningful
       filter(
         hostList,
         host =>
@@ -349,8 +349,8 @@ export default class Plan {
       ),
       [
         host => -vcpuPerCpuRatio(host),
-        // Find host with the most memory used
-        // TODO : if memory is nearly the same between two hosts, ignore this criteria and decide based on CPU usage (do the same in other sortBy)
+        // Find hosts with the most memory used
+        // TODO: if memory is nearly the same between two hosts, ignore this criteria and decide based on CPU usage (do the same in other sortBy)
         host => hostsAverages[host.id].memoryFree,
       ]
     )
@@ -375,7 +375,7 @@ export default class Plan {
           host => -hostsAverages[host.id].memoryFree,
         ]
       )
-      debugVcpuBalancing(`Destinations : ${inspect(destinations, { depth: null })}`)
+      debugVcpuBalancing(`Destinations: ${inspect(destinations, { depth: null })}`)
 
       if (!destinations.length) {
         continue // Cannot find a valid destination.
@@ -400,9 +400,9 @@ export default class Plan {
         }
 
         // deltaSource = max amount of vCPUs source should give, deltaDestination = max amount of vCPUs destination should accept, delta = max amount of vCPUs to migrate to satisfy both
-        // avoiding to migrate too much vCPUs for source or destination : deltaSource is positive, deltaDestination is negative, we check which one has greater absolute value
+        // avoiding to migrate too much vCPUs for source or destination: deltaSource is positive, deltaDestination is negative, we check which one has greater absolute value
         // using ceil instead of floor prevents edge cases where a host would become a bit overloaded, but can lead to some host being a bit underloaded
-        // ex : if we have a host with 19 vCPU and 9 host with 10 vCPU, each with the same number of CPU, then ideal vCPU per host is 10.9, rounding to 10 would make host with 19 vCPU have no destination to send VMs to
+        // ex: if we have a host with 19 vCPU and 9 host with 10 vCPU, each with the same number of CPU, then ideal vCPU per host is 10.9, rounding to 10 would make host with 19 vCPU have no destination to send VMs to
         // reversely, we could have a host with 5 vCPU and 9 host with 10 vCPU, and then the 5 vCPU host would have no source to receive VMs from
         let delta = Math.ceil(Math.min(deltaSource, -deltaDestination))
         const vms = sortBy(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4613,6 +4613,16 @@
     "@vue/babel-plugin-transform-vue-jsx" "^1.4.0"
     camelcase "^5.0.0"
 
+"@vue/compiler-core@3.3.11":
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.3.11.tgz#9fa26f8c81b9b34365f94ce1ed4d0e6e6f94a2ac"
+  integrity sha512-h97/TGWBilnLuRaj58sxNrsUU66fwdRKLOLQ9N/5iNDfp+DZhYH9Obhe0bXxhedl8fjAgpRANpiZfbgWyruQ0w==
+  dependencies:
+    "@babel/parser" "^7.23.5"
+    "@vue/shared" "3.3.11"
+    estree-walker "^2.0.2"
+    source-map-js "^1.0.2"
+
 "@vue/compiler-core@3.4.21":
   version "3.4.21"
   resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.4.21.tgz#868b7085378fc24e58c9aed14c8d62110a62be1a"
@@ -4624,13 +4634,21 @@
     estree-walker "^2.0.2"
     source-map-js "^1.0.2"
 
-"@vue/compiler-dom@3.4.21", "@vue/compiler-dom@^3.3.0":
+"@vue/compiler-dom@3.4.21":
   version "3.4.21"
   resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.4.21.tgz#0077c355e2008207283a5a87d510330d22546803"
   integrity sha512-IZC6FKowtT1sl0CR5DpXSiEB5ayw75oT2bma1BEhV7RRR1+cfwLrxc2Z8Zq/RGFzJ8w5r9QtCOvTjQgdn0IKmA==
   dependencies:
     "@vue/compiler-core" "3.4.21"
     "@vue/shared" "3.4.21"
+
+"@vue/compiler-dom@^3.3.0":
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.3.11.tgz#36a76ea3a296d41bad133a6912cb0a847d969e4f"
+  integrity sha512-zoAiUIqSKqAJ81WhfPXYmFGwDRuO+loqLxvXmfUdR5fOitPoUiIeFI9cTTyv9MU5O1+ZZglJVTusWzy+wfk5hw==
+  dependencies:
+    "@vue/compiler-core" "3.3.11"
+    "@vue/shared" "3.3.11"
 
 "@vue/compiler-sfc@2.7.16":
   version "2.7.16"
@@ -4750,6 +4768,16 @@
   dependencies:
     "@vue/compiler-ssr" "3.4.21"
     "@vue/shared" "3.4.21"
+
+"@vue/shared@3.3.11":
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.3.11.tgz#f6a038e15237edefcc90dbfe7edb806dd355c7bd"
+  integrity sha512-u2G8ZQ9IhMWTMXaWqZycnK4UthG1fA238CD+DP4Dm4WJi5hdUKKLg0RMRaRpDPNMdkTwIDkp7WtD0Rd9BH9fLw==
+
+"@vue/shared@3.4.14":
+  version "3.4.14"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.4.14.tgz#bc2d199a42a87f0349492fdfb83abc205ddd4d60"
+  integrity sha512-nmi3BtLpvqXAWoRZ6HQ+pFJOHBU4UnH3vD3opgmwXac7vhaHKA9nj1VeGjMggdB9eLtW83eHyPCmOU1qzdsC7Q==
 
 "@vue/shared@3.4.21", "@vue/shared@^3.3.0":
   version "3.4.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4774,11 +4774,6 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.3.11.tgz#f6a038e15237edefcc90dbfe7edb806dd355c7bd"
   integrity sha512-u2G8ZQ9IhMWTMXaWqZycnK4UthG1fA238CD+DP4Dm4WJi5hdUKKLg0RMRaRpDPNMdkTwIDkp7WtD0Rd9BH9fLw==
 
-"@vue/shared@3.4.14":
-  version "3.4.14"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.4.14.tgz#bc2d199a42a87f0349492fdfb83abc205ddd4d60"
-  integrity sha512-nmi3BtLpvqXAWoRZ6HQ+pFJOHBU4UnH3vD3opgmwXac7vhaHKA9nj1VeGjMggdB9eLtW83eHyPCmOU1qzdsC7Q==
-
 "@vue/shared@3.4.21", "@vue/shared@^3.3.0":
   version "3.4.21"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.4.21.tgz#de526a9059d0a599f0b429af7037cd0c3ed7d5a1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4613,16 +4613,6 @@
     "@vue/babel-plugin-transform-vue-jsx" "^1.4.0"
     camelcase "^5.0.0"
 
-"@vue/compiler-core@3.3.11":
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.3.11.tgz#9fa26f8c81b9b34365f94ce1ed4d0e6e6f94a2ac"
-  integrity sha512-h97/TGWBilnLuRaj58sxNrsUU66fwdRKLOLQ9N/5iNDfp+DZhYH9Obhe0bXxhedl8fjAgpRANpiZfbgWyruQ0w==
-  dependencies:
-    "@babel/parser" "^7.23.5"
-    "@vue/shared" "3.3.11"
-    estree-walker "^2.0.2"
-    source-map-js "^1.0.2"
-
 "@vue/compiler-core@3.4.21":
   version "3.4.21"
   resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.4.21.tgz#868b7085378fc24e58c9aed14c8d62110a62be1a"
@@ -4634,21 +4624,13 @@
     estree-walker "^2.0.2"
     source-map-js "^1.0.2"
 
-"@vue/compiler-dom@3.4.21":
+"@vue/compiler-dom@3.4.21", "@vue/compiler-dom@^3.3.0":
   version "3.4.21"
   resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.4.21.tgz#0077c355e2008207283a5a87d510330d22546803"
   integrity sha512-IZC6FKowtT1sl0CR5DpXSiEB5ayw75oT2bma1BEhV7RRR1+cfwLrxc2Z8Zq/RGFzJ8w5r9QtCOvTjQgdn0IKmA==
   dependencies:
     "@vue/compiler-core" "3.4.21"
     "@vue/shared" "3.4.21"
-
-"@vue/compiler-dom@^3.3.0":
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.3.11.tgz#36a76ea3a296d41bad133a6912cb0a847d969e4f"
-  integrity sha512-zoAiUIqSKqAJ81WhfPXYmFGwDRuO+loqLxvXmfUdR5fOitPoUiIeFI9cTTyv9MU5O1+ZZglJVTusWzy+wfk5hw==
-  dependencies:
-    "@vue/compiler-core" "3.3.11"
-    "@vue/shared" "3.3.11"
 
 "@vue/compiler-sfc@2.7.16":
   version "2.7.16"
@@ -4768,11 +4750,6 @@
   dependencies:
     "@vue/compiler-ssr" "3.4.21"
     "@vue/shared" "3.4.21"
-
-"@vue/shared@3.3.11":
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.3.11.tgz#f6a038e15237edefcc90dbfe7edb806dd355c7bd"
-  integrity sha512-u2G8ZQ9IhMWTMXaWqZycnK4UthG1fA238CD+DP4Dm4WJi5hdUKKLg0RMRaRpDPNMdkTwIDkp7WtD0Rd9BH9fLw==
 
 "@vue/shared@3.4.21", "@vue/shared@^3.3.0":
   version "3.4.21"


### PR DESCRIPTION
### Description

Adding an option for performance mode to balance VMs on hosts depending on their number of vCPUs and the number of CPUs of the host. See #5389 

![image](https://github.com/vatesfr/xen-orchestra/assets/150058367/ca7f69c8-1496-4efa-9377-ab9d92c661c9)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
