### PR TITLE
docs: XOA default iface is now called enX0

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -109,7 +109,7 @@ If you have something completely different than that, or error messages, lost pa
 
 ### Network issues
 
-You can see your current network configuration by running `ifconfig eth0`. If you have an external firewall, please check that you allow the XOA's IP.
+You can see your current network configuration by running `ifconfig` (default interface is called `enX0` or `eth0`). If you have an external firewall, please check that you allow the XOA's IP.
 
 You can modify the IP configuration with `xoa network static` (for a static IP address) or `xoa network dhcp` to use DHCP.
 

--- a/docs/xoa.md
+++ b/docs/xoa.md
@@ -172,14 +172,14 @@ If you want to go back in DHCP, just run `xoa network dhcp`
 
 ### Other interfaces
 
-If you need to configure other interfaces than `eth0`, you can use the same commands with the name of the interface to configure as supplementary argument:
+If you need to configure other interfaces than the default one, you can use the same commands with the name of the interface to configure as supplementary argument:
 
 ```console
-$ xoa network static eth1
+$ xoa network static enX1
 ? Static IP for this machine 192.168.100.120
 ? Network mask (eg 255.255.255.0) 255.255.255.0
 
-$ xoa network dhcp eth1
+$ xoa network dhcp enX1
 ```
 
 ## Firewall


### PR DESCRIPTION
### Description

XOA default iface is now called enX0.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
