### PR TITLE
fix(xo-server/v2v): extent chain computation

### DIFF
--- a/@xen-orchestra/vmware-explorer/esxi.mjs
+++ b/@xen-orchestra/vmware-explorer/esxi.mjs
@@ -273,13 +273,14 @@ export default class Esxi extends EventEmitter {
 
         // structure of layoutEx is described in  https://developer.vmware.com/apis/1720/
         layoutEx?.disk?.forEach(disk => {
+          // we can stop, even if only one disk is missing an extent
           hasAllExtentsListed &&
             disk.chain?.forEach(({ fileKey: fileKeys }) => {
               // look for the disk extent data , not the descriptor
-              const fileChain = layoutEx.file.find(file => {
+              const fileExtent = layoutEx.file.find(file => {
                 return fileKeys.includes(file.key) && file.type === 'diskExtent'
               })
-              hasAllExtentsListed = hasAllExtentsListed && fileChain.length === fileKeys.length // the chain is complete
+              hasAllExtentsListed = hasAllExtentsListed && fileExtent !== undefined
             })
         })
         const perDatastoreUsage = Array.isArray(storage.perDatastoreUsage)


### PR DESCRIPTION
this is used to show the UI for the import using  exportVm instead of
datastore access
introduced by bb47dafbf9288e32691921091fc835d19f5c7803

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
