### PR TITLE
fix(xo-web/backup): fix error when creating a backup job

### DIFF
--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -263,7 +263,7 @@ const New = decorate([
             [id]: DEFAULT_SCHEDULE,
           }
           settings = {
-            '': state.settings && state.settings.get(''),
+            '': state.settings?.get(''),
             [id]: {
               copyRetention: state.copyMode ? DEFAULT_RETENTION : undefined,
               exportRetention: state.exportMode ? DEFAULT_RETENTION : undefined,
@@ -272,7 +272,7 @@ const New = decorate([
           }
         }
 
-        if (settings[''].maxExportRate <= 0) {
+        if (settings['']?.maxExportRate <= 0) {
           settings[''].maxExportRate = undefined
         }
 

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -350,7 +350,7 @@ const New = decorate([
           snapshotMode: state.snapshotMode,
         }).toObject()
 
-        if (normalizedSettings[''].maxExportRate <= 0) {
+        if (normalizedSettings['']?.maxExportRate <= 0) {
           normalizedSettings[''].maxExportRate = undefined
         }
 


### PR DESCRIPTION
### Description

Introduced by 8a9a67c
Fixes #7990 
An error ```r[''] is undefined``` used to occur when creating a backup job.
Second commit: while fixing this issue, another error was found when editing a backup job : ```normalizedSettings[''] is undefined```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
