### PR TITLE
fix(xo-server/Users): properly check email unicity

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,4 +31,6 @@
 
 <!--packages-start-->
 
+- xo-server patch
+
 <!--packages-end-->

--- a/packages/xo-server/src/collection/redis.mjs
+++ b/packages/xo-server/src/collection/redis.mjs
@@ -35,6 +35,16 @@ import Collection, { ModelAlreadyExists } from '../collection.mjs'
 const VERSION = '20170905'
 
 export default class Redis extends Collection {
+  // Called before a new model is added
+  //
+  // If throws, the add operation is aborted
+  async _beforeAdd(record) {}
+
+  // Called before a model is updated
+  //
+  // If throws, the update operation is aborted
+  async _beforeUpdate(record, previous) {}
+
   // Prepare a record before storing in the database
   //
   // Input object can be mutated or a new one returned
@@ -44,11 +54,6 @@ export default class Redis extends Collection {
   //
   // Input object can be mutated or a new one returned
   _unserialize(record) {}
-
-  // called
-  async _beforeAdd(record) {}
-
-  async _beforeUpdate(record, previous) {}
 
   constructor({ connection, indexes = [], namespace }) {
     super()

--- a/packages/xo-server/src/models/user.mjs
+++ b/packages/xo-server/src/models/user.mjs
@@ -9,7 +9,7 @@ import { parseProp } from './utils.mjs'
 export class Users extends Collection {
   async _beforeAdd({ email }) {
     if (await this.exists({ email })) {
-      throw new Error('duplicate email: ' + email)
+      throw new Error(`the user ${email} already exists`)
     }
   }
 

--- a/packages/xo-server/src/models/user.mjs
+++ b/packages/xo-server/src/models/user.mjs
@@ -7,6 +7,18 @@ import { parseProp } from './utils.mjs'
 // ===================================================================
 
 export class Users extends Collection {
+  async _beforeAdd({ email }) {
+    if (await this.exists({ email })) {
+      throw new Error('duplicate email: ' + email)
+    }
+  }
+
+  _beforeUpdate(user, previous) {
+    if (user.email !== previous.email) {
+      return this._beforeAdd(user)
+    }
+  }
+
   _serialize(user) {
     let tmp
     user.authProviders = isEmpty((tmp = user.authProviders)) ? undefined : JSON.stringify(tmp)
@@ -21,27 +33,5 @@ export class Users extends Collection {
     user.authProviders = parseProp('user', user, 'authProviders', undefined)
     user.groups = parseProp('user', user, 'groups', [])
     user.preferences = parseProp('user', user, 'preferences', {})
-  }
-
-  async create(properties) {
-    const { email } = properties
-
-    // Avoid duplicates.
-    if (await this.exists({ email })) {
-      throw new Error(`the user ${email} already exists`)
-    }
-
-    // Adds the user to the collection.
-    return /* await */ this.add(properties)
-  }
-
-  async update(properties) {
-    const { email } = properties
-
-    if (await this.exists({ email })) {
-      throw new Error(`the user ${email} already exists`)
-    }
-
-    return super.update(properties)
   }
 }

--- a/packages/xo-server/src/xo-mixins/subjects.mjs
+++ b/packages/xo-server/src/xo-mixins/subjects.mjs
@@ -83,7 +83,7 @@ export default class {
       properties.pw_hash = await hash(password)
     }
 
-    return this._users.create(properties)
+    return this._users.add(properties)
   }
 
   async deleteUser(id) {


### PR DESCRIPTION
### Description

Introduced by f2fe7731d

This commit introduce two new `Collection/Redis` protected async methods:

- `_beforeAdd(model)`: called before a new model is added
- `_beforeUpdate(model, previous)`: called before a model is updated

If the method throws, the corresponding operation is aborted.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
