### PR TITLE
fix(xo-server): vdi_not_in_map error on migration

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [VM] Fix `VDI_NOT_IN_MAP` error during migration (PR [#8179](https://github.com/vatesfr/xen-orchestra/pull/8179))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -566,8 +566,12 @@ export default class Xapi extends XapiBase {
     for (const vbd of vbds) {
       if (vbd.type === 'Disk') {
         const vdi = vbd.$VDI
-        // Ignore VDI snapshots which have a parent
-        if (vdi.$snapshot_of !== undefined) {
+        // We need to explicitly test VDI.is_a_snapshot because there is a problem with XAPI itself (observed on
+        // an XCP-ng 8.1 host, might be related to CBT), where some non-snapshot VDIs have a snapshot_of
+        // property not equal to OpaqueRef:NULL as expected but containing a reference to an existing VDI.
+        //
+        // https://team.vates.fr/vates/pl/9m4u5rsr7tfcdroykwq6i6mcmo
+        if (vdi.is_a_snapshot && vdi.$snapshot_of !== undefined) {
           continue
         }
         vdis[vdi.$ref] = getMigrationSrRef(vdi)


### PR DESCRIPTION
### Description

Fix VDI_NOT_IN_MAP error on migration

XP-535
https://project.vates.tech/vates-global/projects/70ab2907-1ac3-4e7d-831f-a8752c36474d/issues/506f7d8a-efc5-4f5e-b381-02012e38a52a

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
