### PR TITLE
fix(web-core): tooltip position does not update when content changes

### DIFF
--- a/@xen-orchestra/web-core/lib/components/tooltip/TooltipItem.vue
+++ b/@xen-orchestra/web-core/lib/components/tooltip/TooltipItem.vue
@@ -10,7 +10,7 @@ import type { TooltipOptions } from '@core/stores/tooltip.store'
 import { hasEllipsis } from '@core/utils/has-ellipsis.util'
 import { isString } from 'lodash-es'
 import place from 'placement.js'
-import { computed, ref, watchEffect } from 'vue'
+import { computed, ref, watch, watchEffect } from 'vue'
 
 const props = defineProps<{
   target: HTMLElement
@@ -41,13 +41,19 @@ const isDisabled = computed(() => content.value === false)
 
 const placement = computed(() => props.options.placement ?? 'top')
 
-watchEffect(() => {
-  if (tooltipElement.value) {
-    place(props.target, tooltipElement.value, {
-      placement: placement.value,
-    })
+function updatePlacement() {
+  if (!tooltipElement.value) {
+    return
   }
-})
+
+  place(props.target, tooltipElement.value, {
+    placement: placement.value,
+  })
+}
+
+watchEffect(() => updatePlacement(), { flush: 'post' })
+
+watch(content, () => updatePlacement(), { flush: 'post' })
 </script>
 
 <style lang="postcss" scoped>


### PR DESCRIPTION
### Description

Tooltip position was not updated when the length of the content changed.

#### Before

![Tooltip position fix - Before](https://github.com/user-attachments/assets/b32359ed-e102-4251-801d-38ccad27188e)

#### After

![Tooltip position fix - After](https://github.com/user-attachments/assets/2362d93d-4c97-4fdf-b5fd-09ab4fa2f95f)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
