### PR TITLE
feat(xo-server/rest-api/dashboard): add storage repositories info

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [REST API] Add backup repository and storage repository information in the `/rest/v0/dashboard` endpoint (PR [#7882](https://github.com/vatesfr/xen-orchestra/pull/7882))
+- [REST API] Add backup repository and storage repository information in the `/rest/v0/dashboard` endpoint (PR [#7882](https://github.com/vatesfr/xen-orchestra/pull/7882), [#7904](https://github.com/vatesfr/xen-orchestra/pull/7904))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [REST API] Add backup repository information in the `/rest/v0/dashboard` endpoint (PR [#7882](https://github.com/vatesfr/xen-orchestra/pull/7882))
+- [REST API] Add backup repository and storage repository information in the `/rest/v0/dashboard` endpoint (PR [#7882](https://github.com/vatesfr/xen-orchestra/pull/7882))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/api/sr.mjs
+++ b/packages/xo-server/src/api/sr.mjs
@@ -7,7 +7,7 @@ import throttle from 'lodash/throttle.js'
 import ensureArray from '../_ensureArray.mjs'
 import { asInteger } from '../xapi/utils.mjs'
 import { destroy as destroyXostor } from './xostor.mjs'
-import { forEach, parseXml } from '../utils.mjs'
+import { forEach, isSrWritable, parseXml } from '../utils.mjs'
 
 // ===================================================================
 
@@ -926,7 +926,7 @@ probeNfsExists.resolve = {
 export const getAllUnhealthyVdiChainsLength = throttle(
   function getAllUnhealthyVdiChainsLength() {
     const unhealthyVdiChainsLengthBySr = {}
-    filter(this.objects.all, obj => obj.type === 'SR' && obj.content_type !== 'iso' && obj.size > 0).forEach(sr => {
+    filter(this.objects.all, obj => obj.type === 'SR' && isSrWritable(obj)).forEach(sr => {
       const unhealthyVdiChainsLengthByVdi = this.getXapi(sr).getVdiChainsInfo(sr)
       if (!isEmpty(unhealthyVdiChainsLengthByVdi)) {
         unhealthyVdiChainsLengthBySr[sr.uuid] = unhealthyVdiChainsLengthByVdi

--- a/packages/xo-server/src/utils.mjs
+++ b/packages/xo-server/src/utils.mjs
@@ -339,4 +339,4 @@ export const unboxIdsFromPattern = pattern => {
 
 // -------------------------------------------------------------------
 
-export const isSrWritable = sr => sr && sr.content_type !== 'iso' && sr.size > 0
+export const isSrWritable = sr => sr !== undefined && sr.content_type !== 'iso' && sr.size > 0

--- a/packages/xo-server/src/utils.mjs
+++ b/packages/xo-server/src/utils.mjs
@@ -336,3 +336,7 @@ export const unboxIdsFromPattern = pattern => {
   const { id } = pattern
   return typeof id === 'string' ? [id] : id.__or
 }
+
+// -------------------------------------------------------------------
+
+export const isSrWritable = sr => sr && sr.content_type !== 'iso' && sr.size > 0


### PR DESCRIPTION
### Screenshot of the UI card that consumes this information

![Capture d’écran de 2024-08-07 10-56-03](https://github.com/user-attachments/assets/fd426a67-c4f9-42e2-9bd6-e4a52f32ebb7)


### Description

Add storage repository info in the dashboard endpoint for the XO6 dashboard
replications and other data will be calculated in another PR as there is no trivial way to do it

```ts
{
 // ...
  "storageRepositories": {
    "size": {
      "available": number,
      "other": 0,
      "replicated": 0,
      "total": number,
      "used": number
    }
  }
}
 ```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
