### PR TITLE
fix(xo-server): USB_group has multiple PSUBs/VUSBs

### DIFF
--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -931,8 +931,8 @@ const TRANSFORMS = {
     return {
       type: 'USB_group',
 
-      PUSB: link(obj, 'PUSBs'),
-      VUSB: link(obj, 'VUSBs'),
+      PUSBs: link(obj, 'PUSBs'),
+      VUSBs: link(obj, 'VUSBs'),
     }
   },
 }

--- a/packages/xo-web/src/xo-app/vm/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/vm/tab-advanced.js
@@ -468,8 +468,8 @@ const NIC_TYPE_OPTIONS = [
     .pick(
       createSelector(createGetObjectsOfType('USB_group'), usbGroups =>
         map(
-          filter(usbGroups, usbGroup => usbGroup.VUSB[0] === undefined),
-          usbGroup => usbGroup.PUSB
+          filter(usbGroups, usbGroup => usbGroup.VUSBs[0] === undefined),
+          usbGroup => usbGroup.PUSBs
         )
       )
     )


### PR DESCRIPTION
### Description

Multiple objects, the fields name should be plural.

Introduced by 73ad9c1e7

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
