### PR TITLE
feat(backups/CBT): retry data_destroy when error is VDI_IN USE

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
@@ -290,7 +290,7 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
       for (const vdiRef of vdiRefs) {
         try {
           // data_destroy will fail with a VDI_NO_CBT_METADATA error if CBT is not enabled on this VDI
-          await this._xapi.call('VDI.data_destroy', vdiRef)
+          await this._xapi.VDI_dataDestroy(vdiRef)
           Task.info(`Snapshot data has been deleted`, { vdiRef })
         } catch (error) {
           Task.warning(`Couldn't deleted snapshot data`, { error, vdiRef })

--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -27,6 +27,9 @@ class Vdi {
       noop
     )
   }
+  async dataDestroy(vdiRef) {
+    return await this.callAsync('VDI.data_destroy', vdiRef)
+  }
 
   async create(
     {
@@ -285,6 +288,13 @@ export default Vdi
 decorateClass(Vdi, {
   // work around a race condition in XCP-ng/XenServer where the disk is not fully unmounted yet
   destroy: [
+    pRetry.wrap,
+    function () {
+      return this._vdiDestroyRetryWhenInUse
+    },
+  ],
+  // same condition when destroying data of a VDI
+  dataDestroy: [
     pRetry.wrap,
     function () {
       return this._vdiDestroyRetryWhenInUse

--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -27,6 +27,7 @@ class Vdi {
       noop
     )
   }
+
   async dataDestroy(vdiRef) {
     return await this.callAsync('VDI.data_destroy', vdiRef)
   }

--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -29,7 +29,7 @@ class Vdi {
   }
 
   async dataDestroy(vdiRef) {
-    return await this.callAsync('VDI.data_destroy', vdiRef)
+    await this.callAsync('VDI.data_destroy', vdiRef)
   }
 
   async create(

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Incremental Backup & Replication] Remove most of `Couldn't delete snapshot data` errors when using _Purge snapshot data when using CBT_ [#7826](https://github.com/vatesfr/xen-orchestra/pull/7826) (PR [#7960](https://github.com/vatesfr/xen-orchestra/pull/7960))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -41,9 +43,11 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
 - @xen-orchestra/lite minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+- @xen-orchestra/xapi minor
 - xo-server minor
 - xo-server-perf-alert minor
 - xo-server-sdn-controller patch


### PR DESCRIPTION
sometimes the capi take too long to detach the VDI
in this case, the timeout is fixed at 4s, non modifiable
when the timeout is reached the xapi raise a VDI_IN_USE error

this is an internal process of the xapi

This commit add a retry on XO side to give more room for the xapi
to work through this process, as XO already do it one vdi destroying

fix #7826

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
