### PR TITLE
feat(web6): subscribable stores, REST API fetching, infra tree view

### DIFF
--- a/@xen-orchestra/web-core/docs/stores/subscribable-stores.md
+++ b/@xen-orchestra/web-core/docs/stores/subscribable-stores.md
@@ -1,0 +1,116 @@
+# Subscribable Stores
+
+Subscribable store is a special kind of store that returns its context only after calling a `subscribe` method.
+
+To create a subscribable store you can use the `createSubscribableStoreContext` helper.
+
+It will take a configuration object as the first argument and an object of dependencies as the second argument.
+
+The configuration object must have the following properties:
+
+- `context`: the store context which will be returned after calling `subscribe`
+- `onSubscribe`: a function that will be called when the first client subscribes to the store
+- `onUnsubscribe`: a function that will be called when the last client unsubscribes from the store
+- `isEnabled`: an optional `MaybeRefOrGetter<boolean>` (default: `true`). If set, `onSubscribe` will be called only if
+  the value is `true`
+
+The function will return an object with the following properties:
+
+- `subscribe(options?: { defer: boolean })`: a function which will register a subscription then return the `context`
+- `$context`: a way to access the `context` object without subscribing (helpful for dependencies)
+
+## Basic store
+
+```ts
+export const useBasicStore = defineStore('basic', () => {
+  const context = {
+    // your store context
+  }
+
+  const onSubscribe = async () => {
+    // make requests, register polling, update context...
+  }
+
+  const onUnsubscribe = () => {
+    // cancel current request if any, stop polling...
+  }
+
+  const config = {
+    context,
+    onSubscribe,
+    onUnsubscribe,
+  }
+
+  return createSubscribableStoreContext(config, {})
+})
+```
+
+## `isEnabled` configuration
+
+You can use the `isEnabled` property to conditionally enable the subscription to start.
+
+```ts
+export const useObjectStore = defineStore('basic', () => {
+  const apiStore = useMyApiStore()
+
+  const config = {
+    // ...
+    isEnabled: () => apiStore.isReady,
+  }
+
+  return createSubscribableStoreContext(config, {})
+})
+```
+
+## Store with dependencies
+
+```ts
+export const useGreetingStore = defineStore('greeting', () => {
+  const deps = {
+    userStore: useUserStore(),
+    groupStore: useGroupStore(),
+  }
+
+  const userGreeting = computed(() => `Hello ${deps.userStore.$context.user.value.name}`)
+  const groupGreeting = computed(() => `Hello ${deps.groupStore.$context.group.value.name}`)
+
+  const context = {
+    userGreeting,
+    groupGreeting,
+  }
+
+  const onSubscribe = async () => {
+    // make requests, register polling, update context...
+  }
+
+  const onUnsubscribe = () => {
+    // cancel current request if any, stop polling...
+  }
+
+  const config = {
+    context,
+    onSubscribe,
+    onUnsubscribe,
+  }
+
+  return createSubscribableStoreContext(config, deps)
+})
+```
+
+## Accessing the store context
+
+```ts
+const { foo, bar } = useFoobarStore().subscribe()
+```
+
+## Defer the subscription
+
+```html
+<template>
+  <button @click="start()">Start subscription</button>
+</template>
+```
+
+```ts
+const { foo, bar, start } = useFoobarStore().subscribe({ defer: true })
+```

--- a/@xen-orchestra/web-core/lib/components/tree/TreeItem.vue
+++ b/@xen-orchestra/web-core/lib/components/tree/TreeItem.vue
@@ -9,16 +9,25 @@
 <script lang="ts" setup>
 import { IK_TREE_ITEM_EXPANDED, IK_TREE_ITEM_HAS_CHILDREN, IK_TREE_ITEM_TOGGLE } from '@core/utils/injection-keys.util'
 import { useToggle } from '@vueuse/core'
-import { computed, provide } from 'vue'
+import { onBeforeMount, onBeforeUpdate, provide, ref, useSlots } from 'vue'
 
