### PR TITLE
feat(xo-server/rest-api/dashboard): avoid iterating over all XAPI objects

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,5 +32,6 @@
 <!--packages-start-->
 
 - @xen-orchestra/log minor
+- xo-server minor
 
 <!--packages-end-->

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -173,10 +173,10 @@ async function _getDashboardStats(app) {
     }
   }
 
-  const pools = Object.values(app.objects.indexes.type.pool)
-  const hosts = Object.values(app.objects.indexes.type.host)
-  const srs = Object.values(app.objects.indexes.type.SR)
-  const vms = Object.values(app.objects.indexes.type.VM)
+  const pools = Object.values(app.objects.indexes.type.pool ?? {})
+  const hosts = Object.values(app.objects.indexes.type.host ?? {})
+  const srs = Object.values(app.objects.indexes.type.SR ?? {})
+  const vms = Object.values(app.objects.indexes.type.VM ?? {})
 
   const writableSrs = srs.filter(isSrWritable)
   const nonReplicaVms = vms.filter(vm => !isReplicaVm(vm))

--- a/packages/xo-server/src/xo.mjs
+++ b/packages/xo-server/src/xo.mjs
@@ -12,6 +12,7 @@ import stubTrue from 'lodash/stubTrue.js'
 import SslCertificate from '@xen-orchestra/mixins/SslCertificate.mjs'
 import Tasks from '@xen-orchestra/mixins/Tasks.mjs'
 import { Collection as XoCollection } from 'xo-collection'
+import { Index } from 'xo-collection/index.js'
 import { createClient as createRedisClient } from 'redis'
 import { createDebounceResource } from '@vates/disposable/debounceResource.js'
 import { createLogger } from '@xen-orchestra/log'
@@ -41,6 +42,7 @@ export default class Xo extends EventEmitter {
 
     this._objects = new XoCollection()
     this._objects.createIndex('byRef', new XoUniqueIndex('_xapiRef'))
+    this._objects.createIndex('type', new Index('type'))
 
     this._httpRequestWatchers = { __proto__: null }
 


### PR DESCRIPTION
### Description

By creating a new index for xo-server, we no longer need to go through all XAPI objects to retrieve the ones we need. This should improve the response time of the dashboard endpoint.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
