### PR TITLE
fix(xo-server): migration of vm with cbt enabled disk

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Migration/CBT] Fix an infinite loop when migrating a VM with CBT enabled (PR [#8017](https://github.com/vatesfr/xen-orchestra/pull/8017))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -614,16 +614,16 @@ export default class Xapi extends XapiBase {
         }
       }
     }
-    const loop = async () => {
+    const loop = async (_failOnCbtError = false) => {
       try {
         await this.callAsync('VM.migrate_send', ...params)
       } catch (err) {
-        if (err.code === 'VDI_CBT_ENABLED') {
+        if (err.code === 'VDI_CBT_ENABLED' && !_failOnCbtError) {
           // as of 20240619, CBT must be disabled on all disks to allow migration to go through
           // it will be re enabled if needed by backups
           // the next backup after a storage migration will be a full backup
           await this.VM_disableChangedBlockTracking(vm.$ref)
-          return loop()
+          return loop(true)
         }
         if (err.code === 'TOO_MANY_STORAGE_MIGRATES') {
           await pDelay(1e4)


### PR DESCRIPTION
### Description

port the fix made https://github.com/vatesfr/xen-orchestra/commit/83a8f295c72770c189e6cac84194c8db8eb72806 to live migration to ensure Xo don't fall in an infinite loop if disabling CBT succeed BUT the error message VDI_CBT_ENABLED occurs ( which indicate CBT is still enabled ) 

Hopefully it wil help us find the root cause

introduced by 442dd16813a292f14673610ee250f3c827693a15

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
