### PR TITLE
fix(web-6/tree-view): issue with item without children

### DIFF
--- a/@xen-orchestra/web-core/lib/composables/tree/branch.ts
+++ b/@xen-orchestra/web-core/lib/composables/tree/branch.ts
@@ -40,15 +40,15 @@ export class Branch<
   }
 
   get failsFilterDownwards(): boolean {
-    return this.passesFilter !== true && this.rawChildren.every(child => child.failsFilterDownwards)
+    if (this.passesFilter !== undefined) {
+      return !this.passesFilter
+    }
+
+    return this.rawChildren.length > 0 && this.rawChildren.every(child => child.failsFilterDownwards)
   }
 
   get isExcluded() {
     if (this.parent?.isExpanded === false) {
-      return true
-    }
-
-    if (!this.hasChildren) {
       return true
     }
 

--- a/@xen-orchestra/web/src/components/tree/HostTreeItem.vue
+++ b/@xen-orchestra/web/src/components/tree/HostTreeItem.vue
@@ -11,7 +11,7 @@
         <UiIcon v-if="isMaster" v-tooltip="$t('master')" :icon="faStar" color="warning" />
       </template>
     </TreeItemLabel>
-    <template #sublist>
+    <template v-if="branch.hasChildren" #sublist>
       <TreeList>
         <VmTreeList :leaves="branch.children" />
       </TreeList>

--- a/@xen-orchestra/web/src/components/tree/PoolTreeItem.vue
+++ b/@xen-orchestra/web/src/components/tree/PoolTreeItem.vue
@@ -3,7 +3,7 @@
     <TreeItemLabel :icon="faCity" :route="`/pool/${branch.data.id}`" @toggle="branch.toggleExpand()">
       {{ branch.data.name_label }}
     </TreeItemLabel>
-    <template #sublist>
+    <template v-if="branch.hasChildren" #sublist>
       <TreeList>
         <HostTreeList :branches="treeBranches" />
         <VmTreeList :leaves="vmLeaves" />


### PR DESCRIPTION
### Description

- Remove the responsibility to exclude branches with no children from `branch.ts`
- `PoolTreeItem` and `HostTreeItem` no longer create a sublist if they have no children

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
