### PR TITLE
fix(xo-server): RPU failed to install host patches

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Rolling Pool Update] Fixed RPU failing to install patches on hosts (and still appearing as successfull) (PR [#7640](https://github.com/vatesfr/xen-orchestra/pull/7640))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -26,5 +28,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- xo-server patch
 
 <!--packages-end-->

--- a/packages/xo-server/src/xapi/mixins/patching.mjs
+++ b/packages/xo-server/src/xapi/mixins/patching.mjs
@@ -533,14 +533,14 @@ const methods = {
         beforeEvacuateVms: async () => {
           // On XS/CH, start by installing patches on all hosts
           if (!isXcp) {
-            Task.run({ properties: { name: `Installing XS patches` } }, async () => {
+            return Task.run({ properties: { name: `Installing XS patches` } }, async () => {
               await this.installPatches({ xsCredentials })
             })
           }
         },
         beforeRebootHost: async host => {
           if (isXcp) {
-            Task.run(
+            return Task.run(
               { properties: { name: `Installing patches`, hostId: host.uuid, hostName: host.name_label } },
               async () => {
                 await this.installPatches({ hosts: [host] })


### PR DESCRIPTION
### Description

Rolling pool update's task appeared as successful when a host update failed.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
