### PR TITLE
fix(web-core/useRouteQuery): URL not updating immediately in some cases

### DIFF
--- a/@xen-orchestra/web-core/lib/composables/route-query/actions/handle-delete.ts
+++ b/@xen-orchestra/web-core/lib/composables/route-query/actions/handle-delete.ts
@@ -4,13 +4,16 @@ export function handleDelete(source: WritableComputedRef<any>, value: any) {
   if (Array.isArray(source.value)) {
     source.value = [...source.value].splice(value, 1)
   } else if (source.value instanceof Set) {
-    source.value = new Set(source.value)
-    source.value.delete(value)
+    const newSet = new Set(source.value)
+    newSet.delete(value)
+    source.value = newSet
   } else if (source.value instanceof Map) {
-    source.value = new Map(source.value)
-    source.value.delete(value)
+    const newMap = new Map(source.value)
+    newMap.delete(value)
+    source.value = newMap
   } else if (typeof source.value === 'object' && source.value !== null) {
-    source.value = { ...source.value }
-    delete source.value[value]
+    const newObject = { ...source.value }
+    delete newObject[value]
+    source.value = newObject
   }
 }

--- a/@xen-orchestra/web-core/lib/composables/route-query/actions/handle-set.ts
+++ b/@xen-orchestra/web-core/lib/composables/route-query/actions/handle-set.ts
@@ -2,11 +2,13 @@ import type { WritableComputedRef } from 'vue'
 
 export function handleSet(source: WritableComputedRef<any>, key: any, value: any) {
   if (Array.isArray(source.value)) {
-    source.value = [...source.value]
-    source.value[key] = value
+    const newArray = source.value.slice()
+    newArray[key] = value
+    source.value = newArray
   } else if (source.value instanceof Map) {
-    source.value = new Map(source.value)
-    source.value.set(key, value)
+    const newMap = new Map(source.value)
+    newMap.set(key, value)
+    source.value = newMap
   } else if (typeof source.value === 'object') {
     if (source.value === null) {
       return

--- a/@xen-orchestra/web-core/lib/composables/route-query/types.ts
+++ b/@xen-orchestra/web-core/lib/composables/route-query/types.ts
@@ -39,4 +39,13 @@ export type GuessActions<TData> =
           ? MapActions<TKey, TValue>
           : EmptyObject
 
-export type RouteQuery<TData> = WritableComputedRef<TData> & GuessActions<TData>
+export type RouteQuery<TData> = WritableComputedRef<
+  TData extends Set<infer V>
+    ? ReadonlySet<V>
+    : TData extends Map<infer K, infer V>
+      ? ReadonlyMap<K, V>
+      : TData extends object
+        ? Readonly<TData>
+        : TData
+> &
+  GuessActions<TData>


### PR DESCRIPTION
### Description

Fix URL not being updated immediately when deleting an item from a `Set`, `Map` or `object` or setting a value of an `array` or a `Map`.

Introduced by 290b5df

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
