### PR TITLE
fix(xo-lite/stories): add missing required props for UiButton component configs

### DIFF
--- a/@xen-orchestra/lite/src/stories/modals/layouts/confirm-modal-layout.story.vue
+++ b/@xen-orchestra/lite/src/stories/modals/layouts/confirm-modal-layout.story.vue
@@ -15,8 +15,8 @@
       <template #title>{{ settings.title }}</template>
       <template #subtitle>{{ settings.subtitle }}</template>
       <template #buttons>
-        <UiButton level="secondary">I prefer not</UiButton>
-        <UiButton>Yes, I'm sure!</UiButton>
+        <UiButton level="secondary" color="normal" size="medium">I prefer not</UiButton>
+        <UiButton level="primary" color="normal" size="medium">Yes, I'm sure!</UiButton>
       </template>
     </ConfirmModalLayout>
   </ComponentStory>

--- a/@xen-orchestra/lite/src/stories/modals/layouts/form-modal-layout.story.vue
+++ b/@xen-orchestra/lite/src/stories/modals/layouts/form-modal-layout.story.vue
@@ -23,8 +23,8 @@
       </div>
 
       <template #buttons>
-        <UiButton level="secondary">Cancel</UiButton>
-        <UiButton>Migrate 3 VMs</UiButton>
+        <UiButton level="secondary" color="normal" size="medium">Cancel</UiButton>
+        <UiButton level="primary" color="normal" size="medium">Migrate 3 VMs</UiButton>
       </template>
     </FormModalLayout>
   </ComponentStory>

--- a/@xen-orchestra/lite/src/stories/web-core/button/button-group.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/button/button-group.story.vue
@@ -7,10 +7,10 @@
     ]"
   >
     <ButtonGroup v-bind="properties">
-      <UiButton level="secondary">Cancel</UiButton>
-      <UiButton>Call to action</UiButton>
+      <UiButton level="secondary" color="normal" size="medium">Cancel</UiButton>
+      <UiButton level="primary" color="normal" size="medium">Call to action</UiButton>
       <template #tertiary>
-        <UiButton level="tertiary" color="warning">Secondary call to action</UiButton>
+        <UiButton level="tertiary" color="warning" size="medium">Secondary call to action</UiButton>
       </template>
     </ButtonGroup>
   </ComponentStory>

--- a/@xen-orchestra/lite/src/stories/web-core/button/ui-button.story.md
+++ b/@xen-orchestra/lite/src/stories/web-core/button/ui-button.story.md
@@ -1,5 +1,5 @@
 Here is some doc for UiButton component
 
 ```vue-template
-<UiButton @click="doSomething">Click me</UiButton>
+<UiButton level="primary" color="normal" size="medium" @click="doSomething">Click me</UiButton>
 ```

--- a/@xen-orchestra/lite/src/stories/web-core/card/card-title.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/card/card-title.story.vue
@@ -15,7 +15,7 @@
       <UiCounter :value="3" color="danger" size="medium" />
       <template #info>
         {{ settings.infoSlotContent }}
-        <UiButton level="tertiary" size="small" :right-icon="faAngleRight">See all</UiButton>
+        <UiButton level="tertiary" size="small" color="normal" :right-icon="faAngleRight">See all</UiButton>
       </template>
       <template #description>{{ settings.descriptionSlotContent }}</template>
     </CardTitle>

--- a/@xen-orchestra/lite/src/stories/web-core/head-bar/head-bar.story.md
+++ b/@xen-orchestra/lite/src/stories/web-core/head-bar/head-bar.story.md
@@ -7,8 +7,8 @@
     <ObjectIcon type="host" state="running" size="medium" />
   </template>
   <template #actions>
-    <UiButton size="medium" :left-icon="faPlus">New VM</UiButton>
-    <UiButton size="medium" :left-icon="faPowerOff">Change state</UiButton>
+    <UiButton size="medium" level="primary" color="normal" :left-icon="faPlus">New VM</UiButton>
+    <UiButton size="medium" level="secondary" color="normal" :left-icon="faPowerOff">Change state</UiButton>
   </template>
 </HeadBar>
 ```

--- a/@xen-orchestra/lite/src/stories/web-core/head-bar/head-bar.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/head-bar/head-bar.story.vue
@@ -19,8 +19,8 @@
         migrating... (34%)
       </template>
       <template v-if="settings.showDemoButtons" #actions>
-        <UiButton size="medium" :left-icon="faPlus">New VM</UiButton>
-        <UiButton size="medium" :left-icon="faPowerOff">Change state</UiButton>
+        <UiButton size="medium" level="primary" color="normal" :left-icon="faPlus">New VM</UiButton>
+        <UiButton size="medium" level="secondary" color="normal" :left-icon="faPowerOff">Change state</UiButton>
       </template>
     </HeadBar>
   </ComponentStory>


### PR DESCRIPTION
### Description

Introduced by f969056

The `UiButton` component usages in the stories weren’t using the required props, causing these stories to break.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
