### PR TITLE
feat(xo-server/api): ability to save all logs for a given call

### DIFF
--- a/@xen-orchestra/log/.USAGE.md
+++ b/@xen-orchestra/log/.USAGE.md
@@ -228,10 +228,13 @@ import { createLogger } from '@xen-orchestra/log'
 const logger = createLogger('my-logger')
 
 await captureLogs(
-  log => {
+  (log, fallbackTransport) => {
     // every logs emitted in the async context of `fn` will arrive here
     //
     // do not emit logs in this function or this will create a loop.
+
+    // logs can be forwarded to the fallback transport
+    fallbackTransport(log)
   },
   async () => {
     logger.debug('synchronous logs are captured')

--- a/@xen-orchestra/log/README.md
+++ b/@xen-orchestra/log/README.md
@@ -246,10 +246,13 @@ import { createLogger } from '@xen-orchestra/log'
 const logger = createLogger('my-logger')
 
 await captureLogs(
-  log => {
+  (log, fallbackTransport) => {
     // every logs emitted in the async context of `fn` will arrive here
     //
     // do not emit logs in this function or this will create a loop.
+
+    // logs can be forwarded to the fallback transport
+    fallbackTransport(log)
   },
   async () => {
     logger.debug('synchronous logs are captured')

--- a/@xen-orchestra/log/capture.js
+++ b/@xen-orchestra/log/capture.js
@@ -16,7 +16,7 @@ const asyncStorage = global[symbol] || (global[symbol] = new AsyncLocalStorage()
  * Runs `fn` capturing all emitted logs (sync and async) and forward them to `onLog`.
  *
  * @template {(...args: any) => any} F
- * @param {undefined | (log: object) => void} onLog
+ * @param {undefined | (log: object, fallbackTransport: (log: object) => void) => void} onLog
  * @param {F} fn
  * @returns {ReturnType<F>}
  */
@@ -34,6 +34,11 @@ exports.createCaptureTransport = function createCaptureTransport(fallback) {
   fallback = fallback === undefined ? Function.prototype : createTransport(fallback)
 
   return function captureTransport(log) {
-    ;(asyncStorage.getStore() || fallback)(log)
+    const onLog = asyncStorage.getStore()
+    if (onLog !== undefined) {
+      onLog(log, fallback)
+    } else {
+      fallback(log)
+    }
   }
 }

--- a/packages/xo-server/package.json
+++ b/packages/xo-server/package.json
@@ -122,6 +122,7 @@
     "semver": "^7.3.2",
     "serve-static": "^1.13.1",
     "set-cookie-parser": "^2.3.5",
+    "sonic-boom": "^4.2.0",
     "source-map-support": "^0.5.16",
     "split-host": "^2.0.0",
     "split2": "^4.1.0",

--- a/packages/xo-server/src/xo-mixins/api.mjs
+++ b/packages/xo-server/src/xo-mixins/api.mjs
@@ -1,6 +1,14 @@
 import emitAsync from '@xen-orchestra/emit-async'
 import Obfuscate from '@vates/obfuscate'
+import SonicBoom from 'sonic-boom'
+import { captureLogs } from '@xen-orchestra/log/capture'
 import { createLogger } from '@xen-orchestra/log'
+import { finished } from 'node:stream/promises'
+import { inspect } from 'node:util'
+import { join } from 'node:path'
+import { NAMES } from '@xen-orchestra/log/levels'
+import { tmpdir } from 'node:os'
+import { unlink } from 'node:fs/promises'
 
 import cloneDeep from 'lodash/cloneDeep.js'
 import forEach from 'lodash/forEach.js'
@@ -11,7 +19,7 @@ import { format, JsonRpcError, MethodNotFound } from 'json-rpc-peer'
 
 import * as methods from '../api/index.mjs'
 import Connection from '../connection.mjs'
-import { noop, serializeError } from '../utils.mjs'
+import { noop, safeDateFormat, serializeError } from '../utils.mjs'
 
 import * as errors from 'xo-common/api-errors.js'
 import { compileXoJsonSchema } from './_xoJsonSchema.mjs'
@@ -342,7 +350,7 @@ export default class Api {
     return this.#apiContext.run(apiContext, fn)
   }
 
-  async #callApiMethod(name, method, params) {
+  async #callApiMethod(name, method, { _log, ...params }) {
     const app = this._app
     const startTime = Date.now()
 
@@ -372,6 +380,10 @@ export default class Api {
     )
 
     try {
+      if (_log !== undefined && this.apiContext.permission !== 'admin') {
+        throw errors.unauthorized('admin')
+      }
+
       await checkPermission.call(app, method)
 
       // API methods are in a namespace.
@@ -398,15 +410,64 @@ export default class Api {
 
       const resolvedParams = await resolveParams.call(app, method, params)
 
-      // data.params contains obfuscated params
-      let result = await (name in NO_LOG_METHODS
-        ? method.call(app, resolvedParams)
-        : app.tasks
-            .create(
-              { name: 'API call: ' + name, method: name, params: data.params, type: 'api.call' },
-              { clearLogOnSuccess: true }
-            )
-            .run(() => method.call(app, resolvedParams)))
+      const run = () =>
+        name in NO_LOG_METHODS
+          ? method.call(app, resolvedParams)
+          : app.tasks
+              .create(
+                { name: 'API call: ' + name, method: name, params: data.params, type: 'api.call' },
+                { clearLogOnSuccess: true }
+              )
+              .run(() => method.call(app, resolvedParams))
+
+      if (_log === undefined) {
+        _log = app.config.getOptional(['api', 'logs', name]) ?? false
+      }
+      let result
+      if (_log) {
+        const file = join(tmpdir(), `xo-api-${safeDateFormat(new Date())}-${name}.log`)
+        const stream = new SonicBoom({
+          dest: file,
+          mode: 0o600,
+        }).on('error', error => {
+          captureLogs(undefined, () => log.warn(error))
+        })
+
+        let success = true
+        try {
+          result = await captureLogs((log, fallbackTransport) => {
+            fallbackTransport(log)
+
+            const { time, level, namespace, message, data } = log
+            const line = [time.toISOString(), namespace, '[' + NAMES[level] + ']', message]
+            if (data != null) {
+              line.push(inspect(data))
+            }
+
+            stream.write(line.join(' ') + '\n')
+          }, run)
+        } catch (error) {
+          success = false
+
+          throw error
+        } finally {
+          const deleteFile = success && _log === 'failure'
+
+          if (deleteFile) {
+            stream.destroy()
+          } else {
+            stream.end()
+          }
+
+          await finished(stream)
+
+          if (deleteFile) {
+            await unlink(file).catch(log.warn)
+          }
+        }
+      } else {
+        result = await run()
+      }
 
       // If nothing was returned, consider this operation a success
       // and return true.

--- a/packages/xo-server/src/xo-mixins/logs/index.mjs
+++ b/packages/xo-server/src/xo-mixins/logs/index.mjs
@@ -1,4 +1,5 @@
 import { configure } from '@xen-orchestra/log/configure'
+import { createCaptureTransport } from '@xen-orchestra/log/capture'
 import { dedupe } from '@xen-orchestra/log/dedupe'
 import { defer, fromEvent } from 'promise-toolbox'
 
@@ -38,11 +39,13 @@ export default class Logs {
       // override env.DEBUG so that spawned process (workers) benefits from the new configuration as well
       process.env.DEBUG = debug
 
-      configure({
-        filter: debug,
-        level,
-        transport: dedupe({ transport: transports }),
-      })
+      configure(
+        createCaptureTransport({
+          filter: debug,
+          level,
+          transport: dedupe({ transport: transports }),
+        })
+      )
     })
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5621,6 +5621,11 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+atomic-sleep@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
+  integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
+
 attr-accept@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-1.1.3.tgz#48230c79f93790ef2775fcec4f0db0f5db41ca52"
@@ -17817,6 +17822,13 @@ socks@^2.8.3:
   dependencies:
     ip-address "^9.0.5"
     smart-buffer "^4.2.0"
+
+sonic-boom@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-4.2.0.tgz#e59a525f831210fa4ef1896428338641ac1c124d"
+  integrity sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==
+  dependencies:
+    atomic-sleep "^1.0.0"
 
 sorted-object@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
### Description

The goal of this new feature is to help developers investigate issues by allowing them to easily gather more information.

When enabled, all logs emitted in a given API call are stored in a file (`${tmpdir}/xo-api-${date}-${method}.log`).

Administrators can use the special `_log` param to request it:

```sh
xo-cli vm.start id=$id _log=json:true

# only keep the log if the call has failed
xo-cli vm.start id=$id _log=failure
```

Or it can be enabled for all calls to a method in xo-server's configuration:

```toml
[api.logs]
'vm.start' = 'failure'
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
