### PR TITLE
fix(lite/console): prevent duplicate consoles on error

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## **next**
 
+- Fix duplicate consoles after failed connection (PR [#7505](https://github.com/vatesfr/xen-orchestra/pull/7505))
+
 ## **0.2.0** (2024-02-29)
 
 - Fix Typescript typings errors when running `yarn type-check` command (PR [#7278](https://github.com/vatesfr/xen-orchestra/pull/7278))

--- a/@xen-orchestra/lite/src/components/RemoteConsole.vue
+++ b/@xen-orchestra/lite/src/components/RemoteConsole.vue
@@ -71,6 +71,11 @@ const clearVncClient = () => {
 const createVncConnection = async () => {
   if (nConnectionAttempts !== 0) {
     await promiseTimeout(FIBONACCI_MS_ARRAY[nConnectionAttempts - 1])
+
+    if (vncClient !== undefined) {
+      // New VNC Client may have been created in the meanwhile
+      return
+    }
   }
 
   vncClient = new VncClient(vmConsoleContainer.value!, url.value!.toString(), {

--- a/@xen-orchestra/lite/src/components/RemoteConsole.vue
+++ b/@xen-orchestra/lite/src/components/RemoteConsole.vue
@@ -73,7 +73,7 @@ const createVncConnection = async () => {
     await promiseTimeout(FIBONACCI_MS_ARRAY[nConnectionAttempts - 1])
 
     if (vncClient !== undefined) {
-      // New VNC Client may have been created in the meanwhile
+      // New VNC Client may have been created in the meantime
       return
     }
   }


### PR DESCRIPTION
### Description

When a console connection fails, we wait before trying again. While waiting, the user may open another console, which creates a new VNC Client, and renders the console. Therefore, when we're done waiting, we must first check that `vncClient` is `undefined` so that we don't create 2 instances of `VncClient`.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
