### PR TITLE
fix(lite/Dashboard): add missing translations and remove hardcoded values

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## **next**
 
+- [Pool/Dashboard] Add missing translations for hosts and VMs statuses (PR [#7744](https://github.com/vatesfr/xen-orchestra/pull/7744))
+
 ## **0.2.3** (2024-05-31)
 
 - [Pool/Dashboard] In the `Storage usage` card, DVDs are no longer taken into account (PR [#7670](https://github.com/vatesfr/xen-orchestra/pull/7670))

--- a/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardStatus.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardStatus.vue
@@ -4,9 +4,21 @@
     <NoDataError v-if="hasError" />
     <UiCardSpinner v-else-if="!isReady" />
     <template v-else>
-      <PoolDashboardStatusItem :active="activeHostsCount" :label="$t('hosts')" :total="totalHostsCount" />
+      <PoolDashboardStatusItem
+        :active="activeHostsCount"
+        :label="$t('hosts')"
+        :active-label="$t('host.active', 2)"
+        :inactive-label="$t('host.inactive', 2)"
+        :total="totalHostsCount"
+      />
       <UiSeparator />
-      <PoolDashboardStatusItem :active="activeVmsCount" :label="$t('vms')" :total="totalVmsCount" />
+      <PoolDashboardStatusItem
+        :active="activeVmsCount"
+        :label="$t('vms')"
+        :active-label="$t('vm.active', 2)"
+        :inactive-label="$t('vm.inactive', 2)"
+        :total="totalVmsCount"
+      />
     </template>
   </UiCard>
 </template>

--- a/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardStatus.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardStatus.vue
@@ -7,16 +7,16 @@
       <PoolDashboardStatusItem
         :active="activeHostsCount"
         :label="$t('hosts')"
-        :active-label="$t('host.active', 2)"
-        :inactive-label="$t('host.inactive', 2)"
+        :active-label="$t('host.active', activeHostsCount)"
+        :inactive-label="$t('host.inactive', totalHostsCount - activeHostsCount)"
         :total="totalHostsCount"
       />
       <UiSeparator />
       <PoolDashboardStatusItem
         :active="activeVmsCount"
         :label="$t('vms')"
-        :active-label="$t('vm.active', 2)"
-        :inactive-label="$t('vm.inactive', 2)"
+        :active-label="$t('vm.active', activeVmsCount)"
+        :inactive-label="$t('vm.inactive', totalVmsCount - activeVmsCount)"
         :total="totalVmsCount"
       />
     </template>

--- a/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardStatusItem.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardStatusItem.vue
@@ -5,16 +5,16 @@
       <h6 class="typo h6-semi-bold">{{ label }}</h6>
       <div class="status-line typo p1-regular">
         <div class="bullet" />
-        <div class="label">Active</div>
+        <div class="label">{{ activeLabel }}</div>
         <div class="count">{{ active }}</div>
       </div>
       <div class="status-line typo p1-regular">
         <div class="bullet inactive" />
-        <div class="label">Inactive</div>
+        <div class="label">{{ inactiveLabel }}</div>
         <div class="count">{{ inactive }}</div>
       </div>
       <div class="total typo c2-semi-bold">
-        Total <span>{{ total }}</span>
+        {{ $t('total') }} <span>{{ total }}</span>
       </div>
     </div>
   </div>
@@ -28,6 +28,8 @@ const props = defineProps<{
   label: string
   active: number
   total: number
+  activeLabel: string
+  inactiveLabel: string
 }>()
 
 const inactive = computed(() => props.total - props.active)

--- a/@xen-orchestra/lite/src/locales/de.json
+++ b/@xen-orchestra/lite/src/locales/de.json
@@ -1,7 +1,6 @@
 {
   "about": "Über",
   "access-xoa": "Access XOA",
-  "active": "Aktiv",
   "add": "Hinzufügen",
   "add-filter": "Filter hinzufügen",
   "add-or": "+Oder",
@@ -110,8 +109,11 @@
   "go-back": "Zurück",
   "gzip": "gzip",
   "here": "Hier",
+  "host": {
+    "active": "Aktiv",
+    "inactive": "Inaktiv"
+  },
   "hosts": "Hosts",
-  "inactive": "Inaktiv",
   "invalid-field": "Ungültiges Feld",
   "keep-me-logged": "Angemeldet bleiben",
   "keep-page-open": "Fenster bis zum Ende der Installation nicht Aktualisieren oder Schließen.",
@@ -227,6 +229,10 @@
   "vcpus": "vCPUs",
   "vcpus-used": "vCPUs in Benutzung",
   "version": "Version",
+  "vm": {
+    "active": "Aktiv",
+    "inactive": "Inaktiv"
+  },
   "vm-is-running": "Die VM ist eingeschalten",
   "vm-running": "VM eingeschalten | VMs eingeschalten",
   "vms": "VMs",

--- a/@xen-orchestra/lite/src/locales/en.json
+++ b/@xen-orchestra/lite/src/locales/en.json
@@ -110,6 +110,10 @@
   "go-back": "Go back",
   "gzip": "gzip",
   "here": "Here",
+  "host": {
+    "active": "Active",
+    "inactive": "Inactive"
+  },
   "hosts": "Hosts",
   "invalid-field": "Invalid field",
   "keep-me-logged": "Keep me logged in",
@@ -217,6 +221,7 @@
   "theme-light": "Light",
   "this-vm-cant-be-migrated": "This VM can't be migrated",
   "top-#": "Top {n}",
+  "total": "Total",
   "total-cpus": "Total CPUs",
   "total-free": "Total free",
   "total-used": "Total used",
@@ -225,6 +230,10 @@
   "vcpus": "vCPUs",
   "vcpus-used": "vCPUs used",
   "version": "Version",
+  "vm": {
+    "active": "Active",
+    "inactive": "Inactive"
+  },
   "vm-is-running": "The VM is running",
   "vm-running": "VM running | VMs running",
   "vms": "VMs",

--- a/@xen-orchestra/lite/src/locales/fr.json
+++ b/@xen-orchestra/lite/src/locales/fr.json
@@ -111,8 +111,8 @@
   "gzip": "gzip",
   "here": "Ici",
   "host": {
-    "active": "Actif | Actifs",
-    "inactive": "Inactif | Inactifs"
+    "active": "Actif | Actif | Actifs",
+    "inactive": "Inactif | Inactif | Inactifs"
   },
   "hosts": "Hôtes",
   "invalid-field": "Champ invalide",
@@ -231,8 +231,8 @@
   "vcpus-used": "vCPUs utilisés",
   "version": "Version",
   "vm": {
-    "active": "Active | Actives",
-    "inactive": "Inactive | Inactives"
+    "active": "Active | Active | Actives",
+    "inactive": "Inactive | Inactive | Inactives"
   },
   "vm-is-running": "La VM est en cours d'exécution",
   "vm-running": "VM en cours d'exécution | VMs en cours d'exécution",

--- a/@xen-orchestra/lite/src/locales/fr.json
+++ b/@xen-orchestra/lite/src/locales/fr.json
@@ -110,6 +110,10 @@
   "go-back": "Revenir en arrière",
   "gzip": "gzip",
   "here": "Ici",
+  "host": {
+    "active": "Actif | Actifs",
+    "inactive": "Inactif | Inactifs"
+  },
   "hosts": "Hôtes",
   "invalid-field": "Champ invalide",
   "keep-me-logged": "Rester connecté",
@@ -217,6 +221,7 @@
   "theme-light": "Clair",
   "this-vm-cant-be-migrated": "Cette VM ne peut pas être migrée",
   "top-#": "Top {n}",
+  "total": "Total",
   "total-cpus": "Total CPUs",
   "total-free": "Total libre",
   "total-used": "Total utilisé",
@@ -225,6 +230,10 @@
   "vcpus": "vCPUs",
   "vcpus-used": "vCPUs utilisés",
   "version": "Version",
+  "vm": {
+    "active": "Active | Actives",
+    "inactive": "Inactive | Inactives"
+  },
   "vm-is-running": "La VM est en cours d'exécution",
   "vm-running": "VM en cours d'exécution | VMs en cours d'exécution",
   "vms": "VMs",


### PR DESCRIPTION
### Description

Add missing translations (EN, FR, DE) in `PoolDashboardStatusItem`.

### Screenshots

EN:
![image](https://github.com/vatesfr/xen-orchestra/assets/66562640/b34a3352-ed99-427a-b1fa-daa8631eb53b)

FR:
![image](https://github.com/vatesfr/xen-orchestra/assets/66562640/86e46fa6-92fa-4fe3-adab-54e199e6e19b)

DE:
![image](https://github.com/vatesfr/xen-orchestra/assets/66562640/94cdee4a-1dd2-4210-af97-22b5a8be6659)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
