### PR TITLE
feat(xo6/core): use same-name shorthand syntax in templates

### DIFF
--- a/@xen-orchestra/lite/src/components/CollectionTable.vue
+++ b/@xen-orchestra/lite/src/components/CollectionTable.vue
@@ -32,7 +32,7 @@
         <td v-if="isSelectable">
           <input v-model="selected" :value="item.$ref" type="checkbox" />
         </td>
-        <slot :item="item" name="body-row" />
+        <slot :item name="body-row" />
       </tr>
     </tbody>
   </UiTable>

--- a/@xen-orchestra/lite/src/components/ColumnHeader.vue
+++ b/@xen-orchestra/lite/src/components/ColumnHeader.vue
@@ -2,7 +2,7 @@
   <th>
     <div class="content">
       <span class="label">
-        <UiIcon :icon="icon" />
+        <UiIcon :icon />
         <slot />
       </span>
     </div>

--- a/@xen-orchestra/lite/src/components/ObjectNotFoundWrapper.vue
+++ b/@xen-orchestra/lite/src/components/ObjectNotFoundWrapper.vue
@@ -2,7 +2,7 @@
   <div v-if="!isReady" class="wrapper-spinner">
     <UiSpinner class="spinner" />
   </div>
-  <ObjectNotFoundView v-else-if="isRecordNotFound" :id="id" />
+  <ObjectNotFoundView v-else-if="isRecordNotFound" :id />
   <slot v-else />
 </template>
 

--- a/@xen-orchestra/lite/src/components/PowerStateIcon.vue
+++ b/@xen-orchestra/lite/src/components/PowerStateIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <UiIcon :class="className" :icon="icon" class="power-state-icon" />
+  <UiIcon :class="className" :icon class="power-state-icon" />
 </template>
 
 <script lang="ts" setup>

--- a/@xen-orchestra/lite/src/components/RouterTab.vue
+++ b/@xen-orchestra/lite/src/components/RouterTab.vue
@@ -1,6 +1,6 @@
 <template>
   <RouterLink v-slot="{ isActive, href }" :to="isDisabled ? '' : to" custom>
-    <UiTab :active="isActive" :disabled="disabled" :href="href" tag="a">
+    <UiTab :active="isActive" :disabled :href tag="a">
       <slot />
     </UiTab>
   </RouterLink>

--- a/@xen-orchestra/lite/src/components/TitleBar.vue
+++ b/@xen-orchestra/lite/src/components/TitleBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="title-bar">
-    <UiIcon :icon="icon" class="icon" />
+    <UiIcon :icon class="icon" />
     <div class="title">
       <slot />
     </div>

--- a/@xen-orchestra/lite/src/components/charts/LinearChart.vue
+++ b/@xen-orchestra/lite/src/components/charts/LinearChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <VueCharts :option="option" autoresize class="chart" />
+  <VueCharts :option autoresize class="chart" />
 </template>
 
 <script lang="ts" setup>

--- a/@xen-orchestra/lite/src/components/component-story/StoryMenu.vue
+++ b/@xen-orchestra/lite/src/components/component-story/StoryMenu.vue
@@ -2,7 +2,7 @@
   <RouterLink :to="{ name: 'story' }">
     <UiTitle type="h4">Stories</UiTitle>
   </RouterLink>
-  <StoryMenuTree :tree="tree" :opened-directories="openedDirectories" @toggle-directory="toggleDirectory" />
+  <StoryMenuTree :tree :opened-directories="openedDirectories" @toggle-directory="toggleDirectory" />
 </template>
 
 <script lang="ts" setup>

--- a/@xen-orchestra/lite/src/components/form/FormCheckbox.vue
+++ b/@xen-orchestra/lite/src/components/form/FormCheckbox.vue
@@ -9,7 +9,7 @@
       v-bind="$attrs"
     />
     <span class="fake-checkbox">
-      <UiIcon :fixed-width="false" :icon="icon" class="icon" />
+      <UiIcon :fixed-width="false" :icon class="icon" />
     </span>
   </component>
 </template>

--- a/@xen-orchestra/lite/src/components/form/FormInput.vue
+++ b/@xen-orchestra/lite/src/components/form/FormInput.vue
@@ -2,12 +2,12 @@
   <span :class="wrapperClass" class="container" v-bind="wrapperAttrs">
     <template v-if="inputType === 'select'">
       <select
