### PR TITLE
fix(backups): ensure vhd are chained with older vhd

### DIFF
--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
@@ -200,7 +200,7 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
               `missing parent of ${id} in ${dirname(path)}, looking for ${vdi.other_config[TAG_BASE_DELTA]}`
             )
             assert.ok(
-              pathBasename(parentPath).localeCompare(pathBasename(path)) < 0,
+              pathBasename(parentPath) < pathBasename(path),
               `vhd must be sorted to be chained`
             )
             parentPath = parentPath.slice(1) // remove leading slash

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
@@ -7,7 +7,7 @@ import { chainVhd, checkVhdChain, openVhd, VhdAbstract } from 'vhd-lib'
 import { createLogger } from '@xen-orchestra/log'
 import { decorateClass } from '@vates/decorate-with'
 import { defer } from 'golike-defer'
-import { dirname } from 'node:path'
+import { dirname, basename as pathBasename } from 'node:path'
 
 import { formatFilenameDate } from '../../_filenameDate.mjs'
 import { getOldEntries } from '../../_getOldEntries.mjs'
@@ -199,7 +199,10 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
               undefined,
               `missing parent of ${id} in ${dirname(path)}, looking for ${vdi.other_config[TAG_BASE_DELTA]}`
             )
-
+            assert.ok(
+              pathBasename(parentPath).localeCompare(pathBasename(path)) < 0,
+              `vhd must be sorted to be chained`
+            )
             parentPath = parentPath.slice(1) // remove leading slash
 
             // TODO remove when this has been done before the export

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,6 +33,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
 - xo-server patch
 - xo-server-audit patch
 - xo-web patch


### PR DESCRIPTION
### Description
vhd chain should always been transfered in ascending order, they are named by timestamp. 

Even in the case of vhd directory, where we have an alias file pointing to a real vhd in ths ./data/ dir, the alias are named in ascending order. This test doesn't list the vhd in ./data


### Testing :
when adding a 2033.vhd file in on of the vhd repo I have now this error 
![image](https://github.com/vatesfr/xen-orchestra/assets/50174/cac96bc3-5b29-4efb-bc2b-8812fab7a9ba)
(note that the file is removed at the end of the backup, since it's a unused vhd)
This will ensure we can't create loop anymore

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
