### PR TITLE
feat(lite): local XO Lite will try to load app from lite.xen-orchestra.com first

### DIFF
--- a/@xen-orchestra/lite/scripts/release.mjs
+++ b/@xen-orchestra/lite/scripts/release.mjs
@@ -270,8 +270,13 @@ if (ghRelease || deploy) {
   if (ghRelease) {
     console.log(`Adding LICENSE file to ${dist}`)
     await fs.copy(fileURLToPath(new URL('agpl-3.0.txt', import.meta.url)), path.join(dist, 'LICENSE'))
+
     console.log(`Adding CHANGELOG.md file to ${dist}`)
     await fs.copy(fileURLToPath(new URL('../CHANGELOG.md', import.meta.url)), path.join(dist, 'CHANGELOG.md'))
+
+    console.log(`Adding xolite-loader.html to ${dist}`)
+    await fs.copy(path.join(dist, 'index.html'), path.join(dist, 'xolite.html'))
+    await fs.copy(fileURLToPath(new URL('xolite-loader.html', import.meta.url)), path.join(dist, 'index.html'))
   }
 
   if (deploy) {

--- a/@xen-orchestra/lite/scripts/xolite-loader.html
+++ b/@xen-orchestra/lite/scripts/xolite-loader.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="theme-color" content="#cc584c" />
+    <title>XO Lite</title>
+    <script>
+      ;(async () => {
+        try {
+          // Try to load XO Lite from lite.xen-orchestra.com
+          const response = await fetch('https://lite.xen-orchestra.com/dist/index.html')
+          if (!response.ok) {
+            throw new Error(`Cannot download XO Lite from lite.xen-orchestra.com (${response.status})`)
+          }
+
+          document.open()
+          document.write(await response.text())
+          document.close()
+        } catch (err) {
+          console.log(err?.message ?? err)
+          // Fallback to local version of XO Lite
+          document.open()
+          document.write(await (await fetch('./xolite.html')).text())
+          document.close()
+        }
+      })()
+    </script>
+  </head>
+</html>


### PR DESCRIPTION
### Description

When XO Lite is accessed directly from an XCP-ng host URL, it will first try to load the app from lite.xen-orchestra.com. If it fails, it will fallback to a (less often updated) version of XO Lite served by the XCP-ng host itself.

In order to do so, the tarball for a GitHub release is prepared as follows:
1. Rename Vite-built `index.html` to `xolite.html`
2. Inject a custom `index.html` that will:
  a. Try to load `lite.xen-orchestra.com/dist/index.html`
  b. If it can't be loaded (air-gap): fallback to local `xolite.html`

### Screenshots

This PR implements "Version 3" of this diagram:
![](https://github.com/user-attachments/assets/6943e05e-e2f4-4884-9d3c-ef9c309dc143)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
