### PR TITLE
feat(nbd-client/multi): harden NBD backups

### DIFF
--- a/@vates/nbd-client/index.mjs
+++ b/@vates/nbd-client/index.mjs
@@ -34,7 +34,6 @@ export default class NbdClient {
   #exportSize
 
   #waitBeforeReconnect
-  #readAhead
   #readBlockRetries
   #reconnectRetry
   #connectTimeout
@@ -55,7 +54,6 @@ export default class NbdClient {
       connectTimeout = 6e4,
       messageTimeout = 6e4,
       waitBeforeReconnect = 1e3,
-      readAhead = 10,
       readBlockRetries = 5,
       reconnectRetry = 5,
     } = {}
@@ -65,7 +63,6 @@ export default class NbdClient {
     this.#exportName = exportname
     this.#serverCert = cert
     this.#waitBeforeReconnect = waitBeforeReconnect
-    this.#readAhead = readAhead
     this.#readBlockRetries = readBlockRetries
     this.#reconnectRetry = reconnectRetry
     this.#connectTimeout = connectTimeout

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
 - [V2V] Fix `Can't import delta of a running VM without its parent VHD` error during warm migration (PR [#7856](https://github.com/vatesfr/xen-orchestra/pull/7856))
 - [Backups] Fix a race condition leading to `VDI_INCOMPATIBLE_TYPE` error when using _Purge snapshot data_ (PR [#7828](https://github.com/vatesfr/xen-orchestra/pull/7828))
 - [Backups] NBD backups now respected _default backup network_ settings (PR [#7836](https://github.com/vatesfr/xen-orchestra/pull/7836))
+- [Backups] NBD backups now ignore unreachable host and retry on reachable ones(PR [#7836](https://github.com/vatesfr/xen-orchestra/pull/7836))
 
 ### Packages to release
 
@@ -36,6 +37,7 @@
 
 <!--packages-start-->
 
+- @vates/nbd-client minor
 - @xen-orchestra/backups patch
 - @xen-orchestra/xapi patch
 - xen-api minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@
 - [Self Service] Always allow administrators to bypass quotas (PR [#7855](https://github.com/vatesfr/xen-orchestra/pull/7855))
 - [V2V] Fix `Can't import delta of a running VM without its parent VHD` error during warm migration (PR [#7856](https://github.com/vatesfr/xen-orchestra/pull/7856))
 - [Backups] Fix a race condition leading to `VDI_INCOMPATIBLE_TYPE` error when using _Purge snapshot data_ (PR [#7828](https://github.com/vatesfr/xen-orchestra/pull/7828))
+- [Backups] NBD backups now respected _default backup network_ settings (PR [#7836](https://github.com/vatesfr/xen-orchestra/pull/7836))
 
 ### Packages to release
 
@@ -36,6 +37,7 @@
 <!--packages-start-->
 
 - @xen-orchestra/backups patch
+- @xen-orchestra/xapi patch
 - xen-api minor
 - xo-server minor
 


### PR DESCRIPTION
review by commit 
### Description

* NBD client  tried to connect to all NBD enabled network, even the network non accessible by xoa or proxy

this PR implement : 
* a parallel retry that should speed up connection when a lot of unreachable NBD network exists and improve reliability, since failing to connect to NBD was leading to a fallback in vdi.exportContent, fallback that was not working with purgeData
* filtering network passed to nbd-client to ensure "default backup network" from the pool setting is respected
* if it's not possible to produce a delta ( no changed blocks but can't compute changed blocks) : make error clearer

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
