### PR TITLE
fix: prettify script must respect `.prettierignore`

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "docs:dev": "NODE_OPTIONS=--openssl-legacy-provider vuepress dev docs",
     "docs:build": "NODE_OPTIONS=--openssl-legacy-provider vuepress build docs",
     "prepare": "husky install",
-    "prettify": "prettier --ignore-path .gitignore --ignore-unknown --write .",
+    "prettify": "prettier --ignore-unknown --write .",
     "test": "npm run test-lint && npm run test-unit",
     "test-integration": "jest \".integ\\.spec\\.js$\" && scripts/run-script.js --parallel test-integration",
     "test-lint": "eslint --ignore-path .gitignore --ignore-pattern packages/xo-web .",


### PR DESCRIPTION
### Description

Fixes Prettier not ignoring patterns from `.prettierignore` file.

Problem is that [`ignore-path`](https://prettier.io/docs/en/cli#--ignore-path) default value (`[.gitignore, .prettierignore]`) is overridden from cli (`--ignore-path .gitignore`).

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
