### PR TITLE
feat(xo-server): testing https to accept given certificate

### DIFF
--- a/scripts/trustCertificate.mjs
+++ b/scripts/trustCertificate.mjs
@@ -46,7 +46,6 @@ console.log('=> Certificate acquired')
 console.log('\n-> Request using acquired certificate')
 tryRequest({
   ...options,
-  cert: certificate.toString(),
   ca: [...tls.rootCertificates, certificate.toString()],
   // adding default ca with ...tls.rootCertificates avoids failing requests with other valid certificates, but it looks likes it also makes succeeding requests we want to fail (like https://pinning-test.badssl.com/)
   // checkServerIdentity: () => {return undefined}, // for localhost

--- a/scripts/trustCertificate.mjs
+++ b/scripts/trustCertificate.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+import https from 'node:https'
+import tls from 'node:tls'
+import { X509Certificate } from 'node:crypto'
+
+const [, , host, port = 443] = process.argv
+
+async function tryRequest(options) {
+  https
+    .request(options, res => {
+      console.log('statusCode:', res.statusCode)
+    })
+    .on('error', function (error) {
+      console.error('error:', error)
+    })
+    .end()
+}
+
+function getCertificate(options) {
+  return new Promise((resolve, reject) => {
+    tls
+      .connect(options, function () {
+        resolve(this.getPeerCertificate())
+        // we could also use directly this.getPeerX509Certificate() but then we can't show certificate informations
+        // pubkey = this.getPeerCertificate().pubkey may be usefull too
+        this.end()
+      })
+      .on('error', function (error) {
+        this.destroy()
+        reject(error)
+      })
+  })
+}
+
+// Trying request : it fails if self-signed certificate
+const options = { host, port, rejectUnauthorized: true, servername: host }
+console.log('\n-> Request with no certificate')
+tryRequest(options)
+
+// Asking for certificate
+const peerCertificate = await getCertificate({ ...options, rejectUnauthorized: false })
+// console.log(peerCertificate)
+
+const certificate = new X509Certificate(peerCertificate.raw)
+// certificate.verify(publicKey: KeyObject) may be usefull too
+
+// Trying again with certificate
+console.log('\n-> Request using acquired certificate')
+tryRequest({
+  ...options,
+  ca: certificate.toString(), // ca can be a certificate or a list of certificates
+  checkServerIdentity: () => {
+    return null
+  }, // maybe usefull only for localhost
+})


### PR DESCRIPTION
### Description

Searching how to allow user to decide if a given unauthorized https certificate should be trusted or not.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
