### PR TITLE
fix(xo-server/rest-api/dashboard): ignore EOL hosts if getHVSupportedVersions unavailable

### DIFF
--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -158,10 +158,12 @@ async function _getDashboardStats(app) {
   let hvSupportedVersions
   let nHostsEol
   try {
-    hvSupportedVersions = await app.apiMethods['xoa.getHVSupportedVersions']()
+    hvSupportedVersions = await app.getHVSupportedVersions()
     nHostsEol = 0
   } catch (error) {
-    console.error(error)
+    if (error.message !== 'app.getHVSupportedVersions is not a function') {
+      console.error(error)
+    }
   }
 
   const poolIds = new Set()

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -156,24 +156,22 @@ async function _getDashboardStats(app) {
   const dashboard = {}
 
   let hvSupportedVersions
+  let nHostsEol
   try {
     hvSupportedVersions = await app.apiMethods['xoa.getHVSupportedVersions']()
-  } catch (e) {
-    hvSupportedVersions = {
-      'Citrix Hypervisor': '>=8.2.0',
-      'XCP-ng': '>=8.2.0',
-    }
+    nHostsEol = 0
+  } catch (error) {
+    console.error(error)
   }
 
   const poolIds = new Set()
   const hosts = []
-  let nHostsEol = 0
 
   for (const obj of app.objects.values()) {
     if (obj.type === 'host') {
       hosts.push(obj)
       poolIds.add(obj.$pool)
-      if (!semver.satisfies(obj.version, hvSupportedVersions[obj.productBrand])) {
+      if (hvSupportedVersions !== undefined && !semver.satisfies(obj.version, hvSupportedVersions[obj.productBrand])) {
         nHostsEol++
       }
     }

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -157,11 +157,11 @@ async function _getDashboardStats(app) {
 
   let hvSupportedVersions
   let nHostsEol
-  try {
-    hvSupportedVersions = await app.getHVSupportedVersions()
-    nHostsEol = 0
-  } catch (error) {
-    if (error.message !== 'app.getHVSupportedVersions is not a function') {
+  if (typeof app.getHVSupportedVersions === 'function') {
+    try {
+      hvSupportedVersions = await app.getHVSupportedVersions()
+      nHostsEol = 0
+    } catch (error) {
       console.error(error)
     }
   }


### PR DESCRIPTION
### Description

Wait for [gitea#211](https://git.vates.tech/vates/xoa/pulls/211)
Introduced by ddfdce9

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
