### PR TITLE
feat(xo-core): add alarm line component

### DIFF
--- a/@xen-orchestra/lite/src/stories/web-core/alarm-line.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/alarm-line.story.vue
@@ -7,41 +7,41 @@
       prop('alarmTriggerLevel').type('number').preset(0.8).required().widget(),
       prop('alarmCls').type('string').preset('on SR').required().widget(),
       slot(),
-      setting('defaultSlotContent').preset('Legend title').widget(text()),
+      setting('defaultSlotContent').preset('Description content').widget(text()),
     ]"
   >
-    <AlarmLine v-bind="properties">
-      {{ settings.defaultSlotContent }}
-      <template #objectLink>
-        <ObjectLink :type="rawTypeToType(alarm.cls)" :uuid="alarm.obj_uuid" />
-      </template>
-      <template #time>
-        <div v-tooltip="new Date(parseDateTime(alarm.timestamp)).toLocaleString()">
-          <RelativeTime :date="alarm.timestamp" />
-        </div>
-      </template>
-    </AlarmLine>
+    <UiTable>
+      <AlarmLine v-bind="properties">
+        {{ settings.defaultSlotContent }}
+        <template #objectLink>
+          <ObjectLink :type="rawTypeToType(alarm.cls)" :uuid="alarm.obj_uuid" />
+        </template>
+        <template #time>
+          <div v-tooltip="new Date(parseDateTime(alarm.timestamp)).toLocaleString()">
+            <RelativeTime :date="alarm.timestamp" />
+          </div>
+        </template>
+      </AlarmLine>
+    </UiTable>
   </ComponentStory>
 </template>
 
 <script lang="ts" setup>
 import ComponentStory from '@/components/component-story/ComponentStory.vue'
-import { prop, slot, setting } from '@/libs/story/story-param'
-import { text } from '@/libs/story/story-widget'
+import UiTable from '@/components/ui/UiTable.vue'
 import AlarmLine from '@core/components/AlarmLine.vue'
 import ObjectLink from '@/components/ObjectLink.vue'
 import RelativeTime from '@/components/RelativeTime.vue'
+import { prop, slot, setting } from '@/libs/story/story-param'
+import { text } from '@/libs/story/story-widget'
 import { vTooltip } from '@core/directives/tooltip.directive'
 import { parseDateTime } from '@/libs/utils'
 import { rawTypeToType } from '@/libs/xen-api/xen-api.utils'
-import type { XenApiAlarm } from '@/types/xen-api'
+// import type { XenApiAlarm } from '@/types/xen-api'
 
 const alarm = {
-  type: 'vm-cpu-usage',
-  triggerLevel: 0.8,
-  level: 0.8,
   cls: 'VM',
   obj_uuid: '1234',
   timestamp: new Date().toISOString(),
-} as XenApiAlarm
+}
 </script>

--- a/@xen-orchestra/lite/src/stories/web-core/alarm-line.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/alarm-line.story.vue
@@ -4,14 +4,18 @@
     :params="[
       prop('alarmType').type('string').preset('VM').required().widget(),
       prop('alarmLevel').type('number').preset(0.8).required().widget(),
-      prop('alarmTriggerLevel').type('number').preset(0.8).required().widget(),
-      prop('alarmCls').type('string').preset('on SR').required().widget(),
+      prop('alarmTrigger-level').type('number').preset(0.8).required().widget(),
       slot(),
       setting('defaultSlotContent').preset('Description content').widget(text()),
     ]"
   >
     <UiTable>
-      <AlarmLine v-bind="properties">
+      <AlarmLine
+        :alarm-level="properties.alarmLevel"
+        :alarm-type="properties.alarmType"
+        :alarm-trigger-level="properties.alarmTriggerLevel"
+        :alarm-cls="properties.alarmCls"
+      >
         {{ settings.defaultSlotContent }}
         <template #objectLink>
           <ObjectLink :type="rawTypeToType(alarm.cls)" :uuid="alarm.obj_uuid" />
@@ -26,7 +30,7 @@
   </ComponentStory>
 </template>
 
-<script lang="ts" setup>
+<script lang="ts" setup generic="T extends RawObjectType">
 import ComponentStory from '@/components/component-story/ComponentStory.vue'
 import UiTable from '@/components/ui/UiTable.vue'
 import AlarmLine from '@core/components/AlarmLine.vue'
@@ -37,11 +41,22 @@ import { text } from '@/libs/story/story-widget'
 import { vTooltip } from '@core/directives/tooltip.directive'
 import { parseDateTime } from '@/libs/utils'
 import { rawTypeToType } from '@/libs/xen-api/xen-api.utils'
-// import type { XenApiAlarm } from '@/types/xen-api'
+import type { RawObjectType, RecordUuid, RecordRef } from '@/libs/xen-api/xen-api.types'
+import type { XenApiAlarm } from '@/types/xen-api'
 
