### PR TITLE
fix(backups/forkStreamUnpipe): unpause stream after unpipe

### DIFF
--- a/@xen-orchestra/backups/_runners/_forkStreamUnpipe.mjs
+++ b/@xen-orchestra/backups/_runners/_forkStreamUnpipe.mjs
@@ -29,6 +29,10 @@ export function forkStreamUnpipe(source) {
     if (source.forks === 0) {
       debug('no more forks, destroying original stream')
       source.destroy(new Error('no more consumers for this stream'))
+    } else {
+      // a combination of stream.unpipe, onReadable and onData may stall stream here
+      // force it to flow again since we're piping it
+      source.resume()
     }
   })
   return fork

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Backup & Replication] Fix job stalling when failing to find a base VM
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -29,6 +31,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
 - @xen-orchestra/vmware-explorer minor
 - xo-server patch
 - xo-server-load-balancer minor


### PR DESCRIPTION
when a backup job does delta replication + backup and the replication
fails to find the base VM, the backup job does not proceed
This commit force the stream to continue to flow after unpiping a
descendant stream

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
