### PR TITLE
fix(xo-server-sdn-controller): install CA certificate on pools after plugin config update

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [SDN-Controller] Fix `tlsv1 alert unknown ca` when creating private network (PR [#7755](https://github.com/vatesfr/xen-orchestra/pull/7755))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -31,5 +33,6 @@
 
 - @xen-orchestra/xapi major
 - xo-server minor
+- xo-server-sdn-controller patch
 
 <!--packages-end-->

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -340,18 +340,12 @@ class SDNController extends EventEmitter {
       fileRead(join(certDirectory, CA_CERT)),
     ])
     this._tlsHelper.updateCertificates(this._clientKey, this._clientCert, this._caCert)
-    const updatedPools = []
+
     await Promise.all(
-      map(this.privateNetworks, async privateNetworks => {
-        await Promise.all(
-          privateNetworks.getPools().map(async pool => {
-            if (!updatedPools.includes(pool)) {
-              const xapi = this._xo.getXapi(pool)
-              await this._installCaCertificateIfNeeded(xapi)
-              updatedPools.push(pool)
-            }
-          })
-        )
+      map(this._xo.getAllXapis(), async xapi => {
+        if (xapi.status === 'connected') {
+          await this._installCaCertificateIfNeeded(xapi)
+        }
       })
     )
   }


### PR DESCRIPTION
### Description

See zammad#25082

The CA certificates were updated only on pools with existing private networks. If, after changing the certificates, a user tries to create a private network on a pool that previously had no private networks, a `tlsv1 alert unknown ca` error is raised because the pool's CA certificate is not up to date.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
