### PR TITLE
Fix vGPU support where there are multiple GPU types

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [VM/Advanced] Fix vGPU support where multiple GPU groups have the same vGPU type [#5750](https://github.com/vatesfr/xen-orchestra/issues/5750)
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -418,6 +418,7 @@ const messages = {
   selectTimezone: 'Select timezone…',
   selectIp: 'Select IP(s)…',
   selectIpPool: 'Select IP pool(s)…',
+  selectGpuGroup: 'Select GPU group…',
   selectVgpuType: 'Select VGPU type(s)…',
   fillOptionalInformations: 'Fill information (optional)',
   selectTableReset: 'Reset',

--- a/packages/xo-web/src/common/render-xo-item.js
+++ b/packages/xo-web/src/common/render-xo-item.js
@@ -493,9 +493,10 @@ BackupJob.defaultProps = {
 
 export const Vgpu = connectStore(() => ({
   vgpuType: createGetObject((_, props) => props.vgpu.vgpuType),
-}))(({ vgpu, vgpuType }) => (
+  gpuGroup: createGetObject((_, props) => props.vgpu.gpuGroup),
+}))(({ vgpu, vgpuType, gpuGroup }) => (
   <span>
-    <Icon icon='vgpu' /> {vgpuType.modelName}
+    <Icon icon='vgpu' /> {renderXoItem(gpuGroup)}: {vgpuType.modelName}
   </span>
 ))
 

--- a/packages/xo-web/src/common/render-xo-item.js
+++ b/packages/xo-web/src/common/render-xo-item.js
@@ -645,13 +645,11 @@ const xoItemToRender = {
   vgpu: vgpu => <Vgpu vgpu={vgpu} />,
 
   vgpuType: type => (
-    <span>
-      <Icon icon='gpu' /> {type.modelName} ({type.vendorName}) {type.maxResolutionX}x{type.maxResolutionY}
-    </span>
+    <span>{type.modelName}{type.vendorName && "("+type.vendorName+")"}{type.maxResolutionX > 0 && type.maxResolutionX+"x"+type.maxResolutionY}</span>
   ),
 
   gpuGroup: group => (
-    <span>{group.name_label.startsWith('Group of ') ? group.name_label.slice(9) : group.name_label}</span>
+    <span>{group.name_label.replace(/^(Group of )?(.*?)( GPUs)?$/, '$2')}</span>
   ),
 
   backup: backup => (

--- a/packages/xo-web/src/common/select-objects.js
+++ b/packages/xo-web/src/common/select-objects.js
@@ -622,34 +622,29 @@ SelectVdi.propTypes = {
 
 // ===================================================================
 
+export const SelectGpuGroup = makeStoreSelect(
+  () => {
+    const getGpuGroups = createSelector(createGetObjectsOfType('gpuGroup').filter(getPredicate).sort(),
+      (gpuGroups) => filter(gpuGroups, (gpuGroup) => gpuGroup.enabledVgpuTypes.length > 0))
+
+    return {
+      xoObjects: getGpuGroups,
+    }
+  },
+  { placeholder: _('selectGpuGroup') }
+)
+
 export const SelectVgpuType = makeStoreSelect(
   () => {
-    const getVgpuTypes = createSelector(createGetObjectsOfType('vgpuType').filter(getPredicate), vgpuTypes => {
-      const gpuGroups = {}
-      forEach(vgpuTypes, vgpuType => {
-        forEach(vgpuType.gpuGroups, gpuGroup => {
-          if (gpuGroups[gpuGroup] === undefined) {
-            gpuGroups[gpuGroup] = []
-          }
-          gpuGroups[gpuGroup].push({
-            ...vgpuType,
-            gpuGroup,
-          })
-        })
-      })
-
-      return gpuGroups
-    })
-
-    const getGpuGroups = createGetObjectsOfType('gpuGroup').pick(createSelector(getVgpuTypes, keys)).sort()
+    const getVgpuTypes = createGetObjectsOfType('vgpuType').filter(getPredicate).sort()
 
     return {
       xoObjects: getVgpuTypes,
-      xoContainers: getGpuGroups,
     }
   },
   { placeholder: _('selectVgpuType') }
 )
+
 
 // ===================================================================
 // Objects from subscriptions.

--- a/packages/xo-web/src/xo-app/vm/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/vm/tab-advanced.js
@@ -22,7 +22,7 @@ import { CustomFields } from 'custom-fields'
 import { injectState, provideState } from 'reaclette'
 import { Number, Select as EditableSelect, Size, Text, XoSelect } from 'editable'
 import { Select, Toggle } from 'form'
-import { SelectResourceSet, SelectRole, SelectSubject, SelectUser, SelectVgpuType } from 'select-objects'
+import { SelectResourceSet, SelectRole, SelectSubject, SelectUser, SelectGpuGroup, SelectVgpuType } from 'select-objects'
 import { addSubscriptions, connectStore, formatSize, getVirtualizationModeLabel, osFamily } from 'utils'
 import { every, filter, find, isEmpty, keyBy, map, times, some, uniq } from 'lodash'
 import {
@@ -310,18 +310,19 @@ class NewVgpu extends Component {
 
   _getPredicate = createSelector(
     () => this.props.vm && this.props.vm.$pool,
-    poolId => vgpuType => poolId === vgpuType.$pool
+    poolId => obj => poolId === obj.$pool
   )
 
   render() {
     return (
       <Container>
-        <Row>
-          <Col size={6}>{_('vmSelectVgpuType')}</Col>
-          <Col size={6}>
-            <SelectVgpuType onChange={this.linkState('vgpuType')} predicate={this._getPredicate()} />
-          </Col>
-        </Row>
+        <Row><Col>{_('vmSelectVgpuType')}</Col></Row>
+        <Row className='mt-1'><Col>
+          <SelectGpuGroup required onChange={this.linkState('gpuGroup')} predicate={this._getPredicate()} />
+        </Col></Row>
+        <Row className='mt-1'><Col>
+          <SelectVgpuType required onChange={this.linkState('vgpuType')} predicate={this._getPredicate()} />
+        </Col></Row>
       </Container>
     )
   }
@@ -333,7 +334,7 @@ class Vgpus extends Component {
       icon: 'gpu',
       title: _('vmAddVgpu'),
       body: <NewVgpu vm={this.props.vm} />,
-    }).then(({ vgpuType }) => createVgpu(this.props.vm, { vgpuType, gpuGroup: vgpuType.gpuGroup }))
+    }).then(({ gpuGroup, vgpuType }) => createVgpu(this.props.vm, { gpuGroup, vgpuType }))
 
   render() {
     const { vgpus, vm } = this.props

--- a/packages/xo-web/src/xo-app/vm/tab-general.js
+++ b/packages/xo-web/src/xo-app/vm/tab-general.js
@@ -249,7 +249,7 @@ const GeneralTab = decorate([
           </Col>
           <Col mediumSize={3}>
             <p>{getVirtualizationModeLabel(vm)}</p>
-            {vgpu !== undefined && <p>{renderXoItem(vgpuTypes[vgpu.vgpuType])}</p>}
+            {vgpu !== undefined && <p>{renderXoItem(vgpu)}</p>}
           </Col>
           <Col mediumSize={3}>
             <BlockLink to={`/vms/${id}/network`}>


### PR DESCRIPTION
vGPUs are defined by the combination of a GPU group (which defines the type of physical GPU on which the vGPU will run) and a vGPU type.  When the pool has multiple GPU models, multiple GPU groups may present the same vGPU type; for example, `passthrough`.  Currently the code assumes that the vGPU type alone is sufficient to disambiguate vGPU configurations, which is not the case in such a situation.

 - When displaying vGPUs, currently only the vGPU type is shown.  This PR adds the GPU model from the GPU group (and also hides the vGPU vendor and resolution where that's not set on the vGPU type object, such as for a passthrough GPU).
   ![image](https://github.com/vatesfr/xen-orchestra/assets/556521/bb4cd9a1-56e0-46a3-803e-6d11acad7c13)
 - When adding vGPUs, currently the UI presents a tree of GPU groups and their respective vGPU types, but the functionality is broken when the same vGPU type appears twice: only the first instance can actually be selected.  This PR separates GPU group and vGPU type into separate fields.
   ![image](https://github.com/vatesfr/xen-orchestra/assets/556521/5a513438-9823-4286-959a-c3706a87f3b7)

Fixes: #5750 