### PR TITLE
feat(xo-core): add card title component to web core

### DIFF
--- a/@xen-orchestra/lite/src/stories/web-core/card/card-title.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/card/card-title.story.vue
@@ -10,12 +10,12 @@
       setting('descriptionSlotContent').preset('Description').widget(text()),
     ]"
   >
-    <CardTitle v-bind="properties"
-      >{{ settings.defaultSlotContent }}<UiCounter :value="3" color="danger" size="medium" />
-      <template #info
-        >{{ settings.infoSlotContent
-        }}<UiButton level="tertiary" size="extra-small" :right-icon="faAngleRight">See all</UiButton></template
-      >
+    <CardTitle v-bind="properties">
+      {{ settings.defaultSlotContent }}<UiCounter :value="3" color="danger" size="medium" />
+      <template #info>
+        {{ settings.infoSlotContent
+        }}<UiButton level="tertiary" size="extra-small" :right-icon="faAngleRight">See all</UiButton>
+      </template>
       <template #description>{{ settings.descriptionSlotContent }}</template>
     </CardTitle>
   </ComponentStory>

--- a/@xen-orchestra/lite/src/stories/web-core/card/card-title.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/card/card-title.story.vue
@@ -2,19 +2,21 @@
   <ComponentStory
     v-slot="{ properties, settings }"
     :params="[
-      prop('count').num().widget(),
-      prop('counterColor').str().enum('info', 'error', 'success', 'warning', 'black').widget(),
       slot(),
+      slot('info').help('Meant to receive an info text'),
+      slot('link').help('Meant to receive a tertiary button'),
+      slot('description').help('Meant to receive a description text, will be displayed under the title'),
       setting('defaultSlotContent').preset('Legend title').widget(text()),
-      setting('rightSlotContent').preset('Info').widget(text()),
-      setting('bottomLeftSlotContent').preset('Description').widget(text()),
+      setting('infoSlotContent').preset('Info').widget(text()),
+      setting('descriptionSlotContent').preset('Description').widget(text()),
     ]"
   >
     <CardTitle v-bind="properties"
-      ><template #left>{{ settings.defaultSlotContent }}</template>
-      <template #right>{{ settings.rightSlotContent }}</template>
-      <template #bottom-left>{{ settings.bottomLeftSlotContent }}</template>
-      <UiButton level="tertiary">Manage<UiIcon :icon="faAngleRight" color="info" /></UiButton>
+      >Title<UiCounter :value="13" color="danger" size="medium" />
+      <template #info
+        ><UiButton level="tertiary" size="extra-small" :right-icon="faAngleRight">See all</UiButton></template
+      >
+      <template #description>{{ settings.descriptionSlotContent }} </template>
     </CardTitle>
   </ComponentStory>
 </template>

--- a/@xen-orchestra/lite/src/stories/web-core/card/card-title.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/card/card-title.story.vue
@@ -6,27 +6,28 @@
       slot('info').help('Meant to receive an info text'),
       slot('link').help('Meant to receive a tertiary button'),
       slot('description').help('Meant to receive a description text, will be displayed under the title'),
-      setting('defaultSlotContent').preset('Legend title').widget(text()),
+      setting('defaultSlotContent').preset('Title').widget(text()),
       setting('infoSlotContent').preset('Info').widget(text()),
       setting('descriptionSlotContent').preset('Description').widget(text()),
     ]"
   >
     <CardTitle v-bind="properties"
-      >Title<UiCounter :value="13" color="danger" size="medium" />
+      >{{ settings.defaultSlotContent }}<UiCounter :value="3" color="danger" size="medium" />
       <template #info
-        ><UiButton level="tertiary" size="extra-small" :right-icon="faAngleRight">See all</UiButton></template
+        >{{ settings.infoSlotContent
+        }}<UiButton level="tertiary" size="extra-small" :right-icon="faAngleRight">See all</UiButton></template
       >
-      <template #description>{{ settings.descriptionSlotContent }} </template>
+      <template #description>{{ settings.descriptionSlotContent }}</template>
     </CardTitle>
   </ComponentStory>
 </template>
 
 <script lang="ts" setup>
 import ComponentStory from '@/components/component-story/ComponentStory.vue'
-import { prop, slot, setting } from '@/libs/story/story-param'
+import { slot, setting } from '@/libs/story/story-param'
 import { text } from '@/libs/story/story-widget'
 import CardTitle from '@core/components/card/CardTitle.vue'
 import UiButton from '@core/components/button/UiButton.vue'
