### PR TITLE
fix(xo-server/getSrStats): Cannot read properties of undefined (reading 'interval')

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 - [VM/Migration] Fix VDIs that were not migrated to the destination SR (PR [#7360](https://github.com/vatesfr/xen-orchestra/pull/7360))
 - [Home/VM] VMs migration from the home view will no longer execute a [Migration with Storage Motion](https://github.com/vatesfr/xen-orchestra/blob/master/docs/manage_infrastructure.md#vm-migration-with-storage-motion-vmmigrate_send) unless it is necessary [Forum#8279](https://xcp-ng.org/forum/topic/8279/getting-errors-when-migrating-4-out-5-vmguest/)(PR [#7360](https://github.com/vatesfr/xen-orchestra/pull/7360))
 - [VM/Migration] SR is no longer required if you select a migration network (PR [#7360](https://github.com/vatesfr/xen-orchestra/pull/7360))
+- [SR Scan] Fix `Cannot read properties of undefined (reading 'interval')` (PR [#7463](https://github.com/vatesfr/xen-orchestra/pull/7463))
 
 ### Packages to release
 

--- a/packages/xo-server/src/xapi-stats.mjs
+++ b/packages/xo-server/src/xapi-stats.mjs
@@ -412,7 +412,7 @@ export default class XapiStats {
 
     const srShortUUID = sr.uuid.slice(0, 8)
     return {
-      interval: hostsStats[Object.keys(hostsStats)[0]].interval,
+      interval: hostsStats[Object.keys(hostsStats)[0]]?.interval,
       endTimestamp: Math.max(...map(hostsStats, 'endTimestamp')),
       localTimestamp: Math.min(...map(hostsStats, 'localTimestamp')),
       stats: {


### PR DESCRIPTION
### Description

```
sr.stats
{
  "id": "0d3f7727-8bce-3b50-8fbb-e321a2071795",
  "granularity": "seconds"
}
{
  "message": "Cannot read properties of undefined (reading 'interval')",
  "name": "TypeError",
  "stack": "TypeError: Cannot read properties of undefined (reading 'interval')
    at XapiStats.getSrStats (file:///usr/local/lib/node_modules/xo-server/src/xapi-stats.mjs:396:56)
    at Api.#callApiMethod (file:///usr/local/lib/node_modules/xo-server/src/xo-mixins/api.mjs:366:20)"
}
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
