### PR TITLE
Properly handle one-time password in JSON-RPC API

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@
 - [Home/VM] VMs migration from the home view will no longer execute a [Migration with Storage Motion](https://github.com/vatesfr/xen-orchestra/blob/master/docs/manage_infrastructure.md#vm-migration-with-storage-motion-vmmigrate_send) unless it is necessary [Forum#8279](https://xcp-ng.org/forum/topic/8279/getting-errors-when-migrating-4-out-5-vmguest/)(PR [#7360](https://github.com/vatesfr/xen-orchestra/pull/7360))
 - [VM/Migration] SR is no longer required if you select a migration network (PR [#7360](https://github.com/vatesfr/xen-orchestra/pull/7360))
 - [Backup] Fix `an error has occurred` when clicking on warning text in logs (PR [#7458](https://github.com/vatesfr/xen-orchestra/pull/7458))
+- [JSON-RPC API] Correctly require one-time password if configured for user (PR [#7459](https://github.com/vatesfr/xen-orchestra/pull/7459))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -10,6 +10,7 @@
 - [VM Creation] Automatically create a VTPM if the template requests it (Windows templates starting from XCP-ng 8.3) (PR [#7436](https://github.com/vatesfr/xen-orchestra/pull/7436))
 - [OTP] Accepts (ignores) whitespaces in the one-time password (some OTP applications add them for nicer display)
 - [VM/General] Show current VM tags without the need to search them in advanced creation tag selector [#7351](https://github.com/vatesfr/xen-orchestra/issues/7351) (PR [#7434](https://github.com/vatesfr/xen-orchestra/pull/7434))
+- [xo-cli] Supports signing in with one-time password (PR [#7459](https://github.com/vatesfr/xen-orchestra/pull/7459))
 
 ### Bug fixes
 
@@ -43,6 +44,7 @@
 - @xen-orchestra/self-signed patch
 - @xen-orchestra/xapi patch
 - xen-api major
+- xo-cli minor
 - xo-server minor
 - xo-web minor
 

--- a/packages/xo-cli/.USAGE.md
+++ b/packages/xo-cli/.USAGE.md
@@ -2,7 +2,7 @@
 > xo-cli --help
 Usage:
 
-  xo-cli --register [--allowUnauthorized] [--expiresIn <duration>] <XO-Server URL> <username> [<password>]
+  xo-cli --register [--allowUnauthorized] [--expiresIn <duration>] [--otp <otp>] <XO-Server URL> <username> [<password>]
   xo-cli --register [--allowUnauthorized] [--expiresIn <duration>] --token <token> <XO-Server URL>
     Registers the XO instance to use.
 
@@ -12,6 +12,9 @@ Usage:
     --expiresIn <duration>
       Can be used to change the validity duration of the
       authorization token (default: one month).
+
+    --otp <otp>
+      One-time password if required for this user.
 
     --token <token>
       An authentication token to use instead of username/password.

--- a/packages/xo-cli/README.md
+++ b/packages/xo-cli/README.md
@@ -20,7 +20,7 @@ npm install --global xo-cli
 > xo-cli --help
 Usage:
 
-  xo-cli --register [--allowUnauthorized] [--expiresIn <duration>] <XO-Server URL> <username> [<password>]
+  xo-cli --register [--allowUnauthorized] [--expiresIn <duration>] [--otp <otp>] <XO-Server URL> <username> [<password>]
   xo-cli --register [--allowUnauthorized] [--expiresIn <duration>] --token <token> <XO-Server URL>
     Registers the XO instance to use.
 
@@ -30,6 +30,9 @@ Usage:
     --expiresIn <duration>
       Can be used to change the validity duration of the
       authorization token (default: one month).
+
+    --otp <otp>
+      One-time password if required for this user.
 
     --token <token>
       An authentication token to use instead of username/password.

--- a/packages/xo-server/src/index.mjs
+++ b/packages/xo-server/src/index.mjs
@@ -326,7 +326,14 @@ async function setUpPassport(express, xo, { authentication: authCfg, http: { coo
   xo.registerPassportStrategy(
     new LocalStrategy({ passReqToCallback: true }, async (req, username, password, done) => {
       try {
-        const { user } = await xo.authenticateUser({ username, password }, { ip: req.ip })
+        const { user } = await xo.authenticateUser(
+          { username, password },
+          { ip: req.ip },
+          {
+            // OTP is handled differently in the web auth process
+            bypassOtp: true,
+          }
+        )
         done(null, user)
       } catch (error) {
         done(null, false, { message: error.message })


### PR DESCRIPTION
**DO NOT SQUASH**, [review by commit](https://github.com/vatesfr/xen-orchestra/pull/7459/commits).

### Description

This is a security issue because OTP was only check when signing in via xo-web, not via `session.signIn` in the JSON-RPC API.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
