### PR TITLE
feat(xo-server,xo-web): manage auto poweron at pool level

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 - [REST API] Export host [SMT](https://en.wikipedia.org/wiki/Simultaneous_multithreading) status at `/hosts/:id/smt` [Forum#71374](https://xcp-ng.org/forum/post/71374)
 - [Home & REST API] `$container` field of an halted VM now points to a host if a VDI is on a local storage [Forum#71769](https://xcp-ng.org/forum/post/71769)
 - [Size Input] Ability to select two new units in the dropdown (`TiB`, `PiB`) (PR [#7382](https://github.com/vatesfr/xen-orchestra/pull/7382))
-
+- [Pool/Advanced] _Auto power on_ can be disabled at pool level (PR [#7401](https://github.com/vatesfr/xen-orchestra/pull/7401))
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”

--- a/packages/xo-server/src/api/pool.mjs
+++ b/packages/xo-server/src/api/pool.mjs
@@ -15,6 +15,7 @@ const log = createLogger('xo:api:pool')
 export async function set({
   pool,
 
+  auto_poweron,
   name_description: nameDescription,
   name_label: nameLabel,
   backupNetwork,
@@ -25,6 +26,7 @@ export async function set({
   pool = this.getXapiObject(pool)
 
   await Promise.all([
+    auto_poweron !== undefined && pool.update_other_config('auto_poweron', String(auto_poweron)),
     nameDescription !== undefined && pool.set_name_description(nameDescription),
     nameLabel !== undefined && pool.set_name_label(nameLabel),
     migrationNetwork !== undefined && pool.update_other_config('xo:migrationNetwork', migrationNetwork),
@@ -38,6 +40,10 @@ export async function set({
 set.params = {
   id: {
     type: 'string',
+  },
+  auto_poweron: {
+    type: 'boolean',
+    optional: true,
   },
   name_label: {
     type: 'string',

--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -98,6 +98,7 @@ const TRANSFORMS = {
   pool(obj) {
     const cpuInfo = obj.cpu_info
     return {
+      auto_poweron: obj.other_config.auto_poweron === 'true',
       crashDumpSr: link(obj, 'crash_dump_SR'),
       current_operations: obj.current_operations,
       default_SR: link(obj, 'default_SR'),

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1404,6 +1404,7 @@ const messages = {
   deleteVtpm: 'Delete the VTPM',
   deleteVtpmWarning:
     'If the VTPM is in use, removing it will result in a dangerous data loss. Are you sure you want to remove the VTPM?',
+  poolAutoPoweronDisabled: 'Auto power on is disabled at pool level, click to fix automatically.',
   vmRemoveButton: 'Remove',
   vmConvertToTemplateButton: 'Convert to template',
   vmSwitchVirtualizationMode: 'Convert to {mode}',

--- a/packages/xo-web/src/xo-app/pool/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/pool/tab-advanced.js
@@ -16,6 +16,7 @@ import { CustomFields } from 'custom-fields'
 import { injectIntl } from 'react-intl'
 import { forEach, map, values } from 'lodash'
 import { Text, XoSelect } from 'editable'
+import { Toggle } from 'form'
 import {
   createGetObject,
   createGetObjectsOfType,
@@ -239,6 +240,8 @@ export default class TabAdvanced extends Component {
     plugins => plugins !== undefined && plugins.some(plugin => plugin.name === 'netbox' && plugin.loaded)
   )
 
+  _onChangeAutoPoweron = value => editPool(this.props.pool, { auto_poweron: value })
+
   _onChangeBackupNetwork = backupNetwork => editPool(this.props.pool, { backupNetwork: backupNetwork.id })
 
   _removeBackupNetwork = () => editPool(this.props.pool, { backupNetwork: null })
@@ -300,6 +303,12 @@ export default class TabAdvanced extends Component {
               <h3>{_('xenSettingsLabel')}</h3>
               <table className='table'>
                 <tbody>
+                  <tr>
+                    <th>{_('autoPowerOn')}</th>
+                    <td>
+                      <Toggle value={pool.auto_poweron} onChange={this._onChangeAutoPoweron} />
+                    </td>
+                  </tr>
                   <tr>
                     <th>{_('poolHaStatus')}</th>
                     <td>{pool.HA_enabled ? _('poolHaEnabled') : _('poolHaDisabled')}</td>

--- a/packages/xo-web/src/xo-app/vm/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/vm/tab-advanced.js
@@ -715,7 +715,17 @@ export default class TabAdvanced extends Component {
                   </td>
                 </tr>
                 <tr>
-                  <th>{_('autoPowerOn')}</th>
+                  <th>
+                    {_('autoPowerOn')}
+                    {vm.auto_poweron && !vmPool.auto_poweron && (
+                      <Tooltip content={_('poolAutoPoweronDisabled')}>
+                        <a className='btn btn-link btn-sm' onClick={() => editVm(vm, { auto_poweron: true })}>
+                          {' '}
+                          <Icon icon='alarm' className='text-warning' />
+                        </a>
+                      </Tooltip>
+                    )}
+                  </th>
                   <td>
                     <Toggle value={Boolean(vm.auto_poweron)} onChange={value => editVm(vm, { auto_poweron: value })} />
                   </td>


### PR DESCRIPTION
### Description

Fixes zammad#21691

On Pool/Advanced:
![image](https://github.com/vatesfr/xen-orchestra/assets/298721/02606ac8-cbec-4ed1-ab09-debdc5ac76ac)

On VM/Advanced when disabled at pool level:
![image](https://github.com/vatesfr/xen-orchestra/assets/298721/ac4968b4-6908-42b0-a3e2-92d203459467)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
