### PR TITLE
feat(xo-server): replug VIFs and PIFs when MTU is modified

### DIFF
--- a/@xen-orchestra/xapi/_Mixins.mjs
+++ b/@xen-orchestra/xapi/_Mixins.mjs
@@ -1,4 +1,5 @@
 export { default as host } from './host.mjs'
+export { default as network } from './network.mjs'
 export { default as pool } from './pool.mjs'
 export { default as SR } from './sr.mjs'
 export { default as task } from './task.mjs'

--- a/@xen-orchestra/xapi/network.mjs
+++ b/@xen-orchestra/xapi/network.mjs
@@ -1,37 +1,46 @@
 import { asyncEach } from '@vates/async-each'
+import { createLogger } from '@xen-orchestra/log'
+
+const { warn } = createLogger('xo:xapi:network')
 
 export default class Network {
   async setMtu(network, mtu) {
     await network.set_MTU(mtu)
 
     // The MTU will not be updated for VIFs of paused VM, but we can't unplug/replug VIF on a paused VM
-    const pluggedVIFs = network.$VIFs.filter(vif => vif.currently_attached && vif.$VM.power_state === 'Running')
-    const pluggedPIFs = network.$PIFs.filter(pif => pif.currently_attached)
+    const pluggedVifsRefs = network.$VIFs
+      .filter(vif => vif.currently_attached && vif.$VM.power_state === 'Running')
+      .map(vif => vif.$ref)
+    const pluggedPifsRefs = network.$PIFs.filter(pif => pif.currently_attached).map(pif => pif.$ref)
 
     let errorOccurred = false
 
     for (const { method, networkInterfaces } of [
       {
         method: 'VIF.unplug',
-        networkInterfaces: pluggedVIFs,
-      }, // unplugging PIFs before re-plugging seems unnecessary
+        networkInterfaces: pluggedVifsRefs,
+      },
+      {
+        method: 'PIF.unplug',
+        networkInterfaces: pluggedPifsRefs,
+      }, // unplugging PIFs may be unnecessary
       {
         method: 'PIF.plug',
-        networkInterfaces: pluggedPIFs,
+        networkInterfaces: pluggedPifsRefs,
       },
       {
         method: 'VIF.plug',
-        networkInterfaces: pluggedVIFs,
+        networkInterfaces: pluggedVifsRefs,
       },
     ]) {
       try {
-        await asyncEach(networkInterfaces, networkInterface => this.callAsync(method, networkInterface.$ref), {
-          concurrency: 20,
+        await asyncEach(networkInterfaces, networkInterface => this.callAsync(method, networkInterface), {
           stopOnError: false,
         })
       } catch (error) {
         // report an error occured, but continue the re-plugging process
         errorOccurred = true
+        warn(error)
       }
     }
 

--- a/@xen-orchestra/xapi/network.mjs
+++ b/@xen-orchestra/xapi/network.mjs
@@ -1,0 +1,14 @@
+export default class Network {
+  async setMtu(network, mtu) {
+    await network.set_MTU(mtu)
+
+    // The MTU will not be updated for VIFs of paused VM, but we can't unplug/replug VIF on a paused VM
+    const pluggedVIFs = network.$VIFs.filter(vif => vif.currently_attached && vif.$VM.power_state === 'Running')
+    const pluggedPIFs = network.$PIFs.filter(pif => pif.currently_attached)
+
+    await Promise.allSettled(pluggedVIFs.map(vif => this.callAsync('VIF.unplug', vif.$ref)))
+    await Promise.allSettled(pluggedPIFs.map(pif => this.callAsync('PIF.plug', pif.$ref)))
+    await Promise.allSettled(pluggedPIFs.map(pif => this.callAsync('PIF.plug', pif.$ref)))
+    await Promise.allSettled(pluggedVIFs.map(vif => this.callAsync('VIF.plug', vif.$ref)))
+  }
+}

--- a/@xen-orchestra/xapi/network.mjs
+++ b/@xen-orchestra/xapi/network.mjs
@@ -14,6 +14,11 @@ export default class Network {
     const network = await this.getRecord('network', ref)
     await network.set_MTU(mtu)
 
+    // Update PIFs and VIFs MTU, see:
+    // - https://github.com/xenserver/xenadmin/blob/b210cd2c2d8547f5bb48b49d71f17429c7d65e44/XenAdmin/SettingsPanels/EditNetworkPage.cs#L575
+    // - https://github.com/xenserver/xenadmin/blob/b210cd2c2d8547f5bb48b49d71f17429c7d65e44/XenAdmin/SettingsPanels/EditNetworkPage.cs#L625-L628
+    // - https://github.com/xenserver/xenadmin/blob/b210cd2c2d8547f5bb48b49d71f17429c7d65e44/XenModel/Actions/Network/UnplugPlugNetworkAction.cs#L81-L153
+
     // The MTU will not be updated for VIFs of paused VM, but we can't unplug/replug VIF on a paused VM
     const pluggedPifs = await asyncFilter(network.PIFs, async pif => {
       try {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 - [VM/General] Show current VM tags without the need to search them in advanced creation tag selector [#7351](https://github.com/vatesfr/xen-orchestra/issues/7351) (PR [#7434](https://github.com/vatesfr/xen-orchestra/pull/7434))
 - [xo-cli] Supports signing in with one-time password (PR [#7459](https://github.com/vatesfr/xen-orchestra/pull/7459))
 - [Plugin/load-balancer] A parameter was added in performance mode to balance VMs on hosts depending on their number of vCPUs, when it does not cause performance issues [#5389](https://github.com/vatesfr/xen-orchestra/issues/5389) (PR [#7333](https://github.com/vatesfr/xen-orchestra/pull/7333))
-- [Pool/Network] Automatically update network interfaces MTU when editing network MTU [Forum#8133](https://xcp-ng.org/forum/topic/8133/set-host-network-mtu-in-xen-orchestra) (PR [#7443](https://github.com/vatesfr/xen-orchestra/pull/7443)).
+- [Pool/Network] Automatically update network interfaces when network MTU is changed [Forum#8133](https://xcp-ng.org/forum/topic/8133/set-host-network-mtu-in-xen-orchestra) (PR [#7443](https://github.com/vatesfr/xen-orchestra/pull/7443)).
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 - [VM/General] Show current VM tags without the need to search them in advanced creation tag selector [#7351](https://github.com/vatesfr/xen-orchestra/issues/7351) (PR [#7434](https://github.com/vatesfr/xen-orchestra/pull/7434))
 - [xo-cli] Supports signing in with one-time password (PR [#7459](https://github.com/vatesfr/xen-orchestra/pull/7459))
 - [Plugin/load-balancer] A parameter was added in performance mode to balance VMs on hosts depending on their number of vCPUs, when it does not cause performance issues [#5389](https://github.com/vatesfr/xen-orchestra/issues/5389) (PR [#7333](https://github.com/vatesfr/xen-orchestra/pull/7333))
+- [Pool/Network] Automatically update network interfaces MTU when editing network MTU [Forum#8133](https://xcp-ng.org/forum/topic/8133/set-host-network-mtu-in-xen-orchestra) (PR [#7443](https://github.com/vatesfr/xen-orchestra/pull/7443)).
 
 ### Bug fixes
 
@@ -44,7 +45,7 @@
 - @xen-orchestra/backups patch
 - @xen-orchestra/proxy minor
 - @xen-orchestra/self-signed patch
-- @xen-orchestra/xapi patch
+- @xen-orchestra/xapi minor
 - xen-api major
 - xo-cli minor
 - xo-server minor

--- a/packages/xo-server/src/api/network.mjs
+++ b/packages/xo-server/src/api/network.mjs
@@ -84,7 +84,7 @@ export async function set({
   await Promise.all([
     automatic !== undefined && network.update_other_config('automatic', automatic ? 'true' : null),
     defaultIsLocked !== undefined && network.set_default_locking_mode(defaultIsLocked ? 'disabled' : 'unlocked'),
-    mtu !== undefined && network.set_MTU(mtu),
+    mtu !== undefined && this.getXapi(network.uuid).network_setMtu(network, mtu),
     nameDescription !== undefined && network.set_name_description(nameDescription),
     nameLabel !== undefined && network.set_name_label(nameLabel),
     nbd !== undefined &&

--- a/packages/xo-server/src/api/network.mjs
+++ b/packages/xo-server/src/api/network.mjs
@@ -79,12 +79,13 @@ export async function set({
   name_label: nameLabel,
   nbd,
 }) {
+  const networkXapiRef = network._xapiRef
   network = this.getXapiObject(network)
 
   await Promise.all([
     automatic !== undefined && network.update_other_config('automatic', automatic ? 'true' : null),
     defaultIsLocked !== undefined && network.set_default_locking_mode(defaultIsLocked ? 'disabled' : 'unlocked'),
-    mtu !== undefined && this.getXapi(network.uuid).network_setMtu(network, mtu),
+    mtu !== undefined && this.getXapi(network.uuid).network_setMtu(networkXapiRef, mtu),
     nameDescription !== undefined && network.set_name_description(nameDescription),
     nameLabel !== undefined && network.set_name_label(nameLabel),
     nbd !== undefined &&

--- a/packages/xo-server/src/api/network.mjs
+++ b/packages/xo-server/src/api/network.mjs
@@ -79,13 +79,12 @@ export async function set({
   name_label: nameLabel,
   nbd,
 }) {
-  const networkXapiRef = network._xapiRef
   network = this.getXapiObject(network)
 
   await Promise.all([
     automatic !== undefined && network.update_other_config('automatic', automatic ? 'true' : null),
     defaultIsLocked !== undefined && network.set_default_locking_mode(defaultIsLocked ? 'disabled' : 'unlocked'),
-    mtu !== undefined && this.getXapi(network.uuid).network_setMtu(networkXapiRef, mtu),
+    mtu !== undefined && network.$setMtu(mtu),
     nameDescription !== undefined && network.set_name_description(nameDescription),
     nameLabel !== undefined && network.set_name_label(nameLabel),
     nbd !== undefined &&


### PR DESCRIPTION
### Description

Unplug and replug VIFs and PIFs when network MTU is modified, to update their MTU value.
See https://xcp-ng.org/forum/topic/8133/set-host-network-mtu-in-xen-orchestra/7

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
