### PR TITLE
feat(backups): option to not send reports for skipped runs

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@
 - [VM/Advanced] Possibility to manually [_Coalesce Leaf_](https://docs.xenserver.com/en-us/xenserver/8/storage/manage.html#reclaim-space-by-using-the-offline-coalesce-tool) [#7757](https://github.com/vatesfr/xen-orchestra/issues/7757) (PR [#7810](https://github.com/vatesfr/xen-orchestra/pull/7810))
 - [i18n] Add Swedish translation (Thanks [@cloudrootab](https://github.com/cloudrootab)!) [#7844](https://github.com/vatesfr/xen-orchestra/pull/7844)
 - [Plugin/backup-reports] Show more information of backups, including NBD and CBT usage (PR [#7815](https://github.com/vatesfr/xen-orchestra/pull/7815))
-- [Backups] Adding an option to avoid sending reports for skipped backups (PR [#7832](https://github.com/vatesfr/xen-orchestra/pull/7832))
+- [Backups] Adding an option to avoid sending reports for skipped backups (e.g. no matching VMs, unhealthy VDI chains, etc.) (PR [#7832](https://github.com/vatesfr/xen-orchestra/pull/7832))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 - [VM/Advanced] Possibility to manually [_Coalesce Leaf_](https://docs.xenserver.com/en-us/xenserver/8/storage/manage.html#reclaim-space-by-using-the-offline-coalesce-tool) [#7757](https://github.com/vatesfr/xen-orchestra/issues/7757) (PR [#7810](https://github.com/vatesfr/xen-orchestra/pull/7810))
 - [i18n] Add Swedish translation (Thanks [@cloudrootab](https://github.com/cloudrootab)!) [#7844](https://github.com/vatesfr/xen-orchestra/pull/7844)
 - [Plugin/backup-reports] Show more information of backups, including NBD and CBT usage (PR [#7815](https://github.com/vatesfr/xen-orchestra/pull/7815))
+- [Backups] Adding an option to avoid sending reports for backups skipped due to no matching VMs (PR [#7832](https://github.com/vatesfr/xen-orchestra/pull/7832))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@
 - [VM/Advanced] Possibility to manually [_Coalesce Leaf_](https://docs.xenserver.com/en-us/xenserver/8/storage/manage.html#reclaim-space-by-using-the-offline-coalesce-tool) [#7757](https://github.com/vatesfr/xen-orchestra/issues/7757) (PR [#7810](https://github.com/vatesfr/xen-orchestra/pull/7810))
 - [i18n] Add Swedish translation (Thanks [@cloudrootab](https://github.com/cloudrootab)!) [#7844](https://github.com/vatesfr/xen-orchestra/pull/7844)
 - [Plugin/backup-reports] Show more information of backups, including NBD and CBT usage (PR [#7815](https://github.com/vatesfr/xen-orchestra/pull/7815))
-- [Backups] Adding an option to avoid sending reports for backups skipped due to no matching VMs (PR [#7832](https://github.com/vatesfr/xen-orchestra/pull/7832))
+- [Backups] Adding an option to avoid sending reports for skipped backups (PR [#7832](https://github.com/vatesfr/xen-orchestra/pull/7832))
 
 ### Bug fixes
 

--- a/packages/xo-server-backup-reports/src/index.js
+++ b/packages/xo-server-backup-reports/src/index.js
@@ -183,7 +183,7 @@ class BackupReportsXoPlugin {
         // https://github.com/vatesfr/xen-orchestra/commit/753ee994f2948bbaca9d3161eaab82329a682773#diff-9c044ab8a42ed6576ea927a64c1ec3ebR105
         reportWhen === 'Never' ||
         (reportWhen === 'failure' && log.status === 'success') ||
-        (log.data.ignoreEmptyBackups && log?.result?.message === 'no VMs match this pattern'))
+        (log.data.ignoreSkippedBackups && log.status === 'skipped'))
     ) {
       return
     }

--- a/packages/xo-server-backup-reports/src/index.js
+++ b/packages/xo-server-backup-reports/src/index.js
@@ -182,7 +182,8 @@ class BackupReportsXoPlugin {
         // Handle improper value introduced by:
         // https://github.com/vatesfr/xen-orchestra/commit/753ee994f2948bbaca9d3161eaab82329a682773#diff-9c044ab8a42ed6576ea927a64c1ec3ebR105
         reportWhen === 'Never' ||
-        (reportWhen === 'failure' && log.status === 'success'))
+        (reportWhen === 'failure' && log.status === 'success') ||
+        (log.data.ignoreEmptyBackups && log?.result?.message === 'no VMs match this pattern'))
     ) {
       return
     }

--- a/packages/xo-server/src/xo-mixins/jobs/index.mjs
+++ b/packages/xo-server/src/xo-mixins/jobs/index.mjs
@@ -173,6 +173,7 @@ export default class Jobs {
       data:
         type === 'backup' || type === 'metadataBackup' || type === 'mirrorBackup'
           ? {
+              ignoreEmptyBackups: job.settings['']?.ignoreEmptyBackups,
               mode: job.mode,
               reportWhen: job.settings['']?.reportWhen ?? 'failure',
             }

--- a/packages/xo-server/src/xo-mixins/jobs/index.mjs
+++ b/packages/xo-server/src/xo-mixins/jobs/index.mjs
@@ -173,7 +173,7 @@ export default class Jobs {
       data:
         type === 'backup' || type === 'metadataBackup' || type === 'mirrorBackup'
           ? {
-              ignoreEmptyBackups: job.settings['']?.ignoreEmptyBackups,
+              ignoreSkippedBackups: job.settings['']?.ignoreSkippedBackups,
               mode: job.mode,
               reportWhen: job.settings['']?.reportWhen ?? 'failure',
             }

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -609,7 +609,7 @@ const messages = {
     "The snapshot won't use any notable space on the SR, won't be shown in the UI and won't be usable to do a rollback",
   cbtDestroySnapshotDataDisabledInformation:
     'Snapshot data can be purged only when NBD is enabled and rolling snapshot is not used',
-  ignoreEmptyBackups: "Don't send reports for backups with no matching VM",
+  ignoreSkippedBackups: "Don't send reports for skipped backups",
 
   // ------ New Remote -----
   newRemote: 'New file system remote',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -607,9 +607,10 @@ const messages = {
   cbtDestroySnapshotData: 'Purge snapshot data when using CBT',
   cbtDestroySnapshotDataInformation:
     "The snapshot won't use any notable space on the SR, won't be shown in the UI and won't be usable to do a rollback",
-
   cbtDestroySnapshotDataDisabledInformation:
     'Snapshot data can be purged only when NBD is enabled and rolling snapshot is not used',
+  ignoreEmptyBackups: "Don't send reports for backups with no matching VM",
+
   // ------ New Remote -----
   newRemote: 'New file system remote',
   remoteTypeLocal: 'Local',

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -189,6 +189,7 @@ const getInitialState = ({ preSelectedVmIds, setHomeVmIdsSelection, suggestedExc
     crMode: false,
     deltaMode: false,
     drMode: false,
+    ignoreEmptyBackups: false,
     name: '',
     nbdConcurrency: 1,
     nRetriesVmBackupFailures: 0,
@@ -650,6 +651,11 @@ const New = decorate([
           nRetriesVmBackupFailures: nRetries,
         })
       },
+      setIgnoreEmptyBackups({ setGlobalSettings }, ignoreEmptyBackups) {
+        setGlobalSettings({
+          ignoreEmptyBackups,
+        })
+      },
     },
     computed: {
       compressionId: generateId,
@@ -657,6 +663,7 @@ const New = decorate([
       inputConcurrencyId: generateId,
       inputCbtDestroySnapshotData: generateId,
       inputFullIntervalId: generateId,
+      inputIgnoreEmptyBackupsId: generateId,
       inputMaxExportRate: generateId,
       inputPreferNbd: generateId,
       inputNbdConcurrency: generateId,
@@ -772,6 +779,7 @@ const New = decorate([
       checkpointSnapshot,
       concurrency,
       fullInterval,
+      ignoreEmptyBackups,
       maxExportRate,
       nbdConcurrency = 1,
       nRetriesVmBackupFailures = 0,
@@ -1163,6 +1171,17 @@ const New = decorate([
                         offlineSnapshot={offlineSnapshot}
                         setGlobalSettings={effects.setGlobalSettings}
                       />
+                      <FormGroup>
+                        <label htmlFor={state.inputIgnoreEmptyBackupsId}>
+                          <strong>{_('ignoreEmptyBackups')}</strong>
+                        </label>
+                        <Toggle
+                          className='pull-right'
+                          id={state.ignoreEmptyBackups}
+                          value={ignoreEmptyBackups}
+                          onChange={effects.setIgnoreEmptyBackups}
+                        />
+                      </FormGroup>
                     </div>
                   )}
                 </CardBlock>

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -189,7 +189,7 @@ const getInitialState = ({ preSelectedVmIds, setHomeVmIdsSelection, suggestedExc
     crMode: false,
     deltaMode: false,
     drMode: false,
-    ignoreEmptyBackups: false,
+    ignoreSkippedBackups: false,
     name: '',
     nbdConcurrency: 1,
     nRetriesVmBackupFailures: 0,
@@ -651,9 +651,9 @@ const New = decorate([
           nRetriesVmBackupFailures: nRetries,
         })
       },
-      setIgnoreEmptyBackups({ setGlobalSettings }, ignoreEmptyBackups) {
+      setIgnoreSkippedBackups({ setGlobalSettings }, ignoreSkippedBackups) {
         setGlobalSettings({
-          ignoreEmptyBackups,
+          ignoreSkippedBackups,
         })
       },
     },
@@ -663,7 +663,7 @@ const New = decorate([
       inputConcurrencyId: generateId,
       inputCbtDestroySnapshotData: generateId,
       inputFullIntervalId: generateId,
-      inputIgnoreEmptyBackupsId: generateId,
+      inputIgnoreSkippedBackupsId: generateId,
       inputMaxExportRate: generateId,
       inputPreferNbd: generateId,
       inputNbdConcurrency: generateId,
@@ -779,7 +779,7 @@ const New = decorate([
       checkpointSnapshot,
       concurrency,
       fullInterval,
-      ignoreEmptyBackups,
+      ignoreSkippedBackups,
       maxExportRate,
       nbdConcurrency = 1,
       nRetriesVmBackupFailures = 0,
@@ -1172,14 +1172,14 @@ const New = decorate([
                         setGlobalSettings={effects.setGlobalSettings}
                       />
                       <FormGroup>
-                        <label htmlFor={state.inputIgnoreEmptyBackupsId}>
-                          <strong>{_('ignoreEmptyBackups')}</strong>
+                        <label htmlFor={state.inputIgnoreSkippedBackupsId}>
+                          <strong>{_('ignoreSkippedBackups')}</strong>
                         </label>
                         <Toggle
                           className='pull-right'
-                          id={state.ignoreEmptyBackups}
-                          value={ignoreEmptyBackups}
-                          onChange={effects.setIgnoreEmptyBackups}
+                          id={state.ignoreSkippedBackups}
+                          value={ignoreSkippedBackups}
+                          onChange={effects.setIgnoreSkippedBackups}
                         />
                       </FormGroup>
                     </div>


### PR DESCRIPTION
### Description

Adding an option to avoid sending reports for skipped backups (in backup `Advanced settings`)

From https://help.vates.tech/#ticket/zoom/26356/111128

![image](https://github.com/user-attachments/assets/b373d685-b610-49c9-aa7c-66a149fc7832)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
