### PR TITLE
feat(xo-core/ButtonIcon): add prop to change the click target size

### DIFF
--- a/@xen-orchestra/lite/src/stories/web-core/button/button-icon.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/button/button-icon.story.vue
@@ -11,6 +11,12 @@
       prop('disabled').bool().widget(),
       prop('active').bool().widget(),
       prop('dot').bool().widget(),
+      prop('targetScale')
+        .type('number | { x: number; y: number }')
+        .default(1)
+        .preset({ x: 2, y: 2 })
+        .help('Meant to increase click target size if needed')
+        .widget(),
     ]"
   >
     <ButtonIcon v-bind="properties" />

--- a/@xen-orchestra/web-core/lib/components/button/ButtonIcon.vue
+++ b/@xen-orchestra/web-core/lib/components/button/ButtonIcon.vue
@@ -10,8 +10,9 @@
 import UiIcon from '@core/components/icon/UiIcon.vue'
 import type { Color } from '@core/types/color.type'
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types'
+import { computed } from 'vue'
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     icon: IconDefinition
     size?: 'small' | 'medium' | 'large'
@@ -19,9 +20,18 @@ withDefaults(
     disabled?: boolean
     active?: boolean
     dot?: boolean
+    targetScale?: number | { x: number; y: number }
   }>(),
-  { color: 'info', size: 'medium' }
+  { color: 'info', size: 'medium', targetScale: 1 }
 )
+
+const cssTargetScale = computed(() => {
+  if (typeof props.targetScale === 'number') {
+    return `scale(${props.targetScale})`
+  }
+
+  return `scale(${props.targetScale.x}, ${props.targetScale.y})`
+})
 </script>
 
 <style lang="postcss" scoped>
@@ -195,5 +205,16 @@ withDefaults(
     top: var(--dot-offset);
     right: var(--dot-offset);
   }
+}
+
+/*
+ * Increase the size of the clickable area,
+ * without changing the padding of the ButtonIcon component
+ */
+.button-icon::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  transform: v-bind(cssTargetScale);
 }
 </style>

--- a/@xen-orchestra/web-core/lib/components/tree/TreeItemLabel.vue
+++ b/@xen-orchestra/web-core/lib/components/tree/TreeItemLabel.vue
@@ -20,6 +20,7 @@
         class="toggle"
         :icon="isExpanded ? faAngleDown : faAngleRight"
         size="small"
+        :target-scale="{ x: 1.5, y: 2 }"
         @click="emit('toggle')"
       />
       <div v-else class="h-line" />
@@ -129,16 +130,5 @@ const depth = inject(IK_TREE_LIST_DEPTH, 0)
   width: 2rem;
   border-bottom: 0.1rem solid var(--color-purple-base);
   margin-left: -0.4rem;
-}
-
-/*
- * Increase the size of the clickable area,
- * without changing the padding of the ButtonIcon component
- */
-.toggle::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  transform: scale(1.5, 2);
 }
 </style>


### PR DESCRIPTION
### Description

To improve accessibility, add a prop `targetScale?: number | { x: number; y: number }` to `ButtonIcon` component to increase the click target size when needed.

Target size is increased using a pseudo element instead of padding to avoid potential layout issues (based on [this article](https://ishadeed.com/article/target-size/#extend-target-size-with-pseudo-elements)).

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
