### PR TITLE
feat(web-core): add `Branded` TS utility type

### DIFF
--- a/@xen-orchestra/web-core/lib/types/utility.type.ts
+++ b/@xen-orchestra/web-core/lib/types/utility.type.ts
@@ -1,3 +1,7 @@
 export type MaybeArray<T> = T | T[]
 
 export type VoidFunction = () => void
+
+declare const __brand: unique symbol
+
+export type Branded<TBrand extends string, TType = string> = TType & { [__brand]: TBrand }


### PR DESCRIPTION
### Description

Add `Branded` TypeScript utility type.

Example: 
```ts
type Foo = {
  id: Branded<'foo'>
}

type Bar = {
  id: Branded<'bar'>
}

function foo(id: Foo['id']) {}

foo(bar.id) // Error
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
