### PR TITLE
feat(xo-server/rest-api/dashboard): add S3 backup repositories information

### DIFF
--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -18,6 +18,7 @@ import fromEvent from 'promise-toolbox/fromEvent'
 import groupBy from 'lodash/groupBy.js'
 import pDefer from 'promise-toolbox/defer'
 import pickBy from 'lodash/pickBy.js'
+import reduce from 'lodash/reduce.js'
 import tar from 'tar'
 import zlib from 'zlib'
 
@@ -825,6 +826,17 @@ export class RemoteAdapter {
       }
     }
     return metadata
+  }
+
+  async getTotalVmBackupSize() {
+    const vmBackups = await this.listAllVmBackups()
+    return reduce(vmBackups, (sum, backups) => sum + backups.reduce((sum, backup) => sum + backup.size, 0), 0)
+  }
+
+  // @TODO: add `getTotalXoBackupSize` and `getTotalPoolBackupSize` once `size` is implemented
+  async getTotalBackupSize() {
+    const backupsSize = await Promise.all([this.getTotalVmBackupSize()])
+    return backupsSize.reduce((sum, backupSize) => sum + backupSize)
   }
 }
 

--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -845,9 +845,10 @@ export class RemoteAdapter {
     return this.#computeTotalBackupSizeRecursively(await this.listAllVmBackups())
   }
 
-  // @TODO: add `getTotalXoBackupSize` and `getTotalPoolBackupSize` once `size` is implemented
   async getTotalBackupSize() {
-    return this.#computeTotalBackupSizeRecursively(await Promise.all([this.getTotalVmBackupSize()]))
+    const vmBackupSize = await this.getTotalVmBackupSize()
+    // @TODO: add `getTotalXoBackupSize` and `getTotalPoolBackupSize` once `size` is implemented by fs
+    return vmBackupSize
   }
 }
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
 - [V2V] Fix computation of `memory_static_max`
 - **XO 6**:
   - [Dashboard] Display backup issues data (PR [#7974](https://github.com/vatesfr/xen-orchestra/pull/7974))
+- [REST API] Add S3 backup repository information in the `/rest/v0/dashboard` endpoint (PR [#7978](https://github.com/vatesfr/xen-orchestra/pull/7978))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/remotes.mjs
+++ b/packages/xo-server/src/xo-mixins/remotes.mjs
@@ -174,7 +174,7 @@ export default class {
             })
           : this.getRemoteHandler(remote.id).then(handler => handler.getInfo())
 
-      const sizeUsedForBackups = await Disposable.use(this._app.getBackupsRemoteAdapter(remote), adapter =>
+      const totalBackupSize = await Disposable.use(this._app.getBackupsRemoteAdapter(remote), adapter =>
         adapter.getTotalBackupSize()
       ).catch(noop)
 
@@ -183,7 +183,7 @@ export default class {
           promise.then(info => {
             remotesInfo[remote.id] = {
               ...info,
-              sizeUsedForBackups,
+              totalBackupSize,
               encryption,
             }
           }),

--- a/packages/xo-server/src/xo-mixins/remotes.mjs
+++ b/packages/xo-server/src/xo-mixins/remotes.mjs
@@ -174,16 +174,16 @@ export default class {
             })
           : this.getRemoteHandler(remote.id).then(handler => handler.getInfo())
 
-      try {
-        const sizeUsedForBackup = await Disposable.use(this._app.getBackupsRemoteAdapter(remote), adapter =>
-          adapter.getTotalBackupSize()
-        ).catch(noop)
+      const sizeUsedForBackups = await Disposable.use(this._app.getBackupsRemoteAdapter(remote), adapter =>
+        adapter.getTotalBackupSize()
+      ).catch(noop)
 
+      try {
         await timeout.call(
           promise.then(info => {
             remotesInfo[remote.id] = {
               ...info,
-              sizeUsedForBackup,
+              sizeUsedForBackups,
               encryption,
             }
           }),

--- a/packages/xo-server/src/xo-mixins/remotes.mjs
+++ b/packages/xo-server/src/xo-mixins/remotes.mjs
@@ -1,5 +1,4 @@
 import asyncMapSettled from '@xen-orchestra/async-map/legacy.js'
-import Disposable from 'promise-toolbox/Disposable'
 import Obfuscate from '@vates/obfuscate'
 import { basename } from 'path'
 import { createLogger } from '@xen-orchestra/log'
@@ -10,7 +9,6 @@ import { invalidParameters, noSuchObject } from 'xo-common/api-errors.js'
 import { synchronized } from 'decorator-synchronized'
 
 import patch from '../patch.mjs'
-import { noop } from '../utils.mjs'
 import { Remotes } from '../models/remote.mjs'
 
 // ===================================================================
@@ -174,16 +172,11 @@ export default class {
             })
           : this.getRemoteHandler(remote.id).then(handler => handler.getInfo())
 
-      const totalBackupSize = await Disposable.use(this._app.getBackupsRemoteAdapter(remote), adapter =>
-        adapter.getTotalBackupSize()
-      ).catch(noop)
-
       try {
         await timeout.call(
           promise.then(info => {
             remotesInfo[remote.id] = {
               ...info,
-              totalBackupSize,
               encryption,
             }
           }),

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -240,14 +240,15 @@ async function _getDashboardStats(app) {
         continue
       }
 
-      const { available, size, sizeUsedForBackups = 0, used } = backupRepositoryInfo
+      const { available, size, totalBackupSize, used } = backupRepositoryInfo
+
       const isS3 = type === 's3'
       const target = isS3 ? s3Brsize : otherBrSize
 
-      target.backups += sizeUsedForBackups
+      target.backups += totalBackupSize?.onDisk ?? 0
       if (!isS3) {
         target.available += available
-        target.other += used - sizeUsedForBackups
+        target.other += used - (totalBackupSize?.onDisk ?? 0)
         target.total += size
         target.used += used
       }

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -250,14 +250,14 @@ async function _getDashboardStats(app) {
         continue
       }
 
-      const sizeUsedForBackup = remoteInfo.sizeUsedForBackup ?? 0
+      const sizeUsedForBackups = remoteInfo.sizeUsedForBackups ?? 0
       const isS3 = type === 's3'
       const target = isS3 ? backupRepositoriesSize.s3 : backupRepositoriesSize.other
 
-      target.backups += sizeUsedForBackup
+      target.backups += sizeUsedForBackups
       if (!isS3) {
         target.available += remoteInfo.available
-        target.other += remoteInfo.used - sizeUsedForBackup
+        target.other += remoteInfo.used - sizeUsedForBackups
         target.total += remoteInfo.size
         target.used += remoteInfo.used
       }


### PR DESCRIPTION
### Description

`XO metadata backups` and `Pool metadata backups` are intentionally not counted, they do not have a `size` property at the moment

```js
{
 ...,
 backupRepositories: {
    s3: {
        size: {
          backups: number
        }
    },
    other: {
       size: {
          available: number,
          backups: number,
          other: number,
          total: number,
          used: number
      }
    }
  } | undefined
}
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
