### PR TITLE
fix(xo-web/host/advanced): handle getSmartctlHealth error

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [REST API] Fix download of host's audit and logs broken in XO 5.93.0
+- [Host/Advanced] Fix _Hyper Threading_ not correctly recognized if _Smartctl_ plugin returned an error
 
 ### Packages to release
 
@@ -30,5 +31,6 @@
 <!--packages-start-->
 
 - xo-server patch
+- xo-web patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [REST API] Fix download of host's audit and logs broken in XO 5.93.0
-- [Host/Advanced] Fix _Hyper Threading_ not correctly recognized if _Smartctl_ plugin returned an error
+- [Host/Advanced] Fix _Hyper Threading_ not correctly recognized if _Smartctl_ plugin returned an error (PR [#7525](https://github.com/vatesfr/xen-orchestra/pull/7525))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 
 - [REST API] Fix download of host's audit and logs broken in XO 5.93.0
 - [VM] Fix `unknown error` on export (broken in XO 5.93.0)
-- [Host/Advanced] Fix _Hyper Threading_ not correctly recognized if _Smartctl_ plugin returned an error (PR [#7525](https://github.com/vatesfr/xen-orchestra/pull/7525))
+- [Host/Advanced] Fix _Hyper Threading_ not correctly recognized if _Smartctl_ plugin returned an error [Forum#8675](https://xcp-ng.org/forum/topic/8675/ht-smt-detection-in-8-3-not-fully-working) (PR [#7525](https://github.com/vatesfr/xen-orchestra/pull/7525))
 
 ### Packages to release
 

--- a/packages/xo-web/src/xo-app/host/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/host/tab-advanced.js
@@ -208,8 +208,8 @@ export default class extends Component {
       })
     }
 
-    const smartctlHealth = await getSmartctlHealth(host)
-    const isSmartctlHealthEnabled = smartctlHealth !== null
+    const smartctlHealth = await getSmartctlHealth(host).catch(console.error)
+    const isSmartctlHealthEnabled = smartctlHealth != null
     const smartctlUnhealthyDevices = isSmartctlHealthEnabled
       ? Object.keys(smartctlHealth).filter(deviceName => smartctlHealth[deviceName] !== 'PASSED')
       : undefined


### PR DESCRIPTION
### Description

Fixes [Forum#8675](https://xcp-ng.org/forum/topic/8675/ht-smt-detection-in-8-3-not-fully-working/10)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
