### PR TITLE
fix(xen-api): various undici fixes

### DIFF
--- a/packages/xen-api/package.json
+++ b/packages/xen-api/package.json
@@ -46,7 +46,6 @@
     "minimist": "^1.2.0",
     "ms": "^2.1.1",
     "promise-toolbox": "^0.21.0",
-    "proxy-agent": "^6.3.1",
     "pw": "0.0.4",
     "undici": "^6.2.1",
     "xmlrpc-parser": "^1.0.3",

--- a/packages/xen-api/transports/json-rpc.mjs
+++ b/packages/xen-api/transports/json-rpc.mjs
@@ -1,25 +1,28 @@
 import { format, parse } from 'json-rpc-protocol'
+import { request } from 'undici'
 
 import XapiError from '../_XapiError.mjs'
 
 import UnsupportedTransport from './_UnsupportedTransport.mjs'
 
 // https://github.com/xenserver/xenadmin/blob/0df39a9d83cd82713f32d24704852a0fd57b8a64/XenModel/XenAPI/Session.cs#L403-L433
-export default ({ agent, client, url }) => {
+export default ({ dispatcher, url }) => {
   url = new URL('./jsonrpc', Object.assign(new URL('http://localhost'), url))
-  const path = url.pathname + url.search
 
   return async function (method, args) {
-    const res = await client.request({
+    const res = await request(url, {
+      dispatcher,
       body: format.request(0, method, args),
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
       },
       method: 'POST',
-      path,
-      agent,
     })
+
+    if ((res.statusCode / 100) | (0 !== 2)) {
+      throw new Error('unexpect statusCode ' + res.statusCode)
+    }
 
     // content-type is `text/xml` on old hosts where JSON-RPC is unsupported
     if (res.headers['content-type'] !== 'application/json') {

--- a/packages/xen-api/transports/json-rpc.mjs
+++ b/packages/xen-api/transports/json-rpc.mjs
@@ -20,7 +20,7 @@ export default ({ dispatcher, url }) => {
       method: 'POST',
     })
 
-    if ((res.statusCode / 100) | (0 !== 2)) {
+    if (((res.statusCode / 100) | 0) !== 2) {
       throw new Error('unexpect statusCode ' + res.statusCode)
     }
 

--- a/packages/xen-api/transports/xml-rpc.mjs
+++ b/packages/xen-api/transports/xml-rpc.mjs
@@ -37,7 +37,7 @@ export default ({ dispatcher, url }) => {
       method: 'POST',
     })
 
-    if ((res.statusCode / 100) | (0 !== 2)) {
+    if (((res.statusCode / 100) | 0) !== 2) {
       throw new Error('unexpect statusCode ' + res.statusCode)
     }
 


### PR DESCRIPTION
### Description

Fixes #7465

Introduced by bfb8d3b29

- don't use single Client as it allows a single parallel request by default
- fix HTTP proxy support (for all methods but `putResource()`
- follow redirects
- `getResource` respects configured protocol
- properly throws on non 2xx responses

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
