### PR TITLE
feat(xo-server): add rolling pool reboot to rest API actions

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 - [Disks] Show and edit the use of CBT (Change Block Tracking) in disks (PR [#7732](https://github.com/vatesfr/xen-orchestra/pull/7732))
 - [Create/SR] Display SCSI ID and LUN during HBA storage creation (PR [#7742](https://github.com/vatesfr/xen-orchestra/pull/7742))
 - [Backups] Implements Change Block Tracking (CBT) (PR [#7750](https://github.com/vatesfr/xen-orchestra/pull/7750))
-- [REST API] Added an endpoint for _rolling pool reboot_ (PR [#7761](https://github.com/vatesfr/xen-orchestra/pull/7761))
+- [REST API] _Rolling Pool Reboot_ action available `pools/<uuid>/actions/rolling_reboot` (PR [#7761](https://github.com/vatesfr/xen-orchestra/pull/7761))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,7 @@
 - [Disks] Show and edit the use of CBT (Change Block Tracking) in disks (PR [#7732](https://github.com/vatesfr/xen-orchestra/pull/7732))
 - [Create/SR] Display SCSI ID and LUN during HBA storage creation (PR [#7742](https://github.com/vatesfr/xen-orchestra/pull/7742))
 - [Backups] Implements Change Block Tracking (CBT) (PR [#7750](https://github.com/vatesfr/xen-orchestra/pull/7750))
+- [REST API] Added an endpoint for _rolling pool reboot_ (PR [#7761](https://github.com/vatesfr/xen-orchestra/pull/7761))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -339,6 +339,11 @@ export default class RestApi {
 
           await xapiObject.$xapi.pool_emergencyShutdown()
         },
+        rolling_reboot: async ({ object }) => {
+          await app.checkFeatureAuthorization('ROLLING_POOL_REBOOT')
+
+          await app.rollingPoolReboot(object)
+        },
         rolling_update: async ({ object }) => {
           await app.checkFeatureAuthorization('ROLLING_POOL_UPDATE')
 


### PR DESCRIPTION
### Description

Adding rolling pool reboot to the rest API actions to make tests easier

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
