### PR TITLE
fix(xo-server): import of @xen-orchestra/xva package

### DIFF
--- a/@xen-orchestra/xva/package.json
+++ b/@xen-orchestra/xva/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "@xen-orchestra/xva-generator",
-  "version": "1.0.0",
+  "name": "@xen-orchestra/xva",
+  "version": "0.0.1",
   "main": "index.js",
   "author": "",
   "license": "ISC",
   "private": false,
-  "homepage": "https://github.com/vatesfr/xen-orchestra/tree/master/@xen-orchestra/xva-generator",
+  "homepage": "https://github.com/vatesfr/xen-orchestra/tree/master/@xen-orchestra/xva",
   "bugs": "https://github.com/vatesfr/xen-orchestra/issues",
   "repository": {
-    "directory": "@xen-orchestra/xva-generator",
+    "directory": "@xen-orchestra/xva",
     "type": "git",
     "url": "https://github.com/vatesfr/xen-orchestra.git"
   },

--- a/packages/xo-server/package.json
+++ b/packages/xo-server/package.json
@@ -53,6 +53,7 @@
     "@xen-orchestra/template": "^0.1.0",
     "@xen-orchestra/vmware-explorer": "^0.3.1",
     "@xen-orchestra/xapi": "^4.2.0",
+    "@xen-orchestra/xva": "0.0.1",
     "ajv": "^8.0.3",
     "app-conf": "^2.3.0",
     "async-iterator-to-stream": "^1.0.1",


### PR DESCRIPTION
### Description

fix https://github.com/vatesfr/xen-orchestra/issues/7344
introduced by 2d047c4fef356104ccbf51bffecc293c36b33beb

cause : we did not run the normalize-package command after renaming

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
