### PR TITLE
feat(web-core): create VtsCardRowKeyValue component

### DIFF
--- a/@xen-orchestra/lite/src/stories/web-core/card/vts-card-row-key-value.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/card/vts-card-row-key-value.story.vue
@@ -1,0 +1,86 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties, settings }"
+    :params="[
+      slot('key').help('Meant to receive a title'),
+      slot('value').help('Meant to receive text, tags or other value'),
+      slot('addons').help('Meant to receive icons or other actions buttons '),
+      setting('defaultSlotContent').preset('Uuid').widget(text()),
+      setting('contentSlotContent').preset('71df26a271df26a271df26a271df26a271df26a').widget(text()),
+    ]"
+  >
+    <UiCard class="card">
+      <VtsCardRowKeyValue v-bind="properties">
+        <template #key>
+          {{ settings.defaultSlotContent }}
+        </template>
+        <template #value>
+          <span>
+            {{ settings.contentSlotContent }}
+          </span>
+        </template>
+        <template #addons>
+          <VtsIcon accent="warning" :icon="faCircle" :overlay-icon="faStar" />
+          <UiButtonIcon :icon="faCopy" size="medium" accent="info" />
+        </template>
+      </VtsCardRowKeyValue>
+
+      <VtsCardRowKeyValue v-bind="properties">
+        <template #key>
+          <span>Network</span>
+        </template>
+
+        <template #value>
+          <UiObjectLink route="`/vm/test/console`">
+            <template #icon>
+              <UiComplexIcon size="medium">
+                <VtsIcon :icon="faNetworkWired" accent="current" />
+                <VtsIcon accent="success" :icon="faCircle" :overlay-icon="faCheck" />
+              </UiComplexIcon>
+            </template>
+            <span>Network Name</span>
+          </UiObjectLink>
+        </template>
+        <template #addons>
+          <UiButtonIcon :icon="faCopy" size="medium" accent="info" />
+        </template>
+      </VtsCardRowKeyValue>
+
+      <VtsCardRowKeyValue v-bind="properties">
+        <template #key>
+          <span>Status</span>
+        </template>
+        <template #value>
+          <UiInfo accent="success">Connected</UiInfo>
+        </template>
+        <template #addons>
+          <UiButtonIcon :icon="faCopy" size="medium" accent="info" />
+          <UiButtonIcon :icon="faEllipsis" size="medium" accent="info" />
+        </template>
+      </VtsCardRowKeyValue>
+    </UiCard>
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import { setting, slot } from '@/libs/story/story-param'
+import { text } from '@/libs/story/story-widget'
+import VtsCardRowKeyValue from '@core/components/card/VtsCardRowKeyValue.vue'
+import VtsIcon from '@core/components/icon/VtsIcon.vue'
+import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
+import UiCard from '@core/components/ui/card/UiCard.vue'
+import UiComplexIcon from '@core/components/ui/complex-icon/UiComplexIcon.vue'
+import UiInfo from '@core/components/ui/info/UiInfo.vue'
+import UiObjectLink from '@core/components/ui/object-link/UiObjectLink.vue'
+import { faCheck, faCircle, faCopy, faEllipsis, faNetworkWired, faStar } from '@fortawesome/free-solid-svg-icons'
+</script>
+
+<style lang="postcss" scoped>
+.card {
+  width: 400px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+</style>

--- a/@xen-orchestra/web-core/lib/components/card/VtsCardRowKeyValue.vue
+++ b/@xen-orchestra/web-core/lib/components/card/VtsCardRowKeyValue.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="vts-card-row-key-value typo p3-regular">
+    <div class="key">
+      <slot name="key" />
+    </div>
+    <div v-tooltip class="value text-ellipsis">
+      <slot name="value" />
+    </div>
+    <div v-if="slots.addons" class="addons">
+      <slot name="addons" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { vTooltip } from '@core/directives/tooltip.directive'
+
+const slots = defineSlots<{
+  key(): any
+  value(): any
+  addons?(): any
+}>()
+</script>
+
+<style lang="postcss" scoped>
+.vts-card-row-key-value {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+
+  .key {
+    min-width: 12rem;
+    overflow-wrap: break-word;
+    color: var(--color-neutral-txt-secondary);
+  }
+
+  .value {
+    color: var(--color-neutral-txt-primary);
+  }
+
+  .addons {
+    display: flex;
+    gap: 0.8rem;
+    margin-left: auto;
+    font-size: 1.6rem;
+  }
+}
+</style>

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,6 +36,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/web-core minor
 - @xen-orchestra/web minor
 - xo-server minor
 - xo-web minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,8 +36,8 @@
 
 <!--packages-start-->
 
-- @xen-orchestra/web-core minor
 - @xen-orchestra/web minor
+- @xen-orchestra/web-core minor
 - xo-server minor
 - xo-web minor
 


### PR DESCRIPTION
### Description

Creation of a card item component

### Screenshot

<img width="491" alt="Capture d’écran 2024-11-28 à 10 14 26" src="https://github.com/user-attachments/assets/eb0a7c22-b05f-4c26-9162-9ceaa8fef076">

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
