### PR TITLE
fix(xo-server): fix 'no object with ...' during VM creation

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,4 +33,6 @@
 
 <!--packages-start-->
 
+- xo-server patch
+
 <!--packages-end-->

--- a/packages/xo-server/src/xapi/mixins/vm.mjs
+++ b/packages/xo-server/src/xapi/mixins/vm.mjs
@@ -8,6 +8,7 @@ import lte from 'lodash/lte.js'
 import forEach from 'lodash/forEach.js'
 import mapValues from 'lodash/mapValues.js'
 import noop from 'lodash/noop.js'
+import { asyncMap } from '@xen-orchestra/async-map'
 import { createLogger } from '@xen-orchestra/log'
 import { decorateObject } from '@vates/decorate-with'
 import { defer as deferrable } from 'golike-defer'
@@ -201,7 +202,8 @@ const methods = {
       await Promise.all(_vdisToDestroy.map(vdi => this.VDI_destroy(vdi.$ref)))
 
       // Some VBDs may be destroyed with the VDI_destroy. We need to get a fresh VBDs list
-      const vbds = (await this.getField('VM', vmRef, 'VBDs')).map(vbdRef => this.getObject(vbdRef))
+      const vbdRefs = await this.getField('VM', vmRef, 'VBDs')
+      const vbds = await asyncMap(vbdRefs, vbdRef => this._getOrWaitObject(vbdRef))
 
       if (!hasBootableDisk) {
         hasBootableDisk = vbds.some(vbd => vbd.bootable)


### PR DESCRIPTION
### Description

Introduced by 04dd9e9
See https://team.vates.fr/vates/pl/u1wncexn6pbxmfywtwjerdhm9o

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
