### PR TITLE
feat(xo-web/host/advanced): list PCIs known by the XAPI

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -10,6 +10,7 @@
 - [i18n] Japanese translation (PR [#7582](https://github.com/vatesfr/xen-orchestra/pull/7582))
 - [REST API] [Watch mode for the tasks collection](./packages/xo-server/docs/rest-api.md#all-tasks) (PR [#7565](https://github.com/vatesfr/xen-orchestra/pull/7565))
 - [Home/SR] Display _Pro Support_ status for XOSTOR SR (PR [#7601](https://github.com/vatesfr/xen-orchestra/pull/7601))
+- [Host/Advanced] Ability to `enable/disable` passthrough for PCIs [#7432](https://github.com/vatesfr/xen-orchestra/issues/7432) (PR [#7455](https://github.com/vatesfr/xen-orchestra/pull/7455))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1026,6 +1026,10 @@ const messages = {
   // ----- host stat tab -----
   statLoad: 'Load average',
   // ----- host advanced tab -----
+  applyChangeOnPcis:
+    'This operation will reboot the host in order to apply the change on the PCI{nPcis, plural, one {} other {s}}. Are you sure you want to continue?',
+  className: 'Class name',
+  deviceName: 'Device name',
   enabled: 'Enabled',
   disksSystemHealthy: 'All disks are healthy ✅',
   editHostIscsiIqnTitle: 'Edit iSCSI IQN',
@@ -1078,6 +1082,11 @@ const messages = {
   hostRemoteSyslog: 'Remote syslog',
   hostIommu: 'IOMMU',
   hostNoCertificateInstalled: 'No certificates installed on this host',
+  'onlyAvailableXcp8.3OrHigher': 'Only available for XCP-ng 8.3.0 or higher',
+  pciDevices: 'PCI Devices',
+  pciId: 'PCI ID',
+  pcisEnable: 'PCI{nPcis, plural, one {} other {s}} enable',
+  pcisDisable: 'PCI{nPcis, plural, one {} other {s}} disable',
   pusbDevices: 'PUSB Devices',
   smartctlPluginNotInstalled: 'Smartctl plugin not installed',
   supplementalPacks: 'Installed supplemental packs',

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -1377,15 +1377,16 @@ export const hidePcis = async (pcis, hide) => {
   try {
     await confirm({
       body: _('applyChangeOnPcis', { nPcis: pcis.length }),
+      // hide `true` means that we will disable dom0's PCI access, so we will "enable" the possibility of passthrough this PCI
       title: _(hide ? 'pcisEnable' : 'pcisDisable', { nPcis: pcis.length }),
     })
   } catch (error) {
     return
   }
-  return _call('pci.hide', { pcis: resolveIds(pcis), hide })
+  return _call('pci.disableDom0Access', { pcis: resolveIds(pcis), disable: hide })
 }
 
-export const isPciHidden = pci => _call('pci.isHidden', { id: resolveId(pci) })
+export const isPciHidden = async pci => (await _call('pci.getDom0AccessStatus', { id: resolveId(pci) })) === 'disabled'
 
 //  ATM, unknown date for the availablity on XS, since they are doing rolling release
 // FIXME: When XS release methods to do PCI passthrough, update this check

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -4,6 +4,7 @@ import cookies from 'js-cookie'
 import copy from 'copy-to-clipboard'
 import fpSortBy from 'lodash/fp/sortBy'
 import React from 'react'
+import semver from 'semver'
 import updater from 'xoa-updater'
 import URL from 'url-parse'
 import Xo from 'xo-lib'
@@ -1371,6 +1372,25 @@ export const installSupplementalPackOnAllHosts = (pool, file) => {
       })
   )
 }
+
+export const hidePcis = async (pcis, hide) => {
+  try {
+    await confirm({
+      body: _('applyChangeOnPcis', { nPcis: pcis.length }),
+      title: _(hide ? 'pcisEnable' : 'pcisDisable', { nPcis: pcis.length }),
+    })
+  } catch (error) {
+    return
+  }
+  return _call('pci.hide', { pcis: resolveIds(pcis), hide })
+}
+
+export const isPciHidden = pci => _call('pci.isHidden', { id: resolveId(pci) })
+
+//  ATM, unknown date for the availablity on XS, since they are doing rolling release
+// FIXME: When XS release methods to do PCI passthrough, update this check
+export const isPciPassthroughAvailable = host =>
+  host.productBrand === 'XCP-ng' && semver.satisfies(host.version, '>=8.3.0')
 
 // Containers --------------------------------------------------------
 

--- a/packages/xo-web/src/xo-app/host/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/host/tab-advanced.js
@@ -31,8 +31,11 @@ import {
   enableAdvancedLiveTelemetry,
   enableHost,
   forgetHost,
+  hidePcis,
   installSupplementalPack,
   isHyperThreadingEnabledHost,
+  isPciHidden,
+  isPciPassthroughAvailable,
   isNetDataInstalledOnHost,
   getPlugin,
   getSmartctlHealth,
@@ -74,6 +77,78 @@ const PUSBS_COLUMNS = [
       const _editPusb = value => editPusb(pusb, { enabled: value })
       return <Toggle value={pusb.passthroughEnabled} onChange={_editPusb} />
     },
+  },
+]
+const PCIS_COLUMNS = [
+  {
+    name: _('id'),
+    itemRenderer: pci => {
+      const { uuid } = pci
+      return (
+        <Copiable data={uuid} tagName='p'>
+          {uuid.slice(4, 8)}
+        </Copiable>
+      )
+    },
+  },
+  {
+    default: true,
+    name: _('pciId'),
+    itemRenderer: pci => pci.pci_id,
+    sortCriteria: pci => pci.pci_id,
+  },
+  {
+    name: _('className'),
+    itemRenderer: pci => pci.class_name,
+    sortCriteria: pci => pci.class_name,
+  },
+  {
+    name: _('deviceName'),
+    itemRenderer: pci => pci.device_name,
+    sortCriteria: pci => pci.device_name,
+  },
+  {
+    name: _('enabled'),
+    itemRenderer: (pci, { pciStateById, isPciPassthroughAvailable }) => {
+      if (pciStateById === undefined) {
+        return <Icon icon='loading' />
+      }
+
+      if (!isPciPassthroughAvailable) {
+        return (
+          <Tooltip content={_('onlyAvailableXcp8.3OrHigher')}>
+            <Toggle disabled />
+          </Tooltip>
+        )
+      }
+
+      const { error, isHidden } = pciStateById[pci.id]
+      if (error !== undefined) {
+        return (
+          <Tooltip content={error}>
+            <Icon icon='alarm' color='text-danger' />
+          </Tooltip>
+        )
+      }
+
+      const _hidePcis = value => hidePcis([pci], value)
+      return <Toggle value={isHidden} onChange={_hidePcis} />
+    },
+    sortCriteria: (pci, { pciStateById }) => pciStateById?.[pci.id]?.isHidden,
+  },
+]
+const PCIS_ACTIONS = [
+  {
+    handler: pcis => hidePcis(pcis, false),
+    icon: 'toggle-off',
+    label: _('disable'),
+    level: 'primary',
+  },
+  {
+    handler: pcis => hidePcis(pcis, true),
+    icon: 'toggle-on',
+    label: _('enable'),
+    level: 'primary',
   },
 ]
 
@@ -181,7 +256,11 @@ MultipathableSrs.propTypes = {
     .pick((_, { host }) => host.$PGPUs)
     .sort()
 
-  const getPcis = createGetObjectsOfType('PCI').pick(createSelector(getPgpus, pgpus => map(pgpus, 'pci')))
+  const getPcis = createGetObjectsOfType('PCI').filter(
+    (_, { host }) =>
+      pci =>
+        pci.$host === host.id
+  )
 
   const getPusbs = createGetObjectsOfType('PUSB').filter(
     (_, { host }) =>
@@ -223,11 +302,30 @@ export default class extends Component {
       }))
     }
 
+    const _isPciPassthroughAvailable = isPciPassthroughAvailable(host)
+    const pciStateById = {}
+    if (_isPciPassthroughAvailable) {
+      await Promise.all(
+        Object.keys(this.props.pcis).map(async id => {
+          const pciSate = {}
+          try {
+            pciSate.isHidden = await isPciHidden(id)
+          } catch (error) {
+            console.error(error)
+            pciSate.error = error.message
+          }
+          pciStateById[id] = pciSate
+        })
+      )
+    }
+
     this.setState({
       isHtEnabled: await isHyperThreadingEnabledHost(host).catch(() => null),
       isSmartctlHealthEnabled,
+      pciStateById,
       smartctlUnhealthyDevices,
       unhealthyDevicesAlerts,
+      isPciPassthroughAvailable: _isPciPassthroughAvailable,
     })
   }
 
@@ -596,6 +694,15 @@ export default class extends Component {
             <h3>{_('pusbDevices')}</h3>
             <SortedTable collection={pusbs} columns={PUSBS_COLUMNS} />
             <br />
+            <h3>{_('pciDevices')}</h3>
+            <SortedTable
+              groupedActions={PCIS_ACTIONS}
+              collection={pcis}
+              columns={PCIS_COLUMNS}
+              data-pciStateById={this.state.pciStateById}
+              data-isPciPassthroughAvailable={this.state.isPciPassthroughAvailable}
+              stateUrlParam='s_pcis'
+            />
             <h3>{_('licenseHostSettingsLabel')}</h3>
             <table className='table'>
               <tbody>


### PR DESCRIPTION
### Screenshot

![Capture d’écran de 2024-03-08 17-33-15](https://github.com/vatesfr/xen-orchestra/assets/70369997/a956d297-a252-465a-b033-56403899c162)


### Description

Related to #7432 

Can be tested on `172.16.211.11`.

Rebase on `pci-api` to have PCI API methods

Wait for #7444

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
