### PR TITLE
fix(xo-server/xostor): fix group-name for thick provisioning

### DIFF
--- a/packages/xo-server/src/api/xostor.mjs
+++ b/packages/xo-server/src/api/xostor.mjs
@@ -217,7 +217,7 @@ export const create = defer(async function (
     const srUuid = await Task.run({ properties: { name: 'creation of the storage' } }, async () => {
       const srRef = await xapi.SR_create({
         device_config: {
-          'group-name': 'linstor_group/' + LV_NAME,
+          'group-name': `linstor_group${provisioning === ENUM_PROVISIONING.Thin ? `/${LV_NAME}` : ''}`,
           redundancy: String(replication),
           provisioning,
         },


### PR DESCRIPTION
### Description

For thick provisioning, group-name must be `linstor_group`

Introduced by 2ff45c6

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
