### PR TITLE
fix(backups): backup worker inspect failed: address already in use

### DIFF
--- a/@xen-orchestra/backups/runBackupWorker.mjs
+++ b/@xen-orchestra/backups/runBackupWorker.mjs
@@ -4,13 +4,21 @@ import { fork } from 'child_process'
 const { warn } = createLogger('xo:backups:backupWorker')
 
 const PATH = new URL('_backupWorker.mjs', import.meta.url).pathname
+const DEFAULT_INSPECTOR_PORT = 9229
 
 export function runBackupWorker(params, onLog) {
   return new Promise((resolve, reject) => {
-    const inspectArg = process.execArgv.find(arg => arg.startsWith('--inspect'))
+    // run Node inspector on port+1 if --inspect or --inspect-brk
+    const inspectArg = process.execArgv.find(arg => arg.startsWith('--inspect') || arg.startsWith('--inspect-brk'))
     const execArgv = inspectArg
-      ? [inspectArg.replace(/^(--inspect)(=.*)?$/, (_, prefix) => `${prefix}=localhost:9230`)]
+      ? [
+          inspectArg.replace(/^(--inspect(-brk)?)(=([^:]+:)?(\d+))?$/, (_, prefix, brk, _fullMatch, host, port) => {
+            const basePort = port ? parseInt(port) : DEFAULT_INSPECTOR_PORT
+            return `${prefix}=${host || ''}${basePort + 1}`
+          }),
+        ]
       : []
+
     const worker = fork(PATH, [], { execArgv })
 
     worker.on('exit', (code, signal) => reject(new Error(`worker exited with code ${code} and signal ${signal}`)))

--- a/@xen-orchestra/backups/runBackupWorker.mjs
+++ b/@xen-orchestra/backups/runBackupWorker.mjs
@@ -7,7 +7,11 @@ const PATH = new URL('_backupWorker.mjs', import.meta.url).pathname
 
 export function runBackupWorker(params, onLog) {
   return new Promise((resolve, reject) => {
-    const worker = fork(PATH)
+    const inspectArg = process.execArgv.find(arg => arg.startsWith('--inspect'))
+    const execArgv = inspectArg
+      ? [inspectArg.replace(/^(--inspect)(=.*)?$/, (_, prefix) => `${prefix}=localhost:9230`)]
+      : []
+    const worker = fork(PATH, [], { execArgv })
 
     worker.on('exit', (code, signal) => reject(new Error(`worker exited with code ${code} and signal ${signal}`)))
     worker.on('error', reject)


### PR DESCRIPTION
### Description

When launching a backup worker, if using node inspector it fails since the port is already in use.

```
Starting inspector on 127.0.0.1:9229 failed: address already in use
2024-12-16T09:22:09.126Z xo:backups:worker INFO starting backup
```

This fix allows to use another port. 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
