### PR TITLE
fix(xo-6): add comments in host and pool pages to fix Vite build

### DIFF
--- a/@xen-orchestra/web/src/pages/host/[id]/index.vue
+++ b/@xen-orchestra/web/src/pages/host/[id]/index.vue
@@ -1,4 +1,7 @@
 <script lang="ts" setup>
+// [DO NOT REMOVE]
+// To fix a Vite error during the build process, this comment is required.
+// The `definePage` macro is removed during the build, leaving an empty script tag that causes the build to fail.
 definePage({
   name: '/host/:id',
   redirect: (to: any) => `/host/${to.params.id}/vms`,

--- a/@xen-orchestra/web/src/pages/pool/[id]/index.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/index.vue
@@ -1,4 +1,7 @@
 <script lang="ts" setup>
+// [DO NOT REMOVE]
+// To fix a Vite error during the build process, this comment is required.
+// The `definePage` macro is removed during the build, leaving an empty script tag that causes the build to fail.
 definePage({
   name: '/pool/:id',
   redirect: (to: any) => `/pool/${to.params.id}/hosts`,


### PR DESCRIPTION
### Description

The components `/host/[id]/index.vue` and `pool/[id]/index.vue` only use `definePage()` macro.
The macro is removed during the build, leaving an empty script tag that causes the build to fail.
This PR addresses this issue by adding a comment in the components to avoid empty content in `<script>` tags at build time.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
