### PR TITLE
fix(xo-server/rest-api): remove alarms info from the dashboard and messages endpoint

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@
   - [Dashboard] Display backup issues data (PR [#7974](https://github.com/vatesfr/xen-orchestra/pull/7974))
 - [REST API] Add S3 backup repository and VMs protection information in the `/rest/v0/dashboard` endpoint (PRs [#7978](https://github.com/vatesfr/xen-orchestra/pull/7978), [#7964](https://github.com/vatesfr/xen-orchestra/pull/7964))
 - [Backups] Display more informations in the _Notes_ column of the backup page (PR [#7977](https://github.com/vatesfr/xen-orchestra/pull/7977))
+- [REST API] Add `/alarms` endpoint and remove `alarms` information in the `/rest/v0/dashboard` endpoint (PR [#7959](https://github.com/vatesfr/xen-orchestra/pull/7959))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,7 +18,7 @@
   - [Dashboard] Display backup issues data (PR [#7974](https://github.com/vatesfr/xen-orchestra/pull/7974))
 - [REST API] Add S3 backup repository and VMs protection information in the `/rest/v0/dashboard` endpoint (PRs [#7978](https://github.com/vatesfr/xen-orchestra/pull/7978), [#7964](https://github.com/vatesfr/xen-orchestra/pull/7964))
 - [Backups] Display more informations in the _Notes_ column of the backup page (PR [#7977](https://github.com/vatesfr/xen-orchestra/pull/7977))
-- [REST API] Add `/alarms` endpoint and remove `alarms` information in the `/rest/v0/dashboard` endpoint (PR [#7959](https://github.com/vatesfr/xen-orchestra/pull/7959))
+- [REST API] Add `/alarms` endpoint and remove alarms from the `/dashboard` and `/messages` endpoints (PR [#7959](https://github.com/vatesfr/xen-orchestra/pull/7959))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/utils.mjs
+++ b/packages/xo-server/src/utils.mjs
@@ -346,4 +346,9 @@ export const isSrWritable = sr => sr !== undefined && sr.content_type !== 'iso' 
 export const isReplicaVm = vm => 'start' in vm.blockedOperations && vm.other['xo:backup:job'] !== undefined
 
 // -------------------------------------------------------------------
+
 export const vmContainsNoBakTag = vm => vm.tags.some(t => t.split('=', 1)[0] === 'xo:no-bak')
+
+// -------------------------------------------------------------------
+
+export const isAlarm = alarm => alarm.type === 'message' && alarm.name === 'ALARM'

--- a/packages/xo-server/src/utils.mjs
+++ b/packages/xo-server/src/utils.mjs
@@ -346,7 +346,6 @@ export const isSrWritable = sr => sr !== undefined && sr.content_type !== 'iso' 
 export const isReplicaVm = vm => 'start' in vm.blockedOperations && vm.other['xo:backup:job'] !== undefined
 
 // -------------------------------------------------------------------
-
 export const vmContainsNoBakTag = vm => vm.tags.some(t => t.split('=', 1)[0] === 'xo:no-bak')
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
### Description

⚠️ alarms info is **removed** from the dashboard endpoint! ⚠️
Alarms are now in a dedicated endpoint `/alarms`
```js
// /alarms
string[]

// /alarms/<uuid>
{
   body: {
      value: string, // NaN, Infinity and -Infinity aren't valid JSON
      name: string
   },
   name: 'ALARM',
   time: number,
   $object: string,
   id: string,
   type: 'message',
   uuid: string,
   $pool: string,
   $poolId: string,
   _xapiRef: string,
   object: {
      type: string,
      uuid: string,
      href: string | undefined
   },
}
```
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
