### PR TITLE
refactor(vmware-explorer): allow the use of remote as datastore

### DIFF
--- a/@xen-orchestra/vmware-explorer/DatastoreSoapEsxi.mjs
+++ b/@xen-orchestra/vmware-explorer/DatastoreSoapEsxi.mjs
@@ -1,0 +1,22 @@
+import { Datastore } from './_Datastore.mjs'
+
+export class DatastoreSoapEsxi extends Datastore {
+  #esxi
+  constructor(datastoreName, { esxi, ...otherOptions } = {}) {
+    super(datastoreName, otherOptions)
+    this.#esxi = esxi
+  }
+  async getStream(path, start, end) {
+    const res = await this.#esxi.download(this.datastoreName, path, start || end ? `${start}-${end}` : undefined)
+    return res.body
+  }
+  async getBuffer(path, start, end) {
+    return (
+      await this.#esxi.download(this.datastoreName, path, start || end ? `${start}-${end - 1}` : undefined)
+    ).buffer()
+  }
+  async getSize(path) {
+    const res = await this.#esxi.download(this.datastoreName, path)
+    return Number(res.headers.get('content-length'))
+  }
+}

--- a/@xen-orchestra/vmware-explorer/DatastoreXoRemote.mjs
+++ b/@xen-orchestra/vmware-explorer/DatastoreXoRemote.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert'
+import { Datastore } from './_Datastore.mjs'
+
+export const DatastoreXoRemote = class DatastoreXoRemote extends Datastore {
+  #handler
+  constructor(datastoreName, { handler, ...otherOptions }) {
+    super(datastoreName, otherOptions)
+    this.#handler = handler
+  }
+  async getStream(path, start, end) {
+    return this.#handler.createReadStream(path, { start, end })
+  }
+  async getBuffer(path, start, end) {
+    const buffer = Buffer.alloc(end - start)
+    const { bytesRead } = await this.#handler.read(path, buffer, start)
+    assert.strictEqual(bytesRead, end - start)
+    return buffer
+  }
+  async getSize(path) {
+    return this.#handler.getSize(path)
+  }
+}

--- a/@xen-orchestra/vmware-explorer/VhdEsxiCowd.mjs
+++ b/@xen-orchestra/vmware-explorer/VhdEsxiCowd.mjs
@@ -4,9 +4,9 @@ import { FOOTER_SIZE } from 'vhd-lib/_constants.js'
 import { notEqual, strictEqual } from 'node:assert'
 import { unpackFooter, unpackHeader } from 'vhd-lib/Vhd/_utils.js'
 import { VhdAbstract } from 'vhd-lib'
