### PR TITLE
feat(lite/header): add a link to XOA when detected on the pool

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## **next**
 
 - [Pool/Dashboard] In the `Storage usage` card, DVDs are no longer taken into account (PR [#7670](https://github.com/vatesfr/xen-orchestra/pull/7670))
-- [Header] Add link to XOA when XOA is detected on the pool
+- [Header] Add link to XOA when XOA is detected on the pool (PR [#7679](https://github.com/vatesfr/xen-orchestra/pull/7679))
 
 ## **0.2.2** (2024-04-30)
 

--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## **next**
 
 - [Pool/Dashboard] In the `Storage usage` card, DVDs are no longer taken into account (PR [#7670](https://github.com/vatesfr/xen-orchestra/pull/7670))
+- [Header] Add link to XOA when XOA is detected on the pool
 
 ## **0.2.2** (2024-04-30)
 

--- a/@xen-orchestra/lite/src/components/AppHeader.vue
+++ b/@xen-orchestra/lite/src/components/AppHeader.vue
@@ -8,14 +8,7 @@
     <slot />
     <div class="right">
       <PoolOverrideWarning as-tooltip />
-      <template v-if="isDesktop">
-        <UiButton v-if="xoaFound" :left-icon="faArrowUpRightFromSquare" @click="openXoa">
-          {{ $t('access-xoa') }}
-        </UiButton>
-        <UiButton v-else :left-icon="faDownload" @click="openXoaDeploy">
-          {{ $t('deploy-xoa') }}
-        </UiButton>
-      </template>
+      <XoaButton v-if="isDesktop" />
       <AccountButton />
     </div>
   </header>
@@ -26,76 +19,11 @@ import AccountButton from '@/components/AccountButton.vue'
 import PoolOverrideWarning from '@/components/PoolOverrideWarning.vue'
 import TextLogo from '@/components/TextLogo.vue'
 import UiIcon from '@/components/ui/icon/UiIcon.vue'
+import XoaButton from '@/components/XoaButton.vue'
 import { useNavigationStore } from '@/stores/navigation.store'
-import { usePoolCollection } from '@/stores/xen-api/pool.store'
-import UiButton from '@core/components/button/UiButton.vue'
 import { useUiStore } from '@core/stores/ui.store'
-import { faBars, faDownload, faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons'
+import { faBars } from '@fortawesome/free-solid-svg-icons'
 import { storeToRefs } from 'pinia'
-import { computed } from 'vue'
-import { useRouter } from 'vue-router'
-import type { PRIMARY_ADDRESS_TYPE } from '@/libs/xen-api/xen-api.enums'
-
-const router = useRouter()
-const { pool } = usePoolCollection()
-const XOA_INFO_KEY_PREFIX = 'xo:clientInfo:'
-
-interface InterfaceInfo {
-  address: string
-  netmask: string
-  mac: string
-  cidr: string
-  family: PRIMARY_ADDRESS_TYPE
-  internal: boolean
-}
-
-interface ClientInfo {
-  lastConnected: number
-  networkInterfaces: Record<string, InterfaceInfo[]>
-}
-
-const xoasInfo = computed(() => {
-  if (pool.value === undefined) {
-    return
-  }
-
-  return Object.fromEntries(
-    Object.entries(pool.value.other_config)
-      .filter(([key]) => key.startsWith(XOA_INFO_KEY_PREFIX))
-      .map(([key, json]) => [key.slice(XOA_INFO_KEY_PREFIX.length), JSON.parse(json)])
-  ) as Record<string, ClientInfo>
-})
-
-const xoaInfo = computed(() => {
-  if (xoasInfo.value === undefined) {
-    return
-  }
-
-  return Object.values(xoasInfo.value).reduce((lastXoaInfo, info) =>
-    lastXoaInfo === undefined || info.lastConnected > lastXoaInfo.lastConnected ? info : lastXoaInfo
-  )
-})
-
-const xoaAddress = computed(() => {
-  if (xoaInfo.value === undefined) {
-    return
-  }
-
-  const { networkInterfaces } = xoaInfo.value
-  if (networkInterfaces === undefined || Object.keys(networkInterfaces).length === 0) {
-    return
-  }
-
-  const ifName = 'eth0' in networkInterfaces ? 'eth0' : Object.keys(networkInterfaces)[0]
-  const xoaAddress = networkInterfaces[ifName][0].address
-
-  return `https://${xoaAddress}`
-})
-
-const xoaFound = computed(() => xoaAddress.value !== undefined)
-
-const openXoaDeploy = () => router.push({ name: 'xoa.deploy' })
-const openXoa = () => window.open(xoaAddress.value, '_blank', 'noopener')
 
 const uiStore = useUiStore()
 const { isMobile, isDesktop } = storeToRefs(uiStore)

--- a/@xen-orchestra/lite/src/components/AppHeader.vue
+++ b/@xen-orchestra/lite/src/components/AppHeader.vue
@@ -8,9 +8,14 @@
     <slot />
     <div class="right">
       <PoolOverrideWarning as-tooltip />
-      <UiButton v-if="isDesktop" :left-icon="faDownload" @click="openXoaDeploy">
-        {{ $t('deploy-xoa') }}
-      </UiButton>
+      <template v-if="isDesktop">
+        <UiButton v-if="xoaFound" :left-icon="faArrowUpRightFromSquare" @click="openXoa">
+          {{ $t('access-xoa') }}
+        </UiButton>
+        <UiButton v-else :left-icon="faDownload" @click="openXoaDeploy">
+          {{ $t('deploy-xoa') }}
+        </UiButton>
+      </template>
       <AccountButton />
     </div>
   </header>
@@ -22,15 +27,75 @@ import PoolOverrideWarning from '@/components/PoolOverrideWarning.vue'
 import TextLogo from '@/components/TextLogo.vue'
 import UiIcon from '@/components/ui/icon/UiIcon.vue'
 import { useNavigationStore } from '@/stores/navigation.store'
+import { usePoolCollection } from '@/stores/xen-api/pool.store'
 import UiButton from '@core/components/button/UiButton.vue'
 import { useUiStore } from '@core/stores/ui.store'
-import { faBars, faDownload } from '@fortawesome/free-solid-svg-icons'
+import { faBars, faDownload, faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons'
 import { storeToRefs } from 'pinia'
+import { computed } from 'vue'
 import { useRouter } from 'vue-router'
+import type { PRIMARY_ADDRESS_TYPE } from '@/libs/xen-api/xen-api.enums'
 
 const router = useRouter()
+const { pool } = usePoolCollection()
+const XOA_INFO_KEY_PREFIX = 'xo:clientInfo:'
+
+interface InterfaceInfo {
+  address: string
+  netmask: string
+  mac: string
+  cidr: string
+  family: PRIMARY_ADDRESS_TYPE
+  internal: boolean
+}
+
+interface ClientInfo {
+  lastConnected: number
+  networkInterfaces: Record<string, InterfaceInfo[]>
+}
+
+const xoasInfo = computed(() => {
+  if (pool.value === undefined) {
+    return
+  }
+
+  return Object.fromEntries(
+    Object.entries(pool.value.other_config)
+      .filter(([key]) => key.startsWith(XOA_INFO_KEY_PREFIX))
+      .map(([key, json]) => [key.slice(XOA_INFO_KEY_PREFIX.length), JSON.parse(json)])
+  ) as Record<string, ClientInfo>
+})
+
+const xoaInfo = computed(() => {
+  if (xoasInfo.value === undefined) {
+    return
+  }
+
+  return Object.values(xoasInfo.value).reduce((lastXoaInfo, info) =>
+    lastXoaInfo === undefined || info.lastConnected > lastXoaInfo.lastConnected ? info : lastXoaInfo
+  )
+})
+
+const xoaAddress = computed(() => {
+  if (xoaInfo.value === undefined) {
+    return
+  }
+
+  const { networkInterfaces } = xoaInfo.value
+  if (networkInterfaces === undefined || Object.keys(networkInterfaces).length === 0) {
+    return
+  }
+
+  const ifName = 'eth0' in networkInterfaces ? 'eth0' : Object.keys(networkInterfaces)[0]
+  const xoaAddress = networkInterfaces[ifName][0].address
+
+  return `https://${xoaAddress}`
+})
+
+const xoaFound = computed(() => xoaAddress.value !== undefined)
 
 const openXoaDeploy = () => router.push({ name: 'xoa.deploy' })
+const openXoa = () => window.open(xoaAddress.value, '_blank', 'noopener')
 
 const uiStore = useUiStore()
 const { isMobile, isDesktop } = storeToRefs(uiStore)

--- a/@xen-orchestra/lite/src/components/XoaButton.vue
+++ b/@xen-orchestra/lite/src/components/XoaButton.vue
@@ -1,0 +1,78 @@
+<template>
+  <UiButton v-if="xoaFound" :left-icon="faArrowUpRightFromSquare" class="xoa-button" @click="openXoa()">
+    {{ $t('access-xoa') }}
+  </UiButton>
+  <UiButton v-else :left-icon="faDownload" class="xoa-button" @click="openXoaDeploy()">
+    {{ $t('deploy-xoa') }}
+  </UiButton>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue'
+import { usePoolStore } from '@/stores/xen-api/pool.store'
+import { useRouter } from 'vue-router'
+import { faDownload, faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons'
+import UiButton from '@core/components/button/UiButton.vue'
+import type { PRIMARY_ADDRESS_TYPE } from '@/libs/xen-api/xen-api.enums'
+
+const router = useRouter()
+const { pool } = usePoolStore().subscribe()
+const XOA_INFO_KEY_PREFIX = 'xo:clientInfo:'
+
+interface InterfaceInfo {
+  address: string
+  netmask: string
+  mac: string
+  cidr: string
+  family: PRIMARY_ADDRESS_TYPE
+  internal: boolean
+}
+
+interface ClientInfo {
+  lastConnected: number
+  networkInterfaces: Record<string, InterfaceInfo[]>
+}
+
+const xoasInfo = computed(() => {
+  if (pool.value === undefined) {
+    return
+  }
+
+  return Object.fromEntries(
+    Object.entries(pool.value.other_config)
+      .filter(([key]) => key.startsWith(XOA_INFO_KEY_PREFIX))
+      .map(([key, json]) => [key.slice(XOA_INFO_KEY_PREFIX.length), JSON.parse(json)])
+  ) as Record<string, ClientInfo>
+})
+
+const xoaInfo = computed(() => {
+  if (xoasInfo.value === undefined) {
+    return
+  }
+
+  return Object.values(xoasInfo.value).reduce((lastXoaInfo, info) =>
+    lastXoaInfo === undefined || info.lastConnected > lastXoaInfo.lastConnected ? info : lastXoaInfo
+  )
+})
+
+const xoaAddress = computed(() => {
+  if (xoaInfo.value === undefined) {
+    return
+  }
+
+  const { networkInterfaces } = xoaInfo.value
+  if (networkInterfaces === undefined || Object.keys(networkInterfaces).length === 0) {
+    return
+  }
+
+  const ifName = 'eth0' in networkInterfaces ? 'eth0' : Object.keys(networkInterfaces)[0]
+  const xoaAddress = networkInterfaces[ifName][0].address
+
+  return `https://${xoaAddress}`
+})
+
+const xoaFound = computed(() => xoaAddress.value !== undefined)
+
+const openXoaDeploy = () => router.push({ name: 'xoa.deploy' })
+const openXoa = () => window.open(xoaAddress.value, '_blank', 'noopener')
+</script>

--- a/@xen-orchestra/lite/src/libs/xen-api/xen-api.types.ts
+++ b/@xen-orchestra/lite/src/libs/xen-api/xen-api.types.ts
@@ -100,6 +100,7 @@ export interface XenApiPool extends XenApiRecord<'pool'> {
   }
   master: XenApiHost['$ref']
   name_label: string
+  other_config: Record<string, string>
 }
 
 export interface XenApiHost extends XenApiRecord<'host'> {


### PR DESCRIPTION
### Screenshots

![Capture_2024-05-21_16:09:28](https://github.com/vatesfr/xen-orchestra/assets/10992860/99b4fe4d-2d3c-4388-86e0-a2bcfe4133de)

### Description

When XOA is connected to a pool, it adds information about itself on the pool's `other_config`. We can use that in XO Lite to find the XOA's IP address and add a link to open Xen Orchestra.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
