### PR TITLE
fix(xo-core/eslint/i18n): add "fa" to the list of excluded locales for missing keys checks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -215,7 +215,7 @@ module.exports = {
         '@intlify/vue-i18n/no-v-html': 'error',
         '@intlify/vue-i18n/valid-message-syntax': 'error',
         '@intlify/vue-i18n/no-duplicate-keys-in-locale': 'error',
-        '@intlify/vue-i18n/no-missing-keys-in-other-locales': ['error', { ignoreLocales: ['de'] }],
+        '@intlify/vue-i18n/no-missing-keys-in-other-locales': ['error', { ignoreLocales: ['de', 'fa'] }],
       },
     },
     // Specific rules for XO dev-related files

--- a/@xen-orchestra/web-core/docs/guidelines/i18n.md
+++ b/@xen-orchestra/web-core/docs/guidelines/i18n.md
@@ -160,3 +160,12 @@ If you really need to **exceptionally** include a literal string, you can either
 
 > [!TIP]
 > In most cases, literal strings will not be necessary. Think twice before using them.
+
+## Adding a new locale
+
+> [!NOTE]
+> Only `EN` and `FR` locales are fully supported by XO team.
+
+For other locales added by contributors, some keys might be missing when we add new translations.
+
+This can result in ESLint errors when some translation keys are missing. To avoid this, remember to add the locale to the list of excluded files in `.eslintrc.js` at the root of the project (rule is `'@intlify/vue-i18n/no-missing-keys-in-other-locales': ['error', { ignoreLocales: ['de', 'fa'] }]` on line 218).


### PR DESCRIPTION
### Description

Introduced by 28f94b3

Fix ESLint errors for missing `fa` locale translation keys.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
