### PR TITLE
fix(fs,xo-server): remote encryption algorithm was private

### DIFF
--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -12,7 +12,7 @@ import { synchronized } from 'decorator-synchronized'
 
 import { basename, dirname, normalize as normalizePath } from './path'
 import { createChecksumStream, validChecksumOfReadStream } from './checksum'
-import { DEFAULT_ENCRYPTION_ALGORITHM, _getEncryptor } from './_encryptor'
+import { DEFAULT_ENCRYPTION_ALGORITHM, UNENCRYPTED_ALGORITHM, _getEncryptor } from './_encryptor'
 
 const { info, warn } = createLogger('xo:fs:abstract')
 
@@ -673,6 +673,10 @@ export default class RemoteHandlerAbstract {
 
   get isEncrypted() {
     return this.#encryptor.id !== 'NULL_ENCRYPTOR'
+  }
+
+  get encryptionAlgorithm() {
+    return this.#encryptor?.algorithm ?? UNENCRYPTED_ALGORITHM
   }
 }
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Settings/Remotes] Fixed remote encryption not displayed ([PR #7638](https://github.com/vatesfr/xen-orchestra/pull/7638))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -40,6 +42,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/fs patch
 - xen-api patch
 - xo-cli minor
 - xo-server minor

--- a/packages/xo-server/src/xo-mixins/remotes.mjs
+++ b/packages/xo-server/src/xo-mixins/remotes.mjs
@@ -2,12 +2,7 @@ import asyncMapSettled from '@xen-orchestra/async-map/legacy.js'
 import { basename } from 'path'
 import { createLogger } from '@xen-orchestra/log'
 import { format, parse } from 'xo-remote-parser'
-import {
-  DEFAULT_ENCRYPTION_ALGORITHM,
-  getHandler,
-  isLegacyEncryptionAlgorithm,
-  UNENCRYPTED_ALGORITHM,
-} from '@xen-orchestra/fs'
+import { DEFAULT_ENCRYPTION_ALGORITHM, getHandler, isLegacyEncryptionAlgorithm } from '@xen-orchestra/fs'
 import { ignoreErrors, timeout } from 'promise-toolbox'
 import { invalidParameters, noSuchObject } from 'xo-common/api-errors.js'
 import { synchronized } from 'decorator-synchronized'
@@ -162,7 +157,7 @@ export default class {
       let encryption
 
       if (this._handlers[remote.id] !== undefined) {
-        const algorithm = this._handlers[remote.id]._encryptor?.algorithm ?? UNENCRYPTED_ALGORITHM
+        const algorithm = this._handlers[remote.id].encryptionAlgorithm
         encryption = {
           algorithm,
           isLegacy: isLegacyEncryptionAlgorithm(algorithm),


### PR DESCRIPTION
### Description

Encryption was not showing up in remote page because the remote mixin was using an attribute that was private. See https://help.vates.tech/#ticket/zoom/24076

Introduced by 86ddb8f2d92b7b75fa65cce5f7a2296739170b7c

![image](https://github.com/vatesfr/xen-orchestra/assets/150058367/024997e6-4080-411c-a9c8-b13496cc9c92)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
