### PR TITLE
feat(@xen-orchestra/fs): add getSizeOnDisk function

### DIFF
--- a/@xen-orchestra/fs/src/fs.test.js
+++ b/@xen-orchestra/fs/src/fs.test.js
@@ -34,6 +34,7 @@ const rejectionOf = p =>
     reason => reason
   )
 
+// TODO : add tests on encrypted remote
 const handlers = [`file://${tmpdir()}`]
 if (process.env.xo_fs_nfs) handlers.push(process.env.xo_fs_nfs)
 if (process.env.xo_fs_smb) handlers.push(process.env.xo_fs_smb)
@@ -97,11 +98,12 @@ handlers.forEach(url => {
       })
     })
 
-    describe('#getSize()', () => {
+    // TODO : add test "should throw if remote is encrypted" on #getSize()
+    describe('#getSizeOnDisk()', () => {
       beforeEach(() => handler.outputFile('file', TEST_DATA))
 
       testWithFileDescriptor('file', 'r', async () => {
-        assert.equal(await handler.getSize('file'), TEST_DATA_LEN)
+        assert.equal(await handler.getSizeOnDisk('file'), TEST_DATA_LEN)
       })
     })
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,7 +37,7 @@
 
 <!--packages-start-->
 
-- @xen-orchestra/fs patch
+- @xen-orchestra/fs minor
 - @xen-orchestra/web patch
 - @xen-orchestra/web-core minor
 - xo-server minor


### PR DESCRIPTION
### Description

Split `getSize` in two functions and have it return a more accurate value without any `ivLength` magic.

[XO-178](https://project.vates.tech/vates-global/projects/70ab2907-1ac3-4e7d-831f-a8752c36474d/issues/eb47fa85-f241-409a-acdb-84e7dea17fb2)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
