### PR TITLE
fix(xo-web/kubernetes): remove `-00` suffix on version

### DIFF
--- a/packages/xo-web/src/xo-app/hub/recipes/recipe-form.js
+++ b/packages/xo-web/src/xo-app/hub/recipes/recipe-form.js
@@ -146,7 +146,7 @@ export default decorate([
             .filter(version => !version.prerelease)
             .map(({ tag_name }) => ({
               label: tag_name,
-              value: tag_name.slice(1) + '-00', // Add this suffix to the version number to respect the required format for installation
+              value: tag_name.slice(1)
             }))
           return versionList
         } else {


### PR DESCRIPTION
### Description

To merge alongside https://git.vates.tech/vates/xoa/pulls/196

This is a change to remove the addition of `-00` that was used to reference packages installed via APT. 

1.  The [new apt repository](https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/) version number do not even match this convention anymore
2. We do not install kubernetes packages with apt anymore, we install the binairies directly. The package versions number listed in Github are an exact match of the various binairies version we want to install