### PR TITLE
chore(xo-server-backup-reports): removing unused legacy handler

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,5 +30,6 @@
 <!--packages-start-->
 
 - xen-api patch
+- xo-server-backup-reports minor
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

Removing `_legacyVmHandler` from the backup reports plugin, which was used for legacy backups and has apparently become useless.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
