### PR TITLE
feat(web-core/tree): enhance tree library

### DIFF
--- a/@xen-orchestra/web-core/docs/composables/tree.composable.md
+++ b/@xen-orchestra/web-core/docs/composables/tree.composable.md
@@ -38,12 +38,14 @@ This option allows you to customize the label of the selected nodes.
 
 ## `useTree` return values
 
-|                 | Type                                       |                                                                                |
-| --------------- | ------------------------------------------ | ------------------------------------------------------------------------------ |
-| `nodes`         | `(Leaf \| Branch)[]`                       | Array of visible `Leaf` and `Branch` instances (See TreeNode Visibility below) |
-| `activeNode`    | `ComputedRef<Leaf \| Branch \| undefined>` | The active node instance                                                       |
-| `selectedNodes` | `ComputedRef<(Leaf \| Branch)[]>`          | Array of selected node instances                                               |
-| `selectedLabel` | `ComputedRef<string>`                      | The generator label for the selected nodes                                     |
+|                 | Type                                       |                                                                                    |
+| --------------- | ------------------------------------------ | ---------------------------------------------------------------------------------- |
+| `nodes`         | `(Leaf \| Branch)[]`                       | Array of **visible** `Leaf` and `Branch` instances (See TreeNode Visibility below) |
+| `activeId`      | `Ref<string \| number \| undefined>`       | The active node id                                                                 |
+| `activeNode`    | `ComputedRef<Leaf \| Branch \| undefined>` | The active node instance                                                           |
+| `selectedIds`   | `Ref<(string \| number)[]>`                | Array of selected nodes id                                                         |
+| `selectedNodes` | `ComputedRef<(Leaf \| Branch)[]>`          | Array of selected nodes instance                                                   |
+| `selectedLabel` | `ComputedRef<string>`                      | The generator label for the selected nodes                                         |
 
 ## `LeafDefinition`
 
@@ -52,14 +54,14 @@ new LeafDefinition(data)
 new LeafDefinition(data, options)
 ```
 
-|                         |     Required     | Type                                         | Default     |                                                                                        |
-| ----------------------- | :--------------: | -------------------------------------------- | ----------- | -------------------------------------------------------------------------------------- |
-| `data`                  |        ✓         | `T`                                          |             | data to be stored in the node                                                          |
-| `options.discriminator` |                  | `string`                                     | `undefined` | discriminator for the node when you mix different data types (see Discriminator below) |
-| `options.predicate`     |                  | `(data: T) => boolean \| undefined`          | `undefined` | filter function (see Filtering below)                                                  |
-| `options.activable`     |                  | `boolean`                                    | `true`      | whether the node can be activated                                                      |
-| `options.getId`         |  if no `T[id]`   | `keyof T` \| `(data: T) => string \| number` | `id`        | field or function to get a unique identifier for the node                              |
-| `options.getLabel`      | if no `T[label]` | `keyof T` \| `(data: T) => string`           | `label`     | field or function to get a label for the node                                          |
+|                         |       Required       | Type                                                 | Default                                 |                                                                                        |
+| ----------------------- | :------------------: | ---------------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------- |
+| `data`                  |          ✓           | `TData`                                              |                                         | data to be stored in the node                                                          |
+| `options.discriminator` |                      | `string`                                             | `undefined`                             | discriminator for the node when you mix different data types (see Discriminator below) |
+| `options.predicate`     |                      | `(node: TreeNode) => boolean \| undefined`           | `undefined`                             | filter function (see Filtering below)                                                  |
+| `options.selectable`    |                      | `boolean`                                            | `true` for `Leaf`, `false` for `Branch` | whether the node can be selected                                                       |
+| `options.getId`         |  if no `TData[id]`   | `keyof TData` \| `(data: TData) => string \| number` | `id`                                    | field or function to get a unique identifier for the node                              |
+| `options.getLabel`      | if no `TData[label]` | `keyof TData` \| `(data: TData) => string`           | `label`                                 | field or function to get a label for the node                                          |
 
 ### Example
 
@@ -76,10 +78,10 @@ new BranchDefinition(data, children)
 new BranchDefinition(data, options, children)
 ```
 
