### PR TITLE
feat(xo-web/tasks): wait 10 seconds before estimating end of task

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,7 +21,7 @@
   ```
 
 - [VM] Yellow icon when VM is busy [#7593](https://github.com/vatesfr/xen-orchestra/issues/7593) (PR [#7680](https://github.com/vatesfr/xen-orchestra/pull/7680))
-- [Tasks] Wait a few seconds before estimating remaining time [#7689](https://github.com/vatesfr/xen-orchestra/issues/7689)
+- [Tasks] Wait a few seconds before estimating remaining time [#7689](https://github.com/vatesfr/xen-orchestra/issues/7689) (PR [#7691](https://github.com/vatesfr/xen-orchestra/pull/7691))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,7 +19,9 @@
 
   xo-prod vm.start id=e6572e82-983b-4780-a2a7-b19831fb7f45
   ```
+
 - [VM] Yellow icon when VM is busy [#7593](https://github.com/vatesfr/xen-orchestra/issues/7593) (PR [#7680](https://github.com/vatesfr/xen-orchestra/pull/7680))
+- [Tasks] Wait a few seconds before estimating remaining time [#7689](https://github.com/vatesfr/xen-orchestra/issues/7689)
 
 ### Bug fixes
 

--- a/packages/xo-web/src/xo-app/tasks/index.js
+++ b/packages/xo-web/src/xo-app/tasks/index.js
@@ -144,10 +144,12 @@ const COLUMNS = [
       const started = task.created * 1000
       const { progress } = task
 
-      if (progress === 0 || progress === 1) {
-        return // not yet started or already finished
+      const elapsed = Date.now() - started
+      if (progress === 0 || progress === 1 || elapsed < 10e3) {
+        return // not yet started, already finished or too early to estimate end
       }
-      return <FormattedRelative value={started + (Date.now() - started) / progress} />
+
+      return <FormattedRelative value={started + elapsed / progress} />
     },
     name: _('taskEstimatedEnd'),
   },


### PR DESCRIPTION
Fixes #7689

### Description

Wait 10 seconds before estimating end of task

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
