### PR TITLE
test(xo-vmdk-to-vhd): fix reference file path

### DIFF
--- a/packages/xo-vmdk-to-vhd/src/ova-generate.integ.spec.js
+++ b/packages/xo-vmdk-to-vhd/src/ova-generate.integ.spec.js
@@ -99,7 +99,7 @@ test('An ova file is generated correctly', async () => {
     try {
       await execXmllint(xml, [
         '--schema',
-        path.join(__dirname, 'ova-schema', 'dsp8023_1.1.1.xsd'),
+        path.join(__dirname, '..', 'src', 'ova-schema', 'dsp8023_1.1.1.xsd'),
         '--noout',
         '--nonet',
         '-',


### PR DESCRIPTION
the xsd is not bundled in dist, the tests are run from
the dist folder

tests are now running in local 
![image](https://github.com/vatesfr/xen-orchestra/assets/50174/9e5a1b08-d0ae-4e7f-afeb-3813d3579032)
and in the github action 
![image](https://github.com/vatesfr/xen-orchestra/assets/50174/d0758eab-7a4e-4430-9ab2-2aa7f390fba7)

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
