### PR TITLE
feat(backups): enable Change Block Tracking Backups

### DIFF
--- a/@xen-orchestra/proxy/config.toml
+++ b/@xen-orchestra/proxy/config.toml
@@ -22,6 +22,8 @@ disableMergeWorker = false
 snapshotNameLabelTpl = '[XO Backup {job.name}] {vm.name_label}'
 vhdDirectoryCompression = 'brotli'
 
+purgeSnapshotData = false
+
 # This is a work-around.
 #
 # See https://github.com/vatesfr/xen-orchestra/pull/4674

--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -3,14 +3,14 @@ import pCatch from 'promise-toolbox/catch'
 import pRetry from 'promise-toolbox/retry'
 import { createLogger } from '@xen-orchestra/log'
 import { decorateClass } from '@vates/decorate-with'
-import { finished } from 'node:stream'
 import { strict as assert } from 'node:assert'
 
 import MultiNbdClient from '@vates/nbd-client/multi.mjs'
 import { createNbdVhdStream, createNbdRawStream } from 'vhd-lib/createStreamNbd.js'
 import { VDI_FORMAT_RAW, VDI_FORMAT_VHD } from './index.mjs'
+import { finished } from 'node:stream'
 
-const { warn } = createLogger('xo:xapi:vdi')
+const { warn, info } = createLogger('xo:xapi:vdi')
 
 const noop = Function.prototype
 class Vdi {
@@ -82,6 +82,25 @@ class Vdi {
     }
   }
 
