### PR TITLE
fix(xen-orchestra/fs): nfs port

### DIFF
--- a/@xen-orchestra/fs/src/nfs.js
+++ b/@xen-orchestra/fs/src/nfs.js
@@ -7,7 +7,8 @@ export default class NfsHandler extends MountHandler {
     const { host, port, path } = parse(remote.url)
     super(remote, opts, {
       type: 'nfs',
-      device: `${host}${port !== undefined ? ':' + port : ''}:${path}`,
+      device: `${host}:${path}`,
+      options: port !== undefined ? `port=${port}` : undefined,
     })
   }
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Host/Network] When reconfiguring IP address on a PIF, no IPv6 reconfiguration if no IPv6 (PR [#8119](https://github.com/vatesfr/xen-orchestra/pull/8119))
+- [Remotes] Fix NFS port (PR [#8085](https://github.com/vatesfr/xen-orchestra/pull/8085))
 
 ### Packages to release
 
@@ -33,6 +34,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/fs patch
 - @xen-orchestra/web patch
 - @xen-orchestra/web-core minor
 - xo-server minor


### PR DESCRIPTION
### Description

XO-375

In "remotes", fix nfs port if specified.
The problem : port was specified in url, when it should be specified as an option.

Options already exist. It should continue to work as before.

Result of tests in XO when port and options are specified / not specified :

![Capture d’écran du 2024-10-30 11-10-02](https://github.com/user-attachments/assets/d022395f-8375-4f17-9da7-84a461c2a056)


Result of mount when port and options are specified / not specified :

```
{ 
  remote: 'nfs://192.168.1.29:/home/stephane/Public/nfs', 
  options: '' 
}
mount [
  '-o',
  '',
  '-t',
  'nfs',
  '192.168.1.29:/home/stephane/Public/nfs',
  '/run/xo-server/mounts/95a7ea9c-17b0-4a91-9595-9c0417693442'
]

{
  remote: 'nfs://192.168.1.29:/home/stephane/Public/nfs',
  options: 'noexec'
}
mount [
  '-o',
  'noexec',
  '-t',
  'nfs',
  '192.168.1.29:/home/stephane/Public/nfs',
  '/run/xo-server/mounts/bb99b303-2ca7-45f0-b8b9-5db254459c74'
]

{
  remote: 'nfs://192.168.1.29:2049:/home/stephane/Public/nfs',
  options: 'port=2049,noexec'
}
mount [
  '-o',
  'port=2049,noexec',
  '-t',
  'nfs',
  '192.168.1.29:/home/stephane/Public/nfs',
  '/run/xo-server/mounts/abbd08fe-f0be-4a3c-8c97-76a8d8808981'
]

{
  remote: 'nfs://192.168.1.29:/mnt/disk3?encryptionKey=%22xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxw%22',
  options: ''
}
mount [
  '-o',
  '',
  '-t',
  'nfs',
  '192.168.1.29:/mnt/disk3',
  '/run/xo-server/mounts/2cf7babd-64eb-4325-8c32-002d7a436a4e'
]

{
  remote: 'nfs://192.168.1.29:2049:/home/stephane/Public/nfs',
  options: 'port=2049'
}
mount [
  '-o',
  'port=2049',
  '-t',
  'nfs',
  '192.168.1.29:/home/stephane/Public/nfs',
  '/run/xo-server/mounts/2a13771e-8244-4183-966e-271ca94750dd'
]
```


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
