### PR TITLE
fix(xo-server,xo-web/XOSTOR): do not require XCP-ng licenses

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Pool] Fix `Headers Timeout Error` when installing patches on XCP-ng
+- [XOSTOR] Users with trial XOSTOR licenses does not need XCP-ng Pro Support on their hosts (PR [#7628](https://github.com/vatesfr/xen-orchestra/pull/7628))
 
 ### Packages to release
 
@@ -30,5 +31,6 @@
 <!--packages-start-->
 
 - xo-server patch
+- xo-web patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Pool] Fix `Headers Timeout Error` when installing patches on XCP-ng
-- [XOSTOR] Users with trial XOSTOR licenses does not need XCP-ng Pro Support on their hosts (PR [#7628](https://github.com/vatesfr/xen-orchestra/pull/7628))
+- [XOSTOR] Remove the limitation of having licensed hosts (PR [#7628](https://github.com/vatesfr/xen-orchestra/pull/7628))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Pool] Fix `Headers Timeout Error` when installing patches on XCP-ng
-- [XOSTOR] Remove the limitation of having licensed hosts (PR [#7628](https://github.com/vatesfr/xen-orchestra/pull/7628))
+- [XOSTOR] Don't require host licenses to run XOSTOR (PR [#7628](https://github.com/vatesfr/xen-orchestra/pull/7628))
 
 ### Packages to release
 

--- a/packages/xo-server/src/api/xostor.mjs
+++ b/packages/xo-server/src/api/xostor.mjs
@@ -206,7 +206,6 @@ export const create = defer(async function (
         throw new Error(`Not enough XOSTOR licenses. Expected: ${nPoolHosts}, actual: ${nAvailableLicenses}`)
       }
 
-      // only if not using trial XOSTOR licenses
       if (availableLicenses.some(license => !license.tags.includes('TRIAL'))) {
         const xcpLicenseByHostId = keyBy(await this.getLicenses({ productType: 'xcpng' }), 'boundObjectId')
         const hostIdsWithoutXcpLicense = poolHostIds.filter(id => {

--- a/packages/xo-server/src/api/xostor.mjs
+++ b/packages/xo-server/src/api/xostor.mjs
@@ -1,4 +1,3 @@
-import keyBy from 'lodash/keyBy.js'
 import { asyncEach } from '@vates/async-each'
 import { defer } from 'golike-defer'
 import { Task } from '@xen-orchestra/mixins/Tasks.mjs'
@@ -204,19 +203,6 @@ export const create = defer(async function (
         )
       } else if (nAvailableLicenses < nPoolHosts) {
         throw new Error(`Not enough XOSTOR licenses. Expected: ${nPoolHosts}, actual: ${nAvailableLicenses}`)
-      }
-
-      if (availableLicenses.some(license => !license.tags.includes('TRIAL'))) {
-        const xcpLicenseByHostId = keyBy(await this.getLicenses({ productType: 'xcpng' }), 'boundObjectId')
-        const hostIdsWithoutXcpLicense = poolHostIds.filter(id => {
-          const license = xcpLicenseByHostId[id]
-          return license === undefined || license.expires < now
-        })
-
-        const nHostWithoutXcpLicense = hostIdsWithoutXcpLicense.length
-        if (nHostWithoutXcpLicense > 0) {
-          throw new Error(`${nHostWithoutXcpLicense} hosts do not have XCP-ng Pro license`)
-        }
       }
 
       await asyncEach(

--- a/packages/xo-server/src/xo-mixins/pool.mjs
+++ b/packages/xo-server/src/xo-mixins/pool.mjs
@@ -77,10 +77,7 @@ export default class Pools {
 
     const hasLinstorSr = some(_app.objects.all, { SR_type: 'linstor', $pool: target.uuid })
     if (hasLinstorSr) {
-      await Promise.all([
-        enforceHostsHaveLicense($defer, _app, 'xcpng', sourceIds),
-        enforceHostsHaveLicense($defer, _app, 'xostor', sourceIds),
-      ])
+      await enforceHostsHaveLicense($defer, _app, 'xostor', sourceIds)
     }
 
     // Find missing patches on the target.

--- a/packages/xo-web/src/xo-app/index.js
+++ b/packages/xo-web/src/xo-app/index.js
@@ -260,25 +260,7 @@ export const ICON_POOL_LICENSE = {
 
         hosts.forEach(host => {
           const hostId = host.id
-          const xcpngLicense = xcpngLicenseByBoundObjectId[hostId]
           const xostorLicenses = xostorLicensesByBoundObjectId[hostId]
-
-          if (xcpngLicense === undefined || xcpngLicense.expires < now) {
-            const isTrialLicenses = xostorLicenses.every(
-              license => license.tags.includes('TRIAL') && license.expires > now
-            )
-            if (!isTrialLicenses) {
-              supportEnabled = false
-            }
-            alerts.push({
-              level: isTrialLicenses ? 'warning' : 'danger',
-              render: (
-                <p>
-                  {_('hostNoSupport')} <HostItem id={hostId} />
-                </p>
-              ),
-            })
-          }
 
           if (xostorLicenses === undefined) {
             supportEnabled = false

--- a/packages/xo-web/src/xo-app/index.js
+++ b/packages/xo-web/src/xo-app/index.js
@@ -264,9 +264,14 @@ export const ICON_POOL_LICENSE = {
           const xostorLicenses = xostorLicensesByBoundObjectId[hostId]
 
           if (xcpngLicense === undefined || xcpngLicense.expires < now) {
-            supportEnabled = false
+            const isTrialLicenses = xostorLicenses.every(
+              license => license.tags.includes('TRIAL') && license.expires > now
+            )
+            if (!isTrialLicenses) {
+              supportEnabled = false
+            }
             alerts.push({
-              level: 'danger',
+              level: isTrialLicenses ? 'warning' : 'danger',
               render: (
                 <p>
                   {_('hostNoSupport')} <HostItem id={hostId} />


### PR DESCRIPTION
### Description

After discussion with Marc.P, it was decided to completely remove the limitation on having licensed hosts for the moment.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
