### PR TITLE
feat(xo-web/tags): add tooltips on xo:no-bak and xo:notify-on-snapshot tags

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@
 - [Backup/Restore] Show whether the memory was backed up (PR [#7315](https://github.com/vatesfr/xen-orchestra/pull/7315))
 - [Plugin/load-balancer] Limit concurrent VM migrations to 2 (configurable) to avoid long paused VMs [#7084](https://github.com/vatesfr/xen-orchestra/issues/7084) (PR [#7297](https://github.com/vatesfr/xen-orchestra/pull/7297))
 - [Tags] Admin can create colored tags (PR [#7262](https://github.com/vatesfr/xen-orchestra/pull/7262))
+- [Tags] Add tooltips on `xo:no-bak` and `xo:notify-on-snapshot` tags (PR [#7335](https://github.com/vatesfr/xen-orchestra/pull/7335))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1853,6 +1853,8 @@ const messages = {
   remoteLoadBackupsFailure: 'Loading backups failed',
   remoteLoadBackupsFailureMessage: 'Failed to load backups from {name}.',
   vmsTags: 'VMs tags',
+  tagNoBak: 'VMs with this tag will not be backed up {reason, select, null {} other {({reason})}}',
+  tagNotifyOnSnapshot: 'An email will be sent when a VM with this tag is snapshotted',
 
   // ----- Restore files view -----
   restoreFiles: 'Restore backup files',

--- a/packages/xo-web/src/common/tags.js
+++ b/packages/xo-web/src/common/tags.js
@@ -17,7 +17,7 @@ import Button from './button'
 import Component from './base-component'
 import getEventValue from './get-event-value'
 import Icon from './icon'
-import Tooltip, { conditionalTooltip } from './tooltip'
+import Tooltip from './tooltip'
 import { confirm } from './modal'
 import { SelectTag } from './select-objects'
 
@@ -281,9 +281,8 @@ export class Tag extends Component {
     const reason = isScoped ? label.slice(i + 1) : null
 
     const messageId = TAG_TO_MESSAGE_ID[scope]
-    const tooltip = messageId && _(messageId, { reason })
 
-    return conditionalTooltip(
+    return (
       <div
         style={{
           background: color,
@@ -297,6 +296,19 @@ export class Tag extends Component {
           overflow: 'clip',
         }}
       >
+        {messageId && (
+          <div
+            style={{
+              cursor: 'help',
+              display: 'inline-block',
+              padding,
+            }}
+          >
+            <Tooltip content={_(messageId, { reason })}>
+              <Icon icon='info' />
+            </Tooltip>
+          </div>
+        )}
         <div
           onClick={onClick && (() => onClick(label))}
           style={{
@@ -341,8 +353,7 @@ export class Tag extends Component {
             <Icon icon='remove-tag' />
           </div>
         )}
-      </div>,
-      tooltip
+      </div>
     )
   }
 }

--- a/packages/xo-web/src/common/tags.js
+++ b/packages/xo-web/src/common/tags.js
@@ -17,7 +17,7 @@ import Button from './button'
 import Component from './base-component'
 import getEventValue from './get-event-value'
 import Icon from './icon'
-import Tooltip from './tooltip'
+import Tooltip, { conditionalTooltip } from './tooltip'
 import { confirm } from './modal'
 import { SelectTag } from './select-objects'
 
@@ -251,6 +251,11 @@ export default class Tags extends Component {
   }
 }
 
+const TAG_TO_MESSAGE_ID = {
+  'xo:no-bak': 'tagNoBak',
+  'xo:notify-on-snapshot': 'tagNotifyOnSnapshot',
+}
+
 @addSubscriptions({
   configuredTags: cb => subscribeConfiguredTags(tags => cb(keyBy(tags, 'id'))),
 })
@@ -272,7 +277,13 @@ export class Tag extends Component {
     const i = label.indexOf('=')
     const isScoped = i !== -1
 
-    return (
+    const scope = isScoped ? label.slice(0, i) : label
+    const reason = isScoped ? label.slice(i + 1) : null
+
+    const messageId = TAG_TO_MESSAGE_ID[scope]
+    const tooltip = messageId && _(messageId, { reason })
+
+    return conditionalTooltip(
       <div
         style={{
           background: color,
@@ -299,7 +310,7 @@ export class Tag extends Component {
               padding,
             }}
           >
-            {isScoped ? label.slice(0, i) : label}
+            {scope}
           </div>
           {isScoped && (
             <div
@@ -310,7 +321,7 @@ export class Tag extends Component {
                 padding,
               }}
             >
-              {label.slice(i + 1) || <i>N/A</i>}
+              {reason || <i>N/A</i>}
             </div>
           )}
         </div>
@@ -330,7 +341,8 @@ export class Tag extends Component {
             <Icon icon='remove-tag' />
           </div>
         )}
-      </div>
+      </div>,
+      tooltip
     )
   }
 }


### PR DESCRIPTION
### Screenshots

![image](https://github.com/vatesfr/xen-orchestra/assets/298721/775037f1-0031-44d1-8087-bf0c23e28812)
![Capture_2024-01-25_10:28:43](https://github.com/vatesfr/xen-orchestra/assets/10992860/6d117c36-8907-4fa0-b8f0-4b6dab4b1641)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
