### PR TITLE
fix(xo-server/api): undefined on connecting iscsi lun to xoa

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,6 +27,7 @@
 - [Host/Network] Fix `an error has occurred` briefly displaying in 'Mode' column of the host's Network tab (PR [#7954](https://github.com/vatesfr/xen-orchestra/pull/7954))
 - [REST API] Fix VDI export broken in XO 5.96.0 and not completely fixed in XO 5.98.0
 - [REST API] Fix VDI import in VHD format when `Content-Length` is not provided
+- [REST API] Fix Issues with connecting iSCSI LUN to XOA
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,7 +27,7 @@
 - [Host/Network] Fix `an error has occurred` briefly displaying in 'Mode' column of the host's Network tab (PR [#7954](https://github.com/vatesfr/xen-orchestra/pull/7954))
 - [REST API] Fix VDI export broken in XO 5.96.0 and not completely fixed in XO 5.98.0
 - [REST API] Fix VDI import in VHD format when `Content-Length` is not provided
-- [REST API] Fix Issues with connecting iSCSI LUN to XOA
+- [REST API] Fix Issues with connecting iSCSI LUN to XOA (PR [#8004](https://github.com/vatesfr/xen-orchestra/pull/8004))
 
 ### Packages to release
 

--- a/packages/xo-server/src/api/sr.mjs
+++ b/packages/xo-server/src/api/sr.mjs
@@ -788,7 +788,7 @@ export async function probeIscsiLuns({ host, target: targetIp, port, targetIqn, 
     luns.push({
       id: lun.LUNid.trim(),
       vendor: lun.vendor.trim(),
-      serial: lun.serial.trim(),
+      serial: lun.serial?.trim() || '',
       size: lun.size?.trim(),
       scsiId: lun.SCSIid.trim(),
     })


### PR DESCRIPTION
### Description

see zammad
https://help.vates.tech/#ticket/zoom/29295

The user can't attach his storage because there is a trim() on a undefined property.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
