### PR TITLE
feat(vmware-explorer): implement ExportVm usage

### DIFF
--- a/@xen-orchestra/vmware-explorer/VhdEsxiStreamOptimized.mjs
+++ b/@xen-orchestra/vmware-explorer/VhdEsxiStreamOptimized.mjs
@@ -1,0 +1,152 @@
+import { VhdAbstract } from 'vhd-lib'
+import { unpackFooter, unpackHeader } from 'vhd-lib/Vhd/_utils.js'
+import _computeGeometryForSize from 'vhd-lib/_computeGeometryForSize.js'
+import {
+  DEFAULT_BLOCK_SIZE as DEFAULT_VHD_BLOCK_SIZE,
+  DISK_TYPES,
+  FOOTER_SIZE,
+  SECTOR_SIZE,
+} from 'vhd-lib/_constants.js'
+import { createFooter, createHeader } from 'vhd-lib/_createFooterHeader.js'
+import { unpackHeader as unpackVmdkHeader } from 'xo-vmdk-to-vhd/dist/definitions.js'
+
+import zlib from 'zlib'
+import assert from 'node:assert'
+
+export default class VhdEsxiStreamOptimized extends VhdAbstract {
+  #handler
+  #vmdkHeader
+  #l1table
+  #l2tables
+  #path
+
+  get header() {
+    // a grain directory entry contains the address of a grain table
+    // a grain table can adresses at most 4096 grain of 512 Bytes of data
+    return unpackHeader(
+      createHeader(Math.ceil((this.#vmdkHeader.capacitySectors * SECTOR_SIZE) / DEFAULT_VHD_BLOCK_SIZE))
+    )
+  }
+
+  get footer() {
+    const size = this.#vmdkHeader.capacitySectors * SECTOR_SIZE
+    const geometry = _computeGeometryForSize(size)
+    return unpackFooter(createFooter(size, Math.floor(Date.now() / 1000), geometry, FOOTER_SIZE, DISK_TYPES.DYNAMIC))
+  }
+
+  constructor(handler, path) {
+    super()
+    this.#handler = handler
+    this.#path = path
+  }
+  async readHeaderAndFooter() {
+    // complete header is at the end of the file
+    // the header at the beginning don't have the L1 table position
+    const size = await this.#handler.getSize(this.#path)
+    const headerBuffer = await this.#read(size - 1024, 1024)
+    this.#vmdkHeader = unpackVmdkHeader(headerBuffer)
+  }
+  async readBlockAllocationTable() {
+    const l1entries = Math.floor(
+      (this.#vmdkHeader.capacitySectors + this.#vmdkHeader.l1EntrySectors - 1) / this.#vmdkHeader.l1EntrySectors
+    )
+    const buffer = await this.#read(this.#vmdkHeader.grainDirectoryOffsetSectors * SECTOR_SIZE, l1entries * 4)
+    this.#l1table = []
+    for (let grainTableIndex = 0; grainTableIndex < l1entries; grainTableIndex++) {
+      this.#l1table.push(buffer.readUInt32LE(grainTableIndex * 4))
+    }
+    // also read all the l2 table since we must be able to check contains synchronously
+    this.#l2tables = []
+    for (let grainTableIndex = 0; grainTableIndex < l1entries; grainTableIndex++) {
+      this.#l2tables[grainTableIndex] = await this.#getGrainTable(grainTableIndex)
+    }
+  }
+  async #read(start, length) {
+    const buffer = Buffer.alloc(length, 0)
+    await this.#handler.read(this.#path, buffer, start)
+    return buffer
+  }
+  async #getGrainTable(grainTableIndex) {
+    const l1Entry = this.#l1table[grainTableIndex]
+    if (l1Entry === 0) {
+      return
+    }
+    const l2ByteSize = this.#vmdkHeader.numGTEsPerGT * 4
+    const buffer = await this.#read(l1Entry * SECTOR_SIZE, l2ByteSize)
+    const table = []
+    for (let i = 0; i < this.#vmdkHeader.numGTEsPerGT; i++) {
+      table.push(buffer.readUInt32LE(i * 4))
+    }
+    return table
+  }
+
+  async #getGrainData(grainTableIndex, grainEntryIndex) {
+    const grainTable = this.#l2tables[grainTableIndex]
+    if (grainTable === undefined) {
+      return
+    }
+    const offset = grainTable[grainEntryIndex]
+    if (offset === 0) {
+      return
+    }
+    const dataSizeBuffer = await this.#read(offset * SECTOR_SIZE + 8, 4)
+    const dataSize = dataSizeBuffer.readUInt32LE(0)
+    const buffer = await this.#read(offset * SECTOR_SIZE + 12, dataSize)
+    const inflated = zlib.inflateSync(buffer)
+    assert(inflated.length, 64 * 1024)
+    return inflated
+  }
+  containsBlock(blockId) {
+    const nbBlocksPerGT = this.#getNumberOfBlockPerGrainTable()
+
+    const grainTableIndex = Math.floor(blockId / nbBlocksPerGT)
+    const length = this.#getNumberOfGrainPerBlock()
+    const grainTableEntryIndexStart = (blockId % nbBlocksPerGT) * length
+
+    const grainTable = this.#l2tables[grainTableIndex]
+    if (!grainTable) {
+      return false
+    }
+
+    for (let i = 0; i < length; i++) {
+      const grainEntryIndex = grainTableEntryIndexStart + i
+      if (grainTable[grainEntryIndex] !== 0) {
+        return true
+      }
+    }
+    return false
+  }
+
+  #getGrainSize() {
+    return this.#vmdkHeader.grainSizeSectors * SECTOR_SIZE
+  }
+  #getNumberOfBlockPerGrainTable() {
+    return (this.#vmdkHeader.numGTEsPerGT * this.#getGrainSize()) / DEFAULT_VHD_BLOCK_SIZE
+  }
+  #getNumberOfGrainPerBlock() {
+    return DEFAULT_VHD_BLOCK_SIZE / this.#getGrainSize()
+  }
+  async readBlock(blockId) {
+    // 1 grain = 128  sectors = 64KB
+    // 512 grain per grain table => 32MB per grain table, 16 vhd blocks
+    const nbBlocksPerGT = this.#getNumberOfBlockPerGrainTable()
+    const buffer = Buffer.alloc(512 /* bitmap */ + DEFAULT_VHD_BLOCK_SIZE /* data */, 0)
+
+    const grainTableIndex = Math.floor(blockId / nbBlocksPerGT)
+    const length = this.#getNumberOfGrainPerBlock()
+    const grainTableEntryIndexStart = (blockId % nbBlocksPerGT) * length
+    for (let i = 0; i < length; i++) {
+      const grainEntryIndex = grainTableEntryIndexStart + i
+      const grain = await this.#getGrainData(grainTableIndex, grainEntryIndex)
+      if (grain !== undefined) {
+        grain.copy(buffer, i * grain.length + 512 /* bitmap */)
+      }
+    }
+    return {
+      id: blockId,
+      bitmap: buffer.slice(0, 512),
+      data: buffer.slice(512),
+      buffer,
+    }
+  }
+}

