### PR TITLE
fix(xo-lite/dashboard): add min-width to hosts patches container

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## **next**
+
+- [Pool/Dashboard] `Patches` and `Status` cards are displayed with a greater minimum width (PR [#8108](https://github.com/vatesfr/xen-orchestra/pull/8108))
+
 ## **0.5.0** (2024-10-31)
 
 - Handle IPv6 hosts (PR [#8044](https://github.com/vatesfr/xen-orchestra/pull/8044))

--- a/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardHostsPatches.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardHostsPatches.vue
@@ -1,5 +1,5 @@
 <template>
-  <UiCard>
+  <UiCard class="pool-dashboard-hosts-patches">
     <UiCardTitle class="patches-title">
       {{ $t('patches') }}
       <template v-if="areAllLoaded && count > 0" #right>
@@ -30,6 +30,10 @@ const { count, patches, areSomeLoaded, areAllLoaded } = useHostPatches(hosts)
 </script>
 
 <style lang="postcss" scoped>
+.pool-dashboard-hosts-patches {
+  min-width: 43.8rem;
+}
+
 .patches-title {
   --section-title-right-color: var(--color-danger-txt-base);
 }

--- a/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardStatus.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardStatus.vue
@@ -1,5 +1,5 @@
 <template>
-  <UiCard :color="hasError ? 'error' : undefined">
+  <UiCard class="pool-dashboard-status" :color="hasError ? 'error' : undefined">
     <UiCardTitle>{{ $t('status') }}</UiCardTitle>
     <NoDataError v-if="hasError" />
     <UiCardSpinner v-else-if="!isReady" />
@@ -54,3 +54,9 @@ const totalVmsCount = computed(() => vms.value.length)
 
 const activeVmsCount = computed(() => vms.value.filter(vm => vm.power_state === 'Running').length)
 </script>
+
+<style lang="postcss" scoped>
+.pool-dashboard-status {
+  min-width: 32rem;
+}
+</style>


### PR DESCRIPTION
### Description

Set a minimum width for the "Patches" and "Status" cards to align with the design system and allocate enough space for displaying data when it is being loaded.

### Screenshots

**Before:**
![image](https://github.com/user-attachments/assets/a7c55268-04f7-4b62-ac44-fcd5006eefe3)

**After:**
![image](https://github.com/user-attachments/assets/eec54ee7-cee3-48e9-b023-539f8226b74b)

![image](https://github.com/user-attachments/assets/e8f9b08c-93a7-4fd6-925c-f3f1f9c40382)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
