### PR TITLE
fix(xo-web/VM/Stats): do not show guest tools warning when VM is offline

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,4 +31,6 @@
 
 <!--packages-start-->
 
+- xo-web patch
+
 <!--packages-end-->

--- a/packages/xo-web/src/xo-app/vm/tab-general.js
+++ b/packages/xo-web/src/xo-app/vm/tab-general.js
@@ -223,13 +223,14 @@ const GeneralTab = decorate([
               </span>
             </h2>
             <BlockLink to={`/vms/${id}/stats`}>
-              {vm.managementAgentDetected ? (
-                statsOverview && <MemorySparkLines data={statsOverview} />
-              ) : (
-                <span className='text-warning'>
-                  <Icon icon='alarm' /> {_('guestToolsNecessary')}
-                </span>
-              )}
+              {statsOverview &&
+                (vm.managementAgentDetected ? (
+                  <MemorySparkLines data={statsOverview} />
+                ) : (
+                  <span className='text-warning'>
+                    <Icon icon='alarm' /> {_('guestToolsNecessary')}
+                  </span>
+                ))}
             </BlockLink>
           </Col>
           <Col mediumSize={3}>


### PR DESCRIPTION
Introduced by #7831

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
