### PR TITLE
fix(xo-server-load-balancer): undefined thresholds in density plan

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Import/VMWare] Fix `Cannot read properties of undefined (reading 'match')`
+- [Plugin/load-balancer] Density plan will no longer try to migrate VMs to a host which is reaching critical memory or CPU usage (PR [#7544](https://github.com/vatesfr/xen-orchestra/pull/7544))
 
 ### Packages to release
 
@@ -36,5 +37,6 @@
 - @xen-orchestra/proxy minor
 - @xen-orchestra/vmware-explorer patch
 - xo-server patch
+- xo-server-load-balancer patch
 
 <!--packages-end-->

--- a/docs/load_balancing.md
+++ b/docs/load_balancing.md
@@ -39,7 +39,7 @@ Those ways can be also called modes: "performance" for 1 and "density" for numbe
 
 ## Configure a plan
 
-In this coming new view, you'll be able to configure a new load balancing plan, or edit an existing one.
+In this view, you can configure a new load balancing plan, or edit an existing one.
 
 A plan has:
 
@@ -83,6 +83,10 @@ For free memory, it will be triggered if there is **less** free RAM than the thr
 ### Exclusion
 
 If you want to prevent load balancing from triggering migrations on a particular host or VM, it is possible to exclude it from load balancing. It can be configured via the "Excluded hosts" parameter in each plan, and in the "Ignored VM tags" parameter which is common to every plan.
+
+### vCPU balancing
+
+With a performance plan, you can enable the "Balance vCPUs" option. When the pool's load is low (under 40% CPU usage), this option attempts to pre-emptively distribute your VMs across hosts to avoid excessive disparities in the number of vCPUs per CPU, instead of just waiting for a host to be overloaded. In this way, VMs are pre-positioned in a way that is likely to trigger less migrations when the load increases.
 
 ### Timing
 

--- a/packages/xo-server-load-balancer/src/density-plan.js
+++ b/packages/xo-server-load-balancer/src/density-plan.js
@@ -165,7 +165,10 @@ export default class DensityPlan extends Plan {
   // Test if a VM migration on a destination (of a destinations set) is possible.
   _testMigration({ vm, destinations, hostsAverages, vmsAverages }) {
     const {
-      _thresholds: { critical: criticalThreshold },
+      _thresholds: {
+        cpu: { critical: criticalThresholdCpu },
+        memoryFree: { critical: criticalThresholdMemoryFree },
+      },
     } = this
 
     // Sort the destinations by available memory. (- -> +)
@@ -177,8 +180,8 @@ export default class DensityPlan extends Plan {
 
       // Unable to move the VM.
       if (
-        destinationAverages.cpu + vmAverages.cpu >= criticalThreshold ||
-        destinationAverages.memoryFree - vmAverages.memory <= criticalThreshold
+        destinationAverages.cpu + vmAverages.cpu >= criticalThresholdCpu ||
+        destinationAverages.memoryFree - vmAverages.memory <= criticalThresholdMemoryFree
       ) {
         continue
       }


### PR DESCRIPTION
### Description

**do not squash**

Undefined cpu and memory thresholds were used in density plan to decide if a host can receive a VM or not, which made the host always accept it.
Introduced by 5a825bd4598f7f97b549f873903f7d882ea7f52b

\+ docs update

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
