### PR TITLE
fix(vmware-explorer): handle new lines in fetchProperty

### DIFF
--- a/@xen-orchestra/vmware-explorer/esxi.mjs
+++ b/@xen-orchestra/vmware-explorer/esxi.mjs
@@ -440,10 +440,12 @@ export default class Esxi extends EventEmitter {
         </soapenv:Envelope>`,
     })
     const text = await res.text()
-    const matches = text.match(/<FetchResponse[^>]*>(.*)<\/FetchResponse>/)
-
+    const matches = text.match(/<FetchResponse[^>]*>(.*)<\/FetchResponse>/s)
+    if (matches === null) {
+      throw new Error(`can't get ${propertyName} of object ${id} (Type: ${type})`)
+    }
     return new Promise((resolve, reject) => {
-      xml2js.parseString(matches?.[1] ?? '', (err, res) => (err ? reject(err) : resolve(res.returnval)))
+      xml2js.parseString(matches[1], (err, res) => (err ? reject(err) : resolve(res.returnval)))
     })
   }
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 - [Console] Fix support of consoles behind an HTTP/HTTPS proxy [Forum#76935](https://xcp-ng.org/forum/post/76935')
 - [Rolling Pool Update] Fixed RPU failing to install patches on hosts (and still appearing as successfull) (PR [#7640](https://github.com/vatesfr/xen-orchestra/pull/7640))
 - [XOSTOR] Throw clearer error if attempt to create multiple trials (PR [#7649](https://github.com/vatesfr/xen-orchestra/pull/7649))
+- [V2V] Fix import stuck (PR [#7653](https://github.com/vatesfr/xen-orchestra/pull/7653))
 
 ### Packages to release
 
@@ -33,6 +34,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/vmware-explorer patch
 - xen-api patch
 - xo-server minor
 


### PR DESCRIPTION
### Description

introduced by #7552
Fix import being stuck  (log error : can't read returnVal of undefined ) 
ticket 24833 (deployed, tested) , 24806 
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
