### PR TITLE
fix(backups): use callAsync instead of call for CBT enabling/disabling

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
@@ -150,7 +150,7 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
           try {
             // enable CBT on all disks if possible
             const diskRefs = await xapi.VM_getDisks(vm.$ref)
-            await Promise.all(diskRefs.map(diskRef => xapi.call('VDI.enable_cbt', diskRef)))
+            await Promise.all(diskRefs.map(diskRef => xapi.callAsync('VDI.enable_cbt', diskRef)))
           } catch (error) {
             Task.info(`couldn't enable CBT`, error)
           }

--- a/@xen-orchestra/xapi/vm.mjs
+++ b/@xen-orchestra/xapi/vm.mjs
@@ -762,7 +762,7 @@ class Vm {
 
   async disableChangedBlockTracking(vmRef) {
     const vdiRefs = await this.VM_getDisks(vmRef)
-    await Promise.all(vdiRefs.map(vdiRef => this.call('VDI.disable_cbt', vdiRef)))
+    await Promise.all(vdiRefs.map(vdiRef => this.callAsync('VDI.disable_cbt', vdiRef)))
   }
 }
 export default Vm

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,9 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [VM] Fix `VDI_NOT_IN_MAP` error during migration (PR [#8179](https://github.com/vatesfr/xen-orchestra/pull/8179))
+- [Backups/CBT] Improve enabling/disabling CBT on slower storages (PR [#8184](https://github.com/vatesfr/xen-orchestra/pull/8184))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -41,7 +44,7 @@
 - @xen-orchestra/backups minor
 - @xen-orchestra/web patch
 - @xen-orchestra/web-core minor
-- @xen-orchestra/xapi patch
+- @xen-orchestra/xapi minor
 - xen-api minor
 - xo-server minor
 - xo-web minor

--- a/packages/xo-server/src/api/vdi.mjs
+++ b/packages/xo-server/src/api/vdi.mjs
@@ -67,7 +67,8 @@ export const set = defer(async function ($defer, params) {
     await xapi.resizeVdi(ref, size)
   }
   if ('cbt' in params) {
-    params.cbt ? await xapi.call('VDI.enable_cbt', ref) : await xapi.call('VDI.disable_cbt', ref)
+    const method = params.cbt ? 'VDI.enable_cbt' : 'VDI.disable_cbt'
+    await xapi.callAsync(method, ref)
   }
 
   // Other fields.

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -1066,7 +1066,7 @@ export default class Xapi extends XapiBase {
         const vbds = vdi.$VBDs.filter(({ $VM }) => $VM.is_control_domain === false)
         if (vbds.length === 0) {
           log.debug(`will disable CBT on ${vdi.name_label}  `)
-          await this.call('VDI.disable_cbt', vdi.$ref)
+          await this.callAsync('VDI.disable_cbt', vdi.$ref)
         } else {
           if (vbds.length > 1) {
             // no implicit workaround if vdi is attached to multiple VMs


### PR DESCRIPTION
enabling and disabling CBT can take a while, and can timeout
with xapi.call().

XO-468

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
