### PR TITLE
feat(web): add polling option to xo store config builder

### DIFF
--- a/@xen-orchestra/web-core/lib/types/utility.type.ts
+++ b/@xen-orchestra/web-core/lib/types/utility.type.ts
@@ -1,3 +1,3 @@
 export type MaybeArray<T> = T | T[]
 
-export type Noop = () => void
+export type VoidFunction = () => void

--- a/@xen-orchestra/web-core/lib/utils/if-else.utils.ts
+++ b/@xen-orchestra/web-core/lib/utils/if-else.utils.ts
@@ -1,4 +1,4 @@
-import type { MaybeArray, Noop } from '@core/types/utility.type'
+import type { MaybeArray, VoidFunction } from '@core/types/utility.type'
 import { toArray } from '@core/utils/to-array.utils'
 import { watch, type WatchOptions, type WatchSource } from 'vue'
 
@@ -6,8 +6,8 @@ export interface IfElseOptions extends Pick<WatchOptions, 'immediate'> {}
 
 export function ifElse(
   source: WatchSource<boolean>,
-  onTrue: MaybeArray<Noop>,
-  onFalse: MaybeArray<Noop>,
+  onTrue: MaybeArray<VoidFunction>,
+  onFalse: MaybeArray<VoidFunction>,
   options?: IfElseOptions
 ) {
   const onTrueFunctions = toArray(onTrue)

--- a/@xen-orchestra/web/src/utils/create-xo-store-config.util.ts
+++ b/@xen-orchestra/web/src/utils/create-xo-store-config.util.ts
@@ -1,7 +1,8 @@
 import type { XoObject, XoObjectContext, XoObjectType, XoObjectTypeToXoObject } from '@/types/xo-object.type'
 import { restApiConfig } from '@/utils/rest-api-config.util'
 import type { SubscribableStoreConfig } from '@core/types/subscribable-store.type'
-import { useFetch } from '@vueuse/core'
+import type { VoidFunction } from '@core/types/utility.type'
+import { noop, useFetch, useIntervalFn } from '@vueuse/core'
 import { computed, readonly, ref, shallowReactive } from 'vue'
 
 export function createXoStoreConfig<
@@ -18,6 +19,7 @@ export function createXoStoreConfig<
   options?: {
     sortBy?: (a: TXoObject, b: TXoObject) => number
     beforeAdd?: TBeforeAdd
+    pollInterval?: number
   }
 ): SubscribableStoreConfig<XoObjectContext<TXoObject>> {
   const recordsById = shallowReactive(new Map<TXoObject['id'], TXoObject>())
@@ -25,7 +27,7 @@ export function createXoStoreConfig<
     const results = Array.from(recordsById.values())
 
     if (options?.sortBy) {
-      return results.sort(options.sortBy)
+      results.sort(options.sortBy)
     }
 
     return results
@@ -55,7 +57,7 @@ export function createXoStoreConfig<
 
   const hasError = computed(() => error.value !== undefined)
 
-  const handleAdd = (record: TXoObjectInput) => {
+  const handleRecordAdded = (record: TXoObjectInput) => {
     const recordToAdd = options?.beforeAdd ? options.beforeAdd(record) : record
 
     if (recordToAdd === undefined) {
@@ -65,23 +67,44 @@ export function createXoStoreConfig<
     recordsById.set(record.id, recordToAdd as TXoObject)
   }
 
-  const handleAfterLoad = (records: TXoObjectInput[]) => {
-    records.forEach(record => handleAdd(record))
+  const handleRecordsLoaded = (records: TXoObjectInput[] | null) => {
+    recordsById.clear()
+
+    if (!records) {
+      return
+    }
+
+    records.forEach(record => handleRecordAdded(record))
     isReady.value = true
   }
 
-  const onSubscribe = async () => {
+  const loadData = async () => {
     await execute()
 
-    if (data.value) {
-      handleAfterLoad(data.value)
-    }
+    handleRecordsLoaded(data.value)
   }
+
+  let startSubscription: VoidFunction = () => loadData()
+  let stopSubscription: VoidFunction = noop
+
+  if (options?.pollInterval !== undefined) {
+    const { pause, resume } = useIntervalFn(() => loadData(), options.pollInterval, {
+      immediate: false,
+      immediateCallback: true,
+    })
+
+    startSubscription = () => resume()
+    stopSubscription = () => pause()
+  }
+
+  const onSubscribe = () => startSubscription()
 
   const onUnsubscribe = () => {
     if (canAbort.value) {
       abort()
     }
+
+    stopSubscription()
 
     isReady.value = false
   }


### PR DESCRIPTION
### Description

`createXoStoreConfig()` can now be passed a `{ pollInterval: number }` option to enable polling on a collection.

> [!NOTE]
> This is a temporary solution. A better implementation will follow.

Also, `handleAdd` and `handleAfterLoad` have been renamed to `handleRecordAdded` and `handleRecordsLoaded` to enhance clarity and comprehension.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
