### PR TITLE
feat(xo-web): display more notes on backup main page

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,7 @@
 
 - [SR/Disks] Display information if the VDI is an empty metadata snapshot (PR [#7970](https://github.com/vatesfr/xen-orchestra/pull/7970))
 - [Netbox] Do not synchronize if detected minor version is not supported (PR [#7992](https://github.com/vatesfr/xen-orchestra/pull/7992))
+- [Backups] Display more informations in the _Notes_ column of the backup page (PR [#7977](https://github.com/vatesfr/xen-orchestra/pull/7977))
 - **XO 6**:
   - [Dashboard] Display backup issues data (PR [#7974](https://github.com/vatesfr/xen-orchestra/pull/7974))
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1962,6 +1962,8 @@ const messages = {
   vmsTags: 'VMs tags',
   tagNoBak: 'VMs with this tag will not be backed up {reason, select, null {} other {({reason})}}',
   tagNotifyOnSnapshot: 'An email will be sent when a VM with this tag is snapshotted',
+  nbdConnections: `NBD connections`,
+  speedLimitNoUnit: 'Speed limit',
 
   // ----- Restore files view -----
   restoreFiles: 'Restore backup files',

--- a/packages/xo-web/src/xo-app/backup/_getSettingsWithNonDefaultValue.js
+++ b/packages/xo-web/src/xo-app/backup/_getSettingsWithNonDefaultValue.js
@@ -3,12 +3,16 @@ import pickBy from 'lodash/pickBy.js'
 const DEFAULTS = {
   __proto__: null,
 
+  backupReportTpl: 'mjml',
+  cbtDestroySnapshotData: false,
   checkpointSnapshot: false,
   compression: '',
   concurrency: 0,
   fullInterval: 0,
+  nbdConcurrency: 1,
   offlineBackup: false,
   offlineSnapshot: false,
+  preferNbd: false,
   reportWhen: 'failure',
   timeout: 0,
 }

--- a/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
+++ b/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
@@ -13,7 +13,7 @@ import SortedTable from 'sorted-table'
 import StateButton from 'state-button'
 import Tooltip from 'tooltip'
 import { confirm } from 'modal'
-import { connectStore } from 'utils'
+import { connectStore, formatSpeed } from 'utils'
 import { createFilter, createGetObjectsOfType, createSelector } from 'selectors'
 import { createPredicate } from 'value-matcher'
 import { get } from '@xen-orchestra/defined'
@@ -41,7 +41,6 @@ import getSettingsWithNonDefaultValue from '../_getSettingsWithNonDefaultValue'
 import { destructPattern } from '../utils'
 import { REPORT_WHEN_LABELS } from '../new/_reportWhen'
 import { LogStatus } from '../../logs/backup-ng'
-import { formatSpeed } from '../../../common/utils'
 
 const Ul = props => <ul {...props} style={{ listStyleType: 'none' }} />
 const Li = props => (

--- a/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
+++ b/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
@@ -345,7 +345,12 @@ class JobsTable extends React.Component {
                 <Li>{_.keyValue(_('reportWhen'), _(REPORT_WHEN_LABELS[reportWhen]))}</Li>
               )}
               {backupReportTpl !== undefined && (
-                <Li>{_.keyValue(_('shorterBackupReports'), _(backupReportTpl ? 'stateEnabled' : 'stateDisabled'))}</Li>
+                <Li>
+                  {_.keyValue(
+                    _('shorterBackupReports'),
+                    _(backupReportTpl === 'compactMjml' ? 'stateEnabled' : 'stateDisabled')
+                  )}
+                </Li>
               )}
               {concurrency !== undefined && <Li>{_.keyValue(_('concurrency'), concurrency)}</Li>}
               {preferNbd && <Li>{_.keyValue(_('nbdConnections'), nbdConcurrency ?? 1)}</Li>}

--- a/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
+++ b/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
@@ -41,6 +41,7 @@ import getSettingsWithNonDefaultValue from '../_getSettingsWithNonDefaultValue'
 import { destructPattern } from '../utils'
 import { REPORT_WHEN_LABELS } from '../new/_reportWhen'
 import { LogStatus } from '../../logs/backup-ng'
+import { formatSize } from '../../../common/utils'
 
 const Ul = props => <ul {...props} style={{ listStyleType: 'none' }} />
 const Li = props => (
@@ -358,9 +359,7 @@ class JobsTable extends React.Component {
               )}
               {timeout !== undefined && <Li>{_.keyValue(_('timeout'), timeout / 3600e3)} hours</Li>}
               {fullInterval !== undefined && <Li>{_.keyValue(_('fullBackupInterval'), fullInterval)}</Li>}
-              {maxExportRate > 0 && (
-                <Li>{_.keyValue(_('speedLimitNoUnit'), maxExportRate / (1024 * 1024) + ' MiB/s')}</Li>
-              )}
+              {maxExportRate > 0 && <Li>{_.keyValue(_('speedLimitNoUnit'), formatSize(maxExportRate) + '/s')}</Li>}
               {offlineBackup !== undefined && (
                 <Li>{_.keyValue(_('offlineBackup'), _(offlineBackup ? 'stateEnabled' : 'stateDisabled'))}</Li>
               )}

--- a/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
+++ b/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
@@ -316,13 +316,18 @@ class JobsTable extends React.Component {
       {
         itemRenderer: job => {
           const {
+            backupReportTpl,
+            cbtDestroySnapshotData,
             checkpointSnapshot,
             compression,
             concurrency,
             fullInterval,
+            maxExportRate,
+            nbdConcurrency,
             nRetriesVmBackupFailures,
             offlineBackup,
             offlineSnapshot,
+            preferNbd,
             proxyId,
             reportWhen,
             timeout,
@@ -338,9 +343,24 @@ class JobsTable extends React.Component {
               {reportWhen in REPORT_WHEN_LABELS && (
                 <Li>{_.keyValue(_('reportWhen'), _(REPORT_WHEN_LABELS[reportWhen]))}</Li>
               )}
+              {backupReportTpl !== undefined && (
+                <Li>{_.keyValue(_('shorterBackupReports'), _(backupReportTpl ? 'stateEnabled' : 'stateDisabled'))}</Li>
+              )}
               {concurrency !== undefined && <Li>{_.keyValue(_('concurrency'), concurrency)}</Li>}
+              {preferNbd && <Li>{_.keyValue(_('nbdConnections'), nbdConcurrency ?? 1)}</Li>}
+              {preferNbd && cbtDestroySnapshotData !== undefined && (
+                <Li>
+                  {_.keyValue(
+                    _('cbtDestroySnapshotData'),
+                    _(cbtDestroySnapshotData ? 'stateEnabled' : 'stateDisabled')
+                  )}
+                </Li>
+              )}
               {timeout !== undefined && <Li>{_.keyValue(_('timeout'), timeout / 3600e3)} hours</Li>}
               {fullInterval !== undefined && <Li>{_.keyValue(_('fullBackupInterval'), fullInterval)}</Li>}
+              {maxExportRate > 0 && (
+                <Li>{_.keyValue(_('speedLimitNoUnit'), maxExportRate / (1024 * 1024) + ' MiB/s')}</Li>
+              )}
               {offlineBackup !== undefined && (
                 <Li>{_.keyValue(_('offlineBackup'), _(offlineBackup ? 'stateEnabled' : 'stateDisabled'))}</Li>
               )}

--- a/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
+++ b/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
@@ -41,7 +41,7 @@ import getSettingsWithNonDefaultValue from '../_getSettingsWithNonDefaultValue'
 import { destructPattern } from '../utils'
 import { REPORT_WHEN_LABELS } from '../new/_reportWhen'
 import { LogStatus } from '../../logs/backup-ng'
-import { formatSize } from '../../../common/utils'
+import { formatSpeed } from '../../../common/utils'
 
 const Ul = props => <ul {...props} style={{ listStyleType: 'none' }} />
 const Li = props => (
@@ -359,7 +359,7 @@ class JobsTable extends React.Component {
               )}
               {timeout !== undefined && <Li>{_.keyValue(_('timeout'), timeout / 3600e3)} hours</Li>}
               {fullInterval !== undefined && <Li>{_.keyValue(_('fullBackupInterval'), fullInterval)}</Li>}
-              {maxExportRate > 0 && <Li>{_.keyValue(_('speedLimitNoUnit'), formatSize(maxExportRate) + '/s')}</Li>}
+              {maxExportRate > 0 && <Li>{_.keyValue(_('speedLimitNoUnit'), formatSpeed(maxExportRate, 1000))}</Li>}
               {offlineBackup !== undefined && (
                 <Li>{_.keyValue(_('offlineBackup'), _(offlineBackup ? 'stateEnabled' : 'stateDisabled'))}</Li>
               )}


### PR DESCRIPTION
### Description

Display more informations on the *Notes* column of the backup main page when values differ from default.
Maximum amount of information that can appear in *Notes* : 

![image](https://github.com/user-attachments/assets/dc5a08f1-3b78-4fec-9ba0-a7a872915616)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
