### PR TITLE
feat(web-core): update heroes + add stories

### DIFF
--- a/@xen-orchestra/lite/src/stories/web-core/state-hero/coming-soon-hero.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/state-hero/coming-soon-hero.story.vue
@@ -1,0 +1,14 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties }"
+    :params="[prop('type').required().enum('page', 'card').preset('card').widget()]"
+  >
+    <ComingSoonHero v-bind="properties" />
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import { prop } from '@/libs/story/story-param'
+import ComingSoonHero from '@core/components/state-hero/ComingSoonHero.vue'
+</script>

--- a/@xen-orchestra/lite/src/stories/web-core/state-hero/loading-hero.story.md
+++ b/@xen-orchestra/lite/src/stories/web-core/state-hero/loading-hero.story.md
@@ -1,0 +1,8 @@
+```vue-template
+<UiCard>
+  <CardTitle>My Card</CardTitle>
+  <LoadingHero :disabled="isReady">
+    <div>Content of my card</div>
+  </LoadingHero>
+</UiCard>
+```

--- a/@xen-orchestra/lite/src/stories/web-core/state-hero/loading-hero.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/state-hero/loading-hero.story.vue
@@ -1,0 +1,21 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties, settings }"
+    :params="[
+      prop('type').required().enum('page', 'card').preset('card').widget(),
+      prop('disabled').bool().widget(),
+      slot(),
+      setting('slotContent').preset('Content to show when loader is disabled').widget(),
+    ]"
+  >
+    <LoadingHero v-bind="properties">
+      {{ settings.slotContent }}
+    </LoadingHero>
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import { prop, setting, slot } from '@/libs/story/story-param'
+import LoadingHero from '@core/components/state-hero/LoadingHero.vue'
+</script>

--- a/@xen-orchestra/lite/src/stories/web-core/state-hero/object-not-found-hero.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/state-hero/object-not-found-hero.story.vue
@@ -1,0 +1,11 @@
+<template>
+  <ComponentStory v-slot="{ properties }" :params="[prop('id').required().str().preset('123-456-789').widget()]">
+    <ObjectNotFoundHero v-bind="properties" />
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import { prop } from '@/libs/story/story-param'
+import ObjectNotFoundHero from '@core/components/state-hero/ObjectNotFoundHero.vue'
+</script>

--- a/@xen-orchestra/lite/src/stories/web-core/state-hero/state-hero.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/state-hero/state-hero.story.vue
@@ -1,0 +1,22 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties, settings }"
+    :params="[
+      prop('type').required().enum('page', 'card').preset('card').widget(),
+      prop('busy').bool().widget(),
+      prop('image').enum('no-result', 'under-construction').widget(),
+      slot(),
+      setting('defaultSlot').preset('Some text').widget(),
+    ]"
+  >
+    <StateHero v-bind="properties">
+      {{ settings.defaultSlot }}
+    </StateHero>
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import { prop, setting, slot } from '@/libs/story/story-param'
+import StateHero from '@core/components/state-hero/StateHero.vue'
+</script>

--- a/@xen-orchestra/web-core/lib/components/state-hero/ComingSoonHero.vue
+++ b/@xen-orchestra/web-core/lib/components/state-hero/ComingSoonHero.vue
@@ -1,9 +1,13 @@
 <template>
-  <StateHero image="under-construction" class="coming-soon-hero">
+  <StateHero :type class="coming-soon-hero" image="under-construction">
     {{ $t('coming-soon') }}
   </StateHero>
 </template>
 
 <script lang="ts" setup>
-import StateHero from '@core/components/state-hero/StateHero.vue'
+import StateHero, { type StateHeroType } from '@core/components/state-hero/StateHero.vue'
+
+defineProps<{
+  type: StateHeroType
+}>()
 </script>

--- a/@xen-orchestra/web-core/lib/components/state-hero/LoadingHero.vue
+++ b/@xen-orchestra/web-core/lib/components/state-hero/LoadingHero.vue
@@ -1,9 +1,15 @@
 <template>
-  <StateHero busy class="loading-hero">
+  <StateHero v-if="!disabled" :type busy class="loading-hero">
     {{ $t('loading-in-progress') }}
   </StateHero>
+  <slot v-else />
 </template>
 
 <script lang="ts" setup>
-import StateHero from '@core/components/state-hero/StateHero.vue'
+import StateHero, { type StateHeroType } from '@core/components/state-hero/StateHero.vue'
+
+defineProps<{
+  type: StateHeroType
+  disabled?: boolean
+}>()
 </script>

--- a/@xen-orchestra/web-core/lib/components/state-hero/ObjectNotFoundHero.vue
+++ b/@xen-orchestra/web-core/lib/components/state-hero/ObjectNotFoundHero.vue
@@ -1,5 +1,5 @@
 <template>
-  <StateHero image="no-result" class="object-not-found-hero">
+  <StateHero class="object-not-found-hero" image="no-result" type="page">
     {{ $t('object-not-found', { id }) }}
   </StateHero>
 </template>

