### PR TITLE
fix(backups): use the right settings in writers

### DIFF
--- a/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.mjs
@@ -108,7 +108,7 @@ export const MixinRemoteWriter = (BaseClass = Object) =>
             restoredVm = await xapi.waitObject(restoredId)
           }
           try {
-            const timeout = ms(this._config.healthCheckTimeout)
+            const timeout = ms(this._settings.healthCheckTimeout)
             await new HealthCheckVmBackup({
               restoredVm,
               timeout,

--- a/@xen-orchestra/backups/_runners/_writers/_MixinXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/_MixinXapiWriter.mjs
@@ -71,7 +71,7 @@ export const MixinXapiWriter = (BaseClass = Object) =>
             const healthCheckVm =
               xapi.getObject(healthCheckVmRef, undefined) ?? (await xapi.waitObject(healthCheckVmRef))
             await healthCheckVm.add_tags('xo:no-bak=Health Check')
-            const timeout = ms(this._config.healthCheckTimeout)
+            const timeout = ms(this._settings.healthCheckTimeout)
             await new HealthCheckVmBackup({
               restoredVm: healthCheckVm,
               timeout,


### PR DESCRIPTION
Fix error `Error: val is not a non-empty string or a valid number. val=undefined`

### Description
from https://xcp-ng.org/forum/topic/8853/health-checks-failing/2 
introduced by 42dc75e7398c558e0ed850d94aafae9f88c615db
tested : backup
![image](https://github.com/vatesfr/xen-orchestra/assets/50174/fe7a96ef-0c3f-49ec-a3fe-a584e0e1e5eb)
replication: 
![image](https://github.com/vatesfr/xen-orchestra/assets/50174/054f9534-5d20-4b6a-9a0d-827cb6823358)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
