### PR TITLE
fix(xo-server): user can set already used email - fix bug in QA

### DIFF
--- a/packages/xo-server/src/models/user.mjs
+++ b/packages/xo-server/src/models/user.mjs
@@ -35,7 +35,7 @@ export class Users extends Collection {
     return /* await */ this.add(properties)
   }
 
-  async update(properties) {
+  async modify(properties) {
     const { id, email } = properties
 
     const currentUser = await this.first({ id })

--- a/packages/xo-server/src/models/user.mjs
+++ b/packages/xo-server/src/models/user.mjs
@@ -36,9 +36,13 @@ export class Users extends Collection {
   }
 
   async update(properties) {
-    const { email } = properties
+    const { id, email } = properties
 
-    if (await this.exists({ email })) {
+    const currentUser = await this.first({ id })
+    const emailUser = await this.first({ email })
+    const emailExists = emailUser !== undefined
+
+    if (emailExists && currentUser.id !== emailUser.id) {
       throw new Error(`the user ${email} already exists`)
     }
 

--- a/packages/xo-server/src/xo-mixins/subjects.mjs
+++ b/packages/xo-server/src/xo-mixins/subjects.mjs
@@ -139,8 +139,8 @@ export default class {
       preferences,
     }
   ) {
-    if (await this._users.exists({ email })) {
-      throw new Error(`the user ${email} already exists`)
+    if (await this._users.exists({ email: name })) {
+      throw new Error(`the user ${name} already exists`)
     }
 
     const user = await this.getUser(id)

--- a/packages/xo-server/src/xo-mixins/subjects.mjs
+++ b/packages/xo-server/src/xo-mixins/subjects.mjs
@@ -139,6 +139,10 @@ export default class {
       preferences,
     }
   ) {
+    if (await this._users.exists({ email })) {
+      throw new Error(`the user ${email} already exists`)
+    }
+
     const user = await this.getUser(id)
 
     if (name) {

--- a/packages/xo-server/src/xo-mixins/subjects.mjs
+++ b/packages/xo-server/src/xo-mixins/subjects.mjs
@@ -193,7 +193,7 @@ export default class {
     user.email = user.name
     delete user.name
 
-    await this._users.update(user)
+    await this._users.modify(user)
   }
 
   // Merge this method in getUser() when plain objects.

--- a/packages/xo-server/src/xo-mixins/subjects.mjs
+++ b/packages/xo-server/src/xo-mixins/subjects.mjs
@@ -193,7 +193,7 @@ export default class {
     user.email = user.name
     delete user.name
 
-    await this._users.updateIfNotExists(user)
+    await this._users.update(user)
   }
 
   // Merge this method in getUser() when plain objects.

--- a/packages/xo-server/src/xo-mixins/subjects.mjs
+++ b/packages/xo-server/src/xo-mixins/subjects.mjs
@@ -139,10 +139,6 @@ export default class {
       preferences,
     }
   ) {
-    if (await this._users.exists({ email: name })) {
-      throw new Error(`the user ${name} already exists`)
-    }
-
     const user = await this.getUser(id)
 
     if (name) {
@@ -197,7 +193,7 @@ export default class {
     user.email = user.name
     delete user.name
 
-    await this._users.update(user)
+    await this._users.updateIfNotExists(user)
   }
 
   // Merge this method in getUser() when plain objects.


### PR DESCRIPTION
### Description

Fix : user can set already used email.
Fix : bug when update password (or other properties), as discovered by @b-Nollet 

We now check if the user update his own properties.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
