### PR TITLE
feat(web-core): new `useItemCounter` composable

### DIFF
--- a/@xen-orchestra/web-core/lib/composables/item-counter.composable.md
+++ b/@xen-orchestra/web-core/lib/composables/item-counter.composable.md
@@ -1,0 +1,25 @@
+# `useItemCounter`
+
+This composable is meant to count items based on given filters then output the categorized count.
+
+## Usage
+
+```typescript
+const collection = [
+  { id: 'a', size: 'S' },
+  { id: 'b', size: 'S' },
+  { id: 'c', size: 'XL' },
+  { id: 'd', size: 'M' },
+  { id: 'e', size: 'L' },
+  { id: 'f', size: 'S' },
+]
+
+const count = useItemCounter(collection, {
+  small: item => item.size === 'S',
+  medium: item => item.size === 'M',
+})
+
+console.log(count.small) // 3
+console.log(count.medium) // 1
+console.log(count.$other) // 2
+```

--- a/@xen-orchestra/web-core/lib/composables/item-counter.composable.ts
+++ b/@xen-orchestra/web-core/lib/composables/item-counter.composable.ts
@@ -1,0 +1,32 @@
+import { computed, type MaybeRefOrGetter, toValue } from 'vue'
+
+type Counters<TConfig> = { [K in keyof TConfig | '$other']: number }
+
+export function useItemCounter<TItem, TConfig extends Record<string, (item: TItem) => boolean>>(
+  items: MaybeRefOrGetter<TItem[]>,
+  config: TConfig
+) {
+  const keys = Object.keys(config) as (keyof TConfig)[]
+
+  return computed(() => {
+    const counters = Object.fromEntries(keys.concat('$other').map(key => [key, 0])) as Counters<TConfig>
+
+    for (const item of toValue(items)) {
+      let matched = false
+
+      for (const key of keys) {
+        if (config[key](item)) {
+          matched = true
+          counters[key] += 1
+          break
+        }
+      }
+
+      if (!matched) {
+        counters.$other += 1
+      }
+    }
+
+    return counters
+  })
+}

--- a/@xen-orchestra/web/src/components/site/dashboard/HostsStatus.vue
+++ b/@xen-orchestra/web/src/components/site/dashboard/HostsStatus.vue
@@ -17,6 +17,7 @@ import CardNumbers from '@core/components/CardNumbers.vue'
 import DonutChartWithLegend from '@core/components/donut-chart-with-legend/DonutChartWithLegend.vue'
 import LoadingHero from '@core/components/state-hero/LoadingHero.vue'
 import UiCard from '@core/components/UiCard.vue'
+import { useItemCounter } from '@core/composables/item-counter.composable'
 import { faServer } from '@fortawesome/free-solid-svg-icons'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -24,21 +25,9 @@ import { useI18n } from 'vue-i18n'
 const { t } = useI18n()
 const { records: hosts, isReady } = useHostStore().subscribe()
 
-const hostsCount = computed(() => {
-  return hosts.value.reduce(
-    (acc, host) => {
-      if (host.power_state === HOST_POWER_STATE.RUNNING) {
-        acc.running++
-      } else if (host.power_state === HOST_POWER_STATE.HALTED) {
-        acc.halted++
-      } else {
-        acc.unknown++
-      }
-
-      return acc
-    },
-    { running: 0, halted: 0, unknown: 0 }
-  )
+const hostsCount = useItemCounter(hosts, {
+  running: host => host.power_state === HOST_POWER_STATE.RUNNING,
+  halted: host => host.power_state === HOST_POWER_STATE.HALTED,
 })
 
 const segments = computed<DonutChartWithLegendProps['segments']>(() => [
@@ -54,7 +43,7 @@ const segments = computed<DonutChartWithLegendProps['segments']>(() => [
   },
   {
     label: t('hosts-status.unknown'),
-    value: hostsCount.value.unknown,
+    value: hostsCount.value.$other,
     color: 'disabled',
     tooltip: t('hosts-status.unknown.tooltip'),
   },

--- a/@xen-orchestra/web/src/components/site/dashboard/VmsStatus.vue
+++ b/@xen-orchestra/web/src/components/site/dashboard/VmsStatus.vue
@@ -18,6 +18,7 @@ import DonutChartWithLegend, {
 } from '@core/components/donut-chart-with-legend/DonutChartWithLegend.vue'
 import LoadingHero from '@core/components/state-hero/LoadingHero.vue'
 import UiCard from '@core/components/UiCard.vue'
+import { useItemCounter } from '@core/composables/item-counter.composable'
 import { faDesktop } from '@fortawesome/free-solid-svg-icons'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -25,22 +26,10 @@ import { useI18n } from 'vue-i18n'
 const { t } = useI18n()
 const { records: vms, isReady } = useVmStore().subscribe()
 
-const vmsCount = computed(() =>
-  vms.value.reduce(
-    (acc, vm) => {
-      if (vm.power_state === VM_POWER_STATE.RUNNING || vm.power_state === VM_POWER_STATE.PAUSED) {
-        acc.running++
-      } else if (vm.power_state === VM_POWER_STATE.HALTED || vm.power_state === VM_POWER_STATE.SUSPENDED) {
-        acc.inactive++
-      } else {
-        acc.unknown++
-      }
-
-      return acc
-    },
-    { running: 0, inactive: 0, unknown: 0 }
-  )
-)
+const vmsCount = useItemCounter(vms, {
+  running: vm => vm.power_state === VM_POWER_STATE.RUNNING || vm.power_state === VM_POWER_STATE.PAUSED,
+  inactive: vm => vm.power_state === VM_POWER_STATE.HALTED || vm.power_state === VM_POWER_STATE.SUSPENDED,
+})
 
 const segments = computed<DonutChartWithLegendProps['segments']>(() => [
   {
@@ -56,7 +45,7 @@ const segments = computed<DonutChartWithLegendProps['segments']>(() => [
   },
   {
     label: t('vms-status.unknown'),
-    value: vmsCount.value.unknown,
+    value: vmsCount.value.$other,
     color: 'disabled',
     tooltip: t('vms-status.unknown.tooltip'),
   },


### PR DESCRIPTION
### Description

Add `useItemCounter` composable to count items of a collection based on given filters, then output the categorized count.

```typescript
const collection = [
  { id: 'a', size: 'S' },
  { id: 'b', size: 'S' },
  { id: 'c', size: 'XL' },
  { id: 'd', size: 'M' },
  { id: 'e', size: 'L' },
  { id: 'f', size: 'S' },
]

const count = useItemCounter(collection, {
  small: item => item.size === 'S',
  medium: item => item.size === 'M',
})

console.log(count.small) // 3
console.log(count.medium) // 1
console.log(count.$other) // 2
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
