### PR TITLE
fix(xo-server-load-balancer): error during optimize

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Import/VMWare] Fix `(Failure \"Expected string, got 'I(0)'\")` (PR [#7361](https://github.com/vatesfr/xen-orchestra/issues/7361))
+- [Plugin/load-balancer] Fixing `TypeError: Cannot read properties of undefined (reading 'high')` happening when trying to optimize a host with performance plan [#7359](https://github.com/vatesfr/xen-orchestra/issues/7359) (PR [#7362](https://github.com/vatesfr/xen-orchestra/pull/7362))
 
 ### Packages to release
 
@@ -30,5 +31,6 @@
 <!--packages-start-->
 
 - xo-server patch
+- xo-server-load-balancer patch
 
 <!--packages-end-->

--- a/packages/xo-server-load-balancer/src/performance-plan.js
+++ b/packages/xo-server-load-balancer/src/performance-plan.js
@@ -178,7 +178,7 @@ export default class PerformancePlan extends Plan {
       const state = this._getThresholdState(exceededAverages)
       if (
         destinationAverages.cpu + vmAverages.cpu >= this._thresholds.cpu.low ||
-        destinationAverages.memoryFree - vmAverages.memory <= this._thresholds.memory.high ||
+        destinationAverages.memoryFree - vmAverages.memory <= this._thresholds.memoryFree.high ||
         (!state.cpu &&
           !state.memory &&
           (exceededAverages.cpu - vmAverages.cpu < destinationAverages.cpu + vmAverages.cpu ||


### PR DESCRIPTION
### Description

Fixing wrong key, which led to errors when this line was executed during optimize function of performance plan.
See #7359
Introduced by #7288 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
