### PR TITLE
Display user auth tokens last datetime and IP address

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 - [App] Implement the initial PWA manifest for Xen Orchestra 5 (PR [#7462](https://github.com/vatesfr/xen-orchestra/pull/7462)).
 - [Pool/Advanced] Default SR can now also be configured from the pool's _Advanced_ tab [#7414](https://github.com/vatesfr/xen-orchestra/issues/7414) (PR [#7451](https://github.com/vatesfr/xen-orchestra/pull/7451))
 - [XOA/License] Ability to change the license assigned to an object already licensed (e.g. expired licenses) (PR [#7390](https://github.com/vatesfr/xen-orchestra/pull/7390))
+- [User] Show authentication tokens last use datetime and IP address (PR [#7479](https://github.com/vatesfr/xen-orchestra/pull/7479))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/authentication.mjs
+++ b/packages/xo-server/src/xo-mixins/authentication.mjs
@@ -63,7 +63,7 @@ export default class {
 
         const MAX_LAST_USE_ENTRIES = 10
         if (Object.keys(last_uses).length > MAX_LAST_USE_ENTRIES) {
-          const entries = Object.entries(last_uses).sort((a, b) => b[0].timestamp - a[0].timestamp)
+          const entries = Object.entries(last_uses).sort((a, b) => b[1].timestamp - a[1].timestamp)
           entries.length = MAX_LAST_USE_ENTRIES
           last_uses = Object.fromEntries(entries)
         }

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -6,7 +6,6 @@ const forEach = require('lodash/forEach')
 const messages = {
   alpha: 'Alpha',
   alerts: 'Alerts',
-  creation: 'Creation',
   connected: 'Connected',
   description: 'Description',
   deleteSourceVm: 'Delete source VM',
@@ -2269,6 +2268,7 @@ const messages = {
   // ----- User -----
   authToken: 'Token',
   authTokens: 'Authentication tokens',
+  authTokenLastUse: 'Last use',
   username: 'Username',
   password: 'Password',
   language: 'Language',

--- a/packages/xo-web/src/xo-app/user/index.js
+++ b/packages/xo-web/src/xo-app/user/index.js
@@ -384,14 +384,18 @@ const COLUMNS_AUTH_TOKENS = [
     sortCriteria: 'description',
   },
   {
-    itemRenderer: ({ created_at }) => {
-      if (created_at !== undefined) {
-        return <NumericDate timestamp={created_at} />
+    itemRenderer: ({ last_use_ip, last_uses }) => {
+      if (last_use_ip !== undefined) {
+        return (
+          <span>
+            <NumericDate timestamp={last_uses[last_use_ip].timestamp} /> by <code>{last_use_ip}</code>
+          </span>
+        )
       }
       return _('notDefined')
     },
-    name: _('creation'),
-    sortCriteria: 'created_at',
+    name: _('authTokenLastUse'),
+    sortCriteria: ({ last_use_ip, last_uses }) => last_use_ip && last_uses[last_use_ip].timestamp,
   },
   {
     default: true,
@@ -420,7 +424,34 @@ const GROUPED_ACTIONS_AUTH_TOKENS = [
 ]
 
 const UserAuthTokens = addSubscriptions({
-  userAuthTokens: subscribeUserAuthTokens,
+  userAuthTokens: cb =>
+    subscribeUserAuthTokens(tokens => {
+      cb(
+        tokens.map(token => {
+          // find and inject last_use_ip from last_uses dictionnary
+          const { last_uses } = token
+          if (last_uses !== undefined) {
+            const ips = Object.keys(last_uses)
+            const n = ips.length
+            if (n !== 0) {
+              let lastIp = ips[0]
+              let lastTimestamp = last_uses[lastIp].timestamp
+              for (let i = 1; i < n; ++i) {
+                const ip = ips[i]
+                const { timestamp } = last_uses[ip]
+                if (timestamp > lastTimestamp) {
+                  lastIp = ip
+                  lastTimestamp = timestamp
+                }
+              }
+              return { ...token, last_use_ip: lastIp }
+            }
+          }
+
+          return token
+        })
+      )
+    }),
 })(({ userAuthTokens }) => (
   <div>
     <Card>


### PR DESCRIPTION
**DO NOT SQUASH**, [review by commit](https://github.com/vatesfr/xen-orchestra/pull/7479/commits).

### Description

More important than when a token has been created is when and by how it was used last.

![image](https://github.com/vatesfr/xen-orchestra/assets/298721/5bde196b-6725-4552-a0ce-c5115616fb16)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
