### PR TITLE
fix(xo-server-perf-alert): improve performances and reliability

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 
 - [Backup & Replication] Fix job stalling when failing to find a base VM
 - [REST API] Host logs are in tar+gzip format, the path is now `/host/:uuid/logs.tgz` [#7703](https://github.com/vatesfr/xen-orchestra/issues/7703)
+- [Plugin/perf-alert] Reduce the number of queries to the hosts [#7692](https://github.com/vatesfr/xen-orchestra/issues/7692)
 
 ### Packages to release
 
@@ -39,6 +40,7 @@
 - @xen-orchestra/web-core patch
 - xo-server patch
 - xo-server-load-balancer minor
+- xo-server-perf-alert patch
 - xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-server-perf-alert/src/index.js
+++ b/packages/xo-server-perf-alert/src/index.js
@@ -701,7 +701,7 @@ ${entriesWithMissingStats.map(({ listItem }) => listItem).join('\n')}`
         .then(res => res.body.text())
         .then(text => JSON5.parse(text))
     }
-    // reuse an ecisting /in flight query
+    // reuse an existing/in flight query
     const json = await hostCache[host.uuid]
     const results = {
       meta: { ...json.meta, legend: [] },

--- a/packages/xo-server-perf-alert/src/index.js
+++ b/packages/xo-server-perf-alert/src/index.js
@@ -421,7 +421,7 @@ ${monitorBodies.join('\n')}`
     )
   }
 
-  _parseDefinition(definition) {
+  _parseDefinition(definition, cache) {
     const { objectType } = definition
     const lcObjectType = objectType.toLowerCase()
     const alarmId = `${lcObjectType}|${definition.variableName}|${definition.alarmTriggerLevel}`
@@ -465,7 +465,6 @@ ${monitorBodies.join('\n')}`
       return parser
     }
     const observationPeriod = definition.alarmTriggerPeriod !== undefined ? definition.alarmTriggerPeriod : 60
-    const cache = {}
     return {
       ...definition,
       alarmId,
@@ -544,8 +543,9 @@ ${monitorBodies.join('\n')}`
   }
 
   _getMonitors() {
-    return map(this._configuration.hostMonitors, def => this._parseDefinition({ ...def, objectType: 'host' }))
-      .concat(map(this._configuration.vmMonitors, def => this._parseDefinition({ ...def, objectType: 'VM' })))
+    const cache = {}
+    return map(this._configuration.hostMonitors, def => this._parseDefinition({ ...def, objectType: 'host' }, cache))
+      .concat(map(this._configuration.vmMonitors, def => this._parseDefinition({ ...def, objectType: 'VM' }, cache)))
       .concat(map(this._configuration.srMonitors, def => this._parseDefinition({ ...def, objectType: 'SR' })))
   }
 

--- a/packages/xo-server-perf-alert/src/index.js
+++ b/packages/xo-server-perf-alert/src/index.js
@@ -700,6 +700,10 @@ ${entriesWithMissingStats.map(({ listItem }) => listItem).join('\n')}`
         })
         .then(res => res.body.text())
         .then(text => JSON5.parse(text))
+        .catch(err => {
+          delete hostCache[host.uuid]
+          throw err
+        })
     }
     // reuse an existing/in flight query
     const json = await hostCache[host.uuid]

--- a/packages/xo-server-perf-alert/src/index.js
+++ b/packages/xo-server-perf-alert/src/index.js
@@ -3,7 +3,7 @@ import { createSchedule } from '@xen-orchestra/cron'
 import { createLogger } from '@xen-orchestra/log'
 import { filter, forOwn, map, mean } from 'lodash'
 import { utcParse } from 'd3-time-format'
-
+import assert from 'node:assert'
 const logger = createLogger('xo:xo-server-perf-alert')
 
 const XAPI_TO_XENCENTER = {
@@ -465,6 +465,7 @@ ${monitorBodies.join('\n')}`
       return parser
     }
     const observationPeriod = definition.alarmTriggerPeriod !== undefined ? definition.alarmTriggerPeriod : 60
+    const cache = {}
     return {
       ...definition,
       alarmId,
@@ -496,7 +497,7 @@ ${monitorBodies.join('\n')}`
 
                 if (typeFunction.createGetter === undefined) {
                   // Stats via RRD
-                  result.rrd = await this.getRrd(result.object, observationPeriod)
+                  result.rrd = await this.getRrd(result.object, observationPeriod, cache)
                   if (result.rrd !== null) {
                     const data = parseData(result.rrd, result.object.uuid)
                     Object.assign(result, {
@@ -672,28 +673,59 @@ ${entriesWithMissingStats.map(({ listItem }) => listItem).join('\n')}`
     }
   }
 
