### PR TITLE
feat(lite/xoa-deploy): configure custom NTP servers

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## **next**
 
 - Handle IPv6 hosts
+- [XOA deploy] Configure custom NTP servers
 
 ## **0.4.0** (2024-09-30)
 

--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## **next**
 
-- Handle IPv6 hosts
-- [XOA deploy] Configure custom NTP servers
+- Handle IPv6 hosts (PR [#8044](https://github.com/vatesfr/xen-orchestra/pull/8044))
+- [XOA deploy] Configure custom NTP servers (PR [#8059](https://github.com/vatesfr/xen-orchestra/pull/8059))
 
 ## **0.4.0** (2024-09-30)
 

--- a/@xen-orchestra/lite/src/locales/en.json
+++ b/@xen-orchestra/lite/src/locales/en.json
@@ -48,6 +48,7 @@
   "deploy": "Deploy",
   "deploy-xoa": "Deploy XOA",
   "deploy-xoa-available-on-desktop": "XOA deployment is available on your desktop interface",
+  "deploy-xoa-custom-ntp-servers": "Custom NTP servers (separated by spaces)",
 
   "deploy-xoa-status.configuring": "Configuring XOA…",
   "deploy-xoa-status.importing": "Importing XOA…",

--- a/@xen-orchestra/lite/src/locales/fr.json
+++ b/@xen-orchestra/lite/src/locales/fr.json
@@ -48,6 +48,7 @@
   "deploy": "Déployer",
   "deploy-xoa": "Déployer XOA",
   "deploy-xoa-available-on-desktop": "Le déploiement de la XOA est disponible sur ordinateur",
+  "deploy-xoa-custom-ntp-servers": "Serveurs NTP (séparés par des espaces)",
 
   "deploy-xoa-status.configuring": "Configuration de la XOA…",
   "deploy-xoa-status.importing": "Importation de la XOA…",

--- a/@xen-orchestra/lite/src/views/xoa-deploy/XoaDeployView.vue
+++ b/@xen-orchestra/lite/src/views/xoa-deploy/XoaDeployView.vue
@@ -88,6 +88,12 @@
                 </option>
               </FormSelect>
             </FormInputWrapper>
+            <FormInputWrapper
+              :label="$t('deploy-xoa-custom-ntp-servers')"
+              learn-more-url="https://xen-orchestra.com/docs/xoa.html#setting-a-custom-ntp-server"
+            >
+              <FormInput v-model="ntp" placeholder="xxx.xxx.xxx.xxx" />
+            </FormInputWrapper>
           </div>
           <div class="row">
             <FormInputWrapper>
@@ -295,6 +301,7 @@ const openXoa = () => {
 
 const selectedSr = ref<XenApiSr>()
 const selectedNetwork = ref<XenApiNetwork>()
+const ntp = ref('')
 const ipStrategy = ref<'static' | 'dhcp'>('dhcp')
 const requireIpConf = computed(() => ipStrategy.value === 'static')
 
@@ -397,6 +404,10 @@ async function deploy() {
         JSON.stringify({ email: xoaUser.value, password: xoaPwd.value }),
       ]),
     ]
+
+    if (ntp.value !== '') {
+      promises.push(xapi.call('VM.add_to_xenstore_data', [vmRef.value, 'vm-data/ntp', ntp.value]))
+    }
 
     // TODO: add host to servers with session token?
 


### PR DESCRIPTION
### Screenshots

![Capture_2024-10-17_16:09:20](https://github.com/user-attachments/assets/dfb2a9c0-3a80-4e88-96df-b3c3ab977de6)

### Description

Add NTP servers to xenstore so that XO can automatically configure them on first start.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