-import UiIcon from '@core/components/icon/UiIcon.vue'
+import UiCounter from '@core/components/UiCounter.vue'
 import { faAngleRight } from '@fortawesome/free-solid-svg-icons'
 </script>

--- a/@xen-orchestra/lite/src/stories/web-core/card/card-title.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/card/card-title.story.vue
@@ -1,0 +1,30 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties, settings }"
+    :params="[
+      prop('count').num().widget(),
+      prop('counterColor').str().enum('info', 'error', 'success', 'warning', 'black').widget(),
+      slot(),
+      setting('defaultSlotContent').preset('Legend title').widget(text()),
+      setting('rightSlotContent').preset('Info').widget(text()),
+      setting('bottomLeftSlotContent').preset('Description').widget(text()),
+    ]"
+  >
+    <CardTitle v-bind="properties"
+      ><template #left>{{ settings.defaultSlotContent }}</template>
+      <template #right>{{ settings.rightSlotContent }}</template>
+      <template #bottom-left>{{ settings.bottomLeftSlotContent }}</template>
+      <UiButton level="tertiary">Manage<UiIcon :icon="faAngleRight" color="info" /></UiButton>
+    </CardTitle>
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import { prop, slot, setting } from '@/libs/story/story-param'
+import { text } from '@/libs/story/story-widget'
+import CardTitle from '@core/components/card/CardTitle.vue'
+import UiButton from '@core/components/button/UiButton.vue'
+import UiIcon from '@core/components/icon/UiIcon.vue'
+import { faAngleRight } from '@fortawesome/free-solid-svg-icons'
+</script>

--- a/@xen-orchestra/lite/src/stories/web-core/card/card-title.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/card/card-title.story.vue
@@ -2,9 +2,8 @@
   <ComponentStory
     v-slot="{ properties, settings }"
     :params="[
-      slot(),
-      slot('info').help('Meant to receive an info text'),
-      slot('link').help('Meant to receive a tertiary button'),
+      slot().help('Meant to receive the title and a UiCounter'),
+      slot('info').help('Meant to receive an info text and / or a tertiary UiButton'),
       slot('description').help('Meant to receive a description text, will be displayed under the title'),
       setting('defaultSlotContent').preset('Title').widget(text()),
       setting('infoSlotContent').preset('Info').widget(text()),

--- a/@xen-orchestra/web-core/lib/components/card/CardTitle.vue
+++ b/@xen-orchestra/web-core/lib/components/card/CardTitle.vue
@@ -4,7 +4,7 @@
     <div class="main-content">
       <div class="title typo h6-medium"><slot /></div>
 
-      <div v-if="$slots.info" class="info typo h7-semi-bold"><slot name="info"></slot></div>
+      <div v-if="$slots.info" class="info typo h7-semi-bold"><slot name="info" /></div>
     </div>
     <p v-if="$slots.description" class="description typo p3-regular">
       <slot name="description" />

--- a/@xen-orchestra/web-core/lib/components/card/CardTitle.vue
+++ b/@xen-orchestra/web-core/lib/components/card/CardTitle.vue
@@ -7,7 +7,7 @@
       <div v-if="$slots.info" class="info typo h7-semi-bold"><slot name="info"></slot></div>
     </div>
     <p v-if="$slots.description" class="description typo p3-regular">
-      <slot name="description"></slot>
+      <slot name="description" />
     </p>
   </div>
 </template>

--- a/@xen-orchestra/web-core/lib/components/card/CardTitle.vue
+++ b/@xen-orchestra/web-core/lib/components/card/CardTitle.vue
@@ -1,4 +1,4 @@
-<!-- v.1.0 -->
+<!-- v1.0 -->
 <template>
   <div class="card-title">
     <div class="left-blok">

