### PR TITLE
feat(xo-web/SizeInput): added 'TiB' and 'PiB' units

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,6 +8,7 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - Disable search engine indexing via a `robots.txt`
+- [Size Input] Ability to select two new units in the dropdown (`TiB`, `PiB`) (PR [#7382](https://github.com/vatesfr/xen-orchestra/pull/7382))
 
 ### Bug fixes
 
@@ -36,6 +37,6 @@
 - @xen-orchestra/backups patch
 - xo-server patch
 - xo-server-audit patch
-- xo-web patch
+- xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-web/src/common/form/index.js
+++ b/packages/xo-web/src/common/form/index.js
@@ -138,7 +138,7 @@ export class Range extends Component {
 
 export Toggle from './toggle'
 
-const UNITS = ['kiB', 'MiB', 'GiB']
+const UNITS = ['kiB', 'MiB', 'GiB', 'TiB', 'PiB']
 const DEFAULT_UNIT = 'GiB'
 
 export class SizeInput extends BaseComponent {


### PR DESCRIPTION
### Screenshot

![Capture d’écran de 2024-02-14 15-27-43](https://github.com/vatesfr/xen-orchestra/assets/70369997/9fd8f76c-9f07-465c-8f18-26bf2cee5e06)

### Description

See zammad#21790

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
