### PR TITLE
Feat(backups): support VTPMs content backup/restore

### DIFF
--- a/@xen-orchestra/backups/ImportVmBackup.mjs
+++ b/@xen-orchestra/backups/ImportVmBackup.mjs
@@ -58,7 +58,7 @@ export class ImportVmBackup {
   async _reuseNearestSnapshot($defer, ignoredVdis) {
     const metadata = this._metadata
     const { mapVdisSrs } = this._importIncrementalVmSettings
-    const { vbds, vhds, vifs, vm, vmSnapshot } = metadata
+    const { vbds, vhds, vifs, vm, vmSnapshot, vtpms } = metadata
     const streams = {}
     const metdataDir = dirname(metadata._filename)
     const vdis = ignoredVdis === undefined ? metadata.vdis : pickBy(metadata.vdis, vdi => !ignoredVdis.has(vdi.uuid))
@@ -191,6 +191,7 @@ export class ImportVmBackup {
       version: '1.0.0',
       vifs,
       vm: { ...vm, suspend_VDI: vmSnapshot.suspend_VDI },
+      vtpms,
     }
   }
 

--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -744,7 +744,7 @@ export class RemoteAdapter {
 
   async readIncrementalVmBackup(metadata, ignoredVdis, { useChain = true } = {}) {
     const handler = this._handler
-    const { vbds, vhds, vifs, vm, vmSnapshot } = metadata
+    const { vbds, vhds, vifs, vm, vmSnapshot, vtpms } = metadata
     const dir = dirname(metadata._filename)
     const vdis = ignoredVdis === undefined ? metadata.vdis : pickBy(metadata.vdis, vdi => !ignoredVdis.has(vdi.uuid))
 
@@ -760,6 +760,7 @@ export class RemoteAdapter {
       version: '1.0.0',
       vifs,
       vm: { ...vm, suspend_VDI: vmSnapshot.suspend_VDI },
+      vtpms,
     }
   }
 

--- a/@xen-orchestra/backups/_incrementalVm.mjs
+++ b/@xen-orchestra/backups/_incrementalVm.mjs
@@ -294,6 +294,12 @@ export const importIncrementalVm = defer(async function importIncrementalVm(
       }
     }),
   ])
+  // recreate VTPMs
+  await Promise.all(
+    (incrementalVm.vtpms ?? []).map(async contents => {
+      await xapi.VTPM_create({ VM: vmRef, contents })
+    })
+  )
 
   await Promise.all([
     incrementalVm.vm.ha_always_run && xapi.setField('VM', vmRef, 'ha_always_run', true),

--- a/@xen-orchestra/backups/_incrementalVm.mjs
+++ b/@xen-orchestra/backups/_incrementalVm.mjs
@@ -104,6 +104,18 @@ export async function exportIncrementalVm(
     }
   })
 
+  const vtpms = await Promise.all(
+    vm.$VTPMs.map(async vtpm => {
+      let content
+      try {
+        content = await vm.$xapi.call('VTPM.get_contents', vtpm.$ref)
+      } catch (err) {
+        console.error(err)
+      }
+      return content
+    })
+  )
+
   return Object.defineProperty(
     {
       version: '1.1.0',
@@ -113,6 +125,7 @@ export async function exportIncrementalVm(
       vm: {
         ...vm,
       },
+      vtpms,
     },
     'streams',
     {

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
@@ -221,6 +221,7 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
       vhds,
       vm,
       vmSnapshot,
+      vtpms: deltaExport.vtpms,
     }
 
     const { size } = await Task.run({ name: 'transfer' }, async () => {

--- a/@xen-orchestra/xapi/vtpm.mjs
+++ b/@xen-orchestra/xapi/vtpm.mjs
@@ -2,7 +2,7 @@ import upperFirst from 'lodash/upperFirst.js'
 import { incorrectState } from 'xo-common/api-errors.js'
 
 export default class Vtpm {
-  async create({ is_unique = false, VM }) {
+  async create({ is_unique = false, VM, contents }) {
     const pool = this.pool
 
     // If VTPM.create is called on a pool that doesn't support VTPM, the errors aren't explicit.
@@ -17,7 +17,11 @@ export default class Vtpm {
     }
 
     try {
-      return await this.call('VTPM.create', VM, is_unique)
+      const ref = await this.call('VTPM.create', VM, is_unique)
+      if (contents !== undefined) {
+        await this.call('VTPM.set_contents', ref, contents)
+      }
+      return ref
     } catch (error) {
       const { code, params } = error
       if (code === 'VM_BAD_POWER_STATE') {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 - [Host/General] Shows if a BIOS update is available for 2CRSi server (PR [#8146](https://github.com/vatesfr/xen-orchestra/pull/8146))
 - **XO 6**:
   - Add 404 page (PR [#8145](https://github.com/vatesfr/xen-orchestra/pull/8145))
+- [backups] Handle VTPM content on incremental backup/replication/restore, including differential restore
 
 ### Bug fixes
 
@@ -36,6 +37,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups minor
 - @xen-orchestra/web minor
 - xo-server minor
 - xo-web minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,8 +15,7 @@
 - [Host/General] Shows if a BIOS update is available for 2CRSi server (PR [#8146](https://github.com/vatesfr/xen-orchestra/pull/8146))
 - **XO 6**:
   - Add 404 page (PR [#8145](https://github.com/vatesfr/xen-orchestra/pull/8145))
-- [backups] Handle VTPM content on incremental backup/replication/restore, including differential restore
-
+- [backups] Handle VTPM content on incremental backup/replication/restore, including differential restore (PR [#8139](https://github.com/vatesfr/xen-orchestra/pull/8139))
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”


### PR DESCRIPTION
### Description

This PR add the support for correctly saving, transfering and restoring the content of VTPMs
This call 2 internal/ undocumented APIs methof of the xapi `VTPM.get_contents` and 
`VTPM.set_contents`

The raw content of the VTPM will be written unencrypted in the metadata JSON, use remote
encryption at rest if you want to protect this data

tested with and without differential restore :  
![Capture d’écran du 2024-11-18 15-20-34](https://github.com/user-attachments/assets/e45b2d08-b6c0-4269-a165-6a83150c52ea)

### Checklist


- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
