### PR TITLE
fix(xo-web/backup): avoid 0 value for backup speed limit

### DIFF
--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -272,6 +272,10 @@ const New = decorate([
           }
         }
 
+        if (settings[''].maxExportRate <= 0) {
+          settings[''].maxExportRate = undefined
+        }
+
         await createBackupNgJob({
           name: state.name,
           mode: state.isDelta ? 'delta' : 'full',
@@ -338,19 +342,25 @@ const New = decorate([
           })
         )
 
+        const normalizedSettings = normalizeSettings({
+          offlineBackupActive: state.offlineBackupActive,
+          settings: settings || state.propSettings,
+          exportMode: state.exportMode,
+          copyMode: state.copyMode,
+          snapshotMode: state.snapshotMode,
+        }).toObject()
+
+        if (normalizedSettings[''].maxExportRate <= 0) {
+          normalizedSettings[''].maxExportRate = undefined
+        }
+
         await editBackupNgJob({
           id: props.job.id,
           name: state.name,
           mode: state.isDelta ? 'delta' : 'full',
           compression: state.compression,
           proxy: state.proxyId,
-          settings: normalizeSettings({
-            offlineBackupActive: state.offlineBackupActive,
-            settings: settings || state.propSettings,
-            exportMode: state.exportMode,
-            copyMode: state.copyMode,
-            snapshotMode: state.snapshotMode,
-          }).toObject(),
+          settings: normalizedSettings,
           remotes: state.deltaMode || state.backupMode ? constructPattern(state.remotes) : constructPattern([]),
           srs: state.crMode || state.drMode ? constructPattern(state.srs) : constructPattern([]),
           vms: state.smartMode ? state.vmsSmartPattern : constructPattern(state.vms),


### PR DESCRIPTION
### Description

Backup job's speed limit (`maxExportRate`) had values `0` and `undefined` leading to the same behaviour, but the values were both accepted, which could be confusing. Null values are now replaced by `undefined` when creating or editing a backup job.

I don't think it's useful to mention this in the changelog.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