+  // return an buffer with 0/1 bit, showing if the 64KB block corresponding
+  // in the raw vdi has changed
+  async listChangedBlock(ref, baseRef) {
+    const encoded = await this.call('VDI.list_changed_blocks', baseRef, ref)
+    const buf = Buffer.from(encoded, 'base64')
+    return buf
+  }
+
+  async enableChangeBlockTracking(ref) {
+    return this.call('VDI.enable_cbt', ref)
+  }
+  async disableChangeBlockTracking(ref) {
+    return this.call('VDI.disable_cbt', ref)
+  }
+
+  async dataDestroy(ref) {
+    return this.call('VDI.data_destroy', ref)
+  }
+
   async exportContent(
     ref,
     { baseRef, cancelToken = CancelToken.none, format, nbdConcurrency = 1, preferNbd = this._preferNbd }
@@ -96,28 +115,64 @@ class Vdi {
 
       query.base = baseRef
     }
-    let nbdClient, stream
+    let nbdClient, stream, exportStream
     try {
+      const [vdiName, cbt_enabled, size, uuid] = await Promise.all([
+        this.getField('VDI', ref, 'name_label'),
+        this.getField('VDI', ref, 'cbt_enabled'),
+        this.getField('VDI', ref, 'virtual_size'),
+        this.getField('VDI', ref, 'uuid'),
+      ])
+      let baseParentUuid
+      if (baseRef) {
+        baseParentUuid = (await this.getField('VDI', baseRef, 'sm_config'))?.['vhd-parent']
+      }
+      let changedBlocks
+
       if (preferNbd) {
+        // use CBT if possible
+        // call to liste changed blocks must be done before the vdi is used for NBD export
+
+        if (cbt_enabled && baseRef !== undefined) {
+          try {
+            changedBlocks = await this.VDI_listChangedBlock(ref, baseRef)
+            info('found changed blocks', changedBlocks)
+          } catch (error) {
+            // do not fail if CBT is not enabled/working
+            info('no changed block', error)
+          }
+        }
         nbdClient = await this._getNbdClient(ref, { nbdConcurrency })
       }
       // the raw nbd export does not need to peek ath the vhd source
       if (nbdClient !== undefined && format === VDI_FORMAT_RAW) {
         stream = createNbdRawStream(nbdClient)
       } else {
-        // raw export without nbd or vhd exports needs a resource stream
-        const vdiName = await this.getField('VDI', ref, 'name_label')
-        stream = (
-          await this.getResource(cancelToken, '/export_raw_vdi/', {
-            query,
-            task: await this.task_create(`Exporting content of VDI ${vdiName}`),
-          })
-        ).body
+        if (changedBlocks === undefined) {
+          // raw export without nbd or vhd exports needs a resource stream
+          // also metadata vdis (vdi that have a data_destroy) can't export a stream
+          stream = exportStream = (
+            await this.getResource(cancelToken, '/export_raw_vdi/', {
+              query,
+              task: await this.task_create(`Exporting content of VDI ${vdiName}`),
+            })
+          ).body
+        }
+
         if (nbdClient !== undefined && format === VDI_FORMAT_VHD) {
-          const taskRef = await this.task_create(`Exporting content of VDI ${vdiName} using NBD`)
-          stream = await createNbdVhdStream(nbdClient, stream)
+          const taskRef = await this.task_create(
+            `Exporting content of VDI ${vdiName} using NBD ${changedBlocks !== undefined ? ' and CBT' : ''}`
+          )
+          exportStream = stream
+          stream = await createNbdVhdStream(nbdClient, exportStream, {
+            changedBlocks,
+            vdiInfos: { size, uuid, parentUuid: baseParentUuid },
+          })
           stream.on('progress', progress => this.call('task.set_progress', taskRef, progress))
-          finished(stream, () => this.task_destroy(taskRef))
+          finished(stream, () => {
+            nbdClient.disconnect()
+            exportStream?.destroy() // ensure the source stream is really closed
+          })
         }
       }
       return stream
@@ -132,6 +187,7 @@ class Vdi {
       error.VDI = vdi
       error.nbdClient = nbdClient
       nbdClient?.disconnect()
+      exportStream?.destroy()
       throw error
     }
   }

--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -90,13 +90,6 @@ class Vdi {
     return buf
   }
 
-  async enableChangeBlockTracking(ref) {
-    return this.call('VDI.enable_cbt', ref)
-  }
-  async disableChangeBlockTracking(ref) {
-    return this.call('VDI.disable_cbt', ref)
-  }
-
   async dataDestroy(ref) {
     return this.call('VDI.data_destroy', ref)
   }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 - [Migration] Disable CBT when needed during a disk/VM migration (PR [#7756](https://github.com/vatesfr/xen-orchestra/pull/7756))
 - [Disks] Show and edit the use of CBT (Change Block Tracking) in disks (PR [#7732](https://github.com/vatesfr/xen-orchestra/pull/7732))
 - [Create/SR] Display SCSI ID and LUN during HBA storage creation (PR [#7742](https://github.com/vatesfr/xen-orchestra/pull/7742))
+- [Backups] Implements Change Block Tracking (CBT) (PR [#7750](https://github.com/vatesfr/xen-orchestra/pull/7750))
 
 ### Bug fixes
 
@@ -45,6 +46,7 @@
 - @xen-orchestra/web patch
 - @xen-orchestra/web-core patch
 - @xen-orchestra/xapi minor
+- vhd-lib minor
 - xo-server minor
 - xo-server-backup-reports major
 - xo-server-netbox minor

--- a/packages/vhd-lib/Vhd/VhdNbd.js
+++ b/packages/vhd-lib/Vhd/VhdNbd.js
@@ -1,0 +1,78 @@
+'use strict'
+
+const { VhdAbstract } = require('./VhdAbstract')
+
+const { DEFAULT_BLOCK_SIZE, FOOTER_SIZE, HEADER_SIZE, SECTOR_SIZE, BLOCK_UNUSED } = require('../_constants.js')
+const { unpackFooter, unpackHeader } = require('./_utils.js')
+
+const assert = require('node:assert')
+const { readChunkStrict, skipStrict } = require('@vates/read-chunk')
+
+const BITMAP = Buffer.alloc(SECTOR_SIZE, 255)
+
+exports.VhdNbd = class VhdNbd extends VhdAbstract {
+  #bat
+  #header
+  #footer
+  #nbdClient
+  #vhdStream
+
+  constructor(nbdClient, { vhdStream }) {
+    super()
+    assert.notEqual(vhdStream, undefined) // either a vhd stream or the changed block list
+
+    this.#nbdClient = nbdClient
+    if (vhdStream) {
+      // @todo : this stream MUST NOT be used outside
+      // if it is problematic we should extract forkStreamUnpipe to its packages and use it here
+      this.#vhdStream = vhdStream
+    }
+  }
+
+  get header() {
+    return this.#header
+  }
+
+  get footer() {
+    return this.#footer
+  }
+
+  containsBlock(blockId) {
+    assert.notEqual(this.#vhdStream, undefined) // either a vhd stream or the changed block list
+
+    const entry = this.#bat.readUInt32BE(blockId * 4)
+    return entry !== BLOCK_UNUSED
+  }
+
+  async readHeaderAndFooter() {
+    assert.notEqual(this.#vhdStream, undefined) // either a vhd stream or the changed block list
+
+    assert.strictEqual(this.#footer, undefined)
+    assert.strictEqual(this.#header, undefined)
+    this.#footer = unpackFooter(await readChunkStrict(this.#vhdStream, FOOTER_SIZE))
+    this.#header = unpackHeader(await readChunkStrict(this.#vhdStream, HEADER_SIZE))
+  }
+
+  async readBlockAllocationTable() {
+    assert.notEqual(this.#vhdStream, undefined) // either a vhd stream or the changed block list
+    assert.notEqual(this.#footer, undefined)
+    assert.notEqual(this.#header, undefined)
+    assert.strictEqual(this.#bat, undefined)
+    const batSize = Math.ceil((this.#header.maxTableEntries * 4) / SECTOR_SIZE) * SECTOR_SIZE
+    // skip space between header and beginning of the table
+    await skipStrict(this.#vhdStream, this.#header.tableOffset - (FOOTER_SIZE + HEADER_SIZE))
+    this.#bat = await readChunkStrict(this.#vhdStream, batSize)
+    this.#vhdStream.destroy() // we w'ont need it anymore
+  }
+
+  async readBlock(blockId) {
+    return this.#nbdClient.readBlock(blockId, DEFAULT_BLOCK_SIZE).then(data => {
+      return {
+        id: blockId,
+        bitmap: BITMAP,
+        data,
+        buffer: Buffer.concat([BITMAP, data]),
+      }
+    })
+  }
+}

--- a/packages/vhd-lib/Vhd/VhdNbd.js
+++ b/packages/vhd-lib/Vhd/VhdNbd.js
@@ -2,31 +2,53 @@
 
 const { VhdAbstract } = require('./VhdAbstract')
 
-const { DEFAULT_BLOCK_SIZE, FOOTER_SIZE, HEADER_SIZE, SECTOR_SIZE, BLOCK_UNUSED } = require('../_constants.js')
+const _computeGeometryForSize = require('../_computeGeometryForSize')
+const { createFooter, createHeader } = require('../_createFooterHeader.js')
+const {
+  DEFAULT_BLOCK_SIZE,
+  DISK_TYPES,
+  FOOTER_SIZE,
+  HEADER_SIZE,
+  SECTOR_SIZE,
+  BLOCK_UNUSED,
+} = require('../_constants.js')
 const { unpackFooter, unpackHeader } = require('./_utils.js')
 
-const assert = require('node:assert')
 const { readChunkStrict, skipStrict } = require('@vates/read-chunk')
+
+const assert = require('node:assert')
 
 const BITMAP = Buffer.alloc(SECTOR_SIZE, 255)
 
+function packUuid(uuid) {
+  const PARSE_UUID_RE = /-/g
+
+  return Buffer.from(uuid.replace(PARSE_UUID_RE, ''), 'hex')
+}
+
 exports.VhdNbd = class VhdNbd extends VhdAbstract {
   #bat
+  #changedBlocks
   #header
   #footer
   #nbdClient
   #vhdStream
+  #vdiInfos
 
-  constructor(nbdClient, { vhdStream }) {
+  constructor(nbdClient, { changedBlocks, vhdStream, vdiInfos }) {
     super()
-    assert.notEqual(vhdStream, undefined) // either a vhd stream or the changed block list
-
+    assert.notEqual(changedBlocks ?? vhdStream, undefined) // either a vhd stream or the changed block list
+    if (changedBlocks) {
+      assert.notEqual(vdiInfos, undefined) // either a vhd stream or the changed block list + vdi infos
+    }
     this.#nbdClient = nbdClient
     if (vhdStream) {
       // @todo : this stream MUST NOT be used outside
       // if it is problematic we should extract forkStreamUnpipe to its packages and use it here
       this.#vhdStream = vhdStream
     }
+    this.#vdiInfos = vdiInfos
+    this.#changedBlocks = changedBlocks
   }
 
   get header() {
@@ -38,31 +60,60 @@ exports.VhdNbd = class VhdNbd extends VhdAbstract {
   }
 
   containsBlock(blockId) {
-    assert.notEqual(this.#vhdStream, undefined) // either a vhd stream or the changed block list
-
+    assert.notEqual(this.#changedBlocks ?? this.#vhdStream, undefined) // either a vhd stream or the changed block list
+    if (this.#changedBlocks) {
+      // block are aligned, we could probably compare the bytes to 255
+      // each CBT block is 64KB
+      // each VHD block is 2MB
+      // => 32 CBT blocks per VHD block
+      // each CBT block used flag is stored in 1 bit
+      // => 4 bytes per VHD block => UINT32
+      // if any sublock is used => download the full block
+      const position = blockId * 4
+      return this.#changedBlocks.readUInt32BE(position) !== 0
+    }
     const entry = this.#bat.readUInt32BE(blockId * 4)
     return entry !== BLOCK_UNUSED
   }
 
   async readHeaderAndFooter() {
-    assert.notEqual(this.#vhdStream, undefined) // either a vhd stream or the changed block list
+    assert.notEqual(this.#changedBlocks ?? this.#vhdStream, undefined) // either a vhd stream or the changed block list
+    if (this.#changedBlocks) {
+      const { size, uuid, parentUuid } = this.#vdiInfos
 
-    assert.strictEqual(this.#footer, undefined)
-    assert.strictEqual(this.#header, undefined)
-    this.#footer = unpackFooter(await readChunkStrict(this.#vhdStream, FOOTER_SIZE))
-    this.#header = unpackHeader(await readChunkStrict(this.#vhdStream, HEADER_SIZE))
+      this.#header = unpackHeader(createHeader(Math.ceil(size / DEFAULT_BLOCK_SIZE)))
+      const geometry = _computeGeometryForSize(size)
+      const diskType = parentUuid ? DISK_TYPES.DIFFERENCING : DISK_TYPES.DYNAMIC
+      this.#footer = unpackFooter(createFooter(size, Math.floor(Date.now() / 1000), geometry, FOOTER_SIZE, diskType))
+      this.#footer.uuid = packUuid(uuid)
+      if (parentUuid) {
+        this.#header.parentUuid = packUuid(parentUuid)
+        const parentName = `${parentUuid}.vhd`
+        this.#header.parentUnicodeName = parentName
+        // @todo : are the parent locator mandatory ?
+      }
+    } else {
+      assert.strictEqual(this.#footer, undefined)
+      assert.strictEqual(this.#header, undefined)
+      this.#footer = unpackFooter(await readChunkStrict(this.#vhdStream, FOOTER_SIZE))
+      this.#header = unpackHeader(await readChunkStrict(this.#vhdStream, HEADER_SIZE))
+    }
   }
 
   async readBlockAllocationTable() {
-    assert.notEqual(this.#vhdStream, undefined) // either a vhd stream or the changed block list
-    assert.notEqual(this.#footer, undefined)
-    assert.notEqual(this.#header, undefined)
-    assert.strictEqual(this.#bat, undefined)
-    const batSize = Math.ceil((this.#header.maxTableEntries * 4) / SECTOR_SIZE) * SECTOR_SIZE
-    // skip space between header and beginning of the table
-    await skipStrict(this.#vhdStream, this.#header.tableOffset - (FOOTER_SIZE + HEADER_SIZE))
-    this.#bat = await readChunkStrict(this.#vhdStream, batSize)
-    this.#vhdStream.destroy() // we w'ont need it anymore
+    assert.notEqual(this.#changedBlocks ?? this.#vhdStream, undefined) // either a vhd stream or the changed block list
+    if (!this.#changedBlocks) {
+      assert.notEqual(this.#footer, undefined)
+      assert.notEqual(this.#header, undefined)
+      assert.strictEqual(this.#bat, undefined)
+      const batSize = Math.ceil((this.#header.maxTableEntries * 4) / SECTOR_SIZE) * SECTOR_SIZE
+      // skip space between header and beginning of the table
+      await skipStrict(this.#vhdStream, this.#header.tableOffset - (FOOTER_SIZE + HEADER_SIZE))
+      this.#bat = await readChunkStrict(this.#vhdStream, batSize)
+      this.#vhdStream.destroy() // we won't need it anymore
+    }
+
+    // changed can be used as a bat, not need to rebuild one
   }
 
   async readBlock(blockId) {
@@ -74,5 +125,12 @@ exports.VhdNbd = class VhdNbd extends VhdAbstract {
         buffer: Buffer.concat([BITMAP, data]),
       }
     })
+  }
+
+  async stream() {
+    const stream = await super.stream()
+
+    stream._nbd = true
+    return stream
   }
 }

--- a/packages/vhd-lib/createStreamNbd.js
+++ b/packages/vhd-lib/createStreamNbd.js
@@ -19,13 +19,13 @@ exports.createNbdRawStream = function createRawStream(nbdClient) {
   return stream
 }
 
-exports.createNbdVhdStream = async function createVhdStream(nbdClient, sourceStream) {
+exports.createNbdVhdStream = async function createVhdStream(nbdClient, sourceStream, { changedBlocks, vdiInfos } = {}) {
   const vhd = new VhdNbd(nbdClient, {
     vhdStream: sourceStream,
+    vdiInfos,
+    changedBlocks,
   })
   await vhd.readHeaderAndFooter()
   await vhd.readBlockAllocationTable()
-  const stream = await vhd.stream()
-  stream._nbd = true
   return vhd.stream()
 }

--- a/packages/vhd-lib/createStreamNbd.js
+++ b/packages/vhd-lib/createStreamNbd.js
@@ -1,21 +1,6 @@
 'use strict'
-const { finished, Readable } = require('node:stream')
-const { readChunkStrict, skipStrict } = require('@vates/read-chunk')
-const { unpackHeader } = require('./Vhd/_utils')
-const {
-  FOOTER_SIZE,
-  HEADER_SIZE,
-  PARENT_LOCATOR_ENTRIES,
-  SECTOR_SIZE,
-  BLOCK_UNUSED,
-  DEFAULT_BLOCK_SIZE,
-  PLATFORMS,
-} = require('./_constants')
-const { fuHeader, checksumStruct } = require('./_structs')
-const assert = require('node:assert')
-
-const MAX_DURATION_BETWEEN_PROGRESS_EMIT = 5e3
-const MIN_TRESHOLD_PERCENT_BETWEEN_PROGRESS_EMIT = 1
+const { Readable } = require('node:stream')
+const { VhdNbd } = require('./Vhd/VhdNbd')
 
 exports.createNbdRawStream = function createRawStream(nbdClient) {
   const exportSize = Number(nbdClient.exportSize)
@@ -34,130 +19,13 @@ exports.createNbdRawStream = function createRawStream(nbdClient) {
   return stream
 }
 
-exports.createNbdVhdStream = async function createVhdStream(
-  nbdClient,
-  sourceStream,
-  {
-    maxDurationBetweenProgressEmit = MAX_DURATION_BETWEEN_PROGRESS_EMIT,
-    minTresholdPercentBetweenProgressEmit = MIN_TRESHOLD_PERCENT_BETWEEN_PROGRESS_EMIT,
-  } = {}
-) {
-  const bufFooter = await readChunkStrict(sourceStream, FOOTER_SIZE)
-
-  const header = unpackHeader(await readChunkStrict(sourceStream, HEADER_SIZE))
-  // compute BAT in order
-  const batSize = Math.ceil((header.maxTableEntries * 4) / SECTOR_SIZE) * SECTOR_SIZE
-  // skip space between header and beginning of the table
-  await skipStrict(sourceStream, header.tableOffset - (FOOTER_SIZE + HEADER_SIZE))
-  // new table offset
-  header.tableOffset = FOOTER_SIZE + HEADER_SIZE
-  const streamBat = await readChunkStrict(sourceStream, batSize)
-  let offset = FOOTER_SIZE + HEADER_SIZE + batSize
-  // check if parentlocator are ordered
-  let precLocator = 0
-  for (let i = 0; i < PARENT_LOCATOR_ENTRIES; i++) {
-    header.parentLocatorEntry[i] = {
-      ...header.parentLocatorEntry[i],
-      platformDataOffset: offset,
-    }
-    offset += header.parentLocatorEntry[i].platformDataSpace * SECTOR_SIZE
-    if (header.parentLocatorEntry[i].platformCode !== PLATFORMS.NONE) {
-      assert(
-        precLocator < offset,
-        `locator must be ordered. numer ${i} is  at ${offset}, precedent is at ${precLocator}`
-      )
-      precLocator = offset
-    }
-  }
-  const rawHeader = fuHeader.pack(header)
-  checksumStruct(rawHeader, fuHeader)
-
-  // BAT
-  const bat = Buffer.allocUnsafe(batSize)
-  let offsetSector = offset / SECTOR_SIZE
-  const blockSizeInSectors = DEFAULT_BLOCK_SIZE / SECTOR_SIZE + 1 /* bitmap */
-  // compute a BAT with the position that the block will have in the resulting stream
-  // blocks starts directly after parent locator entries
-  const entries = []
-  for (let i = 0; i < header.maxTableEntries; i++) {
-    const entry = streamBat.readUInt32BE(i * 4)
-    if (entry !== BLOCK_UNUSED) {
-      bat.writeUInt32BE(offsetSector, i * 4)
-      entries.push(i)
-      offsetSector += blockSizeInSectors
-    } else {
-      bat.writeUInt32BE(BLOCK_UNUSED, i * 4)
-    }
-  }
-
-  const totalLength = (offsetSector + 1) /* end footer */ * SECTOR_SIZE
-
-  let lengthRead = 0
-  let lastUpdate = 0
-  let lastLengthRead = 0
-
-  function throttleEmitProgress() {
-    const now = Date.now()
-
-    if (
-      lengthRead - lastLengthRead > (minTresholdPercentBetweenProgressEmit / 100) * totalLength ||
-      (now - lastUpdate > maxDurationBetweenProgressEmit && lengthRead !== lastLengthRead)
-    ) {
-      stream.emit('progress', lengthRead / totalLength)
-      lastUpdate = now
-      lastLengthRead = lengthRead
-    }
-  }
-
-  function trackAndGet(buffer) {
-    lengthRead += buffer.length
-    throttleEmitProgress()
-    return buffer
-  }
-
-  async function* iterator() {
-    yield trackAndGet(bufFooter)
-    yield trackAndGet(rawHeader)
-    yield trackAndGet(bat)
-
-    let precBlocOffset = FOOTER_SIZE + HEADER_SIZE + batSize
-    for (let i = 0; i < PARENT_LOCATOR_ENTRIES; i++) {
-      const parentLocatorOffset = header.parentLocatorEntry[i].platformDataOffset
-      const space = header.parentLocatorEntry[i].platformDataSpace * SECTOR_SIZE
-      if (space > 0) {
-        await skipStrict(sourceStream, parentLocatorOffset - precBlocOffset)
-        const data = await readChunkStrict(sourceStream, space)
-        precBlocOffset = parentLocatorOffset + space
-        yield trackAndGet(data)
-      }
-    }
-
-    // close export stream we won't use it anymore
-    // destroying a stream can raise an error that can be safely ignored
-    sourceStream.on('error', () => {}).destroy()
-
-    // yield  blocks from nbd
-    const nbdIterator = nbdClient.readBlocks(function* () {
-      for (const entry of entries) {
-        yield { index: entry, size: DEFAULT_BLOCK_SIZE }
-      }
-    })
-    const bitmap = Buffer.alloc(SECTOR_SIZE, 255)
-    for await (const block of nbdIterator) {
-      yield trackAndGet(bitmap) // don't forget the bitmap before the block
-      yield trackAndGet(block)
-    }
-    yield trackAndGet(bufFooter)
-  }
-
-  const stream = Readable.from(iterator(), { objectMode: false })
-  stream.length = totalLength
-  stream._nbd = true
-  finished(stream, () => {
-    clearInterval(interval)
-    nbdClient.disconnect()
+exports.createNbdVhdStream = async function createVhdStream(nbdClient, sourceStream) {
+  const vhd = new VhdNbd(nbdClient, {
+    vhdStream: sourceStream,
   })
-  const interval = setInterval(throttleEmitProgress, maxDurationBetweenProgressEmit)
-
-  return stream
+  await vhd.readHeaderAndFooter()
+  await vhd.readBlockAllocationTable()
+  const stream = await vhd.stream()
+  stream._nbd = true
+  return vhd.stream()
 }

--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -101,7 +101,7 @@ mergeBlockConcurrency = 2
 # how many block can be uploaded in parallel
 # increase to in rease performance, reduce if you have timeout or memory error during transfer
 writeBlockConcurrency = 16
-purgeSnapshotData = true
+purgeSnapshotData = false
 
 # https://github.com/naugtur/blocked-at#params-and-return-value
 [blockedAtOptions]

--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -101,6 +101,7 @@ mergeBlockConcurrency = 2
 # how many block can be uploaded in parallel
 # increase to in rease performance, reduce if you have timeout or memory error during transfer
 writeBlockConcurrency = 16
+purgeSnapshotData = true
 
 # https://github.com/naugtur/blocked-at#params-and-return-value
 [blockedAtOptions]

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -600,8 +600,9 @@ const messages = {
     'Delete old backups before backing up the VMs. If the new backup fails, you will lose your old backups.',
   customTag: 'Custom tag',
   editJobNotFound: "The job you're trying to edit wasn't found",
-  preferNbd: 'Use NBD protocol to transfer disk if available',
-  preferNbdInformation: 'A network accessible by XO or the proxy must have NBD enabled',
+  preferNbd: 'Use NBD + CBT to transfer disk if available',
+  preferNbdInformation:
+    'A network accessible by XO or the proxy must have NBD enabled,. Storage must support Change Block Tracking (CBT) to ue it in a backup',
   nbdConcurrency: 'Number of NBD connection per disk',
 
   // ------ New Remote -----


### PR DESCRIPTION
### Description

review by commit

Enable CBT for all backups
* enable cbt each time a VM should be backuped by nbd
* if there are no rolling snapshot on a job => the snapshots data are only kept during the transfer. Snapshot data deletion is behing a config flag  'purgeSnapshotData' (default false ) 

adverse effect: 
* storage migration of cbt enabled VDI is blocked for now
* rolling back to previous XO version will make full backups
* removed read ahead in nbd , performance gain was low with concurrency and it ake code more complex
![image](https://github.com/vatesfr/xen-orchestra/assets/50174/52d5d989-b248-4e0c-8cd3-06fd5b8db930)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
