### PR TITLE
fix(@vates/node-vsphere-soap): don't use default proxy

### DIFF
--- a/@vates/node-vsphere-soap/lib/client.mjs
+++ b/@vates/node-vsphere-soap/lib/client.mjs
@@ -31,14 +31,20 @@ export function Client(vCenterHostname, username, password, sslVerify) {
   EventEmitter.call(this)
 
   // sslVerify argument handling
+  // don't use any proxy to connect to the esxi
   if (sslVerify) {
-    this.clientopts = {}
+    this.clientopts = {
+      request: axios.create({
+        proxy: false,
+      }),
+    }
   } else {
     this.clientopts = {
       request: axios.create({
         httpsAgent: new https.Agent({
           rejectUnauthorized: false,
         }),
+        proxy: false,
       }),
     }
   }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 
 - [Import/VMWare] Fix `Cannot read properties of undefined (reading 'match')`
 - [Plugin/load-balancer] Density plan will no longer try to migrate VMs to a host which is reaching critical memory or CPU usage (PR [#7544](https://github.com/vatesfr/xen-orchestra/pull/7544))
+- [VMWare/Migration] Don't use default proxy to query the source
 
 ### Packages to release
 
@@ -36,6 +37,7 @@
 - @xen-orchestra/backups minor
 - @xen-orchestra/proxy minor
 - @xen-orchestra/vmware-explorer minor
+- @vates/node-vsphere-soap patch
 - xo-server patch
 - xo-server-load-balancer patch
 


### PR DESCRIPTION
### Description

http proxy to acces internet is injected in environment variable, and used by axios to make the http query to the esxi/vsphere

this commit explicitly ignore any proxy set 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