-const slots = defineSlots<{
+defineSlots<{
   default: () => void
   sublist: () => void
 }>()
 
 const [isExpanded, toggle] = useToggle(true)
 
-const hasChildren = computed(() => slots.sublist !== undefined)
+const hasChildren = ref(false)
+
+const updateHasChildren = () => {
+  const { sublist } = useSlots()
+  hasChildren.value = sublist !== undefined
+}
+
+onBeforeMount(() => updateHasChildren())
+onBeforeUpdate(() => updateHasChildren())
+
 provide(IK_TREE_ITEM_HAS_CHILDREN, hasChildren)
 provide(IK_TREE_ITEM_TOGGLE, toggle)
 provide(IK_TREE_ITEM_EXPANDED, isExpanded)

--- a/@xen-orchestra/web-core/lib/components/tree/TreeItemLabel.vue
+++ b/@xen-orchestra/web-core/lib/components/tree/TreeItemLabel.vue
@@ -48,7 +48,7 @@ import {
 } from '@core/utils/injection-keys.util'
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types'
 import { faAngleDown, faAngleRight } from '@fortawesome/free-solid-svg-icons'
-import { computed, inject, ref } from 'vue'
+import { inject, ref } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
 
 defineProps<{
@@ -58,10 +58,7 @@ defineProps<{
   noIndent?: boolean
 }>()
 
-const hasToggle = inject(
-  IK_TREE_ITEM_HAS_CHILDREN,
-  computed(() => false)
-)
+const hasToggle = inject(IK_TREE_ITEM_HAS_CHILDREN, ref(false))
 
 const toggle = inject(IK_TREE_ITEM_TOGGLE, () => undefined)
 const isExpanded = inject(IK_TREE_ITEM_EXPANDED, ref(true))
@@ -123,5 +120,9 @@ const depth = inject(IK_TREE_LIST_DEPTH, 0)
   white-space: nowrap;
   text-overflow: ellipsis;
   padding-inline-end: 0.4rem;
+}
+
+.icon {
+  font-size: 1.6rem;
 }
 </style>

--- a/@xen-orchestra/web-core/lib/types/subscribable-store.type.ts
+++ b/@xen-orchestra/web-core/lib/types/subscribable-store.type.ts
@@ -1,0 +1,20 @@
+import type { MaybeRefOrGetter, Ref } from 'vue'
+
+export type SubscribeContext<TContext, TDefer extends boolean = false> = TDefer extends true
+  ? TContext & {
+      deferred: true
+      start: () => void
+      isStarted: Readonly<Ref<boolean>>
+    }
+  : TContext & { deferred: false }
+
+export type Subscribe<TDefer extends boolean = false> = (options?: {
+  defer?: TDefer
+}) => SubscribeContext<object, TDefer>
+
+export type SubscribableStoreConfig<TContext> = {
+  context: TContext
+  onSubscribe: () => void
+  onUnsubscribe: () => void
+  isEnabled?: MaybeRefOrGetter<boolean>
+}

--- a/@xen-orchestra/web-core/lib/utils/create-subscribable-store-context.util.ts
+++ b/@xen-orchestra/web-core/lib/utils/create-subscribable-store-context.util.ts
@@ -1,0 +1,59 @@
+import type { SubscribableStoreConfig, Subscribe, SubscribeContext } from '@core/types/subscribable-store.type'
+import { ifElse } from '@core/utils/if-else.utils'
+import { computed, onBeforeUnmount, readonly, type Ref, ref, toValue } from 'vue'
+
+export function createSubscribableStoreContext<TContext>(
+  config: SubscribableStoreConfig<TContext>,
+  dependsOn: Record<any, { subscribe: Subscribe<boolean> }>
+) {
+  const subscriptions = ref(new Set()) as Ref<Set<symbol>>
+  const hasSubscriptions = computed(() => subscriptions.value.size > 0)
+
+  ifElse(() => toValue(config.isEnabled ?? true) && hasSubscriptions.value, config.onSubscribe, config.onUnsubscribe)
+
+  function subscribe(options?: { defer: false }): SubscribeContext<TContext>
+  function subscribe(options: { defer: true }): SubscribeContext<TContext, true>
+  function subscribe<TDefer extends boolean = false>(options?: { defer?: TDefer }): SubscribeContext<TContext, TDefer>
+  function subscribe<TDefer extends boolean>(options?: { defer?: TDefer }): SubscribeContext<TContext, TDefer> {
+    const dependencyStarts = [] as (() => void)[]
+
+    Object.values(dependsOn).forEach(dep => {
+      const context = dep.subscribe({ defer: options?.defer })
+
+      if (context.deferred) {
+        dependencyStarts.push(context.start)
+      }
+    })
+
+    const id = Symbol('Store subscription ID')
+    const isStarted = ref(false)
+
+    const start = () => {
+      isStarted.value = true
+      dependencyStarts.forEach(start => start())
+      subscriptions.value.add(id)
+    }
+
+    onBeforeUnmount(() => subscriptions.value.delete(id))
+
+    if (!options?.defer) {
+      start()
+      return {
+        ...config.context,
+        deferred: false,
+      } as SubscribeContext<TContext, TDefer>
+    }
+
+    return {
+      ...config.context,
+      deferred: true,
+      start,
+      isStarted: readonly(isStarted),
+    } as SubscribeContext<TContext, TDefer>
+  }
+
+  return {
+    $context: config.context,
+    subscribe,
+  }
+}

--- a/@xen-orchestra/web-core/lib/utils/injection-keys.util.ts
+++ b/@xen-orchestra/web-core/lib/utils/injection-keys.util.ts
@@ -1,6 +1,6 @@
 import type { ComputedRef, InjectionKey, Ref } from 'vue'
 
-export const IK_TREE_ITEM_HAS_CHILDREN = Symbol('IK_TREE_ITEM_HAS_CHILDREN') as InjectionKey<ComputedRef<boolean>>
+export const IK_TREE_ITEM_HAS_CHILDREN = Symbol('IK_TREE_ITEM_HAS_CHILDREN') as InjectionKey<Ref<boolean>>
 
 export const IK_TREE_ITEM_TOGGLE = Symbol('IK_TREE_ITEM_TOGGLE') as InjectionKey<(force?: boolean) => void>
 

--- a/@xen-orchestra/web-core/lib/utils/sort-by-name-label.util.ts
+++ b/@xen-orchestra/web-core/lib/utils/sort-by-name-label.util.ts
@@ -1,0 +1,6 @@
+export function sortByNameLabel<TObject extends { name_label: string }>(
+  { name_label: label1 }: TObject,
+  { name_label: label2 }: TObject
+) {
+  return label1.localeCompare(label2, undefined, { numeric: true })
+}

--- a/@xen-orchestra/web/.env.dist
+++ b/@xen-orchestra/web/.env.dist
@@ -1,0 +1,4 @@
+VITE_XO_REST_BASE_URL=
+
+# Set to `true` to disable SSL verification on VITE_XO_REST_BASE_URL
+VITE_XO_REST_UNSECURE=

--- a/@xen-orchestra/web/README.md
+++ b/@xen-orchestra/web/README.md
@@ -1,1 +1,10 @@
 # Xen Orchestra 6
+
+## Development
+
+1. Clone the project
+2. Install dependencies: `yarn`
+3. Copy `.env.dist` to `.env` and adjust the values
+4. Start the project: `yarn dev`
+5. Generate a token from your XO 5 instance
+6. Go to http://localhost:5173/#/dev/token and paste the token

--- a/@xen-orchestra/web/src/components/infra/InfraHostItem.vue
+++ b/@xen-orchestra/web/src/components/infra/InfraHostItem.vue
@@ -1,0 +1,39 @@
+<template>
+  <TreeItem>
+    <TreeItemLabel :icon="faServer" :no-indent="!hasVMs" :route="`/host/${host.id}`">
+      {{ host.name_label }}
+      <template #addons>
+        <UiIcon v-if="isMaster" v-tooltip="$t('core.master')" :icon="faStar" color="warning" />
+      </template>
+    </TreeItemLabel>
+    <template v-if="hasVMs" #sublist>
+      <InfraVmList :host-id="host.id" />
+    </template>
+  </TreeItem>
+</template>
+
+<script lang="ts" setup>
+import InfraVmList from '@/components/infra/InfraVmList.vue'
+import { useHostStore } from '@/stores/xo-rest-api/host.store'
+import { useVmStore } from '@/stores/xo-rest-api/vm.store'
+import type { Host } from '@/types/host.type'
+import UiIcon from '@core/components/icon/UiIcon.vue'
+import TreeItem from '@core/components/tree/TreeItem.vue'
+import TreeItemLabel from '@core/components/tree/TreeItemLabel.vue'
+import { vTooltip } from '@core/directives/tooltip.directive'
+import { faServer, faStar } from '@fortawesome/free-solid-svg-icons'
+import { computed } from 'vue'
+
+const props = defineProps<{
+  host: Host
+}>()
+
+const { isMasterHost } = useHostStore().subscribe()
+const { vmsByHost } = useVmStore().subscribe()
+
+const isMaster = computed(() => isMasterHost(props.host.id))
+
+const vms = computed(() => vmsByHost.value.get(props.host.id) ?? [])
+
+const hasVMs = computed(() => vms.value.length > 0)
+</script>

--- a/@xen-orchestra/web/src/components/infra/InfraHostList.vue
+++ b/@xen-orchestra/web/src/components/infra/InfraHostList.vue
@@ -1,0 +1,21 @@
+<template>
+  <TreeList v-if="isReady">
+    <InfraHostItem v-for="host in hosts" :key="host.id" :host />
+  </TreeList>
+</template>
+
+<script lang="ts" setup>
+import InfraHostItem from '@/components/infra/InfraHostItem.vue'
+import { useHostStore } from '@/stores/xo-rest-api/host.store'
+import type { RecordId } from '@/types/xo-object.type'
+import TreeList from '@core/components/tree/TreeList.vue'
+import { computed } from 'vue'
+
+const props = defineProps<{
+  poolId: RecordId<'pool'>
+}>()
+
+const { hostsByPool, isReady } = useHostStore().subscribe()
+
+const hosts = computed(() => hostsByPool.value.get(props.poolId))
+</script>

--- a/@xen-orchestra/web/src/components/infra/InfraPoolItem.vue
+++ b/@xen-orchestra/web/src/components/infra/InfraPoolItem.vue
@@ -1,0 +1,20 @@
+<template>
+  <TreeItem>
+    <TreeItemLabel :icon="faCity" :route="`/pool/${pool.id}`">{{ pool.name_label }}</TreeItemLabel>
+    <template #sublist>
+      <InfraHostList :pool-id="pool.id" />
+    </template>
+  </TreeItem>
+</template>
+
+<script lang="ts" setup>
+import InfraHostList from '@/components/infra/InfraHostList.vue'
+import type { Pool } from '@/types/pool.type'
+import TreeItem from '@core/components/tree/TreeItem.vue'
+import TreeItemLabel from '@core/components/tree/TreeItemLabel.vue'
+import { faCity } from '@fortawesome/free-solid-svg-icons'
+
+defineProps<{
+  pool: Pool
+}>()
+</script>

--- a/@xen-orchestra/web/src/components/infra/InfraPoolList.vue
+++ b/@xen-orchestra/web/src/components/infra/InfraPoolList.vue
@@ -1,0 +1,20 @@
+<template>
+  <TreeList v-if="isReady" class="infra-pool-list">
+    <InfraPoolItem v-for="pool in pools" :key="pool.id" :pool />
+  </TreeList>
+</template>
+
+<script lang="ts" setup>
+import InfraPoolItem from '@/components/infra/InfraPoolItem.vue'
+import { usePoolStore } from '@/stores/xo-rest-api/pool.store'
+import TreeList from '@core/components/tree/TreeList.vue'
+
+const { records: pools, isReady } = usePoolStore().subscribe()
+</script>
+
+<style lang="postcss" scoped>
+.infra-pool-list {
+  background-color: var(--background-color-primary);
+  padding: 0.8rem;
+}
+</style>

--- a/@xen-orchestra/web/src/components/infra/InfraVmItem.vue
+++ b/@xen-orchestra/web/src/components/infra/InfraVmItem.vue
@@ -1,0 +1,22 @@
+<template>
+  <TreeItem>
+    <TreeItemLabel :route="`/vm/${vm.id}`" no-indent>
+      {{ vm.name_label }}
+      <template #icon>
+        <ObjectIcon :state="vm.power_state.toLocaleLowerCase() as POWER_STATE" size="small" type="vm" />
+      </template>
+    </TreeItemLabel>
+  </TreeItem>
+</template>
+
+<script lang="ts" setup>
+import type { Vm } from '@/types/vm.type'
+import ObjectIcon from '@core/components/icon/ObjectIcon.vue'
+import TreeItem from '@core/components/tree/TreeItem.vue'
+import TreeItemLabel from '@core/components/tree/TreeItemLabel.vue'
+import type { POWER_STATE } from '@core/types/power-state.type'
+
+defineProps<{
+  vm: Vm
+}>()
+</script>

--- a/@xen-orchestra/web/src/components/infra/InfraVmList.vue
+++ b/@xen-orchestra/web/src/components/infra/InfraVmList.vue
@@ -1,0 +1,21 @@
+<template>
+  <TreeList v-if="isReady">
+    <InfraVmItem v-for="vm in vms" :key="vm.id" :vm />
+  </TreeList>
+</template>
+
+<script lang="ts" setup>
+import InfraVmItem from '@/components/infra/InfraVmItem.vue'
+import { useVmStore } from '@/stores/xo-rest-api/vm.store'
+import type { RecordId } from '@/types/xo-object.type'
+import TreeList from '@core/components/tree/TreeList.vue'
+import { computed } from 'vue'
+
+const props = defineProps<{
+  hostId: RecordId<'host'>
+}>()
+
+const { isReady, vmsByHost } = useVmStore().subscribe()
+
+const vms = computed(() => vmsByHost.value.get(props.hostId))
+</script>

--- a/@xen-orchestra/web/src/layouts/DefaultLayout.vue
+++ b/@xen-orchestra/web/src/layouts/DefaultLayout.vue
@@ -1,7 +1,9 @@
 <template>
   <CoreLayout>
     <template #app-logo>
-      <LogoTextOnly :short="uiStore.isMobile" class="logo" />
+      <RouterLink class="logo-link" to="/">
+        <LogoTextOnly :short="uiStore.isMobile" class="logo" />
+      </RouterLink>
     </template>
     <template #app-header>
       <UiButton :right-icon="faArrowUpRightFromSquare" level="tertiary">XO 5</UiButton>
@@ -12,7 +14,9 @@
       />
       <AccountMenu />
     </template>
-    <template #sidebar-content>Sidebar coming soon</template>
+    <template #sidebar-content>
+      <InfraPoolList />
+    </template>
     <template #content-header>
       <slot name="content-header" />
     </template>
@@ -30,6 +34,7 @@
 
 <script lang="ts" setup>
 import AccountMenu from '@/components/account-menu/AccountMenu.vue'
+import InfraPoolList from '@/components/infra/InfraPoolList.vue'
 import LogoTextOnly from '@/components/LogoTextOnly.vue'
 import ButtonIcon from '@core/components/button/ButtonIcon.vue'
 import UiButton from '@core/components/button/UiButton.vue'
@@ -49,6 +54,12 @@ const uiStore = useUiStore()
 </script>
 
 <style lang="postcss" scoped>
+.logo-link {
+  display: flex;
+  align-self: stretch;
+  align-items: center;
+}
+
 .logo {
   height: 1.6rem;
 }

--- a/@xen-orchestra/web/src/pages/dev/index.vue
+++ b/@xen-orchestra/web/src/pages/dev/index.vue
@@ -1,0 +1,5 @@
+<template>Dev</template>
+
+<script lang="ts" setup></script>
+
+<style lang="postcss" scoped></style>

--- a/@xen-orchestra/web/src/pages/dev/token.vue
+++ b/@xen-orchestra/web/src/pages/dev/token.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="token">
+    <form @submit.prevent="handleSubmit">
+      Enter XO 5 token:
+      <input v-model="token" />
+      <button type="submit">Register token</button>
+    </form>
+
+    <button class="clear-token" @click="clearToken">Clear token</button>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const token = ref('')
+const router = useRouter()
+
+const redirect = async () => {
+  await router.push('/')
+  window.location.reload()
+}
+
+const setCookie = (value: string) => {
+  document.cookie = `authenticationToken=${value}; path=/; max-age=31536000`
+  redirect()
+}
+
+function handleSubmit() {
+  setCookie(token.value)
+}
+
+function clearToken() {
+  setCookie('')
+}
+</script>
+
+<style lang="postcss" scoped>
+.token {
+  padding: 2rem;
+}
+
+.clear-token {
+  margin-top: 2rem;
+}
+</style>

--- a/@xen-orchestra/web/src/pages/host/:id.vue
+++ b/@xen-orchestra/web/src/pages/host/:id.vue
@@ -1,0 +1,9 @@
+<template>
+  <DefaultLayout>
+    <template #content> Coming soon</template>
+  </DefaultLayout>
+</template>
+
+<script lang="ts" setup>
+import DefaultLayout from '@/layouts/DefaultLayout.vue'
+</script>

--- a/@xen-orchestra/web/src/pages/pool/:id.vue
+++ b/@xen-orchestra/web/src/pages/pool/:id.vue
@@ -1,0 +1,9 @@
+<template>
+  <DefaultLayout>
+    <template #content> Coming soon</template>
+  </DefaultLayout>
+</template>
+
+<script lang="ts" setup>
+import DefaultLayout from '@/layouts/DefaultLayout.vue'
+</script>

--- a/@xen-orchestra/web/src/pages/vm/:id.vue
+++ b/@xen-orchestra/web/src/pages/vm/:id.vue
@@ -1,0 +1,9 @@
+<template>
+  <DefaultLayout>
+    <template #content> Coming soon</template>
+  </DefaultLayout>
+</template>
+
+<script lang="ts" setup>
+import DefaultLayout from '@/layouts/DefaultLayout.vue'
+</script>

--- a/@xen-orchestra/web/src/stores/xo-rest-api/host.store.ts
+++ b/@xen-orchestra/web/src/stores/xo-rest-api/host.store.ts
@@ -1,0 +1,45 @@
+import { usePoolStore } from '@/stores/xo-rest-api/pool.store'
+import { createXoStoreConfig } from '@/utils/create-xo-store-config.util'
+import type { Host } from '@/types/host.type'
+import type { RecordId } from '@/types/xo-object.type'
+import { createSubscribableStoreContext } from '@core/utils/create-subscribable-store-context.util'
+import { sortByNameLabel } from '@core/utils/sort-by-name-label.util'
+import { defineStore } from 'pinia'
+import { computed } from 'vue'
+
+export const useHostStore = defineStore('host', () => {
+  const deps = {
+    poolStore: usePoolStore(),
+  }
+
+  const { context: baseContext, ...configRest } = createXoStoreConfig('host', {
+    sortBy: sortByNameLabel,
+  })
+
+  const isMasterHost = (hostId: RecordId<'host'>) =>
+    !!deps.poolStore.$context.records.find(pool => pool.master === hostId)
+
+  const hostsByPool = computed(() => {
+    const hostsByPoolMap = new Map<RecordId<'pool'>, Host[]>()
+
+    baseContext.records.value.forEach(host => {
+      const poolId = host.$pool
+
+      if (!hostsByPoolMap.has(poolId)) {
+        hostsByPoolMap.set(poolId, [])
+      }
+
+      hostsByPoolMap.get(poolId)!.push(host)
+    })
+
+    return hostsByPoolMap
+  })
+
+  const context = {
+    ...baseContext,
+    isMasterHost,
+    hostsByPool,
+  }
+
+  return createSubscribableStoreContext({ context, ...configRest }, deps)
+})

--- a/@xen-orchestra/web/src/stores/xo-rest-api/pool.store.ts
+++ b/@xen-orchestra/web/src/stores/xo-rest-api/pool.store.ts
@@ -1,0 +1,12 @@
+import { createXoStoreConfig } from '@/utils/create-xo-store-config.util'
+import { createSubscribableStoreContext } from '@core/utils/create-subscribable-store-context.util'
+import { sortByNameLabel } from '@core/utils/sort-by-name-label.util'
+import { defineStore } from 'pinia'
+
+export const usePoolStore = defineStore('pool', () => {
+  const config = createXoStoreConfig('pool', {
+    sortBy: sortByNameLabel,
+  })
+
+  return createSubscribableStoreContext(config, {})
+})

--- a/@xen-orchestra/web/src/stores/xo-rest-api/vm.store.ts
+++ b/@xen-orchestra/web/src/stores/xo-rest-api/vm.store.ts
@@ -1,0 +1,51 @@
+import type { Vm } from '@/types/vm.type'
+import { VM_POWER_STATE } from '@/types/vm.type'
+import type { RecordId } from '@/types/xo-object.type'
+import { createXoStoreConfig } from '@/utils/create-xo-store-config.util'
+import { createSubscribableStoreContext } from '@core/utils/create-subscribable-store-context.util'
+import { sortByNameLabel } from '@core/utils/sort-by-name-label.util'
+import { defineStore } from 'pinia'
+import { computed } from 'vue'
+
+function createVmsMap<THostLess extends boolean>(vms: Vm[], hostLess: THostLess) {
+  const vmsMap = new Map<THostLess extends true ? RecordId<'pool'> : RecordId<'host'>, Vm[]>()
+
+  vms.forEach(vm => {
+    const hasHost = vm.$container !== vm.$pool
+
+    if (hasHost && hostLess) {
+      return
+    }
+
+    const id = vm.$container as THostLess extends true ? RecordId<'pool'> : RecordId<'host'>
+
+    if (!vmsMap.has(id)) {
+      vmsMap.set(id, [])
+    }
+
+    vmsMap.get(id)!.push(vm)
+  })
+
+  return vmsMap
+}
+
+export const useVmStore = defineStore('vm', () => {
+  const { context: baseContext, ...configRest } = createXoStoreConfig('VM', {
+    sortBy: sortByNameLabel,
+  })
+
+  const runningVms = computed(() => baseContext.records.value.filter(vm => vm.power_state === VM_POWER_STATE.RUNNING))
+
+  const vmsByHost = computed(() => createVmsMap(baseContext.records.value, false))
+
+  const hostLessVmsByPool = computed(() => createVmsMap(baseContext.records.value, true))
+
+  const context = {
+    ...baseContext,
+    runningVms,
+    vmsByHost,
+    hostLessVmsByPool,
+  }
+
+  return createSubscribableStoreContext({ context, ...configRest }, {})
+})

--- a/@xen-orchestra/web/src/types/host.type.ts
+++ b/@xen-orchestra/web/src/types/host.type.ts
@@ -1,0 +1,20 @@
+import type { RecordId } from '@/types/xo-object.type'
+
+export enum HOST_POWER_STATE {
+  HALTED = 'halted',
+  RUNNING = 'running',
+  UNKNOWN = 'unknown',
+}
+
+export type Host = {
+  id: RecordId<'host'>
+  type: 'host'
+  $pool: RecordId<'pool'>
+  _xapiRef: string
+  address: string
+  enabled: boolean
+  name_label: string
+  name_description: string
+  power_state: HOST_POWER_STATE
+  residentVms: RecordId<'VM'>[]
+}

--- a/@xen-orchestra/web/src/types/pool.type.ts
+++ b/@xen-orchestra/web/src/types/pool.type.ts
@@ -1,0 +1,11 @@
+import type { RecordId } from '@/types/xo-object.type'
+
+export type Pool = {
+  id: RecordId<'pool'>
+  type: 'pool'
+  $pool: RecordId<'pool'>
+  master: RecordId<'host'>
+  name_description: string
+  name_label: string
+  _xapiRef: string
+}

--- a/@xen-orchestra/web/src/types/vm.type.ts
+++ b/@xen-orchestra/web/src/types/vm.type.ts
@@ -1,0 +1,21 @@
+import type { RecordId } from '@/types/xo-object.type'
+
+export enum VM_POWER_STATE {
+  HALTED = 'Halted',
+  PAUSED = 'Paused',
+  RUNNING = 'Running',
+  SUSPENDED = 'Suspended',
+}
+
+export type Vm = {
+  id: RecordId<'VM'>
+  type: 'VM'
+  $container: RecordId<'host'> | RecordId<'pool'>
+  $pool: RecordId<'pool'>
+  _xapiRef: string
+  name_label: string
+  name_description: string
+  power_state: VM_POWER_STATE
+  addresses: Record<string, string>
+  mainIpAddress: string
+}

--- a/@xen-orchestra/web/src/types/xo-object.type.ts
+++ b/@xen-orchestra/web/src/types/xo-object.type.ts
@@ -1,0 +1,27 @@
+import type { Host } from '@/types/host.type'
+import type { Pool } from '@/types/pool.type'
+import type { Vm } from '@/types/vm.type'
+import type { ComputedRef, Ref } from 'vue'
+
+declare const __brand: unique symbol
+
+// eslint-disable-next-line no-use-before-define
+export type RecordId<Type extends XoObjectType> = string & { [__brand]: `${Type}Id` }
+
+export type XoObject = Vm | Host | Pool
+
+export type XoObjectType = XoObject['type']
+
+export type XoObjectTypeToXoObject<TType extends XoObjectType> = {
+  [TObject in XoObject as TObject['type']]: TObject
+}[TType]
+
+export type XoObjectContext<TXoObject extends XoObject> = {
+  records: ComputedRef<TXoObject[]>
+  get: (id: TXoObject['id']) => TXoObject | undefined
+  has: (id: TXoObject['id']) => boolean
+  isFetching: Readonly<Ref<boolean>>
+  isReady: Readonly<Ref<boolean>>
+  lastError: Readonly<Ref<string | undefined>>
+  hasError: ComputedRef<boolean>
+}

--- a/@xen-orchestra/web/src/utils/create-xo-store-config.util.ts
+++ b/@xen-orchestra/web/src/utils/create-xo-store-config.util.ts
@@ -1,0 +1,105 @@
+import type { XoObject, XoObjectContext, XoObjectType, XoObjectTypeToXoObject } from '@/types/xo-object.type'
+import { restApiConfig } from '@/utils/rest-api-config.util'
+import type { SubscribableStoreConfig } from '@core/types/subscribable-store.type'
+import { useFetch } from '@vueuse/core'
+import { computed, readonly, ref, shallowReactive } from 'vue'
+
+export function createXoStoreConfig<
+  TType extends XoObjectType,
+  TXoObjectInput extends XoObjectTypeToXoObject<TType>,
+  TBeforeAdd extends ((input: TXoObjectInput) => undefined | XoObject) | undefined = (
+    input: TXoObjectInput
+  ) => TXoObjectInput,
+  TXoObject extends XoObject = TBeforeAdd extends (input: TXoObjectInput) => any
+    ? NonNullable<ReturnType<TBeforeAdd>>
+    : TXoObjectInput,
+>(
+  type: TType,
+  options?: {
+    sortBy?: (a: TXoObject, b: TXoObject) => number
+    beforeAdd?: TBeforeAdd
+  }
+): SubscribableStoreConfig<XoObjectContext<TXoObject>> {
+  const recordsById = shallowReactive(new Map<TXoObject['id'], TXoObject>())
+  const records = computed(() => {
+    const results = Array.from(recordsById.values())
+
+    if (options?.sortBy) {
+      return results.sort(options.sortBy)
+    }
+
+    return results
+  })
+
+  const get = (id: TXoObject['id']) => recordsById.get(id)
+
+  const has = (id: TXoObject['id']) => recordsById.has(id)
+
+  const isReady = ref(false)
+
+  const urlParams = new URLSearchParams(`fields=${restApiConfig[type].fields}`)
+
+  const { isFetching, error, execute, canAbort, abort, data } = useFetch(
+    `/rest/v0/${restApiConfig[type].path}?${urlParams.toString()}`,
+    {
+      immediate: false,
+      beforeFetch({ options }) {
+        options.credentials = 'include'
+
+        return { options }
+      },
+    }
+  )
+    .get()
+    .json<TXoObjectInput[]>()
+
+  const hasError = computed(() => error.value !== undefined)
+
+  const handleAdd = (record: TXoObjectInput) => {
+    const recordToAdd = options?.beforeAdd ? options.beforeAdd(record) : record
+
+    if (recordToAdd === undefined) {
+      return
+    }
+
+    recordsById.set(record.id, recordToAdd as TXoObject)
+  }
+
+  const handleAfterLoad = (records: TXoObjectInput[]) => {
+    records.forEach(record => handleAdd(record))
+    isReady.value = true
+  }
+
+  const onSubscribe = async () => {
+    await execute()
+
+    if (data.value) {
+      handleAfterLoad(data.value)
+    }
+  }
+
+  const onUnsubscribe = () => {
+    if (canAbort.value) {
+      abort()
+    }
+
+    isReady.value = false
+  }
+
+  const context = {
+    records,
+    get,
+    has,
+    isFetching: readonly(isFetching),
+    isReady: readonly(isReady),
+    lastError: readonly(error),
+    hasError,
+  } as XoObjectContext<TXoObject>
+
+  return {
+    context,
+    onSubscribe,
+    onUnsubscribe,
+    isEnabled: true,
+  }
+}

--- a/@xen-orchestra/web/src/utils/rest-api-config.util.ts
+++ b/@xen-orchestra/web/src/utils/rest-api-config.util.ts
@@ -1,0 +1,16 @@
+import type { XoObjectType } from '@/types/xo-object.type'
+
+export const restApiConfig: Record<XoObjectType, { path: string; fields: string }> = {
+  VM: {
+    path: 'vms',
+    fields: 'id,name_label,power_state,$container',
+  },
+  host: {
+    path: 'hosts',
+    fields: 'id,name_label,power_state,residentVms,$pool',
+  },
+  pool: {
+    path: 'pools',
+    fields: 'id,name_label,master',
+  },
+}

--- a/@xen-orchestra/web/typed-router.d.ts
+++ b/@xen-orchestra/web/typed-router.d.ts
@@ -40,6 +40,11 @@ import type {
 declare module 'vue-router/auto/routes' {
   export interface RouteNamedMap {
     '/': RouteRecordInfo<'/', '/', Record<never, never>, Record<never, never>>
+    '/dev/': RouteRecordInfo<'/dev/', '/dev', Record<never, never>, Record<never, never>>
+    '/dev/token': RouteRecordInfo<'/dev/token', '/dev/token', Record<never, never>, Record<never, never>>
+    '/host/:id': RouteRecordInfo<'/host/:id', '/host/:id', Record<never, never>, Record<never, never>>
+    '/pool/:id': RouteRecordInfo<'/pool/:id', '/pool/:id', Record<never, never>, Record<never, never>>
+    '/vm/:id': RouteRecordInfo<'/vm/:id', '/vm/:id', Record<never, never>, Record<never, never>>
   }
 }
 

--- a/@xen-orchestra/web/vite.config.ts
+++ b/@xen-orchestra/web/vite.config.ts
@@ -3,22 +3,36 @@ import vue from '@vitejs/plugin-vue'
 import { fileURLToPath, URL } from 'node:url'
 import { resolve } from 'path'
 import vueRouter from 'unplugin-vue-router/vite'
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  base: './',
-  plugins: [
-    vueRouter(),
-    vue(),
-    vueI18n({
-      include: [resolve(__dirname, 'src/locales/**'), resolve(__dirname, '../web-core/lib/locales/**')],
-    }),
-  ],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-      '@core': fileURLToPath(new URL('../web-core/lib', import.meta.url)),
+export default defineConfig(({ mode }) => {
+  const { VITE_XO_REST_BASE_URL, VITE_XO_REST_UNSECURE } = loadEnv(mode, process.cwd())
+
+  return {
+    base: './',
+    plugins: [
+      vueRouter({
+        exclude: mode !== 'development' ? ['src/pages/dev/**'] : [],
+      }),
+      vue(),
+      vueI18n({
+        include: [resolve(__dirname, 'src/locales/**'), resolve(__dirname, '../web-core/lib/locales/**')],
+      }),
+    ],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+        '@core': fileURLToPath(new URL('../web-core/lib', import.meta.url)),
+      },
     },
-  },
+    server: {
+      proxy: {
+        '/rest': {
+          secure: VITE_XO_REST_UNSECURE !== 'true',
+          target: VITE_XO_REST_BASE_URL,
+        },
+      },
+    },
+  }
 })


### PR DESCRIPTION
### Description

- Implement subscribable store on XO 6
- Fetch data from REST API
- Display infrastructure tree view
- Updated README
- Added dev pages:
  - **index.vue**: empty page for component development
  - **token.vue**: form to register or clear a token cookie

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
