### PR TITLE
fix(Restore): ignore cbt_medata disk when doing differential restores

### DIFF
--- a/@xen-orchestra/backups/ImportVmBackup.mjs
+++ b/@xen-orchestra/backups/ImportVmBackup.mjs
@@ -79,8 +79,13 @@ export class ImportVmBackup {
         debug('found disks, wlll search its snapshots', { snapshots: xapiDisk.snapshots })
         for (const snapshotRef of xapiDisk.snapshots) {
           const snapshot = await this._xapi.getRecord('VDI', snapshotRef)
-          debug('handling snapshot', { snapshot })
 
+          debug('handling snapshot', { snapshot })
+          if (snapshot.type === 'cbt_metadata') {
+            // disk without data can't be used as a base
+            debug('cbt metadata snapshot, skip')
+            continue
+          }
           // take only the first snapshot
           if (snapshotCandidate && snapshotCandidate.snapshot_time < snapshot.snapshot_time) {
             debug('already got a better candidate')

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [V2V] Fix failing transfer at the power off phase (PR [#7839](https://github.com/vatesfr/xen-orchestra/pull/7839))
+- [Backup/Restore] Fix differential restore with purge snapshot (PR [#8082](https://github.com/vatesfr/xen-orchestra/pull/8082))
 
 ### Packages to release
 
@@ -39,6 +40,7 @@
 <!--packages-start-->
 
 - @vates/task minor
+- @xen-orchestra/backups patch
 - @xen-orchestra/web-core minor
 - @xen-orchestra/xapi minor
 - xen-api minor


### PR DESCRIPTION
differential restore works by reusing local data of a snapshot
linked to a delta chain on the remote
cbt_metadata don't have the disks data , thus are not eligible to
be used  for differential restores

from  https://xcp-ng.org/forum/topic/9728/problem-with-differential-restore/8

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
