### PR TITLE
Compact backup reports

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@
 - [OTP] Key can be copied to clipboard because some clients cannot use the QR code
 - [Plugin/perf-alert] Add a toggle to exclude selected items (PR [#7911](https://github.com/vatesfr/xen-orchestra/pull/7911))
 - [Backup/Mirror] Filter the VM that must be mirrored [#7748](https://github.com/vatesfr/xen-orchestra/issues/7748) (PR [#7941](https://github.com/vatesfr/xen-orchestra/pull/7941))
+- [Plugin/backup-reports] Send more concise backup reports to Slack and XMPP webhooks (PR [#7932](https://github.com/vatesfr/xen-orchestra/pull/7932))
 
 ### Bug fixes
 
@@ -42,6 +43,7 @@
 - @xen-orchestra/backups minor
 - @xen-orchestra/web-core patch
 - xo-server minor
+- xo-server-backup-reports minor
 - xo-server-perf-alert minor
 - xo-web minor
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 - [Plugin/perf-alert] Add a toggle to exclude selected items (PR [#7911](https://github.com/vatesfr/xen-orchestra/pull/7911))
 - [Backup/Mirror] Filter the VM that must be mirrored [#7748](https://github.com/vatesfr/xen-orchestra/issues/7748) (PR [#7941](https://github.com/vatesfr/xen-orchestra/pull/7941))
 - [Plugin/backup-reports] Send more concise backup reports to Slack and XMPP webhooks (PR [#7932](https://github.com/vatesfr/xen-orchestra/pull/7932))
+- [Backups] Add an option to send shorter backup reports (PR [#7932](https://github.com/vatesfr/xen-orchestra/pull/7932))
 
 ### Bug fixes
 

--- a/packages/xo-server-backup-reports/src/index.js
+++ b/packages/xo-server-backup-reports/src/index.js
@@ -51,6 +51,8 @@ export const testSchema = {
 
 // ===================================================================
 
+const DEFAULT_TEMPLATE = 'mjml'
+
 const UNKNOWN_ITEM = 'Unknown'
 
 const DATE_FORMAT = 'dddd, MMMM Do YYYY, h:mm:ss a'
@@ -188,10 +190,11 @@ class BackupReportsXoPlugin {
       formatDate,
     }
 
+    const backupReportTpl = log.data?.backupReportTpl ?? DEFAULT_TEMPLATE
     return this._sendReport({
       ...(await templates.markdown.transform(templates.markdown.$metadata(context))),
       ...(await templates.compactMarkdown.transform(templates.compactMarkdown.$metadata(context))),
-      ...(await templates.mjml.transform(templates.mjml.$metadata(context))),
+      ...(await templates[backupReportTpl].transform(templates[backupReportTpl].$metadata(context))),
       mailReceivers,
       subject: templates.mjml.$metadataSubject(context),
       success: log.status === 'success',
@@ -368,10 +371,11 @@ class BackupReportsXoPlugin {
       globalTransferSize,
     }
 
+    const backupReportTpl = log.data?.backupReportTpl ?? DEFAULT_TEMPLATE
     return this._sendReport({
       ...(await templates.markdown.transform(templates.markdown.$vm(context))),
       ...(await templates.compactMarkdown.transform(templates.compactMarkdown.$vm(context))),
-      ...(await templates.mjml.transform(templates.mjml.$vm(context))),
+      ...(await templates[backupReportTpl].transform(templates[backupReportTpl].$vm(context))),
       mailReceivers,
       subject: templates.mjml.$vmSubject(context),
       success: log.status === 'success',

--- a/packages/xo-server-backup-reports/src/index.js
+++ b/packages/xo-server-backup-reports/src/index.js
@@ -190,6 +190,7 @@ class BackupReportsXoPlugin {
 
     return this._sendReport({
       ...(await templates.markdown.transform(templates.markdown.$metadata(context))),
+      ...(await templates.compactMarkdown.transform(templates.compactMarkdown.$metadata(context))),
       ...(await templates.mjml.transform(templates.mjml.$metadata(context))),
       mailReceivers,
       subject: templates.mjml.$metadataSubject(context),
@@ -369,6 +370,7 @@ class BackupReportsXoPlugin {
 
     return this._sendReport({
       ...(await templates.markdown.transform(templates.markdown.$vm(context))),
+      ...(await templates.compactMarkdown.transform(templates.compactMarkdown.$vm(context))),
       ...(await templates.mjml.transform(templates.mjml.$vm(context))),
       mailReceivers,
       subject: templates.mjml.$vmSubject(context),
@@ -376,7 +378,7 @@ class BackupReportsXoPlugin {
     })
   }
 
-  async _sendReport({ mailReceivers, markdown, html, subject, success }) {
+  async _sendReport({ mailReceivers, markdown, compactMarkdown, html, subject, success }) {
     if (mailReceivers === undefined || mailReceivers.length === 0) {
       mailReceivers = this._mailsReceivers
     }
@@ -397,16 +399,16 @@ class BackupReportsXoPlugin {
           ? Promise.reject(new Error('transport-xmpp plugin not enabled'))
           : xo.sendToXmppClient({
               to: this._xmppReceivers,
-              message: markdown,
+              message: compactMarkdown,
             })),
       xo.sendSlackMessage !== undefined &&
         xo.sendSlackMessage({
-          message: markdown,
+          message: compactMarkdown,
         }),
       xo.sendIcinga2Status !== undefined &&
         xo.sendIcinga2Status({
           status: success ? 'OK' : 'CRITICAL',
-          message: markdown,
+          message: compactMarkdown,
         }),
     ]
 

--- a/packages/xo-server-backup-reports/templates/compactMarkdown/metadata.hbs
+++ b/packages/xo-server-backup-reports/templates/compactMarkdown/metadata.hbs
@@ -1,0 +1,13 @@
+## Global status: {{{log.status}}}
+
+- **Job ID**: {{{log.jobId}}}
+- **Job name**: {{{jobName}}}
+- **Run ID**: {{{log.id}}}
+{{>reportTemporalData end=log.end start=log.start}}
+{{#if log.tasks.length}}
+- **Successes**: {{#if tasksByStatus.success.length ~}} {{{tasksByStatus.success.length}}} {{~else~}} 0 {{~/if}} / {{{log.tasks.length}}}
+{{/if}}
+{{>reportError task=log}}
+{{>reportWarnings task=log}}
+---
+*{{{pkg.name}}} v{{{pkg.version}}}*

--- a/packages/xo-server-backup-reports/templates/compactMarkdown/metadataSubject.hbs
+++ b/packages/xo-server-backup-reports/templates/compactMarkdown/metadataSubject.hbs
@@ -1,0 +1,1 @@
+[Xen Orchestra] {{{log.status}}} − Metadata backup report for {{{log.jobName}}} {{{getIcon log.status}}}

--- a/packages/xo-server-backup-reports/templates/compactMarkdown/partials/reportError.hbs
+++ b/packages/xo-server-backup-reports/templates/compactMarkdown/partials/reportError.hbs
@@ -1,0 +1,1 @@
+../../markdown/partials/reportError.hbs

--- a/packages/xo-server-backup-reports/templates/compactMarkdown/partials/reportTemporalData.hbs
+++ b/packages/xo-server-backup-reports/templates/compactMarkdown/partials/reportTemporalData.hbs
@@ -1,0 +1,1 @@
+../../markdown/partials/reportTemporalData.hbs

--- a/packages/xo-server-backup-reports/templates/compactMarkdown/partials/reportWarnings.hbs
+++ b/packages/xo-server-backup-reports/templates/compactMarkdown/partials/reportWarnings.hbs
@@ -1,0 +1,1 @@
+../../markdown/partials/reportWarnings.hbs

--- a/packages/xo-server-backup-reports/templates/compactMarkdown/transform.js
+++ b/packages/xo-server-backup-reports/templates/compactMarkdown/transform.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = async function transform(source) {
+  return { compactMarkdown: source }
+}

--- a/packages/xo-server-backup-reports/templates/compactMarkdown/vm.hbs
+++ b/packages/xo-server-backup-reports/templates/compactMarkdown/vm.hbs
@@ -1,0 +1,20 @@
+## Global status: {{{log.status}}}
+
+- **Job ID**: {{{log.jobId}}}
+- **Run ID**: {{{log.id}}}
+- **Mode**: {{{log.data.mode}}}
+{{>reportTemporalData end=log.end start=log.start}}
+{{#if log.tasks}}
+- **Successes**: {{{tasksByStatus.success.count}}} / {{{tasksByStatus.vmTasks.count}}}
+{{#if globalTransferSize}}
+- **Transfer size**: {{formatSize globalTransferSize}}
+{{/if}}
+{{#if globalMergeSize}}
+- **Merge size**: {{formatSize globalMergeSize}}
+{{/if}}
+{{else}}
+{{>reportError task=log}}
+{{/if}}
+{{>reportWarnings task=log}}
+---
+*{{{pkg.name}}} v{{{pkg.version}}}*

--- a/packages/xo-server-backup-reports/templates/compactMarkdown/vmSubject.hbs
+++ b/packages/xo-server-backup-reports/templates/compactMarkdown/vmSubject.hbs
@@ -1,0 +1,1 @@
+[Xen Orchestra] {{{log.status}}} − Backup report for {{{jobName}}} {{{getIcon log.status}}}

--- a/packages/xo-server-backup-reports/templates/compactMjml/metadata.hbs
+++ b/packages/xo-server-backup-reports/templates/compactMjml/metadata.hbs
@@ -1,0 +1,40 @@
+<mjml>
+  {{>mjmlHeaders}}
+  <mj-body background-color="#1A1B38">
+    <mj-wrapper background-color="#1A1B38">
+      <mj-section padding="0 0 10px 0"> </mj-section>
+      <mj-section padding="0px">
+        <mj-column width="100%">
+          <mj-text align="center" font-size="32px" font-weight="500" padding="0px" font-size="18px" line-height="24px"
+            >Metadata backup report</mj-text
+          >
+        </mj-column>
+      </mj-section>
+      <mj-section padding="0px">
+        <mj-column width="80%">
+          <mj-divider border-width="2px" padding-top="25px"></mj-divider>
+        </mj-column>
+      </mj-section>
+      <mj-section padding="0px">
+        <mj-column width="100%">
+          <mj-text font-size="16px" font-weight="300" line-height="24px">
+            <h1>Global status : {{log.status}} {{getIcon log.status}}</h1>
+            <ul>
+              <li><span style="font-weight: bold">Job ID</span>: {{log.jobId}}</li>
+              <li><span style="font-weight: bold">Job name</span>: {{jobName}}</li>
+              <li><span style="font-weight: bold">Run ID</span>: {{log.id}}</li>
+              {{>reportTemporalData end=log.end start=log.start}} {{#if log.tasks.length}}
+              <li>
+                <span style="font-weight: bold">Successes</span>: {{#if tasksByStatus.success.length ~}}
+                {{tasksByStatus.success.length}} {{~else~}} 0 {{~/if}} / {{log.tasks.length}}
+              </li>
+              {{/if}} {{>reportError task=log}} {{>reportWarnings task=log}}
+            </ul>
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+    {{>mjmlFooter}}
+    </mj-wrapper>
+  </mj-body>
+</mjml>

--- a/packages/xo-server-backup-reports/templates/compactMjml/metadataSubject.hbs
+++ b/packages/xo-server-backup-reports/templates/compactMjml/metadataSubject.hbs
@@ -1,0 +1,1 @@
+[Xen Orchestra] {{{log.status}}} − Metadata backup report for {{{log.jobName}}} {{{getIcon log.status}}}

--- a/packages/xo-server-backup-reports/templates/compactMjml/partials/mjmlFooter.hbs
+++ b/packages/xo-server-backup-reports/templates/compactMjml/partials/mjmlFooter.hbs
@@ -1,0 +1,1 @@
+../../mjml/partials/mjmlFooter.hbs

--- a/packages/xo-server-backup-reports/templates/compactMjml/partials/mjmlHeaders.hbs
+++ b/packages/xo-server-backup-reports/templates/compactMjml/partials/mjmlHeaders.hbs
@@ -1,0 +1,1 @@
+../../mjml/partials/mjmlHeaders.hbs

--- a/packages/xo-server-backup-reports/templates/compactMjml/partials/reportError.hbs
+++ b/packages/xo-server-backup-reports/templates/compactMjml/partials/reportError.hbs
@@ -1,0 +1,1 @@
+../../mjml/partials/reportError.hbs

--- a/packages/xo-server-backup-reports/templates/compactMjml/partials/reportTemporalData.hbs
+++ b/packages/xo-server-backup-reports/templates/compactMjml/partials/reportTemporalData.hbs
@@ -1,0 +1,1 @@
+../../mjml/partials/reportTemporalData.hbs

--- a/packages/xo-server-backup-reports/templates/compactMjml/partials/reportWarnings.hbs
+++ b/packages/xo-server-backup-reports/templates/compactMjml/partials/reportWarnings.hbs
@@ -1,0 +1,1 @@
+../../mjml/partials/reportWarnings.hbs

--- a/packages/xo-server-backup-reports/templates/compactMjml/transform.js
+++ b/packages/xo-server-backup-reports/templates/compactMjml/transform.js
@@ -3,5 +3,5 @@
 const mjml2html = require('mjml')
 
 module.exports = async function transform(source) {
-  return { compactHtml: mjml2html(source).html }
+  return { html: mjml2html(source).html }
 }

--- a/packages/xo-server-backup-reports/templates/compactMjml/transform.js
+++ b/packages/xo-server-backup-reports/templates/compactMjml/transform.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const mjml2html = require('mjml')
+
+module.exports = async function transform(source) {
+  return { compactHtml: mjml2html(source).html }
+}

--- a/packages/xo-server-backup-reports/templates/compactMjml/vm.hbs
+++ b/packages/xo-server-backup-reports/templates/compactMjml/vm.hbs
@@ -1,0 +1,47 @@
+<mjml>
+  {{>mjmlHeaders}}
+  <mj-body background-color="#1A1B38">
+    <mj-wrapper background-color="#1A1B38">
+      <mj-section padding="0 0 10px 0"> </mj-section>
+      <mj-section padding="0px">
+        <mj-column width="100%">
+          <mj-text align="center" font-size="32px" font-weight="500" padding="0px" font-size="18px" line-height="24px"
+            >VM Backup report</mj-text
+          >
+        </mj-column>
+      </mj-section>
+      <mj-section padding="0px">
+        <mj-column width="80%">
+          <mj-divider border-width="2px" padding-top="25px"></mj-divider>
+        </mj-column>
+      </mj-section>
+      <mj-section padding="0px">
+        <mj-column width="100%">
+          <mj-text font-size="16px" font-weight="300" line-height="24px">
+            <h1>Global status : {{log.status}} {{getIcon log.status}}</h1>
+            <ul>
+              <li><span style="font-weight: bold">Job ID</span>: {{log.jobId}}</li>
+              <li><span style="font-weight: bold">Run ID</span>: {{log.id}}</li>
+              <li><span style="font-weight: bold">Mode</span>: {{log.data.mode}}</li>
+              {{>reportTemporalData end=log.end start=log.start}}
+              {{#if log.tasks}}
+              <li>
+                <span style="font-weight: bold">Successes</span>: {{#if tasksByStatus.success.tasks.length ~}}
+                {{tasksByStatus.success.tasks.length}} {{~else~}} 0 {{~/if}} / {{log.tasks.length}}
+              </li>
+              {{#if globalTransferSize}}
+              <li><span style="font-weight: bold">Transfer size</span>: {{formatSize globalTransferSize}}</li>
+              {{/if}}
+              {{#if globalMergeSize}}
+              <li><span style="font-weight: bold">Merge size</span>: {{formatSize globalMergeSize}}</li>
+              {{/if}}
+              {{/if}} {{>reportError task=log}} {{>reportWarnings task=log}}
+            </ul>
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+    {{>mjmlFooter}}
+    </mj-wrapper>
+  </mj-body>
+</mjml>

--- a/packages/xo-server-backup-reports/templates/compactMjml/vmSubject.hbs
+++ b/packages/xo-server-backup-reports/templates/compactMjml/vmSubject.hbs
@@ -1,0 +1,1 @@
+[Xen Orchestra] {{{log.status}}} − Backup report for {{{jobName}}} {{{getIcon log.status}}}

--- a/packages/xo-server/src/xo-mixins/jobs/index.mjs
+++ b/packages/xo-server/src/xo-mixins/jobs/index.mjs
@@ -175,6 +175,7 @@ export default class Jobs {
           ? {
               mode: job.mode,
               reportWhen: job.settings['']?.reportWhen ?? 'failure',
+              backupReportTpl: job.settings['']?.backupReportTpl,
             }
           : undefined,
       event: 'job.start',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -613,6 +613,7 @@ const messages = {
     "The snapshot won't use any notable space on the SR, won't be shown in the UI and won't be usable to do a rollback",
   cbtDestroySnapshotDataDisabledInformation:
     'Snapshot data can be purged only when NBD is enabled and rolling snapshot is not used',
+  shorterBackupReports: 'Shorter backup reports',
 
   // ------ New Remote -----
   newRemote: 'New file system remote',

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -650,6 +650,11 @@ const New = decorate([
           nRetriesVmBackupFailures: nRetries,
         })
       },
+      setBackupReportTpl({ setGlobalSettings }, compactBackupTpl) {
+        setGlobalSettings({
+          backupReportTpl: compactBackupTpl ? 'compactMjml' : 'mjml',
+        })
+      },
     },
     computed: {
       compressionId: generateId,
@@ -661,6 +666,7 @@ const New = decorate([
       inputPreferNbd: generateId,
       inputNbdConcurrency: generateId,
       inputNRetriesVmBackupFailures: generateId,
+      inputBackupReportTplId: generateId,
       inputTimeoutId: generateId,
 
       // In order to keep the user preference, the offline backup is kept in the DB
@@ -780,6 +786,7 @@ const New = decorate([
       preferNbd,
       reportRecipients,
       reportWhen = 'failure',
+      backupReportTpl = 'mjml',
       timeout,
     } = settings.get('') || {}
 
@@ -1163,6 +1170,17 @@ const New = decorate([
                         offlineSnapshot={offlineSnapshot}
                         setGlobalSettings={effects.setGlobalSettings}
                       />
+                      <FormGroup>
+                        <label htmlFor={state.inputBackupReportTplId}>
+                          <strong>{_('shorterBackupReports')}</strong>
+                        </label>
+                        <Toggle
+                          className='pull-right'
+                          id={state.inputBackupReportTplId}
+                          value={backupReportTpl === 'compactMjml'}
+                          onChange={effects.setBackupReportTpl}
+                        />
+                      </FormGroup>
                     </div>
                   )}
                 </CardBlock>

--- a/packages/xo-web/src/xo-app/backup/new/metadata/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/metadata/index.js
@@ -14,6 +14,7 @@ import { injectState, provideState } from 'reaclette'
 import { every, isEmpty, mapValues, map } from 'lodash'
 import { Remote } from 'render-xo-item'
 import { SelectPool, SelectRemote } from 'select-objects'
+import { Toggle } from 'form'
 import {
   createMetadataBackupJob,
   createSchedule,
@@ -193,6 +194,9 @@ export default decorate([
         reportRecipients.splice(key, 1)
         setGlobalSettings('reportRecipients', reportRecipients)
       },
+      setBackupReportTpl({ setGlobalSettings }, compactBackupTpl) {
+        setGlobalSettings('backupReportTpl', compactBackupTpl ? 'compactMjml' : 'mjml')
+      },
       toggleMode:
         (_, { mode }) =>
         state => ({
@@ -213,6 +217,7 @@ export default decorate([
     },
     computed: {
       idForm: generateId,
+      inputBackupReportTplId: generateId,
 
       modePoolMetadata: ({ _modePoolMetadata }, { job }) =>
         defined(_modePoolMetadata, () => !isEmpty(destructPattern(job.pools))),
@@ -287,7 +292,11 @@ export default decorate([
       missingSchedules,
     } = state.showErrors ? state : {}
 
-    const { reportWhen = 'failure', reportRecipients = [] } = defined(() => state.settings[GLOBAL_SETTING_KEY], {})
+    const {
+      reportWhen = 'failure',
+      reportRecipients = [],
+      backupReportTpl = 'mjml',
+    } = defined(() => state.settings[GLOBAL_SETTING_KEY], {})
 
     return (
       <form id={state.idForm}>
@@ -378,6 +387,17 @@ export default decorate([
                     add={effects.addReportRecipient}
                     remove={effects.removeReportRecipient}
                   />
+                  <FormGroup>
+                    <label htmlFor={state.inputBackupReportTplId}>
+                      <strong>{_('shorterBackupReports')}</strong>
+                    </label>
+                    <Toggle
+                      className='pull-right'
+                      id={state.inputBackupReportTplId}
+                      value={backupReportTpl === 'compactMjml'}
+                      onChange={effects.setBackupReportTpl}
+                    />
+                  </FormGroup>
                 </CardBlock>
               </Card>
             </Col>

--- a/packages/xo-web/src/xo-app/backup/new/mirror/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/mirror/index.js
@@ -13,7 +13,7 @@ import { every, isEmpty, map, mapValues } from 'lodash'
 import { generateId, linkState } from 'reaclette-utils'
 import { injectIntl } from 'react-intl'
 import { injectState, provideState } from 'reaclette'
-import { Number } from 'form'
+import { Number, Toggle } from 'form'
 import { Remote } from 'render-xo-item'
 import { resolveId } from 'utils'
 import { SelectRemote } from 'select-objects'
@@ -126,6 +126,8 @@ const NewMirrorBackup = decorate([
         setAdvancedSettings({ maxExportRate: rate !== undefined ? rate * (1024 * 1024) : undefined }),
       setNRetriesVmBackupFailures: ({ setAdvancedSettings }, nRetriesVmBackupFailures) =>
         setAdvancedSettings({ nRetriesVmBackupFailures }),
+      setBackupReportTpl: ({ setAdvancedSettings }, compactBackupTpl) =>
+        setAdvancedSettings({ backupReportTpl: compactBackupTpl ? 'compactMjml' : 'mjml' }),
       setSourceRemote: (_, obj) => () => ({
         sourceRemote: obj === null ? {} : obj.value,
       }),
@@ -207,6 +209,7 @@ const NewMirrorBackup = decorate([
       inputTimeoutId: generateId,
       inputMaxExportRateId: generateId,
       inputNRetriesVmBackupFailures: generateId,
+      inputBackupReportTplId: generateId,
       isBackupInvalid: state =>
         state.isMissingName || state.isMissingBackupMode || state.isMissingSchedules || state.isMissingRetention,
       isFull: state => state.mode === 'full',
@@ -234,7 +237,13 @@ const NewMirrorBackup = decorate([
   }),
   injectState,
   ({ state, effects, intl: { formatMessage } }) => {
-    const { concurrency, timeout, maxExportRate, nRetriesVmBackupFailures = 0 } = state.advancedSettings
+    const {
+      concurrency,
+      timeout,
+      maxExportRate,
+      backupReportTpl = 'mjml',
+      nRetriesVmBackupFailures = 0,
+    } = state.advancedSettings
     return (
       <form id={state.formId}>
         <Container>
@@ -351,6 +360,17 @@ const NewMirrorBackup = decorate([
                           min={0}
                           onChange={effects.setMaxExportRate}
                           value={maxExportRate / (1024 * 1024)}
+                        />
+                      </FormGroup>
+                      <FormGroup>
+                        <label htmlFor={state.inputBackupReportTplId}>
+                          <strong>{_('shorterBackupReports')}</strong>
+                        </label>
+                        <Toggle
+                          className='pull-right'
+                          id={state.inputBackupReportTplId}
+                          value={backupReportTpl === 'compactMjml'}
+                          onChange={effects.setBackupReportTpl}
                         />
                       </FormGroup>
                     </div>


### PR DESCRIPTION
### Description

**review by commit**

Fixes #2278 

Adding compact templates for backup reports. These templates are used :
- for reports sent with slack and xmpp
- for all reports when the new "Shorter backup reports" option of backup job configuration is enabled

![image](https://github.com/user-attachments/assets/ceb0f7c2-6802-4f3c-9a0e-dd3b177539b7)

![image](https://github.com/user-attachments/assets/ee517beb-aac4-490d-a410-cd5523afd0a8)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
