### PR TITLE
feat(XO6/core): creation of the interactive UiTable

### DIFF
--- a/@xen-orchestra/lite/src/stories/web-core/table/column-title.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/table/column-title.story.vue
@@ -1,0 +1,28 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties, settings }"
+    :params="[
+      iconProp(),
+      prop('id').str().widget(),
+      prop('interactive').bool().default(true).widget(),
+      prop('disabled').bool().default(false).widget(),
+      setting('slot').preset('vm').widget(),
+      slot(),
+    ]"
+  >
+    <UiTable vertical-border shadow name="story">
+      <thead>
+        <tr>
+          <ColumnTitle v-bind="properties" id="vm">{{ settings.slot }}</ColumnTitle>
+        </tr>
+      </thead>
+    </UiTable>
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import { iconProp, prop, setting, slot } from '@/libs/story/story-param'
+import ColumnTitle from '@core/components/table/ColumnTitle.vue'
+import UiTable from '@core/components/table/UiTable.vue'
+</script>

--- a/@xen-orchestra/lite/src/stories/web-core/table/column-title.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/table/column-title.story.vue
@@ -10,7 +10,7 @@
       slot(),
     ]"
   >
-    <UiTable vertical-border shadow name="story">
+    <UiTable vertical-border name="story">
       <thead>
         <tr>
           <ColumnTitle v-bind="properties" id="vm">{{ settings.slot }}</ColumnTitle>

--- a/@xen-orchestra/lite/src/stories/web-core/table/ui-table.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/table/ui-table.story.vue
@@ -1,0 +1,42 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties }"
+    :params="[
+      prop('hasError').bool().default(false).widget(),
+      prop('name').str().widget(),
+      prop('verticalBorder').bool().default(false).widget(),
+      slot(),
+    ]"
+  >
+    <UiTable v-bind="properties" shadow>
+      <thead>
+        <tr>
+          <ColumnTitle id="vm" :icon="faDesktop">vm</ColumnTitle>
+          <ColumnTitle id="description" :icon="faAlignLeft">vm description</ColumnTitle>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="vm in vms" :key="vm.id">
+          <td>{{ vm.name_label }}</td>
+          <td>{{ vm.description }}</td>
+        </tr>
+      </tbody>
+    </UiTable>
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import { prop, slot } from '@/libs/story/story-param'
+import ColumnTitle from '@core/components/table/ColumnTitle.vue'
+import UiTable from '@core/components/table/UiTable.vue'
+import { faAlignLeft, faDesktop } from '@fortawesome/free-solid-svg-icons'
+
+const vms = [
+  { id: 1, name_label: 'VM #1', description: 'Lorem upso' },
+  { id: 2, name_label: 'VM #2', description: 'Lorem upso' },
+  { id: 3, name_label: 'VM #3', description: 'Lorem upso' },
+  { id: 4, name_label: 'VM #4', description: 'Lorem upso' },
+  { id: 5, name_label: 'VM #5', description: 'Lorem upso' },
+]
+</script>

--- a/@xen-orchestra/lite/src/stories/web-core/table/ui-table.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/table/ui-table.story.vue
@@ -3,7 +3,7 @@
     v-slot="{ properties }"
     :params="[prop('name').str().widget(), prop('verticalBorder').bool().default(false).widget(), slot()]"
   >
-    <UiTable v-bind="properties" shadow>
+    <UiTable v-bind="properties">
       <thead>
         <tr>
           <ColumnTitle id="vm" :icon="faDesktop">vm</ColumnTitle>

--- a/@xen-orchestra/lite/src/stories/web-core/table/ui-table.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/table/ui-table.story.vue
@@ -1,12 +1,7 @@
 <template>
   <ComponentStory
     v-slot="{ properties }"
-    :params="[
-      prop('hasError').bool().default(false).widget(),
-      prop('name').str().widget(),
-      prop('verticalBorder').bool().default(false).widget(),
-      slot(),
-    ]"
+    :params="[prop('name').str().widget(), prop('verticalBorder').bool().default(false).widget(), slot()]"
   >
     <UiTable v-bind="properties" shadow>
       <thead>

