### PR TITLE
feat(xo-server/rest-api/dashboard): add alarms info

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [REST API] Add backup repository, storage repository and alarms information in the `/rest/v0/dashboard` endpoint (PR [#7882](https://github.com/vatesfr/xen-orchestra/pull/7882), [#7904](https://github.com/vatesfr/xen-orchestra/pull/7904))
+- [REST API] Add backup repository, storage repository and alarms information in the `/rest/v0/dashboard` endpoint (PR [#7882](https://github.com/vatesfr/xen-orchestra/pull/7882), [#7904](https://github.com/vatesfr/xen-orchestra/pull/7904)), [#7914](https://github.com/vatesfr/xen-orchestra/pull/7914)
 - [SR/Disks] Show and edit the use of CBT (Change Block Tracking) [#7786](https://github.com/vatesfr/xen-orchestra/issues/7786) (PR [#7888](https://github.com/vatesfr/xen-orchestra/pull/7888))
 
 ### Bug fixes

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [REST API] Add backup repository and storage repository information in the `/rest/v0/dashboard` endpoint (PR [#7882](https://github.com/vatesfr/xen-orchestra/pull/7882), [#7904](https://github.com/vatesfr/xen-orchestra/pull/7904))
+- [REST API] Add backup repository, storage repository and alarms information in the `/rest/v0/dashboard` endpoint (PR [#7882](https://github.com/vatesfr/xen-orchestra/pull/7882), [#7904](https://github.com/vatesfr/xen-orchestra/pull/7904))
 - [SR/Disks] Show and edit the use of CBT (Change Block Tracking) [#7786](https://github.com/vatesfr/xen-orchestra/issues/7786) (PR [#7888](https://github.com/vatesfr/xen-orchestra/pull/7888))
 
 ### Bug fixes

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -21,7 +21,7 @@ import { compileXoJsonSchema } from './_xoJsonSchema.mjs'
 
 // E.g: 'value: 0.6\nconfig:\n<variable>\n<name value="cpu_usage"/>\n<alarm_trigger_level value="0.4"/>\n<alarm_trigger_period value ="60"/>\n</variable>';
 const ALARM_BODY_REGEX =
-  /^value:\s*(\d+(?:\.\d+)?)\s*config:\s*<variable>\s*<name value="(.*?)"\/>\s*<alarm_trigger_level value="(\d+(?:\.\d+)?)"\/>\s*<alarm_trigger_period value\s*="(\d+)"/
+  /^value:\s*(\d+(?:\.\d+)?)\s*config:\s*<variable>\s*<name value="(.*?)"/
 
 const { join } = path.posix
 const noop = Function.prototype
@@ -263,8 +263,8 @@ async function _getDashboardStats(app) {
   dashboard.storageRepositories = { size: storageRepositoriesSize }
 
   dashboard.alarms = await Promise.all(
-    alarms.map(async ({ $object, body }) => {
-      const [, value, name, triggerLevel, triggerPeriod] = body.match(ALARM_BODY_REGEX)
+    alarms.map(async ({ $object, body, time }) => {
+      const [, value, name] = body.match(ALARM_BODY_REGEX)
 
       let object
       try {
@@ -283,8 +283,7 @@ async function _getDashboardStats(app) {
           type: object.type,
           uuid: object.uuid,
         },
-        triggerLevel: parseFloat(triggerLevel),
-        triggerPeriod: parseInt(triggerPeriod),
+        timestamp: time,
         value: parseFloat(value),
       }
     })


### PR DESCRIPTION
### Screenshot of the UI card that consumes this information

![Capture%20d'%C3%A9cran%202024-07-26%20111609](https://github.com/user-attachments/assets/f31d48b8-27ce-4e6d-b089-07c2ee819ed6)


### Description

```js
...
alarms: {
   name: string,
   object: {
      type: string
      uuid: string
   },
   timestamp: number,
   value: number // float
}[]
```

- `object.type`: Can be any of the possible XAPI object types, `e.g: VM, SR, VDI, host...` There is also the possibility of having an `unknown`type if the REST API was unable to resolve the object.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
