### PR TITLE
fix(backups): remove snapshot data only after the transfer is finished

### DIFF
--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
@@ -140,6 +140,7 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
       if (isDifferencing) {
         assert.notStrictEqual(
           parentVdiPaths,
+          undefined,
           'checkbasevdi must be called before updateUuidAndChain for incremental backups'
         )
         const parentPath = parentVdiPaths[dirname(path)]

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 
 - [Self Service] Always allow administrators to bypass quotas (PR [#7855](https://github.com/vatesfr/xen-orchestra/pull/7855))
 - [V2V] Fix `Can't import delta of a running VM without its parent VHD` error during warm migration (PR [#7856](https://github.com/vatesfr/xen-orchestra/pull/7856))
+- [Backups] Fix a race condition leading to `VDI_INCOMPATIBLE_TYPE` error when using _Purge snapshot data_ (PR [#7828](https://github.com/vatesfr/xen-orchestra/pull/7828))
 
 ### Packages to release
 
@@ -34,6 +35,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
 - xen-api minor
 - xo-server minor
 


### PR DESCRIPTION
### Description

ensure the purge data on snapshot is only called after backup transfer is completly done , since removeunusedsnapshot is called before and after transfer

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
