### PR TITLE
Refactor(backups): move metadata to VDI

### DIFF
--- a/@xen-orchestra/backups/_otherConfig.mjs
+++ b/@xen-orchestra/backups/_otherConfig.mjs
@@ -45,17 +45,41 @@ async function getDeltaChainLength(xapi, type, ref){
   const otherConfig = await xapi.getField(type, ref, 'other_config')  
     return Number(otherConfig[DELTA_CHAIN_LENGTH] ?? 0)
 }
+
+/**
+ * set the delta chain lenght ( number of delta since last base backup) to a VM and its associated VDIs
+ * 
+ * @param {Xapi} xapi 
+ * @param {String} vmRef 
+ * @param {Number} length 
+ * @returns {Promise}
+ */
 export async function setVmDeltaChainLength(xapi, vmRef, length) {
   return applyToVmAndVdis(xapi, vmRef, async (type, ref)=> {
     await xapi.setFieldEntry(type, ref, 'other_config', DELTA_CHAIN_LENGTH, String(length))
   })
 }
 
+/**
+ * Compute the delta chain length of a VM and its associated VDIs
+ * if there is a discrependcy, use, the highest value
+ * @param {Xapi} xapi 
+ * @param {String} vmRef 
+ * @returns {Promise}
+ */
 export async function getVmDeltaChainLength(xapi,vmRef){
   const lengths = await applyToVmAndVdis(xapi,vmRef,async (type, ref)=> getDeltaChainLength(xapi, type, ref) )
   return Math.max(...lengths)
 }
 
