### PR TITLE
fix(vmware-explorer): correctly handle IDE disks

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 - [API/backupNg.getLogs] Fix `after` parameter handling when `limit` parameter is not provided
 - [New/SR] Fix create button never appearing for `smb iso` SR [#7355](https://github.com/vatesfr/xen-orchestra/issues/7355), [Forum#8417](https://xcp-ng.org/forum/topic/8417) (PR [#7405](https://github.com/vatesfr/xen-orchestra/pull/7405))
 - [Pool/Network] Don't allow MTU values that are too small to work (<68) (PR [#7393](https://github.com/vatesfr/xen-orchestra/pull/7393)
+- [Import/VMWare] Correctly handle IDE disks
 
 ### Packages to release
 
@@ -36,6 +37,7 @@
 
 - @xen-orchestra/xapi minor
 - @xen-orchestra/backups minor
+- @xen-orchestra/vmware-explorer patch
 - xo-server minor
 - xo-web minor
 


### PR DESCRIPTION
### Description

the current implementation was only parsing the scsi part of the vm metadata file ( <vm name>.vmx) . This PR also look at the ide part and add them to the disk  list to be handled ( transferred to XCP)  ,while ignoring the cdrom 

example vmx file with IDE : [Eligendo PDC.vmx.txt](https://github.com/vatesfr/xen-orchestra/files/14348475/Eligendo.PDC.vmx.txt) 

tested by the user 
![image](https://github.com/vatesfr/xen-orchestra/assets/50174/688eebea-46fc-4c1d-8ca4-209e189f8e68)

From https://help.vates.tech/#ticket/zoom/21585

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_


