### PR TITLE
fix(nbd): connect to only one host at a time per disk

### DIFF
--- a/@vates/nbd-client/multi.mjs
+++ b/@vates/nbd-client/multi.mjs
@@ -62,8 +62,8 @@ export default class MultiNbdClient {
         return _connect()
       }
     }
-    // don't connect in parallel since this can lead to erace condition
-    // on distritbuted systems ( like the NBD sevrer of the XAPI)
+    // don't connect in parallel since this can lead to race condition
+    // on distributed systems ( like the NBD server of the XAPI)
     for (let i = 0; i < this.#nbdConcurrency; i++) {
       await _connect()
     }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Remote] Better encoding of special chars in username in remote (PR [#8106](https://github.com/vatesfr/xen-orchestra/pull/8106))
+- [Backup] Connect sequentially to hosts when using multiple NBD to alleviate a race condition leading to `VDI_IN_USE` errors (PR [#8086](https://github.com/vatesfr/xen-orchestra/pull/8086))
 
 ### Packages to release
 
@@ -36,6 +37,7 @@
 
 <!--packages-start-->
 
+- @vates/nbd-client patch
 - @xen-orchestra/web patch
 - @xen-orchestra/web-core minor
 - xo-remote-parser patch


### PR DESCRIPTION
### Description

connecting to multiple host in parallel lead to a race condition in xapi-nbd while updating the sm_config property of the vdi. This lead to VDI that are not disconnected, thus VDI_IN_USE error at the next step of the backup

from : https://xcp-ng.org/forum/topic/9864/vdi-staying-connected-to-dom0-when-using-nbd-backups/46?_=1730797966321

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
