### PR TITLE
feat(docs): add VM migration spec

### DIFF
--- a/docs/manage_infrastructure.md
+++ b/docs/manage_infrastructure.md
@@ -429,15 +429,15 @@ In the VM "Snapshots" tab, you can also export a snapshot like you export a VM.
 
 ### Simple VM Migration (VM.pool_migrate)
 
-Simple migration involves moving the VM without moving its disks. This feature is only possible when the VM's disks are on a shared SR by both hosts.
+In simple migration, the VM's active state is transferred from host A to host B while its disks remains in its original location. This feature is only possible when the VM's disks are on a shared SR by both hosts and if the VM is running.
 
 #### Use Case
 
-- Move a VM within the same pool from host A to host B without moving the VM's VDIs.
+- Migrate a VM within the same pool from host A to host B without moving the VM's VDIs.
 
 ### VM Migration with Storage Motion (VM.migrate_send)
 
-VM migration with storage motion allows you to move a VM from one host to another when the VM's disks are not on a shared SR between the two hosts or if a specific network is chosen for the migration.
+VM migration with storage motion allows you to migrate a VM from one host to another when the VM's disks are not on a shared SR between the two hosts or if a specific network is chosen for the migration. VDIs will be migrated to the destination SR if one is provided.
 
 #### Use Cases
 

--- a/docs/manage_infrastructure.md
+++ b/docs/manage_infrastructure.md
@@ -447,7 +447,7 @@ VM migration with storage motion allows you to move a VM from one host to anothe
 
 ### Expected Behavior
 
-- Migrating a VM that has VDIs on a shared SR from host A to host B should trigger a "Simple VM Migration".
+- Migrating a VM that has VDIs on a shared SR from host A to host B must trigger a "Simple VM Migration".
 - Migrating a VM that has VDIs on a shared SR from host A to host B using a particular network must trigger a "VM Migration with Storage Motion" without moving its VDIs.
 - Migrating a VM from host A to host B with a destination SR must trigger a "VM Migration with Storage Motion" and move VDIs to the destination SR, regardless of where the VDIs were stored.
 
@@ -578,10 +578,9 @@ As specified in the [documentation](https://xcp-ng.org/docs/requirements.html#po
 :::
 
 :::warning
-
 - Even with matching CPU vendors, in the case of different CPU models, XCP-ng/Citrix Hypervisor will "level" down to use the CPU having the least instructions.
 - All the hosts in a pool must run the same XCP-ng version.
-  :::
+:::
 
 ### Creating a pool
 
@@ -611,10 +610,9 @@ To remove one host from a pool, you can go to the "Advanced" tab of the host pag
 ![](./assets/detach-host.png)
 
 :::warning
-
 - Detaching a host will remove all the VM disks stored on the Local Storage of this host, and reboot the host.
 - The host you want to remove must be a slave, not the master!
-  :::
+:::
 
 ## Visualizations
 

--- a/docs/manage_infrastructure.md
+++ b/docs/manage_infrastructure.md
@@ -425,6 +425,32 @@ It works even if the VM is running, because we'll automatically export a snapsho
 
 In the VM "Snapshots" tab, you can also export a snapshot like you export a VM.
 
+## VM migration
+
+### Simple VM Migration (VM.pool_migrate)
+
+Simple migration involves moving the VM without moving its disks. This feature is only possible when the VM's disks are on a shared SR by both hosts.
+
+#### Use Case
+
+- Move a VM within the same pool from host A to host B without moving the VM's VDIs.
+
+### VM Migration with Storage Motion (VM.migrate_send)
+
+VM migration with storage motion allows you to move a VM from one host to another when the VM's disks are not on a shared SR between the two hosts or if a specific network is chosen for the migration.
+
+#### Use Cases
+
+- Migrate a VM to another pool.
+- Migrate a VM within the same pool from host A to host B by selecting a network for the migration.
+- Migrate a VM within the same pool from host A to host B by moving the VM's VDIs to another storage.
+
+### Expected Behavior
+
+- Migrating a VM that has VDIs on a shared SR from host A to host B should trigger a "Simple VM Migration".
+- Migrating a VM that has VDIs on a shared SR from host A to host B using a particular network must trigger a "VM Migration with Storage Motion" without moving its VDIs.
+- Migrating a VM from host A to host B with a destination SR must trigger a "VM Migration with Storage Motion" and move VDIs to the destination SR, regardless of where the VDIs were stored.
+
 ## Hosts management
 
 Outside updates (see next section), you can also do host management via Xen Orchestra. Basic operations are supported, like reboot, shutdown and so on.
@@ -552,9 +578,10 @@ As specified in the [documentation](https://xcp-ng.org/docs/requirements.html#po
 :::
 
 :::warning
+
 - Even with matching CPU vendors, in the case of different CPU models, XCP-ng/Citrix Hypervisor will "level" down to use the CPU having the least instructions.
 - All the hosts in a pool must run the same XCP-ng version.
-:::
+  :::
 
 ### Creating a pool
 
@@ -584,9 +611,10 @@ To remove one host from a pool, you can go to the "Advanced" tab of the host pag
 ![](./assets/detach-host.png)
 
 :::warning
+
 - Detaching a host will remove all the VM disks stored on the Local Storage of this host, and reboot the host.
 - The host you want to remove must be a slave, not the master!
-:::
+  :::
 
 ## Visualizations
 


### PR DESCRIPTION
### Description

#### Current behaviour

- Migrating a VM that has VDIs on a shared SR from host A to host B ~must trigger a "Simple VM Migration"~ trigger a "Migration with Storage Motion". (wrong behaviour only for migration from the home view)
- Migrating a VM from host A to host B with a destination SR must trigger a "VM Migration with Storage Motion" and ~move VDIs to the destination SR, regardless of where the VDIs were stored~ do not move VDIs if they where on a shared SR before the migration.
- A destination SR is required (even if VDIs are on shared SR) in case we want to choose a network for the migration.

PR that fix behaviour: #7360

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