-        :id="id"
+        :id
         ref="inputElement"
         v-model="value"
         :class="inputClass"
         :disabled="isDisabled"
-        :required="required"
+        :required
         class="select"
         v-bind="$attrs"
       >
@@ -19,23 +19,23 @@
     </template>
     <textarea
       v-else-if="inputType === 'textarea'"
-      :id="id"
+      :id
       ref="textarea"
       v-model="value"
       :class="inputClass"
       :disabled="isDisabled"
-      :required="required"
+      :required
       class="textarea"
       v-bind="$attrs"
     />
     <input
       v-else
-      :id="id"
+      :id
       ref="inputElement"
       v-model="value"
       :class="inputClass"
       :disabled="isDisabled"
-      :required="required"
+      :required
       class="input"
       v-bind="$attrs"
     />

--- a/@xen-orchestra/lite/src/components/form/FormInputWrapper.vue
+++ b/@xen-orchestra/lite/src/components/form/FormInputWrapper.vue
@@ -2,7 +2,7 @@
   <div class="form-input-wrapper">
     <div v-if="label !== undefined || learnMoreUrl !== undefined" class="label-container">
       <label :class="{ light }" :for="id" class="label">
-        <UiIcon :icon="icon" />
+        <UiIcon :icon />
         {{ label }}
       </label>
       <a v-if="learnMoreUrl !== undefined" :href="learnMoreUrl" class="learn-more-url" target="_blank">

--- a/@xen-orchestra/lite/src/components/form/FormSection.vue
+++ b/@xen-orchestra/lite/src/components/form/FormSection.vue
@@ -3,7 +3,7 @@
     <fieldset class="fieldset">
       <legend class="legend" @click="toggleCollapse">
         {{ label }}
-        <UiIcon :icon="icon" class="collapse-icon" />
+        <UiIcon :icon class="collapse-icon" />
       </legend>
       <div v-if="!isCollapsed" class="content">
         <slot />

--- a/@xen-orchestra/lite/src/components/infra/InfraAction.vue
+++ b/@xen-orchestra/lite/src/components/infra/InfraAction.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="infra-action">
     <slot>
-      <UiIcon :icon="icon" fixed-width />
+      <UiIcon :icon fixed-width />
     </slot>
   </div>
 </template>

--- a/@xen-orchestra/lite/src/components/infra/InfraItemLabel.vue
+++ b/@xen-orchestra/lite/src/components/infra/InfraItemLabel.vue
@@ -5,8 +5,8 @@
       class="infra-item-label"
       v-bind="$attrs"
     >
-      <a v-tooltip="hasTooltip" :href="href" class="link" @click="navigate">
-        <UiIcon :icon="icon" class="icon" />
+      <a v-tooltip="hasTooltip" :href class="link" @click="navigate">
+        <UiIcon :icon class="icon" />
         <div ref="textElement" class="text">
           <slot />
         </div>

--- a/@xen-orchestra/lite/src/components/infra/InfraLoadingItem.vue
+++ b/@xen-orchestra/lite/src/components/infra/InfraLoadingItem.vue
@@ -2,7 +2,7 @@
   <li class="infra-loading-item">
     <div class="infra-item-label-placeholder">
       <div class="link-placeholder">
-        <UiIcon :icon="icon" class="icon" />
+        <UiIcon :icon class="icon" />
         <div class="loader">&nbsp;</div>
       </div>
     </div>

--- a/@xen-orchestra/lite/src/components/menu/AppMenu.vue
+++ b/@xen-orchestra/lite/src/components/menu/AppMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <slot :is-open="isOpen" :open="open" name="trigger" />
+  <slot :is-open="isOpen" :open name="trigger" />
   <Teleport to="body" :disabled="!shouldTeleport">
     <ul v-if="!hasTrigger || isOpen" ref="menu" :class="{ horizontal, shadow }" class="app-menu" v-bind="$attrs">
       <slot />

--- a/@xen-orchestra/lite/src/components/menu/MenuItem.vue
+++ b/@xen-orchestra/lite/src/components/menu/MenuItem.vue
@@ -5,14 +5,14 @@
       :active="isBusy"
       :busy="isBusy"
       :disabled="isDisabled"
-      :icon="icon"
+      :icon
       @click="handleClick"
     >
       <slot />
     </MenuTrigger>
     <AppMenu v-else :disabled="isDisabled" shadow>
       <template #trigger="{ open, isOpen }">
