### PR TITLE
fix(xo-web/VM/Advanced): fix 'not enough permission' error for super admins when attaching PCIs

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [VM/Advanced] Fix `not enought permission` for admin users who wanted to attach PCIs when the VM was on a shared SR [#9260](https://xcp-ng.org/forum/topic/9260/attach-pcis-not-enough-permissions?_=1719393396541)
+- [VM/Advanced] Fix `not enought permission` for admin users who wanted to attach PCIs when the VM was on a shared SR [#9260](https://xcp-ng.org/forum/topic/9260/attach-pcis-not-enough-permissions?_=1719393396541) (PR [#7793](https://github.com/vatesfr/xen-orchestra/pull/7793))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [VM/Advanced] Fix `not enought permission` for admin users who wanted to attach PCIs when the VM was on a shared SR [#9260](https://xcp-ng.org/forum/topic/9260/attach-pcis-not-enough-permissions?_=1719393396541) (PR [#7793](https://github.com/vatesfr/xen-orchestra/pull/7793))
+- [VM/Advanced] Fix `not enough permission` when attaching PCIs [#9260](https://xcp-ng.org/forum/topic/9260/attach-pcis-not-enough-permissions) (PR [#7793](https://github.com/vatesfr/xen-orchestra/pull/7793))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [VM/Advanced] Fix `not enought permission` for admin users who wanted to attach PCIs when the VM was on a shared SR [#9260](https://xcp-ng.org/forum/topic/9260/attach-pcis-not-enough-permissions?_=1719393396541)
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/packages/xo-web/src/xo-app/vm/pci-attach-modal.js
+++ b/packages/xo-web/src/xo-app/vm/pci-attach-modal.js
@@ -60,11 +60,12 @@ export default class PciAttachModal extends Component {
   )
 
   render() {
-    const { hideHostSelector = false } = this.props
+    const { pool } = this.props
     const isHostSelected = this.state.host !== undefined
     return (
       <div>
-        {!hideHostSelector && (
+        {/* For ACL users without authorization on the pool, there is no point in displaying an empty selector */}
+        {pool !== undefined && (
           <SelectHost onChange={this.onChangeHost} predicate={this._getHostPredicate} value={this.state.host} />
         )}
         <Tooltip content={isHostSelected ? undefined : _('selectHostFirst')}>

--- a/packages/xo-web/src/xo-app/vm/pci-attach-modal.js
+++ b/packages/xo-web/src/xo-app/vm/pci-attach-modal.js
@@ -4,14 +4,14 @@ import React from 'react'
 import renderXoItem from 'render-xo-item'
 import Tooltip from 'tooltip'
 import { createSelector } from 'selectors'
-import { isPciHidden, isVmRunning } from 'xo'
+import { isPciHidden } from 'xo'
 import { Select } from 'form'
 import { SelectHost } from 'select-objects'
 
 export default class PciAttachModal extends Component {
   state = {
     hiddenPcis: undefined,
-    host: isVmRunning(this.props.vm) ? this.props.vm.$container : undefined,
+    host: this.props.vm.$container !== this.props.vm.$pool ? this.props.vm.$container : undefined,
     pcis: [],
   }
 
@@ -60,10 +60,13 @@ export default class PciAttachModal extends Component {
   )
 
   render() {
+    const { hideHostSelector = false } = this.props
     const isHostSelected = this.state.host !== undefined
     return (
       <div>
-        <SelectHost onChange={this.onChangeHost} predicate={this._getHostPredicate} value={this.state.host} />
+        {!hideHostSelector && (
+          <SelectHost onChange={this.onChangeHost} predicate={this._getHostPredicate} value={this.state.host} />
+        )}
         <Tooltip content={isHostSelected ? undefined : _('selectHostFirst')}>
           <Select
             className='mt-1'

--- a/packages/xo-web/src/xo-app/vm/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/vm/tab-advanced.js
@@ -638,13 +638,7 @@ export default class TabAdvanced extends Component {
     const { vm, vmPool } = this.props
     const pcis = await confirm({
       body: (
-        <PciAttachModal
-          attachedPciIds={vm.attachedPcis}
-          pcisByHost={this.props.pcisByHost}
-          vm={vm}
-          // For ACL users without authorization on the pool, there is no point in displaying an empty selector
-          hideHostSelector={vmPool === undefined}
-        />
+        <PciAttachModal attachedPciIds={vm.attachedPcis} pcisByHost={this.props.pcisByHost} vm={vm} pool={vmPool} />
       ),
       icon: 'add',
       title: _('attachPcis'),


### PR DESCRIPTION
### Description

Can be tested on the pool `172.16.210.83` with the VM `MRA PCI`.
On the host `XCP XO 8.3.0 slave 2`, the PCI `Non-Volatile memory controller` is ready to be attached to a VM.
Feel free to migrate the VM's VDI if you need to fully test the fix.
If you move the VM's VDI on the `XOSTOR NVME` SR, don't start the VM otherwise the VM will not start

Fixes [Forum#9260](https://xcp-ng.org/forum/topic/9260/attach-pcis-not-enough-permissions/9?_=1719393396541)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
