### PR TITLE
fix(xo-web/host/network): do not PIF.reconfigure_ipv6 if IPv6 is an empty string

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [Host/Network] When reconfiguring IP address on a PIF, no IPv6 reconfiguration if no IPv6
+- [Host/Network] When reconfiguring IP address on a PIF, no IPv6 reconfiguration if no IPv6 (PR [#8119](https://github.com/vatesfr/xen-orchestra/pull/8119))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Host/Network] When reconfiguring IP address on a PIF, no IPv6 reconfiguration if no IPv6
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -33,5 +35,6 @@
 
 - @xen-orchestra/web patch
 - @xen-orchestra/web-core minor
+- xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-web/src/xo-app/host/tab-network.js
+++ b/packages/xo-web/src/xo-app/host/tab-network.js
@@ -42,9 +42,10 @@ class ConfigureIpModal extends Component {
 
     const { pif } = props
     if (pif) {
+      const ipv6 = pif.ipv6?.[0]?.trim()
       this.state = {
         ...pick(pif, ['ip', 'netmask', 'dns', 'gateway']),
-        ipv6: pif.ipv6?.[0],
+        ipv6: ipv6 === '' ? undefined : ipv6,
       }
     }
   }


### PR DESCRIPTION
### To test

On the nested pool: `172.16.210.181`, try to reconfigure IPv4 of the management PIF on the host `mra 8.2 slave`.
On master: You can see an error in the web console. `"INVALID_IP_ADDRESS_SPECIFIED"`
On this branch: No error and IPv4 is reconfigured

### Description

See https://team.vates.fr/vates/pl/utda1cc3p3roiknt5y4yn3xqjo
Introduced by 1becccf
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
