### PR TITLE
feat(web-core/utils): new ifElse utility

### DIFF
--- a/@xen-orchestra/web-core/docs/utils/if-else.utils.md
+++ b/@xen-orchestra/web-core/docs/utils/if-else.utils.md
@@ -1,0 +1,23 @@
+# `ifElse`
+
+`ifElse` utility is a wrapper around `watch`.
+
+It allows watching a `boolean` source and execute the first callback if the source is `true`, or the second one if the
+source is `false`.
+
+```ts
+ifElse(mySource, doSomething, doSomethingElse)
+ifElse(mySource, doSomething, doSomethingElse, { immediate: true })
+```
+
+## Example
+
+```ts
+const myValue = ref(5)
+
+ifElse(
+  () => myValue.value > 10,
+  () => console.log('myValue is greater than 10'),
+  () => console.log('myValue is less than or equal to 10')
+)
+```

--- a/@xen-orchestra/web-core/lib/utils/if-else.utils.ts
+++ b/@xen-orchestra/web-core/lib/utils/if-else.utils.ts
@@ -1,0 +1,22 @@
+import { watch, type WatchOptions, type WatchSource } from 'vue'
+
+export interface IfElseOptions extends Pick<WatchOptions, 'immediate'> {}
+
+export function ifElse(
+  source: WatchSource<boolean>,
+  onTrue: VoidFunction,
+  onFalse: VoidFunction,
+  options?: IfElseOptions
+) {
+  return watch(
+    source,
+    value => {
+      if (value) {
+        onTrue()
+      } else {
+        onFalse()
+      }
+    },
+    options
+  )
+}


### PR DESCRIPTION
### Description

Small utility that mimic [VueUse's `whenever`](https://vueuse.org/shared/whenever/) but watch for a `boolean` and accept a second callback to be run whenever the source is `false`.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
