### PR TITLE
feat(xo-web): add documentation link when the host TLS key is too small

### DIFF
--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1023,6 +1023,7 @@ const messages = {
   hostSupportEnabled: 'XCP-ng Pro Support enabled on this host',
   noMoreMaintained: 'This host version is no longer maintained',
   pubKeyTooShort: 'TLS key is too small to update host to XCP-ng 8.3',
+  pubKeyTooShortLink: 'Follow this link for more details',
   longerCustomCertficate:
     'If your certificate is custom, you need to install a new one with a key length of 2048 or greater.',
   longerDefaultCertificate:

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1004,6 +1004,7 @@ const messages = {
   addSrLabel: 'Add SR',
   addVmLabel: 'Add VM',
   addHostsLabel: 'Add hosts',
+  clickLinkForDetails: 'Follow this link for more details',
   missingPatchesPool:
     'The pool needs to install {nMissingPatches, number} patch{nMissingPatches, plural, one {} other {es}}. This operation may take a while.',
   missingPatchesHost:
@@ -1023,7 +1024,6 @@ const messages = {
   hostSupportEnabled: 'XCP-ng Pro Support enabled on this host',
   noMoreMaintained: 'This host version is no longer maintained',
   pubKeyTooShort: 'TLS key is too small to update host to XCP-ng 8.3',
-  pubKeyTooShortLink: 'Follow this link for more details',
   longerCustomCertficate:
     'If your certificate is custom, you need to install a new one with a key length of 2048 or greater.',
   longerDefaultCertificate:

--- a/packages/xo-web/src/xo-app/home/host-item.js
+++ b/packages/xo-web/src/xo-app/home/host-item.js
@@ -221,15 +221,13 @@ export default class HostItem extends Component {
                 <li>{_('longerCustomCertficate')}</li>
                 <li>{_('longerDefaultCertificate')}</li>
               </ul>
-              <Tooltip>
-                <a
-                  href={`https://docs.xcp-ng.org/releases/release-8-3/#host-certificate-key-too-small-prevents-upgrade`}
-                  target='_blank'
-                  rel='noreferrer'
-                >
-                  <Icon icon='info' /> {_('pubKeyTooShortLink')}
-                </a>
-              </Tooltip>
+              <a
+                href='https://docs.xcp-ng.org/releases/release-8-3/#host-certificate-key-too-small-prevents-upgrade'
+                target='_blank'
+                rel='noreferrer'
+              >
+                <Icon icon='info' /> {_('clickLinkForDetails')}
+              </a>
             </span>
           ),
         })

--- a/packages/xo-web/src/xo-app/home/host-item.js
+++ b/packages/xo-web/src/xo-app/home/host-item.js
@@ -221,6 +221,15 @@ export default class HostItem extends Component {
                 <li>{_('longerCustomCertficate')}</li>
                 <li>{_('longerDefaultCertificate')}</li>
               </ul>
+              <Tooltip>
+                <a
+                  href={`https://docs.xcp-ng.org/releases/release-8-3/#host-certificate-key-too-small-prevents-upgrade`}
+                  target='_blank'
+                  rel='noreferrer'
+                >
+                  <Icon icon='info' /> {_('pubKeyTooShortLink')}
+                </a>
+              </Tooltip>
             </span>
           ),
         })


### PR DESCRIPTION
### Description

![image](https://github.com/user-attachments/assets/2acf0894-c421-4dd3-a294-99a8bf13e67f)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
