### PR TITLE
feat(xo-server, xo-web): warning for too small host TLS keys

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@
 - [SR/Disks] Display information if the VDI is an empty metadata snapshot (PR [#7970](https://github.com/vatesfr/xen-orchestra/pull/7970))
 - [Netbox] Do not synchronize if detected minor version is not supported (PR [#7992](https://github.com/vatesfr/xen-orchestra/pull/7992))
 - [Netbox] Support version 4.1 [#7966](https://github.com/vatesfr/xen-orchestra/issues/7966) (PR [#8002](https://github.com/vatesfr/xen-orchestra/pull/8002))
+- [Hosts] Display a warning for hosts whose TLS key is too short to update to XCP-ng 8.3 (PR [#7995](https://github.com/vatesfr/xen-orchestra/pull/7995))
 - **XO 6**:
   - [Dashboard] Display backup issues data (PR [#7974](https://github.com/vatesfr/xen-orchestra/pull/7974))
 - [REST API] Add S3 backup repository and VMs protection information in the `/rest/v0/dashboard` endpoint (PRs [#7978](https://github.com/vatesfr/xen-orchestra/pull/7978), [#7964](https://github.com/vatesfr/xen-orchestra/pull/7964))

--- a/packages/xo-server/src/api/host.mjs
+++ b/packages/xo-server/src/api/host.mjs
@@ -8,6 +8,7 @@ import { X509Certificate } from 'node:crypto'
 
 import backupGuard from './_backupGuard.mjs'
 
+const CERT_PUBKEY_MIN_SIZE = 2048
 const IPMI_CACHE_TTL = 6e4
 const IPMI_CACHE = new TTLCache({
   ttl: IPMI_CACHE_TTL,
@@ -537,7 +538,7 @@ export async function isPubKeyTooShort({ host }) {
   const certificate = await this.getXapi(host).call('host.get_server_certificate', host._xapiRef)
 
   const cert = new X509Certificate(certificate)
-  return cert.publicKey.asymmetricKeyDetails.modulusLength < 2048
+  return cert.publicKey.asymmetricKeyDetails.modulusLength < CERT_PUBKEY_MIN_SIZE
 }
 
 isPubKeyTooShort.description = 'get TLS key information'

--- a/packages/xo-server/src/api/host.mjs
+++ b/packages/xo-server/src/api/host.mjs
@@ -541,7 +541,7 @@ export async function isPubKeyTooShort({ host }) {
   return cert.publicKey.asymmetricKeyDetails.modulusLength < CERT_PUBKEY_MIN_SIZE
 }
 
-isPubKeyTooShort.description = 'get TLS key information'
+isPubKeyTooShort.description = 'check if host public TLS key is long enough'
 
 isPubKeyTooShort.params = {
   id: { type: 'string' },

--- a/packages/xo-server/src/api/host.mjs
+++ b/packages/xo-server/src/api/host.mjs
@@ -534,14 +534,9 @@ setControlDomainMemory.resolve = {
 // -------------------------------------------------------------------
 
 export async function isPubKeyTooShort({ host }) {
-  const certificate = await this.getXapi(host).callAsync('host.get_server_certificate', host._xapiRef)
+  const certificate = await this.getXapi(host).call('host.get_server_certificate', host._xapiRef)
 
-  // begin and end of certificate need to be on separate lines for correct parsing
-  const correctedCertificate = certificate
-    .replace(/(-----BEGIN CERTIFICATE-----)([^\n]+)/, '$1\n$2')
-    .replace(/([^\n]+)(-----END CERTIFICATE-----)/, '$1\n$2')
-  const cert = new X509Certificate(correctedCertificate)
-
+  const cert = new X509Certificate(certificate)
   return cert.publicKey.asymmetricKeyDetails.modulusLength < 2048
 }
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1015,6 +1015,11 @@ const messages = {
   hostNoSupport: 'No XCP-ng Pro Support enabled on this host',
   hostSupportEnabled: 'XCP-ng Pro Support enabled on this host',
   noMoreMaintained: 'This host version is no longer maintained',
+  pubKeyTooShort: 'TLS key is too small to update host to XCP-ng 8.3',
+  longerCustomCertficate:
+    'If your certificate is custom, you need to install a new one with a key length of 2048 or greater.',
+  longerDefaultCertificate:
+    'If your certificate is the default self-signed certificate from host installation, you need to re-generate it from XCP-ng 8.2.1.',
 
   // ----- Host actions ------
   disableMaintenanceMode: 'Disable maintenance mode',

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -1373,6 +1373,8 @@ export const installCertificateOnHost = (id, props) => _call('host.installCertif
 
 export const setControlDomainMemory = (id, memory) => _call('host.setControlDomainMemory', { id, memory })
 
+export const isPubKeyTooShort = (id) => _call('host.isPubKeyTooShort', { id })
+
 // for XCP-ng now
 export const installAllPatchesOnHost = ({ host }) =>
   confirm({


### PR DESCRIPTION
### Description

Display a warning in host list when host TLS key is too short to update to XCP-ng 8.3

![image](https://github.com/user-attachments/assets/be41105b-6a88-4a01-8cb5-e5889c740799)

![image](https://github.com/user-attachments/assets/ed356425-8ff8-482b-9a00-e424b3bd5fdb)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
