### PR TITLE
fix(xo-server-auth-ldap): do not use syntax "key=value" when key is "DN"

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@
 - [Netbox] Fix "Netbox error could not be retrieved" when an error occurs on Netbox's side (PR [#7758](https://github.com/vatesfr/xen-orchestra/pull/7758))
 - [XOSTOR] Fix the _Approximate SR Capacity_ sometimes showing as 0 if not all hosts had disks (PR [#7765](https://github.com/vatesfr/xen-orchestra/pull/7765))
 - [VM/Advanced] Ignore `Firmware not supported` warning for UEFI boot firmware [Forum#8878](https://xcp-ng.org/forum/topic/8878/uefi-firmware-not-supported) (PR [#7767](https://github.com/vatesfr/xen-orchestra/pull/7767))
+- [LDAP] Fix users being removed from groups when synchronizing groups (PR [#7759](https://github.com/vatesfr/xen-orchestra/pull/7759))
 
 ### Packages to release
 
@@ -52,6 +53,7 @@
 - @xen-orchestra/xapi minor
 - vhd-lib minor
 - xo-server minor
+- xo-server-auth-ldap patch
 - xo-server-backup-reports major
 - xo-server-netbox minor
 - xo-server-transport-email minor

--- a/packages/xo-server-auth-ldap/src/index.js
+++ b/packages/xo-server-auth-ldap/src/index.js
@@ -410,17 +410,26 @@ class AuthLdap {
             sizeLimit: 1,
           })
           if (ldapUser === undefined) {
+            logger.error(
+              `LDAP user ${memberId} belongs to group ${groupLdapName} but could not be found by searching ${membersMapping.userAttribute}=${memberId} in ${this._searchBase}`
+            )
             continue
           }
 
           const xoUser = xoUsers.find(user => user.authProviders.ldap.id === ldapUser[this._userIdAttribute])
           if (xoUser === undefined) {
+            logger.debug(
+              `LDAP user ${ldapUser[this._userIdAttribute]} belongs to group ${groupLdapName} but the corresponding XO user could not be found`
+            )
             continue
           }
           // If the user exists in XO, should be a member of the LDAP-provided
           // group but isn't: add it
           const userIdIndex = xoGroupMembers.findIndex(id => id === xoUser.id)
           if (userIdIndex !== -1) {
+            logger.debug(
+              `LDAP user ${ldapUser[this._userIdAttribute]} belongs to group ${groupLdapName} and is already a member of the corresponding XO group ${xoGroup.name}`
+            )
             xoGroupMembers.splice(userIdIndex, 1)
             continue
           }


### PR DESCRIPTION
See Zammad#25659

### Description

A DN is the full path to a LDAP node that uniquely identifies that node. It isn't simply a property of the element.
So a filter like `DN=...` doesn't work.
Instead, we need to search the DN itself as the base of the search and grab the root node of that search.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
