### PR TITLE
fix(proxy): health check fail while running from proxy

### DIFF
--- a/@xen-orchestra/proxy/config.toml
+++ b/@xen-orchestra/proxy/config.toml
@@ -61,7 +61,7 @@ disableFileRemotes = true
 
 [xapiOptions]
 maxUncoalescedVdis = 1
-watchEvents = ['network', 'PIF', 'pool', 'SR', 'task', 'VBD', 'VDI', 'VIF', 'VM']
+watchEvents = ['network', 'PIF', 'pool', 'SR', 'task', 'VBD', 'VDI', 'VIF', 'VM', 'VM_guest_metrics']
 
 
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,7 +18,7 @@
 - [Plugin/load-balancer] Density plan will no longer try to migrate VMs to a host which is reaching critical memory or CPU usage (PR [#7544](https://github.com/vatesfr/xen-orchestra/pull/7544))
 - [VMWare/Migration] Don't use default proxy to query the source
 - [Import/VMWare] Remove additional whitespaces in host address
-- [Backup/HealthCheck] Health check failing with timeout while waiting for guest metrics on proxy
+- [Backup/HealthCheck] Health check failing with timeout while waiting for guest metrics on XO Proxy
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@
 - [Plugin/load-balancer] Density plan will no longer try to migrate VMs to a host which is reaching critical memory or CPU usage (PR [#7544](https://github.com/vatesfr/xen-orchestra/pull/7544))
 - [VMWare/Migration] Don't use default proxy to query the source
 - [Import/VMWare] Remove additional whitespaces in host address
+- [Backup/HealthCheck] Health check failing with timeout while waiting for guest metrics on proxy
 
 ### Packages to release
 


### PR DESCRIPTION
Health check is dependant on the updates on guest metrics to
ensure vm is corretly booted
proxy wasn't watching these events

### Description

from support ticket : 21282
introduced by 231f09de12eb71f7bc09ce4645e742bab4a69a14

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
