### PR TITLE
fix(backups/healtchcheck): healthcheck must be run in task for mirror

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/FullRemote.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/FullRemote.mjs
@@ -1,5 +1,3 @@
-import { decorateMethodsWith } from '@vates/decorate-with'
-import { defer } from 'golike-defer'
 import { AbstractRemote } from './_AbstractRemote.mjs'
 import { FullRemoteWriter } from '../_writers/FullRemoteWriter.mjs'
 import { forkStreamUnpipe } from '../_forkStreamUnpipe.mjs'
@@ -10,15 +8,9 @@ export const FullRemote = class FullRemoteVmBackupRunner extends AbstractRemote 
   _getRemoteWriter() {
     return FullRemoteWriter
   }
-  async _run($defer) {
+  async _run() {
     const transferList = await this._computeTransferList(({ mode }) => mode === 'full')
 
-    await this._callWriters(async writer => {
-      await writer.beforeBackup()
-      $defer(async () => {
-        await writer.afterBackup()
-      })
-    }, 'writer.beforeBackup()')
     if (transferList.length > 0) {
       for (const metadata of transferList) {
         const stream = await this._sourceRemoteAdapter.readFullVmBackup(metadata)
@@ -46,7 +38,3 @@ export const FullRemote = class FullRemoteVmBackupRunner extends AbstractRemote 
     }
   }
 }
-
-decorateMethodsWith(FullRemote, {
-  _run: defer,
-})

--- a/@xen-orchestra/backups/_runners/_vmRunners/IncrementalRemote.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/IncrementalRemote.mjs
@@ -1,6 +1,4 @@
 import { asyncEach } from '@vates/async-each'
-import { decorateMethodsWith } from '@vates/decorate-with'
-import { defer } from 'golike-defer'
 import assert from 'node:assert'
 import * as UUID from 'uuid'
 import isVhdDifferencingDisk from 'vhd-lib/isVhdDifferencingDisk.js'
@@ -52,14 +50,8 @@ class IncrementalRemoteVmBackupRunner extends AbstractRemote {
     })
     // yeah , let's go
   }
-  async _run($defer) {
+  async _run() {
     const transferList = await this._computeTransferList(({ mode }) => mode === 'delta')
-    await this._callWriters(async writer => {
-      await writer.beforeBackup()
-      $defer(async () => {
-        await writer.afterBackup()
-      })
-    }, 'writer.beforeBackup()')
 
     if (transferList.length > 0) {
       for (const metadata of transferList) {
@@ -110,6 +102,3 @@ class IncrementalRemoteVmBackupRunner extends AbstractRemote {
 }
 
 export const IncrementalRemote = IncrementalRemoteVmBackupRunner
-decorateMethodsWith(IncrementalRemoteVmBackupRunner, {
-  _run: defer,
-})

--- a/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.mjs
@@ -100,7 +100,12 @@ export const MixinRemoteWriter = (BaseClass = Object) =>
               additionnalVmTag: 'xo:no-bak=Health Check',
             },
           }).run()
-          const restoredVm = xapi.getObject(restoredId)
+          let restoredVm
+          try {
+            restoredVm = xapi.getObject(restoredId)
+          } catch (err) {
+            restoredVm = await xapi.waitObject(restoredId)
+          }
           try {
             await new HealthCheckVmBackup({
               restoredVm,

--- a/@xen-orchestra/backups/_runners/_writers/_MixinXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/_MixinXapiWriter.mjs
@@ -38,8 +38,12 @@ export const MixinXapiWriter = (BaseClass = Object) =>
           const { $xapi: xapi } = sr
           let healthCheckVmRef
           try {
-            const baseVm = xapi.getObject(this._targetVmRef) ?? (await xapi.waitObject(this._targetVmRef))
-
+            let baseVm
+            try {
+              baseVm = xapi.getObject(this._targetVmRef)
+            } catch (err) {
+              baseVm = await xapi.waitObject(this._targetVmRef)
+            }
             if (await this.#isAlreadyOnHealthCheckSr(baseVm)) {
               healthCheckVmRef = await Task.run(
                 { name: 'cloning-vm' },

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
 - [VMWare/Migration] Alignment of the end of delta on older ESXi (PR [#7487](https://github.com/vatesfr/xen-orchestra/pull/7487))
 - [Backup] Fix `no object with uuid or opaqueref` when running a health check (PR [#7467](https://github.com/vatesfr/xen-orchestra/pull/7467))
 - [Backup] Fix `task has already ended` when running a health check in a mirror backup (PR [#7467](https://github.com/vatesfr/xen-orchestra/pull/7467))
+- [Backup] Fix health check being stuck when using a different, non shared health check SR (PR [#7467](https://github.com/vatesfr/xen-orchestra/pull/7467))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,8 @@
 
 - [VMWare/Migration] Alignment of the end of delta on older ESXi (PR [#7487](https://github.com/vatesfr/xen-orchestra/pull/7487))
 - [Backup] Fix `no object with uuid or opaqueref` when running a health check (PR [#7467](https://github.com/vatesfr/xen-orchestra/pull/7467))
+- [Backup] Fix `task has already ended` when running a health check in a mirror backup (PR [#7467](https://github.com/vatesfr/xen-orchestra/pull/7467))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [VMWare/Migration] Alignment of the end of delta on older ESXi (PR [#7487](https://github.com/vatesfr/xen-orchestra/pull/7487))
-
+- [Backup] Fix `no object with uuid or opaqueref` when running a health check (PR [#7467](https://github.com/vatesfr/xen-orchestra/pull/7467))
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -34,6 +34,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
 - @xen-orchestra/vmware-explorer minor
 - vhd-lib patch
 - xo-acl-resolver minor


### PR DESCRIPTION
**do not squash** 

the afterBackup writer function mark the task as done, healtcheck should be  inside the run

source :  https://help.vates.tech/#ticket/zoom/21282/88085

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
