### PR TITLE
fix(backups): correctly update allowed_operations - temporary fix

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
@@ -343,10 +343,12 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
           migrate_send: migrate_send === undefined || migrate_send === reason ? null : migrate_send,
           pool_migrate: pool_migrate === undefined || pool_migrate === reason ? null : pool_migrate,
         })
-        // then update allowed operations because the snapshot process updated
-        // them when migrate_send and pool_migrate were blocked
-        // This next line can be removed when allowed_operations automatically
-        // update correctly again
+
+        // 2024-08-19 - Work-around a XAPI bug where allowed_operations are not properly computed when blocked_operations is updated
+        //
+        // this is a problem because some clients (e.g. XenCenter) use this field to allow operations.
+        //
+        // internal source: https://team.vates.fr/vates/pl/mjmxnce9qfdx587r3qpe4z91ho
         await vm.$call('update_allowed_operations')
       })
     }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,7 +22,7 @@
 - [Home/SR] Fix _Shared/Not shared_ sort
 - [Home/VM] When sorted by _Start time_, move VMs with no value at the end
 - [Import/VM Ware] Shows only SRs and networks of the selected pool (PR [#7905](https://github.com/vatesfr/xen-orchestra/pull/7905))
-- [Backups] Work around XAPI not automatically updating VM's `allowed_operations` after backups [Forum#81327(https://xcp-ng.org/forum/post/81327) (PR [#7924](https://github.com/vatesfr/xen-orchestra/pull/7924))
+- [Backups] Work around XAPI not automatically updating VM's `allowed_operations` after backups [Forum#81327](https://xcp-ng.org/forum/post/81327) (PR [#7924](https://github.com/vatesfr/xen-orchestra/pull/7924))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,7 +22,7 @@
 - [Home/SR] Fix _Shared/Not shared_ sort
 - [Home/VM] When sorted by _Start time_, move VMs with no value at the end
 - [Import/VM Ware] Shows only SRs and networks of the selected pool (PR [#7905](https://github.com/vatesfr/xen-orchestra/pull/7905))
-- [Backups] Correctly update VMs _allowed_operations_ after backups [#9486](https://xcp-ng.org/forum/topic/9486/migration-doesn-t-work-in-xcp-ng-centar-after-successful-backup-with-xen-orchestra) (PR [#7924](https://github.com/vatesfr/xen-orchestra/pull/7924))
+- [Backups] Handling XAPI not automatically updating VM's _allowed_operations_ after backups [#9486](https://xcp-ng.org/forum/topic/9486/migration-doesn-t-work-in-xcp-ng-centar-after-successful-backup-with-xen-orchestra) (PR [#7924](https://github.com/vatesfr/xen-orchestra/pull/7924))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@
 - [Home/SR] Fix _Shared/Not shared_ sort
 - [Home/VM] When sorted by _Start time_, move VMs with no value at the end
 - [Import/VM Ware] Shows only SRs and networks of the selected pool (PR [#7905](https://github.com/vatesfr/xen-orchestra/pull/7905))
+- [Backups] Correctly update VMs _allowed_operations_ after backups [#9486](https://xcp-ng.org/forum/topic/9486/migration-doesn-t-work-in-xcp-ng-centar-after-successful-backup-with-xen-orchestra) (PR [#7924](https://github.com/vatesfr/xen-orchestra/pull/7924))
 
 ### Packages to release
 
@@ -39,6 +40,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
 - @xen-orchestra/proxy patch
 - xo-server minor
 - xo-web minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,7 +22,7 @@
 - [Home/SR] Fix _Shared/Not shared_ sort
 - [Home/VM] When sorted by _Start time_, move VMs with no value at the end
 - [Import/VM Ware] Shows only SRs and networks of the selected pool (PR [#7905](https://github.com/vatesfr/xen-orchestra/pull/7905))
-- [Backups] Handling XAPI not automatically updating VM's _allowed_operations_ after backups [#9486](https://xcp-ng.org/forum/topic/9486/migration-doesn-t-work-in-xcp-ng-centar-after-successful-backup-with-xen-orchestra) (PR [#7924](https://github.com/vatesfr/xen-orchestra/pull/7924))
+- [Backups] Work around XAPI not automatically updating VM's `allowed_operations` after backups [Forum#81327(https://xcp-ng.org/forum/post/81327) (PR [#7924](https://github.com/vatesfr/xen-orchestra/pull/7924))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

`allowed_operations` are currently not updated correctly when `blocked_operations` are modified, which causes backup jobs to remove `migrate_send` and `pool_migrate` from VM's `allowed_operations`. This commit fixes that, until `allowed_operations` updates correctly again.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
