### PR TITLE
fix(web-core/novnc): add custom declaration file to fix type-check error

### DIFF
--- a/@xen-orchestra/web-core/env.d.ts
+++ b/@xen-orchestra/web-core/env.d.ts
@@ -1,2 +1,1 @@
-/// <reference types="novnc__novnc" />
 /// <reference types="vite/client" />

--- a/@xen-orchestra/web-core/lib/types/novnc.d.ts
+++ b/@xen-orchestra/web-core/lib/types/novnc.d.ts
@@ -1,4 +1,6 @@
-// Type definitions for @novnc/novnc 1.3
+// [WARNING] Temporary file to fix typecheck error
+// Remove if this PR is merged: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70022
+// Type definitions for @novnc/novnc 1.5
 // Project: https://github.com/novnc/noVNC
 // Definitions by: Jake Jarvis <https://github.com/jakejarvis>
 //                 Maksim Ovcharik <https://github.com/ovcharik>


### PR DESCRIPTION
### Description

See #7824

The types definitions in [DefinitelyTyped/NoVnc](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/287f38cfd2e366071fc4786afafe0d85c002a5a3/types/novnc-core) are outdated and don’t reflect the changes made in the NoVnc package. This causes an error when running `yarn type-check`.

While waiting for this [PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70022) to be merged, a **temporary workaround** is to add a custom `novnc.d.ts` (moved from `lite/src/types/novnc.d.ts`) declaration file in `web-core` to fix the `type-check` error.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
