### PR TITLE
fix(vhd-lib): return accurate merge size

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 - **XO 6**:
   - Add 404 page (PR [#8145](https://github.com/vatesfr/xen-orchestra/pull/8145))
 - [backups] Handle VTPM content on incremental backup/replication/restore, including differential restore (PR [#8139](https://github.com/vatesfr/xen-orchestra/pull/8139))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -39,8 +40,8 @@
 - @xen-orchestra/backups minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+- vhd-lib patch
 - xo-server minor
 - xo-web minor
-- vhd-lib patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -41,5 +41,6 @@
 - @xen-orchestra/web-core minor
 - xo-server minor
 - xo-web minor
+- vhd-lib patch
 
 <!--packages-end-->

--- a/packages/vhd-lib/Vhd/VhdAbstract.js
+++ b/packages/vhd-lib/Vhd/VhdAbstract.js
@@ -114,9 +114,10 @@ exports.VhdAbstract = class VhdAbstract {
    * @returns {number} the merged data size
    */
   async mergeBlock(child, blockId) {
+    const isBlockPresent = this.containsBlock(blockId)
     const block = await child.readBlock(blockId)
     await this.writeEntireBlock(block)
-    return block.data.length
+    return isBlockPresent ? 0 : this.fullBlockSize
   }
 
   /**

--- a/packages/vhd-lib/Vhd/VhdDirectory.js
+++ b/packages/vhd-lib/Vhd/VhdDirectory.js
@@ -264,7 +264,7 @@ exports.VhdDirectory = class VhdDirectory extends VhdAbstract {
     try {
       const blockExists = this.containsBlock(blockId)
       if (blockExists) {
-        initialSize = this._handler.getSizeOnDisk(this._getFullBlockPath(blockId))
+        initialSize = await this._handler.getSizeOnDisk(this._getFullBlockPath(blockId))
       }
 
       await this._handler.rename(childBlockPath, this._getFullBlockPath(blockId))
@@ -290,7 +290,7 @@ exports.VhdDirectory = class VhdDirectory extends VhdAbstract {
       }
     }
     setBitmap(this.#blockTable, blockId)
-    return this._handler.getSizeOnDisk(this._getFullBlockPath(blockId)) - initialSize
+    return (await this._handler.getSizeOnDisk(this._getFullBlockPath(blockId))) - initialSize
   }
 
   async writeEntireBlock(block) {

--- a/packages/vhd-lib/Vhd/VhdDirectory.js
+++ b/packages/vhd-lib/Vhd/VhdDirectory.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { unpackHeader, unpackFooter, sectorsToBytes } = require('./_utils')
+const { unpackHeader, unpackFooter } = require('./_utils')
 const { createLogger } = require('@xen-orchestra/log')
 const { fuFooter, fuHeader, checksumStruct } = require('../_structs')
 const { test, set: setBitmap } = require('../_bitmap')
@@ -248,7 +248,7 @@ exports.VhdDirectory = class VhdDirectory extends VhdAbstract {
   }
 
   // only works if data are in the same handler
-  // and if the full block is modified in child ( which is the case with xcp)
+  // and if the full block is modified in child (which is the case with xcp)
   // and if the compression type is same on both sides
   async mergeBlock(child, blockId, isResumingMerge = false) {
     const childBlockPath = child._getFullBlockPath?.(blockId)
@@ -281,7 +281,7 @@ exports.VhdDirectory = class VhdDirectory extends VhdAbstract {
       }
     }
     setBitmap(this.#blockTable, blockId)
-    return sectorsToBytes(this.sectorsPerBlock)
+    return this._handler.getSizeOnDisk(this._getFullBlockPath(blockId))
   }
 
   async writeEntireBlock(block) {


### PR DESCRIPTION
### Description

Use the new `getSizeOnDisk` function to return the accurate merge size difference instead of the full block size.

Second part of [XO-178](https://project.vates.tech/vates-global/projects/70ab2907-1ac3-4e7d-831f-a8752c36474d/issues/eb47fa85-f241-409a-acdb-84e7dea17fb2)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
