### PR TITLE
fix(vmware-explorer): handling disks without storage

### DIFF
--- a/@xen-orchestra/vmware-explorer/esxi.mjs
+++ b/@xen-orchestra/vmware-explorer/esxi.mjs
@@ -298,8 +298,8 @@ export default class Esxi extends EventEmitter {
           storage: perDatastoreUsage.reduce(
             (prev, curr) => {
               return {
-                used: prev.used + +curr.committed,
-                free: prev.free + +curr.uncommitted,
+                used: prev.used + +(curr?.committed ?? 0),
+                free: prev.free + +(curr?.uncommitted ?? 0),
               }
             },
             { used: 0, free: 0 }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [VM/Advanced] Fix `not enough permission` when attaching PCIs [#9260](https://xcp-ng.org/forum/topic/9260/attach-pcis-not-enough-permissions) (PR [#7793](https://github.com/vatesfr/xen-orchestra/pull/7793))
+- [V2V] Fix `Cannot read properties of undefined (reading 'committed')` when listing importable VM (PR [#7840](https://github.com/vatesfr/xen-orchestra/pull/7840))
 
 ### Packages to release
 
@@ -38,6 +39,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/vmware-explorer patch
 - @xen-orchestra/xapi minor
 - xo-server minor
 - xo-web minor


### PR DESCRIPTION
some VM may have disks without any storage declared. Since we
didn't find the cause, this PR ensure we don't break the VM listing.

ticket 26677

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
