### PR TITLE
feat(backup): hash vhd,  full vhd before writing itdedup

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
@@ -33,7 +33,8 @@ export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends Abstr
       settings.unconditionalSnapshot ||
       (!settings.offlineBackup && vm.power_state === 'Running') ||
       settings.snapshotRetention !== 0 ||
-      settings.fullInterval !== 1
+      settings.fullInterval !== 1 ||
+      settings.deltaComputationMode === 'AGAINST_PARENT_VHD'
     )
   }
 

--- a/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
@@ -26,7 +26,15 @@ export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends Abstr
   }
 
   _mustDoSnapshot() {
-    return true
+    const vm = this._vm
+
+    const settings = this._settings
+    return (
+      settings.unconditionalSnapshot ||
+      (!settings.offlineBackup && vm.power_state === 'Running') ||
+      settings.snapshotRetention !== 0 ||
+      settings.fullInterval !== 1
+    )
   }
 
   async _copy() {

--- a/packages/vhd-lib/Vhd/VhdAbstract.js
+++ b/packages/vhd-lib/Vhd/VhdAbstract.js
@@ -84,6 +84,9 @@ exports.VhdAbstract = class VhdAbstract {
   readBlockAllocationTable() {
     throw new Error(`reading block allocation table is not implemented`)
   }
+  readBlockHashes() {
+    throw new Error(`reading block hashes table is not implemented`)
+  }
 
   /**
    * @typedef {Object} BitmapBlock
@@ -102,6 +105,10 @@ exports.VhdAbstract = class VhdAbstract {
    */
   readBlock(blockId, onlyBitmap = false) {
     throw new Error(`reading  ${onlyBitmap ? 'bitmap of block' : 'block'} ${blockId} is not implemented`)
+  }
+
+  getBlockHash(blockId){
+    throw new Error(`reading block hash ${blockId} is not implemented`)
   }
 
   /**

--- a/packages/vhd-lib/Vhd/VhdSynthetic.js
+++ b/packages/vhd-lib/Vhd/VhdSynthetic.js
@@ -96,6 +96,10 @@ const VhdSynthetic = class VhdSynthetic extends VhdAbstract {
     assert(false, `no such block ${blockId}`)
   }
 
+  async getBlockHash(blockId){
+    return this.#getVhdWithBlock(blockId).getBlockHash(blockId)
+  }
+
   async readBlock(blockId, onlyBitmap = false) {
     // only read the content of the first vhd containing this block
     return await this.#getVhdWithBlock(blockId).readBlock(blockId, onlyBitmap)

--- a/packages/vhd-lib/hashBlock.js
+++ b/packages/vhd-lib/hashBlock.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const { createHash } = require('node:crypto')
+
+// using xxhash as for xva would make smaller hash and the collision risk would be low for the dedup,
+// since we have a tuple(index, hash), but it would be notable if
+// we implement dedup on top of this later
+// at most, a 2TB full vhd will use 32MB for its hashes
+// and this file is compressed with vhd block
+exports.hashBlock = function (buffer) {
+  return createHash('sha256').update(buffer).digest('hex')
+}


### PR DESCRIPTION
### Description

Snapshot are expensive on thick certain storage, coalesce is expensive everytime, this PR intends to use hashes of precedent backup as a comparison base, instead of keeping snapshots. Even with snapshot, the snapshot can be deleted as soon as the backup is done, limiting the size to coalesce.

1. store hash of blocks and check if the content is modified on read/restore
2. uses this hashes to detect if a block have been modified from parent (does not need snapshot)
3. create delta from full vhd and hashes, containing only the modified blocks

Downside : it will read the full disk from the SR to XO
Also the VM will need to be stopped/suspended to skip the snapshot 

it paves the way for : 
* differential backup ( never need to do merge again in the backup repo, but more space consumption)
* dedup

### UI
add the option in the delta compute mode added for CBT 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
