### PR TITLE
feat(backups): show a toggle to enable snapshot destroy with CBT

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
@@ -276,7 +276,7 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
       // preferNbd is not a guarantee that the backup used NBD, depending on the network configuration
       this._settings.preferNbd &&
       // only delete snapshost data if the config allows it
-      this.config.purgeSnapshotData
+      this._settings.cbtDestroySnapshotData
     ) {
       Task.info('will delete snapshot data')
       const vdiRefs = await this._xapi.VM_getDisks(this._exportedVm?.$ref)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -10,6 +10,7 @@
 - [VM] Disks whose name contains the tag `[NOSNAP]` will be ignored when doing a manual snapshot similarly to disks ignored during backups with `[NOBAK]` (possibility to use both tags on the same disk) [Forum#79179](https://xcp-ng.org/forum/post/79179)
 - [Plugin/backup-reports] Backup reports sent by email have a new, less rudimentary look (PR [#7747](https://github.com/vatesfr/xen-orchestra/pull/7747))
 - [Rolling Pool Update/Reboot] Adds a progress bar to RPU and RPR tasks (PR [#7768](https://github.com/vatesfr/xen-orchestra/pull/7768))
+- [Backups] Add a UI to enable purging snapshot data with CBT backups (PR [#7796](https://github.com/vatesfr/xen-orchestra/pull/7796))
 
 ### Bug fixes
 
@@ -39,5 +40,6 @@
 - xo-server minor
 - xo-server-backup-reports minor
 - xo-server-sdn-controller patch
+- xo-web minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -10,7 +10,7 @@
 - [VM] Disks whose name contains the tag `[NOSNAP]` will be ignored when doing a manual snapshot similarly to disks ignored during backups with `[NOBAK]` (possibility to use both tags on the same disk) [Forum#79179](https://xcp-ng.org/forum/post/79179)
 - [Plugin/backup-reports] Backup reports sent by email have a new, less rudimentary look (PR [#7747](https://github.com/vatesfr/xen-orchestra/pull/7747))
 - [Rolling Pool Update/Reboot] Adds a progress bar to RPU and RPR tasks (PR [#7768](https://github.com/vatesfr/xen-orchestra/pull/7768))
-- [Backups] Add a UI to enable purging snapshot data with CBT backups (PR [#7796](https://github.com/vatesfr/xen-orchestra/pull/7796))
+- [Backups] Add a toggle to enable purging snapshot data with CBT backups (PR [#7796](https://github.com/vatesfr/xen-orchestra/pull/7796))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/api/backup-ng.mjs
+++ b/packages/xo-server/src/api/backup-ng.mjs
@@ -12,6 +12,10 @@ const SCHEMA_SETTINGS = {
     '*': {
       type: 'object',
       properties: {
+        cbtDestroySnapshotData: {
+          type: 'boolean',
+          optional: true,
+        },
         concurrency: {
           type: 'number',
           minimum: 0,

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -602,8 +602,11 @@ const messages = {
   editJobNotFound: "The job you're trying to edit wasn't found",
   preferNbd: 'Use NBD + CBT to transfer disk if available',
   preferNbdInformation:
-    'A network accessible by XO or the proxy must have NBD enabled,. Storage must support Change Block Tracking (CBT) to ue it in a backup',
+    'A network accessible by XO or the proxy must have NBD enabled. Storage must support Change Block Tracking (CBT) to use it in a backup',
   nbdConcurrency: 'Number of NBD connection per disk',
+  cbtDestroySnapshotData: 'destroy snapshot data when using CBT',
+  cbtDestroySnapshotDataInformation:
+    "The snapshot won't use any notable space on the SR, won't be shown in the UI and won't be usable to do a rollback",
 
   // ------ New Remote -----
   newRemote: 'New file system remote',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -604,12 +604,12 @@ const messages = {
   preferNbdInformation:
     'A network accessible by XO or the proxy must have NBD enabled. Storage must support Change Block Tracking (CBT) to use it in a backup',
   nbdConcurrency: 'Number of NBD connection per disk',
-  cbtDestroySnapshotData: 'purge snapshot data when using CBT',
+  cbtDestroySnapshotData: 'Purge snapshot data when using CBT',
   cbtDestroySnapshotDataInformation:
     "The snapshot won't use any notable space on the SR, won't be shown in the UI and won't be usable to do a rollback",
 
   cbtDestroySnapshotDataDisabledInformation:
-    'snapshot data can be purged only when NBD is enabled and rolling snapshot is not used',
+    'Snapshot data can be purged only when NBD is enabled and rolling snapshot is not used',
   // ------ New Remote -----
   newRemote: 'New file system remote',
   remoteTypeLocal: 'Local',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -604,10 +604,12 @@ const messages = {
   preferNbdInformation:
     'A network accessible by XO or the proxy must have NBD enabled. Storage must support Change Block Tracking (CBT) to use it in a backup',
   nbdConcurrency: 'Number of NBD connection per disk',
-  cbtDestroySnapshotData: 'destroy snapshot data when using CBT',
+  cbtDestroySnapshotData: 'purge snapshot data when using CBT',
   cbtDestroySnapshotDataInformation:
     "The snapshot won't use any notable space on the SR, won't be shown in the UI and won't be usable to do a rollback",
 
+  cbtDestroySnapshotDataDisabledInformation:
+    'snapshot data can be purged only when NBD is enabled and rolling snapshot is not used',
   // ------ New Remote -----
   newRemote: 'New file system remote',
   remoteTypeLocal: 'Local',

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -1081,12 +1081,8 @@ const New = decorate([
                           <FormGroup>
                             <label htmlFor={state.inputCbtDestroySnapshotData}>
                               <strong>{_('cbtDestroySnapshotData')}</strong>{' '}
-                              <Tooltip
-                                content={_(
-                                  preferNbd && !state.snapshotMode
-                                    ? 'cbtDestroySnapshotDataInformation'
-                                    : 'cbtDestroySnapshotDataDisabledInformation'
-                                )}
+                              <Tooltip content={_('cbtDestroySnapshotDataInformation')}>
+
                               >
                                 <Icon icon='info' />
                               </Tooltip>

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -1102,7 +1102,6 @@ const New = decorate([
                           </FormGroup>
                         </div>
                       )}
-
                       {state.isDelta && (
                         <FormGroup>
                           <label htmlFor={state.inputNbdConcurrency}>

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -145,6 +145,7 @@ const normalizeSettings = ({ copyMode, exportMode, offlineBackupActive, settings
     defined(setting.copyRetention, setting.exportRetention, setting.snapshotRetention) !== undefined
       ? {
           ...setting,
+          cbtDestroySnapshotData: undefined,
           copyRetention: copyMode ? setting.copyRetention : undefined,
           exportRetention: exportMode ? setting.exportRetention : undefined,
           snapshotRetention: snapshotMode && !offlineBackupActive ? setting.snapshotRetention : undefined,
@@ -183,6 +184,7 @@ const getInitialState = ({ preSelectedVmIds, setHomeVmIdsSelection, suggestedExc
     _proxyId: undefined,
     _vmsPattern: undefined,
     backupMode: false,
+    cbtDestroySnapshotData: false,
     compression: undefined,
     crMode: false,
     deltaMode: false,
@@ -631,6 +633,13 @@ const New = decorate([
             preferNbd,
           })
         },
+      setCbtDestroySnapshotData:
+        ({ setGlobalSettings }, cbtDestroySnapshotData) =>
+        () => {
+          setGlobalSettings({
+            cbtDestroySnapshotData,
+          })
+        },
       setNbdConcurrency({ setGlobalSettings }, nbdConcurrency) {
         setGlobalSettings({
           nbdConcurrency,
@@ -646,6 +655,7 @@ const New = decorate([
       compressionId: generateId,
       formId: generateId,
       inputConcurrencyId: generateId,
+      inputCbtDestroySnapshotData: generateId,
       inputFullIntervalId: generateId,
       inputMaxExportRate: generateId,
       inputPreferNbd: generateId,
@@ -758,6 +768,7 @@ const New = decorate([
     const { propSettings, settings = propSettings } = state
     const compression = defined(state.compression, job.compression, '')
     const {
+      cbtDestroySnapshotData,
       checkpointSnapshot,
       concurrency,
       fullInterval,
@@ -1051,22 +1062,41 @@ const New = decorate([
                         </FormGroup>
                       )}
                       {state.isDelta && (
-                        <FormGroup>
-                          <label htmlFor={state.inputPreferNbd}>
-                            <strong>{_('preferNbd')}</strong>{' '}
-                            <Tooltip content={_('preferNbdInformation')}>
-                              <Icon icon='info' />
-                            </Tooltip>
-                          </label>
-                          <Toggle
-                            className='pull-right'
-                            id={state.inputPreferNbd}
-                            name='preferNbd'
-                            value={preferNbd}
-                            onChange={effects.setPreferNbd}
-                          />
-                        </FormGroup>
+                        <div>
+                          <FormGroup>
+                            <label htmlFor={state.inputPreferNbd}>
+                              <strong>{_('preferNbd')}</strong>{' '}
+                              <Tooltip content={_('preferNbdInformation')}>
+                                <Icon icon='info' />
+                              </Tooltip>
+                            </label>
+                            <Toggle
+                              className='pull-right'
+                              id={state.inputPreferNbd}
+                              name='preferNbd'
+                              value={preferNbd}
+                              onChange={effects.setPreferNbd}
+                            />
+                          </FormGroup>
+                          <FormGroup>
+                            <label htmlFor={state.inputCbtDestroySnapshotData}>
+                              <strong>{_('cbtDestroySnapshotData')}</strong>{' '}
+                              <Tooltip content={_('cbtDestroySnapshotDataInformation')}>
+                                <Icon icon='info' />
+                              </Tooltip>
+                            </label>
+                            <Toggle
+                              className='pull-right'
+                              id={state.cbtDestroySnapshotData}
+                              name='cbtDestroySnapshotData'
+                              value={preferNbd && cbtDestroySnapshotData && !state.snapshotMode}
+                              disabled={!preferNbd || state.snapshotMode}
+                              onChange={effects.setCbtDestroySnapshotData}
+                            />
+                          </FormGroup>
+                        </div>
                       )}
+
                       {state.isDelta && (
                         <FormGroup>
                           <label htmlFor={state.inputNbdConcurrency}>

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -1091,14 +1091,22 @@ const New = decorate([
                                 <Icon icon='info' />
                               </Tooltip>
                             </label>
-                            <Toggle
-                              className='pull-right'
-                              id={state.cbtDestroySnapshotData}
-                              name='cbtDestroySnapshotData'
-                              value={preferNbd && cbtDestroySnapshotData && !state.snapshotMode}
-                              disabled={!preferNbd || state.snapshotMode}
-                              onChange={effects.setCbtDestroySnapshotData}
-                            />
+                            <Tooltip
+                              content={
+                                !preferNbd || state.snapshotMode
+                                  ? _('cbtDestroySnapshotDataDisabledInformation')
+                                  : undefined
+                              }
+                            >
+                              <Toggle
+                                className='pull-right'
+                                id={state.cbtDestroySnapshotData}
+                                name='cbtDestroySnapshotData'
+                                value={preferNbd && cbtDestroySnapshotData && !state.snapshotMode}
+                                disabled={!preferNbd || state.snapshotMode}
+                                onChange={effects.setCbtDestroySnapshotData}
+                              />
+                            </Tooltip>
                           </FormGroup>
                         </div>
                       )}

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -1081,7 +1081,13 @@ const New = decorate([
                           <FormGroup>
                             <label htmlFor={state.inputCbtDestroySnapshotData}>
                               <strong>{_('cbtDestroySnapshotData')}</strong>{' '}
-                              <Tooltip content={_('cbtDestroySnapshotDataInformation')}>
+                              <Tooltip
+                                content={_(
+                                  preferNbd && !state.snapshotMode
+                                    ? 'cbtDestroySnapshotDataInformation'
+                                    : 'cbtDestroySnapshotDataDisabledInformation'
+                                )}
+                              >
                                 <Icon icon='info' />
                               </Tooltip>
                             </label>


### PR DESCRIPTION
### Description

![image](https://github.com/vatesfr/xen-orchestra/assets/50174/95cc2609-3b36-4851-8a15-9bb023433c0b)

* add a toggle to purge snapshot data instead of relying on a config file
* this toggle can't be enabled if NBD is not used
* preferNbd enabled don't mean it will be used in all the case, for example if there are no NBD enabled network
* can't be used if there are rolling snapshot

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