--- a/@xen-orchestra/web-core/lib/components/state-hero/StateHero.vue
+++ b/@xen-orchestra/web-core/lib/components/state-hero/StateHero.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="state-hero">
+  <div :class="type" class="state-hero">
     <UiSpinner v-if="busy" class="spinner" />
     <img v-else-if="imageSrc" :src="imageSrc" alt="" class="image" />
-    <p v-if="$slots.default" class="typo h2-black text">
+    <p v-if="$slots.default" :class="typoClass" class="typo text">
       <slot />
     </p>
   </div>
@@ -12,10 +12,15 @@
 import UiSpinner from '@core/components/UiSpinner.vue'
 import { computed } from 'vue'
 
+export type StateHeroType = 'page' | 'card'
+
 const props = defineProps<{
+  type: StateHeroType
   busy?: boolean
   image?: 'no-result' | 'under-construction' // TODO: 'offline' | 'no-data' |  'not-found' | 'all-good' | 'all-done' | 'error'
 }>()
+
+const typoClass = computed(() => (props.type === 'page' ? 'h2-black' : 'h4-medium'))
 
 const imageSrc = computed(() => {
   try {
@@ -28,26 +33,39 @@ const imageSrc = computed(() => {
 
 <style lang="postcss" scoped>
 .state-hero {
+  &.page {
+    --image-width: 90%;
+    --spinner-size: 10rem;
+    --gap: 8.2rem;
+  }
+
+  &.card {
+    --image-width: 70%;
+    --spinner-size: 6rem;
+    --gap: 2rem;
+  }
+}
+
+.state-hero {
   flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 4.2rem;
+  gap: var(--gap);
 }
 
 .image {
-  width: 90%;
+  width: var(--image-width);
   max-width: 55rem;
 }
 
 .spinner {
   color: var(--color-purple-base);
-  font-size: 10rem;
+  font-size: var(--spinner-size);
 }
 
 .text {
   color: var(--color-purple-base);
-  margin-top: 4rem;
 }
 </style>

--- a/@xen-orchestra/web-core/lib/components/state-hero/StateHero.vue
+++ b/@xen-orchestra/web-core/lib/components/state-hero/StateHero.vue
@@ -23,11 +23,11 @@ const props = defineProps<{
 const typoClass = computed(() => (props.type === 'page' ? 'h2-black' : 'h4-medium'))
 
 const imageSrc = computed(() => {
-  try {
-    return new URL(`../../assets/${props.image}.svg`, import.meta.url).href
-  } catch {
+  if (!props.image) {
     return undefined
   }
+
+  return new URL(`../../assets/${props.image}.svg`, import.meta.url).href
 })
 </script>
 

--- a/@xen-orchestra/web/src/pages/host/[id].vue
+++ b/@xen-orchestra/web/src/pages/host/[id].vue
@@ -1,5 +1,5 @@
 <template>
-  <ComingSoonHero />
+  <ComingSoonHero type="page" />
 </template>
 
 <script setup lang="ts">

--- a/@xen-orchestra/web/src/pages/pool/[id].vue
+++ b/@xen-orchestra/web/src/pages/pool/[id].vue
@@ -1,5 +1,5 @@
 <template>
-  <LoadingHero v-if="!isReady" />
+  <LoadingHero v-if="!isReady" type="page" />
   <ObjectNotFoundHero v-else-if="!pool" :id="route.params.id" />
   <RouterView v-else v-slot="{ Component }">
     <PoolHeader :pool />

--- a/@xen-orchestra/web/src/pages/pool/[id]/hosts.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/hosts.vue
@@ -1,5 +1,5 @@
 <template>
-  <LoadingHero v-if="!isReady" />
+  <LoadingHero v-if="!isReady" type="page" />
   <UiCard v-else class="hosts">
     <!-- TODO: update with item selection button and TopBottomTable component when available -->
     <p class="typo p3-regular count">{{ $t('n-hosts', { n: hosts.length }) }}</p>

--- a/@xen-orchestra/web/src/pages/pool/[id]/vms.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/vms.vue
@@ -1,5 +1,5 @@
 <template>
-  <LoadingHero v-if="!isReady" />
+  <LoadingHero v-if="!isReady" type="page" />
   <UiCard v-else class="vms">
     <!-- TODO: update with item selection button and TopBottomTable component when available -->
     <p class="typo p3-regular count">{{ $t('n-vms', { n: vms.length }) }}</p>

--- a/@xen-orchestra/web/src/pages/vm/[id].vue
+++ b/@xen-orchestra/web/src/pages/vm/[id].vue
@@ -1,5 +1,5 @@
 <template>
-  <LoadingHero v-if="!isReady" />
+  <LoadingHero v-if="!isReady" type="page" />
   <ObjectNotFoundHero v-else-if="!vm" :id="route.params.id" />
   <RouterView v-else v-slot="{ Component }">
     <VmHeader :name="vm.name_label" :state="powerState" />


### PR DESCRIPTION
### Description

- `StateHero`, `LoadingHero` and `ComingSoonHero` can now be used inside a card by passing `type="card"` or inside a page by passing `type="page"`
- `LoadingHero` has now a `disabled?: boolean` prop and can now take a slot which will be displayed when `disabled` is `true`
- Added stories for `StateHero`, `ComingSoonHero`, `ObjectNotFoundHero` and `LoadingHero`

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
