### PR TITLE
 Fix computation of `memory_static_max`

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 - [REST API] Add `pifs` and `vm-controllers` collections
 - [REST API/Dashboard] Add name and type of the backup in the backup job issues (PR [#7958](https://github.com/vatesfr/xen-orchestra/pull/7958))
 - [Perf-alert] Display warning if no guest tools are detected while monitoring VM memory (PR [#7886](https://github.com/vatesfr/xen-orchestra/pull/7886))
+- [V2V] Fix computation of `memory_static_max`
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/vmware/index.mjs
+++ b/packages/xo-server/src/xo-mixins/vmware/index.mjs
@@ -38,6 +38,7 @@ export default class MigrateVm {
           ...OTHER_CONFIG_TEMPLATE,
           memory_dynamic_max: memory,
           memory_dynamic_min: memory,
+          memory_static_max: memory,
           // allow the user to reduce the memory of this VM to the limit set by the template
           memory_static_min: template.memory_static_min,
           name_description: `from esxi -- source guest id :${guestId} -- template used:${template.name_label}`,


### PR DESCRIPTION
### Description
the max memory that can be assigned to a VM is not correctly passed by the v2v import

introduced by ad1bf3b348e9d715355c8b30ec44b949c8557f03 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
