### PR TITLE
POC: new rest-api structure + openapi/swagger

### DIFF
--- a/packages/xo-server/src/rest-api/AbstractEntity.mjs
+++ b/packages/xo-server/src/rest-api/AbstractEntity.mjs
@@ -1,0 +1,67 @@
+import { Router } from 'express'
+import { pipeline } from 'node:stream/promises'
+
+// @TODO Move to utils folder
+async function* makeJsonStream(iterable) {
+  yield '['
+  let first = true
+  for await (const object of iterable) {
+    if (first) {
+      first = false
+      yield '\n'
+    } else {
+      yield ',\n'
+    }
+    yield JSON.stringify(object, null, 2)
+  }
+  yield '\n]\n'
+}
+
+async function* makeNdJsonStream(iterable) {
+  for await (const object of iterable) {
+    yield JSON.stringify(object)
+    yield '\n'
+  }
+}
+// ---------
+
+class AbstractEntity {
+  #app
+  #type
+  #router
+  constructor(app, type) {
+    this.#app = app
+    this.#type = type
+    this.#router = new Router()
+  }
+
+  getApp() {
+    return this.#app
+  }
+
+  getRouter() {
+    return this.#router
+  }
+
+  getType() {
+    return this.#type
+  }
+
+  registerRoutes() {
+    throw new Error('Need to be implemented by the children entity')
+  }
+
+  registerRouter(router) {
+    this.registerRoutes()
+
+    router.use(`/${this.getType().toLowerCase() + 's'}`, this.getRouter())
+  }
+
+  sendObjects(iterable, req, res) {
+    const ndjson = req.headers.accept === 'application/x-ndjson'
+    res.setHeader('content-type', ndjson ? 'application/x-ndjson' : 'application/json')
+    return pipeline((ndjson ? makeNdJsonStream : makeJsonStream)(iterable), res)
+  }
+}
+
+export default AbstractEntity

--- a/packages/xo-server/src/rest-api/AbstractXapiCollection.mjs
+++ b/packages/xo-server/src/rest-api/AbstractXapiCollection.mjs
@@ -1,0 +1,62 @@
+import CM from 'complex-matcher'
+import { every } from '@vates/predicates'
+import AbstractEntity from './AbstractEntity.mjs'
+import pick from 'lodash/pick.js'
+
+const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+class AbstractXapiCollection extends AbstractEntity {
+  getObject(uuid) {
+    return this.getApp().getObject(uuid, this.getType())
+  }
+
+  getObjects(filter, limit, fields) {
+    filter = filter !== undefined ? CM.parse(filter).createPredicate() : undefined
+
+    let objects = this.getApp().getObjects({
+      filter: every(obj => obj.type === this.getType(), filter),
+      limit,
+    })
+
+    if (fields === undefined) {
+      objects = Object.keys(objects)
+    } else {
+      objects = Object.values(objects)
+      if (fields !== '*') {
+        const properties = fields.split(',')
+        objects = objects.map(obj => pick(obj, properties))
+      }
+    }
+
+    return objects
+  }
+
+  registerRoutes() {
+    this.getRouter()
+      .param('uuid', (req, res, next) => {
+        const uuid = req.params.uuid
+
+        if (typeof uuid !== 'string' || !uuidRegex.test(uuid)) {
+          return next(new Error('invalid uuid'))
+        }
+
+        res.locals.object = this.getObject(uuid)
+        next()
+      })
+      .get(`/`, (req, res) => {
+        const objects = this.getObjects(req.query.filter, req.query.limit, req.query.fields)
+
+        this.sendObjects(objects, req, res)
+      })
+      .get(`/:uuid`, (req, res) => {
+        const fields = req.query.fields
+        let obj = res.locals.object
+        if (fields !== undefined && fields !== '*') {
+          obj = pick(obj, fields.split())
+        }
+
+        res.json(obj)
+      })
+  }
+}
+
+export default AbstractXapiCollection

