### PR TITLE
chore(web): use relative asset URLs

### DIFF
--- a/@xen-orchestra/web/index.html
+++ b/@xen-orchestra/web/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Xen Orchestra</title>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="/src/main.ts"></script>
+    <script type="module" src="./src/main.ts"></script>
   </body>
 </html>

--- a/@xen-orchestra/web/src/main.ts
+++ b/@xen-orchestra/web/src/main.ts
@@ -2,13 +2,13 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
 // eslint-disable-next-line import/no-unresolved -- https://github.com/posva/unplugin-vue-router/issues/232
-import { createRouter, createWebHistory } from 'vue-router/auto'
+import { createRouter, createWebHashHistory } from 'vue-router/auto'
 import '@xen-orchestra/web-core/assets/css/base.pcss'
 
 const app = createApp(App)
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHashHistory(),
 })
 
 app.use(createPinia())

--- a/@xen-orchestra/web/vite.config.ts
+++ b/@xen-orchestra/web/vite.config.ts
@@ -6,6 +6,7 @@ import vueRouter from 'unplugin-vue-router/vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [vueRouter(), vue()],
   resolve: {
     alias: {


### PR DESCRIPTION
### Description

Since @xen-orchestra/web can be served on different route than /, this change
ensures that assets get fetched with relative URLs

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
