### PR TITLE
fix(xo-core/StackedBar): division by 0 in some cases

### DIFF
--- a/@xen-orchestra/web-core/lib/components/stacked-bar/StackedBar.vue
+++ b/@xen-orchestra/web-core/lib/components/stacked-bar/StackedBar.vue
@@ -5,7 +5,7 @@
       v-for="(segment, index) in segments"
       :key="index"
       :color="segment.color"
-      :percentage="(segment.value / max) * 100"
+      :percentage="max === 0 ? 0 : (segment.value / max) * 100"
     />
   </div>
 </template>

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -35,6 +35,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/web-core patch
 - xo-web patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,6 +37,6 @@
 <!--packages-start-->
 
 - @xen-orchestra/web-core patch
-- xo-web patch
+- xo-web minor
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

The `max` value used for calculating the displayed percentage in the component can sometimes be set to 0 in certain cases, and thus, break the component.

Introduced by 14da422

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