--- a/packages/xo-server/src/rest-api/dashboard.mjs
+++ b/packages/xo-server/src/rest-api/dashboard.mjs
@@ -1,0 +1,20 @@
+import AbstractEntity from './AbstractEntity.mjs'
+
+class Dashboard extends AbstractEntity {
+  constructor(app) {
+    super(app, 'dashboard')
+  }
+
+  computeSomeRandomData() {
+    return {
+      nPool: Math.round(Math.random() * 100),
+      nHosts: Math.round(Math.random() * 100),
+    }
+  }
+
+  registerRoutes() {
+    this.getRouter().get('/', (req, res) => this.sendObject(this.computeSomeRandomData(), req, res))
+  }
+}
+
+export default Dashboard

--- a/packages/xo-server/src/rest-api/entities.mjs
+++ b/packages/xo-server/src/rest-api/entities.mjs
@@ -1,0 +1,2 @@
+export { default as Host } from './host.mjs'
+export { default as Vm } from './vm.mjs'

--- a/packages/xo-server/src/rest-api/entities.mjs
+++ b/packages/xo-server/src/rest-api/entities.mjs
@@ -1,2 +1,4 @@
 export { default as Host } from './host.mjs'
 export { default as Vm } from './vm.mjs'
+export { default as User } from './user.mjs'
+export { default as Dashboard } from './dashboard.mjs'

--- a/packages/xo-server/src/rest-api/host.mjs
+++ b/packages/xo-server/src/rest-api/host.mjs
@@ -1,6 +1,6 @@
-import AbstractXapiCollection from './AbstractXapiCollection.mjs'
+import AbstractCollection from './AbstractCollection.mjs'
 
