### PR TITLE
feat(backups): implement long term retention

### DIFF
--- a/@xen-orchestra/backups/_getOldEntries.mjs
+++ b/@xen-orchestra/backups/_getOldEntries.mjs
@@ -1,4 +1,86 @@
+const LTR_DEFINITIONS = {
+  daily: {
+    makeDateFormatter: ({ firstHourOfTheDay = 0 } = {}) => {
+      return date => {
+        const copy = new Date(date)
+        copy.setHours(copy.getHours() - firstHourOfTheDay)
+        return `${copy.getFullYear()}-${copy.getMonth()}-${copy.getDate()}`
+      }
+    },
+  },
+  weekly: {
+    makeDateFormatter: ({ firstDayOfWeek = 1 /* sunday is 0 , let's use monday as default instead */ } = {}) => {
+      return date => {
+        const copy = new Date(date)
+        copy.setDate(date.getDate() - ((date.getDay() + 7 - firstDayOfWeek) % 7))
+        return `${copy.getFullYear()}-${copy.getMonth()}-${copy.getDate()}`
+      }
+    },
+    ancestor: 'daily',
+  },
+  monthly: {
+    makeDateFormatter: ({ firstDayOfMonth = 0 } = {}) => {
+      return date => {
+        const copy = new Date(date)
+        copy.setDate(copy.getDate() - firstDayOfMonth)
+        return `${copy.getFullYear()}-${copy.getMonth()}`
+      }
+    },
+    ancestor: 'weekly',
+  },
+  yearly: {
+    makeDateFormatter: () => {
+      return date => `${date.getFullYear()}`
+    },
+    ancestor: 'monthly',
+  },
+}
+
 // returns all entries but the last retention-th
