### PR TITLE
feat(xo-web,xo-server/RPU): RPU disabled if XOSTOR in pool

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,7 +7,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [RPU] If a XOSTOR is present in the pool, Rolling Pool Update is no longer available (PR [#7540](https://github.com/vatesfr/xen-orchestra/pull/7540))
+- [RPU] If a XOSTOR is present in the pool, _Rolling Pool Update_ is no longer available (PR [#7540](https://github.com/vatesfr/xen-orchestra/pull/7540))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [RPU] If a XOSTOR is present in the pool, Rolling Pool Update is no longer available (PR [#7540](https://github.com/vatesfr/xen-orchestra/pull/7540))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”

--- a/packages/xo-server/src/xapi/mixins/patching.mjs
+++ b/packages/xo-server/src/xapi/mixins/patching.mjs
@@ -488,6 +488,11 @@ const methods = {
   },
 
   async rollingPoolUpdate($defer, { xsCredentials } = {}) {
+    // Temporary workaround until XCP-ng finds a way to update linstor packages
+    if (some(this.objects.indexes.type.SR, { type: 'linstor' })) {
+      throw new Error('rolling pool update not possible since there is a linstor SR in the pool')
+    }
+
     const isXcp = _isXcp(this.pool.$master)
 
     const hasMissingPatchesByHost = {}

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1156,6 +1156,7 @@ const messages = {
   installPoolPatches: 'Install pool patches',
   confirmPoolPatch:
     'This will automatically restart the toolstack on every host. Running VMs will not be affected. Are you sure you want to continue and install all the patches on this pool?',
+  rollingPoolUpdateDisabledBecauseXostorOnPool: 'RPU is disabled because a XOSTOR storage is present on the pool',
   rollingPoolUpdate: 'Rolling pool update',
   rollingPoolUpdateMessage:
     'Are you sure you want to start a rolling pool update? Running VMs will be migrated back and forth and this can take a while. Scheduled backups that may concern this pool will be disabled.',
@@ -1525,8 +1526,9 @@ const messages = {
   deleteDefaultTemplatesTitle: 'Delete default template{nDefaultTemplates, plural, one {} other {s}}',
   deleteDefaultTemplatesMessage:
     'You are attempting to delete {nDefaultTemplates, number} default template{nDefaultTemplates, plural, one {} other {s}}. Do you want to continue?',
-  deleteProtectedTemplatesTitle:'Delete protected template{nProtectedTemplates, plural, one {} other {s}}',
-  deleteProtectedTemplatesMessage: 'You are attempting to delete {nProtectedTemplates, plural, one {a} other {nProtectedTemplates}} template{nProtectedTemplates, plural, one {} other {s}} protected from accidental deletion. Do you want to continue?',
+  deleteProtectedTemplatesTitle: 'Delete protected template{nProtectedTemplates, plural, one {} other {s}}',
+  deleteProtectedTemplatesMessage:
+    'You are attempting to delete {nProtectedTemplates, plural, one {a} other {nProtectedTemplates}} template{nProtectedTemplates, plural, one {} other {s}} protected from accidental deletion. Do you want to continue?',
   // ----- Dashboard -----
   poolPanel: 'Pool{pools, plural, one {} other {s}}',
   hostPanel: 'Host{hosts, plural, one {} other {s}}',
@@ -2573,7 +2575,7 @@ const messages = {
   licenseBoundUnknownXostor: 'License attached to an unknown XOSTOR',
   licenseNotBoundXostor: 'No XOSTOR attached',
   licenseExpiredXostorWarning:
-    'The license {licenseId} has expired. You can still use the SR but cannot administrate it anymore.',
+  'The license {licenseId} has expired. You can still use the SR but cannot administrate it anymore.',
   networks: 'Networks',
   notXcpPool: 'Not an XCP-ng pool',
   noXostorFound: 'No XOSTOR found',
@@ -2583,6 +2585,7 @@ const messages = {
   poolAlreadyHasXostor: 'Pool already has a XOSTOR',
   poolNotRecentEnough: 'Not recent enough. Current version: {version}',
   replication: 'Replication',
+  rpuNoLongerAvailableIfXostor: 'As long as XOSTOR storage is present on the pool, Rolling Pool Update would no longer be available anymore',
   selectDisks: 'Select disk(s)…',
   selectedDiskTypeIncompatibleXostor: 'Only disks of type "Disk" and "Raid" are accepted. Selected disk type: {type}.',
   storage: 'Storage',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2584,7 +2584,7 @@ const messages = {
   poolAlreadyHasXostor: 'Pool already has a XOSTOR',
   poolNotRecentEnough: 'Not recent enough. Current version: {version}',
   replication: 'Replication',
-  rpuNoLongerAvailableIfXostor: 'As long as XOSTOR storage is present in the pool, Rolling Pool Update would no longer be available',
+  rpuNoLongerAvailableIfXostor: 'As long as a XOSTOR storage is present in the pool, Rolling Pool Update will not be available',
   selectDisks: 'Select disk(s)…',
   selectedDiskTypeIncompatibleXostor: 'Only disks of type "Disk" and "Raid" are accepted. Selected disk type: {type}.',
   storage: 'Storage',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1156,7 +1156,7 @@ const messages = {
   installPoolPatches: 'Install pool patches',
   confirmPoolPatch:
     'This will automatically restart the toolstack on every host. Running VMs will not be affected. Are you sure you want to continue and install all the patches on this pool?',
-  rollingPoolUpdateDisabledBecauseXostorOnPool: 'RPU is disabled because a XOSTOR storage is present on the pool',
+  rollingPoolUpdateDisabledBecauseXostorOnPool: 'RPU is disabled because a XOSTOR storage is present in the pool',
   rollingPoolUpdate: 'Rolling pool update',
   rollingPoolUpdateMessage:
     'Are you sure you want to start a rolling pool update? Running VMs will be migrated back and forth and this can take a while. Scheduled backups that may concern this pool will be disabled.',
@@ -1526,9 +1526,8 @@ const messages = {
   deleteDefaultTemplatesTitle: 'Delete default template{nDefaultTemplates, plural, one {} other {s}}',
   deleteDefaultTemplatesMessage:
     'You are attempting to delete {nDefaultTemplates, number} default template{nDefaultTemplates, plural, one {} other {s}}. Do you want to continue?',
-  deleteProtectedTemplatesTitle: 'Delete protected template{nProtectedTemplates, plural, one {} other {s}}',
-  deleteProtectedTemplatesMessage:
-    'You are attempting to delete {nProtectedTemplates, plural, one {a} other {nProtectedTemplates}} template{nProtectedTemplates, plural, one {} other {s}} protected from accidental deletion. Do you want to continue?',
+  deleteProtectedTemplatesTitle:'Delete protected template{nProtectedTemplates, plural, one {} other {s}}',
+  deleteProtectedTemplatesMessage: 'You are attempting to delete {nProtectedTemplates, plural, one {a} other {nProtectedTemplates}} template{nProtectedTemplates, plural, one {} other {s}} protected from accidental deletion. Do you want to continue?',
   // ----- Dashboard -----
   poolPanel: 'Pool{pools, plural, one {} other {s}}',
   hostPanel: 'Host{hosts, plural, one {} other {s}}',
@@ -2575,7 +2574,7 @@ const messages = {
   licenseBoundUnknownXostor: 'License attached to an unknown XOSTOR',
   licenseNotBoundXostor: 'No XOSTOR attached',
   licenseExpiredXostorWarning:
-  'The license {licenseId} has expired. You can still use the SR but cannot administrate it anymore.',
+    'The license {licenseId} has expired. You can still use the SR but cannot administrate it anymore.',
   networks: 'Networks',
   notXcpPool: 'Not an XCP-ng pool',
   noXostorFound: 'No XOSTOR found',
@@ -2585,7 +2584,7 @@ const messages = {
   poolAlreadyHasXostor: 'Pool already has a XOSTOR',
   poolNotRecentEnough: 'Not recent enough. Current version: {version}',
   replication: 'Replication',
-  rpuNoLongerAvailableIfXostor: 'As long as XOSTOR storage is present on the pool, Rolling Pool Update would no longer be available anymore',
+  rpuNoLongerAvailableIfXostor: 'As long as XOSTOR storage is present in the pool, Rolling Pool Update would no longer be available',
   selectDisks: 'Select disk(s)…',
   selectedDiskTypeIncompatibleXostor: 'Only disks of type "Disk" and "Raid" are accepted. Selected disk type: {type}.',
   storage: 'Storage',

--- a/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
+++ b/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
@@ -217,9 +217,16 @@ const PoolCard = decorate([
               </ul>
             </div>
           )}
-          <em>
-            <Icon icon='info' /> {_('xostorPackagesWillBeInstalled')}
-          </em>
+          <div>
+            <em>
+              <Icon icon='info' /> {_('xostorPackagesWillBeInstalled')}
+            </em>
+          </div>
+          <div className='text-warning'>
+            <em>
+              <Icon icon='alarm' /> {_('rpuNoLongerAvailableIfXostor')}
+            </em>
+          </div>
         </div>
       </CardBlock>
     </Card>


### PR DESCRIPTION
### Screenshots

![Capture d’écran de 2024-04-08 14-35-49](https://github.com/vatesfr/xen-orchestra/assets/70369997/dd3dd16d-821b-485d-bf62-84f9d7363392)
![Capture d’écran de 2024-04-08 11-05-52](https://github.com/vatesfr/xen-orchestra/assets/70369997/0d9ff2e1-ba0d-4a97-9c29-db625bb95bcf)

### Description

Can be tested with: `172.16.210.83`

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
