### PR TITLE
feat(xo-6/account-menu): add menu items (links to doc and support)

### DIFF
--- a/@xen-orchestra/web/src/components/account-menu/AccountMenu.vue
+++ b/@xen-orchestra/web/src/components/account-menu/AccountMenu.vue
@@ -3,6 +3,26 @@
     <template #trigger="{ isOpen, open }">
       <AccountMenuTrigger :active="isOpen" @click="open($event)" />
     </template>
+    <MenuItem :icon="faBook">
+      <a
+        class="link typo p2-medium"
+        href="https://docs.xcp-ng.org?utm_campaign=xo6&utm_term=xcpdoc"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        {{ $t('documentation-name', { name: 'XCP-ng' }) }}
+      </a>
+    </MenuItem>
+    <MenuItem :icon="faHeadset">
+      <a
+        class="link typo p2-medium"
+        href="https://vates.tech/pricing-and-support?utm_campaign=xo6&utm_term=pricing"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        {{ $t('support-name', { name: 'XCP-ng' }) }}
+      </a>
+    </MenuItem>
     <MenuItem :icon="faArrowRightFromBracket" class="logout" @click="logout()">
       {{ $t('core.log-out') }}
     </MenuItem>
@@ -13,7 +33,7 @@
 import AccountMenuTrigger from '@/components/account-menu/AccountMenuTrigger.vue'
 import MenuItem from '@core/components/menu/MenuItem.vue'
 import MenuList from '@core/components/menu/MenuList.vue'
-import { faArrowRightFromBracket } from '@fortawesome/free-solid-svg-icons'
+import { faArrowRightFromBracket, faBook, faHeadset } from '@fortawesome/free-solid-svg-icons'
 
 defineProps<{
   disabled?: boolean
@@ -24,6 +44,15 @@ const logout = () => window.location.assign('/signout')
 </script>
 
 <style lang="postcss" scoped>
+.link {
+  text-decoration: none;
+  color: var(--color-grey-100);
+  /* Make the link take the height of the MenuItem component */
+  padding-block: 1.15rem;
+  /* Make the link take the available width in the MenuItem component */
+  flex-grow: 1;
+}
+
 .logout {
   color: var(--color-red-base);
 }

--- a/@xen-orchestra/web/src/locales/en.json
+++ b/@xen-orchestra/web/src/locales/en.json
@@ -1,5 +1,7 @@
 {
   "account-organization-more": "Account, organization & more...",
+  "documentation-name": "{name} documentation",
+  "support-name": "{name} pro support",
   "tasks": {
     "quick-view": "Tasks' quick view (coming soon)"
   }

--- a/@xen-orchestra/web/src/locales/fr.json
+++ b/@xen-orchestra/web/src/locales/fr.json
@@ -1,5 +1,7 @@
 {
   "account-organization-more": "Compte, organisation et plus…",
+  "documentation-name": "Documentation {name}",
+  "support-name": "Support pro {name}",
   "tasks": {
     "quick-view": "Vue rapide des tâches (bientôt disponible)"
   }


### PR DESCRIPTION
### Description

Add new links to support and documentation in account menu.

### Screenshots

![account-menu](https://github.com/vatesfr/xen-orchestra/assets/66562640/5a11104e-7d07-4942-bd47-3b48bcc81cdb)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
