### PR TITLE
fix(backups): support system without cbt (XS< 7.3)

### DIFF
--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -182,7 +182,9 @@ class Vdi {
     }
 
     const [cbt_enabled, size, uuid, vdiName] = await Promise.all([
-      this.getField('VDI', ref, 'cbt_enabled'),
+      this.getField('VDI', ref, 'cbt_enabled').catch(() => {
+        /* on XS < 7.3 cbt is not supported */
+      }),
       this.getField('VDI', ref, 'virtual_size'),
       this.getField('VDI', ref, 'uuid'),
       this.getField('VDI', ref, 'name_label'),

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Backups] Fix MESSAGE_METHOD_UNKOWN(VDI.get_cbt_enabled) on XenServer < 7.3 (PR [#8038](https://github.com/vatesfr/xen-orchestra/pull/8038))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -32,6 +34,7 @@
 <!--packages-start-->
 
 - @xen-orchestra/log minor
+- @xen-orchestra/xapi patch
 - xo-server minor
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

from https://help.vates.tech/#ticket/zoom/29918/133911
introduced by https://github.com/vatesfr/xen-orchestra/pull/7750

older xenserver system, before 7.3 don't have any cbt_related method. This PR consider that if the hypervisor does not support CBT, then CBT is disabled

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
