### PR TITLE
fix(xo-server/xo-web/mirrorBackup): correct new schedule property on edited mirror backup job

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,13 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Hosts] Display a warning for hosts whose TLS key is too short to update to XCP-ng 8.3 (PR [#7995](https://github.com/vatesfr/xen-orchestra/pull/7995))
+  - [Dashboard] Display S3 backup repository data (PR [#8006](https://github.com/vatesfr/xen-orchestra/pull/8006))
+- **xo-cli**
+  - `rest get --output $file` now displays progress information during download
+  - `rest post` and `rest put` now accept `--input $file` to upload a file and display progress information
+- [Backup] Detect invalid VDI exports that are incorrectly reported as successful by XAPI
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,7 +26,6 @@
 - [Host/Network] Fix `an error has occurred` briefly displaying in 'Mode' column of the host's Network tab (PR [#7954](https://github.com/vatesfr/xen-orchestra/pull/7954))
 - [REST API] Fix VDI export broken in XO 5.96.0 and not completely fixed in XO 5.98.0
 - [REST API] Fix VDI import in VHD format when `Content-Length` is not provided
-- [Backup/New] A second `schedules` property was created when editing a mirror backup job (PR [#8001](https://github.com/vatesfr/xen-orchestra/pull/8001))
 
 ### Packages to release
 
@@ -49,6 +48,6 @@
 - xen-api minor
 - xo-cli minor
 - xo-server patch
-- xo-web patch
+- xo-web minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -48,6 +48,6 @@
 - xen-api minor
 - xo-cli minor
 - xo-server patch
-- xo-web minor
+- xo-web patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,21 +11,9 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [Hosts] Display a warning for hosts whose TLS key is too short to update to XCP-ng 8.3 (PR [#7995](https://github.com/vatesfr/xen-orchestra/pull/7995))
-  - [Dashboard] Display S3 backup repository data (PR [#8006](https://github.com/vatesfr/xen-orchestra/pull/8006))
-- **xo-cli**
-  - `rest get --output $file` now displays progress information during download
-  - `rest post` and `rest put` now accept `--input $file` to upload a file and display progress information
-- [Backup] Detect invalid VDI exports that are incorrectly reported as successful by XAPI
-
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
-
-- [Hub/Recipes/Kubernetes] Properly sort versions in selector
-- [Host/Network] Fix `an error has occurred` briefly displaying in 'Mode' column of the host's Network tab (PR [#7954](https://github.com/vatesfr/xen-orchestra/pull/7954))
-- [REST API] Fix VDI export broken in XO 5.96.0 and not completely fixed in XO 5.98.0
-- [REST API] Fix VDI import in VHD format when `Content-Length` is not provided
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -42,7 +42,7 @@
 - @xen-orchestra/web-core minor
 - xen-api minor
 - xo-cli minor
-- xo-server patch
+- xo-server minor
 - xo-web patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,12 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Hub/Recipes/Kubernetes] Properly sort versions in selector
+- [Host/Network] Fix `an error has occurred` briefly displaying in 'Mode' column of the host's Network tab (PR [#7954](https://github.com/vatesfr/xen-orchestra/pull/7954))
+- [REST API] Fix VDI export broken in XO 5.96.0 and not completely fixed in XO 5.98.0
+- [REST API] Fix VDI import in VHD format when `Content-Length` is not provided
+- [Backup/New] A second `schedules` property was created when editing a mirror backup job (PR [#8001](https://github.com/vatesfr/xen-orchestra/pull/8001))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -42,5 +48,7 @@
 - @xen-orchestra/web-core minor
 - xen-api minor
 - xo-cli minor
-- xo-server minor
+- xo-server patch
+- xo-web patch
+
 <!--packages-end-->

--- a/packages/xo-server/src/api/mirror-backup.mjs
+++ b/packages/xo-server/src/api/mirror-backup.mjs
@@ -113,10 +113,6 @@ editJob.params = {
   remotes: {
     type: 'object',
   },
-  schedules: {
-    type: 'object',
-    optional: true,
-  },
   filter: MIRROR_BACKUP_FILTER,
   settings: SCHEMA_SETTINGS,
 }


### PR DESCRIPTION
### Description

Introduced by ee0adae
A new ```schedules``` property used to be created when editing a mirror backup job 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
