### PR TITLE
fix(xo-lite/stories): bad custom-event name case

### DIFF
--- a/@xen-orchestra/lite/src/components/component-story/StoryMenuTree.vue
+++ b/@xen-orchestra/lite/src/components/component-story/StoryMenuTree.vue
@@ -4,7 +4,7 @@
       <span
         v-if="node.children.size > 0"
         class="directory typo p1-medium"
-        @click="emit('toggle-directory', node.directory)"
+        @click="emit('toggleDirectory', node.directory)"
       >
         <UiIcon :icon="isOpen(node.directory) ? faFolderOpen : faFolderClosed" />
         {{ formatName(key) }}
@@ -18,7 +18,7 @@
         v-if="isOpen(node.directory)"
         :tree="node.children"
         :opened-directories="openedDirectories"
-        @toggle-directory="emit('toggle-directory', $event)"
+        @toggle-directory="emit('toggleDirectory', $event)"
       />
     </li>
   </ul>
@@ -35,7 +35,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  'toggle-directory': [directory: string]
+  toggleDirectory: [directory: string]
 }>()
 
 const isOpen = (directory: string) => props.openedDirectories.has(directory)


### PR DESCRIPTION
### Description

Introduced by 0603b63

Fix custom event-name case in `StoryMenuTree.vue`, to match ESLint `vue/custom-event-name-casing` rule.
Fixes CI.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
