### PR TITLE
fix(xen-orchestra/fs): error creating nfs encrypted remote

### DIFF
--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -388,7 +388,7 @@ export default class RemoteHandlerAbstract {
           info('will update metadata of this remote')
           return this.#createMetadata()
         } else {
-          // to add an new encrypted fs remote, the remote directory must be empty, otherwise metadata.json is not created
+          // to add a new encrypted fs remote, the remote directory must be empty, otherwise metadata.json is not created
           if (error.code === 'ENOENT' && error.path.includes('metadata.json')) {
             throw new Error('Remote directory must be empty.')
           }

--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -388,6 +388,11 @@ export default class RemoteHandlerAbstract {
           info('will update metadata of this remote')
           return this.#createMetadata()
         } else {
+          // to add an new encrypted fs remote, the remote directory must be empty, otherwise metadata.json is not created
+          if (error.code === 'ENOENT' && error.path.includes('metadata.json')) {
+            throw new Error('Remote directory must be empty.')
+          }
+
           warn(
             `The encryptionKey settings of this remote does not match the key used to create it. You won't be able to read any data from this remote`,
             { error }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@
 
 - [V2V] Fix failing transfer at the power off phase (PR [#7839](https://github.com/vatesfr/xen-orchestra/pull/7839))
 - [Backup/Restore] Fix differential restore with purge snapshot (PR [#8082](https://github.com/vatesfr/xen-orchestra/pull/8082))
+- [Remotes] Fix NFS remote encryption "ENOENT metadata.json" error (PR [#8081](https://github.com/vatesfr/xen-orchestra/pull/8081))
 
 ### Packages to release
 
@@ -42,6 +43,7 @@
 
 - @vates/task minor
 - @xen-orchestra/backups patch
+- @xen-orchestra/fs patch
 - @xen-orchestra/web-core minor
 - @xen-orchestra/xapi minor
 - xen-api minor


### PR DESCRIPTION
### Description

XO-386

When adding a nfs remote with encryption, the remote directory must be empty, then we create metadata.json and encryption.json on it.
If not, we fail to test these json files and the user receive an error "file not found: metadata.json" which is not understandable.

In this case, this PR return a message explaining the problem.
![Capture d’écran du 2024-10-29 11-05-53](https://github.com/user-attachments/assets/26957ebd-78cf-486b-8277-71e9e5a381f6)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
