### PR TITLE
feat(xo-server/rest-api/dashboard): add backup issues information

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [REST API] Add backup repository, storage repository, alarms and backups jobs information in the `/rest/v0/dashboard` endpoint (PR [#7882](https://github.com/vatesfr/xen-orchestra/pull/7882), [#7904](https://github.com/vatesfr/xen-orchestra/pull/7904)), [#7914](https://github.com/vatesfr/xen-orchestra/pull/7914)
+- [REST API] Add backup repository, storage repository, alarms, backups jobs and backups issues information in the `/rest/v0/dashboard` endpoint (PR [#7882](https://github.com/vatesfr/xen-orchestra/pull/7882), [#7904](https://github.com/vatesfr/xen-orchestra/pull/7904), [#7914](https://github.com/vatesfr/xen-orchestra/pull/7914), [#7908](https://github.com/vatesfr/xen-orchestra/pull/7908), [#7919](https://github.com/vatesfr/xen-orchestra/pull/7919))
 - [SR/Disks] Show and edit the use of CBT (Change Block Tracking) [#7786](https://github.com/vatesfr/xen-orchestra/issues/7786) (PR [#7888](https://github.com/vatesfr/xen-orchestra/pull/7888))
 
 ### Bug fixes

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -291,6 +291,8 @@ async function _getDashboardStats(app) {
     let failedJobs = 0
     let skippedJobs = 0
     let successfulJobs = 0
+    const backupJobIssues = []
+
     for (const job of jobs) {
       if (!(await _jobHasAtLeastOneScheduleEnabled(job))) {
         disabledJobs++
@@ -313,6 +315,8 @@ async function _getDashboardStats(app) {
             skippedJobs++
           }
 
+          backupJobIssues.push({ uuid: job.id, logs: jobLogs.map(log => log.status) })
+
           break
         }
 
@@ -330,6 +334,7 @@ async function _getDashboardStats(app) {
         successful: successfulJobs,
         total: jobs.length,
       },
+      issues: backupJobIssues,
     }
   } catch (error) {
     console.error(error)


### PR DESCRIPTION
### Screenshot of the UI card that consumes this information

![Capture d’écran de 2024-08-14 10-33-55](https://github.com/user-attachments/assets/49964500-61c7-4767-a6f8-67c2425a7be3)

### Description
```js
// ...
backups: {
 ...
 issues: {
   uuid: string,
   logs: ('failure' | 'interrupted' | 'skipped' | 'success')[] // max length 3
 }[]
} | undefined
```

Wait for #7908 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
