### PR TITLE
fix(xo-web/render-xo-item/Schedule): handle undefined job/schedule name

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,4 +31,6 @@
 
 <!--packages-start-->
 
+- xo-web patch
+
 <!--packages-end-->

--- a/packages/xo-web/src/common/render-xo-item.js
+++ b/packages/xo-web/src/common/render-xo-item.js
@@ -524,8 +524,8 @@ export const Schedule = decorate([
     }
 
     const isEnabled = schedule.enabled
-    const scheduleName = schedule.name.trim()
-    const jobName = job?.name.trim()
+    const scheduleName = (schedule.name ?? '').trim()
+    const jobName = (job?.name ?? '').trim()
 
     return (
       <span>


### PR DESCRIPTION
See https://xcp-ng.org/forum/topic/9690
Introduced by d520e53f9e7ad0d45ee45ebfd13d402a970deede

### Description

In `render-xo-item`'s `Schedule`, handle schedule's (and job's) name being `undefined` even though new schedules with `undefined` names should not be created since [this change](https://github.com/vatesfr/xen-orchestra/commit/1db9ca9e3167aefe8e7292ac9cd010550442f883).

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