-        <MenuTrigger :active="isOpen" :busy="isBusy" :disabled="isDisabled" :icon="icon" @click="open">
+        <MenuTrigger :active="isOpen" :busy="isBusy" :disabled="isDisabled" :icon @click="open">
           <slot />
           <UiIcon :fixed-width="false" :icon="submenuIcon" class="submenu-icon" />
         </MenuTrigger>

--- a/@xen-orchestra/lite/src/components/menu/MenuTrigger.vue
+++ b/@xen-orchestra/lite/src/components/menu/MenuTrigger.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="{ active, disabled }" class="menu-trigger">
-    <UiIcon :busy="busy" :icon="icon" />
+    <UiIcon :busy :icon />
     <slot />
   </div>
 </template>

--- a/@xen-orchestra/lite/src/components/modals/CodeHighlightModal.vue
+++ b/@xen-orchestra/lite/src/components/modals/CodeHighlightModal.vue
@@ -1,7 +1,7 @@
 <template>
   <UiModal>
     <BasicModalLayout>
-      <CodeHighlight :code="code" />
+      <CodeHighlight :code />
     </BasicModalLayout>
   </UiModal>
 </template>

--- a/@xen-orchestra/lite/src/components/modals/VmExportModal.vue
+++ b/@xen-orchestra/lite/src/components/modals/VmExportModal.vue
@@ -13,7 +13,7 @@
         <FormSelect v-model="compressionType">
           <option
             v-for="key in Object.keys(VM_COMPRESSION_TYPE)"
-            :key="key"
+            :key
             :value="VM_COMPRESSION_TYPE[key as keyof typeof VM_COMPRESSION_TYPE]"
           >
             {{ $t(key.toLowerCase()) }}

--- a/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardAlarms.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardAlarms.vue
@@ -30,7 +30,7 @@
     <div v-else class="table-container">
       <UiTable>
         <tbody>
-          <AlarmRow v-for="alarm in alarms" :key="alarm.uuid" :alarm="alarm" />
+          <AlarmRow v-for="alarm in alarms" :key="alarm.uuid" :alarm />
         </tbody>
       </UiTable>
     </div>

--- a/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardCpuProvisioning.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardCpuProvisioning.vue
@@ -9,13 +9,13 @@
             content: $t('cpu-provisioning-warning'),
             placement: 'left',
           }"
-          :state="state"
+          :state
         />
       </template>
     </UiCardTitle>
     <NoDataError v-if="hasError" />
     <div v-else-if="isReady" :class="state" class="progress-item">
-      <UiProgressBar :max-value="maxValue" :value="value" color="custom" />
+      <UiProgressBar :max-value="maxValue" :value color="custom" />
       <UiProgressScale :max-value="maxValue" :steps="1" unit="%" />
       <UiProgressLegend :label="$t('vcpus')" :value="`${value}%`" />
       <UiCardFooter class="ui-card-footer">

--- a/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardHostsPatches.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardHostsPatches.vue
@@ -11,7 +11,7 @@
         :are-all-loaded="areAllLoaded"
         :are-some-loaded="areSomeLoaded"
         :has-multiple-hosts="hosts.length > 1"
-        :patches="patches"
+        :patches
       />
     </div>
   </UiCard>

--- a/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardNetworkChart.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardNetworkChart.vue
@@ -6,7 +6,7 @@
     </UiCardTitle>
     <NoDataError v-if="hasError" />
     <UiCardSpinner v-else-if="isLoading" />
-    <LinearChart v-else :data="data" :max-value="customMaxValue" :value-formatter="customValueFormatter" />
+    <LinearChart v-else :data :max-value="customMaxValue" :value-formatter="customValueFormatter" />
   </UiCard>
 </template>
 

--- a/@xen-orchestra/lite/src/components/pool/dashboard/cpuUsage/HostsCpuUsage.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/cpuUsage/HostsCpuUsage.vue
@@ -7,7 +7,7 @@
   <NoDataError v-if="hasError" />
   <UiCardSpinner v-else-if="isLoading" />
   <NoResult v-else-if="isStatEmpty" />
-  <UsageBar v-else :data="data" :n-items="N_ITEMS" />
+  <UsageBar v-else :data :n-items="N_ITEMS" />
 </template>
 
 <script lang="ts" setup>

