### PR TITLE
feat(netbox): synchronize description and comments

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@
 - [REST API] Ability to pass a cloud configuration when creating VM (For Cloud-Init template) (PR [#8070](https://github.com/vatesfr/xen-orchestra/pull/8070))
 - [New/VM] cloud-init template variable `%` is replaced by `{index}` to avoid interfering with [Jinja templating](https://jinja.palletsprojects.com/) [Forum#84696](https://xcp-ng.org/forum/post/84696)
   - To avoid breaking existing workflows, `%` still works when _Multiple VMs_ is enabled but is deprecated.
+- [Netbox] Synchronize VM description and notes/comments
 
 ### Bug fixes
 
@@ -42,6 +43,7 @@
 - @xen-orchestra/xapi minor
 - xen-api minor
 - xo-server minor
+- xo-server-netbox minor
 - xo-web minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@
 - [REST API] Ability to pass a cloud configuration when creating VM (For Cloud-Init template) (PR [#8070](https://github.com/vatesfr/xen-orchestra/pull/8070))
 - [New/VM] cloud-init template variable `%` is replaced by `{index}` to avoid interfering with [Jinja templating](https://jinja.palletsprojects.com/) [Forum#84696](https://xcp-ng.org/forum/post/84696)
   - To avoid breaking existing workflows, `%` still works when _Multiple VMs_ is enabled but is deprecated.
-- [Netbox] Synchronize VM description and notes/comments
+- [Netbox] Synchronize VM description and notes/comments (PR [#8083](https://github.com/vatesfr/xen-orchestra/pull/8083))
 
 ### Bug fixes
 

--- a/packages/xo-server-netbox/src/index.js
+++ b/packages/xo-server-netbox/src/index.js
@@ -459,7 +459,9 @@ class Netbox {
       const nbVm = {
         custom_fields: { uuid: xoVm.uuid },
         name: xoVm.name_label.slice(0, NAME_MAX_LENGTH).trim(),
-        comments: xoVm.name_description.slice(0, DESCRIPTION_MAX_LENGTH).trim(),
+        description: xoVm.name_description.slice(0, DESCRIPTION_MAX_LENGTH).trim(),
+        // Size limit of `comments` is not specified in Netbox doc: let's use the same limit as XO
+        comments: xoVm.other['xo:notes']?.slice(0, 2048).trim() ?? '',
         vcpus: xoVm.CPUs.number,
         disk: Math.floor(
           xoVm.$VBDs
@@ -474,6 +476,15 @@ class Netbox {
         status: xoVm.power_state === 'Running' ? 'active' : 'offline',
         platform: null,
         tags: [],
+      }
+
+      // https://github.com/netbox-community/netbox/blob/develop/docs/release-notes/version-3.4.md#rest-api-changes
+      // `description` fields was introduced in Netbox v3.4.0
+      // - before that version: keep the same behaviour (description → comments)
+      // - after that version: (description → description) and (notes → comments)
+      if (this.#netboxVersion !== undefined && semver.satisfies(this.#netboxVersion, '< 3.4')) {
+        nbVm.comments = nbVm.description
+        delete nbVm.description
       }
 
       // Prior to Netbox v3.3.0: no "site" field on VMs


### PR DESCRIPTION
See Zammad#25547
See https://github.com/netbox-community/netbox/blob/develop/docs/release-notes/version-3.4.md

### Screenshots

Netbox <3.4:
- XO `description` → Netbox `comments`

![Capture_2024-10-29_15:30:41](https://github.com/user-attachments/assets/853e95d9-ceca-4962-9be7-3c04d371638a)

Netbox >=3.4:
- XO `description` → Netbox `description`
- XO `other[xo:notes]` → Netbox `comments`

![Capture_2024-10-29_15:32:40](https://github.com/user-attachments/assets/b95cd05f-9640-45fb-be6f-e544ddb2579d)

### Description

`description` field was introduced in Netbox v3.4.0
- before that version: keep the same behaviour (description → comments)
- after that version: (description → description) and (notes → comments)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
