### PR TITLE
fix(backup/mirror): don't run healthcheck if nothing as been transferred

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractRemote.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractRemote.mjs
@@ -22,6 +22,7 @@ export const AbstractRemote = class AbstractRemoteVmBackupRunner extends Abstrac
     this.config = config
     this.job = job
     this.remoteAdapters = remoteAdapters
+    this._settings = settings
     this.scheduleId = schedule.id
     this.timestamp = undefined
 

--- a/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.mjs
@@ -77,11 +77,11 @@ export const MixinRemoteWriter = (BaseClass = Object) =>
     healthCheck() {
       const sr = this._healthCheckSr
       assert.notStrictEqual(sr, undefined, 'SR should be defined before making a health check')
-      assert.notStrictEqual(
-        this._metadataFileName,
-        undefined,
-        'Metadata file name should be defined before making a health check'
-      )
+      if (this._metadataFileName === undefined) {
+        // this can happen when making a mirror backup with nothing to transfer
+        Task.info('no health check, since no backup have been transferred')
+        return
+      }
       return Task.run(
         {
           name: 'health check',

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@
 - [New/SR] Fix create button never appearing for `smb iso` SR [#7355](https://github.com/vatesfr/xen-orchestra/issues/7355), [Forum#8417](https://xcp-ng.org/forum/topic/8417) (PR [#7405](https://github.com/vatesfr/xen-orchestra/pull/7405))
 - [Pool/Network] Don't allow MTU values that are too small to work (<68) (PR [#7393](https://github.com/vatesfr/xen-orchestra/pull/7393)
 - [Import/VMWare] Correctly handle IDE disks
+- [Backups/Full] Fix `Cannot read properties of undefined (reading 'healthCheckVmsWithTags')` (PR [#7396](https://github.com/vatesfr/xen-orchestra/pull/7396))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
 - [Pool/Network] Don't allow MTU values that are too small to work (<68) (PR [#7393](https://github.com/vatesfr/xen-orchestra/pull/7393)
 - [Import/VMWare] Correctly handle IDE disks
 - [Backups/Full] Fix `Cannot read properties of undefined (reading 'healthCheckVmsWithTags')` (PR [#7396](https://github.com/vatesfr/xen-orchestra/pull/7396))
+- [Backups/Healthcheck] Don't run health checks after empty mirror backups (PR [#7396](https://github.com/vatesfr/xen-orchestra/pull/7396))
 
 ### Packages to release
 

--- a/docs/mirror_backup.md
+++ b/docs/mirror_backup.md
@@ -10,7 +10,7 @@ Just go into your "Backup" view, and select Vm Mirror Backup.
 Then, select if you want to mirror incremental backups or full backups.
 You must have exactly one source remote, you must have one or more destinations. The mirroring speed will be limited by the slower remote.
 
-Most options of the full/incremental backups applies here, like concurrency (number of VM transferred in parallel), report, proxy and speed limit. You can also add a health check on schedules.
+Most options of the full/incremental backups applies here, like concurrency (number of VM transferred in parallel), report, proxy and speed limit. You can also add a health check on schedules. Please note that only the last transferred backup (if any) will be checked.
 
 :::tip
 If you have full and incremental backups on a remote, you must configure 2 mirror backup jobs, one full and one incremental.


### PR DESCRIPTION
**Do not squash**

### Description

fix healthcheck when no data have been transferred , adding a info for the user

clarifying documentation on healthcheck in case of mirror backups 

![image](https://github.com/vatesfr/xen-orchestra/assets/50174/b681c3b7-7582-4870-a7bd-31160546226e)

From : https://help.vates.tech/#ticket/zoom/21585 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
