### PR TITLE
feat(web-core): new useRouteQuery composable

### DIFF
--- a/@xen-orchestra/web-core/docs/composables/route-query.composable.md
+++ b/@xen-orchestra/web-core/docs/composables/route-query.composable.md
@@ -1,0 +1,62 @@
+# useRouteQuery Composable
+
+`useRouteQuery` is a composable that synchronizes a route query parameter with a reactive reference.
+
+## Usage
+
+### Basic Usage
+
+```typescript
+const query = useRouteQuery('search')
+```
+
+In this example, if URL contains `?search=hello`, then `query.value` will be `'hello'`.
+
+If you set `query.value = 'world'`, then the URL will be replaced with `?search=world`.
+
+### Default Value
+
+You can provide a default value if the query parameter is not present in the URL.
+
+```typescript
+const foo = useRouteQuery('foo', { defaultQuery: 'bar' })
+```
+
+In this case, if the URL does not contain `foo` query parameter, then `foo.value` will be `'bar'`.
+
+If the URL contains `?foo=`, then `foo.value` will be an empty string.
+
+Setting `foo.value = 'baz'` will update the URL to `?foo=baz`.
+
+Setting the reference back to its default value (in this case
+`foo.value = 'bar'`) will remove the query parameter from the URL.
+
+### Advanced Usage with Custom Data Type
+
+By default, the data type is `string`. That means that if the query is `?count=42`, then
+`query.value` will be the string `'42'`.
+
+You can use transformers to convert the query string to a custom data type.
+
+```typescript
+const count = useRouteQuery<number>('count', {
+  toData: query => parseInt(query, 10),
+  toQuery: data => data.toString(),
+  defaultQuery: '0',
+})
+```
+
+Now if the URL contains `?count=42`, then `count.value` will be the number `42`.
+
+### Working with objects or arrays
+
+The data reference is watched deeply, so you can use objects or arrays as values and alter them directly.
+
+```typescript
+const users = useRouteQuery<Set<string>>('users', {
+  toData: query => new Set(value ? value.split(',') : undefined),
+  toQuery: data => Array.from(value).join(','),
+})
+```
+
+In this case, calling `users.value.add('Foo').add('Bar')` will update the URL to `?users=foo,bar`.

