### PR TITLE
fix(xo-server): don't use stats that were cached exactly one step ago

### DIFF
--- a/packages/xo-server/src/xapi-stats.mjs
+++ b/packages/xo-server/src/xapi-stats.mjs
@@ -289,7 +289,7 @@ export default class XapiStats {
   _isCacheStale(hostUuid, step, timestamp) {
     const byHost = this.#hostCache[hostUuid]?.[step]
     // cache is empty or too old
-    return byHost === undefined || byHost.timestamp + step < timestamp
+    return byHost === undefined || byHost.timestamp + step <= timestamp
   }
 
   // Execute one http request on a XenServer for get stats


### PR DESCRIPTION
### Description

Update stats instead of using cache when cache is exactly one step old. It avoids the stats to be twice the same in a row when fetching it every step.

Introduced by 8347ac6ed8359c489b22181bc43da2612b8b03fb

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
