### PR TITLE
feat(web-core): add helper to create subscribable stores

### DIFF
--- a/@xen-orchestra/web-core/docs/stores/subscribable-stores.md
+++ b/@xen-orchestra/web-core/docs/stores/subscribable-stores.md
@@ -1,0 +1,116 @@
+# Subscribable Stores
+
+Subscribable store is a special kind of store that returns its context only after calling a `subscribe` method.
+
+To create a subscribable store you can use the `createSubscribableStoreContext` helper.
+
+It will take a configuration object as the first argument and an object of dependencies as the second argument.
+
+The configuration object must have the following properties:
+
+- `context`: the store context which will be returned after calling `subscribe`
+- `onSubscribe`: a function that will be called when the first client subscribes to the store
+- `onUnsubscribe`: a function that will be called when the last client unsubscribes from the store
+- `isEnabled`: an optional `MaybeRefOrGetter<boolean>` (default: `true`). If set, `onSubscribe` will be called only if
+  the value is `true`
+
+The function will return an object with the following properties:
+
+- `subscribe(options?: { defer: boolean })`: a function which will register a subscription then return the `context`
+- `$context`: a way to access the `context` object without subscribing (helpful for dependencies)
+
+## Basic store
+
+```ts
+export const useBasicStore = defineStore('basic', () => {
+  const context = {
+    // your store context
+  }
+
+  const onSubscribe = async () => {
+    // make requests, register polling, update context...
+  }
+
+  const onUnsubscribe = () => {
+    // cancel current request if any, stop polling...
+  }
+
+  const config = {
+    context,
+    onSubscribe,
+    onUnsubscribe,
+  }
+
+  return createSubscribableStoreContext(config, {})
+})
+```
+
+## `isEnabled` configuration
+
+You can use the `isEnabled` property to conditionally enable the subscription to start.
+
+```ts
+export const useObjectStore = defineStore('basic', () => {
+  const apiStore = useMyApiStore()
+
+  const config = {
+    // ...
+    isEnabled: () => apiStore.isReady,
+  }
+
+  return createSubscribableStoreContext(config, {})
+})
+```
+
+## Store with dependencies
+
+```ts
+export const useGreetingStore = defineStore('greeting', () => {
+  const deps = {
+    userStore: useUserStore(),
+    groupStore: useGroupStore(),
+  }
+
+  const userGreeting = computed(() => `Hello ${deps.userStore.$context.user.value.name}`)
+  const groupGreeting = computed(() => `Hello ${deps.groupStore.$context.group.value.name}`)
+
+  const context = {
+    userGreeting,
+    groupGreeting,
+  }
+
+  const onSubscribe = async () => {
+    // make requests, register polling, update context...
+  }
+
+  const onUnsubscribe = () => {
+    // cancel current request if any, stop polling...
+  }
+
+  const config = {
+    context,
+    onSubscribe,
+    onUnsubscribe,
+  }
+
+  return createSubscribableStoreContext(config, deps)
+})
+```
+
+## Accessing the store context
+
+```ts
+const { foo, bar } = useFoobarStore().subscribe()
+```
+
+## Defer the subscription
+
+```html
+<template>
+  <button @click="start()">Start subscription</button>
+</template>
+```
+
+```ts
+const { foo, bar, start } = useFoobarStore().subscribe({ defer: true })
+```

--- a/@xen-orchestra/web-core/lib/types/subscribable-store.type.ts
+++ b/@xen-orchestra/web-core/lib/types/subscribable-store.type.ts
@@ -1,0 +1,20 @@
+import type { MaybeRefOrGetter, Ref } from 'vue'
+
+export type SubscribeContext<TContext, TDefer extends boolean = false> = TDefer extends true
+  ? TContext & {
+      deferred: true
+      start: () => void
+      isStarted: Readonly<Ref<boolean>>
+    }
+  : TContext & { deferred: false }
+
+export type Subscribe<TDefer extends boolean = false> = (options?: {
+  defer?: TDefer
+}) => SubscribeContext<object, TDefer>
+
+export type SubscribableStoreConfig<TContext> = {
+  context: TContext
+  onSubscribe: () => void
+  onUnsubscribe: () => void
+  isEnabled?: MaybeRefOrGetter<boolean>
+}

--- a/@xen-orchestra/web-core/lib/utils/create-subscribable-store-context.util.ts
+++ b/@xen-orchestra/web-core/lib/utils/create-subscribable-store-context.util.ts
@@ -1,0 +1,59 @@
+import type { SubscribableStoreConfig, Subscribe, SubscribeContext } from '@core/types/subscribable-store.type'
+import { ifElse } from '@core/utils/if-else.utils'
+import { computed, onBeforeUnmount, readonly, type Ref, ref, toValue } from 'vue'
+
+export function createSubscribableStoreContext<TContext>(
+  config: SubscribableStoreConfig<TContext>,
+  dependsOn: Record<any, { subscribe: Subscribe<boolean> }>
+) {
+  const subscriptions = ref(new Set()) as Ref<Set<symbol>>
+  const hasSubscriptions = computed(() => subscriptions.value.size > 0)
+
+  ifElse(() => toValue(config.isEnabled ?? true) && hasSubscriptions.value, config.onSubscribe, config.onUnsubscribe)
+
+  function subscribe(options?: { defer: false }): SubscribeContext<TContext>
+  function subscribe(options: { defer: true }): SubscribeContext<TContext, true>
+  function subscribe<TDefer extends boolean = false>(options?: { defer?: TDefer }): SubscribeContext<TContext, TDefer>
+  function subscribe<TDefer extends boolean>(options?: { defer?: TDefer }): SubscribeContext<TContext, TDefer> {
+    const dependencyStarts = [] as (() => void)[]
+
+    Object.values(dependsOn).forEach(dep => {
+      const context = dep.subscribe({ defer: options?.defer })
+
+      if (context.deferred) {
+        dependencyStarts.push(context.start)
+      }
+    })
+
+    const id = Symbol('Store subscription ID')
+    const isStarted = ref(false)
+
+    const start = () => {
+      isStarted.value = true
+      dependencyStarts.forEach(start => start())
+      subscriptions.value.add(id)
+    }
+
+    onBeforeUnmount(() => subscriptions.value.delete(id))
+
+    if (!options?.defer) {
+      start()
+      return {
+        ...config.context,
+        deferred: false,
+      } as SubscribeContext<TContext, TDefer>
+    }
+
+    return {
+      ...config.context,
+      deferred: true,
+      start,
+      isStarted: readonly(isStarted),
+    } as SubscribeContext<TContext, TDefer>
+  }
+
+  return {
+    $context: config.context,
+    subscribe,
+  }
+}


### PR DESCRIPTION
### Description

Add a helper which allow to easily create a subscribable store (store that return its context only after calling a `subscribe` method and handle what happen on subscribe/unsubscribe)

App-agnostic, to be used with XO Lite and XO 6.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
