### PR TITLE
chore(web stack): add ESLint rule to check style and script tags "lang" attribute

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -138,6 +138,7 @@ module.exports = {
         'vue/no-v-html': 'error',
         'vue/this-in-template': 'error',
         // Vue 3 - Uncategorized
+        'vue/block-lang': ['error', { script: { lang: 'ts' }, style: { lang: 'postcss' } }],
         'vue/block-order': ['error', { order: ['template', 'script', 'style'] }],
         'vue/block-tag-newline': ['error', { singleline: 'consistent', multiline: 'always', maxEmptyLines: 0 }],
         'vue/component-api-style': ['error', ['script-setup']],

--- a/@xen-orchestra/lite/src/components/AccountButton.vue
+++ b/@xen-orchestra/lite/src/components/AccountButton.vue
@@ -46,7 +46,7 @@ const openFeedbackUrl = () => {
 const openSettings = () => router.push({ name: 'settings' })
 </script>
 
-<style scoped>
+<style lang="postcss" scoped>
 .account-button {
   display: flex;
   align-items: center;

--- a/@xen-orchestra/lite/src/components/ObjectNotFoundWrapper.vue
+++ b/@xen-orchestra/lite/src/components/ObjectNotFoundWrapper.vue
@@ -26,7 +26,7 @@ const id = computed(() => props.id ?? (currentRoute.value.params.uuid as I))
 const isRecordNotFound = computed(() => props.isReady && !props.uuidChecker(id.value))
 </script>
 
-<style scoped>
+<style lang="postcss" scoped>
 .wrapper-spinner {
   display: flex;
   height: 100%;


### PR DESCRIPTION
### Description

Add ESLint rule to check style and script tags `lang` attribute in Vue components.
Rule is added to enforce `<script lang="ts" ... >` and `<style lang="postcss" ... >`, to avoid some errors (see #7880).

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
