### PR TITLE
fix(xo-core): wrong CSS lang in StackedBarWithLegend component

### DIFF
--- a/@xen-orchestra/web-core/lib/components/stacked-bar-with-legend/StackedBarWithLegend.vue
+++ b/@xen-orchestra/web-core/lib/components/stacked-bar-with-legend/StackedBarWithLegend.vue
@@ -34,7 +34,7 @@ defineProps<StackedBarWithLegendProps>()
 const uiStore = useUiStore()
 </script>
 
-<style scoped lang="scss">
+<style scoped lang="postcss">
 .stacked-bar-with-legend {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
### Description

Introduced by 14da422

Use `postcss` instead of `scss` in `StackedBarWithLegend.vue` style tag.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
