### PR TITLE
feat(backups): re enable cbt 

### DIFF
--- a/@xen-orchestra/backups/_runners/VmsXapi.mjs
+++ b/@xen-orchestra/backups/_runners/VmsXapi.mjs
@@ -15,6 +15,7 @@ const noop = Function.prototype
 
 const DEFAULT_XAPI_VM_SETTINGS = {
   bypassVdiChainsCheck: false,
+  cbtDestroySnapshotData: false,
   checkpointSnapshot: false,
   concurrency: 2,
   copyRetention: 0,

--- a/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
@@ -147,8 +147,13 @@ export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends Abstr
       ...lastExportedVdis.map(({ other_config }) => Number(other_config[DELTA_CHAIN_LENGTH] ?? 0))
     )
     const fullInterval = this._settings.fullInterval
-    if ( fullInterval !== 0 && fullInterval < deltaChainLength + 1) {
-      debug('not using base VM because fullInterval reached', { fullInterval, deltaChainLength, eq: fullInterval < deltaChainLength + 1, dc1: deltaChainLength + 1 })
+    if (fullInterval !== 0 && fullInterval <= deltaChainLength + 1) {
+      debug('not using base VM because fullInterval reached', {
+        fullInterval,
+        deltaChainLength,
+        eq: fullInterval < deltaChainLength + 1,
+        dc1: deltaChainLength + 1,
+      })
       return
     }
 

--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
@@ -146,6 +146,15 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
         if (!settings.bypassVdiChainsCheck) {
           await vm.$assertHealthyVdiChains()
         }
+        if (settings.preferNbd) {
+          try {
+            // enable CBT on all disks if possible
+            const diskRefs = await xapi.VM_getDisks(vm.$ref)
+            await Promise.all(diskRefs.map(diskRef => xapi.call('VDI.enable_cbt', diskRef)))
+          } catch (error) {
+            Task.info(`couldn't enable CBT`, error)
+          }
+        }
 
         const snapshotRef = await vm[settings.checkpointSnapshot ? '$checkpoint' : '$snapshot']({
           ignoredVdisTag: '[NOBAK]',
@@ -160,7 +169,6 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
           vmUuid: vm.uuid,
         })
         this._exportedVm = await xapi.getRecord('VM', snapshotRef)
-
         return this._exportedVm.uuid
       })
     } else {
@@ -208,7 +216,7 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
 
     const snapshotsPerSchedule = groupBy(this._jobSnapshotVdis, _ => _.other_config[SCHEDULE_ID])
     const xapi = this._xapi
-    await asyncMap(Object.entries(snapshotsPerSchedule), ([scheduleId, snapshots]) => {
+    await asyncMap(Object.entries(snapshotsPerSchedule), async ([scheduleId, snapshots]) => {
       const snapshotPerDatetime = groupBy(snapshots, _ => _.other_config[DATETIME])
 
       const datetimes = Object.keys(snapshotPerDatetime)
@@ -219,12 +227,11 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
         ...allSettings[scheduleId],
         ...allSettings[this._vm.uuid],
       }
-      // ensure we never delete the last one
-      const retention = Math.max(settings.snapshotRetention ?? 0, 1)
-
-      return asyncMap(getOldEntries(retention, datetimes), async datetime => {
+      // ensure we never delete the last one for delta
+      const minRetention = this.job.mode === 'delta' ? 1 : 0
+      const retention = Math.max(settings.snapshotRetention ?? 0, minRetention)
+      await asyncMap(getOldEntries(retention, datetimes), async datetime => {
         const vdis = snapshotPerDatetime[datetime]
-
         let vmRef
         // if there is an attached VM => destroy the VM (Non CBT backups)
         for (const vdi of vdis) {
@@ -234,8 +241,8 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
             // this will throw error for VDI still attached to control domain
             assert.strictEqual(vbds.length, 1, 'VDI must be free or attached to exactly one VM')
             const vm = vbds[0].$VM
+            assert.strictEqual(vm.is_control_domain, false, `Disk is still attached to DOM0 VM`) // don't delete a VM (especially a control domain)
             assert.strictEqual(vm.is_a_snapshot, true, `VM must be a snapshot`) // don't delete a VM (especially a control domain)
-            assert.strictEqual(vm.is_control_domain, false, `VM can't be a DOM0 VM`) // don't delete a VM (especially a control domain)
 
             const vmRefVdi = vm.$ref
             // same vm than other vdi of the same batch
@@ -257,6 +264,34 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
         }
       })
     })
+
+    // now that we use CBT, we can destroy the data of the snapshot used for this backup
+    // going back to a previous version of XO not supporting CBT will create a full backup
+    // this will only do something after snapshot and transfer
+    if (
+      // don't modify the VM
+      this._exportedVm?.is_a_snapshot &&
+      // user don't want to keep the snapshot data
+      this._settings.snapshotRetention === 0 &&
+      // preferNbd is not a guarantee that the backup used NBD, depending on the network configuration,
+      // in that case next runs will be full, but there is not an easy way to prevent that
+      this._settings.preferNbd &&
+      // only delete snapshost data if the config allows it
+      this._settings.cbtDestroySnapshotData
+    ) {
+      Task.info('will delete snapshot data')
+      const vdiRefs = await this._xapi.VM_getDisks(this._exportedVm?.$ref)
+      await xapi.call('VM.destroy', this._exportedVm.$ref)
+      for (const vdiRef of vdiRefs) {
+        try {
+          // data_destroy will fail with a VDI_NO_CBT_METADATA error if CBT is not enabled on this VDI
+          await xapi.call('VDI.data_destroy', vdiRef)
+          Task.info(`Snapshot data has been deleted`, { vdiRef })
+        } catch (error) {
+          Task.warning(`Couldn't deleted snapshot data`, { error, vdiRef })
+        }
+      }
+    }
   }
 
   async copy() {

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
@@ -19,10 +19,10 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
     // @todo use an index if possible
     // @todo : this seems similare to decorateVmMetadata
 
-    const replicatedVdis = sr.$VDIs
-      .filter(({ other_config }) => {
+    const replicatedVdis = sr.$VDIs 
+      .filter(vdi => {
         // REPLICATED_TO_SR_UUID is not used here since we are already filtering from sr.$VDIs
-        return baseUuidToSrcVdi.has(other_config?.[COPY_OF])
+        return baseUuidToSrcVdi.has(vdi?.other_config[COPY_OF])
       })
       .map(({ other_config }) => other_config?.[COPY_OF])
       .filter(_ => !!_)
@@ -103,10 +103,11 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
       .filter(_ => !!_)
     // @todo use index ?
 
-    const replicatedVdis = sr.$VDIs.filter(({ other_config }) => {
-      // REPLICATED_TO_SR_UUID is not used here since we are already filtering from sr.$VDIs
-      return sourceVdiUuids.includes(other_config?.[COPY_OF])
-    })
+    const replicatedVdis = sr.$VDIs
+      .filter(vdi => {
+        // REPLICATED_TO_SR_UUID is not used here since we are already filtering from sr.$VDIs
+        return sourceVdiUuids.includes(vdi?.other_config[COPY_OF])
+      })
 
     Object.values(backup.vdis).forEach(vdi => {
       vdi.other_config[COPY_OF] = vdi.uuid

--- a/@xen-orchestra/proxy/config.toml
+++ b/@xen-orchestra/proxy/config.toml
@@ -22,6 +22,7 @@ disableMergeWorker = false
 snapshotNameLabelTpl = '[XO Backup {job.name}] {vm.name_label}'
 vhdDirectoryCompression = 'brotli'
 
+
 # This is a work-around.
 #
 # See https://github.com/vatesfr/xen-orchestra/pull/4674

--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -3,14 +3,15 @@ import pCatch from 'promise-toolbox/catch'
 import pRetry from 'promise-toolbox/retry'
 import { createLogger } from '@xen-orchestra/log'
 import { decorateClass } from '@vates/decorate-with'
-import { finished } from 'node:stream'
+import { defer } from 'golike-defer'
 import { strict as assert } from 'node:assert'
 
 import MultiNbdClient from '@vates/nbd-client/multi.mjs'
-import { createNbdVhdStream, createNbdRawStream } from 'vhd-lib/createStreamNbd.js'
+import { createNbdVhdStream } from 'vhd-lib/createStreamNbd.js'
 import { VDI_FORMAT_RAW, VDI_FORMAT_VHD } from './index.mjs'
+import { finished } from 'node:stream'
 
-const { warn } = createLogger('xo:xapi:vdi')
+const { warn, info } = createLogger('xo:xapi:vdi')
 
 const noop = Function.prototype
 class Vdi {
@@ -63,7 +64,7 @@ class Vdi {
     })
   }
 
-  async _getNbdClient(ref, { nbdConcurrency = 1 } = {}) {
+  async _connectNbdClientIfPossible(ref, { nbdConcurrency = 1 } = {}) {
     const nbdInfos = await this.call('VDI.get_nbd_info', ref)
     if (nbdInfos.length > 0) {
       // a little bit of randomization to spread the load
@@ -82,7 +83,44 @@ class Vdi {
     }
   }
 
+  /**
+   * return an buffer with 0/1 bit, showing if the 64KB block corresponding
+   * in the raw vdi has changed
+   */
+  async listChangedBlock(ref, baseRef) {
+    const encoded = await this.call('VDI.list_changed_blocks', baseRef, ref)
+    return Buffer.from(encoded, 'base64')
+  }
+
+  async disconnectFromControlDomain(vdiRef) {
+    const vbdRefs = await this.getField('VDI', vdiRef, 'VBDs')
+    await Promise.all(
+      vbdRefs.map(async vbdRef => {
+        const vmRef = await this.getField('VBD', vbdRef, 'VM')
+        const isControlDomain = await this.getField('VM', vmRef, 'is_control_domain')
+        if (isControlDomain) {
+          try {
+            await this.VBD_destroy(vbdRef)
+            info(` ${vbdRef} has been disconnected from dom0`, { vdiRef, vbdRef })
+          } catch (err) {
+            if (err.code === 'HANDLE_INVALID') {
+              info(` ${vbdRef} was already destroyed`, { vdiRef, vbdRef })
+            } else {
+              try {
+                await this.getRecord('VBD', vbdRef)
+                warn(`Couldn't disconnect ${vdiRef} from dom0`, { vdiRef, vbdRef, err })
+              } catch (err2) {
+                // since we can't get the info of this record we assume it is delete or deleting
+              }
+            }
+          }
+        }
+      })
+    )
+  }
+
   async exportContent(
+    $defer,
     ref,
     { baseRef, cancelToken = CancelToken.none, format, nbdConcurrency = 1, preferNbd = this._preferNbd }
   ) {
@@ -90,50 +128,110 @@ class Vdi {
       format,
       vdi: ref,
     }
-    if (baseRef !== undefined) {
-      // delta is not compatible with raw export
-      assert.equal(format, 'vhd')
 
+    const [cbt_enabled, size, uuid, vdiName] = await Promise.all([
+      this.getField('VDI', ref, 'cbt_enabled'),
+      this.getField('VDI', ref, 'virtual_size'),
+      this.getField('VDI', ref, 'uuid'),
+      this.getField('VDI', ref, 'name_label'),
+    ])
+
+    $defer.onFailure(() => this.VDI_disconnectFromControlDomain(ref))
+
+    if (format === VDI_FORMAT_RAW) {
+      // RAW export do not use NBD to simplify code
+      assert.equal(baseRef, undefined)
+      return this.getResource(cancelToken, '/export_raw_vdi/', {
+        query,
+        task: await this.task_create(`Exporting content of VDI ${vdiName}`),
+      })
+    }
+
+    // now we'll handle the VHD
+    assert.equal(format, VDI_FORMAT_VHD)
+    if (baseRef !== undefined) {
       query.base = baseRef
     }
-    let nbdClient, stream
-    try {
-      if (preferNbd) {
-        nbdClient = await this._getNbdClient(ref, { nbdConcurrency })
+
+    let nbdClient, // optional : the nbd client used to transfer this vdi
+      exportStream, // the stream read from the XAPI
+      stream, // the stream that will be returned (exportStream or using NBD)
+      taskRef, // the reference to the export stream (if created manually)
+      changedBlocks, // the CBT list of blocks
+      baseParentUuid // the uuid of the parent of the base for a delta export
+
+    if (baseRef !== undefined && preferNbd && cbt_enabled) {
+      // use CBT if possible
+      // call to list changed blocks must be done before the vdi is mounted for NBD export
+      try {
+        changedBlocks = await this.VDI_listChangedBlock(ref, baseRef)
+
+        info('found changed blocks', { changedBlocks })
+      } catch (error) {
+        // do not fail if CBT is not enabled/working
+        info(`can't get changed block`, { error, ref, baseRef })
+        changedBlocks = undefined
       }
-      // the raw nbd export does not need to peek ath the vhd source
-      if (nbdClient !== undefined && format === VDI_FORMAT_RAW) {
-        stream = createNbdRawStream(nbdClient)
-      } else {
-        // raw export without nbd or vhd exports needs a resource stream
-        const vdiName = await this.getField('VDI', ref, 'name_label')
-        stream = (
-          await this.getResource(cancelToken, '/export_raw_vdi/', {
-            query,
-            task: await this.task_create(`Exporting content of VDI ${vdiName}`),
-          })
-        ).body
-        if (nbdClient !== undefined && format === VDI_FORMAT_VHD) {
-          const taskRef = await this.task_create(`Exporting content of VDI ${vdiName} using NBD`)
-          stream = await createNbdVhdStream(nbdClient, stream)
-          stream.on('progress', progress => this.call('task.set_progress', taskRef, progress))
-          finished(stream, () => this.task_destroy(taskRef))
-        }
-      }
-      return stream
-    } catch (error) {
-      // augment the error with as much relevant info as possible
-      const [poolMaster, vdi] = await Promise.all([
-        this.getRecord('host', this.pool.master),
-        this.getRecord('VDI', ref),
-      ])
-      error.pool_master = poolMaster
-      error.SR = await this.getRecord('SR', vdi.SR)
-      error.VDI = vdi
-      error.nbdClient = nbdClient
-      nbdClient?.disconnect()
-      throw error
+      // parent must exist , fail if it don't
+      // this may be undefined and is a nice to have
+      // but backups and xapi don't trust nor use this value
+      // will only be used with CBT
+      baseParentUuid = await this.getField('VDI', baseRef, 'sm_config').then(sm_config => sm_config['vhd-parent'])
     }
+
+    // really connect to NBD server
+    if (preferNbd) {
+      nbdClient = await this._connectNbdClientIfPossible(ref, { nbdConcurrency })
+      // disconnect on failure or when transfer is finished
+      $defer.onFailure(() => nbdClient?.disconnect())
+    }
+
+    // create a xapi export stream only if we won't make a delta from CBT
+    // a CBT export can only work if we have a NBD client and changed blocks
+    if (changedBlocks === undefined || nbdClient === undefined) {
+      stream = exportStream = (
+        await this.getResource(cancelToken, '/export_raw_vdi/', {
+          query,
+          task: await this.task_create(`Exporting content of VDI ${vdiName}`),
+        })
+      ).body
+
+      $defer.onFailure(() => {
+        exportStream.on('error', noop).destroy()
+      })
+    }
+
+    // we have a NBD client : use it to transfer download data
+    // use either the changed block or exportStream to compute the header/footer/BAT
+    if (nbdClient !== undefined) {
+      taskRef = await this.task_create(
+        `Exporting content of VDI ${vdiName} using NBD ${changedBlocks !== undefined ? ' and CBT' : ''}`
+      )
+      $defer.onFailure(() => this.task_destroy(taskRef).catch(warn))
+      // stream is now using CBT, exportStream still keep a ref to the XAPI export stream
+      stream = await createNbdVhdStream(nbdClient, exportStream, {
+        changedBlocks,
+        vdiInfos: { size, uuid, parentUuid: baseParentUuid },
+        onProgress: progress => {
+          this.call('task.set_progress', taskRef, progress).catch(warn)
+        },
+      })
+      // we don't need the export stream anymore, block data will be read through NBD
+      exportStream?.on('error', noop).destroy()
+    }
+
+    assert.notStrictEqual(stream, undefined)
+
+    // disconnect and clean everything when stream is completly transmitted
+    const self = this
+    finished(stream, async function () {
+      await nbdClient?.disconnect()
+      if (taskRef !== undefined) {
+        self.task_destroy(taskRef).catch(warn)
+      }
+      await self.VDI_disconnectFromControlDomain(ref).catch(warn)
+    })
+    return stream
   }
 
   async importContent(ref, stream, { cancelToken = CancelToken.none, format }) {
@@ -178,4 +276,5 @@ decorateClass(Vdi, {
       return this._vdiDestroyRetryWhenInUse
     },
   ],
+  exportContent: defer,
 })

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,7 @@
 - [REST API] VDIs of a VM, or a VM snapshot, or a VM template, can now be fetched easily by appending `/vdis` at the VM's endpoint
 - [REST API] Expose servers at the `/rest/v0/servers` endpoint
 - [Backups] Implements Change Block Tracking (CBT) (PR [#7750](https://github.com/vatesfr/xen-orchestra/pull/7750))
+- [Backups] Add a toggle to enable purging snapshot data with CBT backups (PR [#7796](https://github.com/vatesfr/xen-orchestra/pull/7796))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Full Backup] Don't keep an unnecessary snapshot (PR [#7805](https://github.com/vatesfr/xen-orchestra/pull/7805))
+- [Incremental Replication] Fix error `Cannot destructure property 'other_config' of 'undefined'` (PR [#7805](https://github.com/vatesfr/xen-orchestra/pull/7805))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Full Backup] Don't keep an unnecessary snapshot (PR [#7805](https://github.com/vatesfr/xen-orchestra/pull/7805))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -31,6 +33,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
 - xo-server minor
 - xo-web minor
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,6 +34,7 @@
 <!--packages-start-->
 
 - @xen-orchestra/backups patch
+- vhd-lib minor
 - xo-server minor
 - xo-web minor
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -10,6 +10,7 @@
 - [SR/XOSTOR] Add _State_ column to the _Resource List_ table (PR [#7784](https://github.com/vatesfr/xen-orchestra/pull/7784))
 - [REST API] VDIs of a VM, or a VM snapshot, or a VM template, can now be fetched easily by appending `/vdis` at the VM's endpoint
 - [REST API] Expose servers at the `/rest/v0/servers` endpoint
+- [Backups] Implements Change Block Tracking (CBT) (PR [#7750](https://github.com/vatesfr/xen-orchestra/pull/7750))
 
 ### Bug fixes
 
@@ -34,7 +35,7 @@
 
 <!--packages-start-->
 
-- @xen-orchestra/backups patch
+- @xen-orchestra/backups minor
 - vhd-lib minor
 - xo-server minor
 - xo-web minor

--- a/packages/vhd-lib/Vhd/VhdNbd.js
+++ b/packages/vhd-lib/Vhd/VhdNbd.js
@@ -1,0 +1,150 @@
+'use strict'
+
+const { VhdAbstract } = require('./VhdAbstract')
+
+const _computeGeometryForSize = require('../_computeGeometryForSize')
+const { createFooter, createHeader } = require('../_createFooterHeader.js')
+const {
+  DEFAULT_BLOCK_SIZE,
+  DISK_TYPES,
+  FOOTER_SIZE,
+  HEADER_SIZE,
+  SECTOR_SIZE,
+  BLOCK_UNUSED,
+  PARENT_LOCATOR_ENTRIES,
+  PLATFORMS,
+} = require('../_constants.js')
+const { unpackFooter, unpackHeader } = require('./_utils.js')
+
+const { readChunkStrict, skipStrict } = require('@vates/read-chunk')
+
+const assert = require('node:assert')
+
+const BITMAP = Buffer.alloc(SECTOR_SIZE, 255)
+
+function packUuid(uuid) {
+  const PARSE_UUID_RE = /-/g
+
+  return Buffer.from(uuid.replace(PARSE_UUID_RE, ''), 'hex')
+}
+
+exports.VhdNbd = class VhdNbd extends VhdAbstract {
+  #bat
+  #changedBlocks
+  #header
+  #footer
+  #nbdClient
+  #vhdStream
+  #vdiInfos
+
+  constructor(nbdClient, { changedBlocks, vhdStream, vdiInfos }) {
+    super()
+    assert.notEqual(changedBlocks ?? vhdStream, undefined) // either a vhd stream or the changed block list
+    if (changedBlocks) {
+      assert.notEqual(vdiInfos, undefined) // either a vhd stream or the changed block list + vdi infos
+    }
+    this.#nbdClient = nbdClient
+    if (vhdStream) {
+      // @todo : this stream MUST NOT be used outside
+      // if it is problematic we should extract forkStreamUnpipe to its packages and use it here
+      this.#vhdStream = vhdStream
+    }
+    this.#vdiInfos = vdiInfos
+    this.#changedBlocks = changedBlocks
+  }
+
+  get header() {
+    return this.#header
+  }
+
+  get footer() {
+    return this.#footer
+  }
+
+  containsBlock(blockId) {
+    assert.notEqual(this.#changedBlocks ?? this.#vhdStream, undefined) // either a vhd stream or the changed block list
+    if (this.#changedBlocks) {
+      // block are aligned, we could probably compare the bytes to 255
+      // each CBT block is 64KB
+      // each VHD block is 2MB
+      // => 32 CBT blocks per VHD block
+      // each CBT block used flag is stored in 1 bit
+      // => 4 bytes per VHD block => UINT32
+      // if any sublock is used => download the full block
+      const position = blockId * 4
+      return this.#changedBlocks.readUInt32BE(position) !== 0
+    }
+    const entry = this.#bat.readUInt32BE(blockId * 4)
+    return entry !== BLOCK_UNUSED
+  }
+
+  async readHeaderAndFooter() {
+    assert.notEqual(this.#changedBlocks ?? this.#vhdStream, undefined) // either a vhd stream or the changed block list
+    if (this.#changedBlocks) {
+      const { size, uuid, parentUuid } = this.#vdiInfos
+
+      this.#header = unpackHeader(createHeader(Math.ceil(size / DEFAULT_BLOCK_SIZE)))
+      const geometry = _computeGeometryForSize(size)
+      // changed block can only be used to compute a differencing disk
+      const diskType = DISK_TYPES.DIFFERENCING
+      this.#footer = unpackFooter(createFooter(size, Math.floor(Date.now() / 1000), geometry, FOOTER_SIZE, diskType))
+      this.#footer.uuid = packUuid(uuid)
+      if (parentUuid) {
+        // this may be undefined and is a nice to have
+        // but backups and xapi don't trust nor use this value
+        this.#header.parentUuid = packUuid(parentUuid)
+        const parentName = `${parentUuid}.vhd`
+        this.#header.parentUnicodeName = parentName
+      }
+    } else {
+      assert.strictEqual(this.#footer, undefined)
+      assert.strictEqual(this.#header, undefined)
+      this.#footer = unpackFooter(await readChunkStrict(this.#vhdStream, FOOTER_SIZE))
+      this.#header = unpackHeader(await readChunkStrict(this.#vhdStream, HEADER_SIZE))
+      // parent locator aren't generated for Vhd from NBD+CBT
+      // we clean the existing parent locator to ensure consistency
+      for (let i = 0; i < PARENT_LOCATOR_ENTRIES; i++) {
+        this.#header.parentLocatorEntry[i] = {
+          platformCode: PLATFORMS.NONE,
+          platformDataSpace: 0,
+          platformDataLength: 0,
+          reserved: 0,
+          platformDataOffset: 0,
+        }
+      }
+    }
+  }
+
+  async readBlockAllocationTable() {
+    assert.notEqual(this.#changedBlocks ?? this.#vhdStream, undefined) // either a vhd stream or the changed block list
+    if (!this.#changedBlocks) {
+      assert.notEqual(this.#footer, undefined)
+      assert.notEqual(this.#header, undefined)
+      assert.strictEqual(this.#bat, undefined)
+      const batSize = Math.ceil((this.#header.maxTableEntries * 4) / SECTOR_SIZE) * SECTOR_SIZE
+      // skip space between header and beginning of the table
+      await skipStrict(this.#vhdStream, this.#header.tableOffset - (FOOTER_SIZE + HEADER_SIZE))
+      this.#bat = await readChunkStrict(this.#vhdStream, batSize)
+    }
+
+    // changed can be used as a bat, not need to rebuild one
+  }
+
+  async readBlock(blockId) {
+    return this.#nbdClient.readBlock(blockId, DEFAULT_BLOCK_SIZE).then(data => {
+      return {
+        id: blockId,
+        bitmap: BITMAP,
+        data,
+        buffer: Buffer.concat([BITMAP, data]),
+      }
+    })
+  }
+
+  async stream(opts) {
+    const stream = await super.stream(opts)
+
+    stream._nbd = true
+    return stream
+  }
+}

--- a/packages/vhd-lib/createStreamNbd.js
+++ b/packages/vhd-lib/createStreamNbd.js
@@ -1,19 +1,6 @@
 'use strict'
-const { finished, Readable } = require('node:stream')
-const { readChunkStrict, skipStrict } = require('@vates/read-chunk')
-const { unpackHeader } = require('./Vhd/_utils')
-const {
-  FOOTER_SIZE,
-  HEADER_SIZE,
-  PARENT_LOCATOR_ENTRIES,
-  SECTOR_SIZE,
-  BLOCK_UNUSED,
-  DEFAULT_BLOCK_SIZE,
-  PLATFORMS,
-} = require('./_constants')
-const { fuHeader, checksumStruct } = require('./_structs')
-const assert = require('node:assert')
-
+const { Readable } = require('node:stream')
+const { VhdNbd } = require('./Vhd/VhdNbd')
 const MAX_DURATION_BETWEEN_PROGRESS_EMIT = 5e3
 const MIN_TRESHOLD_PERCENT_BETWEEN_PROGRESS_EMIT = 1
 
@@ -38,126 +25,39 @@ exports.createNbdVhdStream = async function createVhdStream(
   nbdClient,
   sourceStream,
   {
+    changedBlocks,
+    vdiInfos,
+
     maxDurationBetweenProgressEmit = MAX_DURATION_BETWEEN_PROGRESS_EMIT,
     minTresholdPercentBetweenProgressEmit = MIN_TRESHOLD_PERCENT_BETWEEN_PROGRESS_EMIT,
+    onProgress,
   } = {}
 ) {
-  const bufFooter = await readChunkStrict(sourceStream, FOOTER_SIZE)
-
-  const header = unpackHeader(await readChunkStrict(sourceStream, HEADER_SIZE))
-  // compute BAT in order
-  const batSize = Math.ceil((header.maxTableEntries * 4) / SECTOR_SIZE) * SECTOR_SIZE
-  // skip space between header and beginning of the table
-  await skipStrict(sourceStream, header.tableOffset - (FOOTER_SIZE + HEADER_SIZE))
-  // new table offset
-  header.tableOffset = FOOTER_SIZE + HEADER_SIZE
-  const streamBat = await readChunkStrict(sourceStream, batSize)
-  let offset = FOOTER_SIZE + HEADER_SIZE + batSize
-  // check if parentlocator are ordered
-  let precLocator = 0
-  for (let i = 0; i < PARENT_LOCATOR_ENTRIES; i++) {
-    header.parentLocatorEntry[i] = {
-      ...header.parentLocatorEntry[i],
-      platformDataOffset: offset,
-    }
-    offset += header.parentLocatorEntry[i].platformDataSpace * SECTOR_SIZE
-    if (header.parentLocatorEntry[i].platformCode !== PLATFORMS.NONE) {
-      assert(
-        precLocator < offset,
-        `locator must be ordered. numer ${i} is  at ${offset}, precedent is at ${precLocator}`
-      )
-      precLocator = offset
-    }
-  }
-  const rawHeader = fuHeader.pack(header)
-  checksumStruct(rawHeader, fuHeader)
-
-  // BAT
-  const bat = Buffer.allocUnsafe(batSize)
-  let offsetSector = offset / SECTOR_SIZE
-  const blockSizeInSectors = DEFAULT_BLOCK_SIZE / SECTOR_SIZE + 1 /* bitmap */
-  // compute a BAT with the position that the block will have in the resulting stream
-  // blocks starts directly after parent locator entries
-  const entries = []
-  for (let i = 0; i < header.maxTableEntries; i++) {
-    const entry = streamBat.readUInt32BE(i * 4)
-    if (entry !== BLOCK_UNUSED) {
-      bat.writeUInt32BE(offsetSector, i * 4)
-      entries.push(i)
-      offsetSector += blockSizeInSectors
-    } else {
-      bat.writeUInt32BE(BLOCK_UNUSED, i * 4)
-    }
-  }
-
-  const totalLength = (offsetSector + 1) /* end footer */ * SECTOR_SIZE
-
-  let lengthRead = 0
-  let lastUpdate = 0
-  let lastLengthRead = 0
-
-  function throttleEmitProgress() {
-    const now = Date.now()
-
-    if (
-      lengthRead - lastLengthRead > (minTresholdPercentBetweenProgressEmit / 100) * totalLength ||
-      (now - lastUpdate > maxDurationBetweenProgressEmit && lengthRead !== lastLengthRead)
-    ) {
-      stream.emit('progress', lengthRead / totalLength)
-      lastUpdate = now
-      lastLengthRead = lengthRead
-    }
-  }
-
-  function trackAndGet(buffer) {
-    lengthRead += buffer.length
-    throttleEmitProgress()
-    return buffer
-  }
-
-  async function* iterator() {
-    yield trackAndGet(bufFooter)
-    yield trackAndGet(rawHeader)
-    yield trackAndGet(bat)
-
-    let precBlocOffset = FOOTER_SIZE + HEADER_SIZE + batSize
-    for (let i = 0; i < PARENT_LOCATOR_ENTRIES; i++) {
-      const parentLocatorOffset = header.parentLocatorEntry[i].platformDataOffset
-      const space = header.parentLocatorEntry[i].platformDataSpace * SECTOR_SIZE
-      if (space > 0) {
-        await skipStrict(sourceStream, parentLocatorOffset - precBlocOffset)
-        const data = await readChunkStrict(sourceStream, space)
-        precBlocOffset = parentLocatorOffset + space
-        yield trackAndGet(data)
-      }
-    }
-
-    // close export stream we won't use it anymore
-    // destroying a stream can raise an error that can be safely ignored
-    sourceStream.on('error', () => {}).destroy()
-
-    // yield  blocks from nbd
-    const nbdIterator = nbdClient.readBlocks(function* () {
-      for (const entry of entries) {
-        yield { index: entry, size: DEFAULT_BLOCK_SIZE }
-      }
-    })
-    const bitmap = Buffer.alloc(SECTOR_SIZE, 255)
-    for await (const block of nbdIterator) {
-      yield trackAndGet(bitmap) // don't forget the bitmap before the block
-      yield trackAndGet(block)
-    }
-    yield trackAndGet(bufFooter)
-  }
-
-  const stream = Readable.from(iterator(), { objectMode: false })
-  stream.length = totalLength
-  stream._nbd = true
-  finished(stream, () => {
-    clearInterval(interval)
-    nbdClient.disconnect()
+  const vhd = new VhdNbd(nbdClient, {
+    vhdStream: sourceStream,
+    vdiInfos,
+    changedBlocks,
   })
-  const interval = setInterval(throttleEmitProgress, maxDurationBetweenProgressEmit)
-
+  await vhd.readHeaderAndFooter()
+  await vhd.readBlockAllocationTable()
+  let currentBlockRead = 0
+  let lastTimeProgress = 0
+  let lastBlockProgress = 0
+  // add some condition to trigger onProgress only when significant
+  function handleProgress(current, nb) {
+    currentBlockRead = current
+    const now = Date.now()
+    if (
+      currentBlockRead - lastBlockProgress > (minTresholdPercentBetweenProgressEmit / 100) * nb ||
+      (now - lastTimeProgress > maxDurationBetweenProgressEmit && currentBlockRead !== lastBlockProgress)
+    ) {
+      lastTimeProgress = now
+      lastBlockProgress = currentBlockRead
+      onProgress?.(currentBlockRead / nb)
+    }
+  }
+  const stream = await vhd.stream({
+    onProgress: handleProgress,
+  })
   return stream
 }

--- a/packages/xo-server/src/api/backup-ng.mjs
+++ b/packages/xo-server/src/api/backup-ng.mjs
@@ -12,6 +12,10 @@ const SCHEMA_SETTINGS = {
     '*': {
       type: 'object',
       properties: {
+        cbtDestroySnapshotData: {
+          type: 'boolean',
+          optional: true,
+        },
         concurrency: {
           type: 'number',
           minimum: 0,

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -602,9 +602,14 @@ const messages = {
   editJobNotFound: "The job you're trying to edit wasn't found",
   preferNbd: 'Use NBD + CBT to transfer disk if available',
   preferNbdInformation:
-    'A network accessible by XO or the proxy must have NBD enabled,. Storage must support Change Block Tracking (CBT) to ue it in a backup',
+    'A network accessible by XO or the proxy must have NBD enabled. Storage must support Change Block Tracking (CBT) to use it in a backup',
   nbdConcurrency: 'Number of NBD connection per disk',
+  cbtDestroySnapshotData: 'Purge snapshot data when using CBT',
+  cbtDestroySnapshotDataInformation:
+    "The snapshot won't use any notable space on the SR, won't be shown in the UI and won't be usable to do a rollback",
 
+  cbtDestroySnapshotDataDisabledInformation:
+    'Snapshot data can be purged only when NBD is enabled and rolling snapshot is not used',
   // ------ New Remote -----
   newRemote: 'New file system remote',
   remoteTypeLocal: 'Local',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -600,8 +600,9 @@ const messages = {
     'Delete old backups before backing up the VMs. If the new backup fails, you will lose your old backups.',
   customTag: 'Custom tag',
   editJobNotFound: "The job you're trying to edit wasn't found",
-  preferNbd: 'Use NBD protocol to transfer disk if available',
-  preferNbdInformation: 'A network accessible by XO or the proxy must have NBD enabled',
+  preferNbd: 'Use NBD + CBT to transfer disk if available',
+  preferNbdInformation:
+    'A network accessible by XO or the proxy must have NBD enabled,. Storage must support Change Block Tracking (CBT) to ue it in a backup',
   nbdConcurrency: 'Number of NBD connection per disk',
 
   // ------ New Remote -----

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -145,6 +145,7 @@ const normalizeSettings = ({ copyMode, exportMode, offlineBackupActive, settings
     defined(setting.copyRetention, setting.exportRetention, setting.snapshotRetention) !== undefined
       ? {
           ...setting,
+          cbtDestroySnapshotData: undefined,
           copyRetention: copyMode ? setting.copyRetention : undefined,
           exportRetention: exportMode ? setting.exportRetention : undefined,
           snapshotRetention: snapshotMode && !offlineBackupActive ? setting.snapshotRetention : undefined,
@@ -183,6 +184,7 @@ const getInitialState = ({ preSelectedVmIds, setHomeVmIdsSelection, suggestedExc
     _proxyId: undefined,
     _vmsPattern: undefined,
     backupMode: false,
+    cbtDestroySnapshotData: false,
     compression: undefined,
     crMode: false,
     deltaMode: false,
@@ -631,6 +633,13 @@ const New = decorate([
             preferNbd,
           })
         },
+      setCbtDestroySnapshotData:
+        ({ setGlobalSettings }, cbtDestroySnapshotData) =>
+        () => {
+          setGlobalSettings({
+            cbtDestroySnapshotData,
+          })
+        },
       setNbdConcurrency({ setGlobalSettings }, nbdConcurrency) {
         setGlobalSettings({
           nbdConcurrency,
@@ -646,6 +655,7 @@ const New = decorate([
       compressionId: generateId,
       formId: generateId,
       inputConcurrencyId: generateId,
+      inputCbtDestroySnapshotData: generateId,
       inputFullIntervalId: generateId,
       inputMaxExportRate: generateId,
       inputPreferNbd: generateId,
@@ -758,6 +768,7 @@ const New = decorate([
     const { propSettings, settings = propSettings } = state
     const compression = defined(state.compression, job.compression, '')
     const {
+      cbtDestroySnapshotData,
       checkpointSnapshot,
       concurrency,
       fullInterval,
@@ -1051,21 +1062,47 @@ const New = decorate([
                         </FormGroup>
                       )}
                       {state.isDelta && (
-                        <FormGroup>
-                          <label htmlFor={state.inputPreferNbd}>
-                            <strong>{_('preferNbd')}</strong>{' '}
-                            <Tooltip content={_('preferNbdInformation')}>
-                              <Icon icon='info' />
+                        <div>
+                          <FormGroup>
+                            <label htmlFor={state.inputPreferNbd}>
+                              <strong>{_('preferNbd')}</strong>{' '}
+                              <Tooltip content={_('preferNbdInformation')}>
+                                <Icon icon='info' />
+                              </Tooltip>
+                            </label>
+                            <Toggle
+                              className='pull-right'
+                              id={state.inputPreferNbd}
+                              name='preferNbd'
+                              value={preferNbd}
+                              onChange={effects.setPreferNbd}
+                            />
+                          </FormGroup>
+                          <FormGroup>
+                            <label htmlFor={state.inputCbtDestroySnapshotData}>
+                              <strong>{_('cbtDestroySnapshotData')}</strong>{' '}
+                              <Tooltip content={_('cbtDestroySnapshotDataInformation')}>
+                                <Icon icon='info' />
+                              </Tooltip>
+                            </label>
+                            <Tooltip
+                              content={
+                                !preferNbd || state.snapshotMode
+                                  ? _('cbtDestroySnapshotDataDisabledInformation')
+                                  : undefined
+                              }
+                            >
+                              <Toggle
+                                className='pull-right'
+                                id={state.cbtDestroySnapshotData}
+                                name='cbtDestroySnapshotData'
+                                value={preferNbd && cbtDestroySnapshotData && !state.snapshotMode}
+                                disabled={!preferNbd || state.snapshotMode}
+                                onChange={effects.setCbtDestroySnapshotData}
+                              />
                             </Tooltip>
-                          </label>
-                          <Toggle
-                            className='pull-right'
-                            id={state.inputPreferNbd}
-                            name='preferNbd'
-                            value={preferNbd}
-                            onChange={effects.setPreferNbd}
-                          />
-                        </FormGroup>
+                          </FormGroup>
+                        </div>
                       )}
                       {state.isDelta && (
                         <FormGroup>


### PR DESCRIPTION
### Description

review by commit 
do not squash 

Re enable Change Block Tracking 

* all NBD backup will try to use CBT
* if CBT is not usable , it will fall back to a snapshot comparison 
* optionnaly, the user can enable "purge snapshot data", that keep only the metadata of the snapshot, thus trigerring a merge immediatly after transfer. 

This PR also :
* remove the read ahead used in NBD since the performance gain was not evident
* remove the use of NBD for VDI raw export
* add checks to ensure the VDI is correctly detached from dom0 after the transfer

![image](https://github.com/vatesfr/xen-orchestra/assets/50174/0a1cecb2-3eb9-4f6c-9448-4778a9313360)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
