### PR TITLE
feat(xo-server/rest-api/dashboard): add backupJobs info

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [REST API] Add backup repository, storage repository and alarms information in the `/rest/v0/dashboard` endpoint (PR [#7882](https://github.com/vatesfr/xen-orchestra/pull/7882), [#7904](https://github.com/vatesfr/xen-orchestra/pull/7904)), [#7914](https://github.com/vatesfr/xen-orchestra/pull/7914)
+- [REST API] Add backup repository, storage repository, alarms and backups jobs information in the `/rest/v0/dashboard` endpoint (PR [#7882](https://github.com/vatesfr/xen-orchestra/pull/7882), [#7904](https://github.com/vatesfr/xen-orchestra/pull/7904)), [#7914](https://github.com/vatesfr/xen-orchestra/pull/7914)
 - [SR/Disks] Show and edit the use of CBT (Change Block Tracking) [#7786](https://github.com/vatesfr/xen-orchestra/issues/7786) (PR [#7888](https://github.com/vatesfr/xen-orchestra/pull/7888))
 
 ### Bug fixes

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -329,8 +329,8 @@ async function _getDashboardStats(app) {
     dashboard.backups = {
       jobs: {
         disabled: disabledJobs,
-        successful: successfulJobs,
         failed: failedJobs,
+        successful: successfulJobs,
         total: jobs.length,
       },
     }


### PR DESCRIPTION
### Screenshot of the UI card that consumes this information

![Capture%20d%E2%80%99%C3%A9cran%20de%202024-07-11%2012-02-54 (1)](https://github.com/user-attachments/assets/93aac4ac-d3a8-4ffd-bfd5-630455d785a4)

### Description
```js
// ...
backups: {
 jobs: {
    disabled: number,
    failed: number,
    skipped: number,
    successful: number,
    total: number
 }
} | undefined
```

- `total`: Represents the total number of backup jobs. This count may exceed the sum of `successful`, `failed`,`skipped`, and `disabled` jobs because some jobs may have enabled schedules but were never executed.


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
