### PR TITLE
fix(backups): use config from config file

### DIFF
--- a/@xen-orchestra/backups/_runners/Metadata.mjs
+++ b/@xen-orchestra/backups/_runners/Metadata.mjs
@@ -17,7 +17,7 @@ const DEFAULT_METADATA_SETTINGS = {
 export const Metadata = class MetadataBackupRunner extends Abstract {
   _computeBaseSettings(config, job) {
     const baseSettings = { ...DEFAULT_SETTINGS }
-    Object.assign(baseSettings, DEFAULT_METADATA_SETTINGS, config.defaultSettings, config.metadata?.defaultSettings)
+    Object.assign(baseSettings, DEFAULT_METADATA_SETTINGS, config)
     Object.assign(baseSettings, job.settings[''])
     return baseSettings
   }

--- a/@xen-orchestra/backups/_runners/VmsRemote.mjs
+++ b/@xen-orchestra/backups/_runners/VmsRemote.mjs
@@ -31,7 +31,7 @@ const DEFAULT_REMOTE_VM_SETTINGS = {
 export const VmsRemote = class RemoteVmsBackupRunner extends Abstract {
   _computeBaseSettings(config, job) {
     const baseSettings = { ...DEFAULT_SETTINGS }
-    Object.assign(baseSettings, DEFAULT_REMOTE_VM_SETTINGS, config.defaultSettings, config.vm?.defaultSettings)
+    Object.assign(baseSettings, DEFAULT_REMOTE_VM_SETTINGS, config)
     Object.assign(baseSettings, job.settings[''])
     return baseSettings
   }

--- a/@xen-orchestra/backups/_runners/VmsXapi.mjs
+++ b/@xen-orchestra/backups/_runners/VmsXapi.mjs
@@ -42,7 +42,7 @@ const DEFAULT_XAPI_VM_SETTINGS = {
 export const VmsXapi = class VmsXapiBackupRunner extends Abstract {
   _computeBaseSettings(config, job) {
     const baseSettings = { ...DEFAULT_SETTINGS }
-    Object.assign(baseSettings, DEFAULT_XAPI_VM_SETTINGS, config.defaultSettings, config.vm?.defaultSettings)
+    Object.assign(baseSettings, DEFAULT_XAPI_VM_SETTINGS, config)
     Object.assign(baseSettings, job.settings[''])
     return baseSettings
   }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [VM/New] Cloudbase-Init is now correctly supported (PR [#8154](https://github.com/vatesfr/xen-orchestra/pull/8154))
+- [Backups] Correclty use the XO configuration file values (PR [#8161](https://github.com/vatesfr/xen-orchestra/pull/8161))
 
 ### Packages to release
 
@@ -38,6 +39,7 @@
 <!--packages-start-->
 
 - @vates/fatfs minor
+- @xen-orchestra/backups patch
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
 - xo-server minor

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
@@ -404,8 +404,7 @@ export default class BackupNg {
 
     // FIXME: does not take into account default values defined in @xen-orchestra/backups/Backup
     const jobSettings = {
-      ...config.defaultSettings,
-      ...config.vm?.defaultSettings,
+      ...config,
       ...job.settings[''],
       ...job.settings[schedule.id],
     }


### PR DESCRIPTION
### Description

- fixing values in `[backup]` section in XO config not being used
- removing unused config values `config.defaultSettings`, `config.metadata?.defaultSettings` and `config.vm?.defaultSettings`

[XO-408](https://project.vates.tech/vates-global/projects/70ab2907-1ac3-4e7d-831f-a8752c36474d/issues/3812d884-de73-4516-ab79-767cc417b4e8)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
