### PR TITLE
fix(xo-server/vm.importFromEsxi): userdevice is a string

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- Fix[Import/VMWare]: Fix `(Failure \"Expected string, got 'I(0)'\")` (PR [#7361](https://github.com/vatesfr/xen-orchestra/issues/7361))
+- [Import/VMWare] Fix `(Failure \"Expected string, got 'I(0)'\")` (PR [#7361](https://github.com/vatesfr/xen-orchestra/issues/7361))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- Fix[Import/VMWare]: Fix `(Failure \"Expected string, got 'I(0)'\")` (PR [#7361](https://github.com/vatesfr/xen-orchestra/issues/7361))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -26,5 +28,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- xo-server patch
 
 <!--packages-end-->

--- a/packages/xo-server/src/xo-mixins/migrate-vm.mjs
+++ b/packages/xo-server/src/xo-mixins/migrate-vm.mjs
@@ -265,7 +265,7 @@ export default class MigrateVm {
                 VDI: vdi.$ref,
                 VM: vm.$ref,
                 device: `xvd${String.fromCharCode('a'.charCodeAt(0) + userdevice)}`,
-                userdevice: userdevice < 3 ? userdevice : userdevice + 1,
+                userdevice: String(userdevice < 3 ? userdevice : userdevice + 1),
               })
             } else {
               vhd = await openDeltaVmdkasVhd(esxi, datastore, path + '/' + fileName, parentVhd, {
@@ -316,7 +316,7 @@ export default class MigrateVm {
                 VDI: vdi.$ref,
                 VM: vm.$ref,
                 device: `xvd${String.fromCharCode('a'.charCodeAt(0) + userdevice)}`,
-                userdevice: userdevice < 3 ? userdevice : userdevice + 1,
+                userdevice: String(userdevice < 3 ? userdevice : userdevice + 1),
               })
             } else {
               if (parentVhd === undefined) {


### PR DESCRIPTION
### Description

from https://help.vates.tech/#ticket/zoom/21585/82017 and other tickets
introduced by https://github.com/vatesfr/xen-orchestra/commit/59cc418973599afda16d911b42a5e8cbce56701e

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
