### PR TITLE
chore(web stack): add new ESLint Vue rules #3

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -103,6 +103,13 @@ module.exports = {
         'vue/require-macro-variable-name': 'error',
         'vue/html-button-has-type': 'error',
         'vue/define-emits-declaration': ['error', 'type-literal'],
+        'vue/define-macros-order': [
+          'error',
+          {
+            order: ['defineOptions', 'defineProps', 'defineEmits', 'defineModel', 'defineSlots'],
+            defineExposeLast: true,
+          },
+        ],
       },
     },
     {

--- a/@xen-orchestra/lite/src/components/AppMarkdown.vue
+++ b/@xen-orchestra/lite/src/components/AppMarkdown.vue
@@ -9,11 +9,11 @@ import markdown from '@/libs/markdown'
 import { useEventListener } from '@vueuse/core'
 import { computed, type Ref, ref } from 'vue'
 
-const rootElement = ref() as Ref<HTMLElement>
-
 const props = defineProps<{
   content: string
 }>()
+
+const rootElement = ref() as Ref<HTMLElement>
 
 const html = computed(() => markdown.parse(props.content ?? ''))
 

--- a/@xen-orchestra/lite/src/components/RemoteConsole.vue
+++ b/@xen-orchestra/lite/src/components/RemoteConsole.vue
@@ -9,13 +9,13 @@ import { promiseTimeout } from '@vueuse/shared'
 import { fibonacci } from 'iterable-backoff'
 import { computed, onBeforeUnmount, ref, watchEffect } from 'vue'
 
-const N_TOTAL_TRIES = 8
-const FIBONACCI_MS_ARRAY: number[] = Array.from(fibonacci().toMs().take(N_TOTAL_TRIES))
-
 const props = defineProps<{
   location: string
   isConsoleAvailable: boolean
 }>()
+
+const N_TOTAL_TRIES = 8
+const FIBONACCI_MS_ARRAY: number[] = Array.from(fibonacci().toMs().take(N_TOTAL_TRIES))
 
 const vmConsoleContainer = ref<HTMLDivElement>()
 const xenApiStore = useXenApiStore()

--- a/@xen-orchestra/lite/src/components/UsageBar.vue
+++ b/@xen-orchestra/lite/src/components/UsageBar.vue
@@ -27,10 +27,10 @@ interface Props {
   nItems?: number
 }
 
+const props = defineProps<Props>()
+
 const MIN_WARNING_VALUE = 80
 const MIN_DANGEROUS_VALUE = 90
-
-const props = defineProps<Props>()
 
 const computedData = computed(() => {
   const _data = props.data

--- a/@xen-orchestra/lite/src/components/charts/LinearChart.vue
+++ b/@xen-orchestra/lite/src/components/charts/LinearChart.vue
@@ -14,13 +14,13 @@ import { CanvasRenderer } from 'echarts/renderers'
 import { computed, provide } from 'vue'
 import VueCharts from 'vue-echarts'
 
-const Y_AXIS_MAX_VALUE = 200
-
 const props = defineProps<{
   data: LinearChartData
   valueFormatter?: ValueFormatter
   maxValue?: number
 }>()
+
+const Y_AXIS_MAX_VALUE = 200
 
 const valueFormatter = computed<ValueFormatter>(() => {
   const formatter = props.valueFormatter

--- a/@xen-orchestra/lite/src/components/component-story/ComponentStory.vue
+++ b/@xen-orchestra/lite/src/components/component-story/ComponentStory.vue
@@ -89,6 +89,18 @@ import { uniqueId, upperFirst } from 'lodash-es'
 import { computed, reactive, ref, watch, watchEffect } from 'vue'
 import { useRoute } from 'vue-router'
 
+const props = defineProps<{
+  params: (Param | ModelParam)[]
+  presets?: Record<
+    string,
+    {
+      props?: Record<string, any>
+      settings?: Record<string, any>
+    }
+  >
+  fullWidthComponent?: boolean
+}>()
+
 enum TAB {
   NONE,
   PROPS,
@@ -103,18 +115,6 @@ const tab = (tab: TAB, params: Param[]) =>
     active: computed(() => selectedTab.value === tab),
     disabled: computed(() => params.length === 0),
   })
-
-const props = defineProps<{
-  params: (Param | ModelParam)[]
-  presets?: Record<
-    string,
-    {
-      props?: Record<string, any>
-      settings?: Record<string, any>
-    }
-  >
-  fullWidthComponent?: boolean
-}>()
 
 const modelParams = computed(() => props.params.filter(isModelParam))
 

--- a/@xen-orchestra/lite/src/components/component-story/StoryExampleComponent.vue
+++ b/@xen-orchestra/lite/src/components/component-story/StoryExampleComponent.vue
@@ -29,8 +29,6 @@
 </template>
 
 <script lang="ts" setup>
-const moonDistance = 384400
-
 withDefaults(
   defineProps<{
     imString: string
@@ -51,6 +49,8 @@ const emit = defineEmits<{
   click: []
   clickWithArg: [id: string]
 }>()
+
+const moonDistance = 384400
 </script>
 
 <style lang="postcss" scoped>

--- a/@xen-orchestra/lite/src/components/component-story/StoryPropParams.vue
+++ b/@xen-orchestra/lite/src/components/component-story/StoryPropParams.vue
@@ -96,6 +96,11 @@ const props = defineProps<{
   modelValue: Record<string, any>
 }>()
 
+const emit = defineEmits<{
+  reset: []
+  'update:modelValue': [value: any]
+}>()
+
 const params = useSortedCollection(toRef(props, 'params'), (p1, p2) => {
   if (p1.isRequired() === p2.isRequired()) {
     return 0
@@ -103,11 +108,6 @@ const params = useSortedCollection(toRef(props, 'params'), (p1, p2) => {
 
   return p1.isRequired() ? -1 : 1
 })
-
-const emit = defineEmits<{
-  reset: []
-  'update:modelValue': [value: any]
-}>()
 
 const model = useVModel(props, 'modelValue', emit)
 

--- a/@xen-orchestra/lite/src/components/component-story/StoryWidget.vue
+++ b/@xen-orchestra/lite/src/components/component-story/StoryWidget.vue
@@ -37,13 +37,6 @@ import {
 import { useVModel } from '@vueuse/core'
 import { defineAsyncComponent } from 'vue'
 
-const FormJson = defineAsyncComponent(() => import('@/components/form/FormJson.vue'))
-const FormSelect = defineAsyncComponent(() => import('@/components/form/FormSelect.vue'))
-const FormCheckbox = defineAsyncComponent(() => import('@/components/form/FormCheckbox.vue'))
-const FormInput = defineAsyncComponent(() => import('@/components/form/FormInput.vue'))
-const FormInputWrapper = defineAsyncComponent(() => import('@/components/form/FormInputWrapper.vue'))
-const FormRadio = defineAsyncComponent(() => import('@/components/form/FormRadio.vue'))
-
 const props = defineProps<{
   widget: Widget
   modelValue: any
@@ -53,6 +46,13 @@ const props = defineProps<{
 const emit = defineEmits<{
   'update:modelValue': [value: any]
 }>()
+
+const FormJson = defineAsyncComponent(() => import('@/components/form/FormJson.vue'))
+const FormSelect = defineAsyncComponent(() => import('@/components/form/FormSelect.vue'))
+const FormCheckbox = defineAsyncComponent(() => import('@/components/form/FormCheckbox.vue'))
+const FormInput = defineAsyncComponent(() => import('@/components/form/FormInput.vue'))
+const FormInputWrapper = defineAsyncComponent(() => import('@/components/form/FormInputWrapper.vue'))
+const FormRadio = defineAsyncComponent(() => import('@/components/form/FormRadio.vue'))
 
 const model = useVModel(props, 'modelValue', emit)
 </script>

--- a/@xen-orchestra/lite/src/components/form/FormInput.vue
+++ b/@xen-orchestra/lite/src/components/form/FormInput.vue
@@ -80,13 +80,13 @@ const props = withDefaults(
   { disabled: undefined }
 )
 
-const { name: contextColor } = useContext(ColorContext, () => props.color)
-
-const inputElement = ref()
-
 const emit = defineEmits<{
   'update:modelValue': [value: any]
 }>()
+
+const { name: contextColor } = useContext(ColorContext, () => props.color)
+
+const inputElement = ref()
 
 const value = useVModel(props, 'modelValue', emit)
 const isEmpty = computed(() => props.modelValue == null || String(props.modelValue).trim() === '')

--- a/@xen-orchestra/lite/src/components/form/FormInputWrapper.vue
+++ b/@xen-orchestra/lite/src/components/form/FormInputWrapper.vue
@@ -38,8 +38,6 @@ import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 import { uniqueId } from 'lodash-es'
 import { computed, provide, useSlots } from 'vue'
 
-const slots = useSlots()
-
 const props = withDefaults(
   defineProps<{
     label?: string
@@ -54,6 +52,8 @@ const props = withDefaults(
   }>(),
   { disabled: undefined }
 )
+
+const slots = useSlots()
 
 const id = computed(() => props.id ?? uniqueId('form-input-'))
 provide(IK_INPUT_ID, id)

--- a/@xen-orchestra/lite/src/components/ui/modals/UiModal.vue
+++ b/@xen-orchestra/lite/src/components/ui/modals/UiModal.vue
@@ -14,14 +14,14 @@ import { IK_MODAL } from '@/types/injection-keys'
 import { useMagicKeys, whenever } from '@vueuse/core'
 import { inject } from 'vue'
 
+defineOptions({
+  inheritAttrs: false,
+})
+
 const props = defineProps<{
   color?: Color
   disabled?: boolean
 }>()
-
-defineOptions({
-  inheritAttrs: false,
-})
 
 const modal = inject(IK_MODAL)!
 

--- a/@xen-orchestra/lite/src/components/ui/modals/layouts/ConfirmModalLayout.vue
+++ b/@xen-orchestra/lite/src/components/ui/modals/layouts/ConfirmModalLayout.vue
@@ -43,14 +43,14 @@ defineProps<{
   icon?: IconDefinition
 }>()
 
-const { textClass } = useContext(ColorContext)
-
 defineSlots<{
   title: () => void
   subtitle: () => void
   default: () => void
   buttons: () => void
 }>()
+
+const { textClass } = useContext(ColorContext)
 </script>
 
 <style lang="postcss" scoped>

--- a/@xen-orchestra/web-core/lib/components/menu/MenuList.vue
+++ b/@xen-orchestra/web-core/lib/components/menu/MenuList.vue
@@ -16,6 +16,10 @@ import placementJs, { type Options } from 'placement.js'
 import { computed, inject, nextTick, provide, ref, useSlots } from 'vue'
 import { onClickOutside, unrefElement, whenever } from '@vueuse/core'
 
+defineOptions({
+  inheritAttrs: false,
+})
+
 const props = withDefaults(
   defineProps<{
     horizontal?: boolean
@@ -25,10 +29,6 @@ const props = withDefaults(
   }>(),
   { disabled: undefined }
 )
-
-defineOptions({
-  inheritAttrs: false,
-})
 
 const slots = useSlots()
 const isOpen = ref(false)

--- a/@xen-orchestra/web-core/lib/layouts/CoreLayout.vue
+++ b/@xen-orchestra/web-core/lib/layouts/CoreLayout.vue
@@ -68,10 +68,6 @@ import { useUiStore } from '@core/stores/ui.store'
 import { faAngleDoubleLeft, faAngleLeft, faBars } from '@fortawesome/free-solid-svg-icons'
 import { computed } from 'vue'
 
-const sidebarStore = useSidebarStore()
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
-
 const slots = defineSlots<{
   'app-logo'(): any
   'app-header'(): any
@@ -83,6 +79,10 @@ const slots = defineSlots<{
   'panel-header'(): any
   'panel-content'(): any
 }>()
+
+const sidebarStore = useSidebarStore()
+const panelStore = usePanelStore()
+const uiStore = useUiStore()
 
 const isPanelVisible = computed(() => {
   if (!slots['panel-header'] && !slots['panel-content']) {


### PR DESCRIPTION
### Description

Add `vue/define-macros-order` ESLint rules to ensure consistency across components.

Macros will requires to be defined in the following order:
1. `defineOptions`
2. `defineProps`
3. `defineEmits`
4. `defineModel`
5. `defineSlots`

Also ensures `defineExpose` to be the last statement of `<script setup>`

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
