### PR TITLE
fix(xo-6/css): wrong lang in components style tags

### DIFF
--- a/@xen-orchestra/lite/src/stories/web-core/head-bar/head-bar.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/head-bar/head-bar.story.vue
@@ -36,7 +36,7 @@ import UiSpinner from '@core/components/UiSpinner.vue'
 import { faPlus, faPowerOff } from '@fortawesome/free-solid-svg-icons'
 </script>
 
-<style lang="scss" scoped>
+<style lang="postcss" scoped>
 .spinner {
   font-size: 2rem;
   color: var(--color-purple-base);

--- a/@xen-orchestra/web/src/pages/host/[id]/vms.vue
+++ b/@xen-orchestra/web/src/pages/host/[id]/vms.vue
@@ -59,7 +59,7 @@ const definitions = computed(() =>
 const { nodes: vms } = useTree(definitions)
 </script>
 
-<style lang="scss" scoped>
+<style lang="postcss" scoped>
 .vms {
   margin: 1rem;
   gap: 0.8rem;

--- a/@xen-orchestra/web/src/pages/pool/[id]/hosts.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/hosts.vue
@@ -59,7 +59,7 @@ const definitions = computed(() =>
 const { nodes: hosts } = useTree(definitions)
 </script>
 
-<style lang="scss" scoped>
+<style lang="postcss" scoped>
 .hosts {
   margin: 1rem;
   gap: 0.8rem;

--- a/@xen-orchestra/web/src/pages/pool/[id]/vms.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/vms.vue
@@ -61,7 +61,7 @@ const definitions = computed(() =>
 const { nodes: vms } = useTree(definitions)
 </script>
 
-<style lang="scss" scoped>
+<style lang="postcss" scoped>
 .vms {
   margin: 1rem;
   gap: 0.8rem;


### PR DESCRIPTION
### Description

The wrong CSS lang (`scss` instead of `postcss`) was used in some components.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