-const alarm = {
+const createRecordRef = <T,>(value: string): T => value as unknown as T
+
+const alarm: XenApiAlarm<RawObjectType> = {
+  $ref: createRecordRef<RecordRef<'message'>>('message-ref'),
+  uuid: createRecordRef<RecordUuid<'message'>>('message-uuid'),
   cls: 'VM',
-  obj_uuid: '1234',
+  obj_uuid: createRecordRef<RecordUuid<'vm'>>('1234'),
   timestamp: new Date().toISOString(),
+  level: 0.8,
+  triggerLevel: 0.8,
+  type: 'cpu_usage',
+  body: 'Description content',
+  name: 'Alarm name',
+  priority: 0,
 }
 </script>

--- a/@xen-orchestra/lite/src/stories/web-core/alarm-line.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/alarm-line.story.vue
@@ -1,0 +1,47 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties, settings }"
+    :params="[
+      prop('alarmType').type('string').preset('VM').required().widget(),
+      prop('alarmLevel').type('number').preset(0.8).required().widget(),
+      prop('alarmTriggerLevel').type('number').preset(0.8).required().widget(),
+      prop('alarmCls').type('string').preset('on SR').required().widget(),
+      slot(),
+      setting('defaultSlotContent').preset('Legend title').widget(text()),
+    ]"
+  >
+    <AlarmLine v-bind="properties">
+      {{ settings.defaultSlotContent }}
+      <template #objectLink>
+        <ObjectLink :type="rawTypeToType(alarm.cls)" :uuid="alarm.obj_uuid" />
+      </template>
+      <template #time>
+        <div v-tooltip="new Date(parseDateTime(alarm.timestamp)).toLocaleString()">
+          <RelativeTime :date="alarm.timestamp" />
+        </div>
+      </template>
+    </AlarmLine>
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import { prop, slot, setting } from '@/libs/story/story-param'
+import { text } from '@/libs/story/story-widget'
+import AlarmLine from '@core/components/AlarmLine.vue'
+import ObjectLink from '@/components/ObjectLink.vue'
+import RelativeTime from '@/components/RelativeTime.vue'
+import { vTooltip } from '@core/directives/tooltip.directive'
+import { parseDateTime } from '@/libs/utils'
+import { rawTypeToType } from '@/libs/xen-api/xen-api.utils'
+import type { XenApiAlarm } from '@/types/xen-api'
+
+const alarm = {
+  type: 'vm-cpu-usage',
+  triggerLevel: 0.8,
+  level: 0.8,
+  cls: 'VM',
+  obj_uuid: '1234',
+  timestamp: new Date().toISOString(),
+} as XenApiAlarm
+</script>

--- a/@xen-orchestra/web-core/lib/components/AlarmLine.vue
+++ b/@xen-orchestra/web-core/lib/components/AlarmLine.vue
@@ -1,0 +1,147 @@
+<template>
+  <tbody v-if="isMobile" class="alarm-row" @click="handleCollapse()">
+    <tr>
+      <td class="description" colspan="5">
+        <div v-tooltip class="ellipsis">
+          <UiIcon v-if="$slots.default" :icon="descriptionCollapsed ? faAngleDown : faAngleRight" color="info" />
+          {{ $t(`alarm-type.${alarmType}`, { n: alarmTriggerLevel * 100 }) }}
+        </div>
+      </td>
+    </tr>
+    <tr v-if="!descriptionCollapsed && $slots.default">
+      <td class="description-content" colspan="5">
+        <slot />
+      </td>
+    </tr>
+    <tr class="alarm-details">
+      <td>
+        <div v-if="$slots.time" class="ellipsis time"><slot name="time" /></div>
+      </td>
+      <td class="level typo h7-semi-bold">{{ alarmLevel * 100 }}%</td>
+      <td class="on">{{ $t('on-object', { object: alarmCls }) }}</td>
+      <td class="object">
+        <slot name="objectLink" />
+      </td>
+    </tr>
+  </tbody>
+
+  <tbody v-else class="alarm-row" @click="handleCollapse()">
+    <tr>
+      <th class="table-header">
+        <UiIcon v-if="$slots.default" :icon="descriptionCollapsed ? faAngleDown : faAngleRight" color="info" />
+        <div v-if="$slots.time" class="ellipsis time">
+          <slot name="time" />
+        </div>
+      </th>
+      <td class="description">
+        <div v-tooltip class="ellipsis">
+          {{ $t(`alarm-type.${alarmType}`, { n: alarmTriggerLevel * 100 }) }}
+        </div>
+      </td>
+      <td class="level typo h7-semi-bold">{{ alarmLevel * 100 }}%</td>
+      <td class="on">{{ $t('on-object', { object: alarmCls }) }}</td>
+      <td v-if="$slots.objectLink" class="object">
+        <slot name="objectLink" />
+      </td>
+    </tr>
+    <tr v-if="!descriptionCollapsed && $slots.default">
+      <td class="description-content" colspan="5">
+        <slot />
+      </td>
+    </tr>
+  </tbody>
+</template>
+
+<script lang="ts" setup>
+import { useUiStore } from '@core/stores/ui.store'
+import { storeToRefs } from 'pinia'
+import { useToggle } from '@vueuse/shared'
+import UiIcon from '@core/components/icon/UiIcon.vue'
+import { faAngleDown, faAngleRight } from '@fortawesome/free-solid-svg-icons'
+
+defineProps<{
+  alarmLevel: number
+  alarmType: string
+  alarmTriggerLevel: number
+  alarmCls: string
+}>()
+
+defineSlots<{
+  default: () => void
+  objectLink: () => void
+  time: () => void
+}>()
+
+const uiStore = useUiStore()
+const { isMobile } = storeToRefs(uiStore)
+const [descriptionCollapsed, handleCollapse] = useToggle(true)
+</script>
+
+<style lang="postcss" scoped>
+.alarm-row {
+  cursor: pointer;
+}
+
+.table-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  @media (min-width: 768px) {
+    padding-left: 0 !important;
+    display: flex;
+    align-items: center;
+    gap: 1.6rem;
+  }
+}
+
+.ellipsis {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  display: flex;
+  gap: 1.6rem;
+  align-items: center;
+  @media (min-width: 768px) {
+    display: inherit;
+  }
+}
+
+.level {
+  color: var(--color-red-base);
+}
+
+.on {
+  white-space: nowrap;
+}
+
+.object-link {
+  white-space: nowrap;
+}
+
+.description {
+  padding-left: 0 !important;
+}
+
+.description-content {
+  padding-top: 0 !important;
+  border-top: none !important;
+  font-size: 1.2rem;
+  padding-left: 2.5rem !important;
+  @media (min-width: 768px) {
+    padding-left: 2.5rem !important;
+  }
+}
+
+.alarm-details {
+  padding: 0 0 1rem 2.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  gap: 1rem;
+
+  td {
+    border-top: none !important;
+    padding: 0 !important;
+  }
+}
+</style>

