### PR TITLE
feat(xo-6/tree-view): improve indentation of empty items

### DIFF
--- a/@xen-orchestra/web-core/lib/components/tree/TreeItemLabel.vue
+++ b/@xen-orchestra/web-core/lib/components/tree/TreeItemLabel.vue
@@ -22,7 +22,7 @@
         size="small"
         @click="emit('toggle')"
       />
-      <TreeLine v-else-if="!noIndent" />
+      <div v-else class="h-line" />
       <a v-tooltip="{ selector: '.text' }" :href class="link typo p2-medium" @click="navigate">
         <slot name="icon">
           <UiIcon :icon class="icon" />
@@ -55,7 +55,6 @@ defineProps<{
   icon?: IconDefinition
   route: RouteLocationRaw
   active?: boolean
-  noIndent?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -124,6 +123,12 @@ const depth = inject(IK_TREE_LIST_DEPTH, 0)
 
 .icon {
   font-size: 1.6rem;
+}
+
+.h-line {
+  width: 2rem;
+  border-bottom: 0.1rem solid var(--color-purple-base);
+  margin-left: -0.4rem;
 }
 
 /*

--- a/@xen-orchestra/web/src/components/tree/HostTreeItem.vue
+++ b/@xen-orchestra/web/src/components/tree/HostTreeItem.vue
@@ -1,11 +1,6 @@
 <template>
   <TreeItem :expanded="branch.isExpanded">
-    <TreeItemLabel
-      :icon="faServer"
-      :no-indent="!hasVMs"
-      :route="`/host/${branch.data.id}`"
-      @toggle="branch.toggleExpand()"
-    >
+    <TreeItemLabel :icon="faServer" :route="`/host/${branch.data.id}`" @toggle="branch.toggleExpand()">
       {{ branch.data.name_label }}
       <template #addons>
         <UiIcon v-if="isMaster" v-tooltip="$t('master')" :icon="faStar" color="warning" />
@@ -38,6 +33,4 @@ const props = defineProps<{
 const { isMasterHost } = useHostStore().subscribe()
 
 const isMaster = computed(() => isMasterHost(props.branch.data.id))
-
-const hasVMs = computed(() => props.branch.children.length > 0)
 </script>


### PR DESCRIPTION
### Description

Enhance the indentation of empty items in the tree-view to optimize readability.

### Screenshots

Before:
![tree-view-indentation-before](https://github.com/user-attachments/assets/b49b8a77-ee7b-46f7-b044-54bb4d533575)

After:
![tree-view-indentation-after](https://github.com/user-attachments/assets/3e4f4300-dcb8-4b43-b081-28831aec2f98)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
