### PR TITLE
fix(lite/release): pass "duplex: 'half'" option to tarball request

### DIFF
--- a/@xen-orchestra/lite/scripts/release.mjs
+++ b/@xen-orchestra/lite/scripts/release.mjs
@@ -112,6 +112,7 @@ const ghApiCall = async (path, method = 'GET', data) => {
 const ghApiUploadReleaseAsset = async (releaseId, assetName, file) => {
   const opts = {
     method: 'POST',
+    duplex: 'half',
     body: fs.createReadStream(file),
     headers: {
       Accept: 'application/vnd.github+json',


### PR DESCRIPTION
### Description

If the body of a request is a stream, we could start receiving the response before the request has been fully sent (full duplex). However, Node does not support full duplex. Since other JS runtimes do support full duplex, Node now requires to pass "duplex: 'half'" for compatibility concerns with those JS runtimes.

Spec: https://fetch.spec.whatwg.org/#ref-for-dom-requestinit-duplex
WHATWG discussion: https://github.com/whatwg/fetch/issues/1254
Node discussion: https://github.com/nodejs/node/issues/46221

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
