### PR TITLE
 feat(xo-server/rest-api): support additional options on create_vm action

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -9,6 +9,7 @@
 
 - [i18n] Japanese translation (PR [#7582](https://github.com/vatesfr/xen-orchestra/pull/7582))
 - [REST API] [Watch mode for the tasks collection](./packages/xo-server/docs/rest-api.md#all-tasks) (PR [#7565](https://github.com/vatesfr/xen-orchestra/pull/7565))
+- [REST API] _Create VM_ action enhanced
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -332,6 +332,13 @@ export default class RestApi {
             name_description: { type: 'string', minLength: 0, optional: true },
             name_label: { type: 'string' },
             template: { type: 'string' },
+            CPUs: { type: 'integer', optional: true },
+            cpusMax: { type: 'integer', optional: true },
+            secureBoot: { type: 'boolean', default: false },
+            createVtpm: { type: 'boolean', default: false },
+            hvmBootFirmware: { enum: ['bios', 'uefi'], default: 'bios' },
+            VDIs: { type: 'array' },
+            VIFs: { type: 'array' },
           }
         ),
         emergency_shutdown: async ({ xapiObject }) => {


### PR DESCRIPTION
### Description

Add support for additional options for the `create_vm` action 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