-|                            |     | Type                   | Default |                                                  |
-| -------------------------- | --- | ---------------------- | ------- | ------------------------------------------------ |
-| (same as `LeafDefinition`) |     |                        |         |                                                  |
-| `children`                 | ✓   | `TreeNodeDefinition[]` |         | array of nodes that are contained in this branch |
+|                            |     | Type                   | Default |                                                                  |
+| -------------------------- | --- | ---------------------- | ------- | ---------------------------------------------------------------- |
+| (same as `LeafDefinition`) |     |                        |         |                                                                  |
+| `children`                 | ✓   | `TreeNodeDefinition[]` |         | array of definitions for nodes that are contained in this branch |
 
 ### Example
 
@@ -175,14 +177,14 @@ defineTree(entries, defineChildTree)
 defineTree(entries, options, defineChildTree)
 ```
 
-|                         |     Required     | Type                                          | Default     |                                                                                 |
-| ----------------------- | :--------------: | --------------------------------------------- | ----------- | ------------------------------------------------------------------------------- |
-| `entries`               |        ✓         | `(T extends object)[]`                        |             | array of entries for which to create a definition                               |
-| `options.getId`         |  If no `T[id]`   | `keyof T` \| (data: T) => `string`\| `number` | `id`        | field or function to get a unique identifier for the node                       |
-| `options.getLabel`      | If no `T[label]` | `keyof T` \| (data: T) => `string`            | `label`     | field or function to get a label for the node                                   |
-| `options.discriminator` |                  | `string`                                      | `undefined` | discriminator for the node when you mix different data types                    |
-| `options.predicate`     |                  | `(data) => boolean \| undefined`              | `undefined` | filter function that takes the data as first argument                           |
-| `defineChildTree`       |                  | `(data: T) => TreeNodeDefinition[]`           |             | function that returns an array of definitions that are contained in this branch |
+|                         |       Required       | Type                                                  | Default     |                                                                                 |
+| ----------------------- | :------------------: | ----------------------------------------------------- | ----------- | ------------------------------------------------------------------------------- |
+| `entries`               |          ✓           | `(TData extends object)[]`                            |             | array of entries for which to create a definition                               |
+| `options.getId`         |  If no `TData[id]`   | `keyof TData` \| (data: TData) => `string`\| `number` | `id`        | field or function to get a unique identifier for the node                       |
+| `options.getLabel`      | If no `TData[label]` | `keyof TData` \| (data: TData) => `string`            | `label`     | field or function to get a label for the node                                   |
+| `options.discriminator` |                      | `string`                                              | `undefined` | discriminator for the node when you mix different data types                    |
+| `options.predicate`     |                      | `(node: TreeNode) => boolean \| undefined`            | `undefined` | filter function that takes the data as first argument                           |
+| `defineChildTree`       |                      | `(data: TData) => TreeNodeDefinition[]`               |             | function that returns an array of definitions that are contained in this branch |
 
 Let's take this `families` example:
 
@@ -249,7 +251,7 @@ const families = [
 You can use the `defineTree` helper this way:
 
 ```ts
