### PR TITLE
feat(xo-server/api): add a schedule.runSequence method

### DIFF
--- a/packages/xo-server/src/api/schedule.mjs
+++ b/packages/xo-server/src/api/schedule.mjs
@@ -67,17 +67,16 @@ delete_.params = {
 
 export { delete_ as delete }
 
-export async function runSequence({ idSchedules }) {
-  const t = new Task({ properties: { type: 'xo:schedule:sequence', name: 'Schedule sequence' } })
+export async function runSequence({ schedules }) {
+  const t = this.tasks.create({ type: 'xo:schedule:sequence', name: 'Schedule sequence' })
   await t.run(async () => {
-    const nb = idSchedules.length
+    const nb = schedules.length
     const signal = Task.abortSignal
     for (let i = 0; i < nb; i++) {
-      if (signal.aborted) {
-        throw new Error(signal.reason)
-      }
+      signal.throwIfAborted()
       Task.set('progress', Math.round((i * 100) / nb))
-      const idSchedule = idSchedules[i]
+      const idSchedule = schedules[i]
+      // we can't auto resolve array parameters, we have to resolve them by hand
       const schedule = await this.getSchedule(idSchedule)
       const job = await this.getJob(schedule.jobId)
       await this.runJob(job, schedule)
@@ -85,7 +84,7 @@ export async function runSequence({ idSchedules }) {
   })
 }
 runSequence.permission = 'admin'
-runSequence.description = 'Run a sequence of schedule, one after the other'
+runSequence.description = 'Run a sequence of schedules, one after the other'
 runSequence.params = {
-  idSchedules: { type: 'array', items: { type: 'string' } },
+  schedules: { type: 'array', items: { type: 'string' } },
 }

--- a/packages/xo-server/src/api/schedule.mjs
+++ b/packages/xo-server/src/api/schedule.mjs
@@ -64,3 +64,18 @@ delete_.params = {
 }
 
 export { delete_ as delete }
+
+
+export async function runSequence({idSchedules}){
+
+  for(const idSchedule of idSchedules){
+    const schedule = await this.getSchedule(idSchedule)
+    const job = await this.getJob(schedule.jobId)
+    await this.runJob(job,schedule)
+  }
+}
+runSequence.permission = 'admin'
+runSequence.description = 'Run a sequence of schedule, one after the other'
+runSequence.params = {
+  idSchedules: { type: 'array', items: { type: 'string'} },
+}

--- a/packages/xo-server/src/xo-mixins/jobs/index.mjs
+++ b/packages/xo-server/src/xo-mixins/jobs/index.mjs
@@ -165,7 +165,7 @@ export default class Jobs {
   }
 
   @decorateWith(defer)
-  async _runJob($defer, job, schedule, data_) {
+  async runJob($defer, job, schedule, data_) {
     const logger = this._logger
     const { id, type } = job
 
@@ -316,7 +316,7 @@ export default class Jobs {
     const jobs = await Promise.all(idSequence.map(id => this.getJob(id)))
 
     for (const job of jobs) {
-      await this._runJob(job, schedule, data)
+      await this.runJob(job, schedule, data)
     }
   }
 }


### PR DESCRIPTION
### Description

This expects a job formatted like 


```js
{
  id: 'f3c1b137-9b68-45a1-ad79-342fd826e379',
  key: 'genericTask',
  method: 'schedule.runSequence',
  name: 'demo2',
  paramsVector: '{"type":"crossProduct","items":[{"type":"set","values":[{"idSchedules":["e9bbf460-0174-4e37-9670-9e8ddf382fd3","e9bbf460-0174-4e37-9670-9e8ddf382fd3"]}]}]}',
  type: 'call',
  userId: '50cb27bd-cbad-4683-93fa-104578ef9034'
}
```
where idSchedules are id of the schedules of a backup job
these ids can be obtained by the command `xo-server-db ls schedule` from the xo-server/dist folder


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
