### PR TITLE
fix(xo-web/backup): replace reportWhen raw value with message

### DIFF
--- a/packages/xo-web/src/xo-app/backup/new/_reportWhen.js
+++ b/packages/xo-web/src/xo-app/backup/new/_reportWhen.js
@@ -17,10 +17,7 @@ export const REPORT_WHEN_LABELS = {
   never: 'reportWhenNever',
 }
 
-const REPORT_WHEN_FILTER_OPTIONS = Object.keys(REPORT_WHEN_LABELS).map(key => ({
-  label: REPORT_WHEN_LABELS[key],
-  value: key,
-}))
+const REPORT_WHEN_FILTER_OPTIONS = Object.entries(REPORT_WHEN_LABELS).map(([value, label]) => ({ label, value }))
 
 const getOptionRenderer = ({ label }) => <span>{_(label)}</span>
 

--- a/packages/xo-web/src/xo-app/backup/new/_reportWhen.js
+++ b/packages/xo-web/src/xo-app/backup/new/_reportWhen.js
@@ -11,20 +11,16 @@ import { injectState, provideState } from 'reaclette'
 
 import { FormGroup } from './../utils'
 
-const REPORT_WHEN_FILTER_OPTIONS = [
-  {
-    label: 'reportWhenAlways',
-    value: 'always',
-  },
-  {
-    label: 'reportWhenFailure',
-    value: 'failure',
-  },
-  {
-    label: 'reportWhenNever',
-    value: 'never',
-  },
-]
+export const REPORT_WHEN_LABELS = {
+  always: 'reportWhenAlways',
+  failure: 'reportWhenFailure',
+  never: 'reportWhenNever',
+}
+
+const REPORT_WHEN_FILTER_OPTIONS = Object.keys(REPORT_WHEN_LABELS).map(key => ({
+  label: REPORT_WHEN_LABELS[key],
+  value: key,
+}))
 
 const getOptionRenderer = ({ label }) => <span>{_(label)}</span>
 

--- a/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
+++ b/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
@@ -335,7 +335,7 @@ class JobsTable extends React.Component {
           return (
             <Ul>
               {proxyId !== undefined && <Li>{_.keyValue(_('proxy'), <Proxy id={proxyId} key={proxyId} />)}</Li>}
-              {reportWhen !== undefined && !!REPORT_WHEN_LABELS[reportWhen] && (
+              {reportWhen in REPORT_WHEN_LABELS && (
                 <Li>{_.keyValue(_('reportWhen'), _(REPORT_WHEN_LABELS[reportWhen]))}</Li>
               )}
               {concurrency !== undefined && <Li>{_.keyValue(_('concurrency'), concurrency)}</Li>}

--- a/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
+++ b/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
@@ -39,6 +39,7 @@ import {
 
 import getSettingsWithNonDefaultValue from '../_getSettingsWithNonDefaultValue'
 import { destructPattern } from '../utils'
+import { REPORT_WHEN_LABELS } from '../new/_reportWhen'
 import { LogStatus } from '../../logs/backup-ng'
 
 const Ul = props => <ul {...props} style={{ listStyleType: 'none' }} />
@@ -334,7 +335,9 @@ class JobsTable extends React.Component {
           return (
             <Ul>
               {proxyId !== undefined && <Li>{_.keyValue(_('proxy'), <Proxy id={proxyId} key={proxyId} />)}</Li>}
-              {reportWhen !== undefined && <Li>{_.keyValue(_('reportWhen'), reportWhen)}</Li>}
+              {reportWhen !== undefined && !!REPORT_WHEN_LABELS[reportWhen] && (
+                <Li>{_.keyValue(_('reportWhen'), _(REPORT_WHEN_LABELS[reportWhen]))}</Li>
+              )}
               {concurrency !== undefined && <Li>{_.keyValue(_('concurrency'), concurrency)}</Li>}
               {timeout !== undefined && <Li>{_.keyValue(_('timeout'), timeout / 3600e3)} hours</Li>}
               {fullInterval !== undefined && <Li>{_.keyValue(_('fullBackupInterval'), fullInterval)}</Li>}


### PR DESCRIPTION
### Description

Replace `reportWhen`'s raw value by a message (e.g. *never* is replaced by the `reportWhenNever` message, which is *Never*)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