-const definitions = defineTree(families, family => defineTree(family.members, person => defineTree(person.animals)))
+const definitions = defineTree(families, family => defineTree(family.members, member => defineTree(member.animals)))
 ```
 
 This is the equivalent of the following code:
@@ -303,20 +305,22 @@ const definitionsB = defineTree(entries, {
 | `label`         | `string`                    | the label of the node                                               |
 | `isBranch`      | `boolean`                   | `true`for `Branch` instances, `false` for `Leaf` instances          |
 | `discriminator` | `string` \| `undefined`     | discriminator for the node when you mix different data types        |
-| `data`          | `T`                         | data stored in the node                                             |
+| `data`          | `TData`                     | data stored in the node                                             |
 | `depth`         | `number`                    | depth of the node in the collection                                 |
 | `isSelected`    | `boolean`                   | whether the node is selected                                        |
 | `isActive`      | `boolean`                   | whether the node is active                                          |
 | `isVisible`     | `boolean`                   | whether the node is visible (see TreeNode Visibility below)         |
 | `activate`      | `() => void`                | function to activate the node                                       |
 | `toggleSelect`  | `(force?: boolean) => void` | function to toggle the selection of the node                        |
-| `labelClasses`  | `{ [name]: boolean }`       | object of classes to be used in the template (see below)            |
+| `statuses`      | `{ [name]: boolean }`       | object of Node statuses (see below)                                 |
 
-### `labelClasses`
+### `statuses`
 
-The `labelClasses` properties are classes to be used in the template `:class`.
+The `statuses` properties is an object for Node statuses.
 
-_These classes are just helpers. They don't come with any default style._
+It can, for example, be used in the template `:class`.
+
+_This object is just a helper. It doesn't come with any default style._
 
 For a `Leaf` instance, it contains the following properties:
 
@@ -336,9 +340,9 @@ Additionally, `Branch` instances have the following properties:
 | `rawChildren`                  | `TreeNode[]` | array of all children instances                 |
 | `children`                     | `TreeNode[]` | array of visible children instances (see below) |
 
-### `labelClasses`
+### `statuses`
 
-_These classes are just helpers. They don't come with any default style._
+_This object is just a helper. It doesn't come with any default style._
 
 For a `Branch` instance, it contains the following properties:
 
@@ -418,7 +422,7 @@ Here are the rules to determine whether a node is visible or not.
     <li v-for="family in nodes" :key="family.id">
       <div
         class="label family"
-        :class="family.labelClasses"
+        :class="family.statuses"
         @mouseenter="family.activate()"
         @click="family.toggleChildrenSelect()"
       >
@@ -428,7 +432,7 @@ Here are the rules to determine whether a node is visible or not.
         <li v-for="person in family.children" :key="person.id">
           <div
             class="label person"
-            :class="person.labelClasses"
+            :class="person.statuses"
             @mouseenter="person.activate()"
             @click="person.toggleSelect()"
           >
@@ -486,13 +490,13 @@ Here are the rules to determine whether a node is visible or not.
   </div>
   <ul>
     <li v-for="family in nodes" :key="family.id">
-      <div :class="family.labelClasses">{{ family.label }}</div>
+      <div :class="family.statuses">{{ family.label }}</div>
       <ul class="sub">
         <li v-for="person in family.children" :key="person.id">
-          <div :class="person.labelClasses">{{ person.label }} ({{ person.data.age }})</div>
+          <div :class="person.statuses">{{ person.label }} ({{ person.data.age }})</div>
           <ul class="sub">
             <li v-for="animal in person.children" :key="animal.id">
-              <div :class="animal.labelClasses">{{ animal.label }}</div>
+              <div :class="animal.statuses">{{ animal.label }}</div>
             </li>
           </ul>
         </li>

--- a/@xen-orchestra/web-core/lib/composables/tree.composable.ts
+++ b/@xen-orchestra/web-core/lib/composables/tree.composable.ts
@@ -50,7 +50,7 @@ export function useTree<
     return nodeMap
   })
 
-  const visibleNodes = computed(() => nodes.value.filter(node => node.isVisible))
+  const visibleNodes = computed(() => nodes.value.filter(node => !node.isExcluded))
 
   const getNode = (id: TreeNodeId | undefined) => (id !== undefined ? nodesMap.value.get(id) : undefined)
   const getNodes = (ids: TreeNodeId[]) => ids.map(getNode).filter(node => node !== undefined) as TreeNode[]
@@ -58,10 +58,6 @@ export function useTree<
   const selectedNodes = computed(() => getNodes(Array.from(selectedIds.value.values())))
   const expandedNodes = computed(() => getNodes(Array.from(expandedIds.value.values())))
   const activeNode = computed(() => getNode(activeId.value))
-
-  if (options.expand !== false) {
-    visibleNodes.value.forEach(node => node.isBranch && node.toggleExpand(true, true))
-  }
 
   const selectedLabel = computed(() => {
     if (typeof options.selectedLabel === 'function') {

--- a/@xen-orchestra/web-core/lib/composables/tree/branch-definition.ts
+++ b/@xen-orchestra/web-core/lib/composables/tree/branch-definition.ts
@@ -6,6 +6,7 @@ export class BranchDefinition<
   TChildDefinition extends TreeNodeDefinition = TreeNodeDefinition,
   const TDiscriminator = any,
 > extends TreeNodeDefinitionBase<TData, TDiscriminator> {
+  readonly isBranch = true
   children: TChildDefinition[]
 
   constructor(data: TData, options: TreeNodeOptions<TData, TDiscriminator>, children: TChildDefinition[]) {

--- a/@xen-orchestra/web-core/lib/composables/tree/build-nodes.ts
+++ b/@xen-orchestra/web-core/lib/composables/tree/build-nodes.ts
@@ -1,15 +1,14 @@
 import { Branch } from '@core/composables/tree/branch'
-import { BranchDefinition } from '@core/composables/tree/branch-definition'
 import { Leaf } from '@core/composables/tree/leaf'
 import type { DefinitionToTreeNode, TreeContext, TreeNode, TreeNodeDefinition } from '@core/composables/tree/types'
 
-export function buildTree<TDefinition extends TreeNodeDefinition>(
+export function buildNodes<TDefinition extends TreeNodeDefinition, TTreeNode extends DefinitionToTreeNode<TDefinition>>(
   definitions: TDefinition[],
   context: TreeContext
-): DefinitionToTreeNode<TDefinition>[] {
+): TTreeNode[] {
   function create(definitions: TreeNodeDefinition[], parent: Branch | undefined, depth: number): TreeNode[] {
     return definitions.map(definition =>
-      definition instanceof BranchDefinition
+      definition.isBranch
         ? new Branch(definition.data, parent, context, depth, definition.options, thisBranch =>
             create(definition.children, thisBranch, depth + 1)
           )
@@ -17,5 +16,5 @@ export function buildTree<TDefinition extends TreeNodeDefinition>(
     )
   }
 
-  return create(definitions, undefined, 0) as DefinitionToTreeNode<TDefinition>[]
+  return create(definitions, undefined, 0) as TTreeNode[]
 }

--- a/@xen-orchestra/web-core/lib/composables/tree/leaf-definition.ts
+++ b/@xen-orchestra/web-core/lib/composables/tree/leaf-definition.ts
@@ -3,4 +3,6 @@ import { TreeNodeDefinitionBase } from '@core/composables/tree/tree-node-definit
 export class LeafDefinition<TData extends object = any, const TDiscriminator = any> extends TreeNodeDefinitionBase<
   TData,
   TDiscriminator
-> {}
+> {
+  readonly isBranch = false
+}

--- a/@xen-orchestra/web-core/lib/composables/tree/leaf.ts
+++ b/@xen-orchestra/web-core/lib/composables/tree/leaf.ts
@@ -1,4 +1,5 @@
 import { TreeNodeBase } from '@core/composables/tree/tree-node-base'
+import type { LeafStatuses } from '@core/composables/tree/types'
 
 export class Leaf<TData extends object = any, const TDiscriminator = any> extends TreeNodeBase<TData, TDiscriminator> {
   readonly isBranch = false
@@ -19,7 +20,7 @@ export class Leaf<TData extends object = any, const TDiscriminator = any> extend
     return this.parent?.isExpanded ?? true
   }
 
-  get labelClasses() {
+  get statuses(): LeafStatuses {
     return {
       active: this.isActive,
       selected: this.isSelected,

--- a/@xen-orchestra/web-core/lib/composables/tree/leaf.ts
+++ b/@xen-orchestra/web-core/lib/composables/tree/leaf.ts
@@ -8,16 +8,20 @@ export class Leaf<TData extends object = any, const TDiscriminator = any> extend
     return this.passesFilter ?? false
   }
 
-  get isVisible() {
-    if (this.passesFilterUpwards) {
+  get failsFilterDownwards(): boolean {
+    return this.passesFilter === false
+  }
+
+  get isExcluded() {
+    if (this.parent?.isExpanded === false) {
       return true
     }
 
-    if (this.passesFilter === false) {
+    if (this.passesFilterUpwards) {
       return false
     }
 
-    return this.parent?.isExpanded ?? true
+    return this.passesFilter === false
   }
 
   get statuses(): LeafStatuses {

--- a/@xen-orchestra/web-core/lib/composables/tree/tree-node-base.ts
+++ b/@xen-orchestra/web-core/lib/composables/tree/tree-node-base.ts
@@ -1,11 +1,11 @@
 import type { Branch } from '@core/composables/tree/branch'
-import type { Identifiable, Labeled, TreeContext, TreeNode, TreeNodeOptions } from '@core/composables/tree/types'
+import type { Identifiable, Labeled, TreeContext, TreeNodeOptions } from '@core/composables/tree/types'
 
 export abstract class TreeNodeBase<TData extends object = any, TDiscriminator = any> {
   abstract readonly isBranch: boolean
   abstract passesFilterDownwards: boolean
   abstract isVisible: boolean
-  abstract labelClasses: Record<string, boolean>
+  abstract statuses: Record<string, boolean>
 
   readonly data: TData
   readonly depth: number
@@ -56,40 +56,48 @@ export abstract class TreeNodeBase<TData extends object = any, TDiscriminator = 
   }
 
   get passesFilter() {
-    return this.options.predicate?.(this.data)
+    return this.options.predicate?.(this)
   }
 
   get isSelected() {
-    return this.context.selectedNodes.has(this.id)
+    return this.context.selectedIds.has(this.id)
   }
 
   get isActive() {
-    return this.context.activeNode?.id === this.id
+    return this.context.activeId === this.id
   }
 
   get passesFilterUpwards(): boolean {
     return this.passesFilter || (this.parent?.passesFilterUpwards ?? false)
   }
 
+  get isSelectable() {
+    return this.options.selectable ?? !this.isBranch
+  }
+
   activate() {
-    if (this.options.activable === false) {
+    if (!this.isSelectable) {
       return
     }
 
-    this.context.activeNode = this as unknown as TreeNode
+    this.context.activeId = this.id
   }
 
   toggleSelect(forcedValue?: boolean) {
+    if (!this.isSelectable) {
+      return
+    }
+
     const shouldSelect = forcedValue ?? !this.isSelected
 
     if (shouldSelect) {
       if (!this.context.allowMultiSelect) {
-        this.context.selectedNodes.clear()
+        this.context.selectedIds.clear()
       }
 
-      this.context.selectedNodes.set(this.id, this as unknown as TreeNode)
+      this.context.selectedIds.add(this.id)
     } else {
-      this.context.selectedNodes.delete(this.id)
+      this.context.selectedIds.delete(this.id)
     }
   }
 }

--- a/@xen-orchestra/web-core/lib/composables/tree/tree-node-base.ts
+++ b/@xen-orchestra/web-core/lib/composables/tree/tree-node-base.ts
@@ -4,7 +4,7 @@ import type { Identifiable, Labeled, TreeContext, TreeNodeOptions } from '@core/
 export abstract class TreeNodeBase<TData extends object = any, TDiscriminator = any> {
   abstract readonly isBranch: boolean
   abstract passesFilterDownwards: boolean
-  abstract isVisible: boolean
+  abstract isExcluded: boolean
   abstract statuses: Record<string, boolean>
 
   readonly data: TData
@@ -72,7 +72,7 @@ export abstract class TreeNodeBase<TData extends object = any, TDiscriminator = 
   }
 
   get isSelectable() {
-    return this.options.selectable ?? !this.isBranch
+    return this.options.selectable?.(this.data) ?? !this.isBranch
   }
 
   activate() {

--- a/@xen-orchestra/web-core/lib/composables/tree/tree-node-definition-base.ts
+++ b/@xen-orchestra/web-core/lib/composables/tree/tree-node-definition-base.ts
@@ -1,6 +1,7 @@
 import type { TreeNodeOptions } from '@core/composables/tree/types'
 
 export abstract class TreeNodeDefinitionBase<TData extends object, TDiscriminator> {
+  abstract readonly isBranch: boolean
   data: TData
   options: TreeNodeOptions<TData, TDiscriminator>
 

--- a/@xen-orchestra/web-core/lib/composables/tree/types.ts
+++ b/@xen-orchestra/web-core/lib/composables/tree/types.ts
@@ -26,7 +26,7 @@ export type TreeNode<
 export type BaseTreeNodeOptions<TData extends object, TDiscriminator> = {
   discriminator?: TDiscriminator
   predicate?: (node: TreeNodeBase<TData, TDiscriminator>) => boolean | undefined
-  selectable?: boolean
+  selectable?: (data: TData) => boolean
   meta?: any
 }
 


### PR DESCRIPTION
### Description

- Context now stores the selected/expanded/active IDs instead of the `TreeNode` to allow easy manipulation and initial hydration.
- Rename `activable` option to `selectable`
- Rename `labelClasses` to `statuses`
- Add `hasChildren` on `Branch`
- `predicate` now takes the `TreeNode` as argument instead of `TData`
- Add a `meta` option, to pass additional arbitrary data

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
