### PR TITLE
feat(web-core): add no selection state component

### DIFF
--- a/@xen-orchestra/lite/src/stories/web-core/state-hero/vts-no-selection-hero.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/state-hero/vts-no-selection-hero.story.vue
@@ -1,0 +1,14 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties }"
+    :params="[prop('type').required().enum('page', 'card', 'panel').preset('card').widget()]"
+  >
+    <VtsNoSelectionHero v-bind="properties" />
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import { prop } from '@/libs/story/story-param'
+import VtsNoSelectionHero from '@core/components/state-hero/VtsNoSelectionHero.vue'
+</script>

--- a/@xen-orchestra/web-core/lib/components/state-hero/VtsNoSelectionHero.vue
+++ b/@xen-orchestra/web-core/lib/components/state-hero/VtsNoSelectionHero.vue
@@ -1,0 +1,13 @@
+<template>
+  <VtsStateHero :type class="vts-coming-soon-hero" image="no-selection">
+    {{ $t('select-to-see-details') }}
+  </VtsStateHero>
+</template>
+
+<script lang="ts" setup>
+import VtsStateHero, { type StateHeroType } from '@core/components/state-hero/VtsStateHero.vue'
+
+defineProps<{
+  type: StateHeroType
+}>()
+</script>

--- a/@xen-orchestra/web-core/lib/components/state-hero/VtsNoSelectionHero.vue
+++ b/@xen-orchestra/web-core/lib/components/state-hero/VtsNoSelectionHero.vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsStateHero :type class="vts-coming-soon-hero" image="no-selection">
+  <VtsStateHero :type class="vts-no-selection-hero" image="no-selection">
     {{ $t('select-to-see-details') }}
   </VtsStateHero>
 </template>

--- a/@xen-orchestra/web-core/lib/locales/en.json
+++ b/@xen-orchestra/web-core/lib/locales/en.json
@@ -66,6 +66,7 @@
   "receive": "Receive",
   "running-vm": "Running VM | Running VMs",
   "see-all": "See all",
+  "select-to-see-details": "Select an element to see details",
   "send": "Send",
   "send-ctrl-alt-del": "Send Ctrl+Alt+Del",
   "stats": "Stats",

--- a/@xen-orchestra/web-core/lib/locales/fr.json
+++ b/@xen-orchestra/web-core/lib/locales/fr.json
@@ -66,6 +66,7 @@
   "receive": "Recevoir",
   "running-vm": "VM en cours d'exécution | VMs en cours d'exécution",
   "see-all": "Voir tout",
+  "select-to-see-details": "Sélectionnez un élement pour voir les details",
   "send": "Envoyer",
   "send-ctrl-alt-del": "Envoyer Ctrl+Alt+Suppr",
   "stats": "Stats",

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,6 +31,6 @@
 
 <!--packages-start-->
 
-- @xen-orchestra/web-core patch
+- @xen-orchestra/web-core minor
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

Create a no selection state component for state hero

### Screenshot

<img width="707" alt="Capture d’écran 2024-11-29 à 11 13 00" src="https://github.com/user-attachments/assets/8a2e7763-92eb-4c18-a67f-3754cd541cc9">


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
