### PR TITLE
fix(xo-web/VM): properly identify self user to hide unauthorized actions

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,7 +24,7 @@
 
 - [VM/Advanced] Fix `not enough permission` when attaching PCIs [#9260](https://xcp-ng.org/forum/topic/9260/attach-pcis-not-enough-permissions) (PR [#7793](https://github.com/vatesfr/xen-orchestra/pull/7793))
 - [V2V] Fix `Cannot read properties of undefined (reading 'committed')` when listing importable VM (PR [#7840](https://github.com/vatesfr/xen-orchestra/pull/7840))
-- [VM] Fix Self-Service users being able to see more action buttons than they should in some cases
+- [VM] Fix Self-Service users being able to see more action buttons than they should in some cases (PR [#7854](https://github.com/vatesfr/xen-orchestra/pull/7854))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@
 
 - [VM/Advanced] Fix `not enough permission` when attaching PCIs [#9260](https://xcp-ng.org/forum/topic/9260/attach-pcis-not-enough-permissions) (PR [#7793](https://github.com/vatesfr/xen-orchestra/pull/7793))
 - [V2V] Fix `Cannot read properties of undefined (reading 'committed')` when listing importable VM (PR [#7840](https://github.com/vatesfr/xen-orchestra/pull/7840))
+- [VM] Fix Self-Service users being able to see more action buttons than they should in some cases
 
 ### Packages to release
 

--- a/packages/xo-web/src/xo-app/vm/action-bar.js
+++ b/packages/xo-web/src/xo-app/vm/action-bar.js
@@ -162,15 +162,19 @@ const VmActionBar = addSubscriptions(() => ({
 }))(
   connectStore(() => ({
     checkPermissions: getCheckPermissions,
-    userId: createSelector(getUser, user => user.id),
-  }))(({ checkPermissions, vm, userId, resourceSets }) => {
+    user: getUser,
+  }))(({ checkPermissions, vm, user, resourceSets }) => {
     // Is the user in the same resource set as the VM
     const _getIsSelfUser = createSelector(
       () => resourceSets,
       resourceSets => {
         const vmResourceSet = vm.resourceSet && find(resourceSets, { id: vm.resourceSet })
 
-        return vmResourceSet && includes(vmResourceSet.subjects, userId)
+        return (
+          vmResourceSet &&
+          (includes(vmResourceSet.subjects, user.id) ||
+            user.groups.some(groupId => includes(vmResourceSet.subjects, groupId)))
+        )
       }
     )
 


### PR DESCRIPTION
See Zammad#27288

### Description

In order to hide some VM actions from the user, we check if the current user belongs to a resource set. But we also need to check if they belong to a group that belongs to a resource set.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
