### PR TITLE
fix(backups): EEXIST error when restarting mirror backup

### DIFF
--- a/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.mjs
@@ -31,6 +31,7 @@ export const MixinRemoteWriter = (BaseClass = Object) =>
           return this._adapter.cleanVm(this._vmBackupDir, {
             ...options,
             fixMetadata: true,
+            removeTmp: true,
             logInfo: info,
             logWarn: (message, data) => {
               warn(message, data)

--- a/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.mjs
@@ -31,7 +31,6 @@ export const MixinRemoteWriter = (BaseClass = Object) =>
           return this._adapter.cleanVm(this._vmBackupDir, {
             ...options,
             fixMetadata: true,
-            removeTmp: true,
             logInfo: info,
             logWarn: (message, data) => {
               warn(message, data)
@@ -39,6 +38,7 @@ export const MixinRemoteWriter = (BaseClass = Object) =>
             },
             lock: false,
             mergeBlockConcurrency: this._config.mergeBlockConcurrency,
+            removeTmp: true,
           })
         })
       } catch (error) {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 - [V2V] Fix VSAN import not used when importing from VSAN ([PR #7717](https://github.com/vatesfr/xen-orchestra/pull/7717))
 - [Tasks] Log pending and failed API calls as XO tasks, eventually they will replaced logs in Settings/Logs
 - [Pool] Fix `Text data outside of root node` when installing patches
+- [Backups] Fix EEXIST error after an interrupted mirror backup job ([PR #7694](https://github.com/vatesfr/xen-orchestra/pull/7694))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

* cleanVm can only delete files when backup job is successful
* an interrupted transfer leave the temp file in place
* the temp file don't change name in a mirror backup since we transfer exactly the same file
* outputStream method use, by default, a flag that create the file if not exists and fail otherwise
* => EEXIST error 

This PR change the behaviour of cleanVM to delete temporary files on the pass before the transfer, thus removing any dot file

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