--- a/@xen-orchestra/lite/src/components/pool/dashboard/cpuUsage/PoolCpuUsageChart.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/cpuUsage/PoolCpuUsageChart.vue
@@ -6,7 +6,7 @@
     </UiCardTitle>
     <NoDataError v-if="hasError" />
     <UiCardSpinner v-else-if="isLoading" />
-    <LinearChart v-else :data="data" :max-value="customMaxValue" :value-formatter="customValueFormatter" />
+    <LinearChart v-else :data :max-value="customMaxValue" :value-formatter="customValueFormatter" />
   </UiCard>
 </template>
 

--- a/@xen-orchestra/lite/src/components/pool/dashboard/cpuUsage/VmsCpuUsage.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/cpuUsage/VmsCpuUsage.vue
@@ -3,7 +3,7 @@
   <NoDataError v-if="hasError" />
   <UiCardSpinner v-else-if="isLoading" />
   <NoResult v-else-if="isStatEmpty" />
-  <UsageBar v-else :data="data" :n-items="N_ITEMS" />
+  <UsageBar v-else :data :n-items="N_ITEMS" />
 </template>
 
 <script lang="ts" setup>

--- a/@xen-orchestra/lite/src/components/pool/dashboard/ramUsage/HostsRamUsage.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/ramUsage/HostsRamUsage.vue
@@ -7,7 +7,7 @@
   <NoDataError v-if="hasError" />
   <UiCardSpinner v-else-if="isLoading" />
   <NoResult v-else-if="isStatEmpty" />
-  <UsageBar v-else :data="data" :n-items="N_ITEMS" />
+  <UsageBar v-else :data :n-items="N_ITEMS" />
 </template>
 
 <script lang="ts" setup>

--- a/@xen-orchestra/lite/src/components/pool/dashboard/ramUsage/PoolRamUsage.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/ramUsage/PoolRamUsage.vue
@@ -6,7 +6,7 @@
     </UiCardTitle>
     <NoDataError v-if="hasError" />
     <UiCardSpinner v-else-if="isLoading" />
-    <LinearChart v-else :data="data" :max-value="customMaxValue" :value-formatter="customValueFormatter" />
+    <LinearChart v-else :data :max-value="customMaxValue" :value-formatter="customValueFormatter" />
     <SizeStatsSummary :size="currentData.size" :usage="currentData.usage" />
   </UiCard>
 </template>

--- a/@xen-orchestra/lite/src/components/pool/dashboard/ramUsage/VmsRamUsage.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/ramUsage/VmsRamUsage.vue
@@ -3,7 +3,7 @@
   <NoDataError v-if="hasError" />
   <UiCardSpinner v-else-if="isLoading" />
   <NoResult v-else-if="isStatEmpty" />
-  <UsageBar v-else :data="data" :n-items="N_ITEMS" />
+  <UsageBar v-else :data :n-items="N_ITEMS" />
 </template>
 
 <script lang="ts" setup>

--- a/@xen-orchestra/lite/src/components/tasks/TasksTable.vue
+++ b/@xen-orchestra/lite/src/components/tasks/TasksTable.vue
@@ -24,8 +24,8 @@
         <td class="no-tasks" colspan="5">{{ $t('no-tasks') }}</td>
       </tr>
       <template v-else>
-        <TaskRow v-for="task in pendingTasks" :key="task.uuid" :task="task" is-pending />
-        <TaskRow v-for="task in finishedTasks" :key="task.uuid" :task="task" />
+        <TaskRow v-for="task in pendingTasks" :key="task.uuid" :task is-pending />
+        <TaskRow v-for="task in finishedTasks" :key="task.uuid" :task />
       </template>
     </tbody>
   </UiTable>

--- a/@xen-orchestra/lite/src/components/ui/UiActionButton.vue
+++ b/@xen-orchestra/lite/src/components/ui/UiActionButton.vue
@@ -10,7 +10,7 @@
     class="ui-action-button"
     type="button"
   >
-    <UiIcon :busy="busy" :icon="icon" />
+    <UiIcon :busy :icon />
     <slot />
   </button>
 </template>

--- a/@xen-orchestra/lite/src/components/ui/UiBadge.vue
+++ b/@xen-orchestra/lite/src/components/ui/UiBadge.vue
@@ -1,6 +1,6 @@
 <template>
   <span class="ui-badge">
-    <UiIcon :icon="icon" />
+    <UiIcon :icon />
     <slot />
   </span>
 </template>

