### PR TITLE
fix(xo-server/rest-api/dashboard): fix 'no such VM <uuid>' when calculating vms protection

### DIFF
--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -312,6 +312,11 @@ async function _getDashboardStats(app) {
     return false
   }
 
+  /**
+   * Some IDs may not exists anymore
+   * @param {object} job
+   * @returns {string[]}
+   */
   function _extractVmIdsFromBackupJob(job) {
     let vmIds
     try {

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -315,7 +315,7 @@ async function _getDashboardStats(app) {
   function _extractVmIdsFromBackupJob(job) {
     let vmIds
     try {
-      vmIds = extractIdsFromSimplePattern(job.vms).filter(vmId => app.hasObject(vmId, 'VM'))
+      vmIds = extractIdsFromSimplePattern(job.vms)
     } catch (_) {
       const predicate = createPredicate(job.vms)
       vmIds = nonReplicaVms.filter(predicate).map(vm => vm.id)
@@ -324,7 +324,7 @@ async function _getDashboardStats(app) {
   }
 
   function _updateVmProtection(vmId, isProtected) {
-    if (vmIdsProtected.has(vmId)) {
+    if (vmIdsProtected.has(vmId) || !app.hasObject(vmId, 'VM')) {
       return
     }
 


### PR DESCRIPTION
### Description

introduced by d6bba81

We iterate over all tasks to check if any VMs were backed up. It may happen that the vmId associated with the backup task no longer exists, that lead to `no such VM <uuid>`

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
