### PR TITLE
feat(xo-web/XOSTOR): add confirmation modal informing hosts toolstack may restart

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 - [Plugin/audit] Expose records in the REST API at `/rest/v0/plugins/audit/records`
 - [XOSTOR] List linstor resources in the XOSTOR tab of an SR's view (PR [#7542](https://github.com/vatesfr/xen-orchestra/pull/7542))
 - [XOSTOR] Ability to manage XOSTOR interfaces (PR [#7547](https://github.com/vatesfr/xen-orchestra/pull/7547))
-- [XOSTOR/Create] Add confirmation modal informing hosts toolstask will restart if packages need to be installed (PR [#7570](https://github.com/vatesfr/xen-orchestra/pull/7570))
+- [XOSTOR] Require confirmation before creating SR because hosts toolstack will restart if packages need to be installed (PR [#7570](https://github.com/vatesfr/xen-orchestra/pull/7570))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,7 @@
 - [Plugin/audit] Expose records in the REST API at `/rest/v0/plugins/audit/records`
 - [XOSTOR] List linstor resources in the XOSTOR tab of an SR's view (PR [#7542](https://github.com/vatesfr/xen-orchestra/pull/7542))
 - [XOSTOR] Ability to manage XOSTOR interfaces (PR [#7547](https://github.com/vatesfr/xen-orchestra/pull/7547))
+- [XOSTOR/Create] Add confirmation modal informing hosts toolstask will restart if packages need to be installed (PR [#7570](https://github.com/vatesfr/xen-orchestra/pull/7570))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2571,6 +2571,8 @@ const messages = {
   byDefaultManagementNetworkUsed: 'By default, the management network will be used',
   cantFetchDisksFromNonXcpngHost: 'Unable to fetch physical disks from non-XCP-ng host',
   createInterface: 'Create interface',
+  createXostoreConfirm:
+    'If packages need to be installed, the toolstack on those hosts will restart. Do you want to continue?',
   diskAlreadyMounted: 'The disk is mounted on: {mountpoint}',
   diskHasChildren: 'The disk has children',
   diskIncompatibleXostor: 'Disk incompatible with XOSTOR',
@@ -2602,8 +2604,6 @@ const messages = {
   pifsNotStatic: 'Not all PIFs are static',
   replication: 'Replication',
   resourceList: 'Resource list',
-  restartRequiredWarningMessage:
-    'Hosts toolstask will restart if packages need to be installed. Do you want to continue?',
   rpuNoLongerAvailableIfXostor:
     'As long as a XOSTOR storage is present in the pool, Rolling Pool Update will not be available',
   selectDisks: 'Select disk(s)…',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2602,6 +2602,8 @@ const messages = {
   pifsNotStatic: 'Not all PIFs are static',
   replication: 'Replication',
   resourceList: 'Resource list',
+  restartRequiredWarningMessage:
+    'Hosts toolstask will restart if packages need to be installed. Do you want to continue?',
   rpuNoLongerAvailableIfXostor:
     'As long as a XOSTOR storage is present in the pool, Rolling Pool Update will not be available',
   selectDisks: 'Select disk(s)…',
@@ -2613,6 +2615,7 @@ const messages = {
   wrongNumberOfHosts: 'Wrong number of hosts',
   xostor: 'XOSTOR',
   xostorAvailableInXoa: 'XOSTOR is available in XOA',
+  xostorCreation: 'XOSTOR creation',
   xostorIsInBetaStage: 'XOSTOR is currently in its BETA stage. Do not use it in a production environment!',
   xostorDiskRequired: 'At least one disk is required',
   xostorDisksDropdownLabel: '({nDisks, number} disk{nDisks, plural, one {} other {s}}) {hostname}',

--- a/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
+++ b/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
@@ -650,8 +650,8 @@ const NewXostorForm = decorate([
 
         await confirm({
           title: _('xostorCreation'),
-          body: _('restartRequiredWarningMessage'),
-        }).then(() => createXostorSr())
+          body: _('createXostoreConfirm'),
+        })
 
         const preferredInterface =
           networkId !== undefined

--- a/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
+++ b/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
@@ -9,6 +9,7 @@ import semver from 'semver'
 import { Card, CardBlock, CardHeader } from 'card'
 import { connectStore, formatSize } from 'utils'
 import { Container, Col, Row } from 'grid'
+import { confirm } from 'modal'
 import { createGetObjectsOfType } from 'selectors'
 import { first, map, mapValues, remove, size, some } from 'lodash'
 import { createXostorSr, getBlockdevices } from 'xo'
@@ -646,6 +647,11 @@ const NewXostorForm = decorate([
           provisioning,
           replication,
         } = this.state
+
+        await confirm({
+          title: _('xostorCreation'),
+          body: _('restartRequiredWarningMessage'),
+        }).then(() => createXostorSr())
 
         const preferredInterface =
           networkId !== undefined


### PR DESCRIPTION
### Description
![image](https://github.com/vatesfr/xen-orchestra/assets/119158464/402a7083-94e1-4b90-a41b-f39238416bb8)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
