### PR TITLE
fix(xo-core/CardNumbers): division by 0 in some cases

### DIFF
--- a/@xen-orchestra/web-core/lib/components/CardNumbers.vue
+++ b/@xen-orchestra/web-core/lib/components/CardNumbers.vue
@@ -37,7 +37,7 @@ const valueFontClass = computed(() => (props.size === 'medium' ? 'h3-semi-bold' 
 const unitFontClass = computed(() => (props.size === 'medium' ? 'p2-medium' : 'c2-semi-bold'))
 
 const percentValue = computed(() => {
-  if (props.size !== 'small' || props.max === undefined) {
+  if (props.size !== 'small' || props.max === undefined || props.max === 0) {
     return undefined
   }
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,6 +36,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/web-core patch
 - xo-web minor
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

The `max` value used for calculating the displayed percentage in the component can sometimes be set to 0 in certain cases, and thus, break the component.

Introduced by dc7fd78

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
