### PR TITLE
feat(xo-core): add CellText component

### DIFF
--- a/@xen-orchestra/lite/src/stories/web-core/cell-text/cell-text.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/cell-text/cell-text.story.vue
@@ -1,0 +1,26 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties, settings }"
+    :params="[
+      slot().help('Meant to receive the main label'),
+      slot('secondary').help('Meant to receive the secondary label'),
+      setting('slot').preset('Primary label').widget(),
+      setting('secondary').preset('Secondary label').widget(),
+    ]"
+  >
+    <table>
+      <tr>
+        <CellText v-bind="properties">
+          {{ settings.slot }}
+          <template #secondary>{{ settings.secondary }}</template>
+        </CellText>
+      </tr>
+    </table>
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import { setting, slot } from '@/libs/story/story-param'
+import CellText from '@core/components/cell-text/CellText.vue'
+</script>

--- a/@xen-orchestra/web-core/lib/components/cell-text/CellText.vue
+++ b/@xen-orchestra/web-core/lib/components/cell-text/CellText.vue
@@ -1,0 +1,35 @@
+<!-- v1.0 -->
+<template>
+  <td class="cell-text">
+    <div class="data typo p2-regular">
+      <slot />
+      <span v-if="slots.secondary" class="info typo p4-regular">
+        <slot name="secondary" />
+      </span>
+    </div>
+  </td>
+</template>
+
+<script lang="ts" setup>
+const slots = defineSlots<{
+  default: () => any
+  secondary?: () => any
+}>()
+</script>
+
+<style lang="postcss" scoped>
+.cell-text {
+  padding: 0.8rem;
+  border: 0.1rem solid var(--color-grey-500);
+}
+
+.data {
+  display: flex;
+  gap: 1.6rem;
+  align-items: center;
+}
+
+.info {
+  color: var(--color-grey-300);
+}
+</style>


### PR DESCRIPTION
### Description

Add `CellText` component.
The component is a `td` element, it should be used in a table `<tr>` element.

### Screenshots

![cell-text](https://github.com/vatesfr/xen-orchestra/assets/66562640/bf4d7b12-4ebf-4def-a10d-122b7b3ec729)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
