### PR TITLE
docs(backup): fix link to file level restore

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -12,7 +12,7 @@ Alternatively, here is a video recap on different backup capabilities:
 - [Full Replication](full_replication.md)
 - [Metadata Backups](metadata_backup.md)
 - [Incremental Replication](incremental_replication.md)
-- [File Level Restore](file_level_restore.md)
+- [File Level Restore](backups.md#file-level-restore)
 - [Mirror backup](mirror_backup.md)
 
 :::tip


### PR DESCRIPTION
### Description

The current link to `File level restore` is broken. This is intended to point to the correct section in backups.md

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
