### PR TITLE
feat(xo-6/vm): use HeadBar component instead of custom integration

### DIFF
--- a/@xen-orchestra/web/src/components/vm/VmHeader.vue
+++ b/@xen-orchestra/web/src/components/vm/VmHeader.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script lang="ts" setup>
-import type { Vm } from '@/types/vm.type'
+import type { XoVm } from '@/types/xo/vm.type'
 import type { VmState } from '@core/types/object-icon.type'
 import HeadBar from '@core/components/head-bar/HeadBar.vue'
 import ObjectIcon from '@core/components/icon/ObjectIcon.vue'
@@ -26,6 +26,6 @@ import TabItem from '@core/components/tab/TabItem.vue'
 import TabList from '@core/components/tab/TabList.vue'
 
 defineProps<{
-  vm: Vm
+  vm: XoVm
 }>()
 </script>

--- a/@xen-orchestra/web/src/components/vm/VmHeader.vue
+++ b/@xen-orchestra/web/src/components/vm/VmHeader.vue
@@ -1,8 +1,10 @@
 <template>
-  <div class="vm-header">
-    <ObjectIcon :state size="medium" type="vm" />
-    <h4 v-tooltip class="typo h4-medium text-ellipsis">{{ name }}</h4>
-  </div>
+  <HeadBar>
+    {{ vm.name_label }}
+    <template #icon>
+      <ObjectIcon :state="vm.power_state.toLocaleLowerCase() as VmState" type="vm" />
+    </template>
+  </HeadBar>
   <TabList>
     <TabItem disabled>{{ $t('dashboard') }}</TabItem>
     <TabItem active>{{ $t('console') }}</TabItem>
@@ -16,25 +18,14 @@
 </template>
 
 <script lang="ts" setup>
+import type { Vm } from '@/types/vm.type'
 import type { VmState } from '@core/types/object-icon.type'
+import HeadBar from '@core/components/head-bar/HeadBar.vue'
 import ObjectIcon from '@core/components/icon/ObjectIcon.vue'
 import TabItem from '@core/components/tab/TabItem.vue'
 import TabList from '@core/components/tab/TabList.vue'
-import { vTooltip } from '@core/directives/tooltip.directive'
 
 defineProps<{
-  name?: string
-  state?: VmState
+  vm: Vm
 }>()
 </script>
-
-<style lang="postcss" scoped>
-.vm-header {
-  padding: 1.6rem;
-  display: flex;
-  gap: 1.6rem;
-  align-items: center;
-  border-bottom: 0.1rem solid var(--color-grey-500);
-  background-color: var(--background-color-primary);
-}
-</style>

--- a/@xen-orchestra/web/src/pages/vm/[id].vue
+++ b/@xen-orchestra/web/src/pages/vm/[id].vue
@@ -10,7 +10,7 @@
 <script lang="ts" setup>
 import VmHeader from '@/components/vm/VmHeader.vue'
 import { useVmStore } from '@/stores/xo-rest-api/vm.store'
-import type { RecordId } from '@/types/xo-object.type'
+import type { XoVm } from '@/types/xo/vm.type'
 import LoadingHero from '@core/components/state-hero/LoadingHero.vue'
 import ObjectNotFoundHero from '@core/components/state-hero/ObjectNotFoundHero.vue'
 import { computed } from 'vue'
@@ -20,5 +20,5 @@ const route = useRoute<'/vm/[id]'>()
 
 const { isReady, get: getVm } = useVmStore().subscribe()
 
-const vm = computed(() => getVm(route.params.id as RecordId<'VM'>))
+const vm = computed(() => getVm(route.params.id as XoVm['id']))
 </script>

--- a/@xen-orchestra/web/src/pages/vm/[id].vue
+++ b/@xen-orchestra/web/src/pages/vm/[id].vue
@@ -2,7 +2,7 @@
   <LoadingHero v-if="!isReady" type="page" />
   <ObjectNotFoundHero v-else-if="!vm" :id="route.params.id" />
   <RouterView v-else v-slot="{ Component }">
-    <VmHeader :name="vm.name_label" :state="powerState" />
+    <VmHeader :vm />
     <component :is="Component" :vm />
   </RouterView>
 </template>
@@ -10,8 +10,7 @@
 <script lang="ts" setup>
 import VmHeader from '@/components/vm/VmHeader.vue'
 import { useVmStore } from '@/stores/xo-rest-api/vm.store'
-import type { XoVm } from '@/types/xo/vm.type'
-import type { VmState } from '@core/types/object-icon.type'
+import type { RecordId } from '@/types/xo-object.type'
 import LoadingHero from '@core/components/state-hero/LoadingHero.vue'
 import ObjectNotFoundHero from '@core/components/state-hero/ObjectNotFoundHero.vue'
 import { computed } from 'vue'
@@ -21,7 +20,5 @@ const route = useRoute<'/vm/[id]'>()
 
 const { isReady, get: getVm } = useVmStore().subscribe()
 
-const vm = computed(() => getVm(route.params.id as XoVm['id']))
-
-const powerState = computed(() => vm.value?.power_state.toLocaleLowerCase() as VmState | undefined)
+const vm = computed(() => getVm(route.params.id as RecordId<'VM'>))
 </script>


### PR DESCRIPTION
### Description

Update XO 6 Vm view, use `HeadBar` component instead of custom integration made when the component wasn’t available.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