--- a/@xen-orchestra/web-core/lib/components/AlarmLine.vue
+++ b/@xen-orchestra/web-core/lib/components/AlarmLine.vue
@@ -1,5 +1,5 @@
 <template>
-  <tbody v-if="isMobile" class="alarm-row" @click="handleCollapse()">
+  <tbody v-if="isMobile" class="alarm-line" @click="handleCollapse()">
     <tr>
       <td class="description" colspan="5">
         <div v-tooltip class="ellipsis">
@@ -25,7 +25,7 @@
     </tr>
   </tbody>
 
-  <tbody v-else class="alarm-row" @click="handleCollapse()">
+  <tbody v-else class="alarm-line" @click="handleCollapse()">
     <tr>
       <th class="table-header">
         <UiIcon v-if="$slots.default" :icon="descriptionCollapsed ? faAngleDown : faAngleRight" color="info" />
@@ -78,14 +78,16 @@ const [descriptionCollapsed, handleCollapse] = useToggle(true)
 </script>
 
 <style lang="postcss" scoped>
-.alarm-row {
+.alarm-line {
   cursor: pointer;
+  width: 100%;
 }
 
 .table-header {
   display: flex;
   align-items: center;
   gap: 1rem;
+
   @media (min-width: 768px) {
     padding-left: 0 !important;
     display: flex;
@@ -127,16 +129,14 @@ const [descriptionCollapsed, handleCollapse] = useToggle(true)
   border-top: none !important;
   font-size: 1.2rem;
   padding-left: 2.5rem !important;
-  @media (min-width: 768px) {
-    padding-left: 2.5rem !important;
-  }
 }
 
 .alarm-details {
-  padding: 0 0 1rem 2.5rem;
+  padding: 0 0 1rem 2.75rem;
   display: flex;
   flex-wrap: wrap;
   align-items: end;
+  justify-content: space-between;
   gap: 1rem;
 
   td {


### PR DESCRIPTION
This component takes slots and props from the Xen Api alarms to display collapsible content.
![Capture d'écran 2024-06-21 101450](https://github.com/vatesfr/xen-orchestra/assets/94314524/2cf0c13d-55de-4744-916f-8ef15d6008c5)
![Capture d'écran 2024-06-21 101503](https://github.com/vatesfr/xen-orchestra/assets/94314524/aa8bbb71-70d6-46c3-a621-87507aed2ed1)

Mobile:
![Capture d'écran 2024-06-21 103729](https://github.com/vatesfr/xen-orchestra/assets/94314524/a299699c-82a6-49ba-b131-4e6b47480f5e)
![Capture d'écran 2024-06-21 103619](https://github.com/vatesfr/xen-orchestra/assets/94314524/5818c8d2-d120-43da-92ea-55ee67451c8f)

