### PR TITLE
fix(netbox): force xo-server to use at least http-request-plus@1.0.3

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,7 @@
 
 - [V2V] Fix VSAN import not used when importing from VSAN ([PR #7717](https://github.com/vatesfr/xen-orchestra/pull/7717))
 - [Backups] Fix EEXIST error after an interrupted mirror backup job ([PR #7694](https://github.com/vatesfr/xen-orchestra/pull/7694))
-- [Netbox] Fix "Netbox error could not be retrieved" when an error occurs on Netbox's side
+- [Netbox] Fix "Netbox error could not be retrieved" when an error occurs on Netbox's side (PR [#7758](https://github.com/vatesfr/xen-orchestra/pull/7758))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 
 - [V2V] Fix VSAN import not used when importing from VSAN ([PR #7717](https://github.com/vatesfr/xen-orchestra/pull/7717))
 - [Backups] Fix EEXIST error after an interrupted mirror backup job ([PR #7694](https://github.com/vatesfr/xen-orchestra/pull/7694))
+- [Netbox] Fix "Netbox error could not be retrieved" when an error occurs on Netbox's side
 
 ### Packages to release
 

--- a/packages/xo-server/package.json
+++ b/packages/xo-server/package.json
@@ -85,7 +85,7 @@
     "helmet": "^3.9.0",
     "highland": "^2.11.1",
     "http-proxy": "^1.16.2",
-    "http-request-plus": "^1.0.0",
+    "http-request-plus": "^1.0.3",
     "http-server-plus": "^1.0.0",
     "human-format": "^1.0.0",
     "iterable-backoff": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12854,7 +12854,7 @@ http-proxy@^1.16.2, http-proxy@^1.17.0, http-proxy@^1.18.1:
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
 
-http-request-plus@^1.0.0, http-request-plus@^1.0.2:
+http-request-plus@^1.0.0, http-request-plus@^1.0.2, http-request-plus@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/http-request-plus/-/http-request-plus-1.0.3.tgz#34392950412b95056e05192fe7da15ec2c547c3b"
   integrity sha512-566RDaiBFQ7xfEE01Kw+qjNSBD+a893gJArx/PtQg9Bex5TxGedav7nOOBJzB2/+ZbZ5mMt5aHdiju1sJB2qBw==


### PR DESCRIPTION
See Zammad#24458

`xo-server-netbox` uses `response.text` which has been added in http-request-plus@1.0.3. Therefore, the dependency version in `xo-server` needs to be `^1.0.3` to ensure that `response.text` can be used.

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
