### PR TITLE
fix(xo-server/rest-api/dashboard): exclude disabled and S3 from backupRepositoriesSize

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,7 +26,6 @@
 - [Plugin/perf-alert] Fix 'NaN' values in CPU usage (PR [#7925](https://github.com/vatesfr/xen-orchestra/pull/7925))
 - [Backups] Fix the replication failing with "disk attached to Dom0" error (PR [#7920](https://github.com/vatesfr/xen-orchestra/pull/7920))
 
-
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@
 - [Plugin/perf-alert] Fix 'NaN' values in CPU usage (PR [#7925](https://github.com/vatesfr/xen-orchestra/pull/7925))
 - [Backups] Fix the replication failing with "disk attached to Dom0" error (PR [#7920](https://github.com/vatesfr/xen-orchestra/pull/7920))
 
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.


### PR DESCRIPTION
### Description

S3 backup repositories should not be calculated here.

introduced by 4dfd77b

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
