### PR TITLE
feat(lite/XoaButton): support `xo-server`'s setting `http.publicUrl`

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [Pool/Dashboard] Add missing translations for hosts and VMs statuses (PR [#7744](https://github.com/vatesfr/xen-orchestra/pull/7744))
 - [i18n] Add Persian translation (based on the contribution made by [@Jokar-xen](https://github.com/Jokar-xen)) (PR [#7775](https://github.com/vatesfr/xen-orchestra/pull/7775))
+- [Access XOA] Support `xo-server`'s' setting `http.publicUrl` to redirect to a custom URL when "Access XOA" button is clicked in XO Lite [Forum#9392](https://xcp-ng.org/forum/topic/9392)
 
 ## **0.2.3** (2024-05-31)
 

--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - [Pool/Dashboard] Add missing translations for hosts and VMs statuses (PR [#7744](https://github.com/vatesfr/xen-orchestra/pull/7744))
 - [i18n] Add Persian translation (based on the contribution made by [@Jokar-xen](https://github.com/Jokar-xen)) (PR [#7775](https://github.com/vatesfr/xen-orchestra/pull/7775))
-- [Access XOA] Support `xo-server`'s' setting `http.publicUrl` to redirect to a custom URL when "Access XOA" button is clicked in XO Lite [Forum#9392](https://xcp-ng.org/forum/topic/9392)
+- [Access XOA] Support `xo-server`'s' setting `http.publicUrl` to redirect to a custom URL when "Access XOA" button is clicked in XO Lite [Forum#9392](https://xcp-ng.org/forum/topic/9392) (PR [#7849](https://github.com/vatesfr/xen-orchestra/pull/7849))
 
 ## **0.2.3** (2024-05-31)
 

--- a/@xen-orchestra/lite/src/components/XoaButton.vue
+++ b/@xen-orchestra/lite/src/components/XoaButton.vue
@@ -30,7 +30,8 @@ interface InterfaceInfo {
 
 interface ClientInfo {
   lastConnected: number
-  networkInterfaces: Record<string, InterfaceInfo[]>
+  networkInterfaces?: Record<string, InterfaceInfo[]>
+  publicUrl?: string
 }
 
 const xoasInfo = computed(() => {
@@ -60,7 +61,12 @@ const xoaAddress = computed(() => {
     return
   }
 
-  const { networkInterfaces } = xoaInfo.value
+  const { networkInterfaces, publicUrl } = xoaInfo.value
+
+  if (publicUrl !== undefined) {
+    return publicUrl
+  }
+
   if (networkInterfaces === undefined || Object.keys(networkInterfaces).length === 0) {
     return
   }


### PR DESCRIPTION
See https://xcp-ng.org/forum/topic/9392

`xo-server` has a config setting `http.publicUrl` that allows the user to force XO to report a custom URL in the pool's other_config (along with the `networkInterfaces` fallback). With this change, the "Access XOA" button in XO Lite will open that URL if it exists and fallback to `networkInterfaces` otherwise.

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
