### PR TITLE
feat(task): add start, success & failure methods

### DIFF
--- a/@vates/task/.USAGE.md
+++ b/@vates/task/.USAGE.md
@@ -49,6 +49,15 @@ const result = await task.runInside(fn)
 // if fn rejects, the task will be marked as failed
 // if fn resolves, the task will be marked as succeeded
 const result = await task.run(fn)
+
+// manually starts the task
+task.start()
+
+// manually finishes the task in success state
+task.success(result)
+
+// manually finishes the task in failure state
+task.failure(error)
 ```
 
 Inside a task:

--- a/@vates/task/README.md
+++ b/@vates/task/README.md
@@ -65,6 +65,15 @@ const result = await task.runInside(fn)
 // if fn rejects, the task will be marked as failed
 // if fn resolves, the task will be marked as succeeded
 const result = await task.run(fn)
+
+// manually starts the task
+task.start()
+
+// manually finishes the task in success state
+task.success(result)
+
+// manually finishes the task in failure state
+task.failure(error)
 ```
 
 Inside a task:

--- a/@vates/task/index.js
+++ b/@vates/task/index.js
@@ -132,9 +132,13 @@ class Task {
   #end(status, result) {
     assert.equal(this.#status, PENDING)
 
-    this.#status = status
     this.#emit('end', { status, result })
     this.#onProgress = alreadyEnded
+    this.#status = status
+  }
+
+  failure(error) {
+    this.#end(FAILURE, error)
   }
 
   info(message, data) {
@@ -142,10 +146,8 @@ class Task {
   }
 
   #maybeStart() {
-    const startData = this.#startData
-    if (startData !== undefined) {
-      this.#startData = undefined
-      this.#emit('start', startData)
+    if (this.#startData !== undefined) {
+      this.start()
     }
   }
 
@@ -179,6 +181,18 @@ class Task {
     assert.equal(this.status, PENDING)
 
     this.#emit('property', { name, value })
+  }
+
+  start() {
+    const startData = this.#startData
+    assert.notEqual(startData, undefined, 'task has already started')
+
+    this.#startData = undefined
+    this.#emit('start', startData)
+  }
+
+  success(result) {
+    this.#end(SUCCESS, result)
   }
 
   warning(message, data) {

--- a/@vates/task/index.test.js
+++ b/@vates/task/index.test.js
@@ -307,7 +307,7 @@ describe('Task', function () {
       assert.throws(() => task.success(result), { code: 'ERR_ASSERTION' })
     })
 
-    it('finishes the task and mark it as failed', function () {
+    it('finishes the task and mark it as successful', function () {
       const task = createTask()
       task.start()
       task.success(result)

--- a/@vates/task/index.test.js
+++ b/@vates/task/index.test.js
@@ -145,6 +145,36 @@ describe('Task', function () {
     })
   })
 
+  describe('#failure()', function () {
+    const error = new Error()
+
+    it('throws if the task has not started yet', function () {
+      const task = createTask()
+
+      assert.throws(() => task.failure(error), { message: 'task has not started yet' })
+    })
+
+    it('throws if the task has already finished', function () {
+      const task = createTask()
+      task.start()
+      task.success()
+
+      assert.throws(() => task.failure(error), { code: 'ERR_ASSERTION' })
+    })
+
+    it('finishes the task and mark it as failed', function () {
+      const task = createTask()
+      task.start()
+      task.failure(error)
+
+      assertEvent(task, {
+        status: 'failure',
+        result: error,
+        type: 'end',
+      })
+    })
+  })
+
   describe('.info()', function () {
     it('does nothing when run outside a task', function () {
       Task.info('foo')
@@ -240,6 +270,52 @@ describe('Task', function () {
             value,
           })
         })
+      })
+    })
+  })
+
+  describe('#start', function () {
+    it('starts the task', function () {
+      const task = createTask()
+      task.start()
+
+      assertEvent(task, { type: 'start' })
+    })
+
+    it('throws when the task has already started', function () {
+      const task = createTask()
+      task.start()
+
+      assert.throws(() => task.start(), { message: 'task has already started' })
+    })
+  })
+
+  describe('#success()', function () {
+    const result = {}
+
+    it('throws if the task has not started yet', function () {
+      const task = createTask()
+
+      assert.throws(() => task.success(result), { message: 'task has not started yet' })
+    })
+
+    it('throws if the task has already finished', function () {
+      const task = createTask()
+      task.start()
+      task.success()
+
+      assert.throws(() => task.success(result), { code: 'ERR_ASSERTION' })
+    })
+
+    it('finishes the task and mark it as failed', function () {
+      const task = createTask()
+      task.start()
+      task.success(result)
+
+      assertEvent(task, {
+        status: 'success',
+        result,
+        type: 'end',
       })
     })
   })

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -38,6 +38,7 @@
 
 <!--packages-start-->
 
+- @vates/task minor
 - @xen-orchestra/log minor
 - @xen-orchestra/mixin minor
 - @xen-orchestra/xapi patch


### PR DESCRIPTION
### Description

Allow managing the task manually instead of using `.run()` and `.runInside()`.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
