### PR TITLE
fix(xo-core/UiInfo): issue with typography and add prop to handle text wrap

### DIFF
--- a/@xen-orchestra/lite/src/stories/web-core/ui/info/ui-info.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/info/ui-info.story.vue
@@ -8,7 +8,9 @@
       setting('defaultSlot').widget(text()).preset('message'),
     ]"
   >
-    <UiInfo v-bind="properties">{{ settings.defaultSlot }}</UiInfo>
+    <div class="wrapper">
+      <UiInfo v-bind="properties">{{ settings.defaultSlot }}</UiInfo>
+    </div>
   </ComponentStory>
 </template>
 
@@ -18,3 +20,9 @@ import { prop, setting, slot } from '@/libs/story/story-param'
 import { text } from '@/libs/story/story-widget'
 import UiInfo from '@core/components/ui/info/UiInfo.vue'
 </script>
+
+<style scoped lang="postcss">
+.wrapper {
+  max-width: 30rem;
+}
+</style>

--- a/@xen-orchestra/lite/src/stories/web-core/ui/info/ui-info.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/info/ui-info.story.vue
@@ -3,6 +3,7 @@
     v-slot="{ properties, settings }"
     :params="[
       prop('accent').enum('info', 'success', 'warning', 'danger').required().preset('info').widget(),
+      prop('wrap').bool().help('Choose if the text should wrap if too long').widget(),
       slot(),
       setting('defaultSlot').widget(text()).preset('message'),
     ]"

--- a/@xen-orchestra/web-core/lib/components/ui/info/UiInfo.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/info/UiInfo.vue
@@ -2,7 +2,7 @@
 <template>
   <div class="ui-info">
     <VtsIcon :accent class="icon" :icon="faCircle" :overlay-icon="icon" />
-    <p class="message">
+    <p v-tooltip="!wrap" class="typo p3-regular" :class="{ 'text-ellipsis': !wrap }">
       <slot />
     </p>
   </div>
@@ -10,6 +10,7 @@
 
 <script lang="ts" setup>
 import VtsIcon from '@core/components/icon/VtsIcon.vue'
+import { vTooltip } from '@core/directives/tooltip.directive'
 import {
   faCheck,
   faCircle,
@@ -24,9 +25,10 @@ export type InfoAccent = 'info' | 'success' | 'warning' | 'danger'
 
 type Props = {
   accent: InfoAccent
+  wrap?: boolean
 }
 
-const props = defineProps<Props>()
+const { accent } = defineProps<Props>()
 
 defineSlots<{
   default(): any
@@ -39,7 +41,7 @@ const iconByAccent: Record<Props['accent'], IconDefinition> = {
   danger: faXmark,
 }
 
-const icon = computed(() => iconByAccent[props.accent])
+const icon = computed(() => iconByAccent[accent])
 </script>
 
 <style lang="postcss" scoped>
@@ -50,10 +52,6 @@ const icon = computed(() => iconByAccent[props.accent])
 
   .icon {
     font-size: 1.6rem;
-  }
-
-  .message {
-    font-size: 1.2rem;
   }
 }
 </style>

--- a/@xen-orchestra/web-core/lib/components/ui/info/UiInfo.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/info/UiInfo.vue
@@ -23,18 +23,16 @@ import { computed } from 'vue'
 
 export type InfoAccent = 'info' | 'success' | 'warning' | 'danger'
 
-type Props = {
+const { accent } = defineProps<{
   accent: InfoAccent
   wrap?: boolean
-}
-
-const { accent } = defineProps<Props>()
+}>()
 
 defineSlots<{
   default(): any
 }>()
 
-const iconByAccent: Record<Props['accent'], IconDefinition> = {
+const iconByAccent: Record<InfoAccent, IconDefinition> = {
   info: faInfo,
   success: faCheck,
   warning: faExclamation,


### PR DESCRIPTION
### Description

- Fix typography classes not applied correctly, causing icon misalignment in certain cases
- Add prop to handle text wrap or text ellipsis behaviors:
  - if `wrap = true`, long text wraps into multiple lines
  - if `wrap = false`, long text uses ellipsis plus tooltip

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