+/**
+ * 
+ * Reset the other_config field of a VM and its VDIs
+ * 
+ * @param {Xapi} xapi 
+ * @param {String} vmRef 
+ * @returns {Promise}
+ */
 export function resetVmOtherConfig(xapi, vmRef) {
   return applyToVmAndVdis(xapi, vmRef, (type, ref)=> {
     return xapi.setFieldEntries(type, ref, 'other_config', {
@@ -71,8 +95,14 @@ export function resetVmOtherConfig(xapi, vmRef) {
   
 }
 
-// used to ensure compatibiliy with the previous snapshots
-// that were having the config stored only into VM
+/**
+ * 
+ * used to ensure compatibiliy with the previous snapshots that were having the config stored only into VM
+ * 
+ * @param {Xapi} xapi 
+ * @param {String} vmRef 
+ * @returns {Promise}
+ */
 export async function populateVdisOtherConfig(xapi, vmRef){
   const otherConfig = await xapi.getField('VM', vmRef, 'other_config')
   const {
@@ -98,6 +128,15 @@ export async function populateVdisOtherConfig(xapi, vmRef){
 
 }
 
+/**
+ * 
+ * set the other_config key related to a backup of a VM and its associated VDIs
+ * 
+ * @param {Xapi} xapi 
+ * @param {String} vmRef 
+ * @param {*} settings 
+ * @returns {PRomise}
+ */
 export async function setVmOtherConfig(xapi, vmRef, { timestamp, jobId, scheduleId, vmUuid, srUuid = null, ...other }) {
   assert.notEqual(timestamp, undefined)
   assert.notEqual(jobId, undefined)
@@ -115,6 +154,14 @@ export async function setVmOtherConfig(xapi, vmRef, { timestamp, jobId, schedule
   }))
 
 }
+/**
+ * 
+ * mark the export of he VM and its VDIs as successfull
+ * 
+ * @param {Xapi} xapi 
+ * @param {String} vmRef 
+ * @returns {Promise}
+ */
 export async function markExportSuccessfull(xapi, vmRef) {
   return applyToVmAndVdis(xapi, vmRef,  (type, ref)=>  xapi.setFieldEntry(type, ref, 'other_config', EXPORTED_SUCCESSFULLY, 'true'),
   )

--- a/@xen-orchestra/backups/_otherConfig.mjs
+++ b/@xen-orchestra/backups/_otherConfig.mjs
@@ -1,0 +1,121 @@
+import { formatDateTime } from '@xen-orchestra/xapi'
+import assert from 'node:assert/strict'
+// in `other_config` of an incrementally replicated VM or VDI
+// contains the UUID of the object used as a base for an incremental export
+// used to search for the replica of the base before applying a incremental replication
+export const BASE_DELTA_VDI = 'xo:base_delta_vdi'
+
+// in `other_config` of an incrementally replicated VM, contains the UUID of the target SR used for replication
+//
+// added after the complete replication
+export const REPLICATED_TO_SR_UUID = 'xo:backup:sr'
+
+// in other_config of VDIs of an incrementally replicated VM
+// contains the UUID of the source  exported object (snapshot or VM)
+
+export const COPY_OF = 'xo:copy_of'
+
+export const DATETIME = 'xo:backup:datetime'
+
+export const JOB_ID = 'xo:backup:job'
+export const SCHEDULE_ID = 'xo:backup:schedule'
+
+// contains the number of delta in a chain, stored as a string
+export const DELTA_CHAIN_LENGTH = 'xo:backup:deltaChainLength'
+// contains the string true if this vdi has been exported successfully
+export const EXPORTED_SUCCESSFULLY = 'xo:backup:exported'
+
+// the VM ( not the snapshot) uuid
+export const VM_UUID = 'xo:backup:vm'
+
+async function listVdiRefs(xapi, vmRef) {
+  return xapi.VM_getDisks(vmRef)
+}
+
+async function applyToVmAndVdis(xapi, vmRef, cb){
+  const vdiRefs = await listVdiRefs(xapi, vmRef)
+  return Promise.all([
+    cb('VM', vmRef),
+    ...vdiRefs.map(vdiRef => cb('VDI', vdiRef))
+  ])
+  
+}
+
+async function getDeltaChainLength(xapi, type, ref){
+  const otherConfig = await xapi.getField(type, ref, 'other_config')  
+    return Number(otherConfig[DELTA_CHAIN_LENGTH] ?? 0)
+}
+export async function setVmDeltaChainLength(xapi, vmRef, length) {
+  return applyToVmAndVdis(xapi, vmRef, async (type, ref)=> {
+    await xapi.setFieldEntry(type, ref, 'other_config', DELTA_CHAIN_LENGTH, String(length))
+  })
+}
+
+export async function getVmDeltaChainLength(xapi,vmRef){
+  const lengths = await applyToVmAndVdis(xapi,vmRef,async (type, ref)=> getDeltaChainLength(xapi, type, ref) )
+  return Math.max(...lengths)
+}
+
+export function resetVmOtherConfig(xapi, vmRef) {
+  return applyToVmAndVdis(xapi, vmRef, (type, ref)=> {
+    return xapi.setFieldEntries(type, ref, 'other_config', {
+    [DATETIME]: null,
+    [DELTA_CHAIN_LENGTH]: null,
+    [EXPORTED_SUCCESSFULLY]: null,
+    [JOB_ID]: null,
+    [SCHEDULE_ID]: null,
+    [VM_UUID]: null,
+    // REPLICATED_TO_SR_UUID is not reset since we can replicate a replication
+  })
+})
+  
+}
+
+// used to ensure compatibiliy with the previous snapshots
+// that were having the config stored only into VM
+export async function populateVdisOtherConfig(xapi, vmRef){
+  const otherConfig = await xapi.getField('VM', vmRef, 'other_config')
+  const {
+    [DATETIME]: datetime,
+    [DELTA_CHAIN_LENGTH]: chainLength,
+    [EXPORTED_SUCCESSFULLY]: successfully,
+    [JOB_ID]: jobId,
+    [REPLICATED_TO_SR_UUID]: replicatedTo,
+    [SCHEDULE_ID]: scheduleId,
+    [VM_UUID]: vmUuid,
+  } = otherConfig
+
+  return applyToVmAndVdis(xapi, vmRef, (type, ref)=> xapi.setFieldEntries(type, ref, 'other_config', {
+   [DATETIME]: datetime,
+    [DELTA_CHAIN_LENGTH]: chainLength,
+    [EXPORTED_SUCCESSFULLY]: successfully,
+    [JOB_ID]: jobId,
+    [REPLICATED_TO_SR_UUID]: replicatedTo,
+    [SCHEDULE_ID]: scheduleId,
+    [VM_UUID]: vmUuid,
+  }))
+
+
+}
+
+export async function setVmOtherConfig(xapi, vmRef, { timestamp, jobId, scheduleId, vmUuid, srUuid = null, ...other }) {
+  assert.notEqual(timestamp, undefined)
+  assert.notEqual(jobId, undefined)
+  assert.notEqual(scheduleId, undefined)
+  assert.notEqual(vmUuid, undefined)
+  // srUuid is nullish for backup
+  assert.equal(Object.keys(other).length, 0)
+  
+  return applyToVmAndVdis(xapi, vmRef, (type, ref)=> xapi.setFieldEntries(type, ref, 'other_config', {
+    [REPLICATED_TO_SR_UUID]: srUuid,
+    [DATETIME]: formatDateTime(timestamp),
+    [JOB_ID]: jobId,
+    [SCHEDULE_ID]: scheduleId,
+    [VM_UUID]: vmUuid,
+  }))
+
+}
+export async function markExportSuccessfull(xapi, vmRef) {
+  return applyToVmAndVdis(xapi, vmRef,  (type, ref)=>  xapi.setFieldEntry(type, ref, 'other_config', EXPORTED_SUCCESSFULLY, 'true'),
+  )
+}

--- a/@xen-orchestra/backups/_runners/_writers/FullXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/FullXapiWriter.mjs
@@ -1,6 +1,5 @@
 import ignoreErrors from 'promise-toolbox/ignoreErrors'
 import { asyncMap, asyncMapSettled } from '@xen-orchestra/async-map'
-import { formatDateTime } from '@xen-orchestra/xapi'
 
 import { formatFilenameDate } from '../../_filenameDate.mjs'
 import { getOldEntries } from '../../_getOldEntries.mjs'
@@ -9,6 +8,7 @@ import { Task } from '../../Task.mjs'
 import { AbstractFullWriter } from './_AbstractFullWriter.mjs'
 import { MixinXapiWriter } from './_MixinXapiWriter.mjs'
 import { listReplicatedVms } from './_listReplicatedVms.mjs'
+import { setVmOtherConfig } from '../../_otherConfig.mjs'
 
 export class FullXapiWriter extends MixinXapiWriter(AbstractFullWriter) {
   constructor(props) {
@@ -76,14 +76,12 @@ export class FullXapiWriter extends MixinXapiWriter(AbstractFullWriter) {
           'Start operation for this vm is blocked, clone it if you want to use it.'
         )
       ),
-      targetVm.update_other_config({
-        'xo:backup:sr': srUuid,
-
-        // these entries need to be added in case of offline backup
-        'xo:backup:datetime': formatDateTime(timestamp),
-        'xo:backup:job': job.id,
-        'xo:backup:schedule': scheduleId,
-        'xo:backup:vm': vm.uuid,
+      setVmOtherConfig(xapi, targetVmRef, {
+        timestamp,
+        jobId: job.id,
+        scheduleId,
+        srUuid,
+        vmUuid: vm.uuid,
       }),
     ])
 

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
@@ -106,7 +106,6 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
     Object.values(backup.vdis).forEach(vdi => {
       vdi.other_config[COPY_OF] = vdi.uuid
       if (sourceVdiUuids.length > 0) {
-        vdi.SR = sr.$ref
         const baseReplicatedTo = replicatedVdis.find(
           replicatedVdi => replicatedVdi.other_config[COPY_OF] === vdi.other_config[BASE_DELTA_VDI]
         )
@@ -115,6 +114,8 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
       } else {
         vdi.baseVdi = undefined
       }
+      // ensure the VDI are created on the target SR
+      vdi.SR = sr.$ref
     })
 
     return backup

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
@@ -9,7 +9,7 @@ import { Task } from '../../Task.mjs'
 import { AbstractIncrementalWriter } from './_AbstractIncrementalWriter.mjs'
 import { MixinXapiWriter } from './_MixinXapiWriter.mjs'
 import { listReplicatedVms } from './_listReplicatedVms.mjs'
-import { REPLICATED_TO_SR_UUID, COPY_OF, setVmOtherConfig, BASE_DELTA_VDI } from '../../_otherConfig.mjs'
+import { COPY_OF, setVmOtherConfig, BASE_DELTA_VDI } from '../../_otherConfig.mjs'
 
 import assert from 'node:assert'
 export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWriter) {
@@ -19,9 +19,10 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
     // @todo use an index if possible
     // @todo : this seems similare to decorateVmMetadata
 
-    const replicatedVdis = Object.values(sr.$xapi.objects.all)
+    const replicatedVdis = sr.$VDIs
       .filter(({ other_config }) => {
-        return other_config?.[REPLICATED_TO_SR_UUID] === sr.$id && baseUuidToSrcVdi.has(other_config?.[COPY_OF])
+        // REPLICATED_TO_SR_UUID is not used here since we are already filtering from sr.$VDIs
+        return baseUuidToSrcVdi.has(other_config?.[COPY_OF])
       })
       .map(({ other_config }) => other_config?.[COPY_OF])
       .filter(_ => !!_)
@@ -96,8 +97,10 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
       // full vdi don't have a base
       .filter(_ => !!_)
     // @todo use index ?
-    const replicatedVdis = Object.values(sr.$xapi.objects.all).filter(({ other_config }) => {
-      return other_config?.[REPLICATED_TO_SR_UUID] === sr.$id && sourceVdiUuids.includes(other_config?.[COPY_OF])
+
+    const replicatedVdis = sr.$VDIs.filter(({ other_config }) => {
+      // REPLICATED_TO_SR_UUID is not used here since we are already filtering from sr.$VDIs
+      return sourceVdiUuids.includes(other_config?.[COPY_OF])
     })
 
     Object.values(backup.vdis).forEach(vdi => {

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
@@ -1,39 +1,33 @@
-import assert from 'node:assert'
 import { asyncMap, asyncMapSettled } from '@xen-orchestra/async-map'
 import ignoreErrors from 'promise-toolbox/ignoreErrors'
-import { formatDateTime } from '@xen-orchestra/xapi'
 
 import { formatFilenameDate } from '../../_filenameDate.mjs'
 import { getOldEntries } from '../../_getOldEntries.mjs'
-import { importIncrementalVm, TAG_BACKUP_SR, TAG_BASE_DELTA, TAG_COPY_SRC } from '../../_incrementalVm.mjs'
+import { importIncrementalVm } from '../../_incrementalVm.mjs'
 import { Task } from '../../Task.mjs'
 
 import { AbstractIncrementalWriter } from './_AbstractIncrementalWriter.mjs'
 import { MixinXapiWriter } from './_MixinXapiWriter.mjs'
 import { listReplicatedVms } from './_listReplicatedVms.mjs'
-import find from 'lodash/find.js'
+import { REPLICATED_TO_SR_UUID, COPY_OF, setVmOtherConfig, BASE_DELTA_VDI } from '../../_otherConfig.mjs'
 
+import assert from 'node:assert'
 export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWriter) {
-  async checkBaseVdis(baseUuidToSrcVdi, baseVm) {
-    assert.notStrictEqual(baseVm, undefined)
+  async checkBaseVdis(baseUuidToSrcVdi) {
     const sr = this._sr
-    const replicatedVm = listReplicatedVms(sr.$xapi, this._job.id, sr.uuid, this._vmUuid).find(
-      vm => vm.other_config[TAG_COPY_SRC] === baseVm.uuid
-    )
-    if (replicatedVm === undefined) {
-      return baseUuidToSrcVdi.clear()
-    }
 
-    const xapi = replicatedVm.$xapi
-    const replicatedVdis = new Set(
-      await asyncMap(await replicatedVm.$getDisks(), async vdiRef => {
-        const otherConfig = await xapi.getField('VDI', vdiRef, 'other_config')
-        return otherConfig[TAG_COPY_SRC]
+    // @todo use an index if possible
+    // @todo : this seems similare to decorateVmMetadata
+
+    const replicatedVdis = Object.values(sr.$xapi.objects.all)
+      .filter(({ other_config }) => {
+        return other_config?.[REPLICATED_TO_SR_UUID] === sr.$id && baseUuidToSrcVdi.has(other_config?.[COPY_OF])
       })
-    )
+      .map(({ other_config }) => other_config?.[COPY_OF])
+      .filter(_ => !!_)
 
     for (const uuid of baseUuidToSrcVdi.keys()) {
-      if (!replicatedVdis.has(uuid)) {
+      if (!replicatedVdis.includes(uuid)) {
         baseUuidToSrcVdi.delete(uuid)
       }
     }
@@ -89,45 +83,34 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
   #decorateVmMetadata(backup) {
     const { _warmMigration } = this._settings
     const sr = this._sr
-    const xapi = sr.$xapi
     const vm = backup.vm
-    vm.other_config[TAG_COPY_SRC] = vm.uuid
-    const remoteBaseVmUuid = vm.other_config[TAG_BASE_DELTA]
-    let baseVm
-    if (remoteBaseVmUuid) {
-      baseVm = find(
-        xapi.objects.all,
-        obj => (obj = obj.other_config) && obj[TAG_COPY_SRC] === remoteBaseVmUuid && obj[TAG_BACKUP_SR] === sr.$id
-      )
 
-      if (!baseVm) {
-        throw new Error(`could not find the base VM (copy of ${remoteBaseVmUuid})`)
-      }
-    }
-    const baseVdis = {}
-    baseVm?.$VBDs.forEach(vbd => {
-      const vdi = vbd.$VDI
-      if (vdi !== undefined) {
-        baseVdis[vbd.VDI] = vbd.$VDI
-      }
-    })
-
-    vm.other_config[TAG_COPY_SRC] = vm.uuid
+    vm.other_config[COPY_OF] = vm.uuid
     if (!_warmMigration) {
       vm.tags.push('Continuous Replication')
     }
+    // extracting the uuid of each delta vdi on the source
+    // get all in one pass, since there is a lot of objects
+    const sourceVdiUuids = Object.values(backup.vdis)
+      .map(({ other_config }) => other_config[BASE_DELTA_VDI])
+      // full vdi don't have a base
+      .filter(_ => !!_)
+    // @todo use index ?
+    const replicatedVdis = Object.values(sr.$xapi.objects.all).filter(({ other_config }) => {
+      return other_config?.[REPLICATED_TO_SR_UUID] === sr.$id && sourceVdiUuids.includes(other_config?.[COPY_OF])
+    })
 
     Object.values(backup.vdis).forEach(vdi => {
-      vdi.other_config[TAG_COPY_SRC] = vdi.uuid
-      vdi.SR = sr.$ref
-      // vdi.other_config[TAG_BASE_DELTA] is never defined on a suspend vdi
-      if (vdi.other_config[TAG_BASE_DELTA]) {
-        const remoteBaseVdiUuid = vdi.other_config[TAG_BASE_DELTA]
-        const baseVdi = find(baseVdis, vdi => vdi.other_config[TAG_COPY_SRC] === remoteBaseVdiUuid)
-        if (!baseVdi) {
-          throw new Error(`missing base VDI (copy of ${remoteBaseVdiUuid})`)
-        }
-        vdi.baseVdi = baseVdi
+      vdi.other_config[COPY_OF] = vdi.uuid
+      if (sourceVdiUuids.length > 0) {
+        vdi.SR = sr.$ref
+        const baseReplicatedTo = replicatedVdis.find(
+          replicatedVdi => replicatedVdi.other_config[COPY_OF] === vdi.other_config[BASE_DELTA_VDI]
+        )
+        assert.notStrictEqual(baseReplicatedTo, undefined)
+        vdi.baseVdi = baseReplicatedTo
+      } else {
+        vdi.baseVdi = undefined
       }
     })
 
@@ -164,14 +147,12 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
           'Start operation for this vm is blocked, clone it if you want to use it.'
         )
       ),
-      targetVm.update_other_config({
-        [TAG_BACKUP_SR]: srUuid,
-
-        // these entries need to be added in case of offline backup
-        'xo:backup:datetime': formatDateTime(timestamp),
-        'xo:backup:job': job.id,
-        'xo:backup:schedule': scheduleId,
-        [TAG_BASE_DELTA]: vm.uuid,
+      setVmOtherConfig(xapi, targetVmRef, {
+        timestamp,
+        jobId: job.id,
+        scheduleId,
+        vmUuid: vm.uuid,
+        srUuid,
       }),
     ])
   }

--- a/@xen-orchestra/backups/_runners/_writers/_listReplicatedVms.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/_listReplicatedVms.mjs
@@ -1,5 +1,7 @@
+import { DATETIME, JOB_ID, REPLICATED_TO_SR_UUID, SCHEDULE_ID, VM_UUID } from '../../_otherConfig.mjs'
+
 const getReplicatedVmDatetime = vm => {
-  const { 'xo:backup:datetime': datetime = vm.name_label.slice(-17, -1) } = vm.other_config
+  const { [DATETIME]: datetime = vm.name_label.slice(-17, -1) } = vm.other_config
   return datetime
 }
 
@@ -16,11 +18,11 @@ export function listReplicatedVms(xapi, scheduleOrJobId, srUuid, vmUuid) {
       !object.is_a_snapshot &&
       !object.is_a_template &&
       'start' in object.blocked_operations &&
-      (oc['xo:backup:job'] === scheduleOrJobId || oc['xo:backup:schedule'] === scheduleOrJobId) &&
-      oc['xo:backup:sr'] === srUuid &&
-      (oc['xo:backup:vm'] === vmUuid ||
+      (oc[JOB_ID] === scheduleOrJobId || oc[SCHEDULE_ID] === scheduleOrJobId) &&
+      oc[REPLICATED_TO_SR_UUID] === srUuid &&
+      (oc[VM_UUID] === vmUuid ||
         // 2018-03-28, JFT: to catch VMs replicated before this fix
-        oc['xo:backup:vm'] === undefined)
+        oc[VM_UUID] === undefined)
     ) {
       vms[object.$id] = object
     }

--- a/@xen-orchestra/backups/docs/VM backups/README.md
+++ b/@xen-orchestra/backups/docs/VM backups/README.md
@@ -59,13 +59,13 @@ In case any incoherence is detected, the file is deleted so it will be fully gen
 
 ## Attributes
 
-### Of created snapshots
+### Of created snapshots (VMs and associated VDIs)
 
 - `other_config`:
   - `xo:backup:deltaChainLength` = n (number of delta copies/replicated since a full)
   - `xo:backup:exported` = 'true' (added at the end of the backup)
 
-### Of created VMs and snapshots
+### Of created VMs , their associated VDIs and snapshots 
 
 - `other_config`:
   - `xo:backup:datetime`: format is UTC %Y%m%dT%H:%M:%SZ
@@ -75,7 +75,7 @@ In case any incoherence is detected, the file is deleted so it will be fully gen
   - `xo:backup:schedule` = schedule.id
   - `xo:backup:vm` = vm.uuid
 
-### Of created VMs
+### Of created VMs and their associated VDIs
 
 - `name_label`: `${original name} - ${job name} - (${safeDateFormat(backup timestamp)})`
 - tag:

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -35,6 +35,7 @@
 
 - @vates/fuse-vhd patch
 - @vates/task minor
+- @xen-orchestra/backups 
 - @xen-orchestra/proxy-cli patch
 - @xen-orchestra/vmware-explorer patch
 - @xen-orchestra/web patch

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -35,7 +35,7 @@
 
 - @vates/fuse-vhd patch
 - @vates/task minor
-- @xen-orchestra/backups 
+- @xen-orchestra/backups minor
 - @xen-orchestra/proxy-cli patch
 - @xen-orchestra/vmware-explorer patch
 - @xen-orchestra/web patch


### PR DESCRIPTION
### Description

Preparing for CBT backup that will only keep a part of the VDI snapshot, and remove the VM


* extract most of the other_config operation to a file as constants
* name the constants
* set the relevant metadata values to the vm AND all its attached VDIs
* use the VDI as the base to search and update snapshots/replica/backup
* removed the disableBaseTag option in exportVm 

Main vigilance points : 
* please test on your tests backups if delta/full are correctly handled
* check the otherConfig constant name and propose better name if possible
* 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
