### PR TITLE
feat(xo-server/rest-api/dashboard): add backup repository info

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@
 - [VM/Advanced] Display an accurate secure boot status and allow user to propagate certificates from pool to VM [#7495](https://github.com/vatesfr/xen-orchestra/issues/7495) (PR [#7751](https://github.com/vatesfr/xen-orchestra/pull/7751))
 - [Host/General] Display additional hardware data for 2CRSi server [#7816](https://github.com/vatesfr/xen-orchestra/issues/7816) (PR [#7838](https://github.com/vatesfr/xen-orchestra/pull/7838))
 - [VM/Stats] Display a warning when guest tools are not detected (PR [#7831](https://github.com/vatesfr/xen-orchestra/pull/7831))
+- [REST API] Add backup repository information in the `/rest/v0/dashboard` endpoint (PR [#7882](https://github.com/vatesfr/xen-orchestra/pull/7882))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -183,10 +183,7 @@ async function _getDashboardStats(app) {
   dashboard.nHosts = hosts.length
   dashboard.nHostsEol = nHostsEol
 
-  const hasFeatureAuthorizationListMissingPatchesPromise = app.hasFeatureAuthorization('LIST_MISSING_PATCHES')
-  const remotesInfoPromise = app.getAllRemotesInfo()
-
-  if (await hasFeatureAuthorizationListMissingPatchesPromise) {
+  if (await app.hasFeatureAuthorization('LIST_MISSING_PATCHES')) {
     const poolsWithMissingPatches = new Set()
     let nHostsWithMissingPatches = 0
 
@@ -211,23 +208,27 @@ async function _getDashboardStats(app) {
     dashboard.missingPatches = missingPatches
   }
 
-  const backupRepositorySize = Object.values(await remotesInfoPromise).reduce(
-    (prev, remoteInfo) => ({
-      available: prev.available + remoteInfo.available,
-      backups: 0, // @TODO: compute the space used by backups
-      other: 0, // @TODO: compute the space used by everything that is not a backup
-      total: prev.total + remoteInfo.size,
-      used: prev.used + remoteInfo.used,
-    }),
-    {
-      available: 0,
-      backups: 0,
-      other: 0,
-      total: 0,
-      used: 0,
-    }
-  )
-  dashboard.backupRepository = { size: backupRepositorySize }
+  try {
+    const backupRepositorySize = Object.values(await app.getAllRemotesInfo()).reduce(
+      (prev, remoteInfo) => ({
+        available: prev.available + remoteInfo.available,
+        backups: 0, // @TODO: compute the space used by backups
+        other: 0, // @TODO: compute the space used by everything that is not a backup
+        total: prev.total + remoteInfo.size,
+        used: prev.used + remoteInfo.used,
+      }),
+      {
+        available: 0,
+        backups: 0,
+        other: 0,
+        total: 0,
+        used: 0,
+      }
+    )
+    dashboard.backupRepository = { size: backupRepositorySize }
+  } catch (error) {
+    console.error(error)
+  }
 
   return dashboard
 }

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -209,7 +209,7 @@ async function _getDashboardStats(app) {
   }
 
   try {
-    const backupRepositorySize = Object.values(await app.getAllRemotesInfo()).reduce(
+    const backupRepositoriesSize = Object.values(await app.getAllRemotesInfo()).reduce(
       (prev, remoteInfo) => ({
         available: prev.available + remoteInfo.available,
         backups: 0, // @TODO: compute the space used by backups
@@ -225,7 +225,7 @@ async function _getDashboardStats(app) {
         used: 0,
       }
     )
-    dashboard.backupRepository = { size: backupRepositorySize }
+    dashboard.backupRepositories = { size: backupRepositoriesSize }
   } catch (error) {
     console.error(error)
   }

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -167,7 +167,12 @@ async function _getDashboardStats(app) {
   dashboard.nPools = poolIds.size
   dashboard.nHosts = hosts.length
 
-  if (await app.hasFeatureAuthorization('LIST_MISSING_PATCHES')) {
+  const [hasFeatureAuthorizationListMissingPatches, remotesInfo] = await Promise.all([
+    app.hasFeatureAuthorization('LIST_MISSING_PATCHES'),
+    app.getAllRemotesInfo(),
+  ])
+
+  if (hasFeatureAuthorizationListMissingPatches) {
     const poolsWithMissingPatches = new Set()
     let nHostsWithMissingPatches = 0
 
@@ -191,6 +196,20 @@ async function _getDashboardStats(app) {
 
     dashboard.missingPatches = missingPatches
   }
+
+  const backupRepositorySize = Object.values(remotesInfo).reduce(
+    (prev, remoteInfo) => ({
+      total: prev.total + remoteInfo.size,
+      used: prev.used + remoteInfo.used,
+      available: prev.available + remoteInfo.available,
+    }),
+    {
+      total: 0,
+      used: 0,
+      available: 0,
+    }
+  )
+  dashboard.backupRepository = { size: backupRepositorySize }
 
   return dashboard
 }


### PR DESCRIPTION
### Screenshot of the UI card that consumes this information

![Capture%20d'%C3%A9cran%202024-07-11%20110429](https://github.com/user-attachments/assets/901b2917-ea5c-499a-a1cb-a52850aeb59b)

### Description

Add backup repository info in the `dashboard` endpoint for the XO6 dashboard
`backups` and `other` data will be calculated in another PR as there is no trivial way to do it

```js
{
 ...
  "backupRepositories": {
    "size": {
      "available": 104502157312,
      "backups": 0,
      "other": 0,
      "total": 150189637632,
      "used": 45687480320
    }
  } | undefined
}
 ```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
