### PR TITLE
fix(xo-6): rollup error when building with npm

### DIFF
--- a/@xen-orchestra/web/package.json
+++ b/@xen-orchestra/web/package.json
@@ -40,6 +40,11 @@
     "vue-router": "^4.4.0",
     "vue-tsc": "^1.8.27"
   },
+  "overrides": {
+    "vite": {
+      "rollup": "npm:@rollup/wasm-node"
+    }
+  },
   "private": true,
   "homepage": "https://github.com/vatesfr/xen-orchestra/tree/master/@xen-orchestra/web",
   "bugs": "https://github.com/vatesfr/xen-orchestra/issues",


### PR DESCRIPTION
### Description

Add `overrides` section in XO6 `package.json` to fix `Error: Cannot find module @rollup/rollup-linux-x64-gnu` rollup error when building with npm.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
