### PR TITLE
fix(xo-web/XOSTOR): move 'ignore file sytems' outside of advanced settings

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Jobs] Fix `t.value is undefined` when saving a new job (broken in XO 5.91)
+- [XOSTOR] Move `ignore file sytems` outside of advanced settings
 
 ### Packages to release
 
@@ -29,6 +30,6 @@
 
 <!--packages-start-->
 
-- xo-web patch
+- xo-web minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Jobs] Fix `t.value is undefined` when saving a new job (broken in XO 5.91)
-- [XOSTOR] Move `ignore file sytems` outside of advanced settings
+- [XOSTOR] Move `ignore file sytems` outside of advanced settings (PR [#7429](https://github.com/vatesfr/xen-orchestra/pull/7429))
 
 ### Packages to release
 

--- a/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
+++ b/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
@@ -111,7 +111,8 @@ const SettingsCard = decorate([
     <Card>
       <CardHeader>
         {_('settings')}
-        <ActionButton
+        {/* Uncomment when some advanced settings need to be added  */}
+        {/* <ActionButton
           className='pull-right'
           data-mode='_displayAdvancedSettings'
           handler={effects.toggleDisplayAdvancedSettings}
@@ -120,7 +121,7 @@ const SettingsCard = decorate([
           size='small'
         >
           {_('advancedSettings')}
-        </ActionButton>
+        </ActionButton> */}
       </CardHeader>
       <CardBlock>
         <Row>
@@ -140,14 +141,13 @@ const SettingsCard = decorate([
             <Select onChange={effects.onProvisioningChange} options={PROVISIONING_OPTIONS} value={state.provisioning} />
           </Col>
         </Row>
-        {state.displayAdvancedSettings && (
-          <Row>
-            <Col style={SPACE_BETWEEN}>
-              <label>{_('ignoreFileSystems')}</label>
-              <Toggle value={state.ignoreFileSystems} onChange={effects.onIgnoreFileSystemsChange} size='small' />
-            </Col>
-          </Row>
-        )}
+        <Row className='form-group mt-1'>
+          <Col style={SPACE_BETWEEN}>
+            <label>{_('ignoreFileSystems')}</label>
+            <Toggle value={state.ignoreFileSystems} onChange={effects.onIgnoreFileSystemsChange} size='small' />
+          </Col>
+        </Row>
+        {/* {state.displayAdvancedSettings && ( Advanced settings section )} */}
       </CardBlock>
     </Card>
   ),


### PR DESCRIPTION
### Description

Move the toggle outside of advanced settings as its use is very common. (Discussed with Ronan)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
