### PR TITLE
feat(lite): disable navigation to WiP views via tabs

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## **next**
 
 - Fix duplicate consoles after failed connection (PR [#7505](https://github.com/vatesfr/xen-orchestra/pull/7505))
+- [Tabs] Disable navigation to in-progress views (PR [7482](https://github.com/vatesfr/xen-orchestra/pull/7482))
 
 ## **0.2.0** (2024-02-29)
 

--- a/@xen-orchestra/lite/src/components/RouterTab.vue
+++ b/@xen-orchestra/lite/src/components/RouterTab.vue
@@ -17,13 +17,8 @@ import { useContext } from '@core/composables/context.composable'
 import { DisabledContext } from '@core/context'
 import type { RouteLocationRaw } from 'vue-router'
 
-const props = withDefaults(
-  defineProps<{
-    to: RouteLocationRaw
-    disabled?: boolean
-  }>(),
-  { disabled: undefined }
-)
-
-const isDisabled = useContext(DisabledContext, () => props.disabled)
+defineProps<{
+  to: RouteLocationRaw
+  disabled?: boolean
+}>()
 </script>

--- a/@xen-orchestra/lite/src/components/RouterTab.vue
+++ b/@xen-orchestra/lite/src/components/RouterTab.vue
@@ -17,8 +17,13 @@ import { useContext } from '@core/composables/context.composable'
 import { DisabledContext } from '@core/context'
 import type { RouteLocationRaw } from 'vue-router'
 
-defineProps<{
-  to: RouteLocationRaw
-  disabled?: boolean
-}>()
+const props = withDefaults(
+  defineProps<{
+    to: RouteLocationRaw
+    disabled?: boolean
+  }>(),
+  { disabled: undefined }
+)
+
+const isDisabled = useContext(DisabledContext, () => props.disabled)
 </script>

--- a/@xen-orchestra/lite/src/components/pool/PoolTabBar.vue
+++ b/@xen-orchestra/lite/src/components/pool/PoolTabBar.vue
@@ -3,25 +3,25 @@
     <RouterTab :to="{ name: 'pool.dashboard', params: { uuid: pool?.uuid } }">
       {{ $t('dashboard') }}
     </RouterTab>
-    <RouterTab :to="{ name: 'pool.alarms', params: { uuid: pool?.uuid } }">
+    <RouterTab :to="{ name: 'pool.alarms', params: { uuid: pool?.uuid } }" disabled>
       {{ $t('alarms') }}
     </RouterTab>
-    <RouterTab :to="{ name: 'pool.stats', params: { uuid: pool?.uuid } }">
+    <RouterTab :to="{ name: 'pool.stats', params: { uuid: pool?.uuid } }" disabled>
       {{ $t('stats') }}
     </RouterTab>
-    <RouterTab :to="{ name: 'pool.system', params: { uuid: pool?.uuid } }">
+    <RouterTab :to="{ name: 'pool.system', params: { uuid: pool?.uuid } }" disabled>
       {{ $t('system') }}
     </RouterTab>
-    <RouterTab :to="{ name: 'pool.network', params: { uuid: pool?.uuid } }">
+    <RouterTab :to="{ name: 'pool.network', params: { uuid: pool?.uuid } }" disabled>
       {{ $t('network') }}
     </RouterTab>
-    <RouterTab :to="{ name: 'pool.storage', params: { uuid: pool?.uuid } }">
+    <RouterTab :to="{ name: 'pool.storage', params: { uuid: pool?.uuid } }" disabled>
       {{ $t('storage') }}
     </RouterTab>
     <RouterTab :to="{ name: 'pool.tasks', params: { uuid: pool?.uuid } }">
       {{ $t('tasks') }}
     </RouterTab>
-    <RouterTab :to="{ name: 'pool.hosts', params: { uuid: pool?.uuid } }">
+    <RouterTab :to="{ name: 'pool.hosts', params: { uuid: pool?.uuid } }" disabled>
       {{ $t('hosts') }}
     </RouterTab>
     <RouterTab :to="{ name: 'pool.vms', params: { uuid: pool?.uuid } }">

--- a/@xen-orchestra/lite/src/components/vm/VmTabBar.vue
+++ b/@xen-orchestra/lite/src/components/vm/VmTabBar.vue
@@ -1,6 +1,6 @@
 <template>
   <TabList>
-    <RouterTab :to="{ name: 'vm.dashboard', params: { uuid } }">
+    <RouterTab :to="{ name: 'vm.dashboard', params: { uuid } }" disabled>
       {{ $t('dashboard') }}
     </RouterTab>
     <RouterTab :to="{ name: 'vm.console', params: { uuid } }">

--- a/@xen-orchestra/lite/src/components/vm/VmTabBar.vue
+++ b/@xen-orchestra/lite/src/components/vm/VmTabBar.vue
@@ -6,22 +6,22 @@
     <RouterTab :to="{ name: 'vm.console', params: { uuid } }">
       {{ $t('console') }}
     </RouterTab>
-    <RouterTab :to="{ name: 'vm.alarms', params: { uuid } }">
+    <RouterTab :to="{ name: 'vm.alarms', params: { uuid } }" disabled>
       {{ $t('alarms') }}
     </RouterTab>
-    <RouterTab :to="{ name: 'vm.stats', params: { uuid } }">
+    <RouterTab :to="{ name: 'vm.stats', params: { uuid } }" disabled>
       {{ $t('stats') }}
     </RouterTab>
-    <RouterTab :to="{ name: 'vm.system', params: { uuid } }">
+    <RouterTab :to="{ name: 'vm.system', params: { uuid } }" disabled>
       {{ $t('system') }}
     </RouterTab>
-    <RouterTab :to="{ name: 'vm.network', params: { uuid } }">
+    <RouterTab :to="{ name: 'vm.network', params: { uuid } }" disabled>
       {{ $t('network') }}
     </RouterTab>
-    <RouterTab :to="{ name: 'vm.storage', params: { uuid } }">
+    <RouterTab :to="{ name: 'vm.storage', params: { uuid } }" disabled>
       {{ $t('storage') }}
     </RouterTab>
-    <RouterTab :to="{ name: 'vm.tasks', params: { uuid } }">
+    <RouterTab :to="{ name: 'vm.tasks', params: { uuid } }" disabled>
       {{ $t('tasks') }}
     </RouterTab>
   </TabList>


### PR DESCRIPTION
### Description

Disable navigation to in-progress views via tabs

### Screenshots

![image](https://github.com/vatesfr/xen-orchestra/assets/66562640/9fdee5ef-3410-432d-b43f-7a8c580a59cc)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
