### PR TITLE
fix(xo-6/xo-lite): tree-view vertical line display

### DIFF
--- a/@xen-orchestra/lite/src/components/infra/InfraVmItem.vue
+++ b/@xen-orchestra/lite/src/components/infra/InfraVmItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <TreeItem v-if="vm !== undefined" ref="rootElement" class="infra-vm-item">
+  <TreeItem v-if="vm !== undefined" ref="rootElement" expanded class="infra-vm-item">
     <TreeItemLabel v-if="isVisible" :route="{ name: 'vm.console', params: { uuid: vm.uuid } }" no-indent>
       {{ vm.name_label || '(VM)' }}
       <template #icon>

--- a/@xen-orchestra/web/src/components/tree/VmTreeItem.vue
+++ b/@xen-orchestra/web/src/components/tree/VmTreeItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <TreeItem>
+  <TreeItem expanded>
     <TreeItemLabel :route="`/vm/${leaf.data.id}/console`" no-indent>
       {{ leaf.data.name_label }}
       <template #icon>


### PR DESCRIPTION
### Description

Introduced by fe1f5cb

The `TreeItemLabel` component `expanded` property wasn’t handled correctly when displaying the last item of a sublist.

### Screenshots

Before:

![tree-view-before](https://github.com/user-attachments/assets/d7800d4d-d72c-45c6-8687-f482e2d85f82)

After:

![tree-view-after](https://github.com/user-attachments/assets/04af76fc-6865-4c08-930c-ecc7a877a1d8)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