+import { openDatastore } from './_openDatastore.mjs'
 
 export default class VhdEsxiCowd extends VhdAbstract {
-  #esxi
   #datastore
   #parentVhd
   #path
@@ -17,14 +17,14 @@ export default class VhdEsxiCowd extends VhdAbstract {
 
   #grainDirectory
 
-  static async open(esxi, datastore, path, parentVhd, opts) {
-    const vhd = new VhdEsxiCowd(esxi, datastore, path, parentVhd, opts)
+  static async open(datastoreName, path, parentVhd, opts) {
+    const datastore = openDatastore(datastoreName, opts)
+    const vhd = new VhdEsxiCowd(datastore, path, parentVhd, opts)
     await vhd.readHeaderAndFooter()
     return vhd
   }
-  constructor(esxi, datastore, path, parentVhd, { lookMissingBlockInParent = true } = {}) {
+  constructor(datastore, path, parentVhd, { lookMissingBlockInParent = true } = {}) {
     super()
-    this.#esxi = esxi
     this.#path = path
     this.#datastore = datastore
     this.#parentVhd = parentVhd
@@ -54,7 +54,7 @@ export default class VhdEsxiCowd extends VhdAbstract {
   }
 
   async #read(start, length) {
-    return (await this.#esxi.download(this.#datastore, this.#path, `${start}-${start + length - 1}`)).buffer()
+    return this.#datastore.getBuffer(this.#path, start, start + length)
   }
 
   async readHeaderAndFooter() {

--- a/@xen-orchestra/vmware-explorer/VhdEsxiCowd.mjs
+++ b/@xen-orchestra/vmware-explorer/VhdEsxiCowd.mjs
@@ -74,11 +74,9 @@ export default class VhdEsxiCowd extends VhdAbstract {
     // a grain directory entry contains the address of a grain table
     // a grain table can adresses at most 4096 grain of 512 Bytes of data
     this.#header = unpackHeader(createHeader(Math.ceil(size / (4096 * 512))))
-
     const geometry = _computeGeometryForSize(size)
-    const actualSize = geometry.actualSize
     this.#footer = unpackFooter(
-      createFooter(actualSize, Math.floor(Date.now() / 1000), geometry, FOOTER_SIZE, this.#parentVhd.footer.diskType)
+      createFooter(size, Math.floor(Date.now() / 1000), geometry, FOOTER_SIZE, this.#parentVhd.footer.diskType)
     )
   }
 

--- a/@xen-orchestra/vmware-explorer/_Datastore.mjs
+++ b/@xen-orchestra/vmware-explorer/_Datastore.mjs
@@ -1,0 +1,17 @@
+export class Datastore {
+  #datastoreName
+
+  get datastoreName() {
+    return this.#datastoreName
+  }
+  constructor(dataStoreName) {
+    this.#datastoreName = dataStoreName
+  }
+  async getStream(path, start, end) {
+    throw new Error('Not implemented')
+  }
+  async getBuffer(path, start, end) {
+    throw new Error('Not implemented')
+  }
+  async getSize(path) {}
+}

--- a/@xen-orchestra/vmware-explorer/_openDatastore.mjs
+++ b/@xen-orchestra/vmware-explorer/_openDatastore.mjs
@@ -1,0 +1,10 @@
+import { DatastoreSoapEsxi } from './DatastoreSoapEsxi.mjs'
+import { DatastoreXoRemote } from './DatastoreXoRemote.mjs'
+
+export function openDatastore(dataStoreName, { esxi, remotes = {}, ...otherOptions }) {
+  const handler = remotes[dataStoreName]
+  if (handler === undefined) {
+    return new DatastoreSoapEsxi(dataStoreName, { esxi, ...otherOptions })
+  }
+  return new DatastoreXoRemote(dataStoreName, { handler, ...otherOptions })
+}

--- a/@xen-orchestra/vmware-explorer/_openDatastore.mjs
+++ b/@xen-orchestra/vmware-explorer/_openDatastore.mjs
@@ -1,10 +1,21 @@
 import { DatastoreSoapEsxi } from './DatastoreSoapEsxi.mjs'
 import { DatastoreXoRemote } from './DatastoreXoRemote.mjs'
+import { createLogger } from '@xen-orchestra/log'
+
+const { info } = createLogger('xo:vmware-explorer:openDatastore')
 
 export function openDatastore(dataStoreName, { esxi, dataStoreToHandlers = {}, ...otherOptions }) {
   const handler = dataStoreToHandlers[dataStoreName]
   if (handler === undefined) {
+    info(`use SOAP API to read datastore ${dataStoreName}`, {
+      dataStoreName,
+      dataStoreToHandlers: Object.keys(dataStoreToHandlers),
+    })
     return new DatastoreSoapEsxi(dataStoreName, { esxi, ...otherOptions })
   }
+  info(`use XO remote to read  datastore ${dataStoreName}`, {
+    dataStoreName,
+    dataStoreToHandlers: Object.keys(dataStoreToHandlers),
+  })
   return new DatastoreXoRemote(dataStoreName, { handler, ...otherOptions })
 }

--- a/@xen-orchestra/vmware-explorer/_openDatastore.mjs
+++ b/@xen-orchestra/vmware-explorer/_openDatastore.mjs
@@ -1,8 +1,8 @@
 import { DatastoreSoapEsxi } from './DatastoreSoapEsxi.mjs'
 import { DatastoreXoRemote } from './DatastoreXoRemote.mjs'
 
-export function openDatastore(dataStoreName, { esxi, remotes = {}, ...otherOptions }) {
-  const handler = remotes[dataStoreName]
+export function openDatastore(dataStoreName, { esxi, dataStoreToHandlers = {}, ...otherOptions }) {
+  const handler = dataStoreToHandlers[dataStoreName]
   if (handler === undefined) {
     return new DatastoreSoapEsxi(dataStoreName, { esxi, ...otherOptions })
   }

--- a/@xen-orchestra/vmware-explorer/openDeltaVmdkAsVhd.mjs
+++ b/@xen-orchestra/vmware-explorer/openDeltaVmdkAsVhd.mjs
@@ -1,13 +1,15 @@
 import VHDEsxiSeSparse from './VhdEsxiSeSparse.mjs'
 import VhdEsxiCowd from './VhdEsxiCowd.mjs'
+import { openDatastore } from './_openDatastore.mjs'
 
-export default async function openDeltaVmdkasVhd(esxi, datastore, path, parentVhd, opts) {
+export default async function openDeltaVmdkasVhd(datastoreName, path, parentVhd, opts) {
   let vhd
+  const datastore = openDatastore(datastoreName, opts)
   if (path.endsWith('-sesparse.vmdk')) {
-    vhd = new VHDEsxiSeSparse(esxi, datastore, path, parentVhd, opts)
+    vhd = new VHDEsxiSeSparse(datastore, path, parentVhd, opts)
   } else {
     if (path.endsWith('-delta.vmdk')) {
-      vhd = new VhdEsxiCowd(esxi, datastore, path, parentVhd, opts)
+      vhd = new VhdEsxiCowd(datastore, path, parentVhd, opts)
     } else {
       throw new Error(`Vmdk ${path} does not seems to be a delta vmdk.`)
     }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [VMWare/Migration] Make one pass for the cold base disk and snapshots (PR [#7487](https://github.com/vatesfr/xen-orchestra/pull/7487))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -29,7 +31,7 @@
 
 <!--packages-start-->
 
-- @xen-orchestra/vmware-explorer patch
+- @xen-orchestra/vmware-explorer minor
 - vhd-lib patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [VMWare/Migration] Alignment of the end of delta on older ESXi (PR [#7487](https://github.com/vatesfr/xen-orchestra/pull/7487))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -27,6 +29,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/vmware-explorer patch
 - vhd-lib patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,6 +8,7 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - [VMWare/Migration] Make one pass for the cold base disk and snapshots (PR [#7487](https://github.com/vatesfr/xen-orchestra/pull/7487))
+- [VMWare/Migration] Use NFS datastore from XO Remote to bypass VMFS6 lock (PR [#7487](https://github.com/vatesfr/xen-orchestra/pull/7487))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/migrate-vm.mjs
+++ b/packages/xo-server/src/xo-mixins/migrate-vm.mjs
@@ -171,7 +171,7 @@ export default class MigrateVm {
   @decorateWith(deferrable)
   async migrationfromEsxi(
     $defer,
-    { host, user, password, sslVerify, sr: srId, network: networkId, vm: vmId, stopSource, dataStoreToRemotes }
+    { host, user, password, sslVerify, sr: srId, network: networkId, vm: vmId, stopSource, dataStoreToHandlers }
   ) {
     const app = this._app
     const esxi = await this.#connectToEsxi(host, user, password, sslVerify)
@@ -253,13 +253,13 @@ export default class MigrateVm {
               vhd = await VhdEsxiRaw.open(datastoreName, path + '/' + fileName, {
                 thin: false,
                 esxi,
-                remotes: dataStoreToRemotes,
+                dataStoreToHandlers,
               })
             } else {
               vhd = await openDeltaVmdkasVhd(datastoreName, path + '/' + fileName, parentVhd, {
                 lookMissingBlockInParent: true,
                 esxi,
-                remotes: dataStoreToRemotes,
+                dataStoreToHandlers,
               })
             }
             vhd.label = fileName
@@ -309,7 +309,7 @@ export default class MigrateVm {
               vhd = await VhdEsxiRaw.open(datastoreName, path + '/' + fileName, {
                 thin: false,
                 esxi,
-                remotes: dataStoreToRemotes,
+                dataStoreToHandlers,
               })
               // we don't need to read the BAT with the importVdiThroughXva process
               const vdiMetadata = {
@@ -335,7 +335,7 @@ export default class MigrateVm {
               vhd = await openDeltaVmdkasVhd(datastoreName, path + '/' + fileName, parentVhd, {
                 lookMissingBlockInParent: false,
                 esxi,
-                remotes: dataStoreToRemotes,
+                dataStoreToHandlers,
               })
             }
             const stream = vhd.stream()


### PR DESCRIPTION
### Description

**Review by commit, do not squash first two commits**

Soap access to recent esxi/vsphere lock the full raw and delta chain. To bypass this : 
- Migrate VM to NFS on VMWare side
- mount NFS in XO , named [VMWARE]{datastoreName}
- launch import and it will read through the direct NFS instead of using the soap access layer, bypassing the locks

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
