### PR TITLE
docs(installation): add systemd service

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -266,13 +266,18 @@ ExecStart=/usr/bin/node /home/username/xen-orchestra/packages/xo-server/dist/cli
 WantedBy=multi-user.target
 ```
 
-Reload the systemd-daemon:
+Reload the daemon and enable the service:
 
 ```sh
 systemctl daemon-reload
+systemctl enable --now xo-server
 ```
 
-You can then use standard systemd commands to start/stop/check status e.g. `systemctl start xo-server`
+You can then use standard systemd commands to start/stop/check status e.g.
+
+```sh
+systemctl status xo-server
+```
 
 > **Security:** `xo-server` will be run as `root`, make sure your files are not editable by other users or it may be used as an attack vector.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -204,7 +204,8 @@ Then restart Xen Orchestra if it was running.
 
 ### Always Running
 
-#### Yarn alternative
+#### Using forever
+
 - You can use [forever](https://github.com/nodejitsu/forever) to have the process always running:
 
 ```sh
@@ -241,34 +242,39 @@ forever-service delete orchestra
 ```
 
 #### Systemd service
+
 You can also use systemd to enable the service instead.
 
-*The following example is based on a Ubuntu 24.04 installation*
+_The following example is based on a Ubuntu 24.04 installation_
 
 Create the following file `/etc/systemd/system/xo-server.service` containing the following inside:
-```sh
-# systemd service for XO-Server.
 
+```sh
 [Unit]
-Description= XO Server
+Description=XO Server
 After=network-online.target
 
 [Service]
 Environment="DEBUG=xo:main"
-# Be sure to edit the path below to where your install is located!
-ExecStart=/snap/node/current/bin/node /home/username/xen-orchestra/packages/xo-server/dist/cli.mjs
 Restart=always
 SyslogIdentifier=xo-server
+
+# Be sure to edit the path below to where your Node and your xo-server install is located!
+ExecStart=/usr/bin/node /home/username/xen-orchestra/packages/xo-server/dist/cli.mjs
 
 [Install]
 WantedBy=multi-user.target
 ```
 
-Reload the systemd-daemon: 
+Reload the systemd-daemon:
+
 ```sh
 systemctl daemon-reload
 ```
+
 You can then use standard systemd commands to start/stop/check status e.g. `systemctl start xo-server`
+
+> **Security:** `xo-server` will be run as `root`, make sure your files are not editable by other users or it may be used as an attack vector.
 
 ### Banner and warnings
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -116,7 +116,7 @@ apt-get install build-essential redis-server libpng-dev git python3-minimal libv
 
 On Fedora/CentOS like:
 
-
+```sh
 dnf install redis libpng-devel git lvm2 cifs-utils make automake gcc gcc-c++ nfs-utils ntfs-3g
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -116,7 +116,7 @@ apt-get install build-essential redis-server libpng-dev git python3-minimal libv
 
 On Fedora/CentOS like:
 
-```sh
+
 dnf install redis libpng-devel git lvm2 cifs-utils make automake gcc gcc-c++ nfs-utils ntfs-3g
 ```
 
@@ -249,7 +249,7 @@ _The following example is based on a Ubuntu 24.04 installation_
 
 Create the following file `/etc/systemd/system/xo-server.service` containing the following inside:
 
-```sh
+```ini
 [Unit]
 Description=XO Server
 After=network-online.target

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -204,6 +204,7 @@ Then restart Xen Orchestra if it was running.
 
 ### Always Running
 
+#### Yarn alternative
 - You can use [forever](https://github.com/nodejitsu/forever) to have the process always running:
 
 ```sh
@@ -238,6 +239,36 @@ If you need to delete the service:
 ```sh
 forever-service delete orchestra
 ```
+
+#### Systemd service
+You can also use systemd to enable the service instead.
+
+*The following example is based on a Ubuntu 24.04 installation*
+
+Create the following file `/etc/systemd/system/xo-server.service` containing the following inside:
+```sh
+# systemd service for XO-Server.
+
+[Unit]
+Description= XO Server
+After=network-online.target
+
+[Service]
+Environment="DEBUG=xo:main"
+# Be sure to edit the path below to where your install is located!
+ExecStart=/snap/node/current/bin/node /home/username/xen-orchestra/packages/xo-server/dist/cli.mjs
+Restart=always
+SyslogIdentifier=xo-server
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Reload the systemd-daemon: 
+```sh
+systemctl daemon-reload
+```
+You can then use standard systemd commands to start/stop/check status e.g. `systemctl start xo-server`
 
 ### Banner and warnings
 


### PR DESCRIPTION
### Description

I could never get the _yarn forever service_ variant to work. However, it was quite trivial to make a systemd variant on both my test-systems. So I've decided to share those steps that I did.
Hopefully you'll find it usefull/complementary.

This adds an alternate subsection with examples on what files to create and what commands to execute to have it being a systemd service instead..

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
