### PR TITLE
fix(xo-server-load-balancer): simple plan creation

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@
 - [Import/VMWare] Fix `(Failure \"Expected string, got 'I(0)'\")` (PR [#7361](https://github.com/vatesfr/xen-orchestra/issues/7361))
 - [Plugin/load-balancer] Fixing `TypeError: Cannot read properties of undefined (reading 'high')` happening when trying to optimize a host with performance plan [#7359](https://github.com/vatesfr/xen-orchestra/issues/7359) (PR [#7362](https://github.com/vatesfr/xen-orchestra/pull/7362))
 - Changing the number of displayed items per page should send back to the first page [#7350](https://github.com/vatesfr/xen-orchestra/issues/7350)
+- [Plugin/Load balancer] Preventing the creation of a density plan when simple plan is selected in configuration. (PR [#7358](https://github.com/vatesfr/xen-orchestra/pull/7358))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,7 +18,7 @@
 - [Import/VMWare] Fix `(Failure \"Expected string, got 'I(0)'\")` (PR [#7361](https://github.com/vatesfr/xen-orchestra/issues/7361))
 - [Plugin/load-balancer] Fixing `TypeError: Cannot read properties of undefined (reading 'high')` happening when trying to optimize a host with performance plan [#7359](https://github.com/vatesfr/xen-orchestra/issues/7359) (PR [#7362](https://github.com/vatesfr/xen-orchestra/pull/7362))
 - Changing the number of displayed items per page should send back to the first page [#7350](https://github.com/vatesfr/xen-orchestra/issues/7350)
-- [Plugin/Load balancer] Preventing the creation of a density plan when simple plan is selected in configuration. (PR [#7358](https://github.com/vatesfr/xen-orchestra/pull/7358))
+- [Plugin/load-balancer] Correctly create a *simple* instead of a *density* plan when it is selected (PR [#7358](https://github.com/vatesfr/xen-orchestra/pull/7358))
 
 ### Packages to release
 

--- a/docs/load_balancing.md
+++ b/docs/load_balancing.md
@@ -34,9 +34,8 @@ But it's not the only way to see this: there is multiple possibilities to "optim
 
 - maybe you want to spread the VM load on the maximum number of server, to get the most of your hardware? (previous example)
 - maybe you want to reduce power consumption and migrate your VMs to the minimum number of hosts possible? (and shutdown useless hosts)
-- or maybe both, depending of your own schedule?
 
-Those ways can be also called modes: "performance" for 1, "density" for number 2 and "mixed" for the last.
+Those ways can be also called modes: "performance" for 1 and "density" for number 2.
 
 ## Configure a plan
 
@@ -47,7 +46,6 @@ A plan has:
 - a name
 - pool(s) where to apply the policy
 - a mode (see paragraph below)
-- a behavior (aggressive, normal, low)
 
 ### Plan modes
 
@@ -55,7 +53,7 @@ There are 3 modes possible:
 
 - performance
 - density
-- mixed
+- simple
 
 #### Performance
 
@@ -65,14 +63,9 @@ VMs are placed to use all possible resources. This means balance the load to giv
 
 This time, the objective is to use the least hosts possible, and to concentrate your VMs. In this mode, you can choose to shutdown unused (and compatible) hosts.
 
-#### Mixed
+#### Simple
 
-This mode allows you to use both performance and density, but alternatively, depending of a schedule. E.g:
-
-- **performance** from 6:00 AM to 7:00 PM
-- **density** from 7:01 PM to 5:59 AM
-
-In this case, you'll have the best of both when needed (energy saving during the night and performance during the day).
+This mode allows you to use VM anti-affinity without using any load balancing mechanism. (see paragraph below)
 
 ### Threshold
 
@@ -86,6 +79,10 @@ If the CPU threshold is set to 90%, the load balancer will be only triggered if 
 :::
 
 For free memory, it will be triggered if there is **less** free RAM than the threshold.
+
+### Exclusion
+
+If you want to prevent load balancing from triggering migrations on a particular host or VM, it is possible to exclude it from load balancing. It can be configured via the "Excluded hosts" parameter in each plan, and in the "Ignored VM tags" parameter which is common to every plan.
 
 ### Timing
 

--- a/packages/xo-server-load-balancer/src/index.js
+++ b/packages/xo-server-load-balancer/src/index.js
@@ -12,6 +12,8 @@ import { EXECUTION_DELAY, debug } from './utils'
 
 const PERFORMANCE_MODE = 0
 const DENSITY_MODE = 1
+const SIMPLE_MODE = 2
+const MODES = { 'Performance mode': PERFORMANCE_MODE, 'Density mode': DENSITY_MODE, 'Simple mode': SIMPLE_MODE }
 
 // ===================================================================
 
@@ -147,7 +149,7 @@ class LoadBalancerPlugin {
 
     if (plans) {
       for (const plan of plans) {
-        this._addPlan(plan.mode === 'Performance mode' ? PERFORMANCE_MODE : DENSITY_MODE, plan)
+        this._addPlan(MODES[plan.mode], plan)
       }
     }
   }

--- a/packages/xo-server-load-balancer/src/index.js
+++ b/packages/xo-server-load-balancer/src/index.js
@@ -37,7 +37,7 @@ export const configurationSchema = {
           },
 
           mode: {
-            enum: ['Performance mode', 'Density mode', 'Simple mode'],
+            enum: Object.keys(MODES),
             title: 'Mode',
           },
 


### PR DESCRIPTION
### Description

Previously, a density plan was created when simple plan was selected in load balancer configuration.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
