### PR TITLE
fix typo, clear wrong translations, translated some strings

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,6 +8,7 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - [i18n] Add Persian translation (based on the contribution made by [@Jokar-xen](https://github.com/Jokar-xen)) (PR [#7775](https://github.com/vatesfr/xen-orchestra/pull/7775))
+- [i18n] Improve Russian translation (Thanks [@TristisOris](https://github.com/TristisOris)!) (PR [#7807](https://github.com/vatesfr/xen-orchestra/pull/7807))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/intl/locales/ru.js
+++ b/packages/xo-web/src/common/intl/locales/ru.js
@@ -24,7 +24,7 @@ export default {
   errorNoSuchItem: 'элемент не найден',
 
   // Original text: "Long click to edit"
-  editableLongClickPlaceholder: 'Длительное нажатие для редактирования',
+  editableLongClickPlaceholder: 'Долгое нажатие для редактирования',
 
   // Original text: "Click to edit"
   editableClickPlaceholder: 'Нажмите для редактирования',
@@ -51,16 +51,16 @@ export default {
   filterOnlyManaged: 'Управляемые диски',
 
   // Original text: 'Orphaned disks'
-  filterOnlyOrphaned: 'Потерянные диски',
+  filterOnlyOrphaned: undefined,
 
   // Original text: 'Normal disks'
-  filterOnlyRegular: 'Работающие диски',
+  filterOnlyRegular: undefined,
 
   // Original text: 'Snapshot disks'
   filterOnlySnapshots: 'Снимки дисков',
 
   // Original text: 'Unmanaged disks'
-  filterOnlyUnmanaged: 'Неподключенные диски',
+  filterOnlyUnmanaged: undefined,
 
   // Original text: 'Copy to clipboard'
   copyToClipboard: 'Копировать в буфер обмена',
@@ -72,7 +72,7 @@ export default {
   homePage: 'Главная',
 
   // Original text: 'VMs'
-  homeVmPage: 'Вируальные машины',
+  homeVmPage: 'Виртуальные машины',
 
   // Original text: 'Hosts'
   homeHostPage: 'Хосты',
@@ -87,13 +87,13 @@ export default {
   homeSrPage: 'Хранилища',
 
   // Original text: "Dashboard"
-  dashboardPage: 'Контрольные панели',
+  dashboardPage: 'Контрольная панель',
 
   // Original text: "Overview"
   overviewDashboardPage: 'Обзор',
 
   // Original text: "Visualizations"
-  overviewVisualizationDashboardPage: 'Графики',
+  overviewVisualizationDashboardPage: 'Визуализация',
 
   // Original text: "Statistics"
   overviewStatsDashboardPage: 'Статистика',
@@ -102,7 +102,7 @@ export default {
   overviewHealthDashboardPage: 'Здоровье',
 
   // Original text: "Self service"
-  selfServicePage: 'Самодиагностика',
+  selfServicePage: 'Самообслуживание',
 
   // Original text: "Backup"
   backupPage: 'Резервная копия',
@@ -111,13 +111,13 @@ export default {
   jobsPage: 'Задачи',
 
   // Original text: "Updates"
-  updatePage: 'Обновление',
+  updatePage: 'Обновления',
 
   // Original text: "Settings"
   settingsPage: 'Настройки',
 
   // Original text: "Servers"
-  settingsServersPage: 'Сервисы',
+  settingsServersPage: 'Серверы',
 
   // Original text: "Users"
   settingsUsersPage: 'Пользователи',
@@ -150,7 +150,7 @@ export default {
   taskMenu: 'Задачи',
 
   // Original text: 'Tasks'
-  taskPage: undefined,
+  taskPage: 'Задачи',
 
   // Original text: "VM"
   newVmPage: 'ВМ',
@@ -174,13 +174,13 @@ export default {
   backupNewPage: 'Создать',
 
   // Original text: "Remotes"
-  backupRemotesPage: 'Удаленный',
+  backupRemotesPage: undefined,
 
   // Original text: "Restore"
   backupRestorePage: 'Восстановление',
 
   // Original text: 'File restore'
-  backupFileRestorePage: 'Восстановление из файла',
+  backupFileRestorePage: 'Восстановление файлов',
 
   // Original text: "Schedule"
   schedule: 'Расписание',
@@ -195,25 +195,25 @@ export default {
   backup: 'Резервная копия',
 
   // Original text: "Rolling Snapshot"
-  rollingSnapshot: 'Прокручивающийся снимок',
+  rollingSnapshot: undefined,
 
   // Original text: "Delta Backup"
-  deltaBackup: 'Дельта-резервное копирование',
+  deltaBackup: undefined,
 
   // Original text: "Disaster Recovery"
-  disasterRecovery: 'Аварийное восстановление',
+  disasterRecovery: undefined,
 
   // Original text: "Continuous Replication"
-  continuousReplication: 'Непрерывная репликация',
+  continuousReplication: undefined,
 
   // Original text: "Overview"
   jobsOverviewPage: 'Обзор',
 
   // Original text: "New"
-  jobsNewPage: 'Новый',
+  jobsNewPage: 'Добавить',
 
   // Original text: "Scheduling"
-  jobsSchedulingPage: 'Планирование',
+  jobsSchedulingPage: 'Планировщик',
 
   // Original text: "Custom Job"
   customJob: 'Пользовательская задача',
@@ -222,10 +222,10 @@ export default {
   userPage: 'Пользователь',
 
   // Original text: 'No support'
-  noSupport: 'Не поддерживается',
+  noSupport: 'Без поддержки',
 
   // Original text: 'Free upgrade!'
-  freeUpgrade: 'Беспланое обновление!',
+  freeUpgrade: 'Бесплатное обновление!',
 
   // Original text: "Sign out"
   signOut: 'Выйти',
@@ -234,7 +234,7 @@ export default {
   editUserProfile: 'Изменить мои настройки {username}',
 
   // Original text: "Fetching data…"
-  homeFetchingData: 'Получение данных…',
+  homeFetchingData: 'Извлечение  данных…',
 
   // Original text: "Welcome on Xen Orchestra!"
   homeWelcome: 'Добро пожаловать в Xen Orchestra!',
@@ -279,13 +279,13 @@ export default {
   homeRestoreBackupMessage: 'Восстановить резервную копию из удаленного хранилища',
 
   // Original text: "This will create a new VM"
-  homeNewVmMessage: 'Это создаст новую виртуальную машину',
+  homeNewVmMessage: 'Это создаст новую ВМ',
 
   // Original text: "Filters"
   homeFilters: 'Фильтры',
 
   // Original text: 'No results! Click here to reset your filters'
-  homeNoMatches: 'Ничего не найдено! Нажмите здась что бы сбросить фильтры',
+  homeNoMatches: 'Ничего не найдено! Нажмите, что-бы сбросить фильтры',
 
   // Original text: "Pool"
   homeTypePool: 'Пул',
@@ -297,7 +297,7 @@ export default {
   homeTypeVm: 'ВМ',
 
   // Original text: "SR"
-  homeTypeSr: 'SR',
+  homeTypeSr: undefined,
 
   // Original text: 'Template'
   homeTypeVmTemplate: 'Шаблон',
@@ -336,7 +336,7 @@ export default {
   homeFilterPendingVms: 'Ожидание ВМ',
 
   // Original text: "HVM guests"
-  homeFilterHvmGuests: 'Гости HVM',
+  homeFilterHvmGuests: undefined,
 
   // Original text: "Tags"
   homeFilterTags: 'Тэги',
@@ -348,19 +348,19 @@ export default {
   homeSortByName: 'Название',
 
   // Original text: "Power state"
-  homeSortByPowerstate: 'Статус',
+  homeSortByPowerstate: 'Состояние питания',
 
   // Original text: "RAM"
-  homeSortByRAM: 'Виртуальная память',
+  homeSortByRAM: undefined,
 
   // Original text: "vCPUs"
-  homeSortByvCPUs: 'vCPUs',
+  homeSortByvCPUs: undefined,
 
   // Original text: 'CPUs'
   homeSortByCpus: undefined,
 
   // Original text: 'Shared/Not shared'
-  homeSortByShared: 'Совместное использование/Без совместного использования',
+  homeSortByShared: 'Общий доступ/Без общего доступа',
 
   // Original text: 'Size'
   homeSortBySize: 'Размер',
@@ -375,7 +375,7 @@ export default {
   homeDisplayedItems: '{displayed, number}x {icon} (на {total, number})',
 
   // Original text: "{selected, number}x {icon} selected (on {total, number})"
-  homeSelectedItems: '{selected, number}x {icon} выбраных (на {total, number})',
+  homeSelectedItems: '{selected, number}x {icon} выбранных (на {total, number})',
 
   // Original text: "More"
   homeMore: 'Больше',
@@ -384,7 +384,7 @@ export default {
   homeMigrateTo: 'Переместить на…',
 
   // Original text: 'Missing patches'
-  homeMissingPatches: 'Патчей нет',
+  homeMissingPatches: 'Отсутствующие исправления',
 
   // Original text: 'Master:'
   homePoolMaster: undefined,
@@ -396,10 +396,10 @@ export default {
   highAvailability: 'Высокая доступность',
 
   // Original text: 'Shared {type}'
-  srSharedType: 'Совместное использование {type}',
+  srSharedType: 'Общий доступ {type}',
 
   // Original text: 'Not shared {type}'
-  srNotSharedType: 'Без совместного использования {type}',
+  srNotSharedType: 'Без общего доступа {type}',
 
   // Original text: "Add"
   add: 'Добавить',
@@ -417,7 +417,7 @@ export default {
   item: 'Элемент',
 
   // Original text: "No selected value"
-  noSelectedValue: 'Значение не выбрано',
+  noSelectedValue: 'Нет выбранных значений',
 
   // Original text: "Choose user(s) and/or group(s)"
   selectSubjects: 'Выберите пользователя(ей) и/или группу(ы)',
@@ -534,7 +534,7 @@ export default {
   schedulingMinute: 'Минута',
 
   // Original text: "Each selected minute"
-  schedulingEachSelectedMinute: 'Каждый выбранная минута',
+  schedulingEachSelectedMinute: 'Каждую выбранную минуту',
 
   // Original text: "Every N minute"
   schedulingEveryNMinute: 'Каждый N-ая минута',
@@ -579,7 +579,7 @@ export default {
   failedJobCall: 'Провал',
 
   // Original text: 'In progress'
-  jobCallInProgess: 'В процессе',
+  jobCallInProgess: 'Выполняется',
 
   // Original text: 'size:'
   jobTransferredDataSize: 'размер',
@@ -603,7 +603,7 @@ export default {
   jobName: 'Имя',
 
   // Original text: 'Name of your job (forbidden: "_")'
-  jobNamePlaceholder: 'Данное имя для вашей задачи (запрещено: "_")',
+  jobNamePlaceholder: 'Имя для вашей задачи (запрещено: "_")',
 
   // Original text: "Start"
   jobStart: 'Начало',
@@ -624,16 +624,16 @@ export default {
   jobTag: 'Тэг',
 
   // Original text: "Scheduling"
-  jobScheduling: 'Планирование',
+  jobScheduling: 'Расписание',
 
   // Original text: "State"
   jobState: 'Состояние',
 
   // Original text: 'Enabled'
-  jobStateEnabled: 'Активина',
+  jobStateEnabled: 'Включено',
 
   // Original text: 'Disabled'
-  jobStateDisabled: 'Отключена',
+  jobStateDisabled: 'Отключено',
 
   // Original text: 'Timezone'
   jobTimezone: 'Часовой пояс',
@@ -645,25 +645,25 @@ export default {
   runJob: 'Запустить задачу',
 
   // Original text: "One shot running started. See overview for logs."
-  runJobVerbose: 'Запуск резервного копирования вручную. Перейдите к сводке, чтобы просмотреть журналы.',
+  runJobVerbose: 'Запуск резервного копирования вручную. Перейдите в Обзор, чтобы просмотреть журналы.',
 
   // Original text: "Started"
-  jobStarted: 'Запущена',
+  jobStarted: 'Запущено',
 
   // Original text: "Finished"
-  jobFinished: 'Завершена',
+  jobFinished: 'Завершено',
 
   // Original text: "Save"
   saveBackupJob: 'Сохранить',
 
   // Original text: "Remove backup job"
-  deleteBackupSchedule: 'Удалить задание на резервное копирование',
+  deleteBackupSchedule: 'Удалить задачу резервного копирования',
 
   // Original text: "Are you sure you want to delete this backup job?"
   deleteBackupScheduleQuestion: 'Вы уверены, что хотите удалить это задание резервного копирования?',
 
   // Original text: "Enable immediately after creation"
-  scheduleEnableAfterCreation: 'Активировать сразу после создания',
+  scheduleEnableAfterCreation: 'Активировать после создания',
 
   // Original text: "You are editing Schedule {name} ({id}). Saving will override previous schedule state."
   scheduleEditMessage: 'Вы редактируете расписание {name} ({id}). Текущее состояние будет изменено при сохранении.',
@@ -684,7 +684,7 @@ export default {
   jobActionPlaceHolder: 'Выберите команду API xo-server',
 
   // Original text: ' Timeout (number of seconds after which a VM is considered failed)'
-  jobTimeoutPlaceHolder: 'Тайм-аут (количество секунд, после которого виртуальная машина считается неисправной)',
+  jobTimeoutPlaceHolder: 'Таймаут (количество секунд, после которого виртуальная машина считается неисправной)',
 
   // Original text: 'Schedules'
   jobSchedules: 'Расписания',
@@ -696,19 +696,19 @@ export default {
   jobScheduleJobPlaceHolder: 'Выберите задачу',
 
   // Original text: 'Job owner'
-  jobOwnerPlaceholder: 'Администратор задачи',
+  jobOwnerPlaceholder: 'Владелец задачи',
 
   // Original text: "This job's creator no longer exists"
-  jobUserNotFound: 'Администратор этой задачи больше не существует',
+  jobUserNotFound: 'Создатель задачи больше не существует',
 
   // Original text: "This backup's creator no longer exists"
-  backupUserNotFound: 'Администратор этой резервной копии больше не существует',
+  backupUserNotFound: 'Создатель резервной копии больше не существует',
 
   // Original text: 'Backup owner'
-  backupOwner: 'Администратор резервной копии',
+  backupOwner: 'Владелец резервной копии',
 
   // Original text: "Select your backup type:"
-  newBackupSelection: 'Выберите тип резервной копиии:',
+  newBackupSelection: 'Выберите тип резервной копии:',
 
   // Original text: 'Select backup mode:'
   smartBackupModeSelection: 'Выберите режим резервного копирования',
@@ -717,71 +717,70 @@ export default {
   normalBackup: 'Обычное резервное копирование',
 
   // Original text: 'Smart backup'
-  smartBackup: '"Умное" резервное копирование',
+  smartBackup: 'Умное резервное копирование',
 
   // Original text: 'Local remote selected'
   localRemoteWarningTitle: undefined,
 
   // Original text: 'Warning: local remotes will use limited XOA disk space. Only for advanced users.'
-  localRemoteWarningMessage:
-    'Предупреждение: локальные удаленные устройства будут использовать ограниченное дисковое пространство XOA. Только для продвинутых пользователей.',
+  localRemoteWarningMessage: undefined,
 
   // Original text: 'Warning: this feature works only with XenServer 6.5 or newer.'
-  backupVersionWarning: undefined,
+  backupVersionWarning: 'Внимание: эта функция работает только с XenServer версии 6.5 или новее',
 
   // Original text: 'VMs'
-  editBackupVmsTitle: undefined,
+  editBackupVmsTitle: 'ВМ',
 
   // Original text: 'VMs statuses'
-  editBackupSmartStatusTitle: undefined,
+  editBackupSmartStatusTitle: 'Статусы ВМ',
 
   // Original text: 'Resident on'
   editBackupSmartResidentOn: undefined,
 
   // Original text: 'Pools'
-  editBackupSmartPools: undefined,
+  editBackupSmartPools: 'Пулы',
 
   // Original text: 'Tags'
-  editBackupSmartTags: undefined,
+  editBackupSmartTags: 'Тэги',
 
   // Original text: 'VMs Tags'
-  editBackupSmartTagsTitle: undefined,
+  editBackupSmartTagsTitle: 'Тэги ВМ',
 
   // Original text: 'Reverse'
   editBackupNot: undefined,
 
   // Original text: 'Tag'
-  editBackupTagTitle: undefined,
+  editBackupTagTitle: 'Тэг',
 
   // Original text: 'Report'
-  editBackupReportTitle: undefined,
+  editBackupReportTitle: 'Отчет',
 
   // Original text: 'Automatically run as scheduled'
-  editBackupScheduleEnabled: undefined,
+  editBackupScheduleEnabled: 'Автоматический запуск по расписанию',
 
   // Original text: 'Depth'
-  editBackupDepthTitle: undefined,
+  editBackupDepthTitle: 'Глубина',
 
   // Original text: 'Remote'
   editBackupRemoteTitle: undefined,
 
   // Original text: 'Delete the old backups first'
-  deleteOldBackupsFirst: undefined,
+  deleteOldBackupsFirst: 'Сперва удалите старые резервные копии',
 
   // Original text: "Remote stores for backup"
-  remoteList: 'Удаленное хранилище для резервного копирования',
+  remoteList: undefined,
 
   // Original text: "New File System Remote"
-  newRemote: 'Новая удаленная файловая система',
+  newRemote: undefined,
 
   // Original text: "Local"
-  remoteTypeLocal: 'Локально',
+  remoteTypeLocal: 'Локальный',
 
   // Original text: "NFS"
-  remoteTypeNfs: 'NFS',
+  remoteTypeNfs: undefined,
 
   // Original text: "SMB"
-  remoteTypeSmb: 'SMB',
+  remoteTypeSmb: undefined,
 
   // Original text: "Type"
   remoteType: 'Тип',
@@ -799,7 +798,7 @@ export default {
   remoteTestSuccess: undefined,
 
   // Original text: 'Error'
-  remoteTestError: undefined,
+  remoteTestError: 'Ошибка',
 
   // Original text: 'Test Step'
   remoteTestStep: undefined,
@@ -817,28 +816,28 @@ export default {
   remoteTestSuccessMessage: undefined,
 
   // Original text: 'Connection failed'
-  remoteConnectionFailed: undefined,
+  remoteConnectionFailed: 'Подключение не удалось',
 
   // Original text: 'Name'
-  remoteName: undefined,
+  remoteName: 'Имя',
 
   // Original text: 'Path'
-  remotePath: undefined,
+  remotePath: 'Путь',
 
   // Original text: 'State'
-  remoteState: undefined,
+  remoteState: 'Состояние',
 
   // Original text: 'Device'
-  remoteDevice: undefined,
+  remoteDevice: 'Устройство',
 
   // Original text: 'Share'
   remoteShare: undefined,
 
   // Original text: 'Action'
-  remoteAction: undefined,
+  remoteAction: 'Действие',
 
   // Original text: 'Auth'
-  remoteAuth: undefined,
+  remoteAuth: 'Авторизация',
 
   // Original text: 'Mounted'
   remoteMounted: undefined,
@@ -847,31 +846,31 @@ export default {
   remoteUnmounted: undefined,
 
   // Original text: 'Connect'
-  remoteConnectTip: undefined,
+  remoteConnectTip: 'Подключить',
 
   // Original text: 'Disconnect'
-  remoteDisconnectTip: undefined,
+  remoteDisconnectTip: 'Отключить',
 
   // Original text: 'Connected'
-  remoteConnected: undefined,
+  remoteConnected: 'Подключено',
 
   // Original text: 'Disconnected'
-  remoteDisconnected: undefined,
+  remoteDisconnected: 'Отключено',
 
   // Original text: 'Delete'
-  remoteDeleteTip: undefined,
+  remoteDeleteTip: 'Удалить',
 
   // Original text: 'remote name *'
   remoteNamePlaceHolder: undefined,
 
   // Original text: 'Name *'
-  remoteMyNamePlaceHolder: undefined,
+  remoteMyNamePlaceHolder: 'Имя *',
 
   // Original text: '/path/to/backup'
   remoteLocalPlaceHolderPath: undefined,
 
   // Original text: 'host *'
-  remoteNfsPlaceHolderHost: undefined,
+  remoteNfsPlaceHolderHost: 'хост *',
 
   // Original text: 'path/to/backup'
   remoteNfsPlaceHolderPath: undefined,
@@ -910,7 +909,7 @@ export default {
   newSrUsage: 'Использование хранилища',
 
   // Original text: "Summary"
-  newSrSummary: 'Суммарно',
+  newSrSummary: undefined,
 
   // Original text: "Host"
   newSrHost: 'Хост',
@@ -931,13 +930,13 @@ export default {
   newSrPath: 'Путь',
 
   // Original text: "IQN"
-  newSrIqn: 'IQN',
+  newSrIqn: undefined,
 
   // Original text: "LUN"
-  newSrLun: 'LUN',
+  newSrLun: undefined,
 
   // Original text: "with auth."
-  newSrAuth: 'с аутентификацией.',
+  newSrAuth: 'с авторизацией',
 
   // Original text: "User Name"
   newSrUsername: 'Имя пользователя',
@@ -958,22 +957,22 @@ export default {
   newSrCreate: 'Создать',
 
   // Original text: 'Storage name'
-  newSrNamePlaceHolder: undefined,
+  newSrNamePlaceHolder: 'Имя хранилища',
 
   // Original text: 'Storage description'
-  newSrDescPlaceHolder: undefined,
+  newSrDescPlaceHolder: 'Описание хранилища',
 
   // Original text: 'Address'
-  newSrAddressPlaceHolder: undefined,
+  newSrAddressPlaceHolder: 'Адрес',
 
   // Original text: '[port]'
-  newSrPortPlaceHolder: undefined,
+  newSrPortPlaceHolder: '[порт]',
 
   // Original text: 'Username'
-  newSrUsernamePlaceHolder: undefined,
+  newSrUsernamePlaceHolder: 'Имя пользователя',
 
   // Original text: 'Password'
-  newSrPasswordPlaceHolder: undefined,
+  newSrPasswordPlaceHolder: 'Пароль',
 
   // Original text: 'Device, e.g /dev/sda…'
   newSrLvmDevicePlaceHolder: undefined,
@@ -985,16 +984,16 @@ export default {
   subjectName: 'Пользователи/Группы',
 
   // Original text: "Object"
-  objectName: 'Обьект',
+  objectName: 'Объект',
 
   // Original text: 'No acls found'
-  aclNoneFound: undefined,
+  aclNoneFound: 'Не найдены права доступа',
 
   // Original text: "Role"
   roleName: 'Роль',
 
   // Original text: 'Create'
-  aclCreate: undefined,
+  aclCreate: 'Создать',
 
   // Original text: "New Group Name"
   newGroupName: 'Имя новой группы',
@@ -1012,7 +1011,7 @@ export default {
   deleteGroupConfirm: 'Вы уверены, что хотите удалить эту группу?',
 
   // Original text: "Remove user from Group"
-  removeUserFromGroup: 'Удалить пользователя из группы?',
+  removeUserFromGroup: 'Удалить пользователя из группы',
 
   // Original text: "Are you sure you want to delete this user?"
   deleteUserConfirm: 'Вы уверены, что хотите удалить этого пользователя?',
@@ -1048,7 +1047,7 @@ export default {
   userPasswordColumn: 'Пароль',
 
   // Original text: "Email"
-  userName: 'Email',
+  userName: undefined,
 
   // Original text: "Password"
   userPassword: 'Пароль',
@@ -1066,13 +1065,13 @@ export default {
   adminLabel: 'Admin',
 
   // Original text: "No user in group"
-  noUserInGroup: 'Пользователь не в группе',
+  noUserInGroup: 'В группе нет пользователя',
 
   // Original text: "{users, number} user{users, plural, one {} other {s}}"
   countUsers: '{users, number} пользователь{users, plural, one {} other {s}}',
 
   // Original text: "Select Permission"
-  selectPermission: 'Укажите разрешения',
+  selectPermission: undefined,
 
   // Original text: 'No plugins found'
   noPlugins: undefined,
@@ -1093,7 +1092,7 @@ export default {
   unknownPluginError: 'Неизвестная ошибка',
 
   // Original text: "Purge plugin configuration"
-  purgePluginConfiguration: 'Сбросить конфирурацию плагина',
+  purgePluginConfiguration: 'Сбросить конфигурацию плагина',
 
   // Original text: "Are you sure you want to purge this configuration ?"
   purgePluginConfigurationQuestion: 'Вы уверены, что хотите сбросить эту конфигурацию?',
@@ -1111,55 +1110,55 @@ export default {
   pluginConfigurationChanges: 'Конфигурация плагина успешно сохранена!',
 
   // Original text: 'Predefined configuration'
-  pluginConfigurationPresetTitle: undefined,
+  pluginConfigurationPresetTitle: 'Предопределенная конфигурация',
 
   // Original text: 'Choose a predefined configuration.'
-  pluginConfigurationChoosePreset: undefined,
+  pluginConfigurationChoosePreset: 'Выберите предопределенную конфигурацию',
 
   // Original text: 'Apply'
-  applyPluginPreset: undefined,
+  applyPluginPreset: 'Применить',
 
   // Original text: 'Save filter error'
-  saveNewUserFilterErrorTitle: undefined,
+  saveNewUserFilterErrorTitle: 'Сохранить фильтр ошибок',
 
   // Original text: 'Bad parameter: name must be given.'
-  saveNewUserFilterErrorBody: undefined,
+  saveNewUserFilterErrorBody: 'Неверный параметр: имя должно быть задано',
 
   // Original text: 'Name:'
-  filterName: undefined,
+  filterName: 'Имя',
 
   // Original text: 'Value:'
-  filterValue: undefined,
+  filterValue: 'Значение',
 
   // Original text: 'Save new filter'
-  saveNewFilterTitle: undefined,
+  saveNewFilterTitle: 'Сохранить новый фильтр',
 
   // Original text: 'Set custom filters'
-  setUserFiltersTitle: undefined,
+  setUserFiltersTitle: 'Задать пользовательский фильтр',
 
   // Original text: 'Are you sure you want to set custom filters?'
-  setUserFiltersBody: undefined,
+  setUserFiltersBody: 'Вы уверены, что хотите установить пользовательские фильтры?',
 
   // Original text: 'Remove custom filter'
-  removeUserFilterTitle: undefined,
+  removeUserFilterTitle: 'Удалить пользовательский фильтр',
 
   // Original text: 'Are you sure you want to remove custom filter?'
-  removeUserFilterBody: undefined,
+  removeUserFilterBody: 'Вы уверены, что хотите удалить пользовательский фильтр?',
 
   // Original text: 'Default filter'
-  defaultFilter: undefined,
+  defaultFilter: 'Фильтр по умолчанию',
 
   // Original text: 'Default filters'
-  defaultFilters: undefined,
+  defaultFilters: 'Фильтры по умолчанию',
 
   // Original text: 'Custom filters'
-  customFilters: undefined,
+  customFilters: 'Пользовательские фильтры',
 
   // Original text: 'Customize filters'
-  customizeFilters: undefined,
+  customizeFilters: 'Настройка фильтров',
 
   // Original text: 'Save custom filters'
-  saveCustomFilters: undefined,
+  saveCustomFilters: 'Сохранение пользовательских фильтров',
 
   // Original text: "Start"
   startVmLabel: 'Запустить',
@@ -1195,7 +1194,7 @@ export default {
   exportVmLabel: 'Экспорт',
 
   // Original text: "Resume"
-  resumeVmLabel: 'Проводлжить',
+  resumeVmLabel: 'Возобновить',
 
   // Original text: "Copy"
   copyVmLabel: 'Копировать',
@@ -1243,13 +1242,13 @@ export default {
   poolMaster: undefined,
 
   // Original text: 'Display all hosts of this pool'
-  displayAllHosts: undefined,
+  displayAllHosts: 'Отобразить все хосты в этом пуле',
 
   // Original text: 'Display all storages of this pool'
-  displayAllStorages: undefined,
+  displayAllStorages: 'Отобразить все хранилища в этом пуле',
 
   // Original text: 'Display all VMs of this pool'
-  displayAllVMs: undefined,
+  displayAllVMs: 'Отобразить все ВМ в этом пуле',
 
   // Original text: "Hosts"
   hostsTabName: 'Хосты',
@@ -1294,13 +1293,13 @@ export default {
   poolNetworkDescription: 'Описание',
 
   // Original text: "PIFs"
-  poolNetworkPif: 'PIFs',
+  poolNetworkPif: undefined,
 
   // Original text: "No networks"
   poolNoNetwork: 'Нет сетей',
 
   // Original text: "MTU"
-  poolNetworkMTU: 'MTU',
+  poolNetworkMTU: undefined,
 
   // Original text: "Connected"
   poolNetworkPifAttached: 'Подключено',
@@ -1309,22 +1308,22 @@ export default {
   poolNetworkPifDetached: 'Отключено',
 
   // Original text: 'Show PIFs'
-  showPifs: undefined,
+  showPifs: 'Показать PIFs',
 
   // Original text: 'Hide PIFs'
-  hidePifs: undefined,
+  hidePifs: 'Скрыть PIFs',
 
   // Original text: 'Show details'
-  showDetails: undefined,
+  showDetails: 'Показать подробности',
 
   // Original text: 'Hide details'
-  hideDetails: undefined,
+  hideDetails: 'Скрыть подробности',
 
   // Original text: 'No stats'
   poolNoStats: undefined,
 
   // Original text: 'All hosts'
-  poolAllHosts: undefined,
+  poolAllHosts: 'Все хосты',
 
   // Original text: "Add SR"
   addSrLabel: 'Добавить SR',
@@ -1339,10 +1338,10 @@ export default {
   hostNeedsPatchUpdate: undefined,
 
   // Original text: "This host cannot be added to the pool because it's missing some patches."
-  hostNeedsPatchUpdateNoInstall: undefined,
+  hostNeedsPatchUpdateNoInstall: 'Этот хост не может быть добавлен в пул, так как на нем отсутствуют некоторые исправления.',
 
   // Original text: 'Adding host failed'
-  addHostErrorTitle: undefined,
+  addHostErrorTitle: 'Не удалось добавить хост',
 
   // Original text: 'Host patches could not be homogenized.'
   addHostNotHomogeneousErrorMessage: undefined,
@@ -1363,43 +1362,43 @@ export default {
   disableHostLabel: 'Выключить',
 
   // Original text: "Restart toolstack"
-  restartHostAgent: 'Перезапустить службы',
+  restartHostAgent: undefined,
 
   // Original text: "Force reboot"
-  forceRebootHostLabel: 'Быстрая перезагрузка',
+  forceRebootHostLabel: 'Принудительная перезагрузка',
 
   // Original text: "Reboot"
   rebootHostLabel: 'Перезагрузка',
 
   // Original text: 'Error while restarting host'
-  noHostsAvailableErrorTitle: undefined,
+  noHostsAvailableErrorTitle: 'Ошибка при перезапуске хоста',
 
   // Original text: 'Some VMs cannot be migrated before restarting this host. Please try force reboot.'
-  noHostsAvailableErrorMessage: undefined,
+  noHostsAvailableErrorMessage: 'Некоторые виртуальные машины невозможно перенести до перезапуска этого хоста. Пожалуйста, попробуйте выполнить принудительную перезагрузку.',
 
   // Original text: 'Error while restarting hosts'
-  failHostBulkRestartTitle: undefined,
+  failHostBulkRestartTitle: 'Ошибка при перезапуске хостов',
 
   // Original text: '{failedHosts, number}/{totalHosts, number} host{failedHosts, plural, one {} other {s}} could not be restarted.'
   failHostBulkRestartMessage: undefined,
 
   // Original text: 'Reboot to apply updates'
-  rebootUpdateHostLabel: undefined,
+  rebootUpdateHostLabel: 'Перезагрузите для применения обновлений',
 
   // Original text: "Emergency mode"
-  emergencyModeLabel: 'Режим восстановления',
+  emergencyModeLabel: 'Аварийный режим',
 
   // Original text: "Storage"
   storageTabName: 'Хранилище',
 
   // Original text: "Patches"
-  patchesTabName: 'Патчи',
+  patchesTabName: 'Исправления',
 
   // Original text: "Load average"
   statLoad: 'Средняя нагрузка',
 
   // Original text: 'RAM Usage: {memoryUsed}'
-  memoryHostState: undefined,
+  memoryHostState: 'Использование RAM: {memoryUsed}',
 
   // Original text: "Hardware"
   hardwareHostSettingsLabel: 'Hardware',
@@ -1432,7 +1431,7 @@ export default {
   hostStartedSince: 'Время работы хоста',
 
   // Original text: "Toolstack uptime"
-  hostStackStartedSince: 'Время работы служб',
+  hostStackStartedSince: undefined,
 
   // Original text: "CPU model"
   hostCpusModel: 'Модель CPU',
@@ -1459,40 +1458,40 @@ export default {
   hostLicenseExpiry: 'Срок действия',
 
   // Original text: 'Installed supplemental packs'
-  supplementalPacks: undefined,
+  supplementalPacks: "Установленные пакеты дополнений",
 
   // Original text: 'Install new supplemental pack'
-  supplementalPackNew: undefined,
+  supplementalPackNew: 'Установить новый пакет дополнений',
 
   // Original text: 'Install supplemental pack on every host'
-  supplementalPackPoolNew: undefined,
+  supplementalPackPoolNew: 'Установить пакет дополнений на каждый хост',
 
   // Original text: '{name} (by {author})'
-  supplementalPackTitle: undefined,
+  supplementalPackTitle: '{name} (by {author})',
 
   // Original text: 'Installation started'
-  supplementalPackInstallStartedTitle: undefined,
+  supplementalPackInstallStartedTitle: 'Установка началась',
 
   // Original text: 'Installing new supplemental pack…'
-  supplementalPackInstallStartedMessage: undefined,
+  supplementalPackInstallStartedMessage: 'Установка нового пакета дополнений…',
 
   // Original text: 'Installation error'
-  supplementalPackInstallErrorTitle: undefined,
+  supplementalPackInstallErrorTitle: 'Ошибка установки',
 
   // Original text: 'The installation of the supplemental pack failed.'
-  supplementalPackInstallErrorMessage: undefined,
+  supplementalPackInstallErrorMessage: 'Не удалось установить пакет дополнений',
 
   // Original text: 'Installation success'
-  supplementalPackInstallSuccessTitle: undefined,
+  supplementalPackInstallSuccessTitle: 'Установка успешна',
 
   // Original text: 'Supplemental pack successfully installed.'
-  supplementalPackInstallSuccessMessage: undefined,
+  supplementalPackInstallSuccessMessage: 'Пакет дополнений успешно установлен.',
 
   // Original text: "Add a network"
   networkCreateButton: 'Добавить сеть',
 
   // Original text: 'Add a bonded network'
-  networkCreateBondedButton: undefined,
+  networkCreateBondedButton: 'Добавить bonded сеть',
 
   // Original text: "Device"
   pifDeviceLabel: 'Устройство',
@@ -1507,7 +1506,7 @@ export default {
   pifAddressLabel: 'Адрес',
 
   // Original text: 'Mode'
-  pifModeLabel: undefined,
+  pifModeLabel: 'Режим',
 
   // Original text: "MAC"
   pifMacLabel: 'MAC',
@@ -1537,22 +1536,22 @@ export default {
   defaultLockingMode: undefined,
 
   // Original text: 'Configure IP address'
-  pifConfigureIp: undefined,
+  pifConfigureIp: 'Настройка IP адреса',
 
   // Original text: 'Invalid parameters'
   configIpErrorTitle: undefined,
 
   // Original text: 'Static IP address'
-  staticIp: undefined,
+  staticIp: 'Статичный IP адрес',
 
   // Original text: 'Netmask'
-  netmask: undefined,
+  netmask: 'Маска сети',
 
   // Original text: 'DNS'
-  dns: undefined,
+  dns: 'DNS',
 
   // Original text: 'Gateway'
-  gateway: undefined,
+  gateway: 'Сетевой шлюз',
 
   // Original text: "Add a storage"
   addSrDeviceButton: 'Добавить хранилище',
@@ -1576,13 +1575,13 @@ export default {
   pbdStatusDisconnected: 'Отключен',
 
   // Original text: 'Connect'
-  pbdConnect: undefined,
+  pbdConnect: 'Подключить',
 
   // Original text: 'Disconnect'
-  pbdDisconnect: undefined,
+  pbdDisconnect: 'Отключить',
 
   // Original text: 'Forget'
-  pbdForget: undefined,
+  pbdForget: 'Забыть',
 
   // Original text: "Shared"
   srShared: 'С общим доступом',
@@ -1591,13 +1590,13 @@ export default {
   srNotShared: 'Без общего доступа',
 
   // Original text: "No storage detected"
-  pbdNoSr: 'Хранилище не обнаружено',
+  pbdNoSr: 'Хранилища не обнаружены',
 
   // Original text: "Name"
   patchNameLabel: 'Имя',
 
   // Original text: "Install all patches"
-  patchUpdateButton: 'Установить все патчи',
+  patchUpdateButton: 'Установить все исправления',
 
   // Original text: "Description"
   patchDescription: 'Описание',
@@ -1615,10 +1614,10 @@ export default {
   patchStatusApplied: 'Применяемый',
 
   // Original text: "Missing patches"
-  patchStatusNotApplied: 'Отсутствующие патчи',
+  patchStatusNotApplied: 'Отсутствующие исправления',
 
   // Original text: "No patch detected"
-  patchNothing: 'Патчи не найдены',
+  patchNothing: 'Исправления не найдены',
 
   // Original text: "Release date"
   patchReleaseDate: 'Дата релиза',
@@ -1627,40 +1626,40 @@ export default {
   patchGuidance: 'Руководство',
 
   // Original text: "Action"
-  patchAction: 'Дествие',
+  patchAction: 'Действие',
 
   // Original text: 'Applied patches'
-  hostAppliedPatches: undefined,
+  hostAppliedPatches: 'Примененные исправления',
 
   // Original text: "Missing patches"
-  hostMissingPatches: 'Патчи не найдены',
+  hostMissingPatches: 'Отсутствующие исправления',
 
   // Original text: "Host up-to-date!"
   hostUpToDate: 'Хост в актуальном состоянии!',
 
   // Original text: 'Non-recommended patch install'
-  installPatchWarningTitle: undefined,
+  installPatchWarningTitle: 'Не рекомендуемые для установки исправления',
 
   // Original text: 'This will install a patch only on this host. This is NOT the recommended way: please go into the Pool patch view and follow instructions there. If you are sure about this, you can continue anyway'
-  installPatchWarningContent: undefined,
+  installPatchWarningContent: 'Это установит исправления только на данный хост. Это НЕ рекомендуемый метод: пожалуйста, перейдите в меню обновлений пула и следуйте инструкциям. Но если вы уверены, то можете продолжить.',
 
   // Original text: 'Go to pool'
-  installPatchWarningReject: undefined,
+  installPatchWarningReject: 'Перейти к пулу',
 
   // Original text: 'Install'
-  installPatchWarningResolve: undefined,
+  installPatchWarningResolve: 'Установить',
 
   // Original text: 'Refresh patches'
-  refreshPatches: undefined,
+  refreshPatches: 'Проверить исправления',
 
   // Original text: 'Install pool patches'
-  installPoolPatches: undefined,
+  installPoolPatches: 'Установить исправления на пул',
 
   // Original text: 'Default SR'
-  defaultSr: undefined,
+  defaultSr: 'SR по умолчанию',
 
   // Original text: 'Set as default SR'
-  setAsDefaultSr: undefined,
+  setAsDefaultSr: 'Выбрать SR по умолчанию',
 
   // Original text: "General"
   generalTabName: 'Общее',
@@ -1672,7 +1671,7 @@ export default {
   consoleTabName: 'Консоль',
 
   // Original text: 'Container'
-  containersTabName: undefined,
+  containersTabName: 'Контейнер',
 
   // Original text: "Snapshots"
   snapshotsTabName: 'Снимки',
@@ -1681,7 +1680,7 @@ export default {
   logsTabName: 'Журналы',
 
   // Original text: "Advanced"
-  advancedTabName: 'Расширено',
+  advancedTabName: 'Расширенные',
 
   // Original text: "Network"
   networkTabName: 'Сеть',
@@ -1702,34 +1701,34 @@ export default {
   vmStatus: 'Утилиты XEN не обнаружены',
 
   // Original text: "No IPv4 record"
-  vmName: 'Нет IPv4-записи',
+  vmName: 'Нет IPv4 записи',
 
   // Original text: "No IP record"
-  vmDescription: 'Нет IP-записи',
+  vmDescription: 'Нет IP записи',
 
   // Original text: "Started {ago}"
-  vmSettings: 'Запущена {ago}',
+  vmSettings: 'Запущено {ago}',
 
   // Original text: "Current status:"
   vmCurrentStatus: 'Текущий статус',
 
   // Original text: "Not running"
-  vmNotRunning: 'Не запущена',
+  vmNotRunning: 'Не запущено',
 
   // Original text: 'Halted {ago}'
-  vmHaltedSince: undefined,
+  vmHaltedSince: 'Остановлено {ago}',
 
   // Original text: "No Xen tools detected"
   noToolsDetected: 'Утилиты XEN не обнаружены',
 
   // Original text: "No IPv4 record"
-  noIpv4Record: 'Нет IPv4-записи',
+  noIpv4Record: 'Нет IPv4 записи',
 
   // Original text: "No IP record"
-  noIpRecord: 'Нет IP-записи',
+  noIpRecord: 'Нет IP записи',
 
   // Original text: "Started {ago}"
-  started: 'Запущена {ago}',
+  started: 'Запущено {ago}',
 
   // Original text: "Paravirtualization (PV)"
   paraVirtualizedMode: 'Паравиртуализация (PV)',
@@ -1747,10 +1746,10 @@ export default {
   statsNetwork: 'Использование сети',
 
   // Original text: 'Stacked values'
-  useStackedValuesOnStats: undefined,
+  useStackedValuesOnStats: 'Сложить значения',
 
   // Original text: "Disk throughput"
-  statDisk: 'Использование диска',
+  statDisk: 'Пропускная способность диска',
 
   // Original text: "Last 10 minutes"
   statLastTenMinutes: 'Последние 10 минут',
@@ -1768,55 +1767,55 @@ export default {
   copyToClipboardLabel: 'Копировать',
 
   // Original text: "Ctrl+Alt+Del"
-  ctrlAltDelButtonLabel: 'Ctrl+Alt+Del',
+  ctrlAltDelButtonLabel: undefined,
 
   // Original text: "Tip:"
   tipLabel: 'Совет:',
 
   // Original text: 'Hide infos'
-  hideHeaderTooltip: undefined,
+  hideHeaderTooltip: 'Скрыть информацию',
 
   // Original text: 'Show infos'
-  showHeaderTooltip: undefined,
+  showHeaderTooltip: 'Показать информацию',
 
   // Original text: 'Name'
-  containerName: undefined,
+  containerName: 'Имя',
 
   // Original text: 'Command'
-  containerCommand: undefined,
+  containerCommand: 'Команда',
 
   // Original text: 'Creation date'
-  containerCreated: undefined,
+  containerCreated: 'Дата создания',
 
   // Original text: 'Status'
-  containerStatus: undefined,
+  containerStatus: 'Статус',
 
   // Original text: 'Action'
-  containerAction: undefined,
+  containerAction: 'Действие',
 
   // Original text: 'No existing containers'
-  noContainers: undefined,
+  noContainers: 'Нет существующих контейнеров',
 
   // Original text: 'Stop this container'
-  containerStop: undefined,
+  containerStop: 'Остановить контейнер',
 
   // Original text: 'Start this container'
-  containerStart: undefined,
+  containerStart: 'Запустить контейнер',
 
   // Original text: 'Pause this container'
-  containerPause: undefined,
+  containerPause: 'Приостановить контейнер',
 
   // Original text: 'Resume this container'
-  containerResume: undefined,
+  containerResume: 'Возобновить контейнер',
 
   // Original text: 'Restart this container'
-  containerRestart: undefined,
+  containerRestart: 'Перезапустить контейнер',
 
   // Original text: "Action"
   vdiAction: 'Действие',
 
   // Original text: "Attach disk"
-  vdiAttachDevice: 'Подклчить диск',
+  vdiAttachDevice: 'Подключить диск',
 
   // Original text: "New disk"
   vbdCreateDeviceButton: 'Новый диск',
@@ -1831,10 +1830,10 @@ export default {
   vdiNameDescription: 'Описание',
 
   // Original text: 'Pool'
-  vdiPool: undefined,
+  vdiPool: 'Пул',
 
   // Original text: 'Disconnect'
-  vdiDisconnect: undefined,
+  vdiDisconnect: 'Отключить',
 
   // Original text: "Tags"
   vdiTags: 'Тэги',
@@ -1843,31 +1842,31 @@ export default {
   vdiSize: 'Размер',
 
   // Original text: "SR"
-  vdiSr: 'SR',
+  vdiSr: undefined,
 
   // Original text: 'VM'
-  vdiVm: undefined,
+  vdiVm: 'ВМ',
 
   // Original text: 'Migrate VDI'
-  vdiMigrate: undefined,
+  vdiMigrate: 'Мигрировать VDI',
 
   // Original text: 'Destination SR:'
-  vdiMigrateSelectSr: undefined,
+  vdiMigrateSelectSr: 'Целевая SR',
 
   // Original text: 'No SR'
-  vdiMigrateNoSr: undefined,
+  vdiMigrateNoSr: 'Нет SR',
 
   // Original text: 'A target SR is required to migrate a VDI'
-  vdiMigrateNoSrMessage: undefined,
+  vdiMigrateNoSrMessage: 'Для переноса VDI требуется целевой SR',
 
   // Original text: 'Forget'
-  vdiForget: undefined,
+  vdiForget: 'Забыть',
 
   // Original text: 'Remove VDI'
-  vdiRemove: undefined,
+  vdiRemove: 'Удалить VDI',
 
   // Original text: 'No VDIs attached to Control Domain'
-  noControlDomainVdis: undefined,
+  noControlDomainVdis: 'Нет VDI подключенных к Управляющему Домену',
 
   // Original text: "Boot flag"
   vbdBootableStatus: 'Флаг загрузки',
@@ -1885,10 +1884,10 @@ export default {
   vbdNoVbd: 'Нет дисков',
 
   // Original text: 'Connect VBD'
-  vbdConnect: undefined,
+  vbdConnect: 'Подключить VBD',
 
   // Original text: 'Disconnect VBD'
-  vbdDisconnect: undefined,
+  vbdDisconnect: 'Отключить VBD',
 
   // Original text: 'Bootable'
   vbdBootable: undefined,
@@ -1897,28 +1896,28 @@ export default {
   vbdReadonly: undefined,
 
   // Original text: 'Action'
-  vbdAction: undefined,
+  vbdAction: 'Действие',
 
   // Original text: 'Create'
-  vbdCreate: undefined,
+  vbdCreate: 'Создать',
 
   // Original text: 'Disk name'
-  vbdNamePlaceHolder: undefined,
+  vbdNamePlaceHolder: 'Имя диска',
 
   // Original text: 'Size'
-  vbdSizePlaceHolder: undefined,
+  vbdSizePlaceHolder: 'Размер',
 
   // Original text: 'CD drive not completely installed'
-  cdDriveNotInstalled: undefined,
+  cdDriveNotInstalled: 'CD установлен не полностью',
 
   // Original text: 'Stop and start the VM to install the CD drive'
-  cdDriveInstallation: undefined,
+  cdDriveInstallation: 'Остановить и запустить ВМ для установки CD',
 
   // Original text: 'Save'
-  saveBootOption: undefined,
+  saveBootOption: 'Сохранить',
 
   // Original text: 'Reset'
-  resetBootOption: undefined,
+  resetBootOption: 'Сбросить',
 
   // Original text: "New device"
   vifCreateDeviceButton: 'Новое устройство',
@@ -1930,10 +1929,10 @@ export default {
   vifDeviceLabel: 'Устройство',
 
   // Original text: "MAC address"
-  vifMacLabel: 'MAC-адрес',
+  vifMacLabel: 'MAC адрес',
 
   // Original text: "MTU"
-  vifMtuLabel: 'MTU',
+  vifMtuLabel: undefined,
 
   // Original text: "Network"
   vifNetworkLabel: 'Сеть',
@@ -1948,43 +1947,43 @@ export default {
   vifStatusDisconnected: 'Отключен',
 
   // Original text: 'Connect'
-  vifConnect: undefined,
+  vifConnect: 'Подключить',
 
   // Original text: 'Disconnect'
-  vifDisconnect: undefined,
+  vifDisconnect: 'Отключить',
 
   // Original text: 'Remove'
-  vifRemove: undefined,
+  vifRemove: 'Удалить',
 
   // Original text: "IP addresses"
-  vifIpAddresses: 'IP-адреса',
+  vifIpAddresses: 'IP адреса',
 
   // Original text: 'Auto-generated if empty'
-  vifMacAutoGenerate: undefined,
+  vifMacAutoGenerate: 'Создать если не указано',
 
   // Original text: 'Allowed IPs'
-  vifAllowedIps: undefined,
+  vifAllowedIps: 'Разрешенные IP',
 
   // Original text: 'No IPs'
-  vifNoIps: undefined,
+  vifNoIps: 'Без IP',
 
   // Original text: 'Network locked'
-  vifLockedNetwork: undefined,
+  vifLockedNetwork: 'Сеть заблокирована',
 
   // Original text: 'Network locked and no IPs are allowed for this interface'
-  vifLockedNetworkNoIps: undefined,
+  vifLockedNetworkNoIps: 'Сеть заблокирована, и для этого интерфейса не разрешены IP-адреса',
 
   // Original text: 'Network not locked'
-  vifUnLockedNetwork: undefined,
+  vifUnLockedNetwork: 'Сеть не заблокирована',
 
   // Original text: 'Unknown network'
-  vifUnknownNetwork: undefined,
+  vifUnknownNetwork: 'Неизвестная сеть',
 
   // Original text: 'Action'
-  vifAction: undefined,
+  vifAction: 'Действие',
 
   // Original text: 'Create'
-  vifCreate: undefined,
+  vifCreate: 'Создать',
 
   // Original text: "No snapshots"
   noSnapshots: 'Нет снимков',
@@ -1996,16 +1995,16 @@ export default {
   tipCreateSnapshotLabel: 'Нажмите на кнопку снимка, чтобы создать его!',
 
   // Original text: 'Revert VM to this snapshot'
-  revertSnapshot: undefined,
+  revertSnapshot: 'Откатить ВМ на этот снимок',
 
   // Original text: 'Remove this snapshot'
-  deleteSnapshot: undefined,
+  deleteSnapshot: 'Удалить снимок',
 
   // Original text: 'Create a VM from this snapshot'
-  copySnapshot: undefined,
+  copySnapshot: 'Создать ВМ из снимка',
 
   // Original text: 'Export this snapshot'
-  exportSnapshot: undefined,
+  exportSnapshot: 'Экспортировать снимок',
 
   // Original text: "Creation date"
   snapshotDate: 'Дата создания',
@@ -2047,19 +2046,19 @@ export default {
   xenSettingsLabel: 'Конфигурация Xen',
 
   // Original text: "Guest OS"
-  guestOsLabel: 'Гостнвая оперционная система',
+  guestOsLabel: 'Гостевая ОС',
 
   // Original text: "Misc"
   miscLabel: 'Разное',
 
   // Original text: "UUID"
-  uuid: 'UUID',
+  uuid: undefined,
 
   // Original text: "Virtualization mode"
   virtualizationMode: 'Режим виртуализации',
 
   // Original text: "CPU weight"
-  cpuWeightLabel: 'Приоритезация CPU',
+  cpuWeightLabel: 'Приоритизация CPU',
 
   // Original text: "Default ({value, number})"
   defaultCpuWeight: 'По умолчанию ({value, number})',
@@ -2068,22 +2067,22 @@ export default {
   cpuCapLabel: undefined,
 
   // Original text: 'Default ({value, number})'
-  defaultCpuCap: undefined,
+  defaultCpuCap: 'По умолчанию ({value, number})',
 
   // Original text: "PV args"
   pvArgsLabel: undefined,
 
   // Original text: "Xen tools status"
-  xenToolsStatus: 'Состояние XEN-утилит',
+  xenToolsStatus: 'Состояние XEN утилит',
 
   // Original text: "{status}"
-  xenToolsStatusValue: '{status}',
+  xenToolsStatusValue: undefined,
 
   // Original text: "OS name"
-  osName: 'Имя оперционной системы',
+  osName: 'Имя ОС',
 
   // Original text: "OS kernel"
-  osKernel: 'Ядро оперционной системы',
+  osKernel: 'Ядро ОС',
 
   // Original text: "Auto power on"
   autoPowerOn: 'Автозапуск',
@@ -2116,28 +2115,28 @@ export default {
   unknownOriginalTemplate: 'Неизвестно',
 
   // Original text: "VM limits"
-  vmLimitsLabel: 'Лимиты ВМ',
+  vmLimitsLabel: 'Ограничения ВМ',
 
   // Original text: "CPU limits"
-  vmCpuLimitsLabel: 'Лимиты CPU',
+  vmCpuLimitsLabel: 'Ограничение CPU',
 
   // Original text: 'Topology'
-  vmCpuTopology: undefined,
+  vmCpuTopology: 'Топология',
 
   // Original text: 'Default behavior'
-  vmChooseCoresPerSocket: undefined,
+  vmChooseCoresPerSocket: 'Поведение по умолчанию',
 
   // Original text: '{nSockets, number} socket{nSockets, plural, one {} other {s}} with {nCores, number} core{nCores, plural, one {} other {s}} per socket'
   vmSocketsWithCoresPerSocket: undefined,
 
   // Original text: 'Incorrect cores per socket value'
-  vmCoresPerSocketIncorrectValue: undefined,
+  vmCoresPerSocketIncorrectValue: 'Неверное значение количества ядер на сокет',
 
   // Original text: 'Please change the selected value to fix it.'
-  vmCoresPerSocketIncorrectValueSolution: undefined,
+  vmCoresPerSocketIncorrectValueSolution: 'Пожалуйста, измените выбранное значение, чтобы исправить это.',
 
   // Original text: "Memory limits (min/max)"
-  vmMemoryLimitsLabel: 'Лимиты памяти (мин/мак)',
+  vmMemoryLimitsLabel: 'Ограничение памяти (min/max)',
 
   // Original text: "vCPUs max:"
   vmMaxVcpus: 'Максимум vCPUs:',
@@ -2152,25 +2151,25 @@ export default {
   vmHomeDescriptionPlaceholder: 'Длительное нажатие для добавления описания',
 
   // Original text: "Click to add a name"
-  vmViewNamePlaceholder: 'Нажми для добавления имени',
+  vmViewNamePlaceholder: 'Нажать для добавления имени',
 
   // Original text: "Click to add a description"
-  vmViewDescriptionPlaceholder: 'Нажми для добавления описания',
+  vmViewDescriptionPlaceholder: 'Нажать для добавления описания',
 
   // Original text: 'Click to add a name'
-  templateHomeNamePlaceholder: undefined,
+  templateHomeNamePlaceholder: 'Нажать для добавления имени',
 
   // Original text: 'Click to add a description'
-  templateHomeDescriptionPlaceholder: undefined,
+  templateHomeDescriptionPlaceholder: 'Нажать для добавления описания',
 
   // Original text: 'Delete template'
-  templateDelete: undefined,
+  templateDelete: 'Удалить шаблон',
 
   // Original text: 'Delete VM template{templates, plural, one {} other {s}}'
-  templateDeleteModalTitle: undefined,
+  templateDeleteModalTitle: 'Удалить шаблон VM {templates, plural, one {} other {s}}',
 
   // Original text: 'Are you sure you want to delete {templates, plural, one {this} other {these}} template{templates, plural, one {} other {s}}?'
-  templateDeleteModalBody: undefined,
+  templateDeleteModalBody: 'Вы уверены, что хотите удалить{templates, plural, one {this} other {these}} template{templates, plural, one {} other {s}}?',
 
   // Original text: "Pool{pools, plural, one {} other {s}}"
   poolPanel: 'Пул{pools, plural, one {} other {s}}',
@@ -2191,7 +2190,7 @@ export default {
   vmStatePanel: 'Состояние питания ВМ',
 
   // Original text: "Pending tasks"
-  taskStatePanel: 'Незавершенные задачи',
+  taskStatePanel: 'Отложенные задачи',
 
   // Original text: "Users"
   usersStatePanel: 'Пользователи',
@@ -2221,7 +2220,7 @@ export default {
   srSize: 'Размер',
 
   // Original text: "Usage"
-  srUsage: 'Использется',
+  srUsage: 'Используется',
 
   // Original text: "used"
   srUsed: 'используется',
@@ -2233,22 +2232,22 @@ export default {
   srUsageStatePanel: 'Использование хранилища',
 
   // Original text: "Top 5 SR Usage (in %)"
-  srTopUsageStatePanel: '5 основных SR по использованию (в %)',
+  srTopUsageStatePanel: 'Топ 5 SR по использованию (в %)',
 
   // Original text: '{running, number} running ({halted, number} halted)'
   vmsStates: undefined,
 
   // Original text: 'Clear selection'
-  dashboardStatsButtonRemoveAll: undefined,
+  dashboardStatsButtonRemoveAll: 'Сбросить выделение',
 
   // Original text: 'Add all hosts'
-  dashboardStatsButtonAddAllHost: undefined,
+  dashboardStatsButtonAddAllHost: 'Добавить все хосты',
 
   // Original text: 'Add all VMs'
-  dashboardStatsButtonAddAllVM: undefined,
+  dashboardStatsButtonAddAllVM: 'Добавить все ВМ',
 
   // Original text: "{value} {date, date, medium}"
-  weekHeatmapData: '{value} {date, date, medium}',
+  weekHeatmapData: undefined,
 
   // Original text: "No data."
   weekHeatmapNoData: 'Нет данных.',
@@ -2293,7 +2292,7 @@ export default {
   removeAllOrphanedObject: undefined,
 
   // Original text: 'VDIs attached to Control Domain'
-  vdisOnControlDomain: undefined,
+  vdisOnControlDomain: 'VDI подключенные к Управляющему Домену',
 
   // Original text: "Name"
   vmNameLabel: 'Имя',
@@ -2302,28 +2301,28 @@ export default {
   vmNameDescription: 'Описание',
 
   // Original text: "Resident on"
-  vmContainer: 'Живет в',
+  vmContainer: undefined,
 
   // Original text: "Alarms"
-  alarmMessage: 'Сигналы тревоги',
+  alarmMessage: 'Предупреждения',
 
   // Original text: "No alarms"
-  noAlarms: 'Нет сигналов',
+  noAlarms: 'Нет предупреждений',
 
   // Original text: "Date"
   alarmDate: 'Дата',
 
   // Original text: "Content"
-  alarmContent: 'Содержание',
+  alarmContent: undefined,
 
   // Original text: "Issue on"
-  alarmObject: 'Оъект',
+  alarmObject: undefined,
 
   // Original text: "Pool"
   alarmPool: 'Пул',
 
   // Original text: "Remove all alarms"
-  alarmRemoveAll: 'Удалить все тревоги',
+  alarmRemoveAll: 'Удалить все предупреждения',
 
   // Original text: '{used}% used ({free} left)'
   spaceLeftTooltip: undefined,
@@ -2332,10 +2331,10 @@ export default {
   newVmCreateNewVmOn: 'Создать новую ВМ на {select}',
 
   // Original text: 'Create a new VM on {select1} or {select2}'
-  newVmCreateNewVmOn2: undefined,
+  newVmCreateNewVmOn2: 'Создать новую ВМ на {select1} или {select2}',
 
   // Original text: 'You have no permission to create a VM'
-  newVmCreateNewVmNoPermission: undefined,
+  newVmCreateNewVmNoPermission: 'У вас нет разрешений для создания ВМ',
 
   // Original text: "Infos"
   newVmInfoPanel: 'Информация',
@@ -2353,7 +2352,7 @@ export default {
   newVmPerfPanel: 'Производительность',
 
   // Original text: "vCPUs"
-  newVmVcpusLabel: 'vCPUs',
+  newVmVcpusLabel: undefined,
 
   // Original text: "RAM"
   newVmRamLabel: 'Память',
@@ -2371,7 +2370,7 @@ export default {
   newVmInstallSettingsPanel: 'Варианты установки',
 
   // Original text: "ISO/DVD"
-  newVmIsoDvdLabel: 'ISO/DVD',
+  newVmIsoDvdLabel: undefined,
 
   // Original text: "Network"
   newVmNetworkLabel: 'Сеть',
@@ -2383,13 +2382,13 @@ export default {
   newVmPvArgsLabel: 'Детали PV',
 
   // Original text: "PXE"
-  newVmPxeLabel: 'PXE',
+  newVmPxeLabel: undefined,
 
   // Original text: "Interfaces"
   newVmInterfacesPanel: 'Интерфейсы',
 
   // Original text: "MAC"
-  newVmMacLabel: 'MAC',
+  newVmMacLabel: undefined,
 
   // Original text: "Add interface"
   newVmAddInterface: 'Добавить интерфейс',
@@ -2398,7 +2397,7 @@ export default {
   newVmDisksPanel: 'Диски',
 
   // Original text: "SR"
-  newVmSrLabel: 'SR',
+  newVmSrLabel: undefined,
 
   // Original text: "Size"
   newVmSizeLabel: 'Размер',
@@ -2407,7 +2406,7 @@ export default {
   newVmAddDisk: 'Добавить диск',
 
   // Original text: "Summary"
-  newVmSummaryPanel: 'Суммарно',
+  newVmSummaryPanel: undefined,
 
   // Original text: "Create"
   newVmCreate: 'Создать',
@@ -2419,10 +2418,10 @@ export default {
   newVmSelectTemplate: 'Выбрать шаблон',
 
   // Original text: "SSH key"
-  newVmSshKey: 'SSH-ключ',
+  newVmSshKey: 'SSH ключ',
 
   // Original text: "Config drive"
-  newVmConfigDrive: 'Настоить диск',
+  newVmConfigDrive: 'Настроить диск',
 
   // Original text: "Custom config"
   newVmCustomConfig: 'Пользовательские настройки',
@@ -2434,7 +2433,7 @@ export default {
   newVmMacPlaceholder: 'Создается автоматически, если оставить пустым',
 
   // Original text: "CPU weight"
-  newVmCpuWeightLabel: 'Приоритезация CPU',
+  newVmCpuWeightLabel: 'Приоритизация CPU',
 
   // Original text: 'Default: {value, number}'
   newVmDefaultCpuWeight: undefined,
@@ -2458,7 +2457,7 @@ export default {
   newVmMultipleVms: 'Несколько ВМ:',
 
   // Original text: 'Select a resource set:'
-  newVmSelectResourceSet: undefined,
+  newVmSelectResourceSet: 'Выберите набор ресурсов:',
 
   // Original text: 'Name pattern:'
   newVmMultipleVmsPattern: undefined,
@@ -2527,7 +2526,7 @@ export default {
   resourceSetMissingObjects: 'Объект не найден:',
 
   // Original text: "vCPUs"
-  resourceSetVcpus: 'vCPUs',
+  resourceSetVcpus: undefined,
 
   // Original text: "Memory"
   resourceSetMemory: 'Память',
@@ -2542,20 +2541,19 @@ export default {
   availableHosts: 'Доступные хосты',
 
   // Original text: "Excluded hosts"
-  excludedHosts: 'Используемые хосты',
+  excludedHosts: 'Исключенные хосты',
 
   // Original text: "No hosts available."
   noHostsAvailable: 'Нет доступных хостов',
 
   // Original text: "VMs created from this resource set shall run on the following hosts."
-  availableHostsDescription:
-    'Виртуальные машины, созданные из этого набора ресурсов, должны работать на следующих хостах.',
+  availableHostsDescription: 'Виртуальные машины, созданные из этого набора ресурсов, должны работать на следующих хостах.',
 
   // Original text: "Maximum CPUs"
   maxCpus: 'Максимум CPUs',
 
   // Original text: "Maximum RAM (GiB)"
-  maxRam: 'Максимум памяти (ГиБ)',
+  maxRam: 'Максимум памяти (GiB)',
 
   // Original text: "Maximum disk space"
   maxDiskSpace: 'Максимум дискового пространства',
@@ -2567,7 +2565,7 @@ export default {
   quantity: undefined,
 
   // Original text: "No limits."
-  noResourceSetLimits: 'Нет лимитов',
+  noResourceSetLimits: 'Нет ограничений',
 
   // Original text: "Total:"
   totalResource: 'Итого:',
@@ -2582,11 +2580,10 @@ export default {
   resourceSetNew: undefined,
 
   // Original text: "Try dropping some VMs files here, or click to select VMs to upload. Accept only .xva/.ova files."
-  importVmsList:
-    'Перетащите сюда несколько файлов виртуальных машин или нажмите, чтобы выбрать виртуальные машины для загрузки. Работает только с файлами .xva/.ova.',
+  importVmsList: 'Перетащите сюда несколько файлов виртуальных машин или нажмите, чтобы выбрать виртуальные машины для загрузки. Работает только с файлами .xva/.ova.',
 
   // Original text: "No selected VMs."
-  noSelectedVms: 'Нет выбраных ВМ',
+  noSelectedVms: 'Нет выбранных ВМ',
 
   // Original text: "To Pool:"
   vmImportToPool: 'В пул:',
@@ -2607,49 +2604,49 @@ export default {
   vmImportFailed: 'Ошибка импорта ВМ',
 
   // Original text: "Import starting…"
-  startVmImport: 'Начало импорта…',
+  startVmImport: 'Импорт начался…',
 
   // Original text: "Export starting…"
-  startVmExport: 'Начало экспорта…',
+  startVmExport: 'Экспорт начался…',
 
   // Original text: 'Number of CPUs'
-  nCpus: undefined,
+  nCpus: 'Количество CPUs',
 
   // Original text: 'Memory'
-  vmMemory: undefined,
+  vmMemory: 'Память',
 
   // Original text: 'Disk {position} ({capacity})'
   diskInfo: undefined,
 
   // Original text: 'Disk description'
-  diskDescription: undefined,
+  diskDescription: 'Описание диска',
 
   // Original text: 'No disks.'
-  noDisks: undefined,
+  noDisks: 'Нет дисков',
 
   // Original text: 'No networks.'
-  noNetworks: undefined,
+  noNetworks: 'Нет сетей',
 
   // Original text: 'Network {name}'
-  networkInfo: undefined,
+  networkInfo: 'Сеть {name}',
 
   // Original text: 'No description available'
-  noVmImportErrorDescription: undefined,
+  noVmImportErrorDescription: 'Описание недоступно',
 
   // Original text: 'Error:'
-  vmImportError: undefined,
+  vmImportError: 'Ошибка',
 
   // Original text: '{type} file:'
-  vmImportFileType: undefined,
+  vmImportFileType: '{type} файл:',
 
   // Original text: 'Please to check and/or modify the VM configuration.'
-  vmImportConfigAlert: undefined,
+  vmImportConfigAlert: 'Пожалуйста, проверьте и/или измените конфигурацию виртуальной машины.',
 
   // Original text: "No pending tasks"
-  noTasks: 'Нет незаконченных задач',
+  noTasks: 'Нет отложенных задач',
 
   // Original text: "Currently, there are not any pending XenServer tasks"
-  xsTasks: 'В настоящее время нет задач, ожидающих выполнения на XenServer.',
+  xsTasks: 'В настоящее время нет незавершенных задач XenServer',
 
   // Original text: 'Schedules'
   backupSchedules: undefined,
@@ -2658,13 +2655,13 @@ export default {
   getRemote: undefined,
 
   // Original text: "List Remote"
-  listRemote: 'Список удаленных резервных копий',
+  listRemote: undefined,
 
   // Original text: "simple"
   simpleBackup: 'простой',
 
   // Original text: "delta"
-  delta: 'дифференциальный',
+  delta: undefined,
 
   // Original text: "Restore Backups"
   restoreBackups: 'Восстановить резервную копию',
@@ -2673,7 +2670,7 @@ export default {
   restoreBackupsInfo: undefined,
 
   // Original text: "Enabled"
-  remoteEnabled: 'Доступно',
+  remoteEnabled: 'Подключено',
 
   // Original text: "Error"
   remoteError: 'Ошибка',
@@ -2685,7 +2682,7 @@ export default {
   backupVmNameColumn: 'Имя ВМ',
 
   // Original text: 'Tags'
-  backupTags: undefined,
+  backupTags: 'Тэги',
 
   // Original text: "Last Backup"
   lastBackupColumn: 'Последняя резервная копия',
@@ -2700,10 +2697,10 @@ export default {
   backupRestoreErrorMessage: undefined,
 
   // Original text: 'Select default SR…'
-  backupRestoreSelectDefaultSr: undefined,
+  backupRestoreSelectDefaultSr: 'Выберите SR по умолчанию...',
 
   // Original text: 'Choose a SR for each VDI'
-  backupRestoreChooseSrForEachVdis: undefined,
+  backupRestoreChooseSrForEachVdis: 'Выберите SR для каждого VDI',
 
   // Original text: 'VDI'
   backupRestoreVdiLabel: undefined,
@@ -2805,7 +2802,7 @@ export default {
   restartHostsModalMessage: undefined,
 
   // Original text: "Start VM{vms, plural, one {} other {s}}"
-  startVmsModalTitle: 'Arrancar VM{vms, plural, one {} other {s}}',
+  startVmsModalTitle: undefined,
 
   // Original text: 'Start a copy'
   cloneAndStartVM: undefined,
@@ -2823,7 +2820,7 @@ export default {
   blockedStartVmsModalMessage: undefined,
 
   // Original text: "Are you sure you want to start {vms, number} VM{vms, plural, one {} other {s}}?"
-  startVmsModalMessage: 'Вы уверены, что хотите запустить {vms} ВМ{vms, plural, one {} other {s}}?',
+  startVmsModalMessage: 'Вы уверены, что хотите запустить {vms, number} ВМ{vms, plural, one {} other {s}}?',
 
   // Original text: '{nVms, number} vm{nVms, plural, one {} other {s}} are failed. Please see your logs to get more information'
   failedVmsErrorMessage: undefined,
@@ -2865,21 +2862,19 @@ export default {
   snapshotVmsModalTitle: 'Снимок ВМ{vms, plural, one {} other {s}}',
 
   // Original text: "Are you sure you want to snapshot {vms, number} VM{vms, plural, one {} other {s}}?"
-  snapshotVmsModalMessage: 'Вы уверены, что хотите сделать сникми {vms, number} ВМ{vms, plural, one {} other {s}}?',
+  snapshotVmsModalMessage: 'Вы уверены, что хотите сделать снимки {vms, number} ВМ{vms, plural, one {} other {s}}?',
 
   // Original text: "Delete VM{vms, plural, one {} other {s}}"
   deleteVmsModalTitle: 'Удалить ВМ{vms, plural, one {} other {s}}',
 
   // Original text: "Are you sure you want to delete {vms, number} VM{vms, plural, one {} other {s}}? ALL VM DISKS WILL BE REMOVED"
-  deleteVmsModalMessage:
-    'Вы уверены, что хотите удалить {vms, number} ВМ{vms, plural, one {} other {s}}? ВСЕ ДИСКИ ВИРТУАЛЬНЫХ МАШИН БУДУТ УДАЛЕНЫ!',
+  deleteVmsModalMessage: 'Вы уверены, что хотите удалить {vms, number} ВМ{vms, plural, one {} other {s}}? ВСЕ ДИСКИ ВИРТУАЛЬНЫХ МАШИН БУДУТ УДАЛЕНЫ!',
 
   // Original text: "Delete VM"
   deleteVmModalTitle: 'Удалить ВМ',
 
   // Original text: "Are you sure you want to delete this VM? ALL VM DISKS WILL BE REMOVED"
-  deleteVmModalMessage:
-    'Вы уверены, что хотите удалить эту виртуальную машину? ВСЕ ДИСКИ ВИРТУАЛЬНОЙ МАШИНЫ БУДУТ УДАЛЕНЫ!',
+  deleteVmModalMessage: 'Вы уверены, что хотите удалить эту виртуальную машину? ВСЕ ДИСКИ ВИРТУАЛЬНОЙ МАШИНЫ БУДУТ УДАЛЕНЫ!',
 
   // Original text: "Migrate VM"
   migrateVmModalTitle: 'Переместить ВМ',
@@ -2969,7 +2964,7 @@ export default {
   importBackupModalSelectBackup: 'Выберите резервную копию…',
 
   // Original text: "Are you sure you want to remove all orphaned snapshot VDIs?"
-  removeAllOrphanedModalWarning: 'Вы уверены, что хотите удалить все потерянные VDI?',
+  removeAllOrphanedModalWarning: undefined,
 
   // Original text: "Remove all logs"
   removeAllLogsModalTitle: 'Очистить все журналы',
@@ -2981,31 +2976,28 @@ export default {
   definitiveMessageModal: 'Эта операция является окончательной',
 
   // Original text: "Previous SR Usage"
-  existingSrModalTitle: 'Предыдущее использование SR',
+  existingSrModalTitle: undefined,
 
   // Original text: "This path has been previously used as a Storage by a XenServer host. All data will be lost if you choose to continue the SR creation."
-  existingSrModalText:
-    'Этот путь ранее использовался хостом XenServer в качестве хранилища. Все существующие данные будут потеряны, если вы продолжите создание SR.',
+  existingSrModalText: 'Этот путь ранее использовался хостом XenServer в качестве хранилища. Все существующие данные будут потеряны, если вы продолжите создание SR.',
 
   // Original text: "Previous LUN Usage"
   existingLunModalTitle: 'Предыдущее использование LUN',
 
   // Original text: "This LUN has been previously used as a Storage by a XenServer host. All data will be lost if you choose to continue the SR creation."
-  existingLunModalText:
-    'Этот LUN ранее использовался хостом XenServer в качестве хранилища. Все существующие данные будут потеряны, если вы продолжите создание SR.',
+  existingLunModalText: 'Этот LUN ранее использовался хостом XenServer в качестве хранилища. Все существующие данные будут потеряны, если вы продолжите создание SR.',
 
   // Original text: "Replace current registration?"
-  alreadyRegisteredModal: 'Заменить текущую запись?',
+  alreadyRegisteredModal: 'Заменить текущую регистрацию?',
 
   // Original text: "Your XO appliance is already registered to {email}, do you want to forget and replace this registration ?"
-  alreadyRegisteredModalText: 'Ваш XOA уже зарегистрирован в {email}, вы хотите сменить регистрацию?',
+  alreadyRegisteredModalText: 'Ваш XO уже зарегистрирован в {email}, вы хотите сменить регистрацию?',
 
   // Original text: "Ready for trial?"
   trialReadyModal: 'Готовы к пробному периоду?',
 
   // Original text: "During the trial period, XOA need to have a working internet connection. This limitation does not apply for our paid plans!"
-  trialReadyModalText:
-    'В течение пробного периода для XOA требуется подключение к Интернету. Это ограничение не распространяется на тарифные планы',
+  trialReadyModalText: 'В течение пробного периода для XOA требуется подключение к Интернету. Это ограничение не распространяется на тарифные планы',
 
   // Original text: 'Label'
   serverLabel: undefined,
@@ -3146,7 +3138,7 @@ export default {
   newNetworkDefaultVlan: 'VLAN не определён',
 
   // Original text: "MTU"
-  newNetworkMtu: 'MTU',
+  newNetworkMtu: undefined,
 
   // Original text: "Default: 1500"
   newNetworkDefaultMtu: 'По умолчанию: 1500',
@@ -3188,10 +3180,13 @@ export default {
   noProSupport: '"PRO" поддержка не предоставляется!',
 
   // Original text: "Use in production at your own risks"
-  noProductionUse: 'Использование в производстве на свой страх и риск',
+  noProductionUse: 'Используйте в производстве на свой страх и риск',
 
-  // Original text: "You can download our turnkey appliance at {website}""
-  downloadXoaFromWebsite: 'Вы можете скачать нашу сборку  Xen Orchestra с {веб-сайте}',
+  // Original text: 'Want to use in production?'
+  productionUse: 'Хотите использовать в производстве',
+
+  // Original text: "You can download our turnkey appliance at {website}"
+  downloadXoaFromWebsite: 'Вы можете скачать нашу сборку Xen Orchestra с {website}',
 
   // Original text: "Bug Tracker"
   bugTracker: 'Bug Tracker',
@@ -3203,25 +3198,25 @@ export default {
   community: 'Сообщество',
 
   // Original text: "Join our community forum!"
-  communityText: 'Присоединяйтесь к форуму нашего сообщества!',
+  communityText: 'Присоединяйся к форуму нашего сообщества!',
 
   // Original text: "Free Trial for Premium Edition!"
   freeTrial: 'Бесплатная пробная версия "Premium Edition"!',
 
   // Original text: "Request your trial now!"
-  freeTrialNow: 'Зарегистрируй пробный период сейчас!',
+  freeTrialNow: 'Запросите пробную версию прямо сейчас!',
 
   // Original text: "Any issue?"
-  issues: 'Какая-то проблема?',
+  issues: 'Есть проблема?',
 
   // Original text: "Problem? Contact us!"
-  issuesText: 'Проблема? Свяжитесь с нами!',
+  issuesText: 'Проблема? Свяжись с нами!',
 
   // Original text: "Documentation"
   documentation: 'Документация',
 
   // Original text: "Read our official doc"
-  documentationText: 'Прочитайте нашу официальную документацию',
+  documentationText: 'Прочтите нашу официальную документацию',
 
   // Original text: "Pro support included"
   proSupportIncluded: 'Профессиональная поддержка включена',
@@ -3239,7 +3234,7 @@ export default {
   upgradeNeeded: 'Требуется обновление',
 
   // Original text: "Upgrade now!"
-  upgradeNow: 'Обнови сейчас',
+  upgradeNow: 'Обнови сейчас!',
 
   // Original text: "Or"
   or: 'Или',
@@ -3251,10 +3246,10 @@ export default {
   availableIn: 'Эта функция доступна только в {plan} Edition',
 
   // Original text: 'This feature is not available in your version, contact your administrator to know more.'
-  notAvailable: undefined,
+  notAvailable: 'Эта функция недоступна в вашей версии, обратитесь к своему администратору, чтобы узнать больше.',
 
   // Original text: 'Updates'
-  updateTitle: undefined,
+  updateTitle: 'Обновления',
 
   // Original text: "Registration"
   registration: 'Регистрация',
@@ -3299,12 +3294,10 @@ export default {
   noUpdaterCommunity: 'Для Community Edition обновления не доступны',
 
   // Original text: "Please consider subscribe and try it with all features for free during 15 days on {link}.""
-  considerSubscribe:
-    'Пожалуйста, рассмотрите возможность подписки и попробуйте все функции бесплатно в течение 15 дней на {link}.',
+  considerSubscribe: 'Пожалуйста, рассмотрите возможность подписки и попробуйте все функции бесплатно в течение 15 дней на {link}.',
 
   // Original text: "Manual update could break your current installation due to dependencies issues, do it with caution"
-  noUpdaterWarning:
-    'Ручные обновления можут нарушить работоспособность ПО из-за проблем с зависимостями, делайте это с осторожностью',
+  noUpdaterWarning: 'Обновление вручную может привести к сбою вашей текущей установки из-за проблем с зависимостями, делайте это с осторожностью',
 
   // Original text: "Current version:"
   currentVersion: 'Текущая версия:',
@@ -3313,7 +3306,7 @@ export default {
   register: 'Регистрация',
 
   // Original text: 'Edit registration'
-  editRegistration: undefined,
+  editRegistration: 'Изменить регистрацию',
 
   // Original text: "Please, take time to register in order to enjoy your trial."
   trialRegistration: 'Пожалуйста, зарегистрируйтесь, чтобы испытать пробный период',
@@ -3322,15 +3315,13 @@ export default {
   trialStartButton: 'Активировать пробный период',
 
   // Original text: "You can use a trial version until {date, date, medium}. Upgrade your appliance to get it."
-  trialAvailableUntil:
-    'Вы можете использовать пробную версию до {date, date, medium}. Обновите свою установку Xen Orchestra, чтобы продолжить использовать все преимущества.',
+  trialAvailableUntil: 'Вы можете использовать пробную версию до {date, date, medium}. Обновите свою установку Xen Orchestra, чтобы продолжить использовать все преимущества.',
 
   // Original text: "Your trial has been ended. Contact us or downgrade to Free version"
   trialConsumed: 'Ваш пробный период закончился. Свяжитесь с нами или вернитесь к бесплатной версии',
 
   // Original text: "Your xoa-updater service appears to be down. Your XOA cannot run fully without reaching this service."
-  trialLocked:
-    'Ваша служба xoa-updater, похоже, не работает. XOA не может работать должным образом без обращения к этой службе',
+  trialLocked: 'Ваша служба xoa-updater, похоже, не работает. XOA не может работать должным образом без обращения к этой службе',
 
   // Original text: "No update information available"
   noUpdateInfo: 'Нет информации об обновлении',
@@ -3363,10 +3354,10 @@ export default {
   disclaimerText1: 'Вы используете XO из исходного кода! Отлично подходит для личного/некоммерческого использования',
 
   // Original text: "If you are a company, it's better to use it with our appliance + pro support included:"
-  disclaimerText2: 'Если вы компания, лучше использовать ее с нашим устройством с включенной поддержкой Pro.',
+  disclaimerText2: undefined,
 
   // Original text: "This version is not bundled with any support nor updates. Use it with caution for critical tasks."
-  disclaimerText3: 'Если вы компания, лучше использовать ее с нашим устройством с включенной поддержкой Pro.',
+  disclaimerText3: 'Эта версия без поддержки и обновлений. Используйте с осторожностью при выполнении важных задач.',
 
   // Original text: "Connect PIF"
   connectPif: 'Подключить PIF',
@@ -3390,7 +3381,7 @@ export default {
   pifConnected: undefined,
 
   // Original text: 'Disconnected'
-  pifDisconnected: undefined,
+  pifDisconnected: 'Отключен',
 
   // Original text: 'Physically connected'
   pifPhysicallyConnected: undefined,
@@ -3450,31 +3441,31 @@ export default {
   noSshKeys: undefined,
 
   // Original text: 'New SSH key'
-  newSshKeyModalTitle: undefined,
+  newSshKeyModalTitle: 'Новый SSH ключ',
 
   // Original text: 'Invalid key'
-  sshKeyErrorTitle: undefined,
+  sshKeyErrorTitle: 'Недействительный ключ',
 
   // Original text: 'An SSH key requires both a title and a key.'
-  sshKeyErrorMessage: undefined,
+  sshKeyErrorMessage: 'Для SSH-ключа требуется как заголовок, так и ключ.',
 
   // Original text: 'Title'
-  title: undefined,
+  title: 'Заголовок',
 
   // Original text: 'Key'
-  key: undefined,
+  key: 'Ключ',
 
   // Original text: 'Delete SSH key'
-  deleteSshKeyConfirm: undefined,
+  deleteSshKeyConfirm: 'Удалить SSH ключ',
 
   // Original text: 'Are you sure you want to delete the SSH key {title}?'
-  deleteSshKeyConfirmMessage: undefined,
+  deleteSshKeyConfirmMessage: 'Вы уверены, что хотите удалить SSH ключ {title}?',
 
   // Original text: 'Others'
   others: undefined,
 
   // Original text: 'Loading logs…'
-  loadingLogs: undefined,
+  loadingLogs: 'Загрузка журналов...',
 
   // Original text: 'User'
   logUser: undefined,
@@ -3489,13 +3480,13 @@ export default {
   logMessage: undefined,
 
   // Original text: 'Error'
-  logError: undefined,
+  logError: 'Ошибка',
 
   // Original text: 'Display details'
-  logDisplayDetails: undefined,
+  logDisplayDetails: 'Показать детали',
 
   // Original text: 'Date'
-  logTime: undefined,
+  logTime: 'Дата',
 
   // Original text: 'No stack trace'
   logNoStackTrace: undefined,
@@ -3504,43 +3495,43 @@ export default {
   logNoParams: undefined,
 
   // Original text: 'Delete log'
-  logDelete: undefined,
+  logDelete: 'Удалить журнал',
 
   // Original text: 'Delete all logs'
-  logDeleteAll: undefined,
+  logDeleteAll: 'Удалить все журналы',
 
   // Original text: 'Delete all logs'
-  logDeleteAllTitle: undefined,
+  logDeleteAllTitle: 'Удалить все журналы',
 
   // Original text: 'Are you sure you want to delete all the logs?'
-  logDeleteAllMessage: undefined,
+  logDeleteAllMessage: 'Вы уверены, что хотите удалить все журналы?',
 
   // Original text: 'Click to enable'
-  logIndicationToEnable: undefined,
+  logIndicationToEnable: 'Нажмите для включения',
 
   // Original text: 'Click to disable'
-  logIndicationToDisable: undefined,
+  logIndicationToDisable: 'Нажмите для отключения',
 
   // Original text: 'Report a bug'
-  reportBug: undefined,
+  reportBug: 'Сообщить об ошибке',
 
   // Original text: 'Name'
-  ipPoolName: undefined,
+  ipPoolName: 'Имя',
 
   // Original text: 'IPs'
-  ipPoolIps: undefined,
+  ipPoolIps: 'IPs',
 
   // Original text: 'IPs (e.g.: 1.0.0.12-1.0.0.17;1.0.0.23)'
-  ipPoolIpsPlaceholder: undefined,
+  ipPoolIpsPlaceholder: 'IPs (прим.: 1.0.0.12-1.0.0.17;1.0.0.23)',
 
   // Original text: 'Networks'
-  ipPoolNetworks: undefined,
+  ipPoolNetworks: 'Сети',
 
   // Original text: 'No IP pools'
   ipsNoIpPool: undefined,
 
   // Original text: 'Create'
-  ipsCreate: undefined,
+  ipsCreate: 'Создать',
 
   // Original text: 'Delete all IP pools'
   ipsDeleteAllTitle: undefined,
@@ -3579,7 +3570,7 @@ export default {
   shortcut_GO_TO_SRS: undefined,
 
   // Original text: 'Create a new VM'
-  shortcut_CREATE_VM: undefined,
+  shortcut_CREATE_VM: 'Создать новую ВМ',
 
   // Original text: 'Unfocus field'
   shortcut_UNFOCUS: undefined,
@@ -3594,82 +3585,82 @@ export default {
   shortcut_SEARCH: undefined,
 
   // Original text: 'Next item'
-  shortcut_NAV_DOWN: undefined,
+  shortcut_NAV_DOWN: 'Следующий элемент',
 
   // Original text: 'Previous item'
-  shortcut_NAV_UP: undefined,
+  shortcut_NAV_UP: 'Предыдущий элемент',
 
   // Original text: 'Select item'
-  shortcut_SELECT: undefined,
+  shortcut_SELECT: 'Выбрать элемент',
 
   // Original text: 'Open'
-  shortcut_JUMP_INTO: undefined,
+  shortcut_JUMP_INTO: 'Открыть',
 
   // Original text: 'VM'
-  settingsAclsButtonTooltipVM: undefined,
+  settingsAclsButtonTooltipVM: 'ВМ',
 
   // Original text: 'Hosts'
-  settingsAclsButtonTooltiphost: undefined,
+  settingsAclsButtonTooltiphost: 'Хосты',
 
   // Original text: 'Pool'
-  settingsAclsButtonTooltippool: undefined,
+  settingsAclsButtonTooltippool: 'Пул',
 
   // Original text: 'SR'
   settingsAclsButtonTooltipSR: undefined,
 
   // Original text: 'Network'
-  settingsAclsButtonTooltipnetwork: undefined,
+  settingsAclsButtonTooltipnetwork: 'Сеть',
 
   // Original text: 'No config file selected'
-  noConfigFile: undefined,
+  noConfigFile: 'Файл настроек не выбран',
 
   // Original text: 'Try dropping a config file here, or click to select a config file to upload.'
-  importTip: undefined,
+  importTip: 'Перетащите файл настроек сюда, или выберите файл для загрузки',
 
   // Original text: 'Config'
   config: undefined,
 
   // Original text: 'Import'
-  importConfig: undefined,
+  importConfig: 'Импорт',
 
   // Original text: 'Config file successfully imported'
-  importConfigSuccess: undefined,
+  importConfigSuccess: 'Файл настроек успешно импортирован',
 
   // Original text: 'Error while importing config file'
-  importConfigError: undefined,
+  importConfigError: 'Ошибка при импорте файла настроек',
 
   // Original text: 'Export'
-  exportConfig: undefined,
+  exportConfig: 'Экспорт',
 
   // Original text: 'Download current config'
-  downloadConfig: undefined,
+  downloadConfig: 'Скачать текущие настройки',
 
   // Original text: 'No config import available for Community Edition'
-  noConfigImportCommunity: undefined,
+  noConfigImportCommunity: 'Импорт настроек не доступен в Community Edition',
 
   // Original text: 'Reconnect all hosts'
-  srReconnectAllModalTitle: undefined,
+  srReconnectAllModalTitle: 'Переподключить все хосты',
 
   // Original text: 'This will reconnect this SR to all its hosts.'
-  srReconnectAllModalMessage: undefined,
+  srReconnectAllModalMessage: 'Переподключить этот SR ко всем его хостам',
 
   // Original text: 'This will reconnect each selected SR to its host (local SR) or to every hosts of its pool (shared SR).'
-  srsReconnectAllModalMessage: undefined,
+  srsReconnectAllModalMessage: 'Повторно подключить выбранный SR к его хосту (локальный SR) или ко всем хостам в его пуле (общий SR).',
 
   // Original text: 'Disconnect all hosts'
-  srDisconnectAllModalTitle: undefined,
+  srDisconnectAllModalTitle: 'Отключить все хосты',
 
   // Original text: 'This will disconnect this SR from all its hosts.'
-  srDisconnectAllModalMessage: undefined,
+  srDisconnectAllModalMessage: 'Отключить этот SR от всех хостов.',
 
   // Original text: 'This will disconnect each selected SR from its host (local SR) or from every hosts of its pool (shared SR).'
-  srsDisconnectAllModalMessage: undefined,
+  srsDisconnectAllModalMessage: 'Отключить выбранный SR от его хоста (локальный SR) или от всех хостов в его пуле (общий SR).',
 
   // Original text: 'Forget SR'
-  srForgetModalTitle: undefined,
+  srForgetModalTitle: 'Забыть SR',
 
   // Original text: 'Forget selected SRs'
-  srsForgetModalTitle: undefined,
+  srsForgetModalTitle: 'Забыть выбранные SR',
 
   // Original text: "Are you sure you want to forget this SR? VDIs on this storage won't be removed."
   srForgetModalMessage: undefined,
@@ -3678,13 +3669,13 @@ export default {
   srsForgetModalMessage: undefined,
 
   // Original text: 'Disconnected'
-  srAllDisconnected: undefined,
+  srAllDisconnected: 'Отключено',
 
   // Original text: 'Partially connected'
   srSomeConnected: undefined,
 
   // Original text: 'Connected'
-  srAllConnected: undefined,
+  srAllConnected: 'Подключено',
 
   // Original text: 'XOSAN'
   xosanTitle: undefined,
@@ -3699,19 +3690,19 @@ export default {
   xosanSuggestions: undefined,
 
   // Original text: 'Name'
-  xosanName: undefined,
+  xosanName: 'Имя',
 
   // Original text: 'Host'
-  xosanHost: undefined,
+  xosanHost: 'Хост',
 
   // Original text: 'Hosts'
-  xosanHosts: undefined,
+  xosanHosts: 'Хосты',
 
   // Original text: 'Volume ID'
   xosanVolumeId: undefined,
 
   // Original text: 'Size'
-  xosanSize: undefined,
+  xosanSize: 'Размер',
 
   // Original text: 'Used space'
   xosanUsedSpace: undefined,

--- a/packages/xo-web/src/common/intl/locales/ru.js
+++ b/packages/xo-web/src/common/intl/locales/ru.js
@@ -8,20 +8,170 @@ addLocaleData(reactIntlData)
 // ===================================================================
 
 export default {
-  // Original text: 'Connecting'
+  // Original text: 'Alpha'
+  alpha: undefined,
+
+  // Original text: 'Alerts'
+  alerts: undefined,
+
+  // Original text: 'Connected'
+  connected: undefined,
+
+  // Original text: 'Description'
+  description: undefined,
+
+  // Original text: 'Delete source VM'
+  deleteSourceVm: undefined,
+
+  // Original text: 'Disable'
+  disable: undefined,
+
+  // Original text: 'Disk state'
+  diskState: undefined,
+
+  // Original text: 'Download'
+  download: undefined,
+
+  // Original text: 'Enable'
+  enable: undefined,
+
+  // Original text: 'Expiration'
+  expiration: undefined,
+
+  // Original text: 'Host IP'
+  hostIp: undefined,
+
+  // Original text: 'Interfaces'
+  interfaces: undefined,
+
+  // Original text: '{key}: {value}'
+  keyValue: undefined,
+
+  // Original text: 'Skip SSL check'
+  esxiImportSslCertificate: undefined,
+
+  // Original text: 'Thin mode'
+  esxiImportThin: undefined,
+
+  // Original text: 'Disk created in thin mode (less space used). Data is read twice, no visible task or progress at first'
+  esxiImportThinDescription: undefined,
+
+  // Original text: 'Stop the source VM'
+  esxiImportStopSource: undefined,
+
+  // Original text: 'Source VM stopped before the last delta transfer (after final snapshot). Needed to fully transfer a running VM'
+  esxiImportStopSourceDescription: undefined,
+
+  // Original text: 'Stop on the first error when importing VMs'
+  esxiImportStopOnErrorDescription: undefined,
+
+  // Original text: 'In use'
+  inUse: undefined,
+
+  // Original text: 'Number of VMs to import in parallel'
+  nImportVmsInParallel: undefined,
+
+  // Original text: 'Node'
+  node: undefined,
+
+  // Original text: 'PIFs'
+  pifs: undefined,
+
+  // Original text: 'Stop on error'
+  stopOnError: undefined,
+
+  // Original text: 'UUID'
+  uuid: undefined,
+
+  // Original text: 'VDI'
+  vdi: undefined,
+
+  // Original text: 'Storage: {used} used of {total} ({free} free)'
+  vmSrUsage: undefined,
+
+  // Original text: 'New'
+  new: undefined,
+
+  // Original text: 'Node status'
+  nodeStatus: undefined,
+
+  // Original text: 'Not defined'
+  notDefined: undefined,
+
+  // Original text: 'Status'
+  status: undefined,
+
+  // Original text: "Connecting"
   statusConnecting: 'Подключение',
 
-  // Original text: 'Disconnected'
+  // Original text: "Disconnected"
   statusDisconnected: 'Отключено',
 
-  // Original text: 'Loading…'
+  // Original text: "Loading…"
   statusLoading: 'Загружается...',
 
-  // Original text: 'Page not found'
+  // Original text: "Page not found"
   errorPageNotFound: 'Страница не найдена',
 
-  // Original text: 'no such item'
+  // Original text: "No such item"
   errorNoSuchItem: 'элемент не найден',
+
+  // Original text: 'Unknown {type}'
+  errorUnknownItem: undefined,
+
+  // Original text: 'Generate new MAC addresses'
+  generateNewMacAddress: undefined,
+
+  // Original text: '{memoryFree} RAM free'
+  memoryFree: undefined,
+
+  // Original text: 'Configured'
+  configured: undefined,
+
+  // Original text: 'Not configured'
+  notConfigured: undefined,
+
+  // Original text: 'UTC date'
+  utcDate: undefined,
+
+  // Original text: 'UTC time'
+  utcTime: undefined,
+
+  // Original text: 'Date'
+  date: undefined,
+
+  // Original text: 'Notifications'
+  notifications: undefined,
+
+  // Original text: 'No notifications so far.'
+  noNotifications: undefined,
+
+  // Original text: 'NEW!'
+  notificationNew: undefined,
+
+  // Original text: 'More details'
+  moreDetails: undefined,
+
+  // Original text: 'Subject'
+  messageSubject: undefined,
+
+  // Original text: 'From'
+  messageFrom: undefined,
+
+  // Original text: 'Reply'
+  messageReply: undefined,
+
+  // Original text: 'SR'
+  sr: undefined,
+
+  // Original text: 'Subdirectory'
+  subdirectory: undefined,
+
+  // Original text: 'Try XOA for free and deploy it here.'
+  tryXoa: undefined,
+
+  // Original text: 'Not installed'
+  notInstalled: undefined,
 
   // Original text: "Long click to edit"
   editableLongClickPlaceholder: 'Долгое нажатие для редактирования',
@@ -29,8 +179,263 @@ export default {
   // Original text: "Click to edit"
   editableClickPlaceholder: 'Нажмите для редактирования',
 
-  // Original text: 'Browse files'
+  // Original text: "Browse files"
   browseFiles: 'Просмотреть файлы',
+
+  // Original text: 'Show logs'
+  showLogs: undefined,
+
+  // Original text: 'None'
+  noValue: undefined,
+
+  // Original text: 'No expiration'
+  noExpiration: undefined,
+
+  // Original text: 'Compression'
+  compression: undefined,
+
+  // Original text: 'Core'
+  core: undefined,
+
+  // Original text: 'CPU'
+  cpu: undefined,
+
+  // Original text: 'Multipathing'
+  multipathing: undefined,
+
+  // Original text: 'Multipathing disabled'
+  multipathingDisabled: undefined,
+
+  // Original text: 'Enable multipathing'
+  enableMultipathing: undefined,
+
+  // Original text: 'Disable multipathing'
+  disableMultipathing: undefined,
+
+  // Original text: 'Enable multipathing for all hosts'
+  enableAllHostsMultipathing: undefined,
+
+  // Original text: 'Disable multipathing for all hosts'
+  disableAllHostsMultipathing: undefined,
+
+  // Original text: 'Paths'
+  paths: undefined,
+
+  // Original text: 'PBD disconnected'
+  pbdDisconnected: undefined,
+
+  // Original text: 'Has an inactive path'
+  hasInactivePath: undefined,
+
+  // Original text: 'Pools'
+  pools: undefined,
+
+  // Original text: 'Remotes'
+  remotes: undefined,
+
+  // Original text: 'Scheduler granularity'
+  schedulerGranularity: undefined,
+
+  // Original text: 'Socket'
+  socket: undefined,
+
+  // Original text: 'Type'
+  type: undefined,
+
+  // Original text: 'Restore'
+  restore: undefined,
+
+  // Original text: 'Delete'
+  delete: undefined,
+
+  // Original text: 'VMs'
+  vms: undefined,
+
+  // Original text: 'Max vCPUs'
+  cpusMax: undefined,
+
+  // Original text: 'Metadata'
+  metadata: undefined,
+
+  // Original text: 'Choose a backup'
+  chooseBackup: undefined,
+
+  // Original text: 'Temporarily disabled'
+  temporarilyDisabled: undefined,
+
+  // Original text: 'Click to show error'
+  clickToShowError: undefined,
+
+  // Original text: 'Backup jobs'
+  backupJobs: undefined,
+
+  // Original text: '({ nSessions, number }) iSCSI session{nSessions, plural, one {} other {s}}'
+  iscsiSessions: undefined,
+
+  // Original text: 'Requires admin permissions'
+  requiresAdminPermissions: undefined,
+
+  // Original text: 'Proxy'
+  proxy: undefined,
+
+  // Original text: 'Proxies'
+  proxies: undefined,
+
+  // Original text: 'Name'
+  name: undefined,
+
+  // Original text: 'Value'
+  value: undefined,
+
+  // Original text: 'Address'
+  address: undefined,
+
+  // Original text: 'VM'
+  vm: undefined,
+
+  // Original text: 'Destination SR'
+  destinationSR: undefined,
+
+  // Original text: 'Destination network'
+  destinationNetwork: undefined,
+
+  // Original text: 'DHCP'
+  dhcp: undefined,
+
+  // Original text: 'ID'
+  id: undefined,
+
+  // Original text: 'IP'
+  ip: undefined,
+
+  // Original text: 'Static'
+  static: undefined,
+
+  // Original text: 'User'
+  user: undefined,
+
+  // Original text: 'deleted ({ name })'
+  deletedUser: undefined,
+
+  // Original text: 'Network configuration'
+  networkConfiguration: undefined,
+
+  // Original text: 'Integrity'
+  integrity: undefined,
+
+  // Original text: 'Altered'
+  altered: undefined,
+
+  // Original text: 'Missing'
+  missing: undefined,
+
+  // Original text: 'Verified'
+  verified: undefined,
+
+  // Original text: 'Snapshot mode'
+  snapshotMode: undefined,
+
+  // Original text: 'Normal'
+  normal: undefined,
+
+  // Original text: 'With memory'
+  withMemory: undefined,
+
+  // Original text: 'Offline'
+  offline: undefined,
+
+  // Original text: 'No license available'
+  noLicenseAvailable: undefined,
+
+  // Original text: 'Email address, e.g.: it@company.net'
+  emailPlaceholderExample: undefined,
+
+  // Original text: 'Unknown'
+  unknown: undefined,
+
+  // Original text: 'Upgrades available'
+  upgradesAvailable: undefined,
+
+  // Original text: 'Advanced settings'
+  advancedSettings: undefined,
+
+  // Original text: 'Force upgrade'
+  forceUpgrade: undefined,
+
+  // Original text: 'TX checksumming'
+  txChecksumming: undefined,
+
+  // Original text: 'Thick'
+  thick: undefined,
+
+  // Original text: 'Thin'
+  thin: undefined,
+
+  // Original text: 'Unknown size'
+  unknownSize: undefined,
+
+  // Original text: 'Installed certificates'
+  installedCertificates: undefined,
+
+  // Original text: 'Expiry'
+  expiry: undefined,
+
+  // Original text: 'Fingerprint'
+  fingerprint: undefined,
+
+  // Original text: 'Certificate (PEM)'
+  certificate: undefined,
+
+  // Original text: 'Certificate chain (PEM)'
+  certificateChain: undefined,
+
+  // Original text: 'Private key (PKCS#8)'
+  privateKey: undefined,
+
+  // Original text: 'Install new certificate'
+  installNewCertificate: undefined,
+
+  // Original text: 'Replace existing certificate'
+  replaceExistingCertificate: undefined,
+
+  // Original text: 'Custom fields'
+  customFields: undefined,
+
+  // Original text: 'Add color'
+  addColor: undefined,
+
+  // Original text: 'Add custom field'
+  addCustomField: undefined,
+
+  // Original text: 'Advanced tag creation'
+  advancedTagCreation: undefined,
+
+  // Original text: 'Available in XOA Premium'
+  availableXoaPremium: undefined,
+
+  // Original text: 'Detach'
+  detach: undefined,
+
+  // Original text: 'Edit custom field'
+  editCustomField: undefined,
+
+  // Original text: 'Delete custom field'
+  deleteCustomField: undefined,
+
+  // Original text: 'Only available to XOA users'
+  onlyAvailableXoaUsers: undefined,
+
+  // Original text: 'Remove color'
+  removeColor: undefined,
+
+  // Original text: 'XCP-ng'
+  xcpNg: undefined,
+
+  // Original text: 'No file selected'
+  noFileSelected: undefined,
+
+  // Original text: 'Number of retries if VM backup fails'
+  nRetriesVmBackupFailures: undefined,
 
   // Original text: "OK"
   alertOk: 'OK',
@@ -38,16 +443,25 @@ export default {
   // Original text: "OK"
   confirmOk: 'OK',
 
+  // Original text: 'OK'
+  formOk: undefined,
+
   // Original text: "Cancel"
   genericCancel: 'Отмена',
 
-  // Original text: 'On error'
+  // Original text: 'Enter the following text to confirm:'
+  enterConfirmText: undefined,
+
+  // Original text: "On error"
   onError: 'При ошибке',
 
-  // Original text: 'Successful'
+  // Original text: "Successful"
   successful: 'Успешно',
 
-  // Original text: 'Managed disks'
+  // Original text: 'Hide short tasks'
+  filterOutShortTasks: undefined,
+
+  // Original text: "Managed disks"
   filterOnlyManaged: 'Управляемые диски',
 
   // Original text: 'Orphaned disks'
@@ -56,14 +470,44 @@ export default {
   // Original text: 'Normal disks'
   filterOnlyRegular: undefined,
 
-  // Original text: 'Snapshot disks'
+  // Original text: 'Running VMs'
+  filterOnlyRunningVms: undefined,
+
+  // Original text: "Snapshot disks"
   filterOnlySnapshots: 'Снимки дисков',
 
   // Original text: 'Unmanaged disks'
   filterOnlyUnmanaged: undefined,
 
-  // Original text: 'Copy to clipboard'
+  // Original text: 'Save…'
+  filterSaveAs: undefined,
+
+  // Original text: 'Explore the search syntax in the documentation'
+  filterSyntaxLinkTooltip: undefined,
+
+  // Original text: 'Connected VIFs'
+  filterVifsOnlyConnected: undefined,
+
+  // Original text: 'Disconnected VIFs'
+  filterVifsOnlyDisconnected: undefined,
+
+  // Original text: 'Connected remotes'
+  filterRemotesOnlyConnected: undefined,
+
+  // Original text: 'Disconnected remotes'
+  filterRemotesOnlyDisconnected: undefined,
+
+  // Original text: "Copy to clipboard"
   copyToClipboard: 'Копировать в буфер обмена',
+
+  // Original text: 'Copy VDI UUID'
+  copyToClipboardVdiUuid: undefined,
+
+  // Original text: 'Copy {uuid}'
+  copyUuid: undefined,
+
+  // Original text: 'Copy {value}'
+  copyValue: undefined,
 
   // Original text: 'Master'
   pillMaster: undefined,
@@ -71,19 +515,19 @@ export default {
   // Original text: "Home"
   homePage: 'Главная',
 
-  // Original text: 'VMs'
+  // Original text: "VMs"
   homeVmPage: 'Виртуальные машины',
 
-  // Original text: 'Hosts'
+  // Original text: "Hosts"
   homeHostPage: 'Хосты',
 
-  // Original text: 'Pools'
+  // Original text: "Pools"
   homePoolPage: 'Пулы',
 
-  // Original text: 'Templates'
+  // Original text: "Templates"
   homeTemplatePage: 'Шаблоны',
 
-  // Original text: 'Storages'
+  // Original text: "Storage"
   homeSrPage: 'Хранилища',
 
   // Original text: "Dashboard"
@@ -110,11 +554,26 @@ export default {
   // Original text: "Jobs"
   jobsPage: 'Задачи',
 
+  // Original text: 'XOA'
+  xoaPage: undefined,
+
   // Original text: "Updates"
   updatePage: 'Обновления',
 
+  // Original text: 'Licenses'
+  licensesPage: undefined,
+
+  // Original text: 'Notifications'
+  notificationsPage: undefined,
+
+  // Original text: 'Support'
+  supportPage: undefined,
+
   // Original text: "Settings"
   settingsPage: 'Настройки',
+
+  // Original text: 'Audit'
+  settingsAuditPage: undefined,
 
   // Original text: "Servers"
   settingsServersPage: 'Серверы',
@@ -131,16 +590,19 @@ export default {
   // Original text: "Plugins"
   settingsPluginsPage: 'Плагины',
 
-  // Original text: 'Logs'
+  // Original text: "Logs"
   settingsLogsPage: 'Журналы',
 
-  // Original text: 'IPs'
+  // Original text: 'Cloud configs'
+  settingsCloudConfigsPage: undefined,
+
+  // Original text: "IPs"
   settingsIpsPage: 'IP адреса',
 
   // Original text: "About"
   aboutPage: 'О программе',
 
-  // Original text: 'About XO {xoaPlan}'
+  // Original text: "About XO {xoaPlan}"
   aboutXoaPlan: 'О Xen Orchestra {xoaPlan}',
 
   // Original text: "New"
@@ -149,8 +611,11 @@ export default {
   // Original text: "Tasks"
   taskMenu: 'Задачи',
 
-  // Original text: 'Tasks'
+  // Original text: "Tasks"
   taskPage: 'Задачи',
+
+  // Original text: 'Network'
+  newNetworkPage: undefined,
 
   // Original text: "VM"
   newVmPage: 'ВМ',
@@ -173,38 +638,53 @@ export default {
   // Original text: "New"
   backupNewPage: 'Создать',
 
-  // Original text: "Remotes"
+  // Original text: 'Remotes'
   backupRemotesPage: undefined,
 
   // Original text: "Restore"
   backupRestorePage: 'Восстановление',
 
-  // Original text: 'File restore'
+  // Original text: "File restore"
   backupFileRestorePage: 'Восстановление файлов',
 
   // Original text: "Schedule"
   schedule: 'Расписание',
 
-  // Original text: "New VM backup"
-  newVmBackup: 'Новая резервная копия ВМ',
-
-  // Original text: "Edit VM backup"
-  editVmBackup: 'Изменить резервную копию ВМ',
-
   // Original text: "Backup"
   backup: 'Резервная копия',
 
-  // Original text: "Rolling Snapshot"
+  // Original text: 'Rolling Snapshot'
   rollingSnapshot: undefined,
 
-  // Original text: "Delta Backup"
+  // Original text: 'Delta Backup'
   deltaBackup: undefined,
 
-  // Original text: "Disaster Recovery"
+  // Original text: 'Disaster Recovery'
   disasterRecovery: undefined,
 
-  // Original text: "Continuous Replication"
+  // Original text: 'Continuous Replication'
   continuousReplication: undefined,
+
+  // Original text: 'Backup type'
+  backupType: undefined,
+
+  // Original text: 'Pool metadata'
+  poolMetadata: undefined,
+
+  // Original text: 'XO config'
+  xoConfig: undefined,
+
+  // Original text: 'VM Backup & Replication'
+  backupVms: undefined,
+
+  // Original text: 'XO config & Pool metadata Backup'
+  backupMetadata: undefined,
+
+  // Original text: 'Mirror backup'
+  mirrorBackup: undefined,
+
+  // Original text: 'VM Mirror Backup'
+  mirrorBackupVms: undefined,
 
   // Original text: "Overview"
   jobsOverviewPage: 'Обзор',
@@ -218,31 +698,97 @@ export default {
   // Original text: "Custom Job"
   customJob: 'Пользовательская задача',
 
-  // Original text: 'User'
+  // Original text: "User"
   userPage: 'Пользователь',
 
-  // Original text: 'No support'
+  // Original text: 'XOA'
+  xoa: undefined,
+
+  // Original text: "No support"
   noSupport: 'Без поддержки',
 
-  // Original text: 'Free upgrade!'
+  // Original text: "Free upgrade!"
   freeUpgrade: 'Бесплатное обновление!',
+
+  // Original text: 'Check XOA'
+  checkXoa: undefined,
+
+  // Original text: 'XOA check'
+  xoaCheck: undefined,
+
+  // Original text: 'Close tunnel'
+  closeTunnel: undefined,
+
+  // Original text: 'Create a support ticket'
+  createSupportTicket: undefined,
+
+  // Original text: 'Restart XO Server'
+  restartXoServer: undefined,
+
+  // Original text: 'Restarting XO Server will interrupt any backup job or XO task that is currently running. Xen Orchestra will also be unavailable for a few seconds. Are you sure you want to restart XO Server?'
+  restartXoServerConfirm: undefined,
+
+  // Original text: 'Open tunnel'
+  openTunnel: undefined,
+
+  // Original text: 'The XOA check and the support tunnel are available in XOA.'
+  supportCommunity: undefined,
+
+  // Original text: 'Support tunnel'
+  supportTunnel: undefined,
+
+  // Original text: 'The support tunnel is closed.'
+  supportTunnelClosed: undefined,
 
   // Original text: "Sign out"
   signOut: 'Выйти',
 
-  // Original text: 'Edit my settings {username}'
+  // Original text: "Edit my settings {username}"
   editUserProfile: 'Изменить мои настройки {username}',
+
+  // Original text: 'XenServer Client ID'
+  xsClientId: undefined,
+
+  // Original text: 'Upload Client ID file'
+  uploadClientId: undefined,
+
+  // Original text: 'Forget Client ID'
+  forgetClientId: undefined,
+
+  // Original text: 'Are you sure you want to forget your XenServer Client ID?'
+  forgetXsCredentialsConfirm: undefined,
+
+  // Original text: 'Could not forget Client ID'
+  forgetXsCredentialsError: undefined,
+
+  // Original text: 'Client ID forgotten'
+  forgetXsCredentialsSuccess: undefined,
+
+  // Original text: 'Could not upload Client ID'
+  setXsCredentialsError: undefined,
+
+  // Original text: 'Client ID uploaded'
+  setXsCredentialsSuccess: undefined,
+
+  // Original text: 'All VMs'
+  allVms: undefined,
+
+  // Original text: 'Backed up VMs'
+  backedUpVms: undefined,
+
+  // Original text: 'Not backed up VMs'
+  notBackedUpVms: undefined,
 
   // Original text: "Fetching data…"
   homeFetchingData: 'Извлечение  данных…',
 
-  // Original text: "Welcome on Xen Orchestra!"
+  // Original text: "Welcome to Xen Orchestra!"
   homeWelcome: 'Добро пожаловать в Xen Orchestra!',
 
   // Original text: "Add your XCP-ng hosts or pools"
   homeWelcomeText: 'Добавьте свои хосты и пулы XCP-ng',
 
-  // Original text: 'Some XenServers have been registered but are not connected'
+  // Original text: "Some XCP-ng hosts have been registered but are not connected"
   homeConnectServerText: 'Некоторые серверы XenServer зарегистрированы, но не подключены',
 
   // Original text: "Want some help?"
@@ -251,13 +797,13 @@ export default {
   // Original text: "Add server"
   homeAddServer: 'Добавить сервер',
 
-  // Original text: 'Connect servers'
+  // Original text: "Connect servers"
   homeConnectServer: 'Подключить серверы',
 
-  // Original text: "Online Doc"
+  // Original text: "Online doc"
   homeOnlineDoc: 'Онлайн документация',
 
-  // Original text: "Pro Support"
+  // Original text: "Pro support"
   homeProSupport: 'Поддержка уровня "Pro"',
 
   // Original text: "There are no VMs!"
@@ -284,7 +830,7 @@ export default {
   // Original text: "Filters"
   homeFilters: 'Фильтры',
 
-  // Original text: 'No results! Click here to reset your filters'
+  // Original text: "No results! Click here to reset your filters"
   homeNoMatches: 'Ничего не найдено! Нажмите, что-бы сбросить фильтры',
 
   // Original text: "Pool"
@@ -296,10 +842,10 @@ export default {
   // Original text: "VM"
   homeTypeVm: 'ВМ',
 
-  // Original text: "SR"
+  // Original text: 'SR'
   homeTypeSr: undefined,
 
-  // Original text: 'Template'
+  // Original text: "Template"
   homeTypeVmTemplate: 'Шаблон',
 
   // Original text: "Sort"
@@ -314,35 +860,32 @@ export default {
   // Original text: "Tags"
   homeAllTags: 'Тэги',
 
+  // Original text: 'Resource sets'
+  homeAllResourceSets: undefined,
+
   // Original text: "New VM"
   homeNewVm: 'Новая ВМ',
 
   // Original text: 'None'
   homeFilterNone: undefined,
 
-  // Original text: "Running hosts"
-  homeFilterRunningHosts: 'Работающие хосты',
-
   // Original text: "Disabled hosts"
   homeFilterDisabledHosts: 'Отключенные хосты',
-
-  // Original text: "Running VMs"
-  homeFilterRunningVms: 'Работающие ВМ',
-
-  // Original text: "Non running VMs"
-  homeFilterNonRunningVms: 'Выключенные ВМ',
 
   // Original text: "Pending VMs"
   homeFilterPendingVms: 'Ожидание ВМ',
 
-  // Original text: "HVM guests"
+  // Original text: 'HVM guests'
   homeFilterHvmGuests: undefined,
-
-  // Original text: "Tags"
-  homeFilterTags: 'Тэги',
 
   // Original text: "Sort by"
   homeSortBy: 'Сортировать по',
+
+  // Original text: 'CPUs'
+  homeSortByCpus: undefined,
+
+  // Original text: 'Start time'
+  homeSortByStartTime: undefined,
 
   // Original text: "Name"
   homeSortByName: 'Название',
@@ -350,31 +893,34 @@ export default {
   // Original text: "Power state"
   homeSortByPowerstate: 'Состояние питания',
 
-  // Original text: "RAM"
+  // Original text: 'RAM'
   homeSortByRAM: undefined,
 
-  // Original text: "vCPUs"
-  homeSortByvCPUs: undefined,
-
-  // Original text: 'CPUs'
-  homeSortByCpus: undefined,
-
-  // Original text: 'Shared/Not shared'
+  // Original text: "Shared/Not shared"
   homeSortByShared: 'Общий доступ/Без общего доступа',
 
-  // Original text: 'Size'
+  // Original text: "Size"
   homeSortBySize: 'Размер',
 
-  // Original text: 'Usage'
-  homeSortByUsage: 'Используется',
-
-  // Original text: 'Type'
+  // Original text: "Type"
   homeSortByType: 'Тип',
 
-  // Original text: "{displayed, number}x {icon} (on {total, number})"
+  // Original text: "Usage"
+  homeSortByUsage: 'Используется',
+
+  // Original text: 'Snapshots'
+  homeSortVmsBySnapshots: undefined,
+
+  // Original text: 'Container'
+  homeSortByContainer: undefined,
+
+  // Original text: 'Pool'
+  homeSortByPool: undefined,
+
+  // Original text: "{displayed, number}x {icon} (of {total, number})"
   homeDisplayedItems: '{displayed, number}x {icon} (на {total, number})',
 
-  // Original text: "{selected, number}x {icon} selected (on {total, number})"
+  // Original text: "{selected, number}x {icon} selected (of {total, number})"
   homeSelectedItems: '{selected, number}x {icon} выбранных (на {total, number})',
 
   // Original text: "More"
@@ -383,28 +929,127 @@ export default {
   // Original text: "Migrate to…"
   homeMigrateTo: 'Переместить на…',
 
-  // Original text: 'Missing patches'
+  // Original text: "Missing patches"
   homeMissingPatches: 'Отсутствующие исправления',
 
   // Original text: 'Master:'
   homePoolMaster: undefined,
 
-  // Original text: 'Resource set: {resourceSet}'
+  // Original text: "Resource set: {resourceSet}"
   homeResourceSet: 'Набор ресурсов',
 
-  // Original text: 'High Availability'
+  // Original text: 'Some VDIs need to be coalesced'
+  homeSrVdisToCoalesce: undefined,
+
+  // Original text: "High Availability"
   highAvailability: 'Высокая доступность',
 
-  // Original text: 'Shared {type}'
+  // Original text: 'Power state'
+  powerState: undefined,
+
+  // Original text: "Shared {type}"
   srSharedType: 'Общий доступ {type}',
 
-  // Original text: 'Not shared {type}'
-  srNotSharedType: 'Без общего доступа {type}',
+  // Original text: 'Host time and XOA time are not consistent with each other'
+  warningHostTimeTooltip: undefined,
+
+  // Original text: 'Not all hosts within {pool} have the same version'
+  notAllHostsHaveTheSameVersion: undefined,
+
+  // Original text: 'Disks usage'
+  sortByDisksUsage: undefined,
+
+  // Original text: 'Name'
+  snapshotVmsName: undefined,
+
+  // Original text: 'Description'
+  snapshotVmsDescription: undefined,
+
+  // Original text: 'All of them are selected ({nItems, number})'
+  sortedTableAllItemsSelected: undefined,
+
+  // Original text: 'No items found'
+  sortedTableNoItems: undefined,
+
+  // Original text: '{nFiltered, number} of {nTotal, number} items'
+  sortedTableNumberOfFilteredItems: undefined,
+
+  // Original text: '{nTotal, number} items'
+  sortedTableNumberOfItems: undefined,
+
+  // Original text: '{nSelected, number} selected'
+  sortedTableNumberOfSelectedItems: undefined,
+
+  // Original text: 'Click here to select all items'
+  sortedTableSelectAllItems: undefined,
+
+  // Original text: 'GZIP (very slow)'
+  chooseCompressionGzipOption: undefined,
+
+  // Original text: 'Zstd (fast, XCP-ng only)'
+  chooseCompressionZstdOption: undefined,
+
+  // Original text: 'State'
+  state: undefined,
+
+  // Original text: 'Disabled'
+  stateDisabled: undefined,
+
+  // Original text: 'Enabled'
+  stateEnabled: undefined,
+
+  // Original text: 'Disk'
+  labelDisk: undefined,
+
+  // Original text: 'Merge'
+  labelMerge: undefined,
+
+  // Original text: 'Size'
+  labelSize: undefined,
+
+  // Original text: 'Speed'
+  labelSpeed: undefined,
+
+  // Original text: 'SR'
+  labelSr: undefined,
+
+  // Original text: 'Transfer'
+  labelTransfer: undefined,
+
+  // Original text: 'VM'
+  labelVm: undefined,
+
+  // Original text: 'Cancel'
+  formCancel: undefined,
+
+  // Original text: 'Create'
+  formCreate: undefined,
+
+  // Original text: 'Description'
+  formDescription: undefined,
+
+  // Original text: 'Edit'
+  formEdit: undefined,
+
+  // Original text: 'ID'
+  formId: undefined,
+
+  // Original text: 'Name'
+  formName: undefined,
+
+  // Original text: 'Reset'
+  formReset: undefined,
+
+  // Original text: 'Save'
+  formSave: undefined,
+
+  // Original text: 'Notes'
+  formNotes: undefined,
 
   // Original text: "Add"
   add: 'Добавить',
 
-  // Original text: 'Select all'
+  // Original text: "Select all"
   selectAll: 'Выбрать всё',
 
   // Original text: "Remove"
@@ -412,6 +1057,9 @@ export default {
 
   // Original text: "Preview"
   preview: 'Предпросмотр',
+
+  // Original text: 'Action'
+  action: undefined,
 
   // Original text: "Item"
   item: 'Элемент',
@@ -422,46 +1070,58 @@ export default {
   // Original text: "Choose user(s) and/or group(s)"
   selectSubjects: 'Выберите пользователя(ей) и/или группу(ы)',
 
-  // Original text: "Select Object(s)…"
+  // Original text: "Select object(s)…"
   selectObjects: 'Выберите объект(ы)…',
 
   // Original text: "Choose a role"
   selectRole: 'Выберите роль',
 
-  // Original text: "Select Host(s)…"
+  // Original text: 'Select a host first'
+  selectHostFirst: undefined,
+
+  // Original text: "Select host(s)…"
   selectHosts: 'Выберите Хост(ы)…',
 
   // Original text: "Select object(s)…"
   selectHostsVms: 'Выберите объект(ы)…',
 
-  // Original text: "Select Network(s)…"
+  // Original text: "Select network(s)…"
   selectNetworks: 'Выберите сеть/сети…',
+
+  // Original text: 'Select PCI(s)…'
+  selectPcis: undefined,
 
   // Original text: "Select PIF(s)…"
   selectPifs: 'Выберите физический(ие) сетевой(вые) интерфейс(ы)…',
 
-  // Original text: "Select Pool(s)…"
+  // Original text: "Select pool(s)…"
   selectPools: 'Выберите Пул(ы)…',
 
-  // Original text: "Select Remote(s)…"
+  // Original text: "Select remote(s)…"
   selectRemotes: 'Выберите удаленное(ые) хранилище(я)…',
 
-  // Original text: 'Select resource set(s)…'
+  // Original text: 'Select proxy(ies)…'
+  selectProxies: undefined,
+
+  // Original text: 'Select proxy…'
+  selectProxy: undefined,
+
+  // Original text: "Select resource set(s)…"
   selectResourceSets: 'Выберите набор(ы) ресурсов',
 
-  // Original text: 'Select template(s)…'
+  // Original text: "Select template(s)…"
   selectResourceSetsVmTemplate: 'Выберите шаблон(ы)…',
 
-  // Original text: 'Select SR(s)…'
+  // Original text: "Select SR(s)…"
   selectResourceSetsSr: 'Выберите SR(s)…',
 
-  // Original text: 'Select network(s)…'
+  // Original text: "Select network(s)…"
   selectResourceSetsNetwork: 'Выберите сеть(и)…',
 
-  // Original text: 'Select disk(s)…'
+  // Original text: "Select disk(s)…"
   selectResourceSetsVdi: 'Выберите диск(и)…',
 
-  // Original text: 'Select SSH key(s)…'
+  // Original text: "Select SSH key(s)…"
   selectSshKey: 'Выберите SSH-ключ(и)…',
 
   // Original text: "Select SR(s)…"
@@ -469,6 +1129,9 @@ export default {
 
   // Original text: "Select VM(s)…"
   selectVms: 'Выберите виртуальную(ые) машину(ы)…',
+
+  // Original text: 'Select snapshot(s)…'
+  selectVmSnapshots: undefined,
 
   // Original text: "Select VM template(s)…"
   selectVmTemplates: 'Выберите шаблон(ы) ВМ…',
@@ -479,130 +1142,124 @@ export default {
   // Original text: "Select disk(s)…"
   selectVdis: 'Выберите диск(и)…',
 
-  // Original text: 'Select timezone…'
+  // Original text: "Select timezone…"
   selectTimezone: 'Выберите часовой пояс…',
 
-  // Original text: 'Select IP(s)…'
+  // Original text: "Select IP(s)…"
   selectIp: 'Выберите IP-адрес(а)…',
 
-  // Original text: 'Select IP pool(s)…'
+  // Original text: "Select IP pool(s)…"
   selectIpPool: 'Выберите пул(ы) IP-адресов…',
 
-  // Original text: "Fill required informations."
-  fillRequiredInformations: 'Введите данные (обязательно)',
+  // Original text: 'Select VGPU type(s)…'
+  selectVgpuType: undefined,
 
-  // Original text: "Fill informations (optional)"
+  // Original text: "Fill information (optional)"
   fillOptionalInformations: 'Введите данные (опционально)',
 
   // Original text: "Reset"
   selectTableReset: 'Сброс',
 
+  // Original text: 'Select cloud config(s)…'
+  selectCloudConfigs: undefined,
+
+  // Original text: 'Select network config(s)…'
+  selectNetworkConfigs: undefined,
+
   // Original text: "Month"
   schedulingMonth: 'Месяц',
 
-  // Original text: 'Every N month'
-  schedulingEveryNMonth: 'Каждый N-й месяц',
-
-  // Original text: "Each selected month"
-  schedulingEachSelectedMonth: 'Каждый выбранный месяц',
-
-  // Original text: 'Day'
+  // Original text: "Day"
   schedulingDay: 'День',
 
-  // Original text: 'Every N day'
-  schedulingEveryNDay: 'Каждый N-й день',
-
-  // Original text: "Each selected day"
-  schedulingEachSelectedDay: 'Каждый выбранный день',
-
-  // Original text: 'Switch to week days'
+  // Original text: "Switch to week days"
   schedulingSetWeekDayMode: 'Переключиться на дни недели',
 
-  // Original text: 'Switch to month days'
+  // Original text: "Switch to month days"
   schedulingSetMonthDayMode: 'Переключиться на дни месяца',
 
   // Original text: "Hour"
   schedulingHour: 'Час',
 
-  // Original text: "Each selected hour"
-  schedulingEachSelectedHour: 'Каждый выбранный час',
-
-  // Original text: "Every N hour"
-  schedulingEveryNHour: 'Каждый N-й час',
-
   // Original text: "Minute"
   schedulingMinute: 'Минута',
 
-  // Original text: "Each selected minute"
-  schedulingEachSelectedMinute: 'Каждую выбранную минуту',
-
-  // Original text: "Every N minute"
-  schedulingEveryNMinute: 'Каждый N-ая минута',
-
-  // Original text: 'Every month'
+  // Original text: "Every month"
   selectTableAllMonth: 'Каждый месяц',
 
-  // Original text: 'Every day'
+  // Original text: "Every day"
   selectTableAllDay: 'Каждый день',
 
-  // Original text: 'Every hour'
+  // Original text: "Every hour"
   selectTableAllHour: 'Каждый час',
 
-  // Original text: 'Every minute'
+  // Original text: "Every minute"
   selectTableAllMinute: 'Каждую минуту',
 
-  // Original text: "Reset"
-  schedulingReset: 'Сброс',
-
-  // Original text: "Unknown"
-  unknownSchedule: 'Неизвестно',
-
-  // Original text: 'Web browser timezone'
+  // Original text: "Web browser timezone"
   timezonePickerUseLocalTime: 'Часовой пояс WEB-браузера',
 
-  // Original text: 'Server timezone ({value})'
+  // Original text: "Server timezone ({value})"
   serverTimezoneOption: 'Часовой пояс сервера ({value})',
 
-  // Original text: 'Cron Pattern:'
+  // Original text: "Cron Pattern:"
   cronPattern: 'Cron-шаблон: ',
 
-  // Original text: "Cannot edit backup"
-  backupEditNotFoundTitle: 'Невозможно изменить резервную копию',
-
-  // Original text: "Missing required info for edition"
-  backupEditNotFoundMessage: 'Отсутствует информация, необходимая для редактирования',
-
-  // Original text: 'Successful'
+  // Original text: "Successful"
   successfulJobCall: 'Успешно',
 
-  // Original text: 'Failed'
+  // Original text: "Failed"
   failedJobCall: 'Провал',
 
-  // Original text: 'In progress'
+  // Original text: 'Skipped'
+  jobCallSkipped: undefined,
+
+  // Original text: "In progress"
   jobCallInProgess: 'Выполняется',
 
-  // Original text: 'size:'
+  // Original text: "Transfer size:"
   jobTransferredDataSize: 'размер',
 
-  // Original text: 'speed:'
+  // Original text: "Transfer speed:"
   jobTransferredDataSpeed: 'скорость',
+
+  // Original text: 'Size'
+  operationSize: undefined,
+
+  // Original text: 'Speed'
+  operationSpeed: undefined,
+
+  // Original text: 'Type'
+  exportType: undefined,
+
+  // Original text: 'Merge size:'
+  jobMergedDataSize: undefined,
+
+  // Original text: 'Merge speed:'
+  jobMergedDataSpeed: undefined,
+
+  // Original text: 'All'
+  allJobCalls: undefined,
 
   // Original text: "Job"
   job: 'Задача',
 
-  // Original text: 'Job {job}'
+  // Original text: "Job {job}"
   jobModalTitle: 'Задача {job}',
 
   // Original text: "ID"
   jobId: 'ID задачи',
 
-  // Original text: 'Type'
+  // Original text: "Type"
   jobType: 'Тип',
 
   // Original text: "Name"
   jobName: 'Имя',
 
-  // Original text: 'Name of your job (forbidden: "_")'
+  // Original text: 'Modes'
+  jobModes: undefined,
+
+  // Original text: "Name of your job (forbidden: \"_\")"
   jobNamePlaceholder: 'Имя для вашей задачи (запрещено: "_")',
 
   // Original text: "Start"
@@ -626,32 +1283,98 @@ export default {
   // Original text: "Scheduling"
   jobScheduling: 'Расписание',
 
-  // Original text: "State"
-  jobState: 'Состояние',
-
-  // Original text: 'Enabled'
-  jobStateEnabled: 'Включено',
-
-  // Original text: 'Disabled'
-  jobStateDisabled: 'Отключено',
-
-  // Original text: 'Timezone'
+  // Original text: "Timezone"
   jobTimezone: 'Часовой пояс',
 
-  // Original text: 'Server'
+  // Original text: "Server"
   jobServerTimezone: 'Сервер',
 
   // Original text: "Run job"
   runJob: 'Запустить задачу',
 
-  // Original text: "One shot running started. See overview for logs."
+  // Original text: 'Cancel job'
+  cancelJob: undefined,
+
+  // Original text: "Onetime job started. See overview for logs."
   runJobVerbose: 'Запуск резервного копирования вручную. Перейдите в Обзор, чтобы просмотреть журналы.',
+
+  // Original text: 'Edit job'
+  jobEdit: undefined,
+
+  // Original text: 'Delete'
+  jobDelete: undefined,
+
+  // Original text: "Finished"
+  jobFinished: 'Завершено',
+
+  // Original text: 'Interrupted'
+  jobInterrupted: undefined,
 
   // Original text: "Started"
   jobStarted: 'Запущено',
 
-  // Original text: "Finished"
-  jobFinished: 'Завершено',
+  // Original text: 'Failed'
+  jobFailed: undefined,
+
+  // Original text: 'Skipped'
+  jobSkipped: undefined,
+
+  // Original text: 'Successful'
+  jobSuccess: undefined,
+
+  // Original text: 'All'
+  allTasks: undefined,
+
+  // Original text: 'Start'
+  taskStart: undefined,
+
+  // Original text: 'End'
+  taskEnd: undefined,
+
+  // Original text: 'Duration'
+  taskDuration: undefined,
+
+  // Original text: 'Successful'
+  taskSuccess: undefined,
+
+  // Original text: 'Failed'
+  taskFailed: undefined,
+
+  // Original text: 'Skipped'
+  taskSkipped: undefined,
+
+  // Original text: 'Started'
+  taskStarted: undefined,
+
+  // Original text: 'Interrupted'
+  taskInterrupted: undefined,
+
+  // Original text: 'Aborted'
+  taskAborted: undefined,
+
+  // Original text: 'Transfer size'
+  taskTransferredDataSize: undefined,
+
+  // Original text: 'Transfer speed'
+  taskTransferredDataSpeed: undefined,
+
+  // Original text: 'Merge size'
+  taskMergedDataSize: undefined,
+
+  // Original text: 'Merge speed'
+  taskMergedDataSpeed: undefined,
+
+  // Original text: 'Error'
+  taskError: undefined,
+
+  // Original text: 'Estimated end'
+  taskEstimatedEnd: undefined,
+
+  // Original text: 'Reason'
+  taskReason: undefined,
+
+  // Original text: 'Open raw log'
+  taskOpenRawLog: undefined,
 
   // Original text: "Save"
   saveBackupJob: 'Сохранить',
@@ -662,133 +1385,328 @@ export default {
   // Original text: "Are you sure you want to delete this backup job?"
   deleteBackupScheduleQuestion: 'Вы уверены, что хотите удалить это задание резервного копирования?',
 
+  // Original text: 'Delete selected jobs'
+  deleteSelectedJobs: undefined,
+
   // Original text: "Enable immediately after creation"
   scheduleEnableAfterCreation: 'Активировать после создания',
 
-  // Original text: "You are editing Schedule {name} ({id}). Saving will override previous schedule state."
+  // Original text: "You are editing schedule {name} ({id}). Saving will override previous schedule state."
   scheduleEditMessage: 'Вы редактируете расписание {name} ({id}). Текущее состояние будет изменено при сохранении.',
 
   // Original text: "You are editing job {name} ({id}). Saving will override previous job state."
   jobEditMessage: 'Вы редактируете задачу {name} ({id}). Текущее состояние будет изменено при сохранении.',
 
+  // Original text: 'Edit schedule'
+  scheduleEdit: undefined,
+
+  // Original text: "A name is required to create the backup's job!"
+  missingBackupName: undefined,
+
+  // Original text: 'Missing VMs!'
+  missingVms: undefined,
+
+  // Original text: 'You need to choose a backup mode!'
+  missingBackupMode: undefined,
+
+  // Original text: 'Missing remote!'
+  missingRemote: undefined,
+
+  // Original text: 'Missing remotes!'
+  missingRemotes: undefined,
+
+  // Original text: 'Missing SRs!'
+  missingSrs: undefined,
+
+  // Original text: 'Missing pools!'
+  missingPools: undefined,
+
+  // Original text: 'Missing schedules!'
+  missingSchedules: undefined,
+
+  // Original text: 'The modes need at least a schedule with retention higher than 0'
+  missingRetentions: undefined,
+
+  // Original text: 'The Backup mode and the Delta Backup mode require backup retention to be higher than 0!'
+  missingExportRetention: undefined,
+
+  // Original text: 'The CR mode and The DR mode require replication retention to be higher than 0!'
+  missingCopyRetention: undefined,
+
+  // Original text: 'The Rolling Snapshot mode requires snapshot retention to be higher than 0!'
+  missingSnapshotRetention: undefined,
+
+  // Original text: 'Either the full backup interval or the backup retention should be lower than 50.'
+  deltaChainRetentionWarning: undefined,
+
+  // Original text: 'Requires one retention to be higher than 0!'
+  retentionNeeded: undefined,
+
+  // Original text: 'Invalid schedule'
+  newScheduleError: undefined,
+
+  // Original text: 'No remotes found, please click on the remotes settings button to create one!'
+  createRemoteMessage: undefined,
+
+  // Original text: 'Remotes settings'
+  remotesSettings: undefined,
+
+  // Original text: 'Plugins settings'
+  pluginsSettings: undefined,
+
+  // Original text: 'To receive the report, the plugins backup-reports and transport-email need to be loaded.'
+  pluginsWarning: undefined,
+
+  // Original text: 'Add a schedule'
+  scheduleAdd: undefined,
+
+  // Original text: 'Delete'
+  scheduleDelete: undefined,
+
+  // Original text: 'Run schedule'
+  scheduleRun: undefined,
+
+  // Original text: 'Delete selected schedules'
+  deleteSelectedSchedules: undefined,
+
   // Original text: "No scheduled jobs."
   noScheduledJobs: 'Нет запланированных задач',
 
-  // Original text: "No jobs found."
-  noJobs: 'Задачи не найдены',
+  // Original text: 'You can delete all your legacy backup snapshots.'
+  legacySnapshotsLink: undefined,
+
+  // Original text: 'New schedule'
+  newSchedule: undefined,
 
   // Original text: "No schedules found"
   noSchedules: 'Расписания не найдены',
 
-  // Original text: "Select a xo-server API command"
+  // Original text: "Select an xo-server API command"
   jobActionPlaceHolder: 'Выберите команду API xo-server',
 
-  // Original text: ' Timeout (number of seconds after which a VM is considered failed)'
+  // Original text: "Timeout (number of seconds after which a VM is considered failed)"
   jobTimeoutPlaceHolder: 'Таймаут (количество секунд, после которого виртуальная машина считается неисправной)',
 
-  // Original text: 'Schedules'
+  // Original text: "Schedules"
   jobSchedules: 'Расписания',
 
-  // Original text: 'Name of your schedule'
+  // Original text: "Name of your schedule"
   jobScheduleNamePlaceHolder: 'Название расписания',
 
-  // Original text: 'Select a Job'
+  // Original text: "Select a job"
   jobScheduleJobPlaceHolder: 'Выберите задачу',
 
-  // Original text: 'Job owner'
+  // Original text: "Job owner"
   jobOwnerPlaceholder: 'Владелец задачи',
 
   // Original text: "This job's creator no longer exists"
   jobUserNotFound: 'Создатель задачи больше не существует',
 
-  // Original text: "This backup's creator no longer exists"
-  backupUserNotFound: 'Создатель резервной копии больше не существует',
+  // Original text: 'Click here to see the matching VMs'
+  redirectToMatchingVms: undefined,
 
-  // Original text: 'Backup owner'
-  backupOwner: 'Владелец резервной копии',
+  // Original text: 'There are no matching VMs!'
+  noMatchingVms: undefined,
+
+  // Original text: '{icon} See the matching VMs ({nMatchingVms, number})'
+  allMatchingVms: undefined,
+
+  // Original text: 'Are you sure you want to run {name} ({id})?'
+  runBackupNgJobConfirm: undefined,
+
+  // Original text: 'This job will backup {nVms, number} VM{nVms, plural, one {} other {s}}.'
+  runBackupJobWarningNVms: undefined,
+
+  // Original text: 'Are you sure you want to cancel {name} ({id})?'
+  cancelJobConfirm: undefined,
+
+  // Original text: 'If your country participates in DST, it is advised that you avoid scheduling jobs at the time of change. e.g. 2AM to 3AM for US.'
+  scheduleDstWarning: undefined,
+
+  // Original text: 'Restore health check'
+  checkBackup: undefined,
+
+  // Original text: 'Advanced settings'
+  newBackupAdvancedSettings: undefined,
+
+  // Original text: 'Settings'
+  newBackupSettings: undefined,
+
+  // Original text: 'Always'
+  reportWhenAlways: undefined,
+
+  // Original text: 'Failure'
+  reportWhenFailure: undefined,
+
+  // Original text: 'Never'
+  reportWhenNever: undefined,
+
+  // Original text: 'Report recipients'
+  reportRecipients: undefined,
+
+  // Original text: 'Report when'
+  reportWhen: undefined,
+
+  // Original text: 'Concurrency'
+  concurrency: undefined,
 
   // Original text: "Select your backup type:"
   newBackupSelection: 'Выберите тип резервной копии:',
 
-  // Original text: 'Select backup mode:'
-  smartBackupModeSelection: 'Выберите режим резервного копирования',
+  // Original text: 'Snapshot retention'
+  snapshotRetention: undefined,
 
-  // Original text: 'Normal backup'
-  normalBackup: 'Обычное резервное копирование',
+  // Original text: 'Name'
+  backupName: undefined,
 
-  // Original text: 'Smart backup'
-  smartBackup: 'Умное резервное копирование',
+  // Original text: 'Checkpoint snapshot'
+  checkpointSnapshot: undefined,
+
+  // Original text: 'Offline snapshot'
+  offlineSnapshot: undefined,
+
+  // Original text: 'Offline backup'
+  offlineBackup: undefined,
+
+  // Original text: 'Export VMs without snapshotting them. The VMs will be shutdown during the export.'
+  offlineBackupInfo: undefined,
+
+  // Original text: 'Timeout'
+  timeout: undefined,
+
+  // Original text: 'Number of hours after which a job is considered failed'
+  timeoutInfo: undefined,
+
+  // Original text: 'Full backup interval'
+  fullBackupInterval: undefined,
+
+  // Original text: 'Force full backup'
+  forceFullBackup: undefined,
+
+  // Original text: 'In hours'
+  timeoutUnit: undefined,
+
+  // Original text: 'Delta Backup and DR require an Enterprise plan'
+  dbAndDrRequireEnterprisePlan: undefined,
+
+  // Original text: 'CR requires a Premium plan'
+  crRequiresPremiumPlan: undefined,
+
+  // Original text: 'Smart mode'
+  smartBackupModeTitle: undefined,
+
+  // Original text: 'Target remotes (for export)'
+  backupTargetRemotes: undefined,
+
+  // Original text: 'Target SRs (for replication)'
+  backupTargetSrs: undefined,
 
   // Original text: 'Local remote selected'
   localRemoteWarningTitle: undefined,
 
-  // Original text: 'Warning: local remotes will use limited XOA disk space. Only for advanced users.'
+  // Original text: 'Tip: Using thin-provisioned storage will consume less space. Please click on the icon to get more information'
+  crOnThickProvisionedSrWarning: undefined,
+
+  // Original text: 'Tip: Creating VMs on thin-provisioned storage will consume less space. Please click on the icon to get more information'
+  vmsOnThinProvisionedSrTip: undefined,
+
+  // Original text: 'Delta Backup and Continuous Replication require at least XenServer 6.5.'
+  deltaBackupOnOutdatedXenServerWarning: undefined,
+
+  // Original text: 'Click for more information about the backup methods.'
+  backupNgLinkToDocumentationMessage: undefined,
+
+  // Original text: 'Warning: Local remotes will use limited XOA disk space. Only for advanced users.'
   localRemoteWarningMessage: undefined,
 
-  // Original text: 'Warning: this feature works only with XenServer 6.5 or newer.'
-  backupVersionWarning: 'Внимание: эта функция работает только с XenServer версии 6.5 или новее',
-
-  // Original text: 'VMs'
+  // Original text: "VMs"
   editBackupVmsTitle: 'ВМ',
 
-  // Original text: 'VMs statuses'
+  // Original text: "VMs statuses"
   editBackupSmartStatusTitle: 'Статусы ВМ',
 
   // Original text: 'Resident on'
   editBackupSmartResidentOn: undefined,
 
-  // Original text: 'Pools'
+  // Original text: 'Not resident on'
+  editBackupSmartNotResidentOn: undefined,
+
+  // Original text: "Pools"
   editBackupSmartPools: 'Пулы',
 
-  // Original text: 'Tags'
+  // Original text: "Tags"
   editBackupSmartTags: 'Тэги',
 
-  // Original text: 'VMs Tags'
+  // Original text: "VMs with tags in the form of <b>xo:no-bak</b> or <b>xo:no-bak=Reason</b>won't be included in any backup.For example, ephemeral VMs created by health check have this tag"
+  editBackupSmartTagsInfo: undefined,
+
+  // Original text: 'Sample of matching VMs'
+  sampleOfMatchingVms: undefined,
+
+  // Original text: 'Replicated VMs (VMs with Continuous Replication or Disaster Recovery tag) must be excluded!'
+  backupReplicatedVmsInfo: undefined,
+
+  // Original text: "VMs Tags"
   editBackupSmartTagsTitle: 'Тэги ВМ',
 
-  // Original text: 'Reverse'
-  editBackupNot: undefined,
+  // Original text: 'Excluded VMs tags'
+  editBackupSmartExcludedTagsTitle: undefined,
 
-  // Original text: 'Tag'
-  editBackupTagTitle: 'Тэг',
-
-  // Original text: 'Report'
-  editBackupReportTitle: 'Отчет',
-
-  // Original text: 'Automatically run as scheduled'
-  editBackupScheduleEnabled: 'Автоматический запуск по расписанию',
-
-  // Original text: 'Depth'
-  editBackupDepthTitle: 'Глубина',
-
-  // Original text: 'Remote'
-  editBackupRemoteTitle: undefined,
-
-  // Original text: 'Delete the old backups first'
+  // Original text: "Delete first"
   deleteOldBackupsFirst: 'Сперва удалите старые резервные копии',
 
-  // Original text: "Remote stores for backup"
-  remoteList: undefined,
+  // Original text: 'Delete old backups before backing up the VMs. If the new backup fails, you will lose your old backups.'
+  deleteOldBackupsFirstMessage: undefined,
 
-  // Original text: "New File System Remote"
+  // Original text: 'Custom tag'
+  customTag: undefined,
+
+  // Original text: "The job you're trying to edit wasn't found"
+  editJobNotFound: undefined,
+
+  // Original text: 'Use NBD + CBT to transfer disk if available'
+  preferNbd: undefined,
+
+  // Original text: 'A network accessible by XO or the proxy must have NBD enabled. Storage must support Change Block Tracking (CBT) to use it in a backup'
+  preferNbdInformation: undefined,
+
+  // Original text: 'Number of NBD connection per disk'
+  nbdConcurrency: undefined,
+
+  // Original text: 'Purge snapshot data when using CBT'
+  cbtDestroySnapshotData: undefined,
+
+  // Original text: "The snapshot won't use any notable space on the SR, won't be shown in the UI and won't be usable to do a rollback"
+  cbtDestroySnapshotDataInformation: undefined,
+
+  // Original text: 'Snapshot data can be purged only when NBD is enabled and rolling snapshot is not used'
+  cbtDestroySnapshotDataDisabledInformation: undefined,
+
+  // Original text: 'New file system remote'
   newRemote: undefined,
 
   // Original text: "Local"
   remoteTypeLocal: 'Локальный',
 
-  // Original text: "NFS"
+  // Original text: 'NFS'
   remoteTypeNfs: undefined,
 
-  // Original text: "SMB"
+  // Original text: 'SMB'
   remoteTypeSmb: undefined,
+
+  // Original text: 'Amazon Web Services S3'
+  remoteTypeS3: undefined,
 
   // Original text: "Type"
   remoteType: 'Тип',
 
+  // Original text: 'SMB remotes are meant to work with Windows Server. For other systems (Linux Samba, which means almost all NAS), please use NFS.'
+  remoteSmbWarningMessage: undefined,
+
   // Original text: 'Test your remote'
   remoteTestTip: undefined,
 
-  // Original text: 'Test Remote'
+  // Original text: 'Test remote'
   testRemote: undefined,
 
   // Original text: 'Test failed for {name}'
@@ -797,14 +1715,11 @@ export default {
   // Original text: 'Test passed for {name}'
   remoteTestSuccess: undefined,
 
-  // Original text: 'Error'
+  // Original text: "Error"
   remoteTestError: 'Ошибка',
 
-  // Original text: 'Test Step'
+  // Original text: 'Test step'
   remoteTestStep: undefined,
-
-  // Original text: 'Test file'
-  remoteTestFile: undefined,
 
   // Original text: 'Test name'
   remoteTestName: undefined,
@@ -815,67 +1730,88 @@ export default {
   // Original text: 'The remote appears to work correctly'
   remoteTestSuccessMessage: undefined,
 
-  // Original text: 'Connection failed'
+  // Original text: "Connection failed"
   remoteConnectionFailed: 'Подключение не удалось',
 
-  // Original text: 'Name'
+  // Original text: 'Delete backup job{nJobs, plural, one {} other {s}}'
+  confirmDeleteBackupJobsTitle: undefined,
+
+  // Original text: 'Are you sure you want to delete {nJobs, number} backup job{nJobs, plural, one {} other {s}}?'
+  confirmDeleteBackupJobsBody: undefined,
+
+  // Original text: 'Mirror full backup'
+  mirrorFullBackup: undefined,
+
+  // Original text: 'Mirror incremental backup'
+  mirrorIncrementalBackup: undefined,
+
+  // Original text: 'Run backup job once'
+  runBackupJob: undefined,
+
+  // Original text: 'Speed limit (in MiB/s)'
+  speedLimit: undefined,
+
+  // Original text: 'Source remote'
+  sourceRemote: undefined,
+
+  // Original text: 'Target remotes'
+  targetRemotes: undefined,
+
+  // Original text: "Name"
   remoteName: 'Имя',
 
-  // Original text: 'Path'
+  // Original text: "Path"
   remotePath: 'Путь',
 
-  // Original text: 'State'
+  // Original text: "State"
   remoteState: 'Состояние',
 
-  // Original text: 'Device'
+  // Original text: "Device"
   remoteDevice: 'Устройство',
+
+  // Original text: 'Disk (Used / Total)'
+  remoteDisk: undefined,
+
+  // Original text: 'Speed (Write / Read)'
+  remoteSpeed: undefined,
+
+  // Original text: 'Read and write rate speed performed during latest test'
+  remoteSpeedInfo: undefined,
+
+  // Original text: 'Options'
+  remoteOptions: undefined,
 
   // Original text: 'Share'
   remoteShare: undefined,
 
-  // Original text: 'Action'
-  remoteAction: 'Действие',
-
-  // Original text: 'Auth'
+  // Original text: "Auth"
   remoteAuth: 'Авторизация',
 
-  // Original text: 'Mounted'
-  remoteMounted: undefined,
-
-  // Original text: 'Unmounted'
-  remoteUnmounted: undefined,
-
-  // Original text: 'Connect'
-  remoteConnectTip: 'Подключить',
-
-  // Original text: 'Disconnect'
-  remoteDisconnectTip: 'Отключить',
-
-  // Original text: 'Connected'
-  remoteConnected: 'Подключено',
-
-  // Original text: 'Disconnected'
-  remoteDisconnected: 'Отключено',
-
-  // Original text: 'Delete'
+  // Original text: "Delete"
   remoteDeleteTip: 'Удалить',
 
-  // Original text: 'remote name *'
-  remoteNamePlaceHolder: undefined,
+  // Original text: 'Delete selected remotes'
+  remoteDeleteSelected: undefined,
 
-  // Original text: 'Name *'
+  // Original text: "Name"
   remoteMyNamePlaceHolder: 'Имя *',
 
   // Original text: '/path/to/backup'
   remoteLocalPlaceHolderPath: undefined,
 
-  // Original text: 'host *'
+  // Original text: "Host"
   remoteNfsPlaceHolderHost: 'хост *',
+
+  // Original text: 'Port'
+  remoteNfsPlaceHolderPort: undefined,
 
   // Original text: 'path/to/backup'
   remoteNfsPlaceHolderPath: undefined,
 
-  // Original text: 'subfolder [path\\to\\backup]'
+  // Original text: 'Custom mount options'
+  remoteNfsPlaceHolderOptions: undefined,
+
+  // Original text: 'Subfolder [path\\\\to\\\\backup]'
   remoteSmbPlaceHolderRemotePath: undefined,
 
   // Original text: 'Username'
@@ -887,11 +1823,80 @@ export default {
   // Original text: 'Domain'
   remoteSmbPlaceHolderDomain: undefined,
 
-  // Original text: '<address>\\<share> *'
+  // Original text: '<address>\\\\<share>'
   remoteSmbPlaceHolderAddressShare: undefined,
 
-  // Original text: 'password(fill to edit)'
+  // Original text: 'Custom mount options'
+  remoteSmbPlaceHolderOptions: undefined,
+
+  // Original text: 'Use HTTPS'
+  remoteS3LabelUseHttps: undefined,
+
+  // Original text: 'Allow unauthorized'
+  remoteS3LabelAllowInsecure: undefined,
+
+  // Original text: 'AWS S3 endpoint (ex: s3.us-east-2.amazonaws.com)'
+  remoteS3PlaceHolderEndpoint: undefined,
+
+  // Original text: 'AWS S3 bucket name'
+  remoteS3PlaceHolderBucket: undefined,
+
+  // Original text: 'Directory'
+  remoteS3PlaceHolderDirectory: undefined,
+
+  // Original text: 'Access key ID'
+  remoteS3PlaceHolderAccessKeyID: undefined,
+
+  // Original text: 'Paste secret here to change it'
+  remoteS3PlaceHolderSecret: undefined,
+
+  // Original text: 'Enter your encryption key here (32 characters)'
+  remoteS3PlaceHolderEncryptionKey: undefined,
+
+  // Original text: 'Region, leave blank for default'
+  remoteS3Region: undefined,
+
+  // Original text: 'Uncheck if you want HTTP instead of HTTPS'
+  remoteS3TooltipProtocol: undefined,
+
+  // Original text: 'Check if you want to accept self signed certificates'
+  remoteS3TooltipAcceptInsecure: undefined,
+
+  // Original text: 'Password(fill to edit)'
   remotePlaceHolderPassword: undefined,
+
+  // Original text: 'Store backup as multiple data blocks instead of a whole VHD file. (creates 500-1000 files per backed up GB but allows faster merge)'
+  remoteUseVhdDirectory: undefined,
+
+  // Original text: 'Your remote must be able to handle parallel access (up to 16 write processes per backup) and the number of files (500-1000 files per GB of backed up data)'
+  remoteUseVhdDirectoryTooltip: undefined,
+
+  // Original text: 'Size of backup is not updated when using encryption.'
+  remoteEncryptionBackupSize: undefined,
+
+  // Original text: 'All the files of the remote except the encryption.json are encrypted, that means you can only activate encryption or change key on an empty remote.'
+  remoteEncryptionEncryptedfiles: undefined,
+
+  // Original text: 'Delta backup must use VHD saved as blocks (note: should be enforced when saving settings)'
+  remoteEncryptionMustUseVhd: undefined,
+
+  // Original text: 'Encrypt all new data sent to this remote'
+  remoteEncryptionKey: undefined,
+
+  // Original text: "You won't be able to get your data back if you lose the encryption key. The encryption key is saved in the XO config backup, they should be secured correctly. Be careful, if you saved it on an encrypted remote, then you won't be able to access it without the remote encryption key."
+  remoteEncryptionKeyStorageLocation: undefined,
+
+  // Original text: 'Encryption'
+  encryption: undefined,
+
+  // Original text: 'A legacy encryption algorithm is used ({algorithm}), please create a new remote with the recommended algorithm {recommendedAlgorithm}'
+  remoteEncryptionLegacy: undefined,
+
+  // Original text: 'New SR'
+  newSr: undefined,
+
+  // Original text: 'This will erase the entire disk or partition ({name}) to create a new storage repository. Are you sure you want to continue?'
+  newSrConfirm: undefined,
 
   // Original text: 'Create a new SR'
   newSrTitle: undefined,
@@ -899,16 +1904,16 @@ export default {
   // Original text: "General"
   newSrGeneral: 'Общий',
 
-  // Original text: "Select Storage Type:"
+  // Original text: "Select storage type:"
   newSrTypeSelection: 'Выберите тип хранилища:',
 
   // Original text: "Settings"
   newSrSettings: 'Настройки',
 
-  // Original text: "Storage Usage"
+  // Original text: "Storage usage"
   newSrUsage: 'Использование хранилища',
 
-  // Original text: "Summary"
+  // Original text: 'Summary'
   newSrSummary: undefined,
 
   // Original text: "Host"
@@ -929,16 +1934,19 @@ export default {
   // Original text: "Path"
   newSrPath: 'Путь',
 
-  // Original text: "IQN"
+  // Original text: 'IQN'
   newSrIqn: undefined,
 
-  // Original text: "LUN"
+  // Original text: 'LUN'
   newSrLun: undefined,
 
-  // Original text: "with auth."
+  // Original text: 'No HBA devices'
+  newSrNoHba: undefined,
+
+  // Original text: "With auth."
   newSrAuth: 'с авторизацией',
 
-  // Original text: "User Name"
+  // Original text: "User name"
   newSrUsername: 'Имя пользователя',
 
   // Original text: "Password"
@@ -947,7 +1955,7 @@ export default {
   // Original text: "Device"
   newSrDevice: 'Устройство',
 
-  // Original text: "in use"
+  // Original text: "In use"
   newSrInUse: 'используется',
 
   // Original text: "Size"
@@ -956,22 +1964,28 @@ export default {
   // Original text: "Create"
   newSrCreate: 'Создать',
 
-  // Original text: 'Storage name'
+  // Original text: "Storage name"
   newSrNamePlaceHolder: 'Имя хранилища',
 
-  // Original text: 'Storage description'
+  // Original text: "Storage description"
   newSrDescPlaceHolder: 'Описание хранилища',
 
-  // Original text: 'Address'
-  newSrAddressPlaceHolder: 'Адрес',
+  // Original text: 'e.g 93.184.216.34 or iscsi.example.net'
+  newSrIscsiAddressPlaceHolder: undefined,
 
-  // Original text: '[port]'
+  // Original text: 'e.g 93.184.216.34 or nfs.example.net'
+  newSrNfsAddressPlaceHolder: undefined,
+
+  // Original text: 'e.g \\\\server\\sharename'
+  newSrSmbAddressPlaceHolder: undefined,
+
+  // Original text: "[port]"
   newSrPortPlaceHolder: '[порт]',
 
-  // Original text: 'Username'
+  // Original text: "Username"
   newSrUsernamePlaceHolder: 'Имя пользователя',
 
-  // Original text: 'Password'
+  // Original text: "Password"
   newSrPasswordPlaceHolder: 'Пароль',
 
   // Original text: 'Device, e.g /dev/sda…'
@@ -980,49 +1994,97 @@ export default {
   // Original text: '/path/to/directory'
   newSrLocalPathPlaceHolder: undefined,
 
+  // Original text: 'Default NFS version'
+  newSrNfsDefaultVersion: undefined,
+
+  // Original text: 'Comma delimited NFS options'
+  newSrNfsOptions: undefined,
+
+  // Original text: 'NFS version'
+  newSrNfs: undefined,
+
+  // Original text: 'No shared ZFS available'
+  noSharedZfsAvailable: undefined,
+
+  // Original text: 'Reattach SR'
+  reattachNewSrTooltip: undefined,
+
+  // Original text: 'Storage location'
+  srLocation: undefined,
+
+  // Original text: 'You do not have permission to create a network'
+  createNewNetworkNoPermission: undefined,
+
+  // Original text: 'Create a new network on {select}'
+  createNewNetworkOn: undefined,
+
   // Original text: "Users/Groups"
   subjectName: 'Пользователи/Группы',
 
   // Original text: "Object"
   objectName: 'Объект',
 
-  // Original text: 'No acls found'
-  aclNoneFound: 'Не найдены права доступа',
-
   // Original text: "Role"
   roleName: 'Роль',
 
-  // Original text: 'Create'
+  // Original text: "Create"
   aclCreate: 'Создать',
 
-  // Original text: "New Group Name"
+  // Original text: "New group name"
   newGroupName: 'Имя новой группы',
 
-  // Original text: "Create Group"
+  // Original text: "Create group"
   createGroup: 'Создать группу',
+
+  // Original text: 'Synchronize LDAP groups'
+  syncLdapGroups: undefined,
+
+  // Original text: 'Install and configure the auth-ldap plugin first'
+  ldapPluginNotConfigured: undefined,
+
+  // Original text: 'Are you sure you want to synchronize LDAP groups with XO? This may delete XO groups and their ACLs.'
+  syncLdapGroupsWarning: undefined,
 
   // Original text: "Create"
   createGroupButton: 'Создать',
 
-  // Original text: "Delete Group"
+  // Original text: "Delete group"
   deleteGroup: 'Удалить группу',
 
   // Original text: "Are you sure you want to delete this group?"
   deleteGroupConfirm: 'Вы уверены, что хотите удалить эту группу?',
 
-  // Original text: "Remove user from Group"
+  // Original text: 'Delete selected groups'
+  deleteSelectedGroups: undefined,
+
+  // Original text: 'Delete group{nGroups, plural, one {} other {s}}'
+  deleteGroupsModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to delete {nGroups, number} group{nGroups, plural, one {} other {s}}?'
+  deleteGroupsModalMessage: undefined,
+
+  // Original text: "Remove user from group"
   removeUserFromGroup: 'Удалить пользователя из группы',
 
   // Original text: "Are you sure you want to delete this user?"
   deleteUserConfirm: 'Вы уверены, что хотите удалить этого пользователя?',
 
-  // Original text: "Delete User"
+  // Original text: "Delete user"
   deleteUser: 'Удалить пользователя',
 
-  // Original text: 'no user'
+  // Original text: 'Delete selected users'
+  deleteSelectedUsers: undefined,
+
+  // Original text: 'Delete user{nUsers, plural, one {} other {s}}'
+  deleteUsersModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to delete {nUsers, number} user{nUsers, plural, one {} other {s}}?'
+  deleteUsersModalMessage: undefined,
+
+  // Original text: 'No user'
   noUser: undefined,
 
-  // Original text: "unknown user"
+  // Original text: "Unknown user"
   unknownUser: 'неизвестный пользователь',
 
   // Original text: "No group found"
@@ -1034,19 +2096,25 @@ export default {
   // Original text: "Users"
   groupUsersColumn: 'Пользователи',
 
-  // Original text: "Add User"
+  // Original text: "Add user"
   addUserToGroupColumn: 'Добавить пользователя',
 
-  // Original text: "Email"
+  // Original text: "Username"
   userNameColumn: 'Email',
+
+  // Original text: 'Member of'
+  userGroupsColumn: undefined,
+
+  // Original text: '{nGroups, number} group{nGroups, plural, one {} other {s}}'
+  userCountGroups: undefined,
 
   // Original text: "Permissions"
   userPermissionColumn: 'Разрешения',
 
-  // Original text: "Password"
-  userPasswordColumn: 'Пароль',
+  // Original text: 'Password / Authentication methods'
+  userAuthColumn: undefined,
 
-  // Original text: "Email"
+  // Original text: 'Username'
   userName: undefined,
 
   // Original text: "Password"
@@ -1070,8 +2138,20 @@ export default {
   // Original text: "{users, number} user{users, plural, one {} other {s}}"
   countUsers: '{users, number} пользователь{users, plural, one {} other {s}}',
 
-  // Original text: "Select Permission"
+  // Original text: 'Select permission'
   selectPermission: undefined,
+
+  // Original text: 'Delete ACL'
+  deleteAcl: undefined,
+
+  // Original text: 'Delete selected ACLs'
+  deleteSelectedAcls: undefined,
+
+  // Original text: 'Delete ACL{nAcls, plural, one {} other {s}}'
+  deleteAclsModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to delete {nAcls, number} ACL{nAcls, plural, one {} other {s}}?'
+  deleteAclsModalMessage: undefined,
 
   // Original text: 'No plugins found'
   noPlugins: undefined,
@@ -1085,8 +2165,14 @@ export default {
   // Original text: "Delete configuration"
   deletePluginConfiguration: 'Удалить конфигурацию',
 
+  // Original text: 'The test appears to be working.'
+  pluginConfirmation: undefined,
+
   // Original text: "Plugin error"
   pluginError: 'Ошибка плагина',
+
+  // Original text: 'Plugin test'
+  pluginTest: undefined,
 
   // Original text: "Unknown error"
   unknownPluginError: 'Неизвестная ошибка',
@@ -1094,11 +2180,8 @@ export default {
   // Original text: "Purge plugin configuration"
   purgePluginConfiguration: 'Сбросить конфигурацию плагина',
 
-  // Original text: "Are you sure you want to purge this configuration ?"
+  // Original text: "Are you sure you want to purge this configuration?"
   purgePluginConfigurationQuestion: 'Вы уверены, что хотите сбросить эту конфигурацию?',
-
-  // Original text: "Edit"
-  editPluginConfiguration: 'Изменить',
 
   // Original text: "Cancel"
   cancelPluginEdition: 'Отменить',
@@ -1109,65 +2192,80 @@ export default {
   // Original text: "Plugin configuration successfully saved!"
   pluginConfigurationChanges: 'Конфигурация плагина успешно сохранена!',
 
-  // Original text: 'Predefined configuration'
+  // Original text: "Predefined configuration"
   pluginConfigurationPresetTitle: 'Предопределенная конфигурация',
 
-  // Original text: 'Choose a predefined configuration.'
+  // Original text: "Choose a predefined configuration."
   pluginConfigurationChoosePreset: 'Выберите предопределенную конфигурацию',
 
-  // Original text: 'Apply'
+  // Original text: "Apply"
   applyPluginPreset: 'Применить',
 
-  // Original text: 'Save filter error'
+  // Original text: 'This plugin is not loaded'
+  disabledTestPluginTootltip: undefined,
+
+  // Original text: "Save filter error"
   saveNewUserFilterErrorTitle: 'Сохранить фильтр ошибок',
 
-  // Original text: 'Bad parameter: name must be given.'
+  // Original text: "Bad parameter: name must be given."
   saveNewUserFilterErrorBody: 'Неверный параметр: имя должно быть задано',
 
-  // Original text: 'Name:'
+  // Original text: "Name:"
   filterName: 'Имя',
 
-  // Original text: 'Value:'
+  // Original text: "Value:"
   filterValue: 'Значение',
 
-  // Original text: 'Save new filter'
+  // Original text: "Save new filter"
   saveNewFilterTitle: 'Сохранить новый фильтр',
 
-  // Original text: 'Set custom filters'
-  setUserFiltersTitle: 'Задать пользовательский фильтр',
-
-  // Original text: 'Are you sure you want to set custom filters?'
-  setUserFiltersBody: 'Вы уверены, что хотите установить пользовательские фильтры?',
-
-  // Original text: 'Remove custom filter'
+  // Original text: "Remove custom filter"
   removeUserFilterTitle: 'Удалить пользовательский фильтр',
 
-  // Original text: 'Are you sure you want to remove custom filter?'
+  // Original text: "Are you sure you want to remove the custom filter?"
   removeUserFilterBody: 'Вы уверены, что хотите удалить пользовательский фильтр?',
 
-  // Original text: 'Default filter'
+  // Original text: "Default filter"
   defaultFilter: 'Фильтр по умолчанию',
 
-  // Original text: 'Default filters'
+  // Original text: "Default filters"
   defaultFilters: 'Фильтры по умолчанию',
 
-  // Original text: 'Custom filters'
+  // Original text: "Custom filters"
   customFilters: 'Пользовательские фильтры',
 
-  // Original text: 'Customize filters'
+  // Original text: "Customize filters"
   customizeFilters: 'Настройка фильтров',
 
-  // Original text: 'Save custom filters'
-  saveCustomFilters: 'Сохранение пользовательских фильтров',
+  // Original text: 'Interpool copy requires at least Enterprise plan'
+  cantInterPoolCopy: undefined,
+
+  // Original text: 'Copy the export URL of the VM'
+  copyExportedUrl: undefined,
+
+  // Original text: 'Download VM'
+  downloadVm: undefined,
 
   // Original text: "Start"
   startVmLabel: 'Запустить',
+
+  // Original text: 'Start on…'
+  startVmOnLabel: undefined,
+
+  // Original text: 'No host selected'
+  startVmOnMissingHostTitle: undefined,
+
+  // Original text: 'You must select a host'
+  startVmOnMissingHostMessage: undefined,
 
   // Original text: "Recovery start"
   recoveryModeLabel: 'Запустить восстановление',
 
   // Original text: "Suspend"
   suspendVmLabel: 'Приостановить',
+
+  // Original text: 'Pause'
+  pauseVmLabel: undefined,
 
   // Original text: "Stop"
   stopVmLabel: 'Остановить',
@@ -1183,6 +2281,9 @@ export default {
 
   // Original text: "Delete"
   deleteVmLabel: 'Удалить',
+
+  // Original text: 'Delete selected VMs'
+  deleteSelectedVmsLabel: undefined,
 
   // Original text: "Migrate"
   migrateVmLabel: 'Переместить',
@@ -1202,14 +2303,77 @@ export default {
   // Original text: "Clone"
   cloneVmLabel: 'Клонировать',
 
+  // Original text: 'Clean VM directory'
+  cleanVm: undefined,
+
   // Original text: "Fast clone"
   fastCloneVmLabel: 'Быстрое клонирование',
 
-  // Original text: "Convert to template"
-  convertVmToTemplateLabel: 'Преобразовать в шаблон',
+  // Original text: 'Start the migrated VM'
+  startMigratedVm: undefined,
 
   // Original text: "Console"
   vmConsoleLabel: 'Консоль',
+
+  // Original text: 'The URL is valid once for a short period of time.'
+  vmExportUrlValidity: undefined,
+
+  // Original text: 'Warm migration'
+  vmWarmMigration: undefined,
+
+  // Original text: 'Warm migration process will first create a copy of the VM on the destination while the source VM is still running, then shutdown the source VM and send the changes that happened during the migration to the destination to minimize downtime.'
+  vmWarmMigrationProcessInfo: undefined,
+
+  // Original text: 'Backup'
+  backupLabel: undefined,
+
+  // Original text: '{n, number} base cop{n, plural, one {y} other {ies}} ({usage})'
+  baseCopyTooltip: undefined,
+
+  // Original text: '{name} ({usage})'
+  diskTooltip: undefined,
+
+  // Original text: '{n, number} snapshot{n, plural, one {} other {s}} ({usage})'
+  snapshotsTooltip: undefined,
+
+  // Original text: '{name} ({usage}) on {vmName}'
+  vdiOnVmTooltip: undefined,
+
+  // Original text: '{n, number} VDI{n, plural, one {} other {s}} ({usage})'
+  vdisTooltip: undefined,
+
+  // Original text: 'Provisioning'
+  provisioning: undefined,
+
+  // Original text: 'Depth'
+  srUnhealthyVdiDepth: undefined,
+
+  // Original text: 'Name'
+  srUnhealthyVdiNameLabel: undefined,
+
+  // Original text: 'Size'
+  srUnhealthyVdiSize: undefined,
+
+  // Original text: 'VDI to coalesce ({total, number})'
+  srUnhealthyVdiTitle: undefined,
+
+  // Original text: 'UUID'
+  srUnhealthyVdiUuid: undefined,
+
+  // Original text: 'No stats'
+  srNoStats: undefined,
+
+  // Original text: 'IOPS'
+  statsIops: undefined,
+
+  // Original text: 'IO throughput'
+  statsIoThroughput: undefined,
+
+  // Original text: 'Latency'
+  statsLatency: undefined,
+
+  // Original text: 'IOwait'
+  statsIowait: undefined,
 
   // Original text: "Rescan all disks"
   srRescan: 'Перечитать все диски',
@@ -1226,41 +2390,116 @@ export default {
   // Original text: 'Forget SRs'
   srsForget: undefined,
 
+  // Original text: 'Forget {nSrs, number} SR{nSrs, plural, one {} other{s}}'
+  nSrsForget: undefined,
+
   // Original text: "Remove this SR"
   srRemoveButton: 'Удалить этот SR',
 
   // Original text: "No VDIs in this storage"
   srNoVdis: 'На этом хранилище нет VDI',
 
+  // Original text: 'Reclaim freed space'
+  srReclaimSpace: undefined,
+
+  // Original text: 'Are you sure you want to reclaim freed space on this SR?'
+  srReclaimSpaceConfirm: undefined,
+
+  // Original text: 'Space reclaim not supported. Only supported on block based/LVM based SRs.'
+  srReclaimSpaceNotSupported: undefined,
+
+  // Original text: '{firstVdi} and {nVdis} more'
+  multipleActiveVdis: undefined,
+
+  // Original text: 'No active VDI'
+  noActiveVdi: undefined,
+
+  // Original text: 'Earliest expiration: {dateString}'
+  earliestExpirationDate: undefined,
+
+  // Original text: 'No XCP-ng Pro support enabled on this pool'
+  poolNoSupport: undefined,
+
+  // Original text: 'Only {nHostsLicense, number} host{nHostsLicense, plural, one {} other {s}} under license on {nHosts, number} host{nHosts, plural, one {} other {s}}. This means this pool is not supported at all until you license all its hosts.'
+  poolPartialSupport: undefined,
+
   // Original text: 'Pool RAM usage:'
   poolTitleRamUsage: undefined,
 
-  // Original text: '{used} used on {total}'
+  // Original text: '{used} used of {total} ({free} free)'
   poolRamUsage: undefined,
 
   // Original text: 'Master:'
   poolMaster: undefined,
 
-  // Original text: 'Display all hosts of this pool'
+  // Original text: "Display all hosts of this pool"
   displayAllHosts: 'Отобразить все хосты в этом пуле',
 
-  // Original text: 'Display all storages of this pool'
+  // Original text: "Display all storage for this pool"
   displayAllStorages: 'Отобразить все хранилища в этом пуле',
 
-  // Original text: 'Display all VMs of this pool'
+  // Original text: "Display all VMs of this pool"
   displayAllVMs: 'Отобразить все ВМ в этом пуле',
+
+  // Original text: 'License restrictions'
+  licenseRestrictions: undefined,
+
+  // Original text: 'Warning: You are using a Free XenServer license'
+  licenseRestrictionsModalTitle: undefined,
+
+  // Original text: 'Some functionality is restricted.'
+  actionsRestricted: undefined,
+
+  // Original text: 'You can:'
+  counterRestrictionsOptions: undefined,
+
+  // Original text: 'upgrade to XCP-ng for free to get rid of these restrictions'
+  counterRestrictionsOptionsXcp: undefined,
+
+  // Original text: 'or get a commercial Citrix license'
+  counterRestrictionsOptionsXsLicense: undefined,
 
   // Original text: "Hosts"
   hostsTabName: 'Хосты',
 
-  // Original text: 'Vms'
+  // Original text: 'VMs'
   vmsTabName: undefined,
 
-  // Original text: 'Srs'
+  // Original text: 'SRs'
   srsTabName: undefined,
 
-  // Original text: "High Availability"
-  poolHaStatus: 'Высокая доступность',
+  // Original text: 'Backup network'
+  backupNetwork: undefined,
+
+  // Original text: 'Crash dump SR'
+  crashDumpSr: undefined,
+
+  // Original text: 'Default migration network'
+  defaultMigrationNetwork: undefined,
+
+  // Original text: 'Migration compression'
+  migrationCompression: undefined,
+
+  // Original text: 'Migration compression is not available on this pool'
+  migrationCompressionDisabled: undefined,
+
+  // Original text: 'Disabling high availability'
+  poolDisableHa: undefined,
+
+  // Original text: 'Are you sure you want to disable high availability on this pool?'
+  poolDisableHaConfirm: undefined,
+
+  // Original text: 'Enabling high availability'
+  poolEnableHa: undefined,
+
+  // Original text: 'Edit all'
+  poolEditAll: undefined,
+
+  // Original text: 'Select heartbeat SR candidates'
+  poolHaSelectSrs: undefined,
+
+  // Original text: 'The XAPI will pick one of these SR as heartbeat SR'
+  poolHaSelectSrsDetails: undefined,
 
   // Original text: "Enabled"
   poolHaEnabled: 'Включена',
@@ -1268,14 +2507,59 @@ export default {
   // Original text: "Disabled"
   poolHaDisabled: 'Выключена',
 
+  // Original text: "High Availability"
+  poolHaStatus: 'Высокая доступность',
+
+  // Original text: 'Heartbeat SR'
+  poolHeartbeatSr: undefined,
+
+  // Original text: 'GPU groups'
+  poolGpuGroups: undefined,
+
+  // Original text: 'Logging host'
+  poolRemoteSyslogPlaceHolder: undefined,
+
+  // Original text: 'XCP-ng Pro Support not available for source users'
+  poolSupportSourceUsers: undefined,
+
+  // Original text: 'Only available for pool of XCP-ng hosts'
+  poolSupportXcpngOnly: undefined,
+
+  // Original text: 'The pool is already fully supported'
+  poolLicenseAlreadyFullySupported: undefined,
+
+  // Original text: 'Rolling Pool Reboot'
+  rollingPoolReboot: undefined,
+
+  // Original text: 'High Availability is enabled. This will automatically disable it during the reboot.'
+  rollingPoolRebootHaWarning: undefined,
+
+  // Original text: 'Load Balancer plugin is running. This will automatically pause it during the reboot.'
+  rollingPoolRebootLoadBalancerWarning: undefined,
+
+  // Original text: 'Are you sure you want to start a Rolling Pool Reboot? Running VMs will be migrated back and forth and this can take a while. Scheduled backups that may concern this pool will be disabled.'
+  rollingPoolRebootMessage: undefined,
+
+  // Original text: 'Master'
+  setpoolMaster: undefined,
+
+  // Original text: 'Remote syslog host'
+  syslogRemoteHost: undefined,
+
+  // Original text: 'Synchronize with Netbox'
+  syncNetbox: undefined,
+
+  // Original text: 'Are you sure you want to synchronize with Netbox?'
+  syncNetboxWarning: undefined,
+
+  // Original text: '{networkID} not found, please select a new one'
+  updateMissingNetwork: undefined,
+
   // Original text: "Name"
   hostNameLabel: 'Имя',
 
   // Original text: "Description"
   hostDescription: 'Описание',
-
-  // Original text: "Memory"
-  hostMemory: 'Память',
 
   // Original text: "No hosts"
   noHost: 'Нет хостов',
@@ -1286,19 +2570,28 @@ export default {
   // Original text: 'PIF'
   pif: undefined,
 
+  // Original text: 'Automatic'
+  poolNetworkAutomatic: undefined,
+
   // Original text: "Name"
   poolNetworkNameLabel: 'Имя',
 
   // Original text: "Description"
   poolNetworkDescription: 'Описание',
 
-  // Original text: "PIFs"
+  // Original text: 'PIFs'
   poolNetworkPif: undefined,
+
+  // Original text: 'Private networks'
+  privateNetworks: undefined,
+
+  // Original text: 'Manage'
+  manage: undefined,
 
   // Original text: "No networks"
   poolNoNetwork: 'Нет сетей',
 
-  // Original text: "MTU"
+  // Original text: 'MTU'
   poolNetworkMTU: undefined,
 
   // Original text: "Connected"
@@ -1307,22 +2600,34 @@ export default {
   // Original text: "Disconnected"
   poolNetworkPifDetached: 'Отключено',
 
-  // Original text: 'Show PIFs'
+  // Original text: "Show PIFs"
   showPifs: 'Показать PIFs',
 
-  // Original text: 'Hide PIFs'
+  // Original text: "Hide PIFs"
   hidePifs: 'Скрыть PIFs',
 
-  // Original text: 'Show details'
-  showDetails: 'Показать подробности',
+  // Original text: 'Network(s) selected by default for new VMs'
+  networkAutomaticTooltip: undefined,
 
-  // Original text: 'Hide details'
-  hideDetails: 'Скрыть подробности',
+  // Original text: 'No NBD Connection'
+  noNbdConnection: undefined,
+
+  // Original text: 'NBD Connection'
+  nbdConnection: undefined,
+
+  // Original text: 'Insecure NBD Connection (not allowed through XO)'
+  insecureNbdConnection: undefined,
+
+  // Original text: "Rolling pool update can only work when there's multiple hosts in a pool with a shared storage"
+  multiHostPoolUpdate: undefined,
+
+  // Original text: '{nVms, number} VM{nVms, plural, one {} other {s}} {nVms, plural, one {is} other {are}} currently running and using at least one local storage. A shared storage for all your VMs is needed to start a rolling pool update'
+  nVmsRunningOnLocalStorage: undefined,
 
   // Original text: 'No stats'
   poolNoStats: undefined,
 
-  // Original text: 'All hosts'
+  // Original text: "All hosts"
   poolAllHosts: 'Все хосты',
 
   // Original text: "Add SR"
@@ -1331,23 +2636,53 @@ export default {
   // Original text: "Add VM"
   addVmLabel: 'Добавить ВМ',
 
-  // Original text: "Add Host"
-  addHostLabel: 'Добавить хост',
+  // Original text: 'Add hosts'
+  addHostsLabel: undefined,
 
-  // Original text: 'This host needs to install {patches, number} patch{patches, plural, one {} other {es}} before it can be added to the pool. This operation may be long.'
-  hostNeedsPatchUpdate: undefined,
+  // Original text: 'The pool needs to install {nMissingPatches, number} patch{nMissingPatches, plural, one {} other {es}}. This operation may take a while.'
+  missingPatchesPool: undefined,
 
-  // Original text: "This host cannot be added to the pool because it's missing some patches."
-  hostNeedsPatchUpdateNoInstall: 'Этот хост не может быть добавлен в пул, так как на нем отсутствуют некоторые исправления.',
+  // Original text: 'The selected host{nHosts, plural, one {} other {s}} need{nHosts, plural, one {s} other {}} to install {nMissingPatches, number} patch{nMissingPatches, plural, one {} other {es}}. This operation may take a while.'
+  missingPatchesHost: undefined,
 
-  // Original text: 'Adding host failed'
-  addHostErrorTitle: 'Не удалось добавить хост',
+  // Original text: 'The selected host{nHosts, plural, one {} other {s}} cannot be added to the pool because the patches are not homogeneous.'
+  patchUpdateNoInstall: undefined,
+
+  // Original text: 'Adding host{nHosts, plural, one {} other {s}} failed'
+  addHostsErrorTitle: undefined,
 
   // Original text: 'Host patches could not be homogenized.'
   addHostNotHomogeneousErrorMessage: undefined,
 
   // Original text: "Disconnect"
   disconnectServer: 'Отключен',
+
+  // Original text: 'Host'
+  host: undefined,
+
+  // Original text: 'Hardware-assisted virtualization is not enabled on this host'
+  hostHvmDisabled: undefined,
+
+  // Original text: 'This host does not have an active license, even though it is in a pool with licensed hosts. In order for XCP-ng Pro Support to be enabled on a pool, all hosts within the pool must have an active license'
+  hostNoLicensePartialProSupport: undefined,
+
+  // Original text: 'No XCP-ng Pro Support enabled on this host'
+  hostNoSupport: undefined,
+
+  // Original text: 'XCP-ng Pro Support enabled on this host'
+  hostSupportEnabled: undefined,
+
+  // Original text: 'This host version is no longer maintained'
+  noMoreMaintained: undefined,
+
+  // Original text: 'Disable maintenance mode'
+  disableMaintenanceMode: undefined,
+
+  // Original text: 'Enable maintenance mode'
+  enableMaintenanceMode: undefined,
+
+  // Original text: 'It appears that this host will be more up-to-date than the master ({master}) after the restart. This will result in the slave being unable to contact the pool master. Please update and restart your master node first.'
+  slaveHostMoreUpToDateThanMasterAfterRestart: undefined,
 
   // Original text: "Start"
   startHostLabel: 'Запустить',
@@ -1361,28 +2696,44 @@ export default {
   // Original text: "Disable"
   disableHostLabel: 'Выключить',
 
-  // Original text: "Restart toolstack"
+  // Original text: 'Restart toolstack'
   restartHostAgent: undefined,
+
+  // Original text: 'As the XOA is hosted on the host that is scheduled for a reboot, it will also be restarted. Consequently, XO won\'t be able to resume VMs, and VMs with the "Protect from accidental shutdown" option enabled will not have this option reactivated automatically.'
+  smartRebootBypassCurrentVmCheck: undefined,
+
+  // Original text: 'Smart reboot'
+  smartRebootHostLabel: undefined,
+
+  // Original text: 'Suspend resident VMs, reboot host and resume VMs automatically'
+  smartRebootHostTooltip: undefined,
 
   // Original text: "Force reboot"
   forceRebootHostLabel: 'Принудительная перезагрузка',
 
+  // Original text: 'Smart Reboot failed because {nVms, number} VM{nVms, plural, one {} other {s}} ha{nVms, plural, one {s} other {ve}} {nVms, plural, one {its} other {their}} Suspend operation blocked. Would you like to force?'
+  forceSmartRebootHost: undefined,
+
+  // Original text: 'Restart anyway'
+  restartAnyway: undefined,
+
   // Original text: "Reboot"
   rebootHostLabel: 'Перезагрузка',
 
-  // Original text: 'Error while restarting host'
+  // Original text: "Error while restarting host"
   noHostsAvailableErrorTitle: 'Ошибка при перезапуске хоста',
 
-  // Original text: 'Some VMs cannot be migrated before restarting this host. Please try force reboot.'
-  noHostsAvailableErrorMessage: 'Некоторые виртуальные машины невозможно перенести до перезапуска этого хоста. Пожалуйста, попробуйте выполнить принудительную перезагрузку.',
+  // Original text: "Some VMs cannot be migrated without first rebooting this host. Please try force reboot."
+  noHostsAvailableErrorMessage:
+    'Некоторые виртуальные машины невозможно перенести до перезапуска этого хоста. Пожалуйста, попробуйте выполнить принудительную перезагрузку.',
 
-  // Original text: 'Error while restarting hosts'
+  // Original text: "Error while restarting hosts"
   failHostBulkRestartTitle: 'Ошибка при перезапуске хостов',
 
   // Original text: '{failedHosts, number}/{totalHosts, number} host{failedHosts, plural, one {} other {s}} could not be restarted.'
   failHostBulkRestartMessage: undefined,
 
-  // Original text: 'Reboot to apply updates'
+  // Original text: "Reboot to apply updates"
   rebootUpdateHostLabel: 'Перезагрузите для применения обновлений',
 
   // Original text: "Emergency mode"
@@ -1397,11 +2748,62 @@ export default {
   // Original text: "Load average"
   statLoad: 'Средняя нагрузка',
 
-  // Original text: 'RAM Usage: {memoryUsed}'
+  // Original text: 'This operation will reboot the host in order to apply the change on the PCI{nPcis, plural, one {} other {s}}. Are you sure you want to continue?'
+  applyChangeOnPcis: undefined,
+
+  // Original text: 'Class name'
+  className: undefined,
+
+  // Original text: 'Force reboot?'
+  confirmForceRebootHost: undefined,
+
+  // Original text: 'Device name'
+  deviceName: undefined,
+
+  // Original text: 'Enabled'
+  enabled: undefined,
+
+  // Original text: 'All disks are healthy ✅'
+  disksSystemHealthy: undefined,
+
+  // Original text: 'Edit iSCSI IQN'
+  editHostIscsiIqnTitle: undefined,
+
+  // Original text: 'Are you sure you want to edit the iSCSI IQN? This may result in failures connecting to existing SRs if the host is attached to iSCSI SRs.'
+  editHostIscsiIqnMessage: undefined,
+
+  // Original text: 'Host RAM usage:'
+  hostTitleRamUsage: undefined,
+
+  // Original text: 'The host evacuation failed, do you want to force reboot?'
+  hostEvacuationFailed: undefined,
+
+  // Original text: 'Are you sure you want to enter maintenance mode? This will migrate all the VMs running on this host to other hosts of the pool.'
+  maintenanceHostModalMessage: undefined,
+
+  // Original text: 'Maintenance mode'
+  maintenanceHostModalTitle: undefined,
+
+  // Original text: 'Evacuate and disable the host'
+  maintenanceHostTooltip: undefined,
+
+  // Original text: "RAM: {memoryUsed} used of {memoryTotal} ({memoryFree} free)"
   memoryHostState: 'Использование RAM: {memoryUsed}',
 
   // Original text: "Hardware"
   hardwareHostSettingsLabel: 'Hardware',
+
+  // Original text: 'Hyper-threading (SMT)'
+  hyperThreading: undefined,
+
+  // Original text: 'HT detection is only available on XCP-ng 7.6 and higher'
+  hyperThreadingNotAvailable: undefined,
+
+  // Original text: 'Download system logs'
+  hostDownloadLogs: undefined,
+
+  // Original text: "The logs you are about to download contain the entire host's logs, potentially hundreds of megabytes. Please note that these logs can be technical and complex to analyze, requiring some expertise."
+  hostDownloadLogsContainEntireHostLogs: undefined,
 
   // Original text: "Address"
   hostAddress: 'Адрес',
@@ -1412,8 +2814,26 @@ export default {
   // Original text: "Build number"
   hostBuildNumber: 'Номер сборки',
 
-  // Original text: "iSCSI name"
-  hostIscsiName: 'Имя iSCSI',
+  // Original text: 'iSCSI IQN'
+  hostIscsiIqn: undefined,
+
+  // Original text: 'PCI passthrough capable'
+  hostIommuTooltip: undefined,
+
+  // Original text: 'Not connected to an iSCSI SR'
+  hostNoIscsiSr: undefined,
+
+  // Original text: 'Click to see concerned SRs'
+  hostMultipathingSrs: undefined,
+
+  // Original text: '{nActives, number} of {nPaths, number} path{nPaths, plural, one {} other {s}}'
+  hostMultipathingPaths: undefined,
+
+  // Original text: 'This action will not be fulfilled if a VM is in a running state. Please ensure that all VMs are evacuated or stopped before performing this action!'
+  hostMultipathingRequiredState: undefined,
+
+  // Original text: 'The host{nHosts, plural, one {} other {s}} will lose their connection to the SRs. Do you want to continue?'
+  hostMultipathingWarning: undefined,
 
   // Original text: "Version"
   hostXenServerVersion: 'Версия',
@@ -1427,14 +2847,29 @@ export default {
   // Original text: "Power on mode"
   hostPowerOnMode: 'Режим включения',
 
+  // Original text: 'Control domain memory'
+  hostControlDomainMemory: undefined,
+
+  // Original text: 'Set control domain memory'
+  setControlDomainMemory: undefined,
+
+  // Original text: 'Editing the control domain memory will immediately restart the host in order to apply the changes.'
+  setControlDomainMemoryMessage: undefined,
+
+  // Original text: 'The host needs to be in maintenance mode'
+  maintenanceModeRequired: undefined,
+
   // Original text: "Host uptime"
   hostStartedSince: 'Время работы хоста',
 
-  // Original text: "Toolstack uptime"
+  // Original text: 'Toolstack uptime'
   hostStackStartedSince: undefined,
 
   // Original text: "CPU model"
   hostCpusModel: 'Модель CPU',
+
+  // Original text: 'GPUs'
+  hostGpus: undefined,
 
   // Original text: "Core (socket)"
   hostCpusNumber: 'Ядра (сокеты)',
@@ -1445,7 +2880,7 @@ export default {
   // Original text: "BIOS info"
   hostBiosinfo: 'BIOS',
 
-  // Original text: "Licence"
+  // Original text: "License"
   licenseHostSettingsLabel: 'Лицензия',
 
   // Original text: "Type"
@@ -1457,41 +2892,77 @@ export default {
   // Original text: "Expiry"
   hostLicenseExpiry: 'Срок действия',
 
-  // Original text: 'Installed supplemental packs'
-  supplementalPacks: "Установленные пакеты дополнений",
+  // Original text: 'Remote syslog'
+  hostRemoteSyslog: undefined,
 
-  // Original text: 'Install new supplemental pack'
+  // Original text: 'IOMMU'
+  hostIommu: undefined,
+
+  // Original text: 'No certificates installed on this host'
+  hostNoCertificateInstalled: undefined,
+
+  // Original text: 'Only available for XCP-ng 8.3.0 or higher'
+  'onlyAvailableXcp8.3OrHigher': undefined,
+
+  // Original text: 'PCI Devices'
+  pciDevices: undefined,
+
+  // Original text: 'PCI ID'
+  pciId: undefined,
+
+  // Original text: 'PCI{nPcis, plural, one {} other {s}} enable'
+  pcisEnable: undefined,
+
+  // Original text: 'PCI{nPcis, plural, one {} other {s}} disable'
+  pcisDisable: undefined,
+
+  // Original text: 'PUSB Devices'
+  pusbDevices: undefined,
+
+  // Original text: 'Smartctl plugin not installed'
+  smartctlPluginNotInstalled: undefined,
+
+  // Original text: "Installed supplemental packs"
+  supplementalPacks: 'Установленные пакеты дополнений',
+
+  // Original text: "Install new supplemental pack"
   supplementalPackNew: 'Установить новый пакет дополнений',
 
-  // Original text: 'Install supplemental pack on every host'
+  // Original text: "Install supplemental pack on every host"
   supplementalPackPoolNew: 'Установить пакет дополнений на каждый хост',
 
-  // Original text: '{name} (by {author})'
+  // Original text: "{name} (by {author})"
   supplementalPackTitle: '{name} (by {author})',
 
-  // Original text: 'Installation started'
+  // Original text: "Installation started"
   supplementalPackInstallStartedTitle: 'Установка началась',
 
-  // Original text: 'Installing new supplemental pack…'
+  // Original text: "Installing new supplemental pack…"
   supplementalPackInstallStartedMessage: 'Установка нового пакета дополнений…',
 
-  // Original text: 'Installation error'
+  // Original text: "Installation error"
   supplementalPackInstallErrorTitle: 'Ошибка установки',
 
-  // Original text: 'The installation of the supplemental pack failed.'
+  // Original text: "The installation of the supplemental pack failed."
   supplementalPackInstallErrorMessage: 'Не удалось установить пакет дополнений',
 
-  // Original text: 'Installation success'
+  // Original text: "Installation success"
   supplementalPackInstallSuccessTitle: 'Установка успешна',
 
-  // Original text: 'Supplemental pack successfully installed.'
+  // Original text: "Supplemental pack successfully installed."
   supplementalPackInstallSuccessMessage: 'Пакет дополнений успешно установлен.',
+
+  // Original text: 'System disks health'
+  systemDisksHealth: undefined,
+
+  // Original text: 'The iSCSI IQN must be unique. '
+  uniqueHostIscsiIqnInfo: undefined,
+
+  // Original text: 'Vendor ID'
+  vendorId: undefined,
 
   // Original text: "Add a network"
   networkCreateButton: 'Добавить сеть',
-
-  // Original text: 'Add a bonded network'
-  networkCreateBondedButton: 'Добавить bonded сеть',
 
   // Original text: "Device"
   pifDeviceLabel: 'Устройство',
@@ -1505,7 +2976,7 @@ export default {
   // Original text: "Address"
   pifAddressLabel: 'Адрес',
 
-  // Original text: 'Mode'
+  // Original text: "Mode"
   pifModeLabel: 'Режим',
 
   // Original text: "MAC"
@@ -1514,56 +2985,53 @@ export default {
   // Original text: "MTU"
   pifMtuLabel: 'MTU',
 
+  // Original text: 'Speed'
+  pifSpeedLabel: undefined,
+
   // Original text: "Status"
   pifStatusLabel: 'Статус',
-
-  // Original text: "Connected"
-  pifStatusConnected: 'Подключен',
-
-  // Original text: "Disconnected"
-  pifStatusDisconnected: 'Отключен',
-
-  // Original text: "No physical interface detected"
-  pifNoInterface: 'Физический интерфейс не обнаружен',
 
   // Original text: 'This interface is currently in use'
   pifInUse: undefined,
 
-  // Original text: 'Action'
-  pifAction: undefined,
-
   // Original text: 'Default locking mode'
   defaultLockingMode: undefined,
 
-  // Original text: 'Configure IP address'
+  // Original text: "Configure IP address"
   pifConfigureIp: 'Настройка IP адреса',
 
   // Original text: 'Invalid parameters'
   configIpErrorTitle: undefined,
 
-  // Original text: 'Static IP address'
+  // Original text: "Static IP address"
   staticIp: 'Статичный IP адрес',
 
-  // Original text: 'Netmask'
+  // Original text: 'Static IPv6 address'
+  staticIpv6: undefined,
+
+  // Original text: "Netmask"
   netmask: 'Маска сети',
 
-  // Original text: 'DNS'
+  // Original text: "DNS"
   dns: 'DNS',
 
-  // Original text: 'Gateway'
+  // Original text: "Gateway"
   gateway: 'Сетевой шлюз',
+
+  // Original text: 'An IP address is required'
+  ipRequired: undefined,
+
+  // Original text: 'Netmask required'
+  netmaskRequired: undefined,
 
   // Original text: "Add a storage"
   addSrDeviceButton: 'Добавить хранилище',
 
-  // Original text: "Name"
-  srNameLabel: 'Имя',
-
   // Original text: "Type"
   srType: 'Тип',
 
-  // Original text: 'Action'
-  pbdAction: undefined,
+  // Original text: 'PBD details'
+  pbdDetails: undefined,
 
   // Original text: "Status"
   pbdStatus: 'Статус',
@@ -1574,13 +3042,13 @@ export default {
   // Original text: "Disconnected"
   pbdStatusDisconnected: 'Отключен',
 
-  // Original text: 'Connect'
+  // Original text: "Connect"
   pbdConnect: 'Подключить',
 
-  // Original text: 'Disconnect'
+  // Original text: "Disconnect"
   pbdDisconnect: 'Отключить',
 
-  // Original text: 'Forget'
+  // Original text: "Forget"
   pbdForget: 'Забыть',
 
   // Original text: "Shared"
@@ -1601,22 +3069,16 @@ export default {
   // Original text: "Description"
   patchDescription: 'Описание',
 
+  // Original text: 'Version'
+  patchVersion: undefined,
+
   // Original text: "Applied date"
   patchApplied: 'Дата публикации',
 
   // Original text: "Size"
   patchSize: 'Размер',
 
-  // Original text: "Status"
-  patchStatus: 'Статус',
-
-  // Original text: "Applied"
-  patchStatusApplied: 'Применяемый',
-
-  // Original text: "Missing patches"
-  patchStatusNotApplied: 'Отсутствующие исправления',
-
-  // Original text: "No patch detected"
+  // Original text: "No patches detected"
   patchNothing: 'Исправления не найдены',
 
   // Original text: "Release date"
@@ -1625,10 +3087,7 @@ export default {
   // Original text: "Guidance"
   patchGuidance: 'Руководство',
 
-  // Original text: "Action"
-  patchAction: 'Действие',
-
-  // Original text: 'Applied patches'
+  // Original text: "Applied patches"
   hostAppliedPatches: 'Примененные исправления',
 
   // Original text: "Missing patches"
@@ -1637,29 +3096,98 @@ export default {
   // Original text: "Host up-to-date!"
   hostUpToDate: 'Хост в актуальном состоянии!',
 
-  // Original text: 'Non-recommended patch install'
-  installPatchWarningTitle: 'Не рекомендуемые для установки исправления',
+  // Original text: 'Install all patches'
+  installAllPatchesTitle: undefined,
 
-  // Original text: 'This will install a patch only on this host. This is NOT the recommended way: please go into the Pool patch view and follow instructions there. If you are sure about this, you can continue anyway'
-  installPatchWarningContent: 'Это установит исправления только на данный хост. Это НЕ рекомендуемый метод: пожалуйста, перейдите в меню обновлений пула и следуйте инструкциям. Но если вы уверены, то можете продолжить.',
+  // Original text: 'To install all patches go to pool.'
+  installAllPatchesContent: undefined,
 
   // Original text: 'Go to pool'
-  installPatchWarningReject: 'Перейти к пулу',
+  installAllPatchesRedirect: undefined,
+
+  // Original text: 'The pool master must always be updated FIRST. Updating will automatically restart the toolstack. Running VMs will not be affected. Are you sure you want to continue and install all patches on this host?'
+  installAllPatchesOnHostContent: undefined,
+
+  // Original text: 'Release'
+  patchRelease: undefined,
+
+  // Original text: 'An error occurred while fetching the patches. Please make sure the updater plugin is installed by running `yum install xcp-ng-updater` on the host.'
+  updatePluginNotInstalled: undefined,
+
+  // Original text: 'Show changelog'
+  showChangelog: undefined,
+
+  // Original text: 'Changelog'
+  changelog: undefined,
+
+  // Original text: 'Patch'
+  changelogPatch: undefined,
+
+  // Original text: 'Author'
+  changelogAuthor: undefined,
+
+  // Original text: 'Date'
+  changelogDate: undefined,
+
+  // Original text: 'Description'
+  changelogDescription: undefined,
 
   // Original text: 'Install'
-  installPatchWarningResolve: 'Установить',
+  install: undefined,
 
-  // Original text: 'Refresh patches'
-  refreshPatches: 'Проверить исправления',
+  // Original text: 'Install patch{nPatches, plural, one {} other {es}}'
+  installPatchesTitle: undefined,
 
-  // Original text: 'Install pool patches'
+  // Original text: 'This will automatically restart the toolstack on every host. Running VMs will not be affected. Are you sure you want to continue and install {nPatches, number} patch{nPatches, plural, one {} other {es}}?'
+  installPatchesContent: undefined,
+
+  // Original text: "Install pool patches"
   installPoolPatches: 'Установить исправления на пул',
 
-  // Original text: 'Default SR'
+  // Original text: 'This will automatically restart the toolstack on every host. Running VMs will not be affected. Are you sure you want to continue and install all the patches on this pool?'
+  confirmPoolPatch: undefined,
+
+  // Original text: 'RPU is disabled because a XOSTOR storage is present in the pool'
+  rollingPoolUpdateDisabledBecauseXostorOnPool: undefined,
+
+  // Original text: 'Rolling pool update'
+  rollingPoolUpdate: undefined,
+
+  // Original text: 'Are you sure you want to start a rolling pool update? Running VMs will be migrated back and forth and this can take a while. Scheduled backups that may concern this pool will be disabled.'
+  rollingPoolUpdateMessage: undefined,
+
+  // Original text: 'High Availability is enabled. This will automatically disable it during the update.'
+  rollingPoolUpdateHaWarning: undefined,
+
+  // Original text: 'Load Balancer plugin is running. This will automatically pause it during the update.'
+  rollingPoolUpdateLoadBalancerWarning: undefined,
+
+  // Original text: 'The pool needs a default SR to install the patches.'
+  poolNeedsDefaultSr: undefined,
+
+  // Original text: '{nVms, number} VM{nVms, plural, one {} other {s}} {nVms, plural, one {has} other {have}} CDs'
+  vmsHaveCds: undefined,
+
+  // Original text: 'Eject CDs'
+  ejectCds: undefined,
+
+  // Original text: 'High Availability must be disabled'
+  highAvailabilityNotDisabledTooltip: undefined,
+
+  // Original text: 'In order to install XenServer updates, you first need to configure your XenServer Client ID. See {link}.'
+  xsCredentialsMissing: undefined,
+
+  // Original text: 'Missing XenServer Client ID'
+  xsCredentialsMissingShort: undefined,
+
+  // Original text: "Default SR"
   defaultSr: 'SR по умолчанию',
 
-  // Original text: 'Set as default SR'
+  // Original text: "Set as default SR"
   setAsDefaultSr: 'Выбрать SR по умолчанию',
+
+  // Original text: 'Set default SR:'
+  setDefaultSr: undefined,
 
   // Original text: "General"
   generalTabName: 'Общее',
@@ -1670,7 +3198,7 @@ export default {
   // Original text: "Console"
   consoleTabName: 'Консоль',
 
-  // Original text: 'Container'
+  // Original text: "Container"
   containersTabName: 'Контейнер',
 
   // Original text: "Snapshots"
@@ -1688,26 +3216,23 @@ export default {
   // Original text: "Disk{disks, plural, one {} other {s}}"
   disksTabName: 'Диск{disks, plural, one {} other {s}}',
 
-  // Original text: "halted"
+  // Original text: "Halted"
   powerStateHalted: 'остановлен',
 
-  // Original text: "running"
+  // Original text: "Running"
   powerStateRunning: 'работает',
 
-  // Original text: "suspended"
+  // Original text: "Suspended"
   powerStateSuspended: 'приостановлен',
 
-  // Original text: "No Xen tools detected"
-  vmStatus: 'Утилиты XEN не обнаружены',
+  // Original text: 'Paused'
+  powerStatePaused: undefined,
 
-  // Original text: "No IPv4 record"
-  vmName: 'Нет IPv4 записи',
+  // Original text: 'Disabled'
+  powerStateDisabled: undefined,
 
-  // Original text: "No IP record"
-  vmDescription: 'Нет IP записи',
-
-  // Original text: "Started {ago}"
-  vmSettings: 'Запущено {ago}',
+  // Original text: 'Busy'
+  powerStateBusy: undefined,
 
   // Original text: "Current status:"
   vmCurrentStatus: 'Текущий статус',
@@ -1715,11 +3240,20 @@ export default {
   // Original text: "Not running"
   vmNotRunning: 'Не запущено',
 
-  // Original text: 'Halted {ago}'
+  // Original text: "Halted {ago}"
   vmHaltedSince: 'Остановлено {ago}',
 
   // Original text: "No Xen tools detected"
   noToolsDetected: 'Утилиты XEN не обнаружены',
+
+  // Original text: 'Management agent {version} detected'
+  managementAgentDetected: undefined,
+
+  // Original text: 'Management agent {version} out of date'
+  managementAgentOutOfDate: undefined,
+
+  // Original text: 'Management agent not detected'
+  managementAgentNotDetected: undefined,
 
   // Original text: "No IPv4 record"
   noIpv4Record: 'Нет IPv4 записи',
@@ -1736,6 +3270,39 @@ export default {
   // Original text: "Hardware virtualization (HVM)"
   hardwareVirtualizedMode: 'Аппаратная паравиртуализация (HVM)',
 
+  // Original text: 'Hardware virtualization with paravirtualization drivers enabled (PVHVM)'
+  hvmModeWithPvDriversEnabled: undefined,
+
+  // Original text: 'PV inside a PVH container (PV in PVH)'
+  pvInPvhMode: undefined,
+
+  // Original text: 'Created by {user}\non {date}\nwith template {template}'
+  vmCreatedAdmin: undefined,
+
+  // Original text: 'Created on {date}\nwith template {template}'
+  vmCreatedNonAdmin: undefined,
+
+  // Original text: 'Manage Citrix PV drivers via Windows Update'
+  windowsUpdateTools: undefined,
+
+  // Original text: 'Windows Update Tools'
+  windowsToolsModalTitle: undefined,
+
+  // Original text: 'Enabling this will allow the VM to automatically install Citrix PV drivers from Windows Update. This only includes drivers, the Citrix management agent must still be separately installed.'
+  windowsToolsModalMessage: undefined,
+
+  // Original text: 'If you have previously installed XCP-ng tools instead of Citrix tools, this option will break your VM.'
+  windowsToolsModalWarning: undefined,
+
+  // Original text: 'Edit VM notes'
+  editVmNotes: undefined,
+
+  // Original text: 'Supports Markdown syntax'
+  supportsMarkdown: undefined,
+
+  // Original text: 'VM notes cannot be longer than 2048 characters'
+  vmNotesTooLong: undefined,
+
   // Original text: "CPU usage"
   statsCpu: 'Использование CPU',
 
@@ -1745,7 +3312,7 @@ export default {
   // Original text: "Network throughput"
   statsNetwork: 'Использование сети',
 
-  // Original text: 'Stacked values'
+  // Original text: "Stacked values"
   useStackedValuesOnStats: 'Сложить значения',
 
   // Original text: "Disk throughput"
@@ -1757,6 +3324,9 @@ export default {
   // Original text: "Last 2 hours"
   statLastTwoHours: 'Последние 2 часа',
 
+  // Original text: 'Last day'
+  statLastDay: undefined,
+
   // Original text: "Last week"
   statLastWeek: 'Последняя неделя',
 
@@ -1766,59 +3336,98 @@ export default {
   // Original text: "Copy"
   copyToClipboardLabel: 'Копировать',
 
-  // Original text: "Ctrl+Alt+Del"
+  // Original text: 'Ctrl+Alt+Del'
   ctrlAltDelButtonLabel: undefined,
+
+  // Original text: 'Send Ctrl+Alt+Del to VM?'
+  ctrlAltDelConfirmation: undefined,
+
+  // Original text: 'Console is disabled for this VM'
+  disabledConsole: undefined,
+
+  // Original text: 'Multiline copy'
+  multilineCopyToClipboard: undefined,
 
   // Original text: "Tip:"
   tipLabel: 'Совет:',
 
-  // Original text: 'Hide infos'
+  // Original text: "Hide info"
   hideHeaderTooltip: 'Скрыть информацию',
 
-  // Original text: 'Show infos'
+  // Original text: "Show info"
   showHeaderTooltip: 'Показать информацию',
 
-  // Original text: 'Name'
+  // Original text: 'Send to clipboard'
+  sendToClipboard: undefined,
+
+  // Original text: 'Connect using external SSH tool as root'
+  sshRootTooltip: undefined,
+
+  // Original text: 'SSH'
+  sshRootLabel: undefined,
+
+  // Original text: 'Connect using external SSH tool as user…'
+  sshUserTooltip: undefined,
+
+  // Original text: 'SSH as…'
+  sshUserLabel: undefined,
+
+  // Original text: 'SSH user name'
+  sshUsernameLabel: undefined,
+
+  // Original text: 'No IP address reported by client tools'
+  remoteNeedClientTools: undefined,
+
+  // Original text: 'RDP'
+  rdp: undefined,
+
+  // Original text: 'Connect using external RDP tool'
+  rdpRootTooltip: undefined,
+
+  // Original text: "Name"
   containerName: 'Имя',
 
-  // Original text: 'Command'
+  // Original text: "Command"
   containerCommand: 'Команда',
 
-  // Original text: 'Creation date'
+  // Original text: "Creation date"
   containerCreated: 'Дата создания',
 
-  // Original text: 'Status'
+  // Original text: "Status"
   containerStatus: 'Статус',
 
-  // Original text: 'Action'
+  // Original text: "Action"
   containerAction: 'Действие',
 
-  // Original text: 'No existing containers'
+  // Original text: "No existing containers"
   noContainers: 'Нет существующих контейнеров',
 
-  // Original text: 'Stop this container'
+  // Original text: "Stop this container"
   containerStop: 'Остановить контейнер',
 
-  // Original text: 'Start this container'
+  // Original text: "Start this container"
   containerStart: 'Запустить контейнер',
 
-  // Original text: 'Pause this container'
+  // Original text: "Pause this container"
   containerPause: 'Приостановить контейнер',
 
-  // Original text: 'Resume this container'
+  // Original text: "Resume this container"
   containerResume: 'Возобновить контейнер',
 
-  // Original text: 'Restart this container'
+  // Original text: "Restart this container"
   containerRestart: 'Перезапустить контейнер',
 
-  // Original text: "Action"
-  vdiAction: 'Действие',
+  // Original text: 'Rescan all ISO SRs'
+  rescanIsoSrs: undefined,
+
+  // Original text: "New disk"
+  vbdCreateDeviceButton: 'Новый диск',
 
   // Original text: "Attach disk"
   vdiAttachDevice: 'Подключить диск',
 
-  // Original text: "New disk"
-  vbdCreateDeviceButton: 'Новый диск',
+  // Original text: 'The selected VDI is already attached to this VM. Are you sure you want to continue?'
+  vdiAttachDeviceConfirm: undefined,
 
   // Original text: "Boot order"
   vdiBootOrder: 'Очередность загрузки',
@@ -1829,47 +3438,50 @@ export default {
   // Original text: "Description"
   vdiNameDescription: 'Описание',
 
-  // Original text: 'Pool'
+  // Original text: "Pool"
   vdiPool: 'Пул',
-
-  // Original text: 'Disconnect'
-  vdiDisconnect: 'Отключить',
 
   // Original text: "Tags"
   vdiTags: 'Тэги',
 
+  // Original text: 'VDI tasks'
+  vdiTasks: undefined,
+
   // Original text: "Size"
   vdiSize: 'Размер',
 
-  // Original text: "SR"
+  // Original text: 'SR'
   vdiSr: undefined,
 
-  // Original text: 'VM'
-  vdiVm: 'ВМ',
+  // Original text: 'VMs'
+  vdiVms: undefined,
 
-  // Original text: 'Migrate VDI'
+  // Original text: "Migrate VDI"
   vdiMigrate: 'Мигрировать VDI',
 
-  // Original text: 'Destination SR:'
+  // Original text: "Destination SR:"
   vdiMigrateSelectSr: 'Целевая SR',
 
-  // Original text: 'No SR'
+  // Original text: "No SR"
   vdiMigrateNoSr: 'Нет SR',
 
-  // Original text: 'A target SR is required to migrate a VDI'
+  // Original text: "A target SR is required to migrate a VDI"
   vdiMigrateNoSrMessage: 'Для переноса VDI требуется целевой SR',
 
-  // Original text: 'Forget'
+  // Original text: "Forget"
   vdiForget: 'Забыть',
 
-  // Original text: 'Remove VDI'
-  vdiRemove: 'Удалить VDI',
-
-  // Original text: 'No VDIs attached to Control Domain'
+  // Original text: "No VDIs attached to control domain"
   noControlDomainVdis: 'Нет VDI подключенных к Управляющему Домену',
 
   // Original text: "Boot flag"
   vbdBootableStatus: 'Флаг загрузки',
+
+  // Original text: 'Device'
+  vbdDevice: undefined,
+
+  // Original text: 'CBT'
+  vbdCbt: undefined,
 
   // Original text: "Status"
   vbdStatus: 'Статус',
@@ -1880,13 +3492,10 @@ export default {
   // Original text: "Disconnected"
   vbdStatusDisconnected: 'Отключен',
 
-  // Original text: "No disks"
-  vbdNoVbd: 'Нет дисков',
-
-  // Original text: 'Connect VBD'
+  // Original text: "Connect VBD"
   vbdConnect: 'Подключить VBD',
 
-  // Original text: 'Disconnect VBD'
+  // Original text: "Disconnect VBD"
   vbdDisconnect: 'Отключить VBD',
 
   // Original text: 'Bootable'
@@ -1895,35 +3504,128 @@ export default {
   // Original text: 'Readonly'
   vbdReadonly: undefined,
 
-  // Original text: 'Action'
-  vbdAction: 'Действие',
-
-  // Original text: 'Create'
+  // Original text: "Create"
   vbdCreate: 'Создать',
 
-  // Original text: 'Disk name'
+  // Original text: 'Attach'
+  vbdAttach: undefined,
+
+  // Original text: "Disk name"
   vbdNamePlaceHolder: 'Имя диска',
 
-  // Original text: 'Size'
+  // Original text: "Size"
   vbdSizePlaceHolder: 'Размер',
 
-  // Original text: 'CD drive not completely installed'
+  // Original text: "CD drive not completely installed"
   cdDriveNotInstalled: 'CD установлен не полностью',
 
-  // Original text: 'Stop and start the VM to install the CD drive'
+  // Original text: "Stop and start the VM to install the CD drive"
   cdDriveInstallation: 'Остановить и запустить ВМ для установки CD',
 
-  // Original text: 'Save'
+  // Original text: "Save"
   saveBootOption: 'Сохранить',
 
-  // Original text: 'Reset'
+  // Original text: "Reset"
   resetBootOption: 'Сбросить',
+
+  // Original text: 'Destroy selected VDIs'
+  destroySelectedVdis: undefined,
+
+  // Original text: 'Destroy VDI'
+  destroyVdi: undefined,
+
+  // Original text: 'Export VDI content'
+  exportVdi: undefined,
+
+  // Original text: 'Format'
+  format: undefined,
+
+  // Original text: 'Import VDI content'
+  importVdi: undefined,
+
+  // Original text: 'No file selected'
+  importVdiNoFile: undefined,
+
+  // Original text: 'Drop VHD file here'
+  selectVdiMessage: undefined,
+
+  // Original text: 'Creating this disk will use the disk space quota from the resource set {resourceSet} ({spaceLeft} left)'
+  useQuotaWarning: undefined,
+
+  // Original text: 'Not enough space in resource set {resourceSet} ({spaceLeft} left)'
+  notEnoughSpaceInResourceSet: undefined,
+
+  // Original text: "The VDIs' SRs must either be shared or on the same host for the VM to be able to start."
+  warningVdiSr: undefined,
+
+  // Original text: 'Remove selected VDIs from this VM'
+  removeSelectedVdisFromVm: undefined,
+
+  // Original text: 'Remove VDI from this VM'
+  removeVdiFromVm: undefined,
+
+  // Original text: 'VHD'
+  vhd: undefined,
+
+  // Original text: 'VMDK'
+  vmdk: undefined,
+
+  // Original text: 'RAW'
+  raw: undefined,
+
+  // Original text: 'Edit locking mode'
+  editVifLockingMode: undefined,
+
+  // Original text: 'Allow the traffic'
+  aclRuleAllow: undefined,
+
+  // Original text: 'Select a protocol'
+  aclRuleProtocol: undefined,
+
+  // Original text: 'Select a port'
+  aclRulePort: undefined,
+
+  // Original text: 'Select an IP or an IP range (CIDR format)'
+  aclRuleIpRange: undefined,
+
+  // Original text: 'Select a direction'
+  aclRuleDirection: undefined,
+
+  // Original text: 'Traffic Enabled/Disabled'
+  aclRuleAllowField: undefined,
+
+  // Original text: 'Protocol'
+  aclRuleProtocolField: undefined,
+
+  // Original text: 'Port'
+  aclRulePortField: undefined,
+
+  // Original text: 'IP range (CIDR format)'
+  aclRuleIpRangeField: undefined,
+
+  // Original text: 'Direction'
+  aclRuleDirectionField: undefined,
+
+  // Original text: 'Add rule'
+  addRule: undefined,
+
+  // Original text: 'Delete rule'
+  deleteRule: undefined,
+
+  // Original text: 'Hide rules'
+  hideRules: undefined,
+
+  // Original text: 'SDN Controller must be loaded'
+  sdnControllerNotLoaded: undefined,
+
+  // Original text: 'Show rules'
+  showRules: undefined,
+
+  // Original text: 'Traffic rules'
+  vifAclRules: undefined,
 
   // Original text: "New device"
   vifCreateDeviceButton: 'Новое устройство',
-
-  // Original text: "No interface"
-  vifNoInterface: 'Нет интерфейса',
 
   // Original text: "Device"
   vifDeviceLabel: 'Устройство',
@@ -1931,11 +3633,14 @@ export default {
   // Original text: "MAC address"
   vifMacLabel: 'MAC адрес',
 
-  // Original text: "MTU"
+  // Original text: 'MTU'
   vifMtuLabel: undefined,
 
   // Original text: "Network"
   vifNetworkLabel: 'Сеть',
+
+  // Original text: 'Rate limit (kB/s)'
+  vifRateLimitLabel: undefined,
 
   // Original text: "Status"
   vifStatusLabel: 'Статус',
@@ -1946,47 +3651,95 @@ export default {
   // Original text: "Disconnected"
   vifStatusDisconnected: 'Отключен',
 
-  // Original text: 'Connect'
+  // Original text: "Connect"
   vifConnect: 'Подключить',
 
-  // Original text: 'Disconnect'
+  // Original text: "Disconnect"
   vifDisconnect: 'Отключить',
 
-  // Original text: 'Remove'
+  // Original text: "Remove"
   vifRemove: 'Удалить',
+
+  // Original text: 'Remove selected VIFs'
+  vifsRemove: undefined,
 
   // Original text: "IP addresses"
   vifIpAddresses: 'IP адреса',
 
-  // Original text: 'Auto-generated if empty'
+  // Original text: "Auto-generated if empty"
   vifMacAutoGenerate: 'Создать если не указано',
 
-  // Original text: 'Allowed IPs'
+  // Original text: "Allowed IPs"
   vifAllowedIps: 'Разрешенные IP',
 
-  // Original text: 'No IPs'
+  // Original text: 'Select an IP'
+  selectIpFromIpPool: undefined,
+
+  // Original text: 'Enter an IP'
+  enterIp: undefined,
+
+  // Original text: 'Add allowed IP'
+  addAllowedIp: undefined,
+
+  // Original text: 'Error while adding allowed IP'
+  addIpError: undefined,
+
+  // Original text: 'Invalid IP'
+  invalidIp: undefined,
+
+  // Original text: "No IPs"
   vifNoIps: 'Без IP',
 
-  // Original text: 'Network locked'
-  vifLockedNetwork: 'Сеть заблокирована',
+  // Original text: 'VIF locking mode is disabled'
+  vifLockingModeDisabled: undefined,
 
-  // Original text: 'Network locked and no IPs are allowed for this interface'
+  // Original text: 'VIF locking mode is unlocked'
+  vifLockingModeUnlocked: undefined,
+
+  // Original text: 'VIF locking mode is locked'
+  vifLockingModeLocked: undefined,
+
+  // Original text: 'Network default locking mode is disabled'
+  networkDefaultLockingModeDisabled: undefined,
+
+  // Original text: 'Network default locking mode is unlocked'
+  networkDefaultLockingModeUnlocked: undefined,
+
+  // Original text: "Network locked and no IPs are allowed for this interface"
   vifLockedNetworkNoIps: 'Сеть заблокирована, и для этого интерфейса не разрешены IP-адреса',
 
-  // Original text: 'Network not locked'
-  vifUnLockedNetwork: 'Сеть не заблокирована',
+  // Original text: 'Some IPs are unnecessarily set as allowed for this interface'
+  vifUnlockedNetworkWithIps: undefined,
 
-  // Original text: 'Unknown network'
+  // Original text: "Unknown network"
   vifUnknownNetwork: 'Неизвестная сеть',
 
-  // Original text: 'Action'
-  vifAction: 'Действие',
-
-  // Original text: 'Create'
+  // Original text: "Create"
   vifCreate: 'Создать',
+
+  // Original text: 'NBD'
+  nbd: undefined,
+
+  // Original text: 'Network Block Device status'
+  nbdTootltip: undefined,
+
+  // Original text: 'Use of insecure NBD is not advised'
+  nbdInsecureTooltip: undefined,
+
+  // Original text: 'Nbd connection is secure and ready'
+  nbdSecureTooltip: undefined,
 
   // Original text: "No snapshots"
   noSnapshots: 'Нет снимков',
+
+  // Original text: 'New snapshot with memory'
+  newSnapshotWithMemory: undefined,
+
+  // Original text: 'Are you sure you want to create a snapshot with memory? This could take a while and the VM will be unusable during that time.'
+  newSnapshotWithMemoryConfirm: undefined,
+
+  // Original text: 'Memory saved'
+  snapshotMemorySaved: undefined,
 
   // Original text: "New snapshot"
   snapshotCreateButton: 'Новый снимок',
@@ -1994,29 +3747,53 @@ export default {
   // Original text: "Just click on the snapshot button to create one!"
   tipCreateSnapshotLabel: 'Нажмите на кнопку снимка, чтобы создать его!',
 
-  // Original text: 'Revert VM to this snapshot'
+  // Original text: "Revert VM to this snapshot"
   revertSnapshot: 'Откатить ВМ на этот снимок',
 
-  // Original text: 'Remove this snapshot'
+  // Original text: "Remove this snapshot"
   deleteSnapshot: 'Удалить снимок',
 
-  // Original text: 'Create a VM from this snapshot'
+  // Original text: 'Remove selected snapshots'
+  deleteSnapshots: undefined,
+
+  // Original text: "Create a VM from this snapshot"
   copySnapshot: 'Создать ВМ из снимка',
 
-  // Original text: 'Export this snapshot'
+  // Original text: "Export this snapshot"
   exportSnapshot: 'Экспортировать снимок',
+
+  // Original text: 'Export snapshot memory'
+  exportSnapshotMemory: undefined,
+
+  // Original text: 'Secure boot'
+  secureBoot: undefined,
 
   // Original text: "Creation date"
   snapshotDate: 'Дата создания',
 
+  // Original text: 'Snapshot error'
+  snapshotError: undefined,
+
   // Original text: "Name"
   snapshotName: 'Имя',
 
-  // Original text: "Action"
-  snapshotAction: 'Действие',
+  // Original text: 'Description'
+  snapshotDescription: undefined,
 
   // Original text: 'Quiesced snapshot'
   snapshotQuiesce: undefined,
+
+  // Original text: 'Revert successful'
+  vmRevertSuccessfulTitle: undefined,
+
+  // Original text: 'VM successfully reverted'
+  vmRevertSuccessfulMessage: undefined,
+
+  // Original text: 'Current snapshot'
+  currentSnapshot: undefined,
+
+  // Original text: 'Go to the backup page.'
+  goToBackupPage: undefined,
 
   // Original text: "Remove all logs"
   logRemoveAll: 'Удалить все журналы',
@@ -2036,11 +3813,47 @@ export default {
   // Original text: "Action"
   logAction: 'Действие',
 
+  // Original text: 'Attached PCIs'
+  attachedPcis: undefined,
+
+  // Original text: 'Attaching/detaching a PCI will be taken into consideration for the next VM boot.'
+  attachingDetachingPciNeedVmBoot: undefined,
+
+  // Original text: 'Attach PCIs'
+  attachPcis: undefined,
+
+  // Original text: 'Create a VTPM'
+  createVtpm: undefined,
+
+  // Original text: 'Delete the VTPM'
+  deleteVtpm: undefined,
+
+  // Original text: 'If the VTPM is in use, removing it will result in a dangerous data loss. Are you sure you want to remove the VTPM?'
+  deleteVtpmWarning: undefined,
+
+  // Original text: "When a VM is offline, it's not attached to any host, and therefore, it's impossible to determine the associated PCI devices, as it depends on the hardware environment in which it would be deployed."
+  infoUnknownPciOnNonRunningVm: undefined,
+
+  // Original text: 'Auto power on is disabled at pool level, click to fix automatically.'
+  poolAutoPoweronDisabled: undefined,
+
   // Original text: "Remove"
   vmRemoveButton: 'Удаление',
 
-  // Original text: "Convert"
-  vmConvertButton: 'Конвертация',
+  // Original text: 'Convert to template'
+  vmConvertToTemplateButton: undefined,
+
+  // Original text: 'Convert to {mode}'
+  vmSwitchVirtualizationMode: undefined,
+
+  // Original text: 'Change virtualization mode'
+  vmVirtualizationModeModalTitle: undefined,
+
+  // Original text: "You must know what you are doing, because it could break your setup (if you didn't install the bootloader in the MBR while switching from PV to HVM, or even worse, in HVM to PV, if you don't have the correct PV args)"
+  vmVirtualizationModeModalBody: undefined,
+
+  // Original text: 'Share'
+  vmShareButton: undefined,
 
   // Original text: "Xen settings"
   xenSettingsLabel: 'Конфигурация Xen',
@@ -2051,11 +3864,17 @@ export default {
   // Original text: "Misc"
   miscLabel: 'Разное',
 
-  // Original text: "UUID"
-  uuid: undefined,
-
   // Original text: "Virtualization mode"
   virtualizationMode: 'Режим виртуализации',
+
+  // Original text: 'Start delay (seconds)'
+  startDelayLabel: undefined,
+
+  // Original text: 'CPU mask'
+  cpuMaskLabel: undefined,
+
+  // Original text: 'Select core(s)…'
+  selectCpuMask: undefined,
 
   // Original text: "CPU weight"
   cpuWeightLabel: 'Приоритизация CPU',
@@ -2066,17 +3885,14 @@ export default {
   // Original text: 'CPU cap'
   cpuCapLabel: undefined,
 
-  // Original text: 'Default ({value, number})'
+  // Original text: "Default ({value, number})"
   defaultCpuCap: 'По умолчанию ({value, number})',
 
-  // Original text: "PV args"
+  // Original text: 'PV args'
   pvArgsLabel: undefined,
 
-  // Original text: "Xen tools status"
-  xenToolsStatus: 'Состояние XEN утилит',
-
-  // Original text: "{status}"
-  xenToolsStatusValue: undefined,
+  // Original text: 'Management agent version'
+  managementAgentVersion: undefined,
 
   // Original text: "OS name"
   osName: 'Имя ОС',
@@ -2087,17 +3903,41 @@ export default {
   // Original text: "Auto power on"
   autoPowerOn: 'Автозапуск',
 
+  // Original text: 'Protect from accidental deletion'
+  protectFromDeletion: undefined,
+
+  // Original text: 'Protect from accidental shutdown'
+  protectFromShutdown: undefined,
+
   // Original text: "HA"
   ha: 'Высокая доступность',
 
+  // Original text: 'SR used for High Availability'
+  srHaTooltip: undefined,
+
+  // Original text: 'Nested virtualization'
+  nestedVirt: undefined,
+
   // Original text: 'Affinity host'
   vmAffinityHost: undefined,
+
+  // Original text: 'The VM needs to be halted'
+  vmNeedToBeHalted: undefined,
 
   // Original text: 'VGA'
   vmVga: undefined,
 
   // Original text: 'Video RAM'
   vmVideoram: undefined,
+
+  // Original text: 'NIC type'
+  vmNicType: undefined,
+
+  // Original text: 'VTPM'
+  vtpm: undefined,
+
+  // Original text: 'A UEFI boot firmware is necessary to use a VTPM'
+  vtpmRequireUefi: undefined,
 
   // Original text: 'None'
   noAffinityHost: undefined,
@@ -2117,32 +3957,137 @@ export default {
   // Original text: "VM limits"
   vmLimitsLabel: 'Ограничения ВМ',
 
+  // Original text: 'Resource set'
+  resourceSet: undefined,
+
+  // Original text: 'None'
+  resourceSetNone: undefined,
+
+  // Original text: 'Select user'
+  selectUser: undefined,
+
+  // Original text: 'Suspend SR'
+  suspendSr: undefined,
+
+  // Original text: 'Viridian'
+  viridian: undefined,
+
   // Original text: "CPU limits"
   vmCpuLimitsLabel: 'Ограничение CPU',
 
-  // Original text: 'Topology'
+  // Original text: "Topology"
   vmCpuTopology: 'Топология',
 
-  // Original text: 'Default behavior'
+  // Original text: "Default behavior"
   vmChooseCoresPerSocket: 'Поведение по умолчанию',
 
   // Original text: '{nSockets, number} socket{nSockets, plural, one {} other {s}} with {nCores, number} core{nCores, plural, one {} other {s}} per socket'
   vmSocketsWithCoresPerSocket: undefined,
 
-  // Original text: 'Incorrect cores per socket value'
-  vmCoresPerSocketIncorrectValue: 'Неверное значение количества ядер на сокет',
+  // Original text: 'None'
+  vmCoresPerSocketNone: undefined,
 
-  // Original text: 'Please change the selected value to fix it.'
-  vmCoresPerSocketIncorrectValueSolution: 'Пожалуйста, измените выбранное значение, чтобы исправить это.',
+  // Original text: '{nCores, number} core{nCores, plural, one {} other {s}} per socket'
+  vmCoresPerSocket: undefined,
+
+  // Original text: "Not a divisor of the VM's max CPUs"
+  vmCoresPerSocketNotDivisor: undefined,
+
+  // Original text: 'The selected value exceeds the cores limit ({maxCores, number})'
+  vmCoresPerSocketExceedsCoresLimit: undefined,
+
+  // Original text: 'The selected value exceeds the sockets limit ({maxSockets, number})'
+  vmCoresPerSocketExceedsSocketsLimit: undefined,
+
+  // Original text: 'Disabled'
+  vmHaDisabled: undefined,
 
   // Original text: "Memory limits (min/max)"
   vmMemoryLimitsLabel: 'Ограничение памяти (min/max)',
 
-  // Original text: "vCPUs max:"
-  vmMaxVcpus: 'Максимум vCPUs:',
+  // Original text: 'VM UUID'
+  vmUuid: undefined,
 
-  // Original text: "Memory max:"
-  vmMaxRam: 'Максимум памяти:',
+  // Original text: 'vGPU'
+  vmVgpu: undefined,
+
+  // Original text: 'GPUs'
+  vmVgpus: undefined,
+
+  // Original text: 'None'
+  vmVgpuNone: undefined,
+
+  // Original text: 'Add vGPU'
+  vmAddVgpu: undefined,
+
+  // Original text: 'Select vGPU type'
+  vmSelectVgpuType: undefined,
+
+  // Original text: 'ACLs'
+  vmAcls: undefined,
+
+  // Original text: 'Add ACLs'
+  vmAddAcls: undefined,
+
+  // Original text: 'Failed to add ACL(s)'
+  addAclsErrorTitle: undefined,
+
+  // Original text: 'User(s)/group(s) and role are required.'
+  addAclsErrorMessage: undefined,
+
+  // Original text: 'Create VUSB'
+  createVusb: undefined,
+
+  // Original text: 'Delete'
+  removeAcl: undefined,
+
+  // Original text: '{nAcls, number} more…'
+  moreAcls: undefined,
+
+  // Original text: 'PUSB description'
+  pusbDescription: undefined,
+
+  // Original text: 'PUSB speed'
+  pusbSpeed: undefined,
+
+  // Original text: 'PUSB version'
+  pusbVersion: undefined,
+
+  // Original text: 'Select PUSB'
+  selectPusb: undefined,
+
+  // Original text: 'Boot firmware'
+  vmBootFirmware: undefined,
+
+  // Original text: 'VM creator'
+  vmCreator: undefined,
+
+  // Original text: 'default (bios)'
+  vmDefaultBootFirmwareLabel: undefined,
+
+  // Original text: "You're about to change your boot firmware. This is still experimental in CH/XCP-ng 8.0. Are you sure you want to continue?"
+  vmBootFirmwareWarningMessage: undefined,
+
+  // Original text: 'Error on restarting and setting the VM: {vm}'
+  setAndRestartVmFailed: undefined,
+
+  // Original text: 'VM is currently running'
+  vmEditAndRestartModalTitle: undefined,
+
+  // Original text: 'This VM is currently running, and needs to be stopped to modify this value. Restart VM and modify this value?'
+  vmEditAndRestartModalMessage: undefined,
+
+  // Original text: 'Firmware not supported'
+  firmwareNotSupported: undefined,
+
+  // Original text: 'VUSBs'
+  vusbs: undefined,
+
+  // Original text: 'The VUSB remain unplugged until the next shutdown/start'
+  vusbRemainUnplugged: undefined,
+
+  // Original text: 'Unplug until the next shutdown/start'
+  vusbUnplugTooltip: undefined,
 
   // Original text: "Long click to add a name"
   vmHomeNamePlaceholder: 'Длительное нажатие для добавления имени',
@@ -2150,26 +4095,45 @@ export default {
   // Original text: "Long click to add a description"
   vmHomeDescriptionPlaceholder: 'Длительное нажатие для добавления описания',
 
+  // Original text: 'Copy to template'
+  copyToTemplate: undefined,
+
+  // Original text: 'Are you sure you want to copy this snapshot to a template?'
+  copyToTemplateMessage: undefined,
+
   // Original text: "Click to add a name"
-  vmViewNamePlaceholder: 'Нажать для добавления имени',
-
-  // Original text: "Click to add a description"
-  vmViewDescriptionPlaceholder: 'Нажать для добавления описания',
-
-  // Original text: 'Click to add a name'
   templateHomeNamePlaceholder: 'Нажать для добавления имени',
 
-  // Original text: 'Click to add a description'
+  // Original text: "Click to add a description"
   templateHomeDescriptionPlaceholder: 'Нажать для добавления описания',
 
-  // Original text: 'Delete template'
+  // Original text: "Delete template"
   templateDelete: 'Удалить шаблон',
 
-  // Original text: 'Delete VM template{templates, plural, one {} other {s}}'
+  // Original text: "Delete VM template{templates, plural, one {} other {s}}"
   templateDeleteModalTitle: 'Удалить шаблон VM {templates, plural, one {} other {s}}',
 
-  // Original text: 'Are you sure you want to delete {templates, plural, one {this} other {these}} template{templates, plural, one {} other {s}}?'
-  templateDeleteModalBody: 'Вы уверены, что хотите удалить{templates, plural, one {this} other {these}} template{templates, plural, one {} other {s}}?',
+  // Original text: "Are you sure you want to delete {templates, plural, one {this} other {these}} template{templates, plural, one {} other {s}}?"
+  templateDeleteModalBody:
+    'Вы уверены, что хотите удалить{templates, plural, one {this} other {these}} template{templates, plural, one {} other {s}}?',
+
+  // Original text: 'Delete template{nTemplates, plural, one {} other {s}} failed'
+  failedToDeleteTemplatesTitle: undefined,
+
+  // Original text: 'Failed to delete {nTemplates, number} template{nTemplates, plural, one {} other {s}}.'
+  failedToDeleteTemplatesMessage: undefined,
+
+  // Original text: 'Delete default template{nDefaultTemplates, plural, one {} other {s}}'
+  deleteDefaultTemplatesTitle: undefined,
+
+  // Original text: 'You are attempting to delete {nDefaultTemplates, number} default template{nDefaultTemplates, plural, one {} other {s}}. Do you want to continue?'
+  deleteDefaultTemplatesMessage: undefined,
+
+  // Original text: 'Delete protected template{nProtectedTemplates, plural, one {} other {s}}'
+  deleteProtectedTemplatesTitle: undefined,
+
+  // Original text: 'You are attempting to delete {nProtectedTemplates, plural, one {a} other {nProtectedTemplates}} template{nProtectedTemplates, plural, one {} other {s}} protected from accidental deletion. Do you want to continue?'
+  deleteProtectedTemplatesMessage: undefined,
 
   // Original text: "Pool{pools, plural, one {} other {s}}"
   poolPanel: 'Пул{pools, plural, one {} other {s}}',
@@ -2183,11 +4147,41 @@ export default {
   // Original text: "RAM Usage:"
   memoryStatePanel: 'Использование памяти',
 
+  // Original text: 'Used Memory'
+  usedMemory: undefined,
+
+  // Original text: 'Total Memory'
+  totalMemory: undefined,
+
+  // Original text: 'CPUs Total'
+  totalCpus: undefined,
+
+  // Original text: 'Used vCPUs'
+  usedVCpus: undefined,
+
+  // Original text: 'Used Space'
+  usedSpace: undefined,
+
+  // Original text: 'Total Space'
+  totalSpace: undefined,
+
   // Original text: "CPUs Usage"
   cpuStatePanel: 'Использование CPU',
 
   // Original text: "VMs Power state"
   vmStatePanel: 'Состояние питания ВМ',
+
+  // Original text: 'Halted'
+  vmStateHalted: undefined,
+
+  // Original text: 'Other'
+  vmStateOther: undefined,
+
+  // Original text: 'Running'
+  vmStateRunning: undefined,
+
+  // Original text: 'All'
+  vmStateAll: undefined,
 
   // Original text: "Pending tasks"
   taskStatePanel: 'Отложенные задачи',
@@ -2198,8 +4192,11 @@ export default {
   // Original text: "Storage state"
   srStatePanel: 'Состояние хранилища',
 
-  // Original text: "{usage} (of {total})"
+  // Original text: '{usage} (of {total})'
   ofUsage: undefined,
+
+  // Original text: '{nVcpus, number} vCPU{nVcpus, plural, one {} other {s}} (of {nCpus, number} CPU{nCpus, plural, one {} other {s}})'
+  ofCpusUsage: undefined,
 
   // Original text: "No storage"
   noSrs: 'Нет хранилища',
@@ -2234,19 +4231,34 @@ export default {
   // Original text: "Top 5 SR Usage (in %)"
   srTopUsageStatePanel: 'Топ 5 SR по использованию (в %)',
 
+  // Original text: 'Not enough permissions!'
+  notEnoughPermissionsError: undefined,
+
   // Original text: '{running, number} running ({halted, number} halted)'
   vmsStates: undefined,
 
-  // Original text: 'Clear selection'
+  // Original text: "Clear selection"
   dashboardStatsButtonRemoveAll: 'Сбросить выделение',
 
-  // Original text: 'Add all hosts'
+  // Original text: "Add all hosts"
   dashboardStatsButtonAddAllHost: 'Добавить все хосты',
 
-  // Original text: 'Add all VMs'
+  // Original text: "Add all VMs"
   dashboardStatsButtonAddAllVM: 'Добавить все ВМ',
 
-  // Original text: "{value} {date, date, medium}"
+  // Original text: 'Send report'
+  dashboardSendReport: undefined,
+
+  // Original text: 'Report'
+  dashboardReport: undefined,
+
+  // Original text: 'This will send a usage report to your configured emails.'
+  dashboardSendReportMessage: undefined,
+
+  // Original text: 'The usage report and transport email plugins need to be loaded!'
+  dashboardSendReportInfo: undefined,
+
+  // Original text: '{value} {date, date, medium}'
   weekHeatmapData: undefined,
 
   // Original text: "No data."
@@ -2276,23 +4288,107 @@ export default {
   // Original text: "Loading…"
   metricsLoading: 'Загрузка…',
 
-  // Original text: "Coming soon!"
-  comingSoon: 'Скоро появится',
+  // Original text: 'Length: {length}'
+  length: undefined,
 
-  // Original text: "Orphaned snapshot VDIs"
+  // Original text: 'Delete backup{nBackups, plural, one {} other {s}}'
+  deleteBackups: undefined,
+
+  // Original text: 'Are you sure you want to delete {nBackups, number} backup{nBackups, plural, one {} other {s}}?'
+  deleteBackupsMessage: undefined,
+
+  // Original text: 'Detached backups'
+  detachedBackups: undefined,
+
+  // Original text: 'Detached VM snapshots'
+  detachedVmSnapshots: undefined,
+
+  // Original text: 'Duplicated MAC addresses'
+  duplicatedMacAddresses: undefined,
+
+  // Original text: 'Local default SRs'
+  localDefaultSrs: undefined,
+
+  // Original text: "It is usually recommended for a pool's default SR to be shared to avoid unexpected behaviors"
+  localDefaultSrsStatusTip: undefined,
+
+  // Original text: 'Missing job'
+  missingJob: undefined,
+
+  // Original text: 'Missing VM'
+  missingVm: undefined,
+
+  // Original text: 'This VM does not belong to this job'
+  missingVmInJob: undefined,
+
+  // Original text: 'Missing schedule'
+  missingSchedule: undefined,
+
+  // Original text: 'No backups'
+  noDetachedBackups: undefined,
+
+  // Original text: 'No duplicated MAC addresses'
+  noDuplicatedMacAddresses: undefined,
+
+  // Original text: 'Reason'
+  reason: undefined,
+
+  // Original text: 'Orphan VDIs'
   orphanedVdis: undefined,
 
-  // Original text: "Orphaned VMs snapshot"
+  // Original text: 'VDIs and VDI snapshots that are not attached to a VM'
+  orphanVdisTip: undefined,
+
+  // Original text: 'Orphaned VMs snapshot'
   orphanedVms: undefined,
 
-  // Original text: "No orphans"
+  // Original text: 'No orphans'
   noOrphanedObject: undefined,
 
-  // Original text: "Remove all orphaned snapshot VDIs"
-  removeAllOrphanedObject: undefined,
+  // Original text: 'Pools with no default SR'
+  poolsWithNoDefaultSr: undefined,
 
-  // Original text: 'VDIs attached to Control Domain'
+  // Original text: 'Too many snapshots'
+  tooManySnapshots: undefined,
+
+  // Original text: 'VMs with more than the recommended amount of snapshots'
+  tooManySnapshotsTip: undefined,
+
+  // Original text: 'No local default SRs'
+  noLocalDefaultSrs: undefined,
+
+  // Original text: 'No VMs with too many snapshots'
+  noTooManySnapshotsObject: undefined,
+
+  // Original text: 'Number of snapshots'
+  numberOfSnapshots: undefined,
+
+  // Original text: 'Guest Tools status'
+  guestToolStatus: undefined,
+
+  // Original text: 'VMs with missing or outdated guest tools'
+  guestToolStatusTip: undefined,
+
+  // Original text: 'All running VMs have up to date guest tools'
+  noGuestToolStatusObject: undefined,
+
+  // Original text: 'Status'
+  guestToolStatusColumn: undefined,
+
+  // Original text: 'Delete orphaned snapshot VDI'
+  deleteOrphanedVdi: undefined,
+
+  // Original text: 'Delete selected orphaned snapshot VDIs'
+  deleteSelectedOrphanedVdis: undefined,
+
+  // Original text: "VDIs attached to Control Domain"
   vdisOnControlDomain: 'VDI подключенные к Управляющему Домену',
+
+  // Original text: 'VIF #{vifDevice, number} on {vm} ({network})'
+  vifOnVmWithNetwork: undefined,
+
+  // Original text: 'VIFs'
+  vifs: undefined,
 
   // Original text: "Name"
   vmNameLabel: 'Имя',
@@ -2300,8 +4396,14 @@ export default {
   // Original text: "Description"
   vmNameDescription: 'Описание',
 
-  // Original text: "Resident on"
+  // Original text: 'Resident on'
   vmContainer: undefined,
+
+  // Original text: 'Snapshot of'
+  snapshotOf: undefined,
+
+  // Original text: 'Legacy backups snapshots'
+  legacySnapshots: undefined,
 
   // Original text: "Alarms"
   alarmMessage: 'Предупреждения',
@@ -2312,31 +4414,49 @@ export default {
   // Original text: "Date"
   alarmDate: 'Дата',
 
-  // Original text: "Content"
+  // Original text: 'Content'
   alarmContent: undefined,
 
-  // Original text: "Issue on"
+  // Original text: 'Issue on'
   alarmObject: undefined,
 
   // Original text: "Pool"
   alarmPool: 'Пул',
 
-  // Original text: "Remove all alarms"
-  alarmRemoveAll: 'Удалить все предупреждения',
-
   // Original text: '{used}% used ({free} left)'
   spaceLeftTooltip: undefined,
+
+  // Original text: 'Unhealthy VDIs'
+  unhealthyVdis: undefined,
+
+  // Original text: 'VDIs to coalesce'
+  vdisToCoalesce: undefined,
+
+  // Original text: 'VDIs with invalid parent VHD'
+  vdisWithInvalidVhdParent: undefined,
+
+  // Original text: 'This SR has {nVdis, number} VDI{nVdis, plural, one {} other {s}} to coalesce'
+  srVdisToCoalesceWarning: undefined,
+
+  // Original text: 'Create VM'
+  createVmModalTitle: undefined,
+
+  // Original text: "You're about to use a large amount of resources available on the resource set. Are you sure you want to continue?"
+  createVmModalWarningMessage: undefined,
+
+  // Original text: 'Copy host BIOS strings to VM'
+  copyHostBiosStrings: undefined,
+
+  // Original text: 'Enable VTPM'
+  enableVtpm: undefined,
 
   // Original text: "Create a new VM on {select}"
   newVmCreateNewVmOn: 'Создать новую ВМ на {select}',
 
-  // Original text: 'Create a new VM on {select1} or {select2}'
-  newVmCreateNewVmOn2: 'Создать новую ВМ на {select1} или {select2}',
-
-  // Original text: 'You have no permission to create a VM'
+  // Original text: "You have no permission to create a VM"
   newVmCreateNewVmNoPermission: 'У вас нет разрешений для создания ВМ',
 
-  // Original text: "Infos"
+  // Original text: "Info"
   newVmInfoPanel: 'Информация',
 
   // Original text: "Name"
@@ -2348,14 +4468,17 @@ export default {
   // Original text: "Description"
   newVmDescriptionLabel: 'Описание',
 
-  // Original text: "Performances"
+  // Original text: "Performance"
   newVmPerfPanel: 'Производительность',
 
-  // Original text: "vCPUs"
+  // Original text: 'vCPUs'
   newVmVcpusLabel: undefined,
 
   // Original text: "RAM"
   newVmRamLabel: 'Память',
+
+  // Original text: 'The memory is below the threshold ({threshold})'
+  newVmRamWarning: undefined,
 
   // Original text: 'Static memory max'
   newVmStaticMaxLabel: undefined,
@@ -2369,7 +4492,7 @@ export default {
   // Original text: "Install settings"
   newVmInstallSettingsPanel: 'Варианты установки',
 
-  // Original text: "ISO/DVD"
+  // Original text: 'ISO/DVD'
   newVmIsoDvdLabel: undefined,
 
   // Original text: "Network"
@@ -2381,13 +4504,13 @@ export default {
   // Original text: "PV Args"
   newVmPvArgsLabel: 'Детали PV',
 
-  // Original text: "PXE"
+  // Original text: 'PXE'
   newVmPxeLabel: undefined,
 
   // Original text: "Interfaces"
   newVmInterfacesPanel: 'Интерфейсы',
 
-  // Original text: "MAC"
+  // Original text: 'MAC'
   newVmMacLabel: undefined,
 
   // Original text: "Add interface"
@@ -2396,7 +4519,7 @@ export default {
   // Original text: "Disks"
   newVmDisksPanel: 'Диски',
 
-  // Original text: "SR"
+  // Original text: 'SR'
   newVmSrLabel: undefined,
 
   // Original text: "Size"
@@ -2405,7 +4528,7 @@ export default {
   // Original text: "Add disk"
   newVmAddDisk: 'Добавить диск',
 
-  // Original text: "Summary"
+  // Original text: 'Summary'
   newVmSummaryPanel: undefined,
 
   // Original text: "Create"
@@ -2420,11 +4543,29 @@ export default {
   // Original text: "SSH key"
   newVmSshKey: 'SSH ключ',
 
-  // Original text: "Config drive"
-  newVmConfigDrive: 'Настроить диск',
+  // Original text: 'No config drive'
+  noConfigDrive: undefined,
 
   // Original text: "Custom config"
   newVmCustomConfig: 'Пользовательские настройки',
+
+  // Original text: 'Click here to see the available template variables'
+  availableTemplateVarsInfo: undefined,
+
+  // Original text: 'Available template variables'
+  availableTemplateVarsTitle: undefined,
+
+  // Original text: 'the VM\'s name. It must not contain "_"'
+  templateNameInfo: undefined,
+
+  // Original text: "the VM's index, it will take 0 in case of single VM"
+  templateIndexInfo: undefined,
+
+  // Original text: 'Tip: escape any variable with a preceding backslash (\\)'
+  templateEscape: undefined,
+
+  // Original text: 'Error on getting the default coreOS cloud template'
+  coreOsDefaultTemplateError: undefined,
 
   // Original text: "Boot VM after creation"
   newVmBootAfterCreate: 'Запустить ВМ после создания',
@@ -2456,9 +4597,6 @@ export default {
   // Original text: "Multiple VMs:"
   newVmMultipleVms: 'Несколько ВМ:',
 
-  // Original text: 'Select a resource set:'
-  newVmSelectResourceSet: 'Выберите набор ресурсов:',
-
   // Original text: 'Name pattern:'
   newVmMultipleVmsPattern: undefined,
 
@@ -2489,17 +4627,77 @@ export default {
   // Original text: 'Share this VM'
   newVmShare: undefined,
 
+  // Original text: 'The SRs must either be on the same host or shared'
+  newVmSrsNotOnSameHost: undefined,
+
+  // Original text: 'Network config'
+  newVmNetworkConfigLabel: undefined,
+
+  // Original text: 'Network configuration is only compatible with the {noCloudDatasourceLink}.'
+  newVmNetworkConfigInfo: undefined,
+
+  // Original text: 'See {networkConfigDocLink}.'
+  newVmNetworkConfigDocLink: undefined,
+
+  // Original text: 'Click here to get more information about network config'
+  newVmNetworkConfigTooltip: undefined,
+
+  // Original text: 'User config'
+  newVmUserConfigLabel: undefined,
+
+  // Original text: 'NoCloud datasource'
+  newVmNoCloudDatasource: undefined,
+
+  // Original text: 'Network config documentation'
+  newVmNetworkConfigDoc: undefined,
+
+  // Original text: 'The template already contains the BIOS strings'
+  templateHasBiosStrings: undefined,
+
+  // Original text: 'Click for more information about Guest UEFI Secure Boot.'
+  secureBootLinkToDocumentationMessage: undefined,
+
+  // Original text: 'This pool has not yet been setup for Guest UEFI Secure Boot. Click for more information.'
+  secureBootNotSetup: undefined,
+
+  // Original text: 'See VTPM documentation'
+  seeVtpmDocumentation: undefined,
+
+  // Original text: 'The boot firmware is UEFI'
+  vmBootFirmwareIsUefi: undefined,
+
+  // Original text: 'Destroy cloud config drive after first boot'
+  destroyCloudConfigVdiAfterBoot: undefined,
+
+  // Original text: 'VTPM is only supported on pools running XCP-ng/XS 8.3 or later.'
+  vtpmNotSupported: undefined,
+
+  // Original text: 'This template requires a VTPM, if you proceed, the VM will likely not be able to boot.'
+  warningVtpmRequired: undefined,
+
   // Original text: "Resource sets"
   resourceSets: 'Набор ресурсов',
 
   // Original text: "No resource sets."
   noResourceSets: 'Набор ресурсов не определен',
 
-  // Original text: 'Loading resource sets'
-  loadingResourceSets: undefined,
-
   // Original text: "Resource set name"
   resourceSetName: 'Имя набора ресурсов',
+
+  // Original text: 'Users'
+  resourceSetUsers: undefined,
+
+  // Original text: 'Pools'
+  resourceSetPools: undefined,
+
+  // Original text: 'Templates'
+  resourceSetTemplates: undefined,
+
+  // Original text: 'SRs'
+  resourceSetSrs: undefined,
+
+  // Original text: 'Networks'
+  resourceSetNetworks: undefined,
 
   // Original text: 'Recompute all limits'
   recomputeResourceSets: undefined,
@@ -2513,6 +4711,9 @@ export default {
   // Original text: "Edit"
   editResourceSet: 'Изменить',
 
+  // Original text: 'Default tags'
+  defaultTags: undefined,
+
   // Original text: "Delete"
   deleteResourceSet: 'Удалить',
 
@@ -2524,15 +4725,6 @@ export default {
 
   // Original text: "Missing objects:"
   resourceSetMissingObjects: 'Объект не найден:',
-
-  // Original text: "vCPUs"
-  resourceSetVcpus: undefined,
-
-  // Original text: "Memory"
-  resourceSetMemory: 'Память',
-
-  // Original text: "Storage"
-  resourceSetStorage: 'Хранилище',
 
   // Original text: "Unknown"
   unknownResourceSetValue: 'Неизвестно',
@@ -2547,12 +4739,13 @@ export default {
   noHostsAvailable: 'Нет доступных хостов',
 
   // Original text: "VMs created from this resource set shall run on the following hosts."
-  availableHostsDescription: 'Виртуальные машины, созданные из этого набора ресурсов, должны работать на следующих хостах.',
+  availableHostsDescription:
+    'Виртуальные машины, созданные из этого набора ресурсов, должны работать на следующих хостах.',
 
   // Original text: "Maximum CPUs"
   maxCpus: 'Максимум CPUs',
 
-  // Original text: "Maximum RAM (GiB)"
+  // Original text: "Maximum RAM"
   maxRam: 'Максимум памяти (GiB)',
 
   // Original text: "Maximum disk space"
@@ -2564,26 +4757,54 @@ export default {
   // Original text: 'Quantity'
   quantity: undefined,
 
-  // Original text: "No limits."
-  noResourceSetLimits: 'Нет ограничений',
+  // Original text: 'Used'
+  usedResourceLabel: undefined,
 
-  // Original text: "Total:"
-  totalResource: 'Итого:',
+  // Original text: 'Available'
+  availableResourceLabel: undefined,
 
-  // Original text: "Remaining:"
-  remainingResource: 'Осталось:',
-
-  // Original text: "Used:"
-  usedResource: 'Используется:',
+  // Original text: 'Used: {usage} (Total: {total})'
+  resourceSetQuota: undefined,
 
   // Original text: 'New'
   resourceSetNew: undefined,
 
-  // Original text: "Try dropping some VMs files here, or click to select VMs to upload. Accept only .xva/.ova files."
-  importVmsList: 'Перетащите сюда несколько файлов виртуальных машин или нажмите, чтобы выбрать виртуальные машины для загрузки. Работает только с файлами .xva/.ova.',
+  // Original text: 'Share VMs by default'
+  shareVmsByDefault: undefined,
+
+  // Original text: '{nVms, number} VM{nVms, plural, one {} other {s}} belong{nVms, plural, one {s} other {}} to this Resource Set'
+  nVmsInResourceSet: undefined,
+
+  // Original text: 'Used: {usage}'
+  unlimitedResourceSetUsage: undefined,
+
+  // Original text: 'File type:'
+  fileType: undefined,
+
+  // Original text: 'Firmware'
+  firmware: undefined,
+
+  // Original text: 'From URL'
+  fromUrl: undefined,
+
+  // Original text: 'URL import is only compatible with ISO SRs'
+  UrlImportSrsCompatible: undefined,
+
+  // Original text: 'From VMware'
+  fromVmware: undefined,
+
+  // Original text: "Drop OVA or XVA files here to import Virtual Machines."
+  importVmsList:
+    'Перетащите сюда несколько файлов виртуальных машин или нажмите, чтобы выбрать виртуальные машины для загрузки. Работает только с файлами .xva/.ova.',
 
   // Original text: "No selected VMs."
   noSelectedVms: 'Нет выбранных ВМ',
+
+  // Original text: 'No tools installed'
+  noToolsInstalled: undefined,
+
+  // Original text: 'URL:'
+  url: undefined,
 
   // Original text: "To Pool:"
   vmImportToPool: 'В пул:',
@@ -2594,6 +4815,12 @@ export default {
   // Original text: "VM{nVms, plural, one {} other {s}} to import"
   vmsToImport: 'ВМ для импорта',
 
+  // Original text: '<div>VM running from non file based datastore (like VSAN) will be migrated in a three steps process<ul><li>Stop the VM</li><li>Export the VM disks to a remote of Xen Orchestra</li><li>Load these disks in XCP-ng</li></ul>This process will be slower than migrating the VM to VMFS / NFS datastore and then migrating them to XCP-ng</div>'
+  warningVsanImport: undefined,
+
+  // Original text: 'Remote used to store temporary disk files(VSAN migration)'
+  workDirLabel: undefined,
+
   // Original text: "Reset"
   importVmsCleanList: 'Сбросить',
 
@@ -2603,68 +4830,158 @@ export default {
   // Original text: "VM import failed"
   vmImportFailed: 'Ошибка импорта ВМ',
 
+  // Original text: 'VDI import success'
+  vdiImportSuccess: undefined,
+
+  // Original text: 'VDI import failed'
+  vdiImportFailed: undefined,
+
+  // Original text: 'Error on setting the VM: {vm}'
+  setVmFailed: undefined,
+
   // Original text: "Import starting…"
   startVmImport: 'Импорт начался…',
+
+  // Original text: 'VDI import starting…'
+  startVdiImport: undefined,
 
   // Original text: "Export starting…"
   startVmExport: 'Экспорт начался…',
 
-  // Original text: 'Number of CPUs'
+  // Original text: 'VDI export starting…'
+  startVdiExport: undefined,
+
+  // Original text: "Number of CPUs"
   nCpus: 'Количество CPUs',
 
-  // Original text: 'Memory'
+  // Original text: "Memory"
   vmMemory: 'Память',
 
   // Original text: 'Disk {position} ({capacity})'
   diskInfo: undefined,
 
-  // Original text: 'Disk description'
+  // Original text: "Disk description"
   diskDescription: 'Описание диска',
 
-  // Original text: 'No disks.'
+  // Original text: "No disks."
   noDisks: 'Нет дисков',
 
-  // Original text: 'No networks.'
+  // Original text: "No networks."
   noNetworks: 'Нет сетей',
 
-  // Original text: 'Network {name}'
+  // Original text: "Network {name}"
   networkInfo: 'Сеть {name}',
 
-  // Original text: 'No description available'
+  // Original text: "No description available"
   noVmImportErrorDescription: 'Описание недоступно',
 
-  // Original text: 'Error:'
+  // Original text: "Error:"
   vmImportError: 'Ошибка',
 
-  // Original text: '{type} file:'
+  // Original text: "{type} file:"
   vmImportFileType: '{type} файл:',
 
-  // Original text: 'Please to check and/or modify the VM configuration.'
+  // Original text: "Please check and/or modify the VM configuration."
   vmImportConfigAlert: 'Пожалуйста, проверьте и/или измените конфигурацию виртуальной машины.',
 
-  // Original text: "No pending tasks"
-  noTasks: 'Нет отложенных задач',
+  // Original text: 'The tools are installed'
+  toolsInstalled: undefined,
 
-  // Original text: "Currently, there are not any pending XenServer tasks"
-  xsTasks: 'В настоящее время нет незавершенных задач XenServer',
+  // Original text: 'Disk import failed'
+  diskImportFailed: undefined,
+
+  // Original text: 'Disk import success'
+  diskImportSuccess: undefined,
+
+  // Original text: 'Drop {types} files here to import disks.'
+  dropDisksFiles: undefined,
+
+  // Original text: 'To SR'
+  importToSr: undefined,
+
+  // Original text: 'To import ISO files, an ISO repository is required'
+  isoImportRequirement: undefined,
+
+  // Original text: 'Pool tasks'
+  poolTasks: undefined,
+
+  // Original text: 'XO tasks'
+  xoTasks: undefined,
+
+  // Original text: 'Cancel'
+  cancelTask: undefined,
+
+  // Original text: 'Destroy'
+  destroyTask: undefined,
+
+  // Original text: 'Cancel selected tasks'
+  cancelTasks: undefined,
+
+  // Original text: 'Destroy selected tasks'
+  destroyTasks: undefined,
+
+  // Original text: 'Object'
+  object: undefined,
+
+  // Original text: 'Objects'
+  objects: undefined,
+
+  // Original text: 'Pool'
+  pool: undefined,
+
+  // Original text: 'Task'
+  task: undefined,
+
+  // Original text: 'Progress'
+  progress: undefined,
+
+  // Original text: 'Previous tasks'
+  previousTasks: undefined,
+
+  // Original text: 'Last seen'
+  taskLastSeen: undefined,
 
   // Original text: 'Schedules'
   backupSchedules: undefined,
 
+  // Original text: '{nLoneSnapshots} lone snapshot{nLoneSnapshots, plural, one {} other {s}} to delete!'
+  loneSnapshotsMessages: undefined,
+
+  // Original text: 'Cron pattern'
+  scheduleCron: undefined,
+
+  // Original text: 'Click to display last run details'
+  scheduleLastRun: undefined,
+
+  // Original text: 'Name'
+  scheduleName: undefined,
+
+  // Original text: 'Copy ID {id}'
+  scheduleCopyId: undefined,
+
+  // Original text: 'Timezone'
+  scheduleTimezone: undefined,
+
+  // Original text: 'Backup retention'
+  scheduleExportRetention: undefined,
+
+  // Original text: 'Replication retention'
+  scheduleCopyRetention: undefined,
+
+  // Original text: 'Snapshot retention'
+  scheduleSnapshotRetention: undefined,
+
+  // Original text: 'Pool retention'
+  poolMetadataRetention: undefined,
+
+  // Original text: 'XO retention'
+  xoMetadataRetention: undefined,
+
   // Original text: 'Get remote'
   getRemote: undefined,
 
-  // Original text: "List Remote"
-  listRemote: undefined,
-
-  // Original text: "simple"
-  simpleBackup: 'простой',
-
-  // Original text: "delta"
-  delta: undefined,
-
-  // Original text: "Restore Backups"
-  restoreBackups: 'Восстановить резервную копию',
+  // Original text: 'There are no backups!'
+  noBackups: undefined,
 
   // Original text: 'Click on a VM to display restore options'
   restoreBackupsInfo: undefined,
@@ -2672,19 +4989,28 @@ export default {
   // Original text: "Enabled"
   remoteEnabled: 'Подключено',
 
-  // Original text: "Error"
-  remoteError: 'Ошибка',
+  // Original text: 'Disabled'
+  remoteDisabled: undefined,
 
-  // Original text: "No backup available"
-  noBackup: 'Нет доступных резервных копий',
+  // Original text: 'Enable'
+  enableRemote: undefined,
+
+  // Original text: 'Disable'
+  disableRemote: undefined,
+
+  // Original text: 'The URL ({url}) is invalid (colon in path). Click this button to change the URL to {newUrl}.'
+  remoteErrorMessage: undefined,
 
   // Original text: "VM Name"
   backupVmNameColumn: 'Имя ВМ',
 
-  // Original text: 'Tags'
-  backupTags: 'Тэги',
+  // Original text: 'VM Description'
+  backupVmDescriptionColumn: undefined,
 
-  // Original text: "Last Backup"
+  // Original text: 'Oldest backup'
+  firstBackupColumn: undefined,
+
+  // Original text: "Latest backup"
   lastBackupColumn: 'Последняя резервная копия',
 
   // Original text: "Available Backups"
@@ -2696,38 +5022,137 @@ export default {
   // Original text: 'Choose a SR and a backup'
   backupRestoreErrorMessage: undefined,
 
-  // Original text: 'Select default SR…'
-  backupRestoreSelectDefaultSr: 'Выберите SR по умолчанию...',
+  // Original text: 'key'
+  backupisKey: undefined,
 
-  // Original text: 'Choose a SR for each VDI'
-  backupRestoreChooseSrForEachVdis: 'Выберите SR для каждого VDI',
+  // Original text: 'incremental'
+  backupIsIncremental: undefined,
 
-  // Original text: 'VDI'
-  backupRestoreVdiLabel: undefined,
-
-  // Original text: 'SR'
-  backupRestoreSrLabel: undefined,
-
-  // Original text: 'Display backups'
-  displayBackup: undefined,
-
-  // Original text: "Import VM"
-  importBackupTitle: 'Импорт ВМ',
-
-  // Original text: "Starting your backup import"
-  importBackupMessage: 'Начинаем импорт резервной копии',
+  // Original text: 'differencing'
+  backupIsDifferencing: undefined,
 
   // Original text: 'VMs to backup'
   vmsToBackup: undefined,
 
-  // Original text: 'List remote backups'
-  listRemoteBackups: undefined,
+  // Original text: 'Refresh backup list'
+  refreshBackupList: undefined,
+
+  // Original text: 'Restore'
+  restoreVmBackups: undefined,
+
+  // Original text: 'Restore {vm}'
+  restoreVmBackupsTitle: undefined,
+
+  // Original text: 'Restore health check {vm}'
+  checkVmBackupsTitle: undefined,
+
+  // Original text: 'Restore {nVms, number} VM{nVms, plural, one {} other {s}}'
+  restoreVmBackupsBulkTitle: undefined,
+
+  // Original text: 'Restore {nVms, number} VM{nVms, plural, one {} other {s}} from {nVms, plural, one {its} other {their}} {oldestOrLatest} backup.'
+  restoreVmBackupsBulkMessage: undefined,
+
+  // Original text: 'This operation will overwrite the host metadata. Only perform a metadata restore if it is a new server with nothing running on it.'
+  restoreMetadataBackupWarning: undefined,
+
+  // Original text: 'oldest'
+  oldest: undefined,
+
+  // Original text: 'latest'
+  latest: undefined,
+
+  // Original text: 'Start VM{nVms, plural, one {} other {s}} after restore'
+  restoreVmBackupsStart: undefined,
+
+  // Original text: 'Multi-restore error'
+  restoreVmBackupsBulkErrorTitle: undefined,
+
+  // Original text: 'Use differential restore'
+  restoreVmUseDifferentialRestore: undefined,
+
+  // Original text: 'Restore {item}'
+  restoreMetadataBackupTitle: undefined,
+
+  // Original text: 'Restore {nMetadataBackups, number} metadata backup{nMetadataBackups, plural, one {} other {s}}'
+  bulkRestoreMetadataBackupTitle: undefined,
+
+  // Original text: 'Restore {nMetadataBackups, number} metadata backup{nMetadataBackups, plural, one {} other {s}} from {nMetadataBackups, plural, one {its} other {their}} {oldestOrLatest} backup'
+  bulkRestoreMetadataBackupMessage: undefined,
+
+  // Original text: 'Delete {item} backup'
+  deleteMetadataBackupTitle: undefined,
+
+  // Original text: 'You need to select a destination SR'
+  restoreVmBackupsBulkErrorMessage: undefined,
+
+  // Original text: 'Delete backups…'
+  deleteVmBackups: undefined,
+
+  // Original text: 'Delete {vm} backups'
+  deleteVmBackupsTitle: undefined,
+
+  // Original text: 'Select backups to delete:'
+  deleteBackupsSelect: undefined,
+
+  // Original text: 'All'
+  deleteVmBackupsSelectAll: undefined,
+
+  // Original text: 'Delete backups'
+  deleteVmBackupsBulkTitle: undefined,
+
+  // Original text: 'Are you sure you want to delete all the backups from {nVms, number} VM{nVms, plural, one {} other {s}}?'
+  deleteVmBackupsBulkMessage: undefined,
+
+  // Original text: 'delete {nBackups} backup{nBackups, plural, one {} other {s}}'
+  deleteVmBackupsBulkConfirmText: undefined,
+
+  // Original text: 'Delete metadata backups'
+  bulkDeleteMetadataBackupsTitle: undefined,
+
+  // Original text: 'Are you sure you want to delete all the backups from {nMetadataBackups, number} metadata backup{nMetadataBackups, plural, one {} other {s}}?'
+  bulkDeleteMetadataBackupsMessage: undefined,
+
+  // Original text: 'delete {nMetadataBackups} metadata backup{nMetadataBackups, plural, one {} other {s}}'
+  bulkDeleteMetadataBackupsConfirmText: undefined,
+
+  // Original text: 'Health check'
+  healthCheck: undefined,
+
+  // Original text: 'Choose SR used for VMs restoration'
+  healthCheckChooseSr: undefined,
+
+  // Original text: 'If no tags are specified, all VMs in the backup will be tested.'
+  healthCheckTagsInfo: undefined,
+
+  // Original text: 'Only available to enterprise users'
+  healthCheckAvailableEnterpriseUser: undefined,
+
+  // Original text: "The backup will not be run on this remote because it's not compatible with the selected proxy"
+  remoteNotCompatibleWithSelectedProxy: undefined,
+
+  // Original text: 'Loading backups failed'
+  remoteLoadBackupsFailure: undefined,
+
+  // Original text: 'Failed to load backups from {name}.'
+  remoteLoadBackupsFailureMessage: undefined,
+
+  // Original text: 'VMs tags'
+  vmsTags: undefined,
+
+  // Original text: 'VMs with this tag will not be backed up {reason, select, null {} other {({reason})}}'
+  tagNoBak: undefined,
+
+  // Original text: 'An email will be sent when a VM with this tag is snapshotted'
+  tagNotifyOnSnapshot: undefined,
 
   // Original text: 'Restore backup files'
   restoreFiles: undefined,
 
   // Original text: 'Invalid options'
   restoreFilesError: undefined,
+
+  // Original text: 'Export format:'
+  restoreFilesExportFormat: undefined,
 
   // Original text: 'Restore file from {name}'
   restoreFilesFromBackup: undefined,
@@ -2741,20 +5166,14 @@ export default {
   // Original text: 'Select a partition…'
   restoreFilesSelectPartition: undefined,
 
-  // Original text: 'Folder path'
-  restoreFilesSelectFolderPath: undefined,
-
   // Original text: 'Select a file…'
   restoreFilesSelectFiles: undefined,
-
-  // Original text: 'Content not found'
-  restoreFileContentNotFound: undefined,
 
   // Original text: 'No files selected'
   restoreFilesNoFilesSelected: undefined,
 
-  // Original text: 'Selected files ({files}):'
-  restoreFilesSelectedFiles: undefined,
+  // Original text: 'Selected files/folders ({files}):'
+  restoreFilesSelectedFilesAndFolders: undefined,
 
   // Original text: 'Error while scanning disk'
   restoreFilesDiskError: undefined,
@@ -2762,8 +5181,29 @@ export default {
   // Original text: "Select all this folder's files"
   restoreFilesSelectAllFiles: undefined,
 
+  // Original text: 'Select this folder'
+  restoreFilesSelectFolder: undefined,
+
+  // Original text: 'tar+gzip (.tgz)'
+  restoreFilesTgz: undefined,
+
   // Original text: 'Unselect all files'
   restoreFilesUnselectAll: undefined,
+
+  // Original text: 'ZIP (slow)'
+  restoreFilesZip: undefined,
+
+  // Original text: 'There may be ongoing backups on the host. Are you sure you want to continue?'
+  bypassBackupHostModalMessage: undefined,
+
+  // Original text: 'There may be ongoing backups on the pool. Are you sure you want to continue?'
+  bypassBackupPoolModalMessage: undefined,
+
+  // Original text: 'Emergency shutdown Host'
+  emergencyShutdownHostModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to shutdown {host}?'
+  emergencyShutdownHostModalMessage: undefined,
 
   // Original text: 'Emergency shutdown Host{nHosts, plural, one {} other {s}}'
   emergencyShutdownHostsModalTitle: undefined,
@@ -2776,6 +5216,12 @@ export default {
 
   // Original text: "This will shutdown your host. Do you want to continue? If it's the pool master, your connection to the pool will be lost"
   stopHostModalMessage: undefined,
+
+  // Original text: 'Force shutdown host'
+  forceStopHost: undefined,
+
+  // Original text: 'This will shutdown your host without evacuating its VMs. Do you want to continue?'
+  forceStopHostMessage: undefined,
 
   // Original text: 'Add host'
   addHostModalTitle: undefined,
@@ -2801,7 +5247,7 @@ export default {
   // Original text: 'Are you sure you want to restart {nHosts, number} Host{nHosts, plural, one {} other {s}}?'
   restartHostsModalMessage: undefined,
 
-  // Original text: "Start VM{vms, plural, one {} other {s}}"
+  // Original text: 'Start VM{vms, plural, one {} other {s}}'
   startVmsModalTitle: undefined,
 
   // Original text: 'Start a copy'
@@ -2822,11 +5268,14 @@ export default {
   // Original text: "Are you sure you want to start {vms, number} VM{vms, plural, one {} other {s}}?"
   startVmsModalMessage: 'Вы уверены, что хотите запустить {vms, number} ВМ{vms, plural, one {} other {s}}?',
 
-  // Original text: '{nVms, number} vm{nVms, plural, one {} other {s}} are failed. Please see your logs to get more information'
+  // Original text: '{nVms, number} VM{nVms, plural, one {} other {s}} failed. Please check logs for more information'
   failedVmsErrorMessage: undefined,
 
   // Original text: 'Start failed'
   failedVmsErrorTitle: undefined,
+
+  // Original text: 'Delete failed'
+  failedDeleteErrorTitle: undefined,
 
   // Original text: 'Stop Host{nHosts, plural, one {} other {s}}'
   stopHostsModalTitle: undefined,
@@ -2852,29 +5301,79 @@ export default {
   // Original text: 'Are you sure you want to stop {name}?'
   stopVmModalMessage: undefined,
 
+  // Original text: 'Blocked operation'
+  blockedOperation: undefined,
+
+  // Original text: 'Stop operation for this VM is blocked. Would you like to stop it anyway?'
+  stopVmBlockedModalMessage: undefined,
+
+  // Original text: 'No guest tools'
+  vmHasNoTools: undefined,
+
+  // Original text: "The VM doesn't have Xen tools installed, which are required to properly stop or reboot it."
+  vmHasNoToolsMessage: undefined,
+
+  // Original text: 'Would you like to force shutdown the VM?'
+  confirmForceShutdown: undefined,
+
+  // Original text: 'Would you like to force reboot the VM?'
+  confirmForceReboot: undefined,
+
+  // Original text: 'Suspend VM{vms, plural, one {} other {s}}'
+  suspendVmsModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to suspend {vms, number} VM{vms, plural, one {} other {s}}?'
+  suspendVmsModalMessage: undefined,
+
+  // Original text: 'Pause VM{vms, plural, one {} other {s}}'
+  pauseVmsModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to pause {vms, number} VM{vms, plural, one {} other {s}}?'
+  pauseVmsModalMessage: undefined,
+
   // Original text: "Restart VM{vms, plural, one {} other {s}}"
   restartVmsModalTitle: 'Перезапустить ВМ{vms, plural, one {} other {s}}',
 
   // Original text: "Are you sure you want to restart {vms, number} VM{vms, plural, one {} other {s}}?"
   restartVmsModalMessage: 'Вы уверены, что хотите перезапустить {vms, number} ВМ{vms, plural, one {} other {s}}?',
 
+  // Original text: 'Restart operation for this VM is blocked. Would you like to restart it anyway?'
+  restartVmBlockedModalMessage: undefined,
+
+  // Original text: 'save memory'
+  snapshotSaveMemory: undefined,
+
   // Original text: "Snapshot VM{vms, plural, one {} other {s}}"
   snapshotVmsModalTitle: 'Снимок ВМ{vms, plural, one {} other {s}}',
-
-  // Original text: "Are you sure you want to snapshot {vms, number} VM{vms, plural, one {} other {s}}?"
-  snapshotVmsModalMessage: 'Вы уверены, что хотите сделать снимки {vms, number} ВМ{vms, plural, one {} other {s}}?',
 
   // Original text: "Delete VM{vms, plural, one {} other {s}}"
   deleteVmsModalTitle: 'Удалить ВМ{vms, plural, one {} other {s}}',
 
   // Original text: "Are you sure you want to delete {vms, number} VM{vms, plural, one {} other {s}}? ALL VM DISKS WILL BE REMOVED"
-  deleteVmsModalMessage: 'Вы уверены, что хотите удалить {vms, number} ВМ{vms, plural, one {} other {s}}? ВСЕ ДИСКИ ВИРТУАЛЬНЫХ МАШИН БУДУТ УДАЛЕНЫ!',
+  deleteVmsModalMessage:
+    'Вы уверены, что хотите удалить {vms, number} ВМ{vms, plural, one {} other {s}}? ВСЕ ДИСКИ ВИРТУАЛЬНЫХ МАШИН БУДУТ УДАЛЕНЫ!',
+
+  // Original text: 'delete {nVms, number} vm{nVms, plural, one {} other {s}}'
+  deleteVmsConfirmText: undefined,
 
   // Original text: "Delete VM"
   deleteVmModalTitle: 'Удалить ВМ',
 
   // Original text: "Are you sure you want to delete this VM? ALL VM DISKS WILL BE REMOVED"
-  deleteVmModalMessage: 'Вы уверены, что хотите удалить эту виртуальную машину? ВСЕ ДИСКИ ВИРТУАЛЬНОЙ МАШИНЫ БУДУТ УДАЛЕНЫ!',
+  deleteVmModalMessage:
+    'Вы уверены, что хотите удалить эту виртуальную машину? ВСЕ ДИСКИ ВИРТУАЛЬНОЙ МАШИНЫ БУДУТ УДАЛЕНЫ!',
+
+  // Original text: 'Blocked operation'
+  deleteVmBlockedModalTitle: undefined,
+
+  // Original text: 'Removing the VM is a blocked operation. Would you like to remove it anyway?'
+  deleteVmBlockedModalMessage: undefined,
+
+  // Original text: 'Force migration'
+  forceVmMigrateModalTitle: undefined,
+
+  // Original text: 'The VM is incompatible with the CPU features of the destination host. Would you like to force it anyway?'
+  forceVmMigrateModalMessage: undefined,
 
   // Original text: "Migrate VM"
   migrateVmModalTitle: 'Переместить ВМ',
@@ -2912,13 +5411,19 @@ export default {
   // Original text: 'A target host is required to migrate a VM'
   migrateVmNoTargetHostMessage: undefined,
 
+  // Original text: 'SR required'
+  migrateVmNoSr: undefined,
+
+  // Original text: 'A destination SR is required'
+  migrateVmNoSrMessage: undefined,
+
   // Original text: 'No default SR'
   migrateVmNoDefaultSrError: undefined,
 
   // Original text: 'Default SR not connected to host'
   migrateVmNotConnectedDefaultSrError: undefined,
 
-  // Original text: 'For each VDI, select an SR:'
+  // Original text: 'For each VDI, select an SR (optional)'
   chooseSrForEachVdisModalSelectSr: undefined,
 
   // Original text: 'Select main SR…'
@@ -2930,8 +5435,17 @@ export default {
   // Original text: 'SR*'
   chooseSrForEachVdisModalSrLabel: undefined,
 
-  // Original text: '* optional'
-  optionalEntry: undefined,
+  // Original text: 'Delete job{nJobs, plural, one {} other {s}}'
+  deleteJobsModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to delete {nJobs, number} job{nJobs, plural, one {} other {s}}?'
+  deleteJobsModalMessage: undefined,
+
+  // Original text: 'Delete VBD{nVbds, plural, one {} other {s}}'
+  deleteVbdsModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to delete {nVbds, number} VBD{nVbds, plural, one {} other {s}}?'
+  deleteVbdsModalMessage: undefined,
 
   // Original text: 'Delete VDI'
   deleteVdiModalTitle: undefined,
@@ -2939,8 +5453,38 @@ export default {
   // Original text: 'Are you sure you want to delete this disk? ALL DATA ON THIS DISK WILL BE LOST'
   deleteVdiModalMessage: undefined,
 
+  // Original text: 'Delete VDI{nVdis, plural, one {} other {s}}'
+  deleteVdisModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to delete {nVdis, number} disk{nVdis, plural, one {} other {s}}? ALL DATA ON THESE DISKS WILL BE LOST'
+  deleteVdisModalMessage: undefined,
+
+  // Original text: 'Delete schedule{nSchedules, plural, one {} other {s}}'
+  deleteSchedulesModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to delete {nSchedules, number} schedule{nSchedules, plural, one {} other {s}}?'
+  deleteSchedulesModalMessage: undefined,
+
+  // Original text: 'Delete remote{nRemotes, plural, one {} other {s}}'
+  deleteRemotesModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to delete {nRemotes, number} remote{nRemotes, plural, one {} other {s}}?'
+  deleteRemotesModalMessage: undefined,
+
   // Original text: 'Revert your VM'
   revertVmModalTitle: undefined,
+
+  // Original text: 'Share your VM'
+  shareVmInResourceSetModalTitle: undefined,
+
+  // Original text: 'This VM will be shared with all the members of the self-service {self}. Are you sure?'
+  shareVmInResourceSetModalMessage: undefined,
+
+  // Original text: 'Delete VIF{nVifs, plural, one {} other {s}}'
+  deleteVifsModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to delete {nVifs, number} VIF{nVifs, plural, one {} other {s}}?'
+  deleteVifsModalMessage: undefined,
 
   // Original text: 'Delete snapshot'
   deleteSnapshotModalTitle: undefined,
@@ -2948,44 +5492,51 @@ export default {
   // Original text: 'Are you sure you want to delete this snapshot?'
   deleteSnapshotModalMessage: undefined,
 
+  // Original text: 'Delete snapshot{nVms, plural, one {} other {s}}'
+  deleteSnapshotsModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to delete {nVms, number} snapshot{nVms, plural, one {} other {s}}?'
+  deleteSnapshotsModalMessage: undefined,
+
+  // Original text: 'Disconnect VBD{nVbds, plural, one {} other {s}}'
+  disconnectVbdsModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to disconnect {nVbds, number} VBD{nVbds, plural, one {} other {s}}?'
+  disconnectVbdsModalMessage: undefined,
+
+  // Original text: 'Disable host'
+  disableHost: undefined,
+
+  // Original text: 'Are you sure you want to disable {host}? This will prevent new VMs from starting.'
+  disableHostModalMessage: undefined,
+
   // Original text: 'Are you sure you want to revert this VM to the snapshot state? This operation is irreversible.'
   revertVmModalMessage: undefined,
 
   // Original text: 'Snapshot before'
   revertVmModalSnapshotBefore: undefined,
 
-  // Original text: "Import a {name} Backup"
-  importBackupModalTitle: 'Импортировать {name} резервную копию',
-
-  // Original text: "Start VM after restore"
-  importBackupModalStart: 'Запустить ВМ после восстановления',
-
   // Original text: "Select your backup…"
   importBackupModalSelectBackup: 'Выберите резервную копию…',
 
-  // Original text: "Are you sure you want to remove all orphaned snapshot VDIs?"
-  removeAllOrphanedModalWarning: undefined,
+  // Original text: 'Select a destination SR…'
+  importBackupModalSelectSr: undefined,
 
-  // Original text: "Remove all logs"
-  removeAllLogsModalTitle: 'Очистить все журналы',
+  // Original text: 'Delete orphaned snapshot VDIs'
+  deleteOrphanedVdisModalTitle: undefined,
 
-  // Original text: "Are you sure you want to remove all logs?"
-  removeAllLogsModalWarning: 'Вы уверены, что хотите очистить все журналы?',
+  // Original text: 'Are you sure you want to delete {nVdis, number} orphaned snapshot VDI{nVdis, plural, one {} other {s}}?'
+  deleteOrphanedVdisModalMessage: undefined,
 
   // Original text: "This operation is definitive."
   definitiveMessageModal: 'Эта операция является окончательной',
 
-  // Original text: "Previous SR Usage"
-  existingSrModalTitle: undefined,
-
-  // Original text: "This path has been previously used as a Storage by a XenServer host. All data will be lost if you choose to continue the SR creation."
-  existingSrModalText: 'Этот путь ранее использовался хостом XenServer в качестве хранилища. Все существующие данные будут потеряны, если вы продолжите создание SR.',
-
   // Original text: "Previous LUN Usage"
   existingLunModalTitle: 'Предыдущее использование LUN',
 
-  // Original text: "This LUN has been previously used as a Storage by a XenServer host. All data will be lost if you choose to continue the SR creation."
-  existingLunModalText: 'Этот LUN ранее использовался хостом XenServer в качестве хранилища. Все существующие данные будут потеряны, если вы продолжите создание SR.',
+  // Original text: "This LUN has been previously used as storage by a XenServer host. All data will be lost if you choose to continue with the SR creation."
+  existingLunModalText:
+    'Этот LUN ранее использовался хостом XenServer в качестве хранилища. Все существующие данные будут потеряны, если вы продолжите создание SR.',
 
   // Original text: "Replace current registration?"
   alreadyRegisteredModal: 'Заменить текущую регистрацию?',
@@ -2997,7 +5548,65 @@ export default {
   trialReadyModal: 'Готовы к пробному периоду?',
 
   // Original text: "During the trial period, XOA need to have a working internet connection. This limitation does not apply for our paid plans!"
-  trialReadyModalText: 'В течение пробного периода для XOA требуется подключение к Интернету. Это ограничение не распространяется на тарифные планы',
+  trialReadyModalText:
+    'В течение пробного периода для XOA требуется подключение к Интернету. Это ограничение не распространяется на тарифные планы',
+
+  // Original text: 'Cancel task{nTasks, plural, one {} other {s}}'
+  cancelTasksModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to cancel {nTasks, number} task{nTasks, plural, one {} other {s}}?'
+  cancelTasksModalMessage: undefined,
+
+  // Original text: 'Destroy task{nTasks, plural, one {} other {s}}'
+  destroyTasksModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to destroy {nTasks, number} task{nTasks, plural, one {} other {s}}?'
+  destroyTasksModalMessage: undefined,
+
+  // Original text: 'Forget host'
+  forgetHostFromSrModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to forget this host? This will disconnect the SR from the host by removing the link between them (PBD).'
+  forgetHostFromSrModalMessage: undefined,
+
+  // Original text: 'Forget host{nPbds, plural, one {} other {s}}'
+  forgetHostsFromSrModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to forget {nPbds, number} host{nPbds, plural, one {} other {s}}? This will disconnect the SR from these hosts by removing the links between the SR and the hosts (PBDs).'
+  forgetHostsFromSrModalMessage: undefined,
+
+  // Original text: 'Forget SR'
+  forgetSrFromHostModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to forget this SR? This will disconnect the SR from the host by removing the link between them (PBD).'
+  forgetSrFromHostModalMessage: undefined,
+
+  // Original text: 'Forget SR{nPbds, plural, one {} other {s}}'
+  forgetSrsFromHostModalTitle: undefined,
+
+  // Original text: 'Are you sure you want to forget {nPbds, number} SR{nPbds, plural, one {} other {s}}? This will disconnect the SRs from the host by removing the links between the host and the SRs (PBDs).'
+  forgetSrsFromHostModalMessage: undefined,
+
+  // Original text: '* optional'
+  optionalEntry: undefined,
+
+  // Original text: 'This VM contains a duplicate MAC address or has the same MAC address as another running VM. Do you want to continue?'
+  vmWithDuplicatedMacAddressesMessage: undefined,
+
+  // Original text: '{nVms, number} VM{nVms, plural, one {} other {s}} contain{nVms, plural, one {s} other {}} duplicate MAC addresses or {nVms, plural, one {has} other {have}} the same MAC addresses as other running VMs. Do you want to continue?'
+  vmsWithDuplicatedMacAddressesMessage: undefined,
+
+  // Original text: 'Ignore this VDI'
+  ignoreVdi: undefined,
+
+  // Original text: 'Select a destination SR'
+  selectDestinationSr: undefined,
+
+  // Original text: 'Enable server'
+  enableServerErrorTitle: undefined,
+
+  // Original text: 'Unexpected response. Please check your server address.'
+  enableServerErrorMessage: undefined,
 
   // Original text: 'Label'
   serverLabel: undefined,
@@ -3010,9 +5619,6 @@ export default {
 
   // Original text: "Password"
   serverPassword: 'Пароль',
-
-  // Original text: "Action"
-  serverAction: 'Действие',
 
   // Original text: "Read Only"
   serverReadOnly: 'Только для чтения',
@@ -3053,9 +5659,6 @@ export default {
   // Original text: 'Connection failed. Click for more information.'
   serverConnectionFailed: undefined,
 
-  // Original text: 'Connecting…'
-  serverConnecting: undefined,
-
   // Original text: 'Authentication error'
   serverAuthFailed: undefined,
 
@@ -3068,20 +5671,29 @@ export default {
   // Original text: 'Do you want to accept self-signed certificate for this server even though it would decrease security?'
   serverSelfSignedCertQuestion: undefined,
 
+  // Original text: 'Enable'
+  serverEnable: undefined,
+
+  // Original text: 'Enabled'
+  serverEnabled: undefined,
+
+  // Original text: 'Disabled'
+  serverDisabled: undefined,
+
+  // Original text: 'Disable server'
+  serverDisable: undefined,
+
+  // Original text: ' HTTP proxy URL'
+  serverHttpProxy: undefined,
+
+  // Original text: ' HTTP proxy URL'
+  serverHttpProxyPlaceHolder: undefined,
+
   // Original text: "Copy VM"
   copyVm: 'Копировать ВМ',
 
-  // Original text: "Are you sure you want to copy this VM to {SR}?"
-  copyVmConfirm: 'Вы уверены, что хотите скопировать эту виртуальную машину на {SR}?',
-
   // Original text: "Name"
   copyVmName: 'Имя',
-
-  // Original text: 'Name pattern'
-  copyVmNamePattern: undefined,
-
-  // Original text: "If empty: name of the copied VM"
-  copyVmNamePlaceholder: 'Если пусто: имя копируемой ВМ',
 
   // Original text: 'e.g.: "\\{name\\}_COPY"'
   copyVmNamePatternPlaceholder: undefined,
@@ -3089,14 +5701,26 @@ export default {
   // Original text: "Select SR"
   copyVmSelectSr: 'Выберите SR',
 
-  // Original text: "Use compression"
-  copyVmCompress: 'Использовать сжатие',
-
   // Original text: 'No target SR'
   copyVmsNoTargetSr: undefined,
 
   // Original text: 'A target SR is required to copy a VM'
   copyVmsNoTargetSrMessage: undefined,
+
+  // Original text: 'Zstd is not supported on {nVms, number} VM{nVms, plural, one {} other {s}}'
+  notSupportedZstdWarning: undefined,
+
+  // Original text: 'Click to see the concerned VMs'
+  notSupportedZstdTooltip: undefined,
+
+  // Original text: 'Fast clone'
+  fastCloneMode: undefined,
+
+  // Original text: 'Full copy'
+  fullCopyMode: undefined,
+
+  // Original text: 'Copy template'
+  copyTemplate: undefined,
 
   // Original text: 'Detach host'
   detachHostModalTitle: undefined,
@@ -3107,6 +5731,21 @@ export default {
   // Original text: 'Detach'
   detachHost: undefined,
 
+  // Original text: 'Advanced Live Telemetry'
+  advancedLiveTelemetry: undefined,
+
+  // Original text: 'Netdata plugin is necessary'
+  pluginNetDataIsNecessary: undefined,
+
+  // Original text: 'Enable Advanced Live Telemetry'
+  enableAdvancedLiveTelemetry: undefined,
+
+  // Original text: 'Advanced Live Telemetry successfully enabled'
+  enableAdvancedLiveTelemetrySuccess: undefined,
+
+  // Original text: 'This feature is only XCP-ng compatible'
+  xcpOnlyFeature: undefined,
+
   // Original text: 'Forget host'
   forgetHostModalTitle: undefined,
 
@@ -3116,11 +5755,17 @@ export default {
   // Original text: 'Forget'
   forgetHost: undefined,
 
+  // Original text: 'Designate a new master'
+  setPoolMasterModalTitle: undefined,
+
+  // Original text: 'This operation may take several minutes. Do you want to continue?'
+  setPoolMasterModalMessage: undefined,
+
+  // Original text: 'Management'
+  networkManagement: undefined,
+
   // Original text: "Create network"
   newNetworkCreate: 'Создать сеть',
-
-  // Original text: 'Create bonded network'
-  newBondedNetworkCreate: undefined,
 
   // Original text: "Interface"
   newNetworkInterface: 'Интерфейс',
@@ -3137,20 +5782,38 @@ export default {
   // Original text: "No VLAN if empty"
   newNetworkDefaultVlan: 'VLAN не определён',
 
-  // Original text: "MTU"
+  // Original text: 'MTU'
   newNetworkMtu: undefined,
 
   // Original text: "Default: 1500"
   newNetworkDefaultMtu: 'По умолчанию: 1500',
 
-  // Original text: 'Name required'
-  newNetworkNoNameErrorTitle: undefined,
-
-  // Original text: 'A name is required to create a network'
-  newNetworkNoNameErrorMessage: undefined,
-
   // Original text: 'Bond mode'
   newNetworkBondMode: undefined,
+
+  // Original text: 'Info'
+  newNetworkInfo: undefined,
+
+  // Original text: 'Type'
+  newNetworkType: undefined,
+
+  // Original text: 'Preferred center (optional)'
+  newNetworkPreferredCenter: undefined,
+
+  // Original text: 'Encapsulation'
+  newNetworkEncapsulation: undefined,
+
+  // Original text: 'Encrypted'
+  newNetworkEncrypted: undefined,
+
+  // Original text: 'A pool can have 1 encrypted GRE network and 1 encrypted VxLAN network max'
+  encryptionWarning: undefined,
+
+  // Original text: 'The host to try first to elect as center of the network'
+  preferredCenterTip: undefined,
+
+  // Original text: 'Please see the requirements'
+  newNetworkSdnControllerTip: undefined,
 
   // Original text: "Delete network"
   deleteNetwork: 'Удалить сеть',
@@ -3164,8 +5827,17 @@ export default {
   // Original text: 'Bonded'
   pillBonded: undefined,
 
-  // Original text: 'Host'
-  addHostSelectHost: undefined,
+  // Original text: 'Bonded network'
+  bondedNetwork: undefined,
+
+  // Original text: 'Private network'
+  privateNetwork: undefined,
+
+  // Original text: 'Add pool'
+  addPool: undefined,
+
+  // Original text: 'Hosts'
+  hosts: undefined,
 
   // Original text: 'No host'
   addHostNoHost: undefined,
@@ -3173,20 +5845,17 @@ export default {
   // Original text: 'No host selected to be added'
   addHostNoHostMessage: undefined,
 
-  // Original text: "Xen Orchestra"
-  xenOrchestra: 'Xen Orchestra',
+  // Original text: 'Failed to fetch latest master commit'
+  failedToFetchLatestMasterCommit: undefined,
 
-  // Original text: "No pro support provided!"
+  // Original text: "Professional support missing!"
   noProSupport: '"PRO" поддержка не предоставляется!',
 
-  // Original text: "Use in production at your own risks"
-  noProductionUse: 'Используйте в производстве на свой страх и риск',
-
-  // Original text: 'Want to use in production?'
+  // Original text: "Want to use in production?"
   productionUse: 'Хотите использовать в производстве',
 
-  // Original text: "You can download our turnkey appliance at {website}"
-  downloadXoaFromWebsite: 'Вы можете скачать нашу сборку Xen Orchestra с {website}',
+  // Original text: 'Get pro support with the Xen Orchestra Appliance at {website}'
+  getSupport: undefined,
 
   // Original text: "Bug Tracker"
   bugTracker: 'Bug Tracker',
@@ -3230,6 +5899,12 @@ export default {
   // Original text: "Problem? Open a ticket!"
   openTicketText: 'Проблема? Открой заявку!',
 
+  // Original text: 'Your Xen Orchestra is up to date'
+  xoUpToDate: undefined,
+
+  // Original text: 'You are not up to date with master. {nBehind} commit{nBehind, plural, one {} other {s}} behind {nAhead, plural, =0 {} other {and {nAhead, number} commit{nAhead, plural, one {} other {s}} ahead}}'
+  xoFromSourceNotUpToDate: undefined,
+
   // Original text: "Upgrade needed"
   upgradeNeeded: 'Требуется обновление',
 
@@ -3245,17 +5920,11 @@ export default {
   // Original text: "This feature is available starting from {plan} Edition"
   availableIn: 'Эта функция доступна только в {plan} Edition',
 
-  // Original text: 'This feature is not available in your version, contact your administrator to know more.'
+  // Original text: "This feature is not available in your version, contact your administrator to know more."
   notAvailable: 'Эта функция недоступна в вашей версии, обратитесь к своему администратору, чтобы узнать больше.',
-
-  // Original text: 'Updates'
-  updateTitle: 'Обновления',
 
   // Original text: "Registration"
   registration: 'Регистрация',
-
-  // Original text: "Trial"
-  trial: 'Пробный период',
 
   // Original text: "Settings"
   settings: 'Настройки',
@@ -3281,6 +5950,9 @@ export default {
   // Original text: 'Your password'
   updateRegistrationPasswordPlaceHolder: undefined,
 
+  // Original text: 'Troubleshooting documentation'
+  updaterTroubleshootingLink: undefined,
+
   // Original text: "Update"
   update: 'Обновить',
 
@@ -3290,14 +5962,12 @@ export default {
   // Original text: "Upgrade"
   upgrade: 'Обновить',
 
-  // Original text: "No updater available for Community Edition"
-  noUpdaterCommunity: 'Для Community Edition обновления не доступны',
+  // Original text: 'Downgrade'
+  downgrade: undefined,
 
-  // Original text: "Please consider subscribe and try it with all features for free during 15 days on {link}.""
-  considerSubscribe: 'Пожалуйста, рассмотрите возможность подписки и попробуйте все функции бесплатно в течение 15 дней на {link}.',
-
-  // Original text: "Manual update could break your current installation due to dependencies issues, do it with caution"
-  noUpdaterWarning: 'Обновление вручную может привести к сбою вашей текущей установки из-за проблем с зависимостями, делайте это с осторожностью',
+  // Original text: "Please consider subscribing and trying it with all the features for free during 15 days on {link}."
+  considerSubscribe:
+    'Пожалуйста, рассмотрите возможность подписки и попробуйте все функции бесплатно в течение 15 дней на {link}.',
 
   // Original text: "Current version:"
   currentVersion: 'Текущая версия:',
@@ -3305,7 +5975,7 @@ export default {
   // Original text: "Register"
   register: 'Регистрация',
 
-  // Original text: 'Edit registration'
+  // Original text: "Edit registration"
   editRegistration: 'Изменить регистрацию',
 
   // Original text: "Please, take time to register in order to enjoy your trial."
@@ -3315,13 +5985,15 @@ export default {
   trialStartButton: 'Активировать пробный период',
 
   // Original text: "You can use a trial version until {date, date, medium}. Upgrade your appliance to get it."
-  trialAvailableUntil: 'Вы можете использовать пробную версию до {date, date, medium}. Обновите свою установку Xen Orchestra, чтобы продолжить использовать все преимущества.',
+  trialAvailableUntil:
+    'Вы можете использовать пробную версию до {date, date, medium}. Обновите свою установку Xen Orchestra, чтобы продолжить использовать все преимущества.',
 
   // Original text: "Your trial has been ended. Contact us or downgrade to Free version"
   trialConsumed: 'Ваш пробный период закончился. Свяжитесь с нами или вернитесь к бесплатной версии',
 
   // Original text: "Your xoa-updater service appears to be down. Your XOA cannot run fully without reaching this service."
-  trialLocked: 'Ваша служба xoa-updater, похоже, не работает. XOA не может работать должным образом без обращения к этой службе',
+  trialLocked:
+    'Ваша служба xoa-updater, похоже, не работает. XOA не может работать должным образом без обращения к этой службе',
 
   // Original text: "No update information available"
   noUpdateInfo: 'Нет информации об обновлении',
@@ -3347,6 +6019,33 @@ export default {
   // Original text: 'Your XOA has successfully upgraded, and your browser must reload the application. Do you want to reload now ?'
   promptUpgradeReloadMessage: undefined,
 
+  // Original text: 'Upgrade warning'
+  upgradeWarningTitle: undefined,
+
+  // Original text: 'You have some backup jobs in progress. If you upgrade now, these jobs will be interrupted! Are you sure you want to continue?'
+  upgradeWarningMessage: undefined,
+
+  // Original text: 'Release channels'
+  releaseChannels: undefined,
+
+  // Original text: 'unlisted channel'
+  unlistedChannel: undefined,
+
+  // Original text: 'Unlisted channel name'
+  unlistedChannelName: undefined,
+
+  // Original text: 'Select channel'
+  selectChannel: undefined,
+
+  // Original text: 'Change channel'
+  changeChannel: undefined,
+
+  // Original text: 'The Web updater, the release channels and the proxy settings are available in XOA.'
+  updaterCommunity: undefined,
+
+  // Original text: 'XOA build:'
+  xoaBuild: undefined,
+
   // Original text: "Xen Orchestra from the sources"
   disclaimerTitle: 'Xen Orchestra из исходного кода',
 
@@ -3356,8 +6055,20 @@ export default {
   // Original text: "If you are a company, it's better to use it with our appliance + pro support included:"
   disclaimerText2: undefined,
 
-  // Original text: "This version is not bundled with any support nor updates. Use it with caution for critical tasks."
+  // Original text: "This version is not bundled with any support nor updates. Use it with caution."
   disclaimerText3: 'Эта версия без поддержки и обновлений. Используйте с осторожностью при выполнении важных задач.',
+
+  // Original text: 'Why do I see this message?'
+  disclaimerText4: undefined,
+
+  // Original text: 'You are not registered. Your XOA may not be up to date.'
+  notRegisteredDisclaimerInfo: undefined,
+
+  // Original text: 'Click here to create an account.'
+  notRegisteredDisclaimerCreateAccount: undefined,
+
+  // Original text: 'Click here to register and update your XOA.'
+  notRegisteredDisclaimerRegister: undefined,
 
   // Original text: "Connect PIF"
   connectPif: 'Подключить PIF',
@@ -3377,10 +6088,16 @@ export default {
   // Original text: "Are you sure you want to delete this PIF?"
   deletePifConfirm: 'Вы уверены, что хотите удалить этот PIF?',
 
+  // Original text: 'Delete PIFs'
+  deletePifs: undefined,
+
+  // Original text: 'Are you sure you want to delete {nPifs, number} PIF{nPifs, plural, one {} other {s}}?'
+  deletePifsConfirm: undefined,
+
   // Original text: 'Connected'
   pifConnected: undefined,
 
-  // Original text: 'Disconnected'
+  // Original text: "Disconnected"
   pifDisconnected: 'Отключен',
 
   // Original text: 'Physically connected'
@@ -3388,6 +6105,15 @@ export default {
 
   // Original text: 'Physically disconnected'
   pifPhysicallyDisconnected: undefined,
+
+  // Original text: 'Token'
+  authToken: undefined,
+
+  // Original text: 'Authentication tokens'
+  authTokens: undefined,
+
+  // Original text: 'Last use'
+  authTokenLastUse: undefined,
 
   // Original text: 'Username'
   username: undefined,
@@ -3428,116 +6154,212 @@ export default {
   // Original text: 'OK'
   changePasswordOk: undefined,
 
+  // Original text: 'Forget all authentication tokens'
+  forgetTokens: undefined,
+
+  // Original text: 'This prevents authenticating with existing tokens but the one used by the current session'
+  forgetTokensExplained: undefined,
+
+  // Original text: 'Successfully forgot authentication tokens'
+  forgetTokensSuccess: undefined,
+
+  // Original text: 'Error while forgetting authentication tokens'
+  forgetTokensError: undefined,
+
   // Original text: 'SSH keys'
   sshKeys: undefined,
+
+  // Original text: 'New token'
+  newAuthToken: undefined,
 
   // Original text: 'New SSH key'
   newSshKey: undefined,
 
+  // Original text: 'Delete selected authentication tokens'
+  deleteAuthTokens: undefined,
+
   // Original text: 'Delete'
   deleteSshKey: undefined,
 
-  // Original text: 'No SSH keys'
-  noSshKeys: undefined,
+  // Original text: 'Delete selected SSH keys'
+  deleteSshKeys: undefined,
 
-  // Original text: 'New SSH key'
+  // Original text: 'New authentication token'
+  newAuthTokenModalTitle: undefined,
+
+  // Original text: "New SSH key"
   newSshKeyModalTitle: 'Новый SSH ключ',
 
-  // Original text: 'Invalid key'
+  // Original text: 'SSH key already exists!'
+  sshKeyAlreadyExists: undefined,
+
+  // Original text: "Invalid key"
   sshKeyErrorTitle: 'Недействительный ключ',
 
-  // Original text: 'An SSH key requires both a title and a key.'
+  // Original text: "An SSH key requires both a title and a key."
   sshKeyErrorMessage: 'Для SSH-ключа требуется как заголовок, так и ключ.',
 
-  // Original text: 'Title'
+  // Original text: "Title"
   title: 'Заголовок',
 
-  // Original text: 'Key'
+  // Original text: "Key"
   key: 'Ключ',
 
-  // Original text: 'Delete SSH key'
+  // Original text: 'Delete authentication token'
+  deleteAuthTokenConfirm: undefined,
+
+  // Original text: 'Are you sure you want to delete the authentication token: {id}?'
+  deleteAuthTokenConfirmMessage: undefined,
+
+  // Original text: 'Delete authentication token{nTokens, plural, one {} other {s}}'
+  deleteAuthTokensConfirm: undefined,
+
+  // Original text: 'Are you sure you want to delete {nTokens, number} autentication token{nTokens, plural, one {} other {s}}?'
+  deleteAuthTokensConfirmMessage: undefined,
+
+  // Original text: "Delete SSH key"
   deleteSshKeyConfirm: 'Удалить SSH ключ',
 
-  // Original text: 'Are you sure you want to delete the SSH key {title}?'
+  // Original text: "Are you sure you want to delete the SSH key {title}?"
   deleteSshKeyConfirmMessage: 'Вы уверены, что хотите удалить SSH ключ {title}?',
 
-  // Original text: 'Others'
-  others: undefined,
+  // Original text: 'Delete SSH key{nKeys, plural, one {} other {s}}'
+  deleteSshKeysConfirm: undefined,
 
-  // Original text: 'Loading logs…'
-  loadingLogs: 'Загрузка журналов...',
+  // Original text: 'Are you sure you want to delete {nKeys, number} SSH key{nKeys, plural, one {} other {s}}?'
+  deleteSshKeysConfirmMessage: undefined,
+
+  // Original text: 'Add OTP authentication'
+  addOtpConfirm: undefined,
+
+  // Original text: 'To enable OTP authentication, add it to your application and then enter the current password to validate.'
+  addOtpConfirmMessage: undefined,
+
+  // Original text: 'Password is invalid'
+  addOtpInvalidPassword: undefined,
+
+  // Original text: 'Remove OTP authentication'
+  removeOtpConfirm: undefined,
+
+  // Original text: 'Are you sure you want to remove OTP authentication?'
+  removeOtpConfirmMessage: undefined,
+
+  // Original text: 'OTP authentication'
+  OtpAuthentication: undefined,
+
+  // Original text: '{nOthers, number} other{nOthers, plural, one {} other {s}}'
+  others: undefined,
 
   // Original text: 'User'
   logUser: undefined,
 
-  // Original text: 'Method'
-  logMethod: undefined,
-
-  // Original text: 'Params'
-  logParams: undefined,
-
   // Original text: 'Message'
   logMessage: undefined,
 
-  // Original text: 'Error'
+  // Original text: 'Use XCP-ng to get rid of restrictions'
+  logSuggestXcpNg: undefined,
+
+  // Original text: 'This is a XenServer/XCP-ng error'
+  logXapiError: undefined,
+
+  // Original text: "Error"
   logError: 'Ошибка',
 
-  // Original text: 'Display details'
+  // Original text: 'Logs'
+  logTitle: undefined,
+
+  // Original text: "Display details"
   logDisplayDetails: 'Показать детали',
 
-  // Original text: 'Date'
+  // Original text: 'Download log'
+  logDownload: undefined,
+
+  // Original text: "Date"
   logTime: 'Дата',
 
-  // Original text: 'No stack trace'
-  logNoStackTrace: undefined,
-
-  // Original text: 'No params'
-  logNoParams: undefined,
-
-  // Original text: 'Delete log'
+  // Original text: "Delete log"
   logDelete: 'Удалить журнал',
 
-  // Original text: 'Delete all logs'
-  logDeleteAll: 'Удалить все журналы',
+  // Original text: 'Delete logs'
+  logsDelete: undefined,
 
-  // Original text: 'Delete all logs'
-  logDeleteAllTitle: 'Удалить все журналы',
+  // Original text: 'Job ID'
+  logsJobId: undefined,
 
-  // Original text: 'Are you sure you want to delete all the logs?'
-  logDeleteAllMessage: 'Вы уверены, что хотите удалить все журналы?',
+  // Original text: 'Job name'
+  logsJobName: undefined,
 
-  // Original text: 'Click to enable'
+  // Original text: 'Backup time'
+  logsBackupTime: undefined,
+
+  // Original text: 'Restore time'
+  logsRestoreTime: undefined,
+
+  // Original text: 'Copy log to clipboard'
+  copyLogToClipboard: undefined,
+
+  // Original text: 'VM not found!'
+  logsVmNotFound: undefined,
+
+  // Original text: 'Click to show error'
+  logsFailedRestoreError: undefined,
+
+  // Original text: 'Restore error'
+  logsFailedRestoreTitle: undefined,
+
+  // Original text: 'Delete log{nLogs, plural, one {} other {s}}'
+  logDeleteMultiple: undefined,
+
+  // Original text: 'Are you sure you want to delete {nLogs, number} log{nLogs, plural, one {} other {s}}?'
+  logDeleteMultipleMessage: undefined,
+
+  // Original text: "Click to enable"
   logIndicationToEnable: 'Нажмите для включения',
 
-  // Original text: 'Click to disable'
+  // Original text: "Click to disable"
   logIndicationToDisable: 'Нажмите для отключения',
 
-  // Original text: 'Report a bug'
+  // Original text: "Report a bug"
   reportBug: 'Сообщить об ошибке',
 
-  // Original text: 'Name'
+  // Original text: 'Job canceled to protect the VDI chain'
+  unhealthyVdiChainError: undefined,
+
+  // Original text: "Restart VM's backup"
+  backupRestartVm: undefined,
+
+  // Original text: "Force restart VM's backup"
+  backupForceRestartVm: undefined,
+
+  // Original text: "Restart failed VMs' backup"
+  backupRestartFailedVms: undefined,
+
+  // Original text: "Force restart failed VMs' backup"
+  backupForceRestartFailedVms: undefined,
+
+  // Original text: 'Click for more information'
+  clickForMoreInformation: undefined,
+
+  // Original text: 'Click to go to this job'
+  goToThisJob: undefined,
+
+  // Original text: 'Click to see corresponding logs'
+  goToCorrespondingLogs: undefined,
+
+  // Original text: "Name"
   ipPoolName: 'Имя',
 
-  // Original text: 'IPs'
+  // Original text: "IPs"
   ipPoolIps: 'IPs',
 
-  // Original text: 'IPs (e.g.: 1.0.0.12-1.0.0.17;1.0.0.23)'
-  ipPoolIpsPlaceholder: 'IPs (прим.: 1.0.0.12-1.0.0.17;1.0.0.23)',
-
-  // Original text: 'Networks'
+  // Original text: "Networks"
   ipPoolNetworks: 'Сети',
 
   // Original text: 'No IP pools'
   ipsNoIpPool: undefined,
 
-  // Original text: 'Create'
+  // Original text: "Create"
   ipsCreate: 'Создать',
-
-  // Original text: 'Delete all IP pools'
-  ipsDeleteAllTitle: undefined,
-
-  // Original text: 'Are you sure you want to delete all the IP pools?'
-  ipsDeleteAllMessage: undefined,
 
   // Original text: 'VIFs'
   ipsVifs: undefined,
@@ -3558,156 +6380,241 @@ export default {
   shortcut_XoApp: undefined,
 
   // Original text: 'Go to hosts list'
-  shortcut_GO_TO_HOSTS: undefined,
+  shortcut_XoApp_GO_TO_HOSTS: undefined,
 
   // Original text: 'Go to pools list'
-  shortcut_GO_TO_POOLS: undefined,
+  shortcut_XoApp_GO_TO_POOLS: undefined,
 
   // Original text: 'Go to VMs list'
-  shortcut_GO_TO_VMS: undefined,
+  shortcut_XoApp_GO_TO_VMS: undefined,
 
   // Original text: 'Go to SRs list'
-  shortcut_GO_TO_SRS: undefined,
+  shortcut_XoApp_GO_TO_SRS: undefined,
 
   // Original text: 'Create a new VM'
-  shortcut_CREATE_VM: 'Создать новую ВМ',
+  shortcut_XoApp_CREATE_VM: undefined,
 
   // Original text: 'Unfocus field'
-  shortcut_UNFOCUS: undefined,
+  shortcut_XoApp_UNFOCUS: undefined,
 
   // Original text: 'Show shortcuts key bindings'
-  shortcut_HELP: undefined,
+  shortcut_XoApp_HELP: undefined,
 
   // Original text: 'Home'
   shortcut_Home: undefined,
 
   // Original text: 'Focus search bar'
-  shortcut_SEARCH: undefined,
+  shortcut_Home_SEARCH: undefined,
 
   // Original text: 'Next item'
-  shortcut_NAV_DOWN: 'Следующий элемент',
+  shortcut_Home_NAV_DOWN: undefined,
 
   // Original text: 'Previous item'
-  shortcut_NAV_UP: 'Предыдущий элемент',
+  shortcut_Home_NAV_UP: undefined,
 
   // Original text: 'Select item'
-  shortcut_SELECT: 'Выбрать элемент',
+  shortcut_Home_SELECT: undefined,
 
   // Original text: 'Open'
-  shortcut_JUMP_INTO: 'Открыть',
+  shortcut_Home_JUMP_INTO: undefined,
 
-  // Original text: 'VM'
+  // Original text: 'Supported tables'
+  shortcut_SortedTable: undefined,
+
+  // Original text: 'Focus the table search bar'
+  shortcut_SortedTable_SEARCH: undefined,
+
+  // Original text: 'Next item'
+  shortcut_SortedTable_NAV_DOWN: undefined,
+
+  // Original text: 'Previous item'
+  shortcut_SortedTable_NAV_UP: undefined,
+
+  // Original text: 'Select item'
+  shortcut_SortedTable_SELECT: undefined,
+
+  // Original text: 'Action'
+  shortcut_SortedTable_ROW_ACTION: undefined,
+
+  // Original text: "VM"
   settingsAclsButtonTooltipVM: 'ВМ',
 
-  // Original text: 'Hosts'
+  // Original text: "Hosts"
   settingsAclsButtonTooltiphost: 'Хосты',
 
-  // Original text: 'Pool'
+  // Original text: "Pool"
   settingsAclsButtonTooltippool: 'Пул',
 
   // Original text: 'SR'
   settingsAclsButtonTooltipSR: undefined,
 
-  // Original text: 'Network'
+  // Original text: "Network"
   settingsAclsButtonTooltipnetwork: 'Сеть',
 
-  // Original text: 'No config file selected'
+  // Original text: 'Template'
+  settingsCloudConfigTemplate: undefined,
+
+  // Original text: 'Delete cloud config{nCloudConfigs, plural, one {} other {s}}'
+  confirmDeleteCloudConfigsTitle: undefined,
+
+  // Original text: 'Are you sure you want to delete {nCloudConfigs, number} cloud config{nCloudConfigs, plural, one {} other {s}}?'
+  confirmDeleteCloudConfigsBody: undefined,
+
+  // Original text: 'Delete network config{nNetworkConfigs, plural, one {} other {s}}'
+  confirmDeleteNetworkConfigsTitle: undefined,
+
+  // Original text: 'Are you sure you want to delete {nNetworkConfigs, number} network config{nNetworkConfigs, plural, one {} other {s}}?'
+  confirmDeleteNetworkConfigsBody: undefined,
+
+  // Original text: 'Delete cloud config'
+  deleteCloudConfig: undefined,
+
+  // Original text: 'Edit cloud config'
+  editCloudConfig: undefined,
+
+  // Original text: 'Delete selected cloud configs'
+  deleteSelectedCloudConfigs: undefined,
+
+  // Original text: 'Network config'
+  networkConfig: undefined,
+
+  // Original text: 'Cloud config'
+  cloudConfig: undefined,
+
+  // Original text: "No config file selected"
   noConfigFile: 'Файл настроек не выбран',
 
-  // Original text: 'Try dropping a config file here, or click to select a config file to upload.'
+  // Original text: "Try dropping a config file here or click to select a config file to upload."
   importTip: 'Перетащите файл настроек сюда, или выберите файл для загрузки',
 
   // Original text: 'Config'
   config: undefined,
 
-  // Original text: 'Import'
+  // Original text: "Import"
   importConfig: 'Импорт',
 
-  // Original text: 'Config file successfully imported'
+  // Original text: 'If the config is encrypted, please enter the passphrase:'
+  importConfigEnterPassphrase: undefined,
+
+  // Original text: "Config file successfully imported"
   importConfigSuccess: 'Файл настроек успешно импортирован',
 
-  // Original text: 'Error while importing config file'
+  // Original text: "Error while importing config file"
   importConfigError: 'Ошибка при импорте файла настроек',
 
-  // Original text: 'Export'
+  // Original text: "Export"
   exportConfig: 'Экспорт',
 
-  // Original text: 'Download current config'
+  // Original text: 'If you want to encrypt the exported config, please enter a passphrase:'
+  exportConfigEnterPassphrase: undefined,
+
+  // Original text: "Download current config"
   downloadConfig: 'Скачать текущие настройки',
 
-  // Original text: 'No config import available for Community Edition'
-  noConfigImportCommunity: 'Импорт настроек не доступен в Community Edition',
+  // Original text: 'and {n} more'
+  andNMore: undefined,
 
-  // Original text: 'Reconnect all hosts'
+  // Original text: "Snapshots and base copies can't be migrated individually"
+  disabledVdiMigrateTooltip: undefined,
+
+  // Original text: "Reconnect all hosts"
   srReconnectAllModalTitle: 'Переподключить все хосты',
 
-  // Original text: 'This will reconnect this SR to all its hosts.'
+  // Original text: "This will reconnect this SR to all its hosts."
   srReconnectAllModalMessage: 'Переподключить этот SR ко всем его хостам',
 
-  // Original text: 'This will reconnect each selected SR to its host (local SR) or to every hosts of its pool (shared SR).'
-  srsReconnectAllModalMessage: 'Повторно подключить выбранный SR к его хосту (локальный SR) или ко всем хостам в его пуле (общий SR).',
-
-  // Original text: 'Disconnect all hosts'
+  // Original text: "Disconnect all hosts"
   srDisconnectAllModalTitle: 'Отключить все хосты',
 
-  // Original text: 'This will disconnect this SR from all its hosts.'
+  // Original text: "This will disconnect this SR from all its hosts."
   srDisconnectAllModalMessage: 'Отключить этот SR от всех хостов.',
 
-  // Original text: 'This will disconnect each selected SR from its host (local SR) or from every hosts of its pool (shared SR).'
-  srsDisconnectAllModalMessage: 'Отключить выбранный SR от его хоста (локальный SR) или от всех хостов в его пуле (общий SR).',
+  // Original text: "This will disconnect each selected SR from its host (local SR) or from every hosts of its pool (shared SR)."
+  srsDisconnectAllModalMessage:
+    'Отключить выбранный SR от его хоста (локальный SR) или от всех хостов в его пуле (общий SR).',
 
-  // Original text: 'Forget SR'
-  srForgetModalTitle: 'Забыть SR',
+  // Original text: 'Are you sure you want to forget {nSrs, number} SR{nSrs, plural, one {} other{s}}?'
+  forgetNSrsModalMessage: undefined,
 
-  // Original text: 'Forget selected SRs'
-  srsForgetModalTitle: 'Забыть выбранные SR',
+  // Original text: 'You will lose all the metadata, meaning all the links between the VDIs (disks) and their respective VMs. This operation cannot be undone.'
+  srForgetModalWarning: undefined,
 
-  // Original text: "Are you sure you want to forget this SR? VDIs on this storage won't be removed."
-  srForgetModalMessage: undefined,
-
-  // Original text: "Are you sure you want to forget all the selected SRs? VDIs on these storages won't be removed."
-  srsForgetModalMessage: undefined,
-
-  // Original text: 'Disconnected'
+  // Original text: "Disconnected"
   srAllDisconnected: 'Отключено',
 
   // Original text: 'Partially connected'
   srSomeConnected: undefined,
 
-  // Original text: 'Connected'
+  // Original text: "Connected"
   srAllConnected: 'Подключено',
+
+  // Original text: 'In order to put this SR in maintenance mode, the following VM{n, plural, one {} other {s}} will be shut down. Are you sure you want to continue?'
+  maintenanceSrModalBody: undefined,
+
+  // Original text: 'Maintenance mode'
+  maintenanceMode: undefined,
+
+  // Original text: 'Migrate selected VDIs'
+  migrateSelectedVdis: undefined,
+
+  // Original text: 'All the VDIs attached to a VM must either be on a shared SR or on the same host (local SR) for the VM to be able to start.'
+  migrateVdiMessage: undefined,
+
+  // Original text: 'Backed up XO Configs'
+  backedUpXoConfigs: undefined,
+
+  // Original text: 'Manage XO Config Cloud Backup'
+  manageXoConfigCloudBackup: undefined,
+
+  // Original text: 'Select XO config'
+  selectXoConfig: undefined,
+
+  // Original text: 'XO Config Cloud Backup'
+  xoConfigCloudBackup: undefined,
+
+  // Original text: 'Your encrypted configuration is securely stored inside your Vates account and backed up once a day'
+  xoConfigCloudBackupTips: undefined,
+
+  // Original text: 'Passphrase is required to encrypt backups'
+  xoCloudConfigEnterPassphrase: undefined,
+
+  // Original text: 'Enter the passphrase:'
+  xoCloudConfigRestoreEnterPassphrase: undefined,
 
   // Original text: 'XOSAN'
   xosanTitle: undefined,
 
-  // Original text: 'Xen Orchestra SAN SR'
-  xosanSrTitle: undefined,
-
-  // Original text: 'Select local SRs (lvm)'
-  xosanAvailableSrsTitle: undefined,
-
   // Original text: 'Suggestions'
   xosanSuggestions: undefined,
 
-  // Original text: 'Name'
+  // Original text: 'Warning: using disperse layout is not recommended right now. Please read {link}.'
+  xosanDisperseWarning: undefined,
+
+  // Original text: "Name"
   xosanName: 'Имя',
 
-  // Original text: 'Host'
+  // Original text: "Host"
   xosanHost: 'Хост',
 
-  // Original text: 'Hosts'
+  // Original text: "Connected Hosts"
   xosanHosts: 'Хосты',
 
-  // Original text: 'Volume ID'
-  xosanVolumeId: undefined,
+  // Original text: 'Pool'
+  xosanPool: undefined,
 
-  // Original text: 'Size'
+  // Original text: "Size"
   xosanSize: 'Размер',
 
   // Original text: 'Used space'
   xosanUsedSpace: undefined,
 
-  // Original text: 'XOSAN pack needs to be installed on each host of the pool.'
+  // Original text: 'License'
+  license: undefined,
+
+  // Original text: 'This XOSAN has more than 1 license!'
+  xosanMultipleLicenses: undefined,
+
+  // Original text: 'XOSAN pack needs to be installed and up to date on each host of the pool.'
   xosanNeedPack: undefined,
 
   // Original text: 'Install it now!'
@@ -3719,14 +6626,8 @@ export default {
   // Original text: 'Restart toolstacks'
   xosanRestartAgents: undefined,
 
-  // Original text: 'Pool master is not running'
-  xosanMasterOffline: undefined,
-
-  // Original text: 'Install XOSAN pack on {pool}'
-  xosanInstallPackTitle: undefined,
-
-  // Original text: 'Select at least 2 SRs'
-  xosanSelect2Srs: undefined,
+  // Original text: 'Select no more than 1 SR per host'
+  xosanSrOnSameHostMessage: undefined,
 
   // Original text: 'Layout'
   xosanLayout: undefined,
@@ -3746,39 +6647,852 @@ export default {
   // Original text: 'Create'
   xosanCreate: undefined,
 
-  // Original text: 'Installing XOSAN. Please wait…'
-  xosanInstalling: undefined,
-
-  // Original text: 'No XOSAN available for Community Edition'
+  // Original text: 'XOSAN is available in XOA'
   xosanCommunity: undefined,
 
-  // Original text: 'Install cloud plugin first'
+  // Original text: 'New'
+  xosanNew: undefined,
+
+  // Original text: 'Advanced'
+  xosanAdvanced: undefined,
+
+  // Original text: 'Remove subvolumes'
+  xosanRemoveSubvolumes: undefined,
+
+  // Original text: 'Add subvolume…'
+  xosanAddSubvolume: undefined,
+
+  // Original text: "This version of XOSAN SR is from the first beta phase. You can keep using it, but to modify it you'll have to save your disks and re-create it."
+  xosanWarning: undefined,
+
+  // Original text: 'VLAN'
+  xosanVlan: undefined,
+
+  // Original text: 'No XOSAN found'
+  xosanNoSrs: undefined,
+
+  // Original text: 'Some SRs are detached from the XOSAN'
+  xosanPbdsDetached: undefined,
+
+  // Original text: 'Something is wrong with: {badStatuses}'
+  xosanBadStatus: undefined,
+
+  // Original text: 'Running'
+  xosanRunning: undefined,
+
+  // Original text: 'Update packs'
+  xosanUpdatePacks: undefined,
+
+  // Original text: 'Checking for updates'
+  xosanPackUpdateChecking: undefined,
+
+  // Original text: 'Error while checking XOSAN packs. Please make sure that the Cloud plugin is installed and loaded, and that the updater is reachable.'
+  xosanPackUpdateError: undefined,
+
+  // Original text: 'XOSAN resources are unavailable'
+  xosanPackUpdateUnavailable: undefined,
+
+  // Original text: 'Not registered for XOSAN resources'
+  xosanPackUpdateUnregistered: undefined,
+
+  // Original text: "✓ This pool's XOSAN packs are up to date!"
+  xosanPackUpdateUpToDate: undefined,
+
+  // Original text: 'Update pool with latest pack v{version}'
+  xosanPackUpdateVersion: undefined,
+
+  // Original text: 'Delete XOSAN'
+  xosanDelete: undefined,
+
+  // Original text: 'Fix'
+  xosanFixIssue: undefined,
+
+  // Original text: 'Creating XOSAN on {pool}'
+  xosanCreatingOn: undefined,
+
+  // Original text: 'Configuring network…'
+  xosanState_configuringNetwork: undefined,
+
+  // Original text: 'Importing VM…'
+  xosanState_importingVm: undefined,
+
+  // Original text: 'Copying VMs…'
+  xosanState_copyingVms: undefined,
+
+  // Original text: 'Configuring VMs…'
+  xosanState_configuringVms: undefined,
+
+  // Original text: 'Configuring gluster…'
+  xosanState_configuringGluster: undefined,
+
+  // Original text: 'Creating SR…'
+  xosanState_creatingSr: undefined,
+
+  // Original text: 'Scanning SR…'
+  xosanState_scanningSr: undefined,
+
+  // Original text: 'XOSAN cannot be installed on XCP-ng yet. Incoming XOSANv2 will be compatible with XCP-ng: {link}.'
+  xosanXcpngWarning: undefined,
+
+  // Original text: 'Install XOA plugin first'
   xosanInstallCloudPlugin: undefined,
 
-  // Original text: 'Load cloud plugin first'
+  // Original text: 'Load XOA plugin first'
   xosanLoadCloudPlugin: undefined,
-
-  // Original text: 'Loading…'
-  xosanLoading: undefined,
-
-  // Original text: 'XOSAN is not available at the moment'
-  xosanNotAvailable: undefined,
-
-  // Original text: 'Register for the XOSAN beta'
-  xosanRegisterBeta: undefined,
-
-  // Original text: 'You have successfully registered for the XOSAN beta. Please wait until your request has been approved.'
-  xosanSuccessfullyRegistered: undefined,
-
-  // Original text: 'Install XOSAN pack on these hosts:'
-  xosanInstallPackOnHosts: undefined,
-
-  // Original text: 'Install {pack} v{version}?'
-  xosanInstallPack: undefined,
 
   // Original text: 'No compatible XOSAN pack found for your XenServer versions.'
   xosanNoPackFound: undefined,
 
-  // Original text: 'At least one of these version requirements must be satisfied by all the hosts in this pool:'
-  xosanPackRequirements: undefined,
+  // Original text: 'Some XOSAN Virtual Machines are not running'
+  xosanVmsNotRunning: undefined,
+
+  // Original text: 'Some XOSAN Virtual Machines could not be found'
+  xosanVmsNotFound: undefined,
+
+  // Original text: 'Files needing healing'
+  xosanFilesNeedingHealing: undefined,
+
+  // Original text: 'Some XOSAN Virtual Machines have files needing healing'
+  xosanFilesNeedHealing: undefined,
+
+  // Original text: 'Host {hostName} is not in XOSAN network'
+  xosanHostNotInNetwork: undefined,
+
+  // Original text: 'VM controller'
+  xosanVm: undefined,
+
+  // Original text: 'SR'
+  xosanUnderlyingStorage: undefined,
+
+  // Original text: 'Replace…'
+  xosanReplace: undefined,
+
+  // Original text: 'On same VM'
+  xosanOnSameVm: undefined,
+
+  // Original text: 'Brick name'
+  xosanBrickName: undefined,
+
+  // Original text: 'Brick UUID'
+  xosanBrickUuid: undefined,
+
+  // Original text: 'Brick size'
+  xosanBrickSize: undefined,
+
+  // Original text: 'Memory size'
+  xosanMemorySize: undefined,
+
+  // Original text: 'Status'
+  xosanStatus: undefined,
+
+  // Original text: 'Arbiter'
+  xosanArbiter: undefined,
+
+  // Original text: 'Used Inodes'
+  xosanUsedInodes: undefined,
+
+  // Original text: 'Block size'
+  xosanBlockSize: undefined,
+
+  // Original text: 'Device'
+  xosanDevice: undefined,
+
+  // Original text: 'FS name'
+  xosanFsName: undefined,
+
+  // Original text: 'Mount options'
+  xosanMountOptions: undefined,
+
+  // Original text: 'Path'
+  xosanPath: undefined,
+
+  // Original text: 'Job'
+  xosanJob: undefined,
+
+  // Original text: 'PID'
+  xosanPid: undefined,
+
+  // Original text: 'Port'
+  xosanPort: undefined,
+
+  // Original text: 'Missing values'
+  xosanReplaceBrickErrorTitle: undefined,
+
+  // Original text: 'You need to select a SR and a size'
+  xosanReplaceBrickErrorMessage: undefined,
+
+  // Original text: 'Bad values'
+  xosanAddSubvolumeErrorTitle: undefined,
+
+  // Original text: 'You need to select {nSrs, number} and a size'
+  xosanAddSubvolumeErrorMessage: undefined,
+
+  // Original text: 'Select {nSrs, number} SRs'
+  xosanSelectNSrs: undefined,
+
+  // Original text: 'Run'
+  xosanRun: undefined,
+
+  // Original text: 'Remove'
+  xosanRemove: undefined,
+
+  // Original text: 'Volume'
+  xosanVolume: undefined,
+
+  // Original text: 'Volume options'
+  xosanVolumeOptions: undefined,
+
+  // Original text: 'Could not find VM'
+  xosanCouldNotFindVm: undefined,
+
+  // Original text: 'Using {usage}'
+  xosanUnderlyingStorageUsage: undefined,
+
+  // Original text: 'Custom IP network (/24)'
+  xosanCustomIpNetwork: undefined,
+
+  // Original text: 'Will configure the host xosan network device with a static IP address and plug it in.'
+  xosanIssueHostNotInNetwork: undefined,
+
+  // Original text: 'Approximate SR capacity'
+  approximateSrCapacity: undefined,
+
+  // Original text: 'By default, the management network will be used'
+  byDefaultManagementNetworkUsed: undefined,
+
+  // Original text: 'Unable to fetch physical disks from non-XCP-ng host'
+  cantFetchDisksFromNonXcpngHost: undefined,
+
+  // Original text: 'Create interface'
+  createInterface: undefined,
+
+  // Original text: 'If packages need to be installed, the toolstack on those hosts will restart. Do you want to continue?'
+  createXostoreConfirm: undefined,
+
+  // Original text: 'The disk is mounted on: {mountpoint}'
+  diskAlreadyMounted: undefined,
+
+  // Original text: 'Diskful'
+  diskful: undefined,
+
+  // Original text: 'The disk has existing partition'
+  diskHasExistingPartition: undefined,
+
+  // Original text: 'Disk incompatible with XOSTOR'
+  diskIncompatibleXostor: undefined,
+
+  // Original text: 'The disk is Read-Only'
+  diskIsReadOnly: undefined,
+
+  // Original text: 'Diskless'
+  diskless: undefined,
+
+  // Original text: 'Disks'
+  disks: undefined,
+
+  // Original text: '{field} is required'
+  fieldRequired: undefined,
+
+  // Original text: 'Some fields are missing'
+  fieldsMissing: undefined,
+
+  // Original text: 'More than 1 XOSTOR license on {host}'
+  hostBoundToMultipleXostorLicenses: undefined,
+
+  // Original text: 'No XOSTOR license on {host}'
+  hostHasNoXostorLicense: undefined,
+
+  // Original text: 'Hosts do not have the same number of disks'
+  hostsNotSameNumberOfDisks: undefined,
+
+  // Original text: 'Ignore file systems'
+  ignoreFileSystems: undefined,
+
+  // Original text: 'Force LINSTOR group creation on existing filesystem'
+  ignoreFileSystemsInfo: undefined,
+
+  // Original text: 'Interface name'
+  interfaceName: undefined,
+
+  // Original text: 'Interface name is required if a network is provided'
+  interfaceNameRequired: undefined,
+
+  // Original text: 'This interface name is reserved'
+  interfaceNameReserved: undefined,
+
+  // Original text: 'This is "tapdev" disk'
+  isTapdevDisk: undefined,
+
+  // Original text: 'License attached to an unknown XOSTOR'
+  licenseBoundUnknownXostor: undefined,
+
+  // Original text: 'No XOSTOR attached'
+  licenseNotBoundXostor: undefined,
+
+  // Original text: 'License{nLicenseIds, plural, one {} other {s}} {licenseIds} ha{nLicenseIds, plural, one {s} other {ve}} expired on {host}'
+  licenseExpiredXostorWarning: undefined,
+
+  // Original text: 'To manage this XOSTOR storage, you must resolve the following issues:'
+  manageXostorWarning: undefined,
+
+  // Original text: 'The network does not have PIFs'
+  networkNoPifs: undefined,
+
+  // Original text: 'Networks'
+  networks: undefined,
+
+  // Original text: 'Not an XCP-ng pool'
+  notXcpPool: undefined,
+
+  // Original text: 'No XOSTOR found'
+  noXostorFound: undefined,
+
+  // Original text: 'Number of hosts'
+  numberOfHosts: undefined,
+
+  // Original text: '{object} does not meet XOSTOR requirements. Refer to the documentation.'
+  objectDoesNotMeetXostorRequirements: undefined,
+
+  // Original text: 'Only show {type} that meet XOSTOR requirements'
+  onlyShowXostorRequirements: undefined,
+
+  // Original text: 'Pool already has a XOSTOR'
+  poolAlreadyHasXostor: undefined,
+
+  // Original text: 'Not recent enough. Current version: {version}'
+  poolNotRecentEnough: undefined,
+
+  // Original text: 'Not all PIFs have an IP'
+  pifsNoIp: undefined,
+
+  // Original text: 'Not all PIFs are attached'
+  pifsNotAttached: undefined,
+
+  // Original text: 'Not all PIFs are static'
+  pifsNotStatic: undefined,
+
+  // Original text: 'Replication'
+  replication: undefined,
+
+  // Original text: 'Replication count is higher than number of hosts with disks'
+  replicationCountHigherThanHostsWithDisks: undefined,
+
+  // Original text: 'Resource list'
+  resourceList: undefined,
+
+  // Original text: 'As long as a XOSTOR storage is present in the pool, Rolling Pool Update will not be available'
+  rpuNoLongerAvailableIfXostor: undefined,
+
+  // Original text: 'Select disk(s)…'
+  selectDisks: undefined,
+
+  // Original text: 'Only disks of type "Disk" and "Raid" are accepted. Selected disk type: {type}.'
+  selectedDiskTypeIncompatibleXostor: undefined,
+
+  // Original text: 'Set as preferred'
+  setAsPreferred: undefined,
+
+  // Original text: 'Storage'
+  storage: undefined,
+
+  // Original text: 'Summary'
+  summary: undefined,
+
+  // Original text: 'Tie breaker'
+  tieBreaker: undefined,
+
+  // Original text: 'White space not allowed'
+  whiteSpaceNotAllowed: undefined,
+
+  // Original text: 'Wrong number of hosts'
+  wrongNumberOfHosts: undefined,
+
+  // Original text: 'XOSTOR'
+  xostor: undefined,
+
+  // Original text: 'XOSTOR is available in XOA'
+  xostorAvailableInXoa: undefined,
+
+  // Original text: 'XOSTOR creation'
+  xostorCreation: undefined,
+
+  // Original text: 'At least one disk is required'
+  xostorDiskRequired: undefined,
+
+  // Original text: '({nDisks, number} disk{nDisks, plural, one {} other {s}}) {hostname}'
+  xostorDisksDropdownLabel: undefined,
+
+  // Original text: '"xcp-ng-release-linstor" and "xcp-ng-linstor" will be installed on each host'
+  xostorPackagesWillBeInstalled: undefined,
+
+  // Original text: 'If a disk dies, you will lose data'
+  xostorReplicationWarning: undefined,
+
+  // Original text: 'Hub'
+  hubPage: undefined,
+
+  // Original text: 'Hub is available in XOA'
+  hubCommunity: undefined,
+
+  // Original text: 'The selected pool has no default SR'
+  noDefaultSr: undefined,
+
+  // Original text: 'VM installed successfully'
+  successfulInstall: undefined,
+
+  // Original text: 'No VMs available '
+  vmNoAvailable: undefined,
+
+  // Original text: 'Create'
+  create: undefined,
+
+  // Original text: 'Resource alert'
+  hubResourceAlert: undefined,
+
+  // Original text: 'OS'
+  os: undefined,
+
+  // Original text: 'Version'
+  version: undefined,
+
+  // Original text: 'Size'
+  size: undefined,
+
+  // Original text: 'Total disk size'
+  totalDiskSize: undefined,
+
+  // Original text: 'Already installed templates are hidden'
+  hideInstalledPool: undefined,
+
+  // Original text: 'XVA import'
+  hubImportNotificationTitle: undefined,
+
+  // Original text: 'No description available for this template'
+  hubTemplateDescriptionNotAvailable: undefined,
+
+  // Original text: 'Recipe created successfully'
+  recipeCreatedSuccessfully: undefined,
+
+  // Original text: 'View created VMs'
+  recipeViewCreatedVms: undefined,
+
+  // Original text: 'Templates'
+  templatesLabel: undefined,
+
+  // Original text: 'Recipes'
+  recipesLabel: undefined,
+
+  // Original text: 'Network'
+  network: undefined,
+
+  // Original text: 'Select Kubernetes version'
+  recipeSelectK8sVersion: undefined,
+
+  // Original text: 'Cluster name'
+  recipeClusterNameLabel: undefined,
+
+  // Original text: 'Number of worker nodes'
+  recipeNumberOfNodesLabel: undefined,
+
+  // Original text: 'SSH key'
+  recipeSshKeyLabel: undefined,
+
+  // Original text: 'Static IP addresses'
+  recipeStaticIpAddresses: undefined,
+
+  // Original text: 'Control plane fault tolerance'
+  recipeFaultTolerance: undefined,
+
+  // Original text: 'No fault tolerance (one control plane)'
+  recipeNoneFaultTolerance: undefined,
+
+  // Original text: 'One fault tolerance (three control planes)'
+  recipeOneFaultTolerance: undefined,
+
+  // Original text: 'Two fault tolerances (five control planes)'
+  recipeTwoFaultTolerance: undefined,
+
+  // Original text: 'Three fault tolerances (seven control planes)'
+  recipeThreeFaultTolerance: undefined,
+
+  // Original text: 'Control plane { i, number } node IP address/subnet mask'
+  recipeHaControPlaneIpAddress: undefined,
+
+  // Original text: 'VIP address'
+  recipeVip: undefined,
+
+  // Original text: 'Control plane node IP address/subnet mask'
+  recipeControlPlaneIpAddress: undefined,
+
+  // Original text: 'Worker node { i, number } IP address/subnet mask'
+  recipeWorkerIpAddress: undefined,
+
+  // Original text: 'Gateway IP address'
+  recipeGatewayIpAddress: undefined,
+
+  // Original text: 'Nameserver IP addresses'
+  recipeNameserverAddresses: undefined,
+
+  // Original text: '192.168.1.0,172.16.1.0'
+  recipeNameserverAddressesExample: undefined,
+
+  // Original text: 'Search domains'
+  recipeSearches: undefined,
+
+  // Original text: 'domain.com,search.org'
+  recipeSearchesExample: undefined,
+
+  // Original text: 'Action/Event'
+  auditActionEvent: undefined,
+
+  // Original text: 'The record ({ id }) was altered ({ n, number } valid records)'
+  auditAlteredRecord: undefined,
+
+  // Original text: 'Check integrity'
+  auditCheckIntegrity: undefined,
+
+  // Original text: 'Copy fingerprint to clipboard'
+  auditCopyFingerprintToClipboard: undefined,
+
+  // Original text: 'Generate a new fingerprint'
+  auditGenerateNewFingerprint: undefined,
+
+  // Original text: 'The record ({ id }) is missing ({ n, number } valid records)'
+  auditMissingRecord: undefined,
+
+  // Original text: 'Fingerprint'
+  auditEnterFingerprint: undefined,
+
+  // Original text: "Enter the saved fingerprint to check the previous logs' integrity. If you don't have any, click OK."
+  auditEnterFingerprintInfo: undefined,
+
+  // Original text: 'Audit record'
+  auditRecord: undefined,
+
+  // Original text: 'Integrity verified'
+  auditIntegrityVerified: undefined,
+
+  // Original text: 'Keep this fingerprint to be able to check the integrity of the current records later.'
+  auditSaveFingerprintInfo: undefined,
+
+  // Original text: 'However, if you trust the current state of the records, keep this fingerprint to be able to check their integrity later.'
+  auditSaveFingerprintInErrorInfo: undefined,
+
+  // Original text: 'New fingerprint'
+  auditNewFingerprint: undefined,
+
+  // Original text: 'Download records'
+  downloadAuditRecords: undefined,
+
+  // Original text: 'Display record'
+  displayAuditRecord: undefined,
+
+  // Original text: 'No audit record available'
+  noAuditRecordAvailable: undefined,
+
+  // Original text: 'Refresh records list'
+  refreshAuditRecordsList: undefined,
+
+  // Original text: 'User actions recording is currently inactive'
+  auditInactiveUserActionsRecord: undefined,
+
+  // Original text: 'All hosts must be bound to a license'
+  allHostsMustBeBound: undefined,
+
+  // Original text: 'Bound (Plan (ID), expiration date, host - pool)'
+  boundSelectLicense: undefined,
+
+  // Original text: 'Bind XCP-ng licenses'
+  bindXcpngLicenses: undefined,
+
+  // Original text: 'You are about to bind {nLicenses, number} professional support license{nLicenses, plural, one {} other {s}} on older and unsupported XCP-ng version{nLicenses, plural, one {} other {s}}. Are you sure you want to continue?'
+  confirmBindingOnUnsupportedHost: undefined,
+
+  // Original text: 'The following pools will no longer be fully supported'
+  confirmRebindLicenseFromFullySupportedPool: undefined,
+
+  // Original text: 'Licenses'
+  licenses: undefined,
+
+  // Original text: 'Licenses binding'
+  licensesBinding: undefined,
+
+  // Original text: 'Not enough XCP-ng licenses'
+  notEnoughXcpngLicenses: undefined,
+
+  // Original text: 'Not bound (Plan (ID), expiration date)'
+  notBoundSelectLicense: undefined,
+
+  // Original text: "To bind an XCP-ng license, go to the pool's Advanced tab."
+  xcpngLicensesBindingAvancedView: undefined,
+
+  // Original text: 'You are not registered and therefore will not be able to create or manage your XOSAN SRs. {link}'
+  xosanUnregisteredDisclaimer: undefined,
+
+  // Original text: 'In order to create a XOSAN SR, you need to use the Xen Orchestra Appliance and buy a XOSAN license on {link}.'
+  xosanSourcesDisclaimer: undefined,
+
+  // Original text: 'Register now!'
+  registerNow: undefined,
+
+  // Original text: 'You need to register your appliance to manage your licenses.'
+  licensesUnregisteredDisclaimer: undefined,
+
+  // Original text: 'Product'
+  licenseProduct: undefined,
+
+  // Original text: 'Purchaser'
+  licensePurchaser: undefined,
+
+  // Original text: 'Expires'
+  licenseExpires: undefined,
+
+  // Original text: 'You'
+  licensePurchaserYou: undefined,
+
+  // Original text: 'Support'
+  productSupport: undefined,
+
+  // Original text: 'No XOSAN attached'
+  licenseNotBoundXosan: undefined,
+
+  // Original text: 'No proxy attached'
+  licenseNotBoundProxy: undefined,
+
+  // Original text: 'License attached to an unknown XOSAN'
+  licenseBoundUnknownXosan: undefined,
+
+  // Original text: 'License attached to an unknown proxy'
+  licenseBoundUnknownProxy: undefined,
+
+  // Original text: 'Manage the licenses'
+  licensesManage: undefined,
+
+  // Original text: 'New license'
+  newLicense: undefined,
+
+  // Original text: 'Refresh'
+  refreshLicenses: undefined,
+
+  // Original text: 'Limited size because XOSAN is in trial'
+  xosanLicenseRestricted: undefined,
+
+  // Original text: 'You need a license on this SR to manage the XOSAN.'
+  xosanAdminNoLicenseDisclaimer: undefined,
+
+  // Original text: 'Your XOSAN license has expired. You can still use the SR but cannot administrate it anymore.'
+  xosanAdminExpiredLicenseDisclaimer: undefined,
+
+  // Original text: 'Could not check the license on this XOSAN SR'
+  xosanCheckLicenseError: undefined,
+
+  // Original text: 'Could not fetch licenses'
+  getLicensesError: undefined,
+
+  // Original text: 'License has expired.'
+  licenseHasExpired: undefined,
+
+  // Original text: 'License bound to another XOA'
+  licenseBoundToOtherXoa: undefined,
+
+  // Original text: 'This license is active on this XOA'
+  licenseBoundToThisXoa: undefined,
+
+  // Original text: 'License expires on {date}.'
+  licenseExpiresDate: undefined,
+
+  // Original text: 'Update the license now!'
+  updateLicenseMessage: undefined,
+
+  // Original text: 'Unknown XOSAN SR.'
+  xosanUnknownSr: undefined,
+
+  // Original text: 'Contact us!'
+  contactUs: undefined,
+
+  // Original text: 'No license.'
+  xosanNoLicense: undefined,
+
+  // Original text: 'Unlock now!'
+  unlockNow: undefined,
+
+  // Original text: 'Select a license'
+  selectLicense: undefined,
+
+  // Original text: 'Bind license'
+  bindLicense: undefined,
+
+  // Original text: 'Bind licenses'
+  bindLicenses: undefined,
+
+  // Original text: 'expires on {date}'
+  expiresOn: undefined,
+
+  // Original text: 'Install XOA plugin first'
+  xosanInstallXoaPlugin: undefined,
+
+  // Original text: 'Load XOA plugin first'
+  xosanLoadXoaPlugin: undefined,
+
+  // Original text: 'Activate license'
+  bindXoaLicense: undefined,
+
+  // Original text: 'Move license to this XOA'
+  rebindXoaLicense: undefined,
+
+  // Original text: 'Are you sure you want to activate this license on your XOA? This action is not reversible!'
+  bindXoaLicenseConfirm: undefined,
+
+  // Original text: 'activate {licenseType} license'
+  bindXoaLicenseConfirmText: undefined,
+
+  // Original text: 'Update needed'
+  updateNeeded: undefined,
+
+  // Original text: 'Starter license'
+  starterLicense: undefined,
+
+  // Original text: 'Enterprise license'
+  enterpriseLicense: undefined,
+
+  // Original text: 'Premium license'
+  premiumLicense: undefined,
+
+  // Original text: 'You are currently in a {edition} trial period that will end on {date, date, medium}'
+  trialLicenseInfo: undefined,
+
+  // Original text: 'This proxy has more than 1 license!'
+  proxyMultipleLicenses: undefined,
+
+  // Original text: 'Unknown proxy VM.'
+  proxyUnknownVm: undefined,
+
+  // Original text: 'XOSTOR Pro Support enabled'
+  xostorProSupportEnabled: undefined,
+
+  // Original text: 'Only available to Enterprise users'
+  onlyAvailableToEnterprise: undefined,
+
+  // Original text: 'Forget prox{n, plural, one {y} other {ies}}'
+  forgetProxyApplianceTitle: undefined,
+
+  // Original text: 'Are you sure you want to forget {n, number} prox{n, plural, one {y} other {ies}}?'
+  forgetProxyApplianceMessage: undefined,
+
+  // Original text: 'Forget proxy(ies)'
+  forgetProxies: undefined,
+
+  // Original text: 'Destroy prox{n, plural, one {y} other {ies}}'
+  destroyProxyApplianceTitle: undefined,
+
+  // Original text: 'Are you sure you want to destroy {n, number} prox{n, plural, one {y} other {ies}}?'
+  destroyProxyApplianceMessage: undefined,
+
+  // Original text: 'Destroy proxy(ies)'
+  destroyProxies: undefined,
+
+  // Original text: 'Deploy a proxy'
+  deployProxy: undefined,
+
+  // Original text: 'Redeploy proxy'
+  redeployProxy: undefined,
+
+  // Original text: 'Redeploy this proxy'
+  redeployProxyAction: undefined,
+
+  // Original text: 'This action will destroy the old proxy VM'
+  redeployProxyWarning: undefined,
+
+  // Original text: 'Register a proxy'
+  registerProxy: undefined,
+
+  // Original text: 'No proxies available'
+  noProxiesAvailable: undefined,
+
+  // Original text: 'Test your proxy'
+  checkProxyHealth: undefined,
+
+  // Original text: 'Update appliance settings'
+  updateProxyApplianceSettings: undefined,
+
+  // Original text: 'URL not found'
+  urlNotFound: undefined,
+
+  // Original text: 'Authentication token'
+  proxyAuthToken: undefined,
+
+  // Original text: 'Unable to connect to this proxy. Do you want to forget it?'
+  proxyConnectionFailedAfterRegistrationMessage: undefined,
+
+  // Original text: 'Copy proxy URL'
+  proxyCopyUrl: undefined,
+
+  // Original text: 'Proxy error'
+  proxyError: undefined,
+
+  // Original text: 'VM UUID is optional but recommended.'
+  proxyOptionalVmUuid: undefined,
+
+  // Original text: 'Test passed for {name}'
+  proxyTestSuccess: undefined,
+
+  // Original text: 'The proxy appears to work correctly'
+  proxyTestSuccessMessage: undefined,
+
+  // Original text: 'Test failed for {name}'
+  proxyTestFailed: undefined,
+
+  // Original text: 'Unable to connect to this proxy'
+  proxyTestFailedConnectionIssueMessage: undefined,
+
+  // Original text: 'Click to see linked remotes'
+  proxyLinkedRemotes: undefined,
+
+  // Original text: 'Click to see linked backups'
+  proxyLinkedBackups: undefined,
+
+  // Original text: 'Default to: {dns}'
+  proxyNetworkDnsPlaceHolder: undefined,
+
+  // Original text: 'Default to: {netmask}'
+  proxyNetworkNetmaskPlaceHolder: undefined,
+
+  // Original text: 'The select only contains SRs connected to at least one HVM-capable host'
+  proxySrPredicateInfo: undefined,
+
+  // Original text: 'HTTP proxy'
+  httpProxy: undefined,
+
+  // Original text: 'protocol://username:password@address:port'
+  httpProxyPlaceholder: undefined,
+
+  // Original text: 'Unable to check upgrades availability'
+  proxyUpgradesError: undefined,
+
+  // Original text: 'Leave the field empty and click on OK to remove the existing configuration'
+  proxyApplianceSettingsInfo: undefined,
+
+  // Original text: 'Your proxy is up-to-date'
+  proxyUpToDate: undefined,
+
+  // Original text: 'The upgrade will interrupt {nJobs, number} running backup job{nJobs, plural, one {} other {s}}. Do you want to continue?'
+  proxyRunningBackupsMessage: undefined,
+
+  // Original text: 'Some proxies need to be upgraded.'
+  proxiesNeedUpgrade: undefined,
+
+  // Original text: 'Some proxies need to be upgraded. Click here to get more information.'
+  upgradeNeededForProxies: undefined,
+
+  // Original text: 'XO Proxy: a concrete guide'
+  xoProxyConcreteGuide: undefined,
+
+  // Original text: '{n, number} prox{n, plural, one {y} other {ies}} ha{n, plural, one {s} other {ve}} error{n, plural, one {} other {s}}'
+  someProxiesHaveErrors: undefined,
+
+  // Original text: '{seconds, plural, one {# second} other {# seconds}}'
+  secondsFormat: undefined,
+
+  // Original text: '{days, plural, =0 {} one {# day } other {# days }}{hours, plural, =0 {} one {# hour } other {# hours }}{minutes, plural, =0 {} one {# minute } other {# minutes }}{seconds, plural, =0 {} one {# second} other {# seconds}}'
+  durationFormat: undefined,
 }


### PR DESCRIPTION
### Description

Corrected grammatical errors, typos, incorrect translations. Translated new lines.
Some strings which **can't** be translated or require a some balanced decision, i replaced back to `undefined`, because current version misleads or distorts the meaning.

File must be synchronized with en.js to continue translation, because a lot of strings not exist here.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
