### PR TITLE
feat(xo-web/xostor): ability to copy VDI uuid in the resources table

### DIFF
--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2628,6 +2628,7 @@ const messages = {
   pifsNotAttached: 'Not all PIFs are attached',
   pifsNotStatic: 'Not all PIFs are static',
   replication: 'Replication',
+  replicationCount: 'Replication count is higher than hosts with disks',
   resourceList: 'Resource list',
   rpuNoLongerAvailableIfXostor:
     'As long as a XOSTOR storage is present in the pool, Rolling Pool Update will not be available',

--- a/packages/xo-web/src/xo-app/sr/tab-xostor.js
+++ b/packages/xo-web/src/xo-app/sr/tab-xostor.js
@@ -1,6 +1,7 @@
 import _ from 'intl'
 import ActionButton from 'action-button'
 import Component from 'base-component'
+import Copiable from 'copiable'
 import Icon from 'icon'
 import PifsColumn from 'sorted-table/pifs-column'
 import React from 'react'
@@ -40,7 +41,7 @@ const RESOURCE_COLUMNS = [
   },
   {
     name: _('vdi'),
-    itemRenderer: ({ vdiId }) => vdiId !== '' && <Vdi id={vdiId} />,
+    itemRenderer: ({ vdiId }) => <Copiable data={vdiId}>{vdiId !== '' && <Vdi id={vdiId} />}</Copiable>,
   },
   {
     name: _('inUse'),

--- a/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
+++ b/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
@@ -522,6 +522,7 @@ const SummaryCard = decorate([
 
         return (totalSize * state.numberOfHostsWithDisks) / state.replication.value
       },
+      replicationCount: state => state.replication.value > state.numberOfHostsWithDisks,
     },
   }),
   injectState,
@@ -547,6 +548,11 @@ const SummaryCard = decorate([
               {!state.areHostsDisksConsistent && (
                 <p className='text-warning'>
                   <Icon icon='alarm' /> {_('hostsNotSameNumberOfDisks')}
+                </p>
+              )}
+              {state.replicationCount && (
+                <p className='text-warning'>
+                  <Icon icon='alarm' /> {_('replicationCount')}
                 </p>
               )}
               <Row>


### PR DESCRIPTION
### Description

![Screenshot from 2024-05-02 15-14-00](https://github.com/vatesfr/xen-orchestra/assets/119158464/9a7250d2-286b-4133-9fc9-bfcad0cf4142)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