--- a/@xen-orchestra/web-core/lib/components/card/CardTitle.vue
+++ b/@xen-orchestra/web-core/lib/components/card/CardTitle.vue
@@ -41,6 +41,7 @@ defineProps<{
   display: flex;
   gap: 0.8rem;
   align-items: center;
+  height: fit-content;
 }
 
 .title-and-counter {

--- a/@xen-orchestra/web-core/lib/components/card/CardTitle.vue
+++ b/@xen-orchestra/web-core/lib/components/card/CardTitle.vue
@@ -2,7 +2,7 @@
 <template>
   <div class="card-title">
     <div class="main-content">
-      <div class="title typo h6-medium"><slot></slot></div>
+      <div class="title typo h6-medium"><slot /></div>
 
       <div v-if="$slots.info" class="info typo h7-semi-bold"><slot name="info"></slot></div>
     </div>

--- a/@xen-orchestra/web-core/lib/components/card/CardTitle.vue
+++ b/@xen-orchestra/web-core/lib/components/card/CardTitle.vue
@@ -1,64 +1,52 @@
 <!-- v1.0 -->
 <template>
   <div class="card-title">
-    <div class="left-blok">
-      <div class="title-and-counter">
-        <span class="typo h6-medium"><slot name="left"></slot></span>
-        <UiCounter v-if="count" class="count" :value="count" :color="counterColor" />
-      </div>
-      <span class="typo p3-regular bottom-left"><slot name="bottom-left"></slot></span>
-    </div>
+    <div class="main-content">
+      <div class="title typo h6-medium"><slot></slot></div>
 
-    <div class="right-blok">
-      <span class="typo h7-semi-bold right"> <slot name="right"></slot></span>
-      <slot></slot>
+      <div v-if="$slots.info" class="info typo h7-semi-bold"><slot name="info"></slot></div>
     </div>
+    <p v-if="$slots.description" class="description typo p3-regular">
+      <slot name="description"></slot>
+    </p>
   </div>
 </template>
 
 <script lang="ts" setup>
-import UiCounter from '@core/components/UiCounter.vue'
-import type { CounterColor } from '@core/types/color.type'
-
-defineProps<{
-  count?: number
-  counterColor?: CounterColor
+defineSlots<{
+  default: () => void
+  info: () => void
+  description: () => void
 }>()
 </script>
 
 <style lang="postcss" scoped>
 .card-title {
   display: flex;
-  justify-content: space-between;
-}
-
-.left-blok {
-  display: flex;
   flex-direction: column;
 }
 
-.right-blok {
+.main-content {
   display: flex;
-  gap: 0.8rem;
+  gap: 1.6rem;
   align-items: center;
-  height: fit-content;
 }
 
-.title-and-counter {
+.title {
   display: flex;
   align-items: center;
   gap: 1.6rem;
 }
 
-.right {
+.info {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
   color: var(--color-purple-base);
 }
 
-.bottom-left {
+.description {
   color: var(--color-grey-300);
-}
-
-.count {
-  font-size: 1.6rem;
 }
 </style>

--- a/@xen-orchestra/web-core/lib/components/card/CardTitle.vue
+++ b/@xen-orchestra/web-core/lib/components/card/CardTitle.vue
@@ -1,0 +1,63 @@
+<!-- v.1.0 -->
+<template>
+  <div class="card-title">
+    <div class="left-blok">
+      <div class="title-and-counter">
+        <span class="typo h6-medium"><slot name="left"></slot></span>
+        <UiCounter v-if="count" class="count" :value="count" :color="counterColor" />
+      </div>
+      <span class="typo p3-regular bottom-left"><slot name="bottom-left"></slot></span>
+    </div>
+
+    <div class="right-blok">
+      <span class="typo h7-semi-bold right"> <slot name="right"></slot></span>
+      <slot></slot>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import UiCounter from '@core/components/UiCounter.vue'
+import type { CounterColor } from '@core/types/color.type'
+
+defineProps<{
+  count?: number
+  counterColor?: CounterColor
+}>()
+</script>
+
+<style lang="postcss" scoped>
+.card-title {
+  display: flex;
+  justify-content: space-between;
+}
+
+.left-blok {
+  display: flex;
+  flex-direction: column;
+}
+
+.right-blok {
+  display: flex;
+  gap: 0.8rem;
+  align-items: center;
+}
+
+.title-and-counter {
+  display: flex;
+  align-items: center;
+  gap: 1.6rem;
+}
+
+.right {
+  color: var(--color-purple-base);
+}
+
+.bottom-left {
+  color: var(--color-grey-300);
+}
+
+.count {
+  font-size: 1.6rem;
+}
+</style>


### PR DESCRIPTION

![Capture d'écran 2024-06-14 101926](https://github.com/vatesfr/xen-orchestra/assets/94314524/1f20f8c0-4a46-4475-ada1-8d1f0556f80d)


This component takes slots to display a title, a description, a button and info text. It goes inside the UiCard component.