### PR TITLE
feat(xo-server-backup-reports): include info

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,7 @@
 - [REST API] Expose XO6 dashboard informations at the `/rest/v0/dashboard` endpoint (PR [#7823](https://github.com/vatesfr/xen-orchestra/pull/7823))
 - [VM/Advanced] Possibility to manually [_Coalesce Leaf_](https://docs.xenserver.com/en-us/xenserver/8/storage/manage.html#reclaim-space-by-using-the-offline-coalesce-tool) [#7757](https://github.com/vatesfr/xen-orchestra/issues/7757) (PR [#7810](https://github.com/vatesfr/xen-orchestra/pull/7810))
 - [i18n] Add Swedish translation (Thanks [@cloudrootab](https://github.com/cloudrootab)!) [#7844](https://github.com/vatesfr/xen-orchestra/pull/7844)
-- [Plugin/backup-reports] Show more informations of backups, including NBD and CBT usage (PR [#7815](https://github.com/vatesfr/xen-orchestra/pull/7815))
+- [Plugin/backup-reports] Show more information of backups, including NBD and CBT usage (PR [#7815](https://github.com/vatesfr/xen-orchestra/pull/7815))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,7 @@
 - [REST API] Expose XO6 dashboard informations at the `/rest/v0/dashboard` endpoint (PR [#7823](https://github.com/vatesfr/xen-orchestra/pull/7823))
 - [VM/Advanced] Possibility to manually [_Coalesce Leaf_](https://docs.xenserver.com/en-us/xenserver/8/storage/manage.html#reclaim-space-by-using-the-offline-coalesce-tool) [#7757](https://github.com/vatesfr/xen-orchestra/issues/7757) (PR [#7810](https://github.com/vatesfr/xen-orchestra/pull/7810))
 - [i18n] Add Swedish translation (Thanks [@cloudrootab](https://github.com/cloudrootab)!) [#7844](https://github.com/vatesfr/xen-orchestra/pull/7844)
-- [Plugin/backup-reports] Show in email reports when NBD is used for backups (PR [#7815](https://github.com/vatesfr/xen-orchestra/pull/7815))
+- [Plugin/backup-reports] Show more informations of backups, including NBD and CBT usage(PR [#7815](https://github.com/vatesfr/xen-orchestra/pull/7815))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,7 @@
 - [REST API] Expose XO6 dashboard informations at the `/rest/v0/dashboard` endpoint (PR [#7823](https://github.com/vatesfr/xen-orchestra/pull/7823))
 - [VM/Advanced] Possibility to manually [_Coalesce Leaf_](https://docs.xenserver.com/en-us/xenserver/8/storage/manage.html#reclaim-space-by-using-the-offline-coalesce-tool) [#7757](https://github.com/vatesfr/xen-orchestra/issues/7757) (PR [#7810](https://github.com/vatesfr/xen-orchestra/pull/7810))
 - [i18n] Add Swedish translation (Thanks [@cloudrootab](https://github.com/cloudrootab)!) [#7844](https://github.com/vatesfr/xen-orchestra/pull/7844)
-- [Plugin/backup-reports] Show more informations of backups, including NBD and CBT usage(PR [#7815](https://github.com/vatesfr/xen-orchestra/pull/7815))
+- [Plugin/backup-reports] Show more informations of backups, including NBD and CBT usage (PR [#7815](https://github.com/vatesfr/xen-orchestra/pull/7815))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 - [REST API] Expose XO6 dashboard informations at the `/rest/v0/dashboard` endpoint (PR [#7823](https://github.com/vatesfr/xen-orchestra/pull/7823))
 - [VM/Advanced] Possibility to manually [_Coalesce Leaf_](https://docs.xenserver.com/en-us/xenserver/8/storage/manage.html#reclaim-space-by-using-the-offline-coalesce-tool) [#7757](https://github.com/vatesfr/xen-orchestra/issues/7757) (PR [#7810](https://github.com/vatesfr/xen-orchestra/pull/7810))
 - [i18n] Add Swedish translation (Thanks [@cloudrootab](https://github.com/cloudrootab)!) [#7844](https://github.com/vatesfr/xen-orchestra/pull/7844)
+- [Plugin/backup-reports] Show in email reports when NBD is used for backups (PR [#7815](https://github.com/vatesfr/xen-orchestra/pull/7815))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -45,6 +45,7 @@
 - @xen-orchestra/xapi minor
 - xen-api minor
 - xo-server minor
+- xo-server-backup-reports minor
 - xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-server-backup-reports/templates/mjml/partials/reportInfo.hbs
+++ b/packages/xo-server-backup-reports/templates/mjml/partials/reportInfo.hbs
@@ -1,0 +1,3 @@
+{{#each task.infos}}
+  <li>ℹ️  {{message}}</li>
+{{/each}}

--- a/packages/xo-server-backup-reports/templates/mjml/partials/reportInfo.hbs
+++ b/packages/xo-server-backup-reports/templates/mjml/partials/reportInfo.hbs
@@ -1,3 +1,3 @@
 {{#each task.infos}}
-  <li>ℹ️  {{message}}</li>
+  <li>ℹ️ {{message}}</li>
 {{/each}}

--- a/packages/xo-server-backup-reports/templates/mjml/partials/vmText.hbs
+++ b/packages/xo-server-backup-reports/templates/mjml/partials/vmText.hbs
@@ -10,5 +10,5 @@
   <li><span style="font-weight: bold">UUID</span>: {{taskLog.data.id}}</li>
 {{/if}}
 {{>reportTemporalData end=taskLog.end start=taskLog.start}}
-{{>reportInfo task=taskLog}}
 {{>reportWarnings task=taskLog}}
+{{>reportInfo task=taskLog}}

--- a/packages/xo-server-backup-reports/templates/mjml/partials/vmText.hbs
+++ b/packages/xo-server-backup-reports/templates/mjml/partials/vmText.hbs
@@ -1,12 +1,10 @@
 {{#if vm}}
 <h3>{{vm.name_label}}</h3>
-{{else}}
-<h3>VM not found</h3>
-{{/if}}
 <ul>
-{{#if vm}}
   <li><span style="font-weight: bold">UUID</span>: {{vm.uuid}}</li>
 {{else}}
+<h3>VM not found</h3>
+<ul>
   <li><span style="font-weight: bold">UUID</span>: {{taskLog.data.id}}</li>
 {{/if}}
 {{>reportTemporalData end=taskLog.end start=taskLog.start}}

--- a/packages/xo-server-backup-reports/templates/mjml/partials/vmText.hbs
+++ b/packages/xo-server-backup-reports/templates/mjml/partials/vmText.hbs
@@ -3,9 +3,6 @@
 {{else}}
 <h3>VM not found</h3>
 {{/if}}
-{{#each taskLog.infos}}
-  ℹ️ {{message}}
-{{/each}}
 <ul>
 {{#if vm}}
   <li><span style="font-weight: bold">UUID</span>: {{vm.uuid}}</li>
@@ -13,4 +10,5 @@
   <li><span style="font-weight: bold">UUID</span>: {{taskLog.data.id}}</li>
 {{/if}}
 {{>reportTemporalData end=taskLog.end start=taskLog.start}}
+{{>reportInfo task=taskLog}}
 {{>reportWarnings task=taskLog}}

--- a/packages/xo-server-backup-reports/templates/mjml/partials/vmText.hbs
+++ b/packages/xo-server-backup-reports/templates/mjml/partials/vmText.hbs
@@ -1,11 +1,15 @@
-
 {{#if vm}}
 <h3>{{vm.name_label}}</h3>
-<ul>
-  <li><span style="font-weight: bold">UUID</span>: {{vm.uuid}}</li>
 {{else}}
 <h3>VM not found</h3>
+{{/if}}
+{{#each taskLog.infos}}
+  ℹ️ {{message}}
+{{/each}}
 <ul>
+{{#if vm}}
+  <li><span style="font-weight: bold">UUID</span>: {{vm.uuid}}</li>
+{{else}}
   <li><span style="font-weight: bold">UUID</span>: {{taskLog.data.id}}</li>
 {{/if}}
 {{>reportTemporalData end=taskLog.end start=taskLog.start}}


### PR DESCRIPTION
### Description

Show info of backup tasks in MJML template, for example show when NBD is used.

Currently it only displays a the message associated with the info, not its data (unlike [here](https://github.com/vatesfr/xen-orchestra/blob/e44933e2f798e07d5b739b4b929e7e1dc8f1535f/packages/xo-web/src/xo-app/logs/backup-ng/log-alert-body.js#L131-L159)). It would be possible to display the info data, but it would probably not be done in a clean way in the current template (and I'm not sure it would be that useful).

From forum : [CBT feedback thread](https://xcp-ng.org/forum/post/79833)

![image](https://github.com/user-attachments/assets/da60488b-42f7-410e-a3d1-93c279959fd8)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
