### PR TITLE
fix(xo-server): VHD is a disposable

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [V2V] Fix warm migration (PR [#7856](https://github.com/vatesfr/xen-orchestra/pull/7856))
+- [V2V] Fix `Can't import delta of a running VM without its parent VHD` error during warm migration (PR [#7856](https://github.com/vatesfr/xen-orchestra/pull/7856))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [V2V] Fix warm migration (PR [#7856](https://github.com/vatesfr/xen-orchestra/pull/7856))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -30,5 +32,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- xo-server patch
 
 <!--packages-end-->

--- a/packages/xo-server/src/xo-mixins/vmware/importDisksfromDatastore.mjs
+++ b/packages/xo-server/src/xo-mixins/vmware/importDisksfromDatastore.mjs
@@ -76,8 +76,9 @@ export const importDisksFromDatastore = async function importDisksFromDatastore(
     Object.keys(chainsByNodes).map(async (node, userdevice) =>
       Task.run({ properties: { name: `Cold import of disks ${node}` } }, async () => {
         const chainByNode = chainsByNodes[node]
-        const { vdi, vhd: parentVhd } = vhds[userdevice] ?? {}
-        return importDiskChain($defer, { esxi, dataStoreToHandlers, vm, chainByNode, userdevice, sr, parentVhd, vdi })
+        return Disposable.use(vhds[userdevice] ?? {}, ({ vdi, vhd: parentVhd }) =>
+          importDiskChain($defer, { esxi, dataStoreToHandlers, vm, chainByNode, userdevice, sr, parentVhd, vdi })
+        )
       })
     )
   )


### PR DESCRIPTION
vhd are disposable and can't be used directly
introduced by 24d584e9056379b03f8440935b24519e02dd94f1

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
