### PR TITLE
feat(xo-web/xostor): ability to copy VDI UUID in the resources table

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,7 +7,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [XOSTOR] Allow to copy VDI uuid in the resources table (PR [#7629](https://github.com/vatesfr/xen-orchestra/pull/7629))
+- [XOSTOR] Ability to copy VDI UUID in the resources table (PR [#7629](https://github.com/vatesfr/xen-orchestra/pull/7629))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [XOSTOR] Allow to copy VDI uuid in the resources table (PR [#7629](https://github.com/vatesfr/xen-orchestra/pull/7629))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -30,5 +32,6 @@
 <!--packages-start-->
 
 - xo-server patch
+- xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2628,6 +2628,7 @@ const messages = {
   pifsNotAttached: 'Not all PIFs are attached',
   pifsNotStatic: 'Not all PIFs are static',
   replication: 'Replication',
+  replicationCount: 'Replication count is higher than hosts with disks',
   resourceList: 'Resource list',
   rpuNoLongerAvailableIfXostor:
     'As long as a XOSTOR storage is present in the pool, Rolling Pool Update will not be available',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2628,7 +2628,6 @@ const messages = {
   pifsNotAttached: 'Not all PIFs are attached',
   pifsNotStatic: 'Not all PIFs are static',
   replication: 'Replication',
-  replicationCount: 'Replication count is higher than hosts with disks',
   resourceList: 'Resource list',
   rpuNoLongerAvailableIfXostor:
     'As long as a XOSTOR storage is present in the pool, Rolling Pool Update will not be available',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -178,6 +178,7 @@ const messages = {
 
   // ----- Copiable component -----
   copyToClipboard: 'Copy to clipboard',
+  copyToClipboardVdiUuid: 'Copy VDI UUID',
   copyUuid: 'Copy {uuid}',
   copyValue: 'Copy {value}',
 

--- a/packages/xo-web/src/xo-app/sr/tab-xostor.js
+++ b/packages/xo-web/src/xo-app/sr/tab-xostor.js
@@ -1,6 +1,7 @@
 import _ from 'intl'
 import ActionButton from 'action-button'
 import Component from 'base-component'
+import Copiable from 'copiable'
 import Icon from 'icon'
 import PifsColumn from 'sorted-table/pifs-column'
 import React from 'react'
@@ -40,7 +41,7 @@ const RESOURCE_COLUMNS = [
   },
   {
     name: _('vdi'),
-    itemRenderer: ({ vdiId }) => vdiId !== '' && <Vdi id={vdiId} />,
+    itemRenderer: ({ vdiId }) => <Copiable data={vdiId}>{vdiId !== '' && <Vdi id={vdiId} />}</Copiable>,
   },
   {
     name: _('inUse'),

--- a/packages/xo-web/src/xo-app/sr/tab-xostor.js
+++ b/packages/xo-web/src/xo-app/sr/tab-xostor.js
@@ -41,7 +41,7 @@ const RESOURCE_COLUMNS = [
   },
   {
     name: _('vdi'),
-    itemRenderer: ({ vdiId }) => <Copiable data={vdiId}>{vdiId !== '' && <Vdi id={vdiId} />}</Copiable>,
+    itemRenderer: ({ vdiId }) => vdiId !== '' && <Copiable data={vdiId}>{<Vdi id={vdiId} />}</Copiable>,
   },
   {
     name: _('inUse'),

--- a/packages/xo-web/src/xo-app/sr/tab-xostor.js
+++ b/packages/xo-web/src/xo-app/sr/tab-xostor.js
@@ -6,6 +6,7 @@ import Icon from 'icon'
 import PifsColumn from 'sorted-table/pifs-column'
 import React from 'react'
 import SortedTable from 'sorted-table'
+import Tooltip from 'tooltip'
 import { addSubscriptions, connectStore, TryXoa } from 'utils'
 import { Card, CardHeader, CardBlock } from 'card'
 import { Container, Row, Col } from 'grid'
@@ -41,7 +42,14 @@ const RESOURCE_COLUMNS = [
   },
   {
     name: _('vdi'),
-    itemRenderer: ({ vdiId }) => vdiId !== '' && <Copiable data={vdiId}>{<Vdi id={vdiId} />}</Copiable>,
+    itemRenderer: ({ vdiId }) =>
+      vdiId !== '' && (
+        <Copiable data={vdiId}>
+          <Tooltip content={_('copyUuid', { uuid: vdiId })}>
+            <Vdi id={vdiId} />
+          </Tooltip>
+        </Copiable>
+      ),
   },
   {
     name: _('inUse'),

--- a/packages/xo-web/src/xo-app/sr/tab-xostor.js
+++ b/packages/xo-web/src/xo-app/sr/tab-xostor.js
@@ -2,11 +2,11 @@ import _ from 'intl'
 import ActionButton from 'action-button'
 import Component from 'base-component'
 import Copiable from 'copiable'
+import copy from 'copy-to-clipboard'
 import Icon from 'icon'
 import PifsColumn from 'sorted-table/pifs-column'
 import React from 'react'
 import SortedTable from 'sorted-table'
-import Tooltip from 'tooltip'
 import { addSubscriptions, connectStore, TryXoa } from 'utils'
 import { Card, CardHeader, CardBlock } from 'card'
 import { Container, Row, Col } from 'grid'
@@ -42,14 +42,7 @@ const RESOURCE_COLUMNS = [
   },
   {
     name: _('vdi'),
-    itemRenderer: ({ vdiId }) =>
-      vdiId !== '' && (
-        <Copiable data={vdiId}>
-          <Tooltip content={_('copyUuid', { uuid: vdiId })}>
-            <Vdi id={vdiId} />
-          </Tooltip>
-        </Copiable>
-      ),
+    itemRenderer: ({ vdiId }) => vdiId !== '' && <Vdi id={vdiId} />,
   },
   {
     name: _('inUse'),
@@ -107,6 +100,16 @@ export default class TabXostor extends Component {
       icon: 'favorite',
       label: _('setAsPreferred'),
       level: 'primary',
+    },
+  ]
+
+  _individualActionsResourceList = [
+    {
+      handler: ({ vdiId }) => copy(vdiId),
+      icon: 'clipboard',
+      label: _('copyToClipboardVdiUuid'),
+      level: 'secondary',
+      disabled: ({ vdiId }) => vdiId === '',
     },
   ]
 
@@ -229,7 +232,12 @@ export default class TabXostor extends Component {
                 <Icon icon='disk' /> {_('resourceList')}
               </CardHeader>
               <CardBlock>
-                <SortedTable collection={resourceInfos} columns={RESOURCE_COLUMNS} stateUrlParam='r' />
+                <SortedTable
+                  collection={resourceInfos}
+                  columns={RESOURCE_COLUMNS}
+                  stateUrlParam='r'
+                  individualActions={this._individualActionsResourceList}
+                />
               </CardBlock>
             </Card>
           </Col>

--- a/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
+++ b/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
@@ -522,6 +522,7 @@ const SummaryCard = decorate([
 
         return (totalSize * state.numberOfHostsWithDisks) / state.replication.value
       },
+      replicationCount: state => state.replication.value > state.numberOfHostsWithDisks,
     },
   }),
   injectState,
@@ -547,6 +548,11 @@ const SummaryCard = decorate([
               {!state.areHostsDisksConsistent && (
                 <p className='text-warning'>
                   <Icon icon='alarm' /> {_('hostsNotSameNumberOfDisks')}
+                </p>
+              )}
+              {state.replicationCount && (
+                <p className='text-warning'>
+                  <Icon icon='alarm' /> {_('replicationCount')}
                 </p>
               )}
               <Row>

--- a/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
+++ b/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
@@ -522,7 +522,6 @@ const SummaryCard = decorate([
 
         return (totalSize * state.numberOfHostsWithDisks) / state.replication.value
       },
-      replicationCount: state => state.replication.value > state.numberOfHostsWithDisks,
     },
   }),
   injectState,
@@ -548,11 +547,6 @@ const SummaryCard = decorate([
               {!state.areHostsDisksConsistent && (
                 <p className='text-warning'>
                   <Icon icon='alarm' /> {_('hostsNotSameNumberOfDisks')}
-                </p>
-              )}
-              {state.replicationCount && (
-                <p className='text-warning'>
-                  <Icon icon='alarm' /> {_('replicationCount')}
                 </p>
               )}
               <Row>


### PR DESCRIPTION
### Description

![image](https://github.com/vatesfr/xen-orchestra/assets/119158464/31c8007b-013a-4af2-b130-30b54ca7c3f6)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
