### PR TITLE
fix(xo-web/pool): only show pool SRs in default SR selector

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Pool] Fix `Headers Timeout Error` when installing patches on XCP-ng
+- [Pool/Advanced] Only show current pool's SRs in default SR selector (PR [#7626](https://github.com/vatesfr/xen-orchestra/pull/7626))
 
 ### Packages to release
 
@@ -30,5 +31,6 @@
 <!--packages-start-->
 
 - xo-server patch
+- xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-web/src/xo-app/pool/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/pool/tab-advanced.js
@@ -201,10 +201,10 @@ class PoolMaster extends Component {
 }))
 class SelectDefaultSr extends Component {
   render() {
-    const { defaultSr } = this.props
+    const { defaultSr, pool } = this.props
 
     return (
-      <XoSelect onChange={setDefaultSr} value={defaultSr} xoType='SR'>
+      <XoSelect onChange={setDefaultSr} value={defaultSr} xoType='SR' predicate={sr => sr.$pool === pool.id}>
         {defaultSr !== undefined ? <Sr id={defaultSr.id} /> : _('noValue')}
       </XoSelect>
     )


### PR DESCRIPTION
Introduced by #7451

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
