### PR TITLE
feat(xo-web/xo-server/VM): ability to attach PCIs to a VM

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,7 @@
 - [REST API] [Watch mode for the tasks collection](./packages/xo-server/docs/rest-api.md#all-tasks) (PR [#7565](https://github.com/vatesfr/xen-orchestra/pull/7565))
 - [Home/SR] Display _Pro Support_ status for XOSTOR SR (PR [#7601](https://github.com/vatesfr/xen-orchestra/pull/7601))
 - [Host/Advanced] Ability to `enable/disable` passthrough for PCIs [#7432](https://github.com/vatesfr/xen-orchestra/issues/7432) (PR [#7455](https://github.com/vatesfr/xen-orchestra/pull/7455))
+- [VM/Advanced] Ability to `attach/detach` PCIs to a VM [#7432](https://github.com/vatesfr/xen-orchestra/issues/7432) (PR [#7464](https://github.com/vatesfr/xen-orchestra/pull/7464))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -364,6 +364,7 @@ const TRANSFORMS = {
 
       addresses: normalizeVmNetworks(guestMetrics?.networks ?? {}),
       affinityHost: link(obj, 'affinity'),
+      attachedPcis: otherConfig.pci?.split(',')?.map(s => s.split('/')[1]),
       auto_poweron: otherConfig.auto_poweron === 'true',
       bios_strings: obj.bios_strings,
       blockedOperations: obj.blocked_operations,

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1029,11 +1029,8 @@ const messages = {
   // ----- host stat tab -----
   statLoad: 'Load average',
   // ----- host advanced tab -----
-<<<<<<< HEAD
   applyChangeOnPcis:
     'This operation will reboot the host in order to apply the change on the PCI{nPcis, plural, one {} other {s}}. Are you sure you want to continue?',
-=======
->>>>>>> 340668bbc (feat(xo-web/xo-server/VM): ability to attach PCIs to a VM)
   className: 'Class name',
   deviceName: 'Device name',
   enabled: 'Enabled',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -143,6 +143,7 @@ const messages = {
   addCustomField: 'Add custom field',
   advancedTagCreation: 'Advanced tag creation',
   availableXoaPremium: 'Available in XOA Premium',
+  detach: 'Detach',
   editCustomField: 'Edit custom field',
   deleteCustomField: 'Delete custom field',
   onlyAvailableXoaUsers: 'Only available to XOA users',
@@ -391,9 +392,11 @@ const messages = {
   selectSubjects: 'Choose user(s) and/or group(s)',
   selectObjects: 'Select object(s)…',
   selectRole: 'Choose a role',
+  selectHostFirst: 'Select a host first',
   selectHosts: 'Select host(s)…',
   selectHostsVms: 'Select object(s)…',
   selectNetworks: 'Select network(s)…',
+  selectPcis: 'Select PCI(s)…',
   selectPifs: 'Select PIF(s)…',
   selectPools: 'Select pool(s)…',
   selectRemotes: 'Select remote(s)…',
@@ -1026,8 +1029,11 @@ const messages = {
   // ----- host stat tab -----
   statLoad: 'Load average',
   // ----- host advanced tab -----
+<<<<<<< HEAD
   applyChangeOnPcis:
     'This operation will reboot the host in order to apply the change on the PCI{nPcis, plural, one {} other {s}}. Are you sure you want to continue?',
+=======
+>>>>>>> 340668bbc (feat(xo-web/xo-server/VM): ability to attach PCIs to a VM)
   className: 'Class name',
   deviceName: 'Device name',
   enabled: 'Enabled',
@@ -1428,10 +1434,15 @@ const messages = {
   logAction: 'Action',
 
   // ----- VM advanced tab -----
+  attachedPcis: 'Attached PCIs',
+  attachingDetachingPciNeedVmBoot: 'Attaching/detaching a PCI will be taken into consideration for the next VM boot.',
+  attachPcis: 'Attach PCIs',
   createVtpm: 'Create a VTPM',
   deleteVtpm: 'Delete the VTPM',
   deleteVtpmWarning:
     'If the VTPM is in use, removing it will result in a dangerous data loss. Are you sure you want to remove the VTPM?',
+  infoUnknownPciOnNonRunningVm:
+    "When a VM is offline, it's not attached to any host, and therefore, it's impossible to determine the associated PCI devices, as it depends on the hardware environment in which it would be deployed.",
   poolAutoPoweronDisabled: 'Auto power on is disabled at pool level, click to fix automatically.',
   vmRemoveButton: 'Remove',
   vmConvertToTemplateButton: 'Convert to template',

--- a/packages/xo-web/src/common/render-xo-item.js
+++ b/packages/xo-web/src/common/render-xo-item.js
@@ -546,6 +546,19 @@ User.defaultProps = {
 
 // ===================================================================
 
+export const Pci = decorate([
+  connectStore(() => ({
+    pci: createGetObject(),
+  })),
+  ({ pci }) => (
+    <span>
+      {pci.class_name} {pci.device_name} ({pci.pci_id})
+    </span>
+  ),
+])
+
+// ===================================================================
+
 const xoItemToRender = {
   // Subscription objects.
   cloudConfig: template => (
@@ -666,6 +679,8 @@ const xoItemToRender = {
       <NumericDate timestamp={backup.timestamp} />
     </span>
   ),
+
+  PCI: props => <Pci {...props} self />,
 }
 
 const renderXoItem = (item, { className, type: xoType, ...props } = {}) => {

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -1393,6 +1393,10 @@ export const isPciHidden = async pci => (await _call('pci.getDom0AccessStatus', 
 export const isPciPassthroughAvailable = host =>
   host.productBrand === 'XCP-ng' && semver.satisfies(host.version, '>=8.3.0')
 
+export const vmAttachPcis = (vm, pcis) => _call('vm.attachPcis', { id: resolveId(vm), pcis: resolveIds(pcis) })
+
+export const vmDetachPcis = (vm, pciIds) => _call('vm.detachPcis', { id: resolveId(vm), pciIds })
+
 // Containers --------------------------------------------------------
 
 export const pauseContainer = (vm, container) => _call('docker.pause', { vm: resolveId(vm), container })

--- a/packages/xo-web/src/xo-app/vm/pci-attach-modal.js
+++ b/packages/xo-web/src/xo-app/vm/pci-attach-modal.js
@@ -1,0 +1,82 @@
+import _ from 'intl'
+import Component from 'base-component'
+import React from 'react'
+import renderXoItem from 'render-xo-item'
+import Tooltip from 'tooltip'
+import { createSelector } from 'selectors'
+import { isPciHidden, isVmRunning } from 'xo'
+import { Select } from 'form'
+import { SelectHost } from 'select-objects'
+
+export default class PciAttachModal extends Component {
+  state = {
+    hiddenPcis: undefined,
+    host: isVmRunning(this.props.vm) ? this.props.vm.$container : undefined,
+    pcis: [],
+  }
+
+  get value() {
+    return this.state.pcis
+  }
+
+  async componentDidMount() {
+    this.setState({ hiddenPcis: await this.getHiddenPcis() })
+  }
+
+  async componentDidUpdate(prevProps, prevState) {
+    if (prevState.host !== this.state.host) {
+      this.setState({
+        pcis: [],
+        hiddenPcis: await this.getHiddenPcis(),
+      })
+    }
+  }
+
+  async getHiddenPcis() {
+    const host = this.state.host
+    if (host === undefined) {
+      return undefined
+    }
+    const hidden = []
+    await Promise.all(
+      this.props.pcisByHost[host].map(async pci => {
+        if (await isPciHidden(pci.id)) {
+          hidden.push(pci)
+        }
+      })
+    )
+    return hidden
+  }
+
+  onChangeHost = host => this.linkState('host')(host?.id)
+
+  _getHostPredicate = host => this.props.vm.$pool === host.$pool
+
+  _getPcis = createSelector(
+    () => this.state.hiddenPcis,
+    () => this.props.attachedPciIds,
+    (pcis, attachedPciIds) =>
+      pcis?.filter(pci => !attachedPciIds?.includes(pci.pci_id)).map(pci => ({ value: pci.id, ...pci })) // value property is needed for multi select
+  )
+
+  render() {
+    const isHostSelected = this.state.host !== undefined
+    return (
+      <div>
+        <SelectHost onChange={this.onChangeHost} predicate={this._getHostPredicate} value={this.state.host} />
+        <Tooltip content={isHostSelected ? undefined : _('selectHostFirst')}>
+          <Select
+            className='mt-1'
+            disabled={!isHostSelected}
+            multi
+            onChange={this.linkState('pcis')}
+            optionRenderer={renderXoItem}
+            options={this._getPcis()}
+            placeholder={_('selectPcis')}
+            value={this.state.pcis}
+          />
+        </Tooltip>
+      </div>
+    )
+  }
+}


### PR DESCRIPTION
### Screenshot

![Capture d’écran de 2024-03-12 16-55-03](https://github.com/vatesfr/xen-orchestra/assets/70369997/81329a36-f8d8-4068-ad85-32f4360c61a4)

### Description

Related to #7432 

Can be tested on 172.16.211.11

Rebase on `pci-api` to have PCI API methods

Wait for #7444 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