-  async getRrd(xapiObject, secondsAgo) {
+  async getRrd(xapiObject, secondsAgo, hostCache = {}) {
     const host = xapiObject.$type === 'host' ? xapiObject : xapiObject.$resident_on
     if (host == null) {
       return null
     }
-    // we get the xapi per host, because the alarms can check VMs in various pools
     const xapi = this._xo.getXapi(host.uuid)
-    const serverTimestamp = await getServerTimestamp(xapi, host)
-    const payload = {
-      host,
-      query: {
-        cf: 'AVERAGE',
-        host: (xapiObject.$type === 'host').toString(),
-        json: 'true',
-        start: serverTimestamp - secondsAgo,
-      },
+    if (hostCache[host.uuid] === undefined) {
+      hostCache[host.uuid] = getServerTimestamp(xapi, host)
+        .then(serverTimestamp => {
+          const payload = {
+            host,
+            query: {
+              cf: 'AVERAGE',
+              host: 'true',
+              json: 'true',
+              start: serverTimestamp - secondsAgo,
+            },
+          }
+          return xapi.getResource('/rrd_updates', payload)
+        })
+        .then(res => res.body.text())
+        .then(text => JSON5.parse(text))
     }
-    if (xapiObject.$type === 'VM') {
-      payload.vm_uuid = xapiObject.uuid
+    // reuse an ecisting /in flight query
+    const json = await hostCache[host.uuid]
+    const results = {
+      meta: { ...json.meta, legend: [] },
+      data: [],
     }
-    // JSON is not well formed, can't use the default node parser
-    return JSON5.parse(await (await xapi.getResource('/rrd_updates', payload)).body.text())
+    if (json.data.length > 0) {
+      // copy only the data relevant the object
+      const data = [...json.data]
+
+      let firstPass = true
+      json.meta.legend.forEach((legend, index) => {
+        const [, , /* type */ uuidInStat /* metricType */] = /^AVERAGE:([^:]+):(.+):(.+)$/.exec(legend)
+        if (uuidInStat !== xapiObject.uuid) {
+          return
+        }
+        results.meta.legend.push(legend)
+        let timestampIndex = 0
+        for (const { t, values } of data) {
+          if (firstPass) {
+            results.data.push({ t, values: [] })
+          }
+          assert.strictEqual(results.data[timestampIndex].t, t)
+          results.data[timestampIndex].values.push(values[index])
+          timestampIndex++
+        }
+        firstPass = false
+      })
+    }
+    return results
   }
 }
 

--- a/packages/xo-server-perf-alert/src/index.js
+++ b/packages/xo-server-perf-alert/src/index.js
@@ -54,7 +54,12 @@ const VM_FUNCTIONS = {
       return {
         parseRow: data => {
           const memory = data.values[memoryBytesLegend.index]
-          usedMemoryRatio.push((memory - 1024 * data.values[memoryKBytesFreeLegend.index]) / memory)
+          // some VM don't have this counter
+          usedMemoryRatio.push(
+            memoryKBytesFreeLegend === undefined
+              ? 0
+              : (memory - 1024 * data.values[memoryKBytesFreeLegend.index]) / memory
+          )
         },
         getDisplayableValue,
         shouldAlarm: () => COMPARATOR_FN[comparator](getDisplayableValue(), threshold),


### PR DESCRIPTION
### Description
review by commit

from  ticket 24847 

today one rrd query is done per object, per refresh. So a smart mode refresh can make hundred of queries at the same time, reaching these errors that keeps orphan tasks hanging 
```js

2024-05-27T12:57:00.095Z xo:xo-server-perf-alert WARN other side closed {
  error: SocketError: other side closed
      at Socket.<anonymous> (/home/florent/xen-orchestra/node_modules/undici/lib/dispatcher/client-h1.js:681:24)
      at Socket.emit (node:events:529:35)
      at Socket.patchedEmit [as emit] (/home/florent/xen-orchestra/@xen-orchestra/log/configure.js:52:17)
      at endReadableNT (node:internal/streams/readable:1400:12)
      at processTicksAndRejections (node:internal/process/task_queues:82:21) {
    code: 'UND_ERR_SOCKET',
    socket: {
      localAddress: '192.168.1.180',
      localPort: 35944,
      remoteAddress: '192.168.1.45',
      remotePort: 80,
      remoteFamily: 'IPv4',
      timeout: undefined,
      bytesWritten: 1155,
      bytesRead: 302854
    },
    call: { method: 'host.get_servertime', params: [Array] }
  }
}
```
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
