### PR TITLE
Revert "feat(xo-web/XOA update): display "Downgrade" when trial is over"

### DIFF
--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2303,7 +2303,6 @@ const messages = {
   update: 'Update',
   refresh: 'Refresh',
   upgrade: 'Upgrade',
-  downgrade: 'Downgrade',
   considerSubscribe:
     'Please consider subscribing and trying it with all the features for free during 30 days on {link}.',
   currentVersion: 'Current version:',

--- a/packages/xo-web/src/xo-app/xoa/update/index.js
+++ b/packages/xo-web/src/xo-app/xoa/update/index.js
@@ -343,7 +343,7 @@ const Updates = decorate([
                     handler={effects.upgrade}
                     icon='upgrade'
                   >
-                    {xoaTrialState.state !== 'untrustedTrial' ? _('upgrade') : _('downgrade')}
+                    {_('upgrade')}
                   </ActionButton>
                   <hr />
                   <pre>


### PR DESCRIPTION
This reverts commit c6f3b2b1ceb7070ca3b8218e9b6ce7213b3df066.

### Description

Showing "Downgrade" after a trial has ended can be confusing.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