-export function getOldEntries(retention, entries) {
-  return entries === undefined ? [] : retention > 0 ? entries.slice(0, -retention) : entries
+/**
+ * return the entries too old to be kept
+ *  if multiple entries are i the same time bucket : keep only the most recent one
+ *  if an entry is valid in any of the bucket OR the  minRetentionCount : keep it
+ *  if a bucket is cmpletly empty : it does not count as one, thus it may extend the retention
+ * @returns Array<Backup>
+ */
+export function getOldEntries(minRetentionCount, entries, { longTermRetention = {} } = {}) {
+  const dateBuckets = {}
+  for (const [duration, { retention, settings }] of Object.entries(longTermRetention)) {
+    if (LTR_DEFINITIONS[duration] === undefined) {
+      throw new Error(`Retention of type ${retention} is invalid`)
+    }
+    dateBuckets[duration] = {
+      remaining: retention,
+      lastMatchingBucket: null,
+      formatter: LTR_DEFINITIONS[duration].makeDateFormatter(settings),
+    }
+  }
+  const nb = entries.length
+  const oldEntries = []
+
+  for (let i = nb - 1; i >= 0; i--) {
+    const entry = entries[i]
+    const entryDate = new Date(entry.timestamp)
+    let shouldBeKept = false
+    for (const [duration, { remaining, lastMatchingBucket, formatter }] of Object.entries(dateBuckets)) {
+      if (remaining === 0) {
+        continue
+      }
+      const bucket = formatter(entryDate)
+      if (lastMatchingBucket !== bucket) {
+        shouldBeKept = true
+        dateBuckets[duration].remaining -= 1
+        dateBuckets[duration].lastMatchingBucket = bucket
+      }
+    }
+    if (i >= nb - minRetentionCount) {
+      shouldBeKept = true
+    }
+    if (!shouldBeKept) {
+      oldEntries.push(entry)
+    }
+  }
+  // we expect the entries to be in the right order
+  return oldEntries.reverse()
 }

--- a/@xen-orchestra/backups/_getOldEntries.mjs
+++ b/@xen-orchestra/backups/_getOldEntries.mjs
@@ -55,17 +55,40 @@ const LTR_DEFINITIONS = {
  * return the entries too old to be kept
  *  if multiple entries are i the same time bucket : keep only the most recent one
  *  if an entry is valid in any of the bucket OR the  minRetentionCount : keep it
- *  if a bucket is cmpletly empty : it does not count as one, thus it may extend the retention
+ *  if a bucket is completly empty : it does not count as one, thus it may extend the retention
  * @returns Array<Backup>
  */
 export function getOldEntries(minRetentionCount, entries, { longTermRetention = {}, timezone } = {}) {
+  assert.strictEqual(
+    typeof minRetentionCount,
+    'number',
+    `minRetentionCount must be a number, got ${JSON.stringify(minRetentionCount)}`
+  )
+  assert.strictEqual(
+    minRetentionCount >= 0,
+    true,
+    `minRetentionCount must be a positive number, got ${JSON.stringify(minRetentionCount)}`
+  )
   const dateBuckets = {}
   const dateCreator = instantiateTimezonedDateCreator(timezone)
   // only check buckets that have a retention set
   for (const [duration, { retention, settings }] of Object.entries(longTermRetention)) {
-    if (LTR_DEFINITIONS[duration] === undefined) {
-      throw new Error(`Retention of type ${retention} is invalid`)
-    }
+    assert.notStrictEqual(LTR_DEFINITIONS[duration], undefined, `Retention of type ${duration} is not defined`)
+    assert.notStrictEqual(
+      timezone,
+      undefined,
+      `timezone must defined for ltr, got ${JSON.stringify({ minRetentionCount, longTermRetention, timezone })}`
+    )
+    assert.strictEqual(
+      typeof retention,
+      'number',
+      `retention  of type ${duration} must be a number, got ${JSON.stringify(retention)}`
+    )
+    assert.strictEqual(
+      retention > 0,
+      true,
+      `retention  of type ${duration} must be a positive number, got ${JSON.stringify(retention)}`
+    )
     dateBuckets[duration] = {
       remaining: retention,
       lastMatchingBucket: null,

--- a/@xen-orchestra/backups/_getOldEntries.mjs
+++ b/@xen-orchestra/backups/_getOldEntries.mjs
@@ -2,7 +2,11 @@ import moment from 'moment-timezone'
 import assert from 'node:assert'
 
 function instantiateTimezonedDateCreator(timezone) {
-  return date => (timezone ? moment.tz(date, timezone) : moment(date))
+  return date => {
+    const transformed = timezone ? moment.tz(date, timezone) : moment(date)
+    assert.ok(transformed.isValid(), `date ${date} , timezone ${timezone} is invalid`)
+    return transformed
+  }
 }
 
 const LTR_DEFINITIONS = {

--- a/@xen-orchestra/backups/_getOldEntries.test.mjs
+++ b/@xen-orchestra/backups/_getOldEntries.test.mjs
@@ -242,9 +242,9 @@ describe('_getOldEntries() should fail when called incorrectly', () => {
       args: [
         5,
         [
-          { timestamp: new Date('2024-09-01'), id: 1 },
-          { timestamp: new Date('2024-09-03'), id: 3 },
-          { timestamp: new Date('2024-09-02'), id: 2 },
+          { timestamp: +new Date('2024-09-01'), id: 1 },
+          { timestamp: +new Date('2024-09-03'), id: 3 },
+          { timestamp: +new Date('2024-09-02'), id: 2 },
         ],
         {
           longTermRetention: {
@@ -254,6 +254,23 @@ describe('_getOldEntries() should fail when called incorrectly', () => {
         },
       ],
       testLabel: 'unsorted entries ',
+    },
+
+    {
+      args: [
+        5,
+        [
+          { timestamp: 'notadate', id: 1 },
+          { timestamp: 'still not a date, but after', id: 3 },
+        ],
+        {
+          longTermRetention: {
+            daily: { retention: 5 },
+          },
+          timezone: 'Europe/Paris',
+        },
+      ],
+      testLabel: 'broken date ',
     },
   ]
 

--- a/@xen-orchestra/backups/_getOldEntries.test.mjs
+++ b/@xen-orchestra/backups/_getOldEntries.test.mjs
@@ -34,6 +34,7 @@ describe('_getOldEntries() should succeed', () => {
           longTermRetention: {
             daily: { retention: 3 },
           },
+          timezone: 'Europe/Paris',
         },
       ],
       expectedIds: [1, 2, 3, 6],
@@ -81,6 +82,7 @@ describe('_getOldEntries() should succeed', () => {
           longTermRetention: {
             monthly: { retention: 3 },
           },
+          timezone: 'Europe/Paris',
         },
       ],
       expectedIds: [1, 3, 4, 6, 7],
@@ -160,5 +162,104 @@ describe('_getOldEntries() should succeed', () => {
   }
 })
 
-describe('_getOldEntries() should fail when called incorrectly', () => {})
-describe('_getOldEntries() should handle picking specific backup to promote', () => {})
+describe('_getOldEntries() should fail when called incorrectly', () => {
+  const tests = [
+    {
+      args: [
+        -1,
+        [
+          { timestamp: 1, id: 1 },
+          { timestamp: 3, id: 2 },
+          { timestamp: 2, id: 3 },
+        ],
+      ],
+      testLabel: 'negative min retention ',
+    },
+    {
+      args: [
+        { not: 'a number' },
+        [
+          { timestamp: 1, id: 1 },
+          { timestamp: 3, id: 2 },
+          { timestamp: 2, id: 3 },
+        ],
+      ],
+      testLabel: 'non number min retention ',
+    },
+    {
+      args: [
+        4,
+        [
+          { timestamp: 1, id: 1 },
+          { timestamp: 2, id: 2 },
+          { timestamp: 3, id: 3 },
+        ],
+        {
+          longTermRetention: {
+            invalidType: { retention: 3 },
+          },
+          timezone: 'Europe/Paris',
+        },
+      ],
+      testLabel: 'invalid type ltr ',
+    },
+    {
+      args: [
+        3,
+        [
+          { timestamp: 1, id: 1 },
+          { timestamp: 3, id: 2 },
+          { timestamp: 2, id: 3 },
+        ],
+        {
+          longTermRetention: {
+            daily: { retention: 0 },
+          },
+          timezone: 'Europe/Paris',
+        },
+      ],
+      testLabel: 'zero retention ltr ',
+    },
+    {
+      args: [
+        1,
+        [
+          { timestamp: 1, id: 1 },
+          { timestamp: 2, id: 2 },
+          { timestamp: 3, id: 3 },
+        ],
+        {
+          longTermRetention: {
+            daily: { retention: 'not a number' },
+          },
+          timezone: 'Europe/Paris',
+        },
+      ],
+      testLabel: 'no timezone ltr ',
+    },
+
+    {
+      args: [
+        5,
+        [
+          { timestamp: new Date('2024-09-01'), id: 1 },
+          { timestamp: new Date('2024-09-03'), id: 3 },
+          { timestamp: new Date('2024-09-02'), id: 2 },
+        ],
+        {
+          longTermRetention: {
+            daily: { retention: 5 },
+          },
+          timezone: 'Europe/Paris',
+        },
+      ],
+      testLabel: 'unsorted entries ',
+    },
+  ]
+
+  for (const { args, testLabel } of tests) {
+    it(testLabel, () => {
+      assert.throws(() => getOldEntries.apply(null, args), { code: 'ERR_ASSERTION' })
+    })
+  }
+})

--- a/@xen-orchestra/backups/_getOldEntries.test.mjs
+++ b/@xen-orchestra/backups/_getOldEntries.test.mjs
@@ -1,0 +1,132 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { getOldEntries } from './_getOldEntries.mjs'
+
+describe('_getOldEntries() should succeed', () => {
+  const tests = [
+    {
+      args: [
+        1,
+        [
+          { timestamp: 1, id: 1 },
+          { timestamp: 3, id: 2 },
+          { timestamp: 2, id: 3 },
+        ],
+      ],
+      expectedIds: [1, 2],
+      testLabel: 'should  handle number based retention ',
+    },
+
+    {
+      args: [
+        0,
+        [
+          { timestamp: +new Date('2024-09-01 00:01:00'), id: 1 }, // too old
+          { timestamp: +new Date('2024-09-01 00:00:00'), id: 2 }, // too old
+          { timestamp: +new Date('2024-09-02 00:09:00'), id: 3 }, // too old in same day
+          { timestamp: +new Date('2024-09-02 00:10:00'), id: 4 },
+          { timestamp: +new Date('2024-09-03 00:09:00'), id: 5 },
+          { timestamp: +new Date('2024-09-04 00:09:00'), id: 6 }, // too old in same day
+          { timestamp: +new Date('2024-09-04 00:10:00'), id: 7 },
+        ],
+        {
+          longTermRetention: {
+            daily: { retention: 3 },
+          },
+        },
+      ],
+      expectedIds: [1, 2, 3, 6],
+      testLabel: 'should  handle day based retention  ',
+    },
+    {
+      args: [
+        0,
+        [
+          { timestamp: +new Date('2024-09-01 00:01:00'), id: 1 }, // week n-3 too old
+          { timestamp: +new Date('2024-09-02 00:00:00'), id: 2 }, // week n-3 too old
+          { timestamp: +new Date('2024-09-03 00:09:00'), id: 3 }, // week n-2
+          { timestamp: +new Date('2024-09-04 00:09:00'), id: 4 }, // week n-2
+          { timestamp: +new Date('2024-09-05 00:09:00'), id: 5 }, // week n-2
+          { timestamp: +new Date('2024-09-06 00:09:00'), id: 6 }, // week n-2
+          { timestamp: +new Date('2024-09-07 00:09:00'), id: 7 }, // week n-2
+          { timestamp: +new Date('2024-09-09 00:09:00'), id: 8 }, // week n-2 , most recent kept
+          { timestamp: +new Date('2024-09-15 00:09:00'), id: 9 }, // week n-1  kept
+          { timestamp: +new Date('2024-09-22 00:09:00'), id: 10 }, // week n  kept
+        ],
+        {
+          longTermRetention: {
+            weekly: { retention: 3 },
+          },
+        },
+      ],
+      expectedIds: [1, 2, 3, 4, 5, 6, 8],
+      testLabel: 'should  handle week based retention  ',
+    },
+    {
+      args: [
+        0,
+        [
+          { timestamp: +new Date('2024-06-22 00:09:00'), id: 1 }, // too old
+          { timestamp: +new Date('2024-07-31 00:09:00'), id: 2 }, // first of july
+          { timestamp: +new Date('2024-08-01 00:09:00'), id: 3 }, // older of august
+          { timestamp: +new Date('2024-08-05 00:09:00'), id: 4 }, // older of august
+          { timestamp: +new Date('2024-08-07 00:09:00'), id: 5 }, // most recent of august
+          { timestamp: +new Date('2024-09-09 00:09:00'), id: 6 }, // older of september
+          { timestamp: +new Date('2024-09-15 00:09:00'), id: 7 }, // older of september
+          { timestamp: +new Date('2024-09-22 00:09:00'), id: 8 }, // most recent of september
+        ],
+        {
+          longTermRetention: {
+            weekly: { retention: 3 },
+          },
+        },
+      ],
+      expectedIds: [1, 2, 3, 4, 6],
+      testLabel: 'should  handle month based retention',
+    },
+    {
+      args: [
+        0,
+        [
+          { timestamp: +new Date('2023-05-18 00:09:00'), id: 1 }, // too old
+          { timestamp: +new Date('2024-06-15 00:09:00'), id: 2 }, // too old in same year
+          { timestamp: +new Date('2024-07-04 00:09:00'), id: 3 },
+          { timestamp: +new Date('2024-08-12 00:09:00'), id: 4 },
+          { timestamp: +new Date('2024-09-05 00:09:00'), id: 5 },
+          { timestamp: +new Date('2024-10-02 00:09:00'), id: 6 },
+          { timestamp: +new Date('2024-11-01 00:09:00'), id: 7 },
+          { timestamp: +new Date('2024-12-17 00:09:00'), id: 8 },
+          { timestamp: +new Date('2024-12-24 00:09:00'), id: 10 },
+          { timestamp: +new Date('2025-12-31 00:09:00'), id: 11 }, // same day/week/month/year
+          { timestamp: +new Date('2025-12-31 00:09:00'), id: 12 }, // new month /year
+          { timestamp: +new Date('2025-01-01 00:09:00'), id: 13 }, // same day/week/month/year
+          { timestamp: +new Date('2025-01-01 00:10:00'), id: 14 }, //  new year /
+        ],
+        {
+          longTermRetention: {
+            daily: { retention: 2 },
+            weekly: { retention: 4 },
+            monthly: { retention: 8 },
+            yearly: { retention: 2 },
+          },
+        },
+      ],
+      expectedIds: [1, 2, 11, 13],
+      testLabel: 'complete test  ',
+    },
+  ]
+
+  for (const { args, expectedIds, testLabel } of tests) {
+    it(testLabel, () => {
+      const oldEntries = getOldEntries.apply(null, args)
+      assert.strictEqual(oldEntries.length, expectedIds.length, 'different length')
+      for (let i = 0; i < expectedIds.length; i++) {
+        assert.strictEqual(oldEntries[i].id, expectedIds[i])
+      }
+    })
+  }
+})
+
+describe('_getOldEntries() should fail when called incorrectly', () => {})
+describe('_getOldEntries() should handle picking specific backup to promote', () => {})

--- a/@xen-orchestra/backups/_getOldEntries.test.mjs
+++ b/@xen-orchestra/backups/_getOldEntries.test.mjs
@@ -50,8 +50,8 @@ describe('_getOldEntries() should succeed', () => {
           { timestamp: +new Date('2024-09-04 00:09:00'), id: 4 }, // week n-2
           { timestamp: +new Date('2024-09-05 00:09:00'), id: 5 }, // week n-2
           { timestamp: +new Date('2024-09-06 00:09:00'), id: 6 }, // week n-2
-          { timestamp: +new Date('2024-09-07 00:09:00'), id: 7 }, // week n-2
-          { timestamp: +new Date('2024-09-09 00:09:00'), id: 8 }, // week n-2 , most recent kept
+          { timestamp: +new Date('2024-09-07 00:09:00'), id: 7 }, // week n-2, most recent kept
+          { timestamp: +new Date('2024-09-09 00:09:00'), id: 8 }, // week n-1, too old
           { timestamp: +new Date('2024-09-15 00:09:00'), id: 9 }, // week n-1  kept
           { timestamp: +new Date('2024-09-22 00:09:00'), id: 10 }, // week n  kept
         ],

--- a/@xen-orchestra/backups/_runners/_writers/FullRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/FullRemoteWriter.mjs
@@ -38,7 +38,8 @@ export class FullRemoteWriter extends MixinRemoteWriter(AbstractFullWriter) {
 
     const oldBackups = getOldEntries(
       settings.exportRetention - 1,
-      await adapter.listVmBackups(vm.uuid, _ => _.mode === 'full' && _.scheduleId === scheduleId)
+      await adapter.listVmBackups(vm.uuid, _ => _.mode === 'full' && _.scheduleId === scheduleId),
+      { longTermRetention: settings.longTermRetention }
     )
     const deleteOldBackups = () => adapter.deleteFullVmBackups(oldBackups)
 

--- a/@xen-orchestra/backups/_runners/_writers/FullRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/FullRemoteWriter.mjs
@@ -39,7 +39,7 @@ export class FullRemoteWriter extends MixinRemoteWriter(AbstractFullWriter) {
     const oldBackups = getOldEntries(
       settings.exportRetention - 1,
       await adapter.listVmBackups(vm.uuid, _ => _.mode === 'full' && _.scheduleId === scheduleId),
-      { longTermRetention: settings.longTermRetention }
+      { longTermRetention: settings.longTermRetention, timezone: settings.timezone }
     )
     const deleteOldBackups = () => adapter.deleteFullVmBackups(oldBackups)
 

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
@@ -95,7 +95,8 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
 
     const oldEntries = getOldEntries(
       settings.exportRetention - 1,
-      await adapter.listVmBackups(vmUuid, _ => _.mode === 'delta' && _.scheduleId === scheduleId)
+      await adapter.listVmBackups(vmUuid, _ => _.mode === 'delta' && _.scheduleId === scheduleId),
+      { longTermRetention: settings.longTermRetention }
     )
     this._oldEntries = oldEntries
 

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
@@ -96,7 +96,7 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
     const oldEntries = getOldEntries(
       settings.exportRetention - 1,
       await adapter.listVmBackups(vmUuid, _ => _.mode === 'delta' && _.scheduleId === scheduleId),
-      { longTermRetention: settings.longTermRetention }
+      { longTermRetention: settings.longTermRetention, timezone: settings.timezone }
     )
     this._oldEntries = oldEntries
 

--- a/@xen-orchestra/backups/package.json
+++ b/@xen-orchestra/backups/package.json
@@ -39,6 +39,7 @@
     "human-format": "^1.2.0",
     "limit-concurrency-decorator": "^0.6.0",
     "lodash": "^4.17.20",
+    "moment-timezone": "^0.5.46",
     "ms": "^2.1.3",
     "node-zone": "^0.4.0",
     "parse-pairs": "^2.0.0",


### PR DESCRIPTION
long term retention sometimes called GFS ( Grand Father / Father / Son)
is a way to promote some backup to be kept on a long time

that way , the user can use the find the best equilibrium between
storage and security

This commit add the code mechanics to identify backups that
can be deleted safely. It is intended to use with a form
that ask the user for the number of day, week, month, and year
for which XO will keep the most recent

It extends the actual system of keeping the n most recent backup

Keep in mind that the backup promoted by week and month can be unaligned

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
