### PR TITLE
feat(xo-web/XOSTOR): warn if replication count is higher than number of hosts with disks

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+-[XOSTOR] Display a warning when replication count is higher than then number of hosts with disks (PR [#7625](https://github.com/vatesfr/xen-orchestra/pull/7625))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -30,5 +32,6 @@
 <!--packages-start-->
 
 - xo-server patch
+- xo-web minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,7 +7,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
--[XOSTOR] Display a warning when replication count is higher than then number of hosts with disks (PR [#7625](https://github.com/vatesfr/xen-orchestra/pull/7625))
+-[XOSTOR] Display a warning when replication count is higher than number of hosts with disks (PR [#7625](https://github.com/vatesfr/xen-orchestra/pull/7625))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,7 +7,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
--[XOSTOR] Display a warning when replication count is higher than number of hosts with disks (PR [#7625](https://github.com/vatesfr/xen-orchestra/pull/7625))
+- [New XOSTOR] Display a warning when replication count is higher than number of hosts with disks (PR [#7625](https://github.com/vatesfr/xen-orchestra/pull/7625))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2628,6 +2628,7 @@ const messages = {
   pifsNotAttached: 'Not all PIFs are attached',
   pifsNotStatic: 'Not all PIFs are static',
   replication: 'Replication',
+  replicationCount: 'Replication count is higher than hosts with disks',
   resourceList: 'Resource list',
   rpuNoLongerAvailableIfXostor:
     'As long as a XOSTOR storage is present in the pool, Rolling Pool Update will not be available',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2628,7 +2628,6 @@ const messages = {
   pifsNotAttached: 'Not all PIFs are attached',
   pifsNotStatic: 'Not all PIFs are static',
   replication: 'Replication',
-  replicationCount: 'Replication count is higher than hosts with disks',
   resourceList: 'Resource list',
   rpuNoLongerAvailableIfXostor:
     'As long as a XOSTOR storage is present in the pool, Rolling Pool Update will not be available',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2628,6 +2628,7 @@ const messages = {
   pifsNotAttached: 'Not all PIFs are attached',
   pifsNotStatic: 'Not all PIFs are static',
   replication: 'Replication',
+  replicationCount: 'Replication count is higher than number of hosts with disks',
   resourceList: 'Resource list',
   rpuNoLongerAvailableIfXostor:
     'As long as a XOSTOR storage is present in the pool, Rolling Pool Update will not be available',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2628,7 +2628,7 @@ const messages = {
   pifsNotAttached: 'Not all PIFs are attached',
   pifsNotStatic: 'Not all PIFs are static',
   replication: 'Replication',
-  replicationCount: 'Replication count is higher than number of hosts with disks',
+  replicationCountHigherThanHostsWithDisks: 'Replication count is higher than number of hosts with disks',
   resourceList: 'Resource list',
   rpuNoLongerAvailableIfXostor:
     'As long as a XOSTOR storage is present in the pool, Rolling Pool Update will not be available',

--- a/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
+++ b/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
@@ -522,7 +522,7 @@ const SummaryCard = decorate([
 
         return (totalSize * state.numberOfHostsWithDisks) / state.replication.value
       },
-      isReplicationValid: state => state.replication.value > state.numberOfHostsWithDisks,
+      replicationNotValid: state => state.replication.value > state.numberOfHostsWithDisks,
     },
   }),
   injectState,
@@ -550,7 +550,7 @@ const SummaryCard = decorate([
                   <Icon icon='alarm' /> {_('hostsNotSameNumberOfDisks')}
                 </p>
               )}
-              {state.isReplicationValid && (
+              {state.replicationNotValid && (
                 <p className='text-warning'>
                   <Icon icon='alarm' /> {_('replicationCountHigherThanHostsWithDisks')}
                 </p>

--- a/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
+++ b/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
@@ -522,6 +522,7 @@ const SummaryCard = decorate([
 
         return (totalSize * state.numberOfHostsWithDisks) / state.replication.value
       },
+      replicationCount: state => state.replication.value > state.numberOfHostsWithDisks,
     },
   }),
   injectState,
@@ -547,6 +548,11 @@ const SummaryCard = decorate([
               {!state.areHostsDisksConsistent && (
                 <p className='text-warning'>
                   <Icon icon='alarm' /> {_('hostsNotSameNumberOfDisks')}
+                </p>
+              )}
+              {state.replicationCount && (
+                <p className='text-warning'>
+                  <Icon icon='alarm' /> {_('replicationCount')}
                 </p>
               )}
               <Row>

--- a/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
+++ b/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
@@ -522,7 +522,7 @@ const SummaryCard = decorate([
 
         return (totalSize * state.numberOfHostsWithDisks) / state.replication.value
       },
-      replicationCount: state => state.replication.value > state.numberOfHostsWithDisks,
+      isReplicationValid: state => state.replication.value > state.numberOfHostsWithDisks,
     },
   }),
   injectState,
@@ -550,9 +550,9 @@ const SummaryCard = decorate([
                   <Icon icon='alarm' /> {_('hostsNotSameNumberOfDisks')}
                 </p>
               )}
-              {state.replicationCount && (
+              {state.isReplicationValid && (
                 <p className='text-warning'>
-                  <Icon icon='alarm' /> {_('replicationCount')}
+                  <Icon icon='alarm' /> {_('replicationCountHigherThanHostsWithDisks')}
                 </p>
               )}
               <Row>

--- a/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
+++ b/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
@@ -522,7 +522,6 @@ const SummaryCard = decorate([
 
         return (totalSize * state.numberOfHostsWithDisks) / state.replication.value
       },
-      replicationCount: state => state.replication.value > state.numberOfHostsWithDisks,
     },
   }),
   injectState,
@@ -548,11 +547,6 @@ const SummaryCard = decorate([
               {!state.areHostsDisksConsistent && (
                 <p className='text-warning'>
                   <Icon icon='alarm' /> {_('hostsNotSameNumberOfDisks')}
-                </p>
-              )}
-              {state.replicationCount && (
-                <p className='text-warning'>
-                  <Icon icon='alarm' /> {_('replicationCount')}
                 </p>
               )}
               <Row>


### PR DESCRIPTION
### Description

![Screenshot from 2024-05-02 11-42-56](https://github.com/vatesfr/xen-orchestra/assets/119158464/e9f15cb7-c61f-4e52-a40c-5ad6d82283a2)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
