### PR TITLE
fix(xen-api/putResource): fix proxy and HTTPS support

### DIFF
--- a/packages/xen-api/index.mjs
+++ b/packages/xen-api/index.mjs
@@ -13,6 +13,7 @@ import { Index } from 'xo-collection/index.js'
 import { cancelable, defer, fromCallback, ignoreErrors, pDelay, pRetry, pTimeout } from 'promise-toolbox'
 import { limitConcurrency } from 'limit-concurrency-decorator'
 import { decorateClass } from '@vates/decorate-with'
+import { ProxyAgent as HttpProxyAgent } from 'proxy-agent'
 
 import debug from './_debug.mjs'
 import getTaskResult from './_getTaskResult.mjs'
@@ -135,6 +136,7 @@ export class Xapi extends EventEmitter {
     }
 
     const { httpProxy } = opts
+    this._allowUnauthorized = opts.allowUnauthorized
     const dispatcherOpts = {
       maxRedirections: 3,
     }
@@ -143,6 +145,11 @@ export class Xapi extends EventEmitter {
       rejectUnauthorized: !opts.allowUnauthorized,
     }
     if (httpProxy !== undefined) {
+      this._httpAgent = new HttpProxyAgent({
+        getProxyForUrl: () => httpProxy,
+        rejectUnauthorized: !opts.allowUnauthorized,
+      })
+
       const uri = new URL(httpProxy)
       const token = 'Basic ' + Buffer.from(`${uri.username}:${uri.password}`).toString('base64')
       this._undiciDispatcher = new ProxyAgent({
@@ -509,6 +516,7 @@ export class Xapi extends EventEmitter {
 
     const doRequest = (url, opts) =>
       httpRequest(url, {
+        agent: this._httpAgent,
         body,
         headers,
         method: 'PUT',

--- a/packages/xen-api/package.json
+++ b/packages/xen-api/package.json
@@ -45,6 +45,7 @@
     "make-error": "^1.3.0",
     "minimist": "^1.2.0",
     "ms": "^2.1.1",
+    "proxy-agent": "^6.3.1",
     "promise-toolbox": "^0.21.0",
     "pw": "0.0.4",
     "undici": "^6.2.1",


### PR DESCRIPTION
### Description

Fixes #7477 #7490 #7496 #7499 #7502 #7507

Introduced by 6c16055a1

`putResource()` is not using `undici` for the moment because it needs work to make it work with the work-around for chunked encoding not supported in XAPI.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