--- a/@xen-orchestra/web-core/lib/composables/route-query.composable.ts
+++ b/@xen-orchestra/web-core/lib/composables/route-query.composable.ts
@@ -1,0 +1,46 @@
+import { type Ref, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+type Options = {
+  defaultQuery?: string
+}
+
+type Transformers<TData> = {
+  toData: (value: string) => TData
+  toQuery: (value: TData) => string
+}
+
+export function useRouteQuery(name: string): Ref<string>
+export function useRouteQuery(name: string, options: Options): Ref<string>
+export function useRouteQuery<TData>(name: string, options: Options & Transformers<TData>): Ref<TData>
+export function useRouteQuery<TData>(name: string, options: Partial<Options & Transformers<TData>> = {}) {
+  const router = useRouter()
+  const route = useRoute()
+
+  const data = ref() as Ref<TData>
+
+  const {
+    defaultQuery = '',
+    toData = (value: string) => value as unknown as TData,
+    toQuery = (value: TData) => value as unknown as string,
+  } = options
+
+  watch(
+    data,
+    newData => {
+      const query = toQuery(newData)
+      void router.replace({ query: { ...route.query, [name]: query === defaultQuery ? undefined : query } })
+    },
+    { deep: true }
+  )
+
+  watch(
+    () => route.query[name] as string | undefined,
+    newQuery => {
+      data.value = toData(newQuery ?? defaultQuery)
+    },
+    { immediate: true }
+  )
+
+  return data
+}

--- a/@xen-orchestra/web-core/lib/composables/route-query.composable.ts
+++ b/@xen-orchestra/web-core/lib/composables/route-query.composable.ts
@@ -1,46 +1,42 @@
-import { type Ref, ref, watch } from 'vue'
+import { handleAdd } from '@core/composables/route-query/actions/handle-add'
+import { handleDelete } from '@core/composables/route-query/actions/handle-delete'
+import { handleSet } from '@core/composables/route-query/actions/handle-set'
+import { handleToggle } from '@core/composables/route-query/actions/handle-toggle'
+import type { Actions, Options, RouteQuery, Transformers } from '@core/composables/route-query/types'
+import { extendRef } from '@vueuse/core'
+import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
-type Options = {
-  defaultQuery?: string
-}
-
-type Transformers<TData> = {
-  toData: (value: string) => TData
-  toQuery: (value: TData) => string
-}
-
-export function useRouteQuery(name: string): Ref<string>
-export function useRouteQuery(name: string, options: Options): Ref<string>
-export function useRouteQuery<TData>(name: string, options: Options & Transformers<TData>): Ref<TData>
+export function useRouteQuery<TData extends string>(name: string): RouteQuery<TData>
+export function useRouteQuery<TData extends string>(name: string, options: Options): RouteQuery<TData>
+export function useRouteQuery<TData>(name: string, options: Options & Transformers<TData>): RouteQuery<TData>
 export function useRouteQuery<TData>(name: string, options: Partial<Options & Transformers<TData>> = {}) {
   const router = useRouter()
   const route = useRoute()
 
-  const data = ref() as Ref<TData>
-
   const {
     defaultQuery = '',
-    toData = (value: string) => value as unknown as TData,
-    toQuery = (value: TData) => value as unknown as string,
+    toData = (query: string) => query as TData,
+    toQuery = (data: TData) => data as string,
   } = options
 
-  watch(
-    data,
-    newData => {
+  const source = computed<TData>({
+    get() {
+      return toData((route.query[name] as string | undefined) ?? defaultQuery)
+    },
+    set(newData) {
       const query = toQuery(newData)
+
       void router.replace({ query: { ...route.query, [name]: query === defaultQuery ? undefined : query } })
     },
-    { deep: true }
-  )
+  })
 
-  watch(
-    () => route.query[name] as string | undefined,
-    newQuery => {
-      data.value = toData(newQuery ?? defaultQuery)
-    },
-    { immediate: true }
-  )
+  const actions: Actions = {
+    add: handleAdd.bind(null, source),
+    delete: handleDelete.bind(null, source),
+    set: handleSet.bind(null, source),
+    toggle: handleToggle.bind(null, source),
+  }
 
-  return data
+  return extendRef(source, actions) as unknown as RouteQuery<TData>
 }

--- a/@xen-orchestra/web-core/lib/composables/route-query/actions/handle-add.ts
+++ b/@xen-orchestra/web-core/lib/composables/route-query/actions/handle-add.ts
@@ -1,0 +1,9 @@
+import type { WritableComputedRef } from 'vue'
+
+export function handleAdd(source: WritableComputedRef<any>, value: any) {
+  if (Array.isArray(source.value)) {
+    source.value = [...source.value, value]
+  } else if (source.value instanceof Set) {
+    source.value = new Set(source.value).add(value)
+  }
+}

--- a/@xen-orchestra/web-core/lib/composables/route-query/actions/handle-delete.ts
+++ b/@xen-orchestra/web-core/lib/composables/route-query/actions/handle-delete.ts
@@ -1,0 +1,16 @@
+import type { WritableComputedRef } from 'vue'
+
+export function handleDelete(source: WritableComputedRef<any>, value: any) {
+  if (Array.isArray(source.value)) {
+    source.value = [...source.value].splice(value, 1)
+  } else if (source.value instanceof Set) {
+    source.value = new Set(source.value)
+    source.value.delete(value)
+  } else if (source.value instanceof Map) {
+    source.value = new Map(source.value)
+    source.value.delete(value)
+  } else if (typeof source.value === 'object' && source.value !== null) {
+    source.value = { ...source.value }
+    delete source.value[value]
+  }
+}

--- a/@xen-orchestra/web-core/lib/composables/route-query/actions/handle-set.ts
+++ b/@xen-orchestra/web-core/lib/composables/route-query/actions/handle-set.ts
@@ -1,0 +1,17 @@
+import type { WritableComputedRef } from 'vue'
+
+export function handleSet(source: WritableComputedRef<any>, key: any, value: any) {
+  if (Array.isArray(source.value)) {
+    source.value = [...source.value]
+    source.value[key] = value
+  } else if (source.value instanceof Map) {
+    source.value = new Map(source.value)
+    source.value.set(key, value)
+  } else if (typeof source.value === 'object') {
+    if (source.value === null) {
+      return
+    }
+
+    source.value = { ...source.value, [key]: value }
+  }
+}

--- a/@xen-orchestra/web-core/lib/composables/route-query/actions/handle-toggle.ts
+++ b/@xen-orchestra/web-core/lib/composables/route-query/actions/handle-toggle.ts
@@ -1,0 +1,18 @@
+import type { WritableComputedRef } from 'vue'
+
+export function handleToggle(source: WritableComputedRef<any>, valueOrState?: any, state?: any) {
+  if (source.value instanceof Set) {
+    const shouldAdd = state ?? !source.value.has(valueOrState)
+    const newSource = new Set(source.value)
+
+    if (shouldAdd) {
+      newSource.add(valueOrState)
+    } else {
+      newSource.delete(valueOrState)
+    }
+
+    source.value = newSource
+  } else if (typeof source.value === 'boolean') {
+    source.value = valueOrState ?? !source.value
+  }
+}

--- a/@xen-orchestra/web-core/lib/composables/route-query/types.ts
+++ b/@xen-orchestra/web-core/lib/composables/route-query/types.ts
@@ -1,0 +1,42 @@
+import type { EmptyObject } from '@core/types/utility.type'
+import type { WritableComputedRef } from 'vue'
+
+export type Options = {
+  defaultQuery?: string
+}
+
+export type Transformers<TData> = {
+  toData: (value: string) => TData
+  toQuery: (value: TData) => string
+}
+
+export type SetActions<TValue> = {
+  add: (value: TValue) => void
+  delete: (value: TValue) => void
+  toggle: (value: TValue, state?: boolean) => void
+}
+
+export type MapActions<TKey, TValue> = { set: (key: TKey, value: TValue) => void; delete: (key: TKey) => void }
+
+export type ArrayActions<TValue> = {
+  add: (value: TValue) => void
+  delete: (index: number) => void
+  set: (index: number, value: TValue) => void
+}
+
+export type BooleanActions = { toggle: (value?: boolean) => void }
+
+export type Actions = SetActions<any> & MapActions<any, any> & ArrayActions<any> & BooleanActions
+
+export type GuessActions<TData> =
+  TData extends Set<infer TValue>
+    ? SetActions<TValue>
+    : TData extends (infer TValue)[]
+      ? ArrayActions<TValue>
+      : TData extends boolean
+        ? BooleanActions
+        : TData extends Map<infer TKey, infer TValue> | Record<infer TKey, infer TValue>
+          ? MapActions<TKey, TValue>
+          : EmptyObject
+
+export type RouteQuery<TData> = WritableComputedRef<TData> & GuessActions<TData>

--- a/@xen-orchestra/web-core/lib/types/utility.type.ts
+++ b/@xen-orchestra/web-core/lib/types/utility.type.ts
@@ -5,3 +5,5 @@ export type VoidFunction = () => void
 declare const __brand: unique symbol
 
 export type Branded<TBrand extends string, TType = string> = TType & { [__brand]: TBrand }
+
+export type EmptyObject = Record<string, never>


### PR DESCRIPTION
### Description

Add `useRouteQuery` composable which allows updating a route query dynamically by altering the returned `Ref`.

Support transformers to convert the query to custom data.

See the doc for usage.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
