### PR TITLE
fix(xo-web/new/sr): fix `an error as occured` when host is missing

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [New/SR] Fix 'an error as occured' when creating a new SR (PR [#7931](https://github.com/vatesfr/xen-orchestra/pull/7931))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,4 +33,6 @@
 
 <!--packages-start-->
 
+- xo-web patch
+
 <!--packages-end-->

--- a/packages/xo-web/src/xo-app/new/sr/index.js
+++ b/packages/xo-web/src/xo-app/new/sr/index.js
@@ -234,7 +234,7 @@ export default class New extends Component {
     () => this.props.srs,
     createSelector(
       () => this.state.host,
-      host => host !== undefined && (sr => sr.$container === host.$pool || sr.$container === host.id)
+      host => host != null && (sr => sr.$container === host.$pool || sr.$container === host.id)
     )
   )
 


### PR DESCRIPTION
### Description

Error occured when creating a new storage, selecting a host, then clearing the selection

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
