### PR TITLE
feat(xo6/core): update chip component to v1.1.0

### DIFF
--- a/@xen-orchestra/web-core/lib/components/chip/ChipRemoveIcon.vue
+++ b/@xen-orchestra/web-core/lib/components/chip/ChipRemoveIcon.vue
@@ -1,6 +1,6 @@
 <!-- v1.1.0 -->
 <template>
-  <ButtonIcon v-if="!disabled" :color :disabled :icon="faXmark" class="chip-remove-icon" size="small" />
+  <ButtonIcon :color :icon="faXmark" class="chip-remove-icon" size="small" />
 </template>
 
 <script lang="ts" setup>
@@ -10,18 +10,5 @@ import { faXmark } from '@fortawesome/free-solid-svg-icons'
 
 defineProps<{
   color: Color
-  disabled?: boolean
 }>()
 </script>
-
-<style lang="postcss" scoped>
-.chip-remove-icon {
-  &.disabled {
-    color: var(--color-grey-600);
-
-    &.info {
-      color: var(--color-grey-400);
-    }
-  }
-}
-</style>

--- a/@xen-orchestra/web-core/lib/components/chip/ChipRemoveIcon.vue
+++ b/@xen-orchestra/web-core/lib/components/chip/ChipRemoveIcon.vue
@@ -1,11 +1,12 @@
+<!-- v1.1.0 -->
 <template>
-  <ButtonIcon :color :disabled :icon="faCircleXmark" class="chip-remove-icon" size="small" />
+  <ButtonIcon v-if="!disabled" :color :disabled :icon="faXmark" class="chip-remove-icon" size="small" />
 </template>
 
 <script lang="ts" setup>
 import ButtonIcon from '@core/components/button/ButtonIcon.vue'
 import type { Color } from '@core/types/color.type'
-import { faCircleXmark } from '@fortawesome/free-solid-svg-icons'
+import { faXmark } from '@fortawesome/free-solid-svg-icons'
 
 defineProps<{
   color: Color

--- a/@xen-orchestra/web-core/lib/components/chip/UiChip.vue
+++ b/@xen-orchestra/web-core/lib/components/chip/UiChip.vue
@@ -4,7 +4,7 @@
     <span class="content">
       <slot />
     </span>
-    <ChipRemoveIcon :color :disabled @click.stop="emit('remove')" />
+    <ChipRemoveIcon v-if="!disabled" :color @click.stop="emit('remove')" />
   </span>
 </template>
 


### PR DESCRIPTION
### Description

Update the `ChipRemoveIcon` component by replacing the `faCircleXmark` icon with the `faXmark` icon to match version 1.1.0 from the design system.

## Screenshots

- Before:
![image](https://github.com/vatesfr/xen-orchestra/assets/66562640/6d05e76c-da41-4277-98a7-ff978cdf9769)

- After:
![image](https://github.com/vatesfr/xen-orchestra/assets/66562640/774da91c-ed49-4c8e-a756-5ae84d6e10fb)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