--- a/@xen-orchestra/web-core/lib/components/table/ColumnHeader.vue
+++ b/@xen-orchestra/web-core/lib/components/table/ColumnHeader.vue
@@ -1,0 +1,132 @@
+<template>
+  <MenuList placement="bottom-start" shadow :disabled="disabled">
+    <template #trigger="{ open, isOpen }">
+      <th
+        class="column-header"
+        :class="{ interactive, disabled, focus: isOpen }"
+        @click="ev => (interactive ? open(ev) : noop())"
+      >
+        <div class="content">
+          <span class="label">
+            <UiIcon :icon />
+            <slot />
+          </span>
+          <UiIcon v-if="currentInteraction !== undefined" :icon="currentInteraction.icon" />
+        </div>
+      </th>
+    </template>
+    <MenuItem
+      v-for="interaction in interactions"
+      v-tooltip="$t('coming-soon')"
+      :disabled="interaction.disabled"
+      :key="interaction.id"
+      :on-click="() => updateInteraction(interaction)"
+    >
+      <UiIcon :icon="interaction.icon" />{{ interaction.label }}
+      <i v-if="currentInteraction?.id === interaction.id" class="current-interaction">current</i>
+    </MenuItem>
+  </MenuList>
+</template>
+
+<script lang="ts" setup>
+import MenuList from '@core/components/menu/MenuList.vue'
+import MenuItem from '@core/components/menu/MenuItem.vue'
+import UiIcon from '@core/components/icon/UiIcon.vue'
+import { vTooltip } from '@core/directives/tooltip.directive'
+import { faArrowDown, faArrowUp, faEyeSlash, faFilter, faLayerGroup } from '@fortawesome/free-solid-svg-icons'
+import { noop } from '@vueuse/core'
+import type { IconDefinition } from '@fortawesome/fontawesome-common-types'
+import { computed, inject } from 'vue'
+import { useRouter } from 'vue-router'
+
+type InteractionId = 'sort-asc' | 'sort-desc' | 'group' | 'filter' | 'hide'
+type Interaction = {
+  disabled?: boolean
+  id: InteractionId
+  icon: IconDefinition
+  label: string
+}
+
+const props = withDefaults(
+  defineProps<{
+    id?: string
+    icon?: IconDefinition
+    interactive?: boolean
+    disabled?: boolean
+  }>(),
+  {
+    disabled: false,
+    interactive: true,
+  }
+)
+
+const interactions: readonly Interaction[] = [
+  { id: 'sort-asc', icon: faArrowDown, label: 'Sort ascending', disabled: true },
+  { id: 'sort-desc', icon: faArrowUp, label: 'Sort descending', disabled: true },
+  { id: 'group', icon: faLayerGroup, label: 'Group', disabled: true },
+  { id: 'filter', icon: faFilter, label: 'Filter', disabled: true },
+  { id: 'hide', icon: faEyeSlash, label: 'Hide', disabled: true },
+]
+
+const router = useRouter()
+
+const tableName = inject<string>('tableName')
+
+const currentInteraction = computed(() =>
+  interactions.find(interaction => router.currentRoute.value.query[columnName] === interaction.id)
+)
+
+const columnName = `${tableName}__${props.id}`
+
+const updateInteraction = (interaction: Interaction) => {
+  router.replace({
+    query: {
+      [columnName]: interaction.id,
+    },
+  })
+}
+</script>
+
+<style lang="postcss" scoped>
+.column-header.interactive {
+  cursor: pointer;
+
+  &:is(.focus) {
+    background-color: var(--background-color-purple-10);
+  }
+  &:is(:hover) {
+    background-color: var(--background-color-purple-20);
+  }
+  &:is(:active) {
+    background-color: var(--background-color-purple-30);
+  }
+
+  &:is(.disabled) {
+    background-color: var(--background-color-secondary);
+    color: var(--color-grey-400);
+    cursor: not-allowed;
+  }
+}
+
+.current-interaction {
+  color: var(--color-grey-300);
+  font-size: 1.4rem;
+}
+
+.content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.label {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.filter-icon {
+  cursor: pointer;
+}
+</style>

--- a/@xen-orchestra/web-core/lib/components/table/ColumnHeader.vue
+++ b/@xen-orchestra/web-core/lib/components/table/ColumnHeader.vue
@@ -1,9 +1,9 @@
 <template>
-  <MenuList placement="bottom-start" shadow :disabled="disabled">
+  <MenuList :disabled="disabled" placement="bottom-start" shadow>
     <template #trigger="{ open, isOpen }">
       <th
-        class="column-header"
         :class="{ interactive, disabled, focus: isOpen }"
+        class="column-header"
         @click="ev => (interactive ? open(ev) : noop())"
       >
         <div class="content">
@@ -17,13 +17,15 @@
     </template>
     <MenuItem
       v-for="interaction in interactions"
-      v-tooltip="$t('coming-soon')"
+      v-tooltip="$t('core.coming-soon')"
       :disabled="interaction.disabled"
       :key="interaction.id"
       :on-click="() => updateInteraction(interaction)"
     >
       <UiIcon :icon="interaction.icon" />{{ interaction.label }}
-      <i v-if="currentInteraction?.id === interaction.id" class="current-interaction">current</i>
+      <i v-if="currentInteraction?.id === interaction.id" class="current-interaction">
+        {{ $t('core.current').toLowerCase() }}
+      </i>
     </MenuItem>
   </MenuList>
 </template>
@@ -38,6 +40,7 @@ import { noop } from '@vueuse/core'
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types'
 import { computed, inject } from 'vue'
 import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 
 type InteractionId = 'sort-asc' | 'sort-desc' | 'group' | 'filter' | 'hide'
 type Interaction = {
@@ -59,16 +62,16 @@ const props = withDefaults(
     interactive: true,
   }
 )
+const { t } = useI18n()
+const router = useRouter()
 
 const interactions: readonly Interaction[] = [
-  { id: 'sort-asc', icon: faArrowDown, label: 'Sort ascending', disabled: true },
-  { id: 'sort-desc', icon: faArrowUp, label: 'Sort descending', disabled: true },
-  { id: 'group', icon: faLayerGroup, label: 'Group', disabled: true },
-  { id: 'filter', icon: faFilter, label: 'Filter', disabled: true },
-  { id: 'hide', icon: faEyeSlash, label: 'Hide', disabled: true },
+  { id: 'sort-asc', icon: faArrowDown, label: t('core.sort.ascending'), disabled: true },
+  { id: 'sort-desc', icon: faArrowUp, label: t('core.sort.descending'), disabled: true },
+  { id: 'group', icon: faLayerGroup, label: t('core.group'), disabled: true },
+  { id: 'filter', icon: faFilter, label: t('core.filter'), disabled: true },
+  { id: 'hide', icon: faEyeSlash, label: t('core.hide'), disabled: true },
 ]
-
-const router = useRouter()
 
 const tableName = inject<string>('tableName')
 
@@ -90,15 +93,18 @@ const updateInteraction = (interaction: Interaction) => {
 <style lang="postcss" scoped>
 .column-header.interactive {
   cursor: pointer;
+  color: var(--color-purple-base);
 
   &:is(.focus) {
     background-color: var(--background-color-purple-10);
   }
   &:is(:hover) {
     background-color: var(--background-color-purple-20);
+    color: var(--color-purple-d20);
   }
   &:is(:active) {
     background-color: var(--background-color-purple-30);
+    color: var(--color-purple-d40);
   }
 
   &:is(.disabled) {

--- a/@xen-orchestra/web-core/lib/components/table/ColumnTitle.vue
+++ b/@xen-orchestra/web-core/lib/components/table/ColumnTitle.vue
@@ -1,5 +1,6 @@
+<!-- v1.0 -->
 <template>
-  <MenuList :disabled="disabled" placement="bottom-start" shadow>
+  <MenuList :disabled placement="bottom-start" shadow>
     <template #trigger="{ open, isOpen }">
       <th
         :class="{ interactive, disabled, focus: isOpen }"
@@ -11,19 +12,19 @@
             <UiIcon :icon />
             <slot />
           </span>
-          <UiIcon v-if="currentInteraction !== undefined" :icon="currentInteraction.icon" />
+          <UiIcon :icon="currentInteraction?.icon" />
         </div>
       </th>
     </template>
     <MenuItem
       v-for="interaction in interactions"
       v-tooltip="$t('core.coming-soon')"
-      :disabled="interaction.disabled"
       :key="interaction.id"
+      :disabled="interaction.disabled"
       :on-click="() => updateInteraction(interaction)"
     >
       <UiIcon :icon="interaction.icon" />{{ interaction.label }}
-      <i v-if="currentInteraction?.id === interaction.id" class="current-interaction">
+      <i v-if="currentInteraction?.id === interaction.id" class="current-interaction typo p3-regular-italic">
         {{ $t('core.current').toLowerCase() }}
       </i>
     </MenuItem>
@@ -65,18 +66,18 @@ const props = withDefaults(
 const { t } = useI18n()
 const router = useRouter()
 
-const interactions: readonly Interaction[] = [
+const interactions = computed<Interaction[]>(() => [
   { id: 'sort-asc', icon: faArrowDown, label: t('core.sort.ascending'), disabled: true },
   { id: 'sort-desc', icon: faArrowUp, label: t('core.sort.descending'), disabled: true },
   { id: 'group', icon: faLayerGroup, label: t('core.group'), disabled: true },
   { id: 'filter', icon: faFilter, label: t('core.filter'), disabled: true },
   { id: 'hide', icon: faEyeSlash, label: t('core.hide'), disabled: true },
-]
+])
 
 const tableName = inject<string>('tableName')
 
 const currentInteraction = computed(() =>
-  interactions.find(interaction => router.currentRoute.value.query[columnName] === interaction.id)
+  interactions.value.find(interaction => router.currentRoute.value.query[columnName] === interaction.id)
 )
 
 const columnName = `${tableName}__${props.id}`
@@ -91,32 +92,43 @@ const updateInteraction = (interaction: Interaction) => {
 </script>
 
 <style lang="postcss" scoped>
+/* COLOR VARIANTS */
+.column-header.interactive {
+  --color: var(--color-purple-base);
+  --background-color: var(--background-color-primary);
+
+  &.focus {
+    --color: var(--color-purple-base);
+    --background-color: var(--background-color-purple-10);
+  }
+
+  &:hover {
+    --color: var(--color-purple-d20);
+    --background-color: var(--background-color-purple-20);
+  }
+
+  &:active {
+    --color: var(--color-purple-d40);
+    --background-color: var(--background-color-purple-30);
+  }
+
+  &.disabled {
+    --color: var(--color-grey-400);
+    --background-color: var(--background-color-secondary);
+  }
+}
+/* IMPLEMENTATION */
 .column-header.interactive {
   cursor: pointer;
-  color: var(--color-purple-base);
-
-  &:is(.focus) {
-    background-color: var(--background-color-purple-10);
-  }
-  &:is(:hover) {
-    background-color: var(--background-color-purple-20);
-    color: var(--color-purple-d20);
-  }
-  &:is(:active) {
-    background-color: var(--background-color-purple-30);
-    color: var(--color-purple-d40);
-  }
-
-  &:is(.disabled) {
-    background-color: var(--background-color-secondary);
-    color: var(--color-grey-400);
+  color: var(--color);
+  background-color: var(--background-color);
+  &.disabled {
     cursor: not-allowed;
   }
 }
 
 .current-interaction {
   color: var(--color-grey-300);
-  font-size: 1.4rem;
 }
 
 .content {

--- a/@xen-orchestra/web-core/lib/components/table/UiTable.vue
+++ b/@xen-orchestra/web-core/lib/components/table/UiTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <table :class="{ 'vertical-border': verticalBorder, error: color === 'error' }" class="ui-table typo p2-regular">
+  <table :class="{ 'vertical-border': verticalBorder, error: hasError }" class="ui-table typo p2-regular">
     <slot />
   </table>
 </template>
@@ -8,7 +8,7 @@
 import { provide } from 'vue'
 
 const props = defineProps<{
-  color?: 'error'
+  hasError?: boolean
   name?: string
   verticalBorder?: boolean
 }>()
@@ -17,17 +17,27 @@ provide('tableName', props.name)
 </script>
 
 <style lang="postcss" scoped>
+/* BACKGROUND COLOR VARIANTS */
+.ui-table {
+  --background-color: var(--background-color-primary);
+
+  &.error {
+    background-color: var(--background-color-red-10);
+  }
+}
+
+/* IMPLEMENTATION */
 .ui-table {
   width: 100%;
   border-spacing: 0;
-  background-color: var(--background-color-primary);
+  background-color: var(--background-color);
   line-height: 2.4rem;
   color: var(--color-grey-200);
 
   :deep(th),
   :deep(td) {
     padding: 1rem;
-    border-top: 1px solid var(--color-grey-500);
+    border-top: 0.1rem solid var(--color-grey-500);
     text-align: left;
   }
 
@@ -48,16 +58,12 @@ provide('tableName', props.name)
   &.vertical-border {
     :deep(th),
     :deep(td) {
-      border-right: 1px solid var(--color-grey-500);
+      border-right: 0.1rem solid var(--color-grey-500);
 
       &:last-child {
         border-right: none;
       }
     }
   }
-}
-
-.error {
-  background-color: var(--background-color-red-10);
 }
 </style>

--- a/@xen-orchestra/web-core/lib/components/table/UiTable.vue
+++ b/@xen-orchestra/web-core/lib/components/table/UiTable.vue
@@ -1,0 +1,63 @@
+<template>
+  <table :class="{ 'vertical-border': verticalBorder, error: color === 'error' }" class="ui-table typo p2-regular">
+    <slot foo="test" />
+  </table>
+</template>
+
+<script lang="ts" setup>
+import { provide } from 'vue'
+
+const props = defineProps<{
+  color?: 'error'
+  name?: string
+  verticalBorder?: boolean
+}>()
+
+provide('tableName', props.name)
+</script>
+
+<style lang="postcss" scoped>
+.ui-table {
+  width: 100%;
+  border-spacing: 0;
+  background-color: var(--background-color-primary);
+  line-height: 2.4rem;
+  color: var(--color-grey-200);
+
+  :deep(th),
+  :deep(td) {
+    padding: 1rem;
+    border-top: 1px solid var(--color-grey-500);
+    text-align: left;
+  }
+
+  :deep(th) {
+    font-weight: 700;
+  }
+
+  :deep(thead) {
+    th,
+    td {
+      color: var(--color-purple-base);
+      font-size: 1.4rem;
+      font-weight: 400;
+      text-transform: uppercase;
+    }
+  }
+
+  &.vertical-border {
+    :deep(th),
+    :deep(td) {
+      border-right: 1px solid var(--color-grey-500);
+
+      &:last-child {
+        border-right: none;
+      }
+    }
+  }
+}
+
+.error {
+  background-color: var(--background-color-red-10);
+}
+</style>

--- a/@xen-orchestra/web-core/lib/components/table/UiTable.vue
+++ b/@xen-orchestra/web-core/lib/components/table/UiTable.vue
@@ -1,6 +1,6 @@
 <template>
   <table :class="{ 'vertical-border': verticalBorder, error: color === 'error' }" class="ui-table typo p2-regular">
-    <slot foo="test" />
+    <slot />
   </table>
 </template>
 

--- a/@xen-orchestra/web-core/lib/components/table/UiTable.vue
+++ b/@xen-orchestra/web-core/lib/components/table/UiTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <table :class="{ 'vertical-border': verticalBorder, error: hasError }" class="ui-table typo p2-regular">
+  <table :class="{ 'vertical-border': verticalBorder }" class="ui-table typo p2-regular">
     <slot />
   </table>
 </template>
@@ -8,7 +8,6 @@
 import { provide } from 'vue'
 
 const props = defineProps<{
-  hasError?: boolean
   name?: string
   verticalBorder?: boolean
 }>()
@@ -17,20 +16,10 @@ provide('tableName', props.name)
 </script>
 
 <style lang="postcss" scoped>
-/* BACKGROUND COLOR VARIANTS */
-.ui-table {
-  --background-color: var(--background-color-primary);
-
-  &.error {
-    background-color: var(--background-color-red-10);
-  }
-}
-
-/* IMPLEMENTATION */
 .ui-table {
   width: 100%;
   border-spacing: 0;
-  background-color: var(--background-color);
+  background-color: var(--background-color-primary);
   line-height: 2.4rem;
   color: var(--color-grey-200);
 

--- a/@xen-orchestra/web-core/lib/locales/en.json
+++ b/@xen-orchestra/web-core/lib/locales/en.json
@@ -1,6 +1,11 @@
 {
   "core": {
     "close": "Close",
+    "coming-soon": "Coming soon!",
+    "current": "Current",
+    "filter": "Filter",
+    "group": "Group",
+    "hide": "Hide",
     "log-out": "Log out",
     "master": "Primary host",
     "open": "Open",
@@ -10,6 +15,10 @@
       "lock": "Lock sidebar open",
       "open": "Open sidebar",
       "unlock": "Unlock sidebar"
+    },
+    "sort": {
+      "ascending": "Sort ascending",
+      "descending": "Sort descending"
     }
   }
 }

--- a/@xen-orchestra/web-core/lib/locales/fr.json
+++ b/@xen-orchestra/web-core/lib/locales/fr.json
@@ -1,6 +1,11 @@
 {
   "core": {
     "close": "Fermer",
+    "coming-soon": "Bientôt disponible !",
+    "current": "Actuel",
+    "filter": "Filtrer",
+    "group": "Grouper",
+    "hide": "Masquer",
     "log-out": "Se déconnecter",
     "master": "Hôte primaire",
     "open": "Ouvrir",
@@ -10,6 +15,10 @@
       "lock": "Verrouiller la barre latérale",
       "open": "Ouvrir la barre latérale",
       "unlock": "Déverrouiller la barre latérale"
+    },
+    "sort": {
+      "ascending": "Trier par ordre croissant",
+      "descending": "Trier par ordre décroissant"
     }
   }
 }


### PR DESCRIPTION
### Screenshots

#### Nothing
![Capture d’écran de 2024-05-21 15-56-57](https://github.com/vatesfr/xen-orchestra/assets/70369997/3772172a-1eac-42f0-a529-898c858ce07a)
#### Hover
![Capture d’écran de 2024-05-21 15-56-59](https://github.com/vatesfr/xen-orchestra/assets/70369997/a0b30404-c938-41a5-99ae-9094e737e4df)
#### On click
![Capture d’écran de 2024-05-21 15-57-03](https://github.com/vatesfr/xen-orchestra/assets/70369997/5c3bd5ac-51bd-4d8b-b618-60a55d3f26e8)
#### Focus
![Capture d’écran de 2024-05-21 15-57-07](https://github.com/vatesfr/xen-orchestra/assets/70369997/1e805192-0067-4ed3-8a2d-1c586c73e9fa)
#### Focus with an action selected
![Capture d’écran de 2024-05-21 15-57-13](https://github.com/vatesfr/xen-orchestra/assets/70369997/1429054e-056f-475c-8880-c3e394a78a79)

### Use case
```js
      <UiTable vertical-border name="vms">
        <thead>
          <tr>
            <ColumnHeader id="vm" :icon="faDesktop">VM</ColumnHeader>
            <ColumnHeader id="desc" :icon="faAlignLeft">VM Description</ColumnHeader>
          </tr>
        </thead>
        <tbody>
          <tr v-for="vm of vmStore.runningVms.value">
            <td>{{ vm.name_label }}</td>
            <td>some random description</td>
          </tr>
        </tbody>
      </UiTable>
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
