### PR TITLE
feat(xo-server): ability to manage VIFs using REST API when creating a VM

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [REST/VM] When creating a VM, the template's VIFs are created. It is also possible to create more VIFs or delete/update template's VIFs (PR [#8137](https://github.com/vatesfr/xen-orchestra/pull/8137))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -30,5 +32,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- xo-server minor
 
 <!--packages-end-->

--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -148,11 +148,16 @@ export const create = defer(async function ($defer, params) {
   params.vifs =
     vifs &&
     map(vifs, vif => {
+      if (vif.remove) {
+        return vif
+      }
+
       const network = this.getObject(vif.network)
 
       objectIds.push(network.id)
 
       return {
+        device: vif.device,
         mac: vif.mac,
         network: network._xapiId,
         ipv4_allowed: vif.allowedIpv4Addresses,
@@ -315,7 +320,7 @@ create.params = {
       type: 'object',
       properties: {
         // UUID of the network to create the interface in.
-        network: { type: 'string' },
+        network: { type: 'string', optional: true },
 
         mac: {
           optional: true, // Auto-generated per default.
@@ -333,6 +338,17 @@ create.params = {
           type: 'array',
           items: { type: 'string' },
         },
+        device: { type: 'string', optional: true },
+        remove: { type: 'boolean', optional: true },
+
+        // device: {
+        //   optional: true,
+        //   type: 'string',
+        // },
+        // remove: {
+        //   optional: true,
+        //   type: 'boolean',
+        // },
       },
     },
   },

--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -148,16 +148,11 @@ export const create = defer(async function ($defer, params) {
   params.vifs =
     vifs &&
     map(vifs, vif => {
-      if (vif.remove) {
-        return vif
-      }
-
       const network = this.getObject(vif.network)
 
       objectIds.push(network.id)
 
       return {
-        device: vif.device,
         mac: vif.mac,
         network: network._xapiId,
         ipv4_allowed: vif.allowedIpv4Addresses,
@@ -185,7 +180,7 @@ export const create = defer(async function ($defer, params) {
     params.tags = paramsTags !== undefined ? paramsTags.concat(resourceSetTags) : resourceSetTags
   }
 
-  const xapiVm = await xapi.createVm(template._xapiId, params, checkLimits, user.id)
+  const xapiVm = await xapi.createVm(template._xapiId, params, checkLimits, user.id, { destroyAllVifs: true })
   $defer.onFailure(() => xapi.VM_destroy(xapiVm.$ref, { deleteDisks: true, force: true }))
 
   const vm = xapi.xo.addObject(xapiVm)
@@ -320,7 +315,7 @@ create.params = {
       type: 'object',
       properties: {
         // UUID of the network to create the interface in.
-        network: { type: 'string', optional: true },
+        network: { type: 'string' },
 
         mac: {
           optional: true, // Auto-generated per default.
@@ -338,8 +333,6 @@ create.params = {
           type: 'array',
           items: { type: 'string' },
         },
-        device: { type: 'string', optional: true },
-        remove: { type: 'boolean', optional: true },
       },
     },
   },

--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -340,15 +340,6 @@ create.params = {
         },
         device: { type: 'string', optional: true },
         remove: { type: 'boolean', optional: true },
-
-        // device: {
-        //   optional: true,
-        //   type: 'string',
-        // },
-        // remove: {
-        //   optional: true,
-        //   type: 'boolean',
-        // },
       },
     },
   },

--- a/packages/xo-server/src/xapi/mixins/vm.mjs
+++ b/packages/xo-server/src/xapi/mixins/vm.mjs
@@ -3,6 +3,7 @@ import find from 'lodash/find.js'
 import gte from 'lodash/gte.js'
 import includes from 'lodash/includes.js'
 import isEmpty from 'lodash/isEmpty.js'
+import keyBy from 'lodash/keyBy.js'
 import lte from 'lodash/lte.js'
 import mapToArray from 'lodash/map.js'
 import mapValues from 'lodash/mapValues.js'
@@ -187,19 +188,41 @@ const methods = {
       )
     }
 
-    // Destroys the VIFs cloned from the template.
-    await Promise.all(vm.$VIFs.map(vif => this._deleteVif(vif)))
-
-    // Creates the VIFs specified by the user.
     if (vifs) {
       const devices = await this.call('VM.get_allowed_VIF_devices', vm.$ref)
+      const _vifsToCreate = []
+      const _vifsToRemove = []
+      const vmVifByDevice = keyBy(vm.$VIFs, 'device')
+
+      vifs.forEach(vif => {
+        if (vif.device === undefined) {
+          vif.device = devices.shift()
+          _vifsToCreate.push(vif)
+          return
+        }
+
+        const vmVif = vmVifByDevice[vif.device]
+        if (vif.remove) {
+          if (vmVif !== undefined) {
+            _vifsToRemove.push(vmVif)
+          }
+          return
+        }
+
+        if (vmVif !== undefined) {
+          _vifsToRemove.push(vmVif)
+        }
+        _vifsToCreate.push(vif)
+      })
+
+      await Promise.all(_vifsToRemove.map(vif => this._deleteVif(vif)))
       await Promise.all(
-        mapToArray(vifs, (vif, index) =>
+        _vifsToCreate.map(vif =>
           this.VIF_create(
             {
               ipv4_allowed: vif.ipv4_allowed,
               ipv6_allowed: vif.ipv6_allowed,
-              device: devices[index],
+              device: vif.device,
               locking_mode: isEmpty(vif.ipv4_allowed) && isEmpty(vif.ipv6_allowed) ? 'network_default' : 'locked',
               MTU: vif.mtu,
               network: this.getObject(vif.network).$ref,

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -765,6 +765,21 @@ export default class RestApi {
             name_label: { type: 'string' },
             network_config: { type: 'string', optional: true },
             template: { type: 'string' },
+            vifs: {
+              default: [],
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  remove: { type: 'boolean', optional: true },
+                  network: { type: 'string', optional: true },
+                  device: { type: 'string', optional: true },
+                  mac: { type: 'string', optional: true },
+                  ipv4_allowed: { type: 'array', items: { type: 'string' }, optional: true },
+                  ipv6_allowed: { type: 'array', items: { type: 'string' }, optional: true },
+                },
+              },
+            },
           }
         ),
         emergency_shutdown: async ({ xapiObject }) => {

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -771,12 +771,12 @@ export default class RestApi {
               items: {
                 type: 'object',
                 properties: {
-                  remove: { type: 'boolean', optional: true },
-                  network: { type: 'string', optional: true },
+                  destroy: { type: 'boolean', optional: true },
                   device: { type: 'string', optional: true },
-                  mac: { type: 'string', optional: true },
                   ipv4_allowed: { type: 'array', items: { type: 'string' }, optional: true },
                   ipv6_allowed: { type: 'array', items: { type: 'string' }, optional: true },
+                  mac: { type: 'string', optional: true },
+                  network: { type: 'string', optional: true },
                 },
               },
             },

--- a/packages/xo-web/src/xo-app/new-vm/index.js
+++ b/packages/xo-web/src/xo-app/new-vm/index.js
@@ -485,9 +485,9 @@ export default class NewVm extends BaseComponent {
     const resourceSet = this._getResourceSet()
     const { template } = this.props
 
-    // In case the user remove some VIFs created by the template
+    // In case user deletes some VIF created by the template
     // We need to mark them with `remove:true`
-    // so that xo-server correctly remove it
+    // so that xo-server deletes them properly
     if (_VIFs.length < templateVifs.length) {
       const _vifByDevice = keyBy(_VIFs, 'device')
       templateVifs.forEach(templateVif => {
@@ -497,7 +497,6 @@ export default class NewVm extends BaseComponent {
       })
     }
 
-    // return
     // Either use `memory` OR `memory*` params
     let { memory, memoryStaticMax, memoryDynamicMin, memoryDynamicMax } = state
     if ((memoryStaticMax != null || memoryDynamicMin != null) && memoryDynamicMax == null) {


### PR DESCRIPTION
### Description

Previously, we destroyed all VIFs then `xo-web` sent the VIFs created by the user + the template's VIFs and xo-server creates all the VIFs sent by the user. This behavior was a bit weird, but since we mainly use xo-server with xo-web, it wasn't a problem.
This behavior meant that creating a VM from the REST API did not create the VIFs of the VM template.

This PR changes the handling of VIFs when creating a VM.
Instead of deleting all VIFs and only creating the VIFs sent by the client, the VIFs template are not removed. There is always the possibility of removing a VIF from the template by passing the `destroy` parameter with the VIF's device. 
`{device: <vif-device>, destroy: true}`
To edit a VIF of the template, simply pass the device the information:
`{device: <vif-device>, ...all other vif fields`

### Example
```
// the VM will be created with the template's VIFs
xo-cli rest post pools/<your-pool-id>/actions/create_vm \
name_label="mra-vm-from-rest-api" \
template="<your-template-id>"

// the VM will be created with the template's VIFs + one VIF
xo-cli rest post pools/<your-pool-id>/actions/create_vm \
name_label="mra-vm-from-rest-api" \
template="<your-template-id>" \
vifs=json:'[{"network":"<your-network-id>"}]'

// the VM will be created with the template's VIFs but the VIF with `device 0` will be updated
xo-cli rest post pools/<your-pool-id>/actions/create_vm \
name_label="mra-vm-from-rest-api" \
template="<your-template-id>" \
vifs=json:'[{"device":"0", "network":"<your-network-id>"}]'

// the VM will be created with the template's VIFs but, the VIF with `device 0` will be removed
xo-cli rest post pools/<your-pool-id>/actions/create_vm \
name_label="mra-vm-from-rest-api" \
template="<your-template-id>" \
vifs=json:'[{"device":"0", "destroy": true}]'
```



### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