--- a/@xen-orchestra/lite/src/components/ui/icon/UiStatusIcon.vue
+++ b/@xen-orchestra/lite/src/components/ui/icon/UiStatusIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <UiIcon :icon="icon" class="icon" :class="props.state" />
+  <UiIcon :icon class="icon" :class="props.state" />
 </template>
 
 <script lang="ts" setup>

--- a/@xen-orchestra/lite/src/components/ui/modals/ModalList.vue
+++ b/@xen-orchestra/lite/src/components/ui/modals/ModalList.vue
@@ -1,5 +1,5 @@
 <template>
-  <ModalListItem v-for="modal in modalStore.modals" :key="modal.id" :modal="modal" />
+  <ModalListItem v-for="modal in modalStore.modals" :key="modal.id" :modal />
 </template>
 
 <script lang="ts" setup>

--- a/@xen-orchestra/lite/src/components/ui/modals/layouts/FormModalLayout.vue
+++ b/@xen-orchestra/lite/src/components/ui/modals/layouts/FormModalLayout.vue
@@ -2,7 +2,7 @@
   <ModalContainer tag="form">
     <template #header>
       <div :class="borderClass" class="title-bar">
-        <UiIcon :class="textClass" :icon="icon" />
+        <UiIcon :class="textClass" :icon />
         <slot name="title" />
         <ModalCloseIcon class="close-icon" />
       </div>

--- a/@xen-orchestra/lite/src/components/ui/resources/UiResource.vue
+++ b/@xen-orchestra/lite/src/components/ui/resources/UiResource.vue
@@ -1,6 +1,6 @@
 <template>
   <li class="ui-resource">
-    <UiIcon :icon="icon" class="icon" />
+    <UiIcon :icon class="icon" />
     <div class="separator" />
     <div class="label">{{ label }}</div>
     <div class="count">{{ count }}</div>

--- a/@xen-orchestra/lite/src/stories/form/form-input.story.vue
+++ b/@xen-orchestra/lite/src/stories/form/form-input.story.vue
@@ -12,7 +12,7 @@
       prop('before-width').str().widget(),
       prop('after-width').str().widget(),
     ]"
-    :presets="presets"
+    :presets
   >
     <FormInput v-bind="properties" />
   </ComponentStory>

--- a/@xen-orchestra/lite/src/stories/linear-chart.story.vue
+++ b/@xen-orchestra/lite/src/stories/linear-chart.story.vue
@@ -6,7 +6,7 @@
       prop('value-formatter').type('(value: number) => string'),
       prop('max-value').type('number').widget().default(200),
     ]"
-    :presets="presets"
+    :presets
   >
     <LinearChart v-bind="properties" />
   </ComponentStory>

--- a/@xen-orchestra/lite/src/stories/progress-circle.story.vue
+++ b/@xen-orchestra/lite/src/stories/progress-circle.story.vue
@@ -2,7 +2,7 @@
   <ComponentStory
     v-slot="{ properties }"
     :params="[prop('value').num().preset(25).required().widget(), prop('max-value').num().default(100).widget()]"
-    :presets="presets"
+    :presets
   >
     <ProgressCircle v-bind="properties" />
   </ComponentStory>

--- a/@xen-orchestra/lite/src/stories/story-example.story.vue
+++ b/@xen-orchestra/lite/src/stories/story-example.story.vue
@@ -1,7 +1,7 @@
 <template>
   <ComponentStory
     v-slot="{ properties, settings }"
-    :presets="presets"
+    :presets
     :params="[
       prop('imString').str().required().preset('Example').widget().help('This is a required string prop'),
       prop('imNumber').num().required().preset(42).widget().help('This is a required number prop'),

--- a/@xen-orchestra/lite/src/stories/ui-resources/ui-resource.story.vue
+++ b/@xen-orchestra/lite/src/stories/ui-resources/ui-resource.story.vue
@@ -6,7 +6,7 @@
       prop('label').required().str().widget().preset('Rockets'),
       prop('count').required().type('string | number').widget(text()).preset('175'),
     ]"
-    :presets="presets"
+    :presets
   >
     <UiResource v-bind="properties" />
   </ComponentStory>


### PR DESCRIPTION
### Description

With the introduction of VueJS 3.4, a new [shorthand syntax](https://vuejs.org/guide/essentials/template-syntax.html#same-name-shorthand) for attribute binding in templates has been made available.

This PR applies this shorthand syntax across XO Lite to ensure consistency and prepare for its adoption in XO 6.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
