### PR TITLE
feat(web-core): new collection management

### DIFF
--- a/@xen-orchestra/web-core/docs/composables/collection.composable.md
+++ b/@xen-orchestra/web-core/docs/composables/collection.composable.md
@@ -30,11 +30,8 @@ useCollection(definitions, options)
 |                 | Type                                      |                                                                           |
 | --------------- | ----------------------------------------- | ------------------------------------------------------------------------- |
 | `items`         | `(Leaf \| Group)[]`                       | Array of visible `Leaf` and `Group` instances (See Item Visibility below) |
-| `activeId`      | `ComputedRef<string \| undefined>`        | The id of the active item                                                 |
 | `activeItem`    | `ComputedRef<Leaf \| Group \| undefined>` | The active item instance                                                  |
-| `selectedIds`   | `ComputedRef<string[]>`                   | Array of selected item ids                                                |
 | `selectedItems` | `ComputedRef<(Leaf \| Group)[]>`          | Array of selected item instances                                          |
-| `expandedIds`   | `ComputedRef<string[]>`                   | Array of expanded group ids                                               |
 | `expandedItems` | `ComputedRef<Group[]>`                    | Array of expanded group instances                                         |
 
 ## `LeafDefinition`

--- a/@xen-orchestra/web-core/docs/composables/collection.composable.md
+++ b/@xen-orchestra/web-core/docs/composables/collection.composable.md
@@ -320,6 +320,8 @@ const definitionsB = defineCollection(items, {
 
 The `labelClasses` properties are classes to be used in the template `:class`.
 
+_These classes are just helpers. They don't come with any default style._
+
 For a `Leaf` instance, it contains the following properties:
 
 - `selected`: whether the leaf is selected
@@ -339,6 +341,8 @@ Additionally, `Group` instances have the following properties:
 | `children`                     | `Item[]`  | array of visible children instances (see below) |
 
 ### `labelClasses`
+
+_These classes are just helpers. They don't come with any default style._
 
 For a `Group` instance, it contains the following properties:
 

--- a/@xen-orchestra/web-core/docs/composables/collection.md
+++ b/@xen-orchestra/web-core/docs/composables/collection.md
@@ -1,0 +1,346 @@
+# `useCollection` composable
+
+The `useCollection` composable handles a collection of items (called `Leaf` and `Group`) in a tree structure.
+
+`Leaf` and `Group` can be _selected_, _activated_, and/or _filtered_.
+
+Additionally, `Group` can be _expanded_ and contains `Leaf` and/or `Group` children.
+
+Multiple items can be selected at the same time (if `allowMultiSelect` is `true`). But only one item can be activated at
+a time.
+
+## Usage
+
+The `useCollection` composable takes an array of definitions (called `LeafDefinition` and `GroupDefinition`) as first
+argument, and an optional object of options as second argument.
+
+```ts
+useCollection(definitions)
+useCollection(definitions, options)
+```
+
+|                            | Required | Type                                    | Default |                                                       |
+| -------------------------- | :------: | --------------------------------------- | ------- | ----------------------------------------------------- |
+| `definitions`              |    ✓     | `(LeafDefinition \| GroupDefinition)[]` |         | The definitions of the items in the collection        |
+| `options.allowMultiSelect` |          | `boolean`                               | `false` | Whether more than one item can be selected at a time. |
+| `options.expanded`         |          | `boolean`                               | `true`  | Whether all groups are initially expanded.            |
+
+## `useCollection` return values
+
+|                 | Type                                      |                                                                           |
+| --------------- | ----------------------------------------- | ------------------------------------------------------------------------- |
+| `items`         | `(Leaf \| Group)[]`                       | Array of visible `Leaf` and `Group` instances (See Item Visibility below) |
+| `activeId`      | `ComputedRef<string \| undefined>`        | The id of the active item                                                 |
+| `activeItem`    | `ComputedRef<Leaf \| Group \| undefined>` | The active item instance                                                  |
+| `selectedIds`   | `ComputedRef<string[]>`                   | Array of selected item ids                                                |
+| `selectedItems` | `ComputedRef<(Leaf \| Group)[]>`          | Array of selected item instances                                          |
+| `expandedIds`   | `ComputedRef<string[]>`                   | Array of expanded group ids                                               |
+| `expandedItems` | `ComputedRef<Group[]>`                    | Array of expanded group instances                                         |
+
+## `LeafDefinition`
+
+```ts
+new LeafDefinition(id, data)
+new LeafDefinition(id, data, options)
+```
+
+|                         | Required | Type                                | Default     |                                                                                        |
+| ----------------------- | :------: | ----------------------------------- | ----------- | -------------------------------------------------------------------------------------- |
+| `id`                    |    ✓     | `string`                            |             | unique identifier across the whole collection of leafs and groups                      |
+| `data`                  |    ✓     | `T`                                 |             | data to be stored in the item                                                          |
+| `options.discriminator` |          | `string`                            | `undefined` | discriminator for the item when you mix different data types (see Discriminator below) |
+| `options.passesFilter`  |          | `(data: T) => boolean \| undefined` | `undefined` | filter function (see Filtering below)                                                  |
+
+### Example
+
+```ts
+const definition = new LeafDefinition('jd-1', { name: 'John Doe', age: 30 })
+```
+
+## `GroupDefinition`
+
+A `GroupDefinition` is very similar to a `LeafDefinition`, but it contains a collection of children definitions.
+
+```ts
+new GroupDefinition(id, data, children)
+new GroupDefinition(id, data, options, children)
+```
+
+|                         |     | Type                                    | Default     |                                                                                        |
+| ----------------------- | --- | --------------------------------------- | ----------- | -------------------------------------------------------------------------------------- |
+| `id`                    | ✓   | `string`                                |             | unique identifier across the whole collection of leafs and groups                      |
+| `data`                  | ✓   | `any`                                   |             | data to be stored in the item                                                          |
+| `options.discriminator` |     | `string`                                | `undefined` | discriminator for the item when you mix different data types (see Discriminator below) |
+| `options.passesFilter`  |     | `(data) => boolean \| undefined`        | `undefined` | filter function (see Filtering below)                                                  |
+| `children`              | ✓   | `(LeafDefinition \| GroupDefinition)[]` |             | array of items that are contained in this group                                        |
+
+### Example
+
+```ts
+const definition = new GroupDefinition('smithes', { name: 'The Smithes' }, [
+  new ItemDefinition('jd-1', { name: 'John Smith', age: 30 }),
+  new ItemDefinition('jd-2', { name: 'Jane Smith', age: 28 }),
+])
+```
+
+## Discriminator
+
+The `discriminator` is a string used to differentiate between different types of items. This is useful when you want to
+mix different types of items at the same collection depth.
+
+### Mixed data without discriminator
+
+```ts
+const definitions = [
+  new LeafDefinition('jd-1', { name: 'John Doe', age: 30 }),
+  new LeafDefinition('rx-1', { name: 'Rex', breed: 'Golden Retriever' }),
+]
+
+const { items } = useCollection(definitions)
+
+items.value.forEach(item => {
+  // item.data.<cursor> neither 'age' nor 'breed' are available here because we can't know the type of the item
+})
+```
+
+### Using the discriminator
+
+```ts
+const definitions = [
+  new LeafDefinition('jd-1', { name: 'John Doe', age: 30 }, { discriminator: 'person' }),
+  new LeafDefinition('rx-1', { name: 'Rex', breed: 'Golden Retriever' }, { discriminator: 'animal' }),
+]
+
+const { items } = useCollection(definitions)
+
+items.value.forEach(item => {
+  if (item.discriminator === 'person') {
+    // item.data.<cursor> `name` and `age` are available here
+  } else {
+    // item.data.<cursor> `name` and `breed` are available here
+  }
+})
+```
+
+### Mixing `GroupDefinition` and `LeafDefinition` (of same types each)
+
+If you mix `LeafDefinition` and `GroupDefinition` (of same types each), you don't need to use the discriminator because
+the `isGroup` property will serve the same purpose.
+
+```ts
+const definitions = [
+  new LeafDefinition('jd-1', { name: 'John Doe', age: 30 }),
+  new GroupDefinition('dogs', { name: 'Dogs', legs: 4 }, [
+    /* ... */
+  ]),
+]
+
+const { items } = useCollection(definitions)
+
+items.value.forEach(item => {
+  if (item.isGroup) {
+    // item.data.<cursor> `name` and `legs` are available here
+  } else {
+    // item.data.<cursor> `name` and `age` are available here
+  }
+})
+```
+
+## Filtering
+
+The optional `passesFilter` function is used to filter the item across the collection and can affect its visibility (see
+Item Visibility below).
+
+It takes the `data` as first argument and will return:
+
+- `true` if the item explicitly passes the filter
+- `false` if the item explicitly doesn't pass the filter
+- `undefined` if the filter is ignored
+
+## `defineCollection` helper
+
+The `defineCollection` helper creates a collection of definitions in a more convenient way.
+
+```ts
+defineCollection(entries)
+defineCollection(entries, options)
+defineCollection(entries, getChildren)
+defineCollection(entries, options, getChildren)
+```
+
+|                         | Required | Type                             | Default     |                                                                                |
+| ----------------------- | :------: | -------------------------------- | ----------- | ------------------------------------------------------------------------------ |
+| `entries`               |    ✓     | `T[]`                            |             | array of items to be stored in the collection                                  |
+| `options.idField`       |          | `keyof T`                        | `id`        | field to be used as the unique identifier for the items.                       |
+| `options.discriminator` |          | `string`                         | `undefined` | discriminator for the item when you mix different data types                   |
+| `options.passesFilter`  |          | `(data) => boolean \| undefined` | `undefined` | filter function that takes the data as first argument                          |
+| `getChildren`           |    ✓     | `(data: T) => Definition[]`      |             | function that returns an array of definitions that are contained in this group |
+
+Let's take this `families` example:
+
+```ts
+const familiesData = [
+  {
+    id: 'does',
+    name: 'The Does',
+    members: [
+      {
+        id: 'jd-1',
+        name: 'John Doe',
+        age: 30,
+        animals: [
+          {
+            id: 'jd-1-dog',
+            name: 'Rex',
+          },
+        ],
+      },
+      {
+        id: 'jd-2',
+        name: 'Jane Doe',
+        age: 28,
+        animals: [],
+      },
+    ],
+  },
+  {
+    id: 'smiths',
+    name: 'The Smiths',
+    members: [
+      {
+        id: 'js-1',
+        name: 'John Smith',
+        age: 35,
+        animals: [
+          {
+            id: 'js-1-cat',
+            name: 'Whiskers',
+          },
+          {
+            id: 'js-1-dog',
+            name: 'Fido',
+          },
+        ],
+      },
+      {
+        id: 'js-2',
+        name: 'Jane Smith',
+        age: 33,
+        animals: [
+          {
+            id: 'js-2-cat',
+            name: 'Mittens',
+          },
+        ],
+      },
+    ],
+  },
+]
+```
+
+You can use the `defineCollection` helper:
+
+```ts
+const definitions = defineCollection(familiesData, family =>
+  defineCollection(family.members, person => defineCollection(person.animals))
+)
+```
+
+This is the equivalent of the following code:
+
+```ts
+const definitions = familiesData.map(
+  family =>
+    new GroupDefinition(
+      family.id,
+      family,
+      family.members.map(
+        person =>
+          new GroupDefinition(
+            person.id,
+            person,
+            person.animals.map(animal => new ItemDefinition(animal.id, animal))
+          )
+      )
+    )
+)
+```
+
+## `Leaf` and `Group` instances
+
+`Leaf` and `Group` instances have the following properties:
+
+|                 |                             |                                                                   |
+| --------------- | --------------------------- | ----------------------------------------------------------------- |
+| `id`            | `string`                    | unique identifier across the whole collection of leafs and groups |
+| `isGroup`       | `boolean`                   | `true`for `Group` instances, `false` for `Leaf` instances         |
+| `discriminator` | `string` \| `undefined`     | discriminator for the item when you mix different data types      |
+| `data`          | `T`                         | data stored in the item                                           |
+| `depth`         | `number`                    | depth of the item in the collection                               |
+| `isSelected`    | `boolean`                   | whether the item is selected                                      |
+| `isActive`      | `boolean`                   | whether the item is active                                        |
+| `isVisible`     | `boolean`                   | whether the item is visible (see below)                           |
+| `activate`      | `() => void`                | function to activate the item                                     |
+| `toggleSelect`  | `(force?: boolean) => void` | function to toggle the selection of the item                      |
+
+## `Group` instances
+
+Additionally, `Group` instances have the following properties:
+
+|                                |           |                                                 |
+| ------------------------------ | --------- | ----------------------------------------------- |
+| `isExpanded`                   | `boolean` | whether the item is expanded                    |
+| `areChildrenFullySelected`     | `boolean` | whether all children are selected               |
+| `areChildrenPartiallySelected` | `boolean` | whether some children are selected              |
+| `rawChildren`                  | `Item[]`  | array of all children instances                 |
+| `children`                     | `Item[]`  | array of visible children instances (see below) |
+
+## Item Visibility
+
+Here are the rules to determine whether an item is visible or not.
+
+If a rule applies, other rules are not evaluated.
+
+1. If `passesFilter` returns `true` => _visible_
+2. If any of its ancestors `passesFilter` returns `true` => _visible_
+3. _(`Group` only)_ If any of its descendants `passesFilter` returns `true` => _visible_
+4. If `passesFilter` returns `false` => _**not** visible_
+5. If it doesn't have a parent => _visible_
+6. If the parent's `isExpanded` is `true` => _visible_
+7. If the parent's `isExpanded` is `false` => _**not** visible_
+
+## Example 1: Tree View
+
+```ts
+const definitions = defineCollection(familiesData, family =>
+  defineCollection(family.members, person => defineCollection(person.animals))
+)
+
+const { items: families } = useCollection(definitions)
+```
+
+```html
+
+<template>
+  <ul>
+    <li v-for="family in families" :key="family.id">
+      <button @click="family.toggleExpand()">
+        {{ family.isExpanded ? '↓' : '→' }}
+      </button>
+      {{ family.data.name }}
+      <ul v-if="family.isExpanded">
+        <li v-for="person in family.children" :key="person.id">
+          <button @click="person.toggleExpand()">
+            {{ person.isExpanded ? '↓' : '→' }}
+          </button>
+          {{ person.data.name }} ({{ person.data.age }})
+          <ul v-if="person.isExpanded">
+            <li v-for="animal in person.children" :key="animal.id">
+              {{ animal.data.name }}
+            </li>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</template>
+```

--- a/@xen-orchestra/web-core/lib/composables/collection.composable.ts
+++ b/@xen-orchestra/web-core/lib/composables/collection.composable.ts
@@ -6,22 +6,22 @@ import type {
   Item,
   UseCollectionOptions,
 } from '@core/composables/collection/types'
-import { computed, type MaybeRefOrGetter, reactive, type Ref, ref, toValue } from 'vue'
+import { computed, type MaybeRefOrGetter, reactive, ref, toValue } from 'vue'
 
 export function useCollection<TDefinition extends Definition, TItem extends Item = DefinitionToItem<TDefinition>>(
   definitions: MaybeRefOrGetter<TDefinition[]>,
   options?: UseCollectionOptions
 ) {
-  const selected = ref(new Map()) as Ref<Map<string, TItem>>
-  const expanded = ref(new Map()) as Ref<Map<string, TItem>>
-  const active = ref() as Ref<TItem | undefined>
-
   const context = reactive({
     allowMultiSelect: options?.allowMultiSelect ?? false,
-    selected,
-    expanded,
-    active,
+    selectedItems: ref(new Map()),
+    expandedItems: ref(new Map()),
+    activeItem: ref(),
   }) as CollectionContext<TItem>
+
+  const selectedItems = computed(() => Array.from(context.selectedItems.values()))
+  const expandedItems = computed(() => Array.from(context.expandedItems.values()))
+  const activeItem = computed(() => context.activeItem)
 
   const rawItems = computed(() => buildCollection(toValue(definitions), context))
   const items = computed(() => rawItems.value.filter(item => item.isVisible))
@@ -30,9 +30,8 @@ export function useCollection<TDefinition extends Definition, TItem extends Item
     items.value.forEach(item => item.isGroup && item.toggleExpand(true, true))
   }
 
-  const deactivate = () => (active.value = undefined)
+  const deactivate = () => (context.activeItem = undefined)
 
-  const selectedItems = computed(() => Array.from(context.selected.values()))
   const selectedLabel = computed(() => {
     if (typeof options?.selectedLabel === 'function') {
       return options.selectedLabel(selectedItems.value)
@@ -48,9 +47,9 @@ export function useCollection<TDefinition extends Definition, TItem extends Item
   return {
     items,
     deactivate,
-    activeItem: computed(() => context.active),
+    activeItem,
     selectedItems,
     selectedLabel,
-    expandedItems: computed(() => Array.from(context.expanded.values())),
+    expandedItems,
   }
 }

--- a/@xen-orchestra/web-core/lib/composables/collection.composable.ts
+++ b/@xen-orchestra/web-core/lib/composables/collection.composable.ts
@@ -1,10 +1,16 @@
 import { buildCollection } from '@core/composables/collection/build-collection'
-import type { CollectionContext, Definition, DefinitionToItem, Item } from '@core/composables/collection/types'
+import type {
+  CollectionContext,
+  Definition,
+  DefinitionToItem,
+  Item,
+  UseCollectionOptions,
+} from '@core/composables/collection/types'
 import { computed, type MaybeRefOrGetter, reactive, type Ref, ref, toValue } from 'vue'
 
 export function useCollection<TDefinition extends Definition, TItem extends Item = DefinitionToItem<TDefinition>>(
   definitions: MaybeRefOrGetter<TDefinition[]>,
-  options?: { allowMultiSelect?: boolean; expand?: boolean; maxSelectedLabels: number }
+  options?: UseCollectionOptions
 ) {
   const selected = ref(new Map()) as Ref<Map<string, TItem>>
   const expanded = ref(new Map()) as Ref<Map<string, TItem>>
@@ -28,19 +34,15 @@ export function useCollection<TDefinition extends Definition, TItem extends Item
 
   const selectedItems = computed(() => Array.from(context.selected.values()))
   const selectedLabel = computed(() => {
-    if (selectedItems.value.length === 0) {
-      return ''
+    if (typeof options?.selectedLabel === 'function') {
+      return options.selectedLabel(selectedItems.value)
     }
 
-    if (selectedItems.value.length === 1) {
-      return selectedItems.value[0].label
+    if (typeof options?.selectedLabel === 'object' && selectedItems.value.length > options.selectedLabel.max) {
+      return options.selectedLabel.fn(selectedItems.value.length)
     }
 
-    if (selectedItems.value.length <= (options?.maxSelectedLabels ?? 3)) {
-      return selectedItems.value.map(item => item.label).join(', ')
-    }
-
-    return `${selectedItems.value.length} items selected`
+    return selectedItems.value.map(item => item.label).join(', ')
   })
 
   return {

--- a/@xen-orchestra/web-core/lib/composables/collection.composable.ts
+++ b/@xen-orchestra/web-core/lib/composables/collection.composable.ts
@@ -1,0 +1,54 @@
+import { buildCollection } from '@core/composables/collection/build-collection'
+import type { CollectionContext, Definition, DefinitionToItem, Item } from '@core/composables/collection/types'
+import { computed, type MaybeRefOrGetter, reactive, type Ref, ref, toValue } from 'vue'
+
+export function useCollection<TDefinition extends Definition, TItem extends Item = DefinitionToItem<TDefinition>>(
+  definitions: MaybeRefOrGetter<TDefinition[]>,
+  options?: { allowMultiSelect?: boolean; expand?: boolean; maxSelectedLabels: number }
+) {
+  const selected = ref(new Map()) as Ref<Map<string, TItem>>
+  const expanded = ref(new Map()) as Ref<Map<string, TItem>>
+  const active = ref() as Ref<TItem | undefined>
+
+  const context = reactive({
+    allowMultiSelect: options?.allowMultiSelect ?? false,
+    selected,
+    expanded,
+    active,
+  }) as CollectionContext<TItem>
+
+  const rawItems = computed(() => buildCollection(toValue(definitions), context))
+  const items = computed(() => rawItems.value.filter(item => item.isVisible))
+
+  if (options?.expand !== false) {
+    items.value.forEach(item => item.isGroup && item.toggleExpand(true, true))
+  }
+
+  const deactivate = () => (active.value = undefined)
+
+  const selectedItems = computed(() => Array.from(context.selected.values()))
+  const selectedLabel = computed(() => {
+    if (selectedItems.value.length === 0) {
+      return ''
+    }
+
+    if (selectedItems.value.length === 1) {
+      return selectedItems.value[0].label
+    }
+
+    if (selectedItems.value.length <= (options?.maxSelectedLabels ?? 3)) {
+      return selectedItems.value.map(item => item.label).join(', ')
+    }
+
+    return `${selectedItems.value.length} items selected`
+  })
+
+  return {
+    items,
+    deactivate,
+    activeItem: computed(() => context.active),
+    selectedItems,
+    selectedLabel,
+    expandedItems: computed(() => Array.from(context.expanded.values())),
+  }
+}

--- a/@xen-orchestra/web-core/lib/composables/collection/base.ts
+++ b/@xen-orchestra/web-core/lib/composables/collection/base.ts
@@ -1,0 +1,95 @@
+import type { Group } from '@core/composables/collection/group'
+import type { CollectionContext, Identifiable, Item, ItemOptions } from '@core/composables/collection/types'
+
+export abstract class Base<T extends object = any, TDiscriminator = any> {
+  abstract readonly isGroup: boolean
+  abstract passesFilterDownwards: boolean
+  abstract isVisible: boolean
+  abstract labelClasses: Record<string, boolean>
+
+  readonly data: T
+  readonly depth: number
+  readonly parent: Group | undefined
+  readonly context: CollectionContext
+  readonly options: ItemOptions<T, TDiscriminator>
+
+  constructor(
+    data: T,
+    parent: Group | undefined,
+    context: CollectionContext,
+    depth: number,
+    options?: ItemOptions<T, TDiscriminator>
+  ) {
+    this.data = data
+    this.parent = parent
+    this.context = context
+    this.depth = depth
+    this.options = options ?? ({} as ItemOptions<T, TDiscriminator>)
+  }
+
+  get id() {
+    if (this.options.getId === undefined) {
+      return (this.data as Identifiable).id
+    }
+
+    if (typeof this.options.getId === 'function') {
+      return this.options.getId(this.data)
+    }
+
+    return this.data[this.options.getId]
+  }
+
+  get label() {
+    if (this.options.getLabel === undefined) {
+      return (this.data as { label: string }).label
+    }
+
+    if (typeof this.options.getLabel === 'function') {
+      return this.options.getLabel(this.data)
+    }
+
+    return this.data[this.options.getLabel]
+  }
+
+  get discriminator() {
+    return this.options.discriminator
+  }
+
+  get passesFilter() {
+    return this.options.predicate?.(this.data)
+  }
+
+  get isSelected() {
+    return this.context.selected.has(this.id)
+  }
+
+  get isActive() {
+    return this.context.active?.id === this.id
+  }
+
+  get passesFilterUpwards(): boolean {
+    return this.passesFilter || (this.parent?.passesFilterUpwards ?? false)
+  }
+
+  activate() {
+    if (this.options.activable === false) {
+      return
+    }
+
+    this.context.active = this as unknown as Item
+  }
+
+  toggleSelect(force?: boolean) {
+    const shouldSelect = force ?? !this.isSelected
+
+    if (shouldSelect) {
+      if (!this.context.allowMultiSelect) {
+        this.context.selected.clear()
+      }
+
+      this.context.selected.set(this.id, this as unknown as Item)
+    } else {
+      this.context.selected.delete(this.id)
+    }
+  }
+}

--- a/@xen-orchestra/web-core/lib/composables/collection/base.ts
+++ b/@xen-orchestra/web-core/lib/composables/collection/base.ts
@@ -1,5 +1,5 @@
 import type { Group } from '@core/composables/collection/group'
-import type { CollectionContext, Identifiable, Item, ItemOptions } from '@core/composables/collection/types'
+import type { CollectionContext, Identifiable, Item, ItemOptions, Labeled } from '@core/composables/collection/types'
 
 export abstract class Base<T extends object = any, TDiscriminator = any> {
   abstract readonly isGroup: boolean
@@ -41,7 +41,7 @@ export abstract class Base<T extends object = any, TDiscriminator = any> {
 
   get label() {
     if (this.options.getLabel === undefined) {
-      return (this.data as { label: string }).label
+      return (this.data as Labeled).label
     }
 
     if (typeof this.options.getLabel === 'function') {
@@ -60,11 +60,11 @@ export abstract class Base<T extends object = any, TDiscriminator = any> {
   }
 
   get isSelected() {
-    return this.context.selected.has(this.id)
+    return this.context.selectedItems.has(this.id)
   }
 
   get isActive() {
-    return this.context.active?.id === this.id
+    return this.context.activeItem?.id === this.id
   }
 
   get passesFilterUpwards(): boolean {
@@ -76,20 +76,20 @@ export abstract class Base<T extends object = any, TDiscriminator = any> {
       return
     }
 
-    this.context.active = this as unknown as Item
+    this.context.activeItem = this as unknown as Item
   }
 
-  toggleSelect(force?: boolean) {
-    const shouldSelect = force ?? !this.isSelected
+  toggleSelect(forcedValue?: boolean) {
+    const shouldSelect = forcedValue ?? !this.isSelected
 
     if (shouldSelect) {
       if (!this.context.allowMultiSelect) {
-        this.context.selected.clear()
+        this.context.selectedItems.clear()
       }
 
-      this.context.selected.set(this.id, this as unknown as Item)
+      this.context.selectedItems.set(this.id, this as unknown as Item)
     } else {
-      this.context.selected.delete(this.id)
+      this.context.selectedItems.delete(this.id)
     }
   }
 }

--- a/@xen-orchestra/web-core/lib/composables/collection/build-collection.ts
+++ b/@xen-orchestra/web-core/lib/composables/collection/build-collection.ts
@@ -1,0 +1,21 @@
+import { Group } from '@core/composables/collection/group'
+import { GroupDefinition } from '@core/composables/collection/group-definition'
+import { Leaf } from '@core/composables/collection/leaf'
+import type { CollectionContext, Definition, DefinitionToItem, Item } from '@core/composables/collection/types'
+
+export function buildCollection<TDefinition extends Definition>(
+  definitions: TDefinition[],
+  context: CollectionContext
+): DefinitionToItem<TDefinition>[] {
+  function create(definitions: Definition[], parent: Group | undefined, depth: number): Item[] {
+    return definitions.map(definition =>
+      definition instanceof GroupDefinition
+        ? new Group(definition.data, parent, context, depth, definition.options, thisGroup =>
+            create(definition.children, thisGroup, depth + 1)
+          )
+        : new Leaf(definition.data, parent, context, depth, definition.options)
+    )
+  }
+
+  return create(definitions, undefined, 0) as DefinitionToItem<TDefinition>[]
+}

--- a/@xen-orchestra/web-core/lib/composables/collection/define-collection.ts
+++ b/@xen-orchestra/web-core/lib/composables/collection/define-collection.ts
@@ -1,0 +1,56 @@
+import { GroupDefinition } from '@core/composables/collection/group-definition'
+import { LeafDefinition } from '@core/composables/collection/leaf-definition'
+import type { ItemOptions, Definition, Identifiable, Labeled } from '@core/composables/collection/types'
+
+// Overload 1: Leaf with no options
+export function defineCollection<T extends Identifiable & Labeled, const TDiscriminator = any>(
+  entries: T[]
+): LeafDefinition<T, TDiscriminator>[]
+
+// Overload 2: Leaf with options
+export function defineCollection<T extends object, const TDiscriminator = any>(
+  entries: T[],
+  options: ItemOptions<T, TDiscriminator>
+): LeafDefinition<T, TDiscriminator>[]
+
+// Overload 3: Group with no options
+export function defineCollection<
+  T extends Identifiable & Labeled,
+  TChildDefinition extends Definition,
+  const TDiscriminator = any,
+>(entries: T[], getChildren: (data: T) => TChildDefinition[]): GroupDefinition<T, TChildDefinition, TDiscriminator>[]
+
+// Overload 4: Group with options
+export function defineCollection<
+  T extends object,
+  TChildDefinition extends Definition = Definition,
+  const TDiscriminator = any,
+>(
+  entries: T[],
+  options: ItemOptions<T, TDiscriminator>,
+  getChildren: (data: T) => TChildDefinition[]
+): GroupDefinition<T, TChildDefinition, TDiscriminator>[]
+
+// Implementation
+export function defineCollection<
+  T extends object,
+  TChildDefinition extends Definition = Definition,
+  const TDiscriminator = any,
+>(
+  entries: T[],
+  optionsOrGetChildren?: ItemOptions<T, TDiscriminator> | ((data: T) => TChildDefinition[]),
+  getChildren?: (data: T) => TChildDefinition[]
+) {
+  const options = (typeof optionsOrGetChildren === 'function' ? {} : optionsOrGetChildren ?? {}) as ItemOptions<
+    T,
+    TDiscriminator
+  >
+
+  const getChildrenFn = typeof optionsOrGetChildren === 'function' ? optionsOrGetChildren : getChildren
+
+  if (getChildrenFn !== undefined) {
+    return entries.map(data => new GroupDefinition(data, options, getChildrenFn(data)))
+  }
+
+  return entries.map(data => new LeafDefinition(data, options))
+}

--- a/@xen-orchestra/web-core/lib/composables/collection/define-group.ts
+++ b/@xen-orchestra/web-core/lib/composables/collection/define-group.ts
@@ -1,0 +1,23 @@
+import { GroupDefinition } from '@core/composables/collection/group-definition'
+import type { Definition, Identifiable, ItemOptions, Labeled } from '@core/composables/collection/types'
+
+export function defineGroup<
+  T extends Identifiable & Labeled,
+  TChildDefinition extends Definition,
+  const TDiscriminator,
+>(data: T, children: TChildDefinition[]): GroupDefinition<T, TChildDefinition, TDiscriminator>
+export function defineGroup<T extends object, TChildDefinition extends Definition, const TDiscriminator>(
+  data: T,
+  options: ItemOptions<T, TDiscriminator>,
+  children: TChildDefinition[]
+): GroupDefinition<T, TChildDefinition, TDiscriminator>
+export function defineGroup<T extends object, TChildDefinition extends Definition, const TDiscriminator>(
+  data: T,
+  optionsOrChildren: ItemOptions<T, TDiscriminator> | TChildDefinition[],
+  children?: TChildDefinition[]
+): GroupDefinition<T, TChildDefinition, TDiscriminator> {
+  const options = Array.isArray(optionsOrChildren) ? ({} as ItemOptions<T, TDiscriminator>) : optionsOrChildren
+  const actualChildren = Array.isArray(optionsOrChildren) ? optionsOrChildren : children!
+
+  return new GroupDefinition(data, options, actualChildren)
+}

--- a/@xen-orchestra/web-core/lib/composables/collection/define-leaf.ts
+++ b/@xen-orchestra/web-core/lib/composables/collection/define-leaf.ts
@@ -1,0 +1,16 @@
+import { LeafDefinition } from '@core/composables/collection/leaf-definition'
+import type { Identifiable, ItemOptions, Labeled } from '@core/composables/collection/types'
+
+export function defineLeaf<T extends Identifiable & Labeled, const TDiscriminator>(
+  data: T
+): LeafDefinition<T, TDiscriminator>
+export function defineLeaf<T extends object, const TDiscriminator>(
+  data: T,
+  options: ItemOptions<T, TDiscriminator>
+): LeafDefinition<T, TDiscriminator>
+export function defineLeaf<T extends object, const TDiscriminator>(
+  data: T,
+  options?: ItemOptions<T, TDiscriminator>
+): LeafDefinition<T, TDiscriminator> {
+  return new LeafDefinition(data, options ?? ({} as ItemOptions<T, TDiscriminator>))
+}

--- a/@xen-orchestra/web-core/lib/composables/collection/definition-base.ts
+++ b/@xen-orchestra/web-core/lib/composables/collection/definition-base.ts
@@ -1,0 +1,11 @@
+import type { ItemOptions } from '@core/composables/collection/types'
+
+export abstract class DefinitionBase<T extends object, TDiscriminator> {
+  data: T
+  options: ItemOptions<T, TDiscriminator>
+
+  constructor(data: T, options: ItemOptions<T, TDiscriminator>) {
+    this.data = data
+    this.options = options
+  }
+}

--- a/@xen-orchestra/web-core/lib/composables/collection/group-definition.ts
+++ b/@xen-orchestra/web-core/lib/composables/collection/group-definition.ts
@@ -1,0 +1,16 @@
+import { DefinitionBase } from '@core/composables/collection/definition-base'
+import type { Definition, ItemOptions } from '@core/composables/collection/types'
+
+export class GroupDefinition<
+  T extends object = any,
+  TChildDefinition extends Definition = Definition,
+  const TDiscriminator = any,
+> extends DefinitionBase<T, TDiscriminator> {
+  children: TChildDefinition[]
+
+  constructor(data: T, options: ItemOptions<T, TDiscriminator>, children: TChildDefinition[]) {
+    super(data, options)
+
+    this.children = children
+  }
+}

--- a/@xen-orchestra/web-core/lib/composables/collection/group.ts
+++ b/@xen-orchestra/web-core/lib/composables/collection/group.ts
@@ -41,7 +41,7 @@ export class Group<T extends object = any, TChild extends Item = Item, const TDi
   }
 
   get isExpanded() {
-    return this.context.expanded.has(this.id) || this.passesFilterDownwards || this.passesFilterUpwards
+    return this.context.expandedItems.has(this.id) || this.passesFilterDownwards || this.passesFilterUpwards
   }
 
   get areChildrenFullySelected(): boolean {
@@ -82,33 +82,33 @@ export class Group<T extends object = any, TChild extends Item = Item, const TDi
     return this.areChildrenFullySelected ? 'all' : this.areChildrenPartiallySelected ? 'some' : 'none'
   }
 
-  toggleExpand(force?: boolean, recursive?: boolean) {
-    const shouldExpand = force ?? !this.isExpanded
+  toggleExpand(forcedValue?: boolean, recursive?: boolean) {
+    const nextExpanded = forcedValue ?? !this.isExpanded
 
-    if (shouldExpand) {
-      this.context.expanded.set(this.id, this as Item)
+    if (nextExpanded) {
+      this.context.expandedItems.set(this.id, this as Item)
     } else {
-      this.context.expanded.delete(this.id)
+      this.context.expandedItems.delete(this.id)
     }
 
-    const shouldPropagate = recursive ?? !shouldExpand
+    const shouldPropagate = recursive ?? !nextExpanded
 
     if (shouldPropagate) {
       this.rawChildren.forEach(child => {
         if (child.isGroup) {
-          child.toggleExpand(shouldExpand, recursive)
+          child.toggleExpand(nextExpanded, recursive)
         }
       })
     }
   }
 
-  toggleChildrenSelect(force?: boolean) {
+  toggleChildrenSelect(forcedValue?: boolean) {
     if (!this.context.allowMultiSelect) {
       console.warn('allowMultiSelect must be enabled to use toggleChildrenSelect')
       return
     }
 
-    const shouldSelect = force ?? !this.areChildrenFullySelected
+    const shouldSelect = forcedValue ?? !this.areChildrenFullySelected
     this.rawChildren.forEach(child => {
       child instanceof Group ? child.toggleChildrenSelect(shouldSelect) : child.toggleSelect(shouldSelect)
     })

--- a/@xen-orchestra/web-core/lib/composables/collection/group.ts
+++ b/@xen-orchestra/web-core/lib/composables/collection/group.ts
@@ -1,0 +1,116 @@
+import { Base } from '@core/composables/collection/base'
+import type { CollectionContext, Item, ItemOptions } from '@core/composables/collection/types'
+
+export class Group<T extends object = any, TChild extends Item = Item, const TDiscriminator = any> extends Base<
+  T,
+  TDiscriminator
+> {
+  readonly isGroup = true
+  readonly rawChildren: TChild[]
+
+  constructor(
+    data: T,
+    parent: Group | undefined,
+    context: CollectionContext,
+    depth: number,
+    options: ItemOptions<T, TDiscriminator> | undefined,
+    getChildren: (thisGroup: Group<T, TChild, TDiscriminator>) => TChild[]
+  ) {
+    super(data, parent, context, depth, options)
+    this.rawChildren = getChildren(this)
+  }
+
+  get children() {
+    return this.rawChildren.filter(child => child.isVisible)
+  }
+
+  get passesFilterDownwards(): boolean {
+    return this.passesFilter || this.rawChildren.some(child => child.passesFilterDownwards)
+  }
+
+  get isVisible() {
+    if (this.passesFilterUpwards || this.passesFilterDownwards) {
+      return true
+    }
+
+    if (this.passesFilter === false) {
+      return false
+    }
+
+    return this.parent?.isExpanded ?? true
+  }
+
+  get isExpanded() {
+    return this.context.expanded.has(this.id) || this.passesFilterDownwards || this.passesFilterUpwards
+  }
+
+  get areChildrenFullySelected(): boolean {
+    if (!this.context.allowMultiSelect) {
+      console.warn('allowMultiSelect must be enabled to use areChildrenFullySelected')
+      return false
+    }
+
+    return this.rawChildren.every(child => (child.isGroup ? child.areChildrenFullySelected : child.isSelected))
+  }
+
+  get areChildrenPartiallySelected(): boolean {
+    if (!this.context.allowMultiSelect) {
+      console.warn('allowMultiSelect must be enabled to use areChildrenPartiallySelected')
+      return false
+    }
+
+    if (this.areChildrenFullySelected) {
+      return false
+    }
+
+    return this.rawChildren.some(child => (child.isGroup ? child.areChildrenPartiallySelected : child.isSelected))
+  }
+
+  get labelClasses() {
+    return {
+      active: this.isActive,
+      selected: this.isSelected,
+      matches: this.passesFilter === true,
+      'selected-partial': this.context.allowMultiSelect && this.areChildrenPartiallySelected,
+      'selected-full': this.context.allowMultiSelect && this.areChildrenFullySelected,
+      expanded: this.isExpanded,
+    }
+  }
+
+  get childrenSelectedState() {
+    console.warn('allowMultiSelect must be enabled to use childrenSelectedState')
+    return this.areChildrenFullySelected ? 'all' : this.areChildrenPartiallySelected ? 'some' : 'none'
+  }
+
+  toggleExpand(force?: boolean, recursive?: boolean) {
+    const shouldExpand = force ?? !this.isExpanded
+
+    if (shouldExpand) {
+      this.context.expanded.set(this.id, this as Item)
+    } else {
+      this.context.expanded.delete(this.id)
+    }
+
+    const shouldPropagate = recursive ?? !shouldExpand
+
+    if (shouldPropagate) {
+      this.rawChildren.forEach(child => {
+        if (child.isGroup) {
+          child.toggleExpand(shouldExpand, recursive)
+        }
+      })
+    }
+  }
+
+  toggleChildrenSelect(force?: boolean) {
+    if (!this.context.allowMultiSelect) {
+      console.warn('allowMultiSelect must be enabled to use toggleChildrenSelect')
+      return
+    }
+
+    const shouldSelect = force ?? !this.areChildrenFullySelected
+    this.rawChildren.forEach(child => {
+      child instanceof Group ? child.toggleChildrenSelect(shouldSelect) : child.toggleSelect(shouldSelect)
+    })
+  }
+}

--- a/@xen-orchestra/web-core/lib/composables/collection/leaf-definition.ts
+++ b/@xen-orchestra/web-core/lib/composables/collection/leaf-definition.ts
@@ -1,0 +1,6 @@
+import { DefinitionBase } from '@core/composables/collection/definition-base'
+
+export class LeafDefinition<T extends object = any, const TDiscriminator = any> extends DefinitionBase<
+  T,
+  TDiscriminator
+> {}

--- a/@xen-orchestra/web-core/lib/composables/collection/leaf.ts
+++ b/@xen-orchestra/web-core/lib/composables/collection/leaf.ts
@@ -1,0 +1,29 @@
+import { Base } from '@core/composables/collection/base'
+
+export class Leaf<T extends object = any, const TDiscriminator = any> extends Base<T, TDiscriminator> {
+  readonly isGroup = false
+
+  get passesFilterDownwards(): boolean {
+    return this.passesFilter ?? false
+  }
+
+  get isVisible() {
+    if (this.passesFilterUpwards) {
+      return true
+    }
+
+    if (this.passesFilter === false) {
+      return false
+    }
+
+    return this.parent?.isExpanded ?? true
+  }
+
+  get labelClasses() {
+    return {
+      active: this.isActive,
+      selected: this.isSelected,
+      matches: this.passesFilter === true,
+    }
+  }
+}

--- a/@xen-orchestra/web-core/lib/composables/collection/types.ts
+++ b/@xen-orchestra/web-core/lib/composables/collection/types.ts
@@ -1,0 +1,50 @@
+import type { Group } from '@core/composables/collection/group'
+import type { GroupDefinition } from '@core/composables/collection/group-definition'
+import type { Leaf } from '@core/composables/collection/leaf'
+import type { LeafDefinition } from '@core/composables/collection/leaf-definition'
+
+export type Identifiable = { id: string | number }
+
+export type Labeled = { label: string }
+
+type AcceptableKeys<T, TAccepted> = {
+  [K in keyof T]: T[K] extends TAccepted ? K : never
+}[keyof T]
+
+type AcceptableGetter<T, TAccepted> = AcceptableKeys<T, TAccepted> | ((data: T) => TAccepted)
+
+export type BaseOptions<T, TDiscriminator> = {
+  discriminator?: TDiscriminator
+  predicate?: (data: T) => boolean | undefined
+  activable?: boolean
+}
+
+type GetIdOption<T extends object> = T extends Identifiable
+  ? { getId?: AcceptableGetter<T, string | number> }
+  : { getId: AcceptableGetter<T, string | number> }
+
+type GetLabelOption<T extends object> = T extends Labeled
+  ? { getLabel?: AcceptableGetter<T, string> }
+  : { getLabel: AcceptableGetter<T, string> }
+
+export type ItemOptions<T extends object, TDiscriminator> = BaseOptions<T, TDiscriminator> &
+  GetIdOption<T> &
+  GetLabelOption<T>
+
+export type Definition = LeafDefinition | GroupDefinition
+
+export type DefinitionToItem<TDefinition> =
+  TDefinition extends GroupDefinition<infer T, infer TChildDefinition, infer TDiscriminator>
+    ? Group<T, DefinitionToItem<TChildDefinition>, TDiscriminator>
+    : TDefinition extends LeafDefinition<infer T, infer TDiscriminator>
+      ? Leaf<T, TDiscriminator>
+      : never
+
+export type Item = Leaf | Group
+
+export type CollectionContext<TItem extends Item = Item> = {
+  allowMultiSelect: boolean
+  selected: Map<string | number, TItem>
+  expanded: Map<string | number, TItem>
+  active: TItem | undefined
+}

--- a/@xen-orchestra/web-core/lib/composables/collection/types.ts
+++ b/@xen-orchestra/web-core/lib/composables/collection/types.ts
@@ -44,9 +44,9 @@ export type Item = Leaf | Group
 
 export type CollectionContext<TItem extends Item = Item> = {
   allowMultiSelect: boolean
-  selected: Map<string | number, TItem>
-  expanded: Map<string | number, TItem>
-  active: TItem | undefined
+  selectedItems: Map<string | number, TItem>
+  expandedItems: Map<string | number, TItem>
+  activeItem: TItem | undefined
 }
 
 export type UseCollectionOptions = {

--- a/@xen-orchestra/web-core/lib/composables/collection/types.ts
+++ b/@xen-orchestra/web-core/lib/composables/collection/types.ts
@@ -48,3 +48,14 @@ export type CollectionContext<TItem extends Item = Item> = {
   expanded: Map<string | number, TItem>
   active: TItem | undefined
 }
+
+export type UseCollectionOptions = {
+  allowMultiSelect?: boolean
+  expand?: boolean
+  selectedLabel?:
+    | ((items: Item[]) => string)
+    | {
+        max: number
+        fn: (count: number) => string
+      }
+}


### PR DESCRIPTION
### Description

This PR brings a new way to manage collections and sub-collections or items.

It will handle different informations (id, label, depth, css classes etc.), status (active, selected, expanded, etc.), filtering, actions (activate, select, select children etc.), optional multi-select and generation of selection label (`Foo`, `Foo, Bar, Baz`, `5 items selected`)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