-class Host extends AbstractXapiCollection {
+class Host extends AbstractCollection {
   constructor(app) {
     super(app, 'host')
   }

--- a/packages/xo-server/src/rest-api/host.mjs
+++ b/packages/xo-server/src/rest-api/host.mjs
@@ -1,0 +1,9 @@
+import AbstractXapiCollection from './AbstractXapiCollection.mjs'
+
+class Host extends AbstractXapiCollection {
+  constructor(app) {
+    super(app, 'host')
+  }
+}
+
+export default Host

--- a/packages/xo-server/src/rest-api/middleware.mjs
+++ b/packages/xo-server/src/rest-api/middleware.mjs
@@ -1,0 +1,14 @@
+import { invalidCredentials } from 'xo-common/api-errors.js'
+
+export const authenticateUserFromToken = app => async (req, res, next) => {
+  const { cookies, ip } = req
+  try {
+    const user = await app.authenticateUser({ token: cookies.authenticationToken ?? cookies.token }, { ip })
+    return app.runWithApiContext(user, next)
+  } catch (error) {
+    if (invalidCredentials.is(error)) {
+      return res.sendStatus(401)
+    }
+    next(error)
+  }
+}

--- a/packages/xo-server/src/rest-api/user.mjs
+++ b/packages/xo-server/src/rest-api/user.mjs
@@ -1,0 +1,41 @@
+import pick from 'lodash/pick.js'
+import AbstractCollection from './AbstractCollection.mjs'
+import CM from 'complex-matcher'
+
+class User extends AbstractCollection {
+  constructor(app) {
+    super(app, 'user')
+  }
+
+  async getObject(id) {
+    const user = await this.getApp().getUser(id)
+    delete user.pw_hash
+
+    return user
+  }
+
+  async getObjects(filter, limit, fields) {
+    filter = filter !== undefined ? CM.parse(filter).createPredicate() : undefined
+    limit = Number(limit)
+
+    let users = await this.getApp().getAllUsers()
+    if (filter !== undefined) {
+      users = users.filter(filter)
+    }
+
+    if (Number.isInteger(limit)) {
+      users = users.slice(0, limit)
+    }
+
+    if (fields === undefined) {
+      users = users.map(user => user.id)
+    } else if (fields !== '*') {
+      const properties = fields.split(',')
+      users = users.map(obj => pick(obj, properties))
+    }
+
+    return users
+  }
+}
+
+export default User

--- a/packages/xo-server/src/rest-api/vm.mjs
+++ b/packages/xo-server/src/rest-api/vm.mjs
@@ -1,15 +1,19 @@
-import AbstractXapiCollection from './AbstractXapiCollection.mjs'
+import AbstractCollection from './AbstractCollection.mjs'
 
-class Vm extends AbstractXapiCollection {
+class Vm extends AbstractCollection {
   constructor(app) {
     super(app, 'VM')
   }
 
   registerRoutes() {
     super.registerRoutes()
-    this.getRouter().get('/:uuid/name_label', (req, res) => {
-      return res.json(res.locals.object.name_label)
-    })
+    this.getRouter()
+      .get('/foo', (req, res) => {
+        res.json('foo')
+      })
+      .get('/:uuid/name_label', (req, res) => {
+        return res.json(res.locals.object.name_label)
+      })
   }
 }
 

--- a/packages/xo-server/src/rest-api/vm.mjs
+++ b/packages/xo-server/src/rest-api/vm.mjs
@@ -1,0 +1,16 @@
+import AbstractXapiCollection from './AbstractXapiCollection.mjs'
+
+class Vm extends AbstractXapiCollection {
+  constructor(app) {
+    super(app, 'VM')
+  }
+
+  registerRoutes() {
+    super.registerRoutes()
+    this.getRouter().get('/:uuid/name_label', (req, res) => {
+      return res.json(res.locals.object.name_label)
+    })
+  }
+}
+
+export default Vm

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -1,5 +1,6 @@
 import { Router } from 'express'
 import * as entities from '../rest-api/entities.mjs'
+import { authenticateUserFromToken } from '../rest-api/middleware.mjs'
 
 // @TODO:
 // - implement middlewhare to retrieve user from a token
@@ -482,6 +483,8 @@ export default class RestApi {
     if (express === undefined) {
       return
     }
+
+    express.use(authenticateUserFromToken(app))
 
     const coreRouter = new Router()
 


### PR DESCRIPTION
### Description

POC for REST API redesign.

What about: [tsoa](https://github.com/lukeautry/tsoa)?

For all objects that extend `AbstractCollection`, `/rest/v0/${type}/` and `/rest/v0/${type}/:id` are automatically registered. For collections that are not a XAPI collection, such as users, simply add the `getObjects` and `getObject` methods in the class.
If the endpoint point to one object. (/rest/v0/users/1234/foo), the object will be automatically resolved (using `getObject`) and injected in `res.locals.object`

`/rest/v0/dashboard`
`/rest/v0/hosts`
`/rest/v0/hosts/:id`
`/rest/v0/users`
`/rest/v0/users/:id`
`/rest/v0/vms`
`/rest/v0/vms/foo`
`/rest/v0/vms/:id`
`/rest/v0/vms/:id/name_label`


endpoint rules:

`/rest/<version>/ressources/<ressource_id>/sub-resource`
`/rest/<version>/ressources/<ressource_id>/actions/<action>`
to create/delete/update a ressource (e.g. VM), always do a POST/DELETE/PATCH/ requestion on the ressource.
`POST/DELETE/PATCH rest/v0/vms/`


### Checklist
- Can all actions be performed in a group? (create multiple VMs, delete multiple VMs, start mutlitple VMs)
- [-] use TS (and update the build or maybe put the REST API in @xen-orchestra?)
   ```
   #xo-server/package.json
   ...
   "build:rest-api": "tsc --project src/_rest-api/tsconfig.json",
   "build:rm-rest-api-build": "rm -rf src/rest-api",
   "_build": "npm run build:rest-api && index-modules --index-file index.mjs src/api src/xapi/mixins src/xo-mixins src/rest-api && babel --delete-dir-on-start --keep-file-extension --source-maps --out-dir=dist/ src/ && npm run build:rm-rest-api-build",
   ...
   ```
- [ ] expose an action
- [ ] handle sync an async actions
- [ ] handle `AbstractCollection` routes with user permission
     - [ ] Filter Objects based on ACLs user
- [ ] expose openapi + swagger docs

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
