### PR TITLE
fix(vmware-explorer): harden vmx parsing

### DIFF
--- a/@xen-orchestra/vmware-explorer/parsers/vmx.mjs
+++ b/@xen-orchestra/vmware-explorer/parsers/vmx.mjs
@@ -14,7 +14,11 @@ function set(obj, keyPath, val) {
     }
     if (!other.length) {
       // without descendant
-      obj[key][index] = val
+      if (typeof obj[key][index] !== 'object') {
+        // sometimes there are additional properties on a string (like guestOS="ubuntu" and then guestOS.detailed =)
+        // we ignore these data for now
+        obj[key][index] = val
+      }
     } else {
       // with descendant
       if (!obj[key][index]) {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,8 @@
 
 - Fix support of XenServer 6.5 (broken in XO 5.93.0)
 
+- [VMWare/Import] Fix `Cannot create property 'xxx' on string 'yyy' when trying to import from ESXi
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -35,6 +37,7 @@
 - @vates/xml major
 - @vates/xml-rpc major
 - @xen-orchestra/mixins minor
+- @xen-orchestra/vmware patch
 - xen-api patch
 - xo-cli patch
 - xo-server minor


### PR DESCRIPTION
### Description

from : https://xcp-ng.org/forum/topic/8864/cannot-create-property-ctkenabled-on-string-true-on-trying-to-import-from-esxi/9

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
