### PR TITLE
feat(web-core): remove aliasing from DonutChart

### DIFF
--- a/@xen-orchestra/web-core/lib/components/ui/donut-chart/UiDonutChart.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/donut-chart/UiDonutChart.vue
@@ -1,7 +1,7 @@
 <!-- v3 -->
 <template>
   <svg class="ui-donut-chart" viewBox="0 0 100 100">
-    <circle class="segment" cx="50" cy="50" r="40" />
+    <circle class="segment accent--muted" cx="50" cy="50" r="40" />
     <circle
       v-for="(segment, index) in computedSegments"
       :key="index"
@@ -43,7 +43,7 @@ const totalValue = computed(() => props.segments.reduce((total, segment) => tota
 const computedSegments = computed(() => {
   let nextOffset = circumference / 4
 
-  const segments = props.segments.map(segment => {
+  return props.segments.map(segment => {
     const percent = totalValue.value === 0 ? 0 : (segment.value / totalValue.value) * circumference
     const offset = nextOffset
     nextOffset -= percent
@@ -54,17 +54,6 @@ const computedSegments = computed(() => {
       offset,
     }
   })
-
-  if (segments.every(segment => segment.percent === 0)) {
-    return [
-      {
-        accent: 'muted',
-        percent: circumference,
-        offset: nextOffset,
-      },
-    ]
-  }
-  return segments
 })
 </script>
 

--- a/@xen-orchestra/web-core/lib/components/ui/donut-chart/UiDonutChart.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/donut-chart/UiDonutChart.vue
@@ -43,9 +43,9 @@ const totalValue = computed(() => props.segments.reduce((total, segment) => tota
 const computedSegments = computed(() => {
   let nextOffset = circumference / 4
 
-  return props.segments.map(segment => {
+  const segments = props.segments.map(segment => {
+    const percent = totalValue.value === 0 ? 0 : (segment.value / totalValue.value) * circumference
     const offset = nextOffset
-    const percent = (segment.value / totalValue.value) * circumference
     nextOffset -= percent
 
     return {
@@ -54,6 +54,17 @@ const computedSegments = computed(() => {
       offset,
     }
   })
+
+  if (segments.every(segment => segment.percent === 0)) {
+    return [
+      {
+        accent: 'muted',
+        percent: circumference,
+        offset: nextOffset,
+      },
+    ]
+  }
+  return segments
 })
 </script>
 


### PR DESCRIPTION
### Description

Remove aliasing from chart

### Screenshot

Before
<img width="231" alt="Capture d’écran 2024-12-04 à 16 38 02" src="https://github.com/user-attachments/assets/270898d6-e07c-4f29-90b5-4b54f36c0939">

After
<img width="276" alt="Capture d’écran 2024-12-04 à 16 42 09" src="https://github.com/user-attachments/assets/73fb72b2-81f4-44b0-94fe-c7f0333547d4">

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