--- a/@xen-orchestra/vmware-explorer/esxi.mjs
+++ b/@xen-orchestra/vmware-explorer/esxi.mjs
@@ -90,22 +90,11 @@ export default class Esxi extends EventEmitter {
     })
   }
 
-  async #download(dataStore, path, range) {
-    strictEqual(this.#ready, true)
-    const url = new URL('https://localhost')
-    url.host = this.#host
-    url.pathname = '/folder/' + path
-    url.searchParams.set('dcPath', this.#findDatacenter(dataStore))
-    url.searchParams.set('dsName', dataStore)
-    const headers = {}
+  async #fetch(url, headers = {}) {
     if (this.#cookies) {
       headers.cookie = this.#cookies
     } else {
       headers.Authorization = 'Basic ' + Buffer.from(this.#user + ':' + this.#password).toString('base64')
-    }
-    if (range) {
-      headers['content-type'] = 'multipart/byteranges'
-      headers.Range = 'bytes=' + range
     }
     const res = await fetch(url, {
       agent: this.#httpsAgent,
@@ -125,6 +114,21 @@ export default class Esxi extends EventEmitter {
         .join('; ')
     }
     return res
+  }
+
+  async #download(dataStore, path, range) {
+    strictEqual(this.#ready, true)
+    const url = new URL('https://localhost')
+    url.host = this.#host
+    url.pathname = '/folder/' + path
+    url.searchParams.set('dcPath', this.#findDatacenter(dataStore))
+    url.searchParams.set('dsName', dataStore)
+    const headers = {}
+    if (range) {
+      headers['content-type'] = 'multipart/byteranges'
+      headers.Range = 'bytes=' + range
+    }
+    return this.#fetch(url, headers)
   }
 
   async download(dataStore, path, range) {

--- a/@xen-orchestra/vmware-explorer/package.json
+++ b/@xen-orchestra/vmware-explorer/package.json
@@ -11,7 +11,8 @@
     "lodash": "^4.17.21",
     "node-fetch": "^3.3.0",
     "vhd-lib": "^4.9.2",
-    "xml2js": "^0.6.2"
+    "xml2js": "^0.6.2",
+    "xo-vmdk-to-vhd": "^2.5.7"
   },
   "engines": {
     "node": ">=14"

--- a/@xen-orchestra/vmware-explorer/parsers/vmdk.mjs
+++ b/@xen-orchestra/vmware-explorer/parsers/vmdk.mjs
@@ -16,7 +16,9 @@ export function parseDescriptor(text) {
       descriptorDict[defLine[0].toLowerCase()] = defLine[1].replace(/['"]+/g, '')
     } else {
       const [, access, sizeSectors, type, name, offset] = line.match(/([A-Z]+) ([0-9]+) ([A-Z]+) "(.*)" ?(.*)$/)
-      extentList.push({ access, sizeSectors, type, name, offset })
+      const usingVsan = name.startsWith('vsan://')
+
+      extentList.push({ access, sizeSectors, type, name, offset, usingVsan })
     }
   }
   strictEqual(extentList.length, 1, 'only one extent per vmdk is supported')

--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -1391,8 +1391,28 @@ import_.resolve = {
 
 export { import_ as import }
 
-export async function importFromEsxi({ host, network, password, sr, sslVerify = true, stopSource = false, user, vm }) {
-  return importMultipleFromEsxi.call(this, { host, network, password, sr, sslVerify, stopSource, user, vms: [vm] })
+export async function importFromEsxi({
+  host,
+  network,
+  password,
+  sr,
+  sslVerify = true,
+  stopSource = false,
+  user,
+  vm,
+  workDirRemote,
+}) {
+  return importMultipleFromEsxi.call(this, {
+    host,
+    network,
+    password,
+    sr,
+    sslVerify,
+    stopSource,
+    user,
+    vms: [vm],
+    workDirRemote,
+  })
 }
 
 importFromEsxi.params = {
@@ -1404,6 +1424,7 @@ importFromEsxi.params = {
   stopSource: { type: 'boolean', optional: true },
   user: { type: 'string' },
   vm: { type: 'string' },
+  workDirRemote: { type: 'string' },
 }
 
 /**
@@ -1423,6 +1444,7 @@ export async function importMultipleFromEsxi({
   thin,
   user,
   vms,
+  workDirRemote,
 }) {
   const task = await this.tasks.create({ name: `importing vms ${vms.join(',')}` })
   let done = 0
@@ -1433,6 +1455,7 @@ export async function importMultipleFromEsxi({
         .filter(({ name, enabled }) => enabled && name.toLocaleLowerCase().startsWith(PREFIX))
         .map(remote => this.getRemoteHandler(remote))
     )
+    const workDirRemoteHandler = workDirRemote ? await this.getRemoteHandler(workDirRemote) : undefined
     const dataStoreToHandlers = {}
     handlers.forEach(handler => {
       const name = handler._remote.name
@@ -1461,6 +1484,7 @@ export async function importMultipleFromEsxi({
                 network,
                 stopSource,
                 dataStoreToHandlers,
+                workDirRemote: workDirRemoteHandler,
               })
               result[vm] = vmUuid
             } finally {
@@ -1519,6 +1543,7 @@ importMultipleFromEsxi.params = {
     type: 'array',
     uniqueItems: true,
   },
+  workDirRemote: { type: 'string', optional: true },
 }
 
 // -------------------------------------------------------------------

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1794,6 +1794,9 @@ const messages = {
   vmImportToPool: 'To Pool:',
   vmImportToSr: 'To SR:',
   vmsToImport: 'VM{nVms, plural, one {} other {s}} to import',
+  warningVsanImport:
+    '<div>VM running from non file based datastore (like VSAN) will be migrated in a three steps process<ul><li>Stop the VM</li><li>Export the VM disks to a remote of Xen Orchestra</li><li>Load these disks in XCP-ng</li></ul>This process will be slower than migrating the VM to VMFS / NFS datastore and then migrating them to XCP-ng</div>',
+  workDirLabel: 'Remote used to store temporary disk files(VSAN migration)',
   importVmsCleanList: 'Reset',
   vmImportSuccess: 'VM import success',
   vmImportFailed: 'VM import failed',


### PR DESCRIPTION
review by commit 
wait for #7571 

### Description
Use an alternate migration path : the ExportVM command from the web service API

#### why

VSAN datastore can't give access to the underlying vmdk files. 

#### limits

* VM must will be stopped at the beginning of the migration
* this is a 2 steps process, slower than other imports modes : 
  *  export the disks in vmdk ( stream optimized ) format to a backup repository of XO
  *  import the content to XCP-ng  


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
