### PR TITLE
feat(xo-server): remember server's pool name and description

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,6 +33,6 @@
 
 <!--packages-start-->
 
-- xo-server patch
+- xo-server minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Settings/Servers] Display last known pool name as server default label (PR [#8206](https://github.com/vatesfr/xen-orchestra/pull/8206))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -30,5 +32,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- xo-server patch
 
 <!--packages-end-->

--- a/packages/xo-server/src/api/pool.mjs
+++ b/packages/xo-server/src/api/pool.mjs
@@ -43,10 +43,6 @@ export async function set({
     crashDumpSr !== undefined &&
       pool.$call('set_crash_dump_SR', crashDumpSr === null ? Ref.EMPTY : crashDumpSr._xapiRef),
   ])
-  if (nameLabel !== undefined || nameDescription !== undefined) {
-    const serverId = this.getXenServerIdByObject(pool.uuid, 'pool')
-    await this.updateXenServer(serverId, { poolNameDescription: nameDescription, poolNameLabel: nameLabel })
-  }
 }
 
 set.params = {

--- a/packages/xo-server/src/api/pool.mjs
+++ b/packages/xo-server/src/api/pool.mjs
@@ -43,6 +43,10 @@ export async function set({
     crashDumpSr !== undefined &&
       pool.$call('set_crash_dump_SR', crashDumpSr === null ? Ref.EMPTY : crashDumpSr._xapiRef),
   ])
+  if (nameLabel !== undefined || nameDescription !== undefined) {
+    const serverId = this.getXenServerIdByObject(pool.uuid, 'pool')
+    await this.updateXenServer(serverId, { poolNameDescription: nameDescription, poolNameLabel: nameLabel })
+  }
 }
 
 set.params = {

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -139,7 +139,19 @@ export default class XenServers {
 
   async updateXenServer(
     id,
-    { allowUnauthorized, enabled, error, host, label, password, readOnly, username, httpProxy }
+    {
+      allowUnauthorized,
+      enabled,
+      error,
+      host,
+      label,
+      password,
+      poolNameDescription,
+      poolNameLabel,
+      readOnly,
+      username,
+      httpProxy,
+    }
   ) {
     const server = await this.getXenServerWithCredentials(id)
     const xapi = this._xapis[id]
@@ -155,6 +167,8 @@ export default class XenServers {
     }
 
     if (label !== undefined) server.label = label || undefined
+    if (poolNameDescription !== undefined) server.poolNameDescription = poolNameDescription || undefined
+    if (poolNameLabel !== undefined) server.poolNameLabel = poolNameLabel || undefined
     if (host) server.host = host
     if (username) server.username = username
     if (password) server.password = password
@@ -339,6 +353,12 @@ export default class XenServers {
       const poolId = xapi.pool.$id
       if (serverIdsByPool[poolId] !== undefined) {
         throw new PoolAlreadyConnected(poolId, serverIdsByPool[poolId], server.id)
+      }
+      if (xapi.pool.name_label !== undefined || xapi.pool.name_description !== undefined) {
+        await this.updateXenServer(id, {
+          poolNameLabel: xapi.pool.name_label,
+          poolNameDescription: xapi.pool.name_description,
+        })
       }
 
       serverIdsByPool[poolId] = server.id

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -162,11 +162,16 @@ export default class XenServers {
       'poolNameLabel',
       'username',
     ]) {
-      // if value is falseish pass undefined to the model to delete this property
-      const value = properties[key] || undefined
-      if (value !== server[key]) {
-        server[key] = value
-        hasChanged = true
+      let value = properties[key]
+      if (value !== undefined) {
+        // if value is falseish pass undefined to the model to delete this property
+        if (value === null || value === '') {
+          value = undefined
+        }
+        if (value !== server[key]) {
+          server[key] = value
+          hasChanged = true
+        }
       }
     }
 

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -137,66 +137,51 @@ export default class XenServers {
     }
   }
 
-  async updateXenServer(
-    id,
-    {
-      allowUnauthorized,
-      enabled,
-      error,
-      host,
-      label,
-      password,
-      poolNameDescription,
-      poolNameLabel,
-      readOnly,
-      username,
-      httpProxy,
-    }
-  ) {
+  async updateXenServer(id, properties) {
     const server = await this.getXenServerWithCredentials(id)
     const xapi = this._xapis[id]
-    const requireDisconnected =
-      allowUnauthorized !== undefined ||
-      host !== undefined ||
-      password !== undefined ||
-      username !== undefined ||
-      httpProxy !== undefined
 
+    const requireDisconnected = ['allowUnauthorized', 'host', 'httpProxy', 'password', 'username'].some(
+      key => properties[key] !== undefined
+    )
     if (requireDisconnected && xapi !== undefined && xapi.status !== 'disconnected') {
       throw new Error('this entry require disconnecting the server to update it')
     }
 
-    if (label !== undefined) server.label = label || undefined
-    if (poolNameDescription !== undefined) server.poolNameDescription = poolNameDescription || undefined
-    if (poolNameLabel !== undefined) server.poolNameLabel = poolNameLabel || undefined
-    if (host) server.host = host
-    if (username) server.username = username
-    if (password) server.password = password
+    let hasChanged = false
 
-    if (error !== undefined) {
-      server.error = error
+    for (const key of [
+      'allowUnauthorized',
+      'enabled',
+      'error',
+      'host',
+      'httpProxy',
+      'label',
+      'password',
+      'poolNameDescription',
+      'poolNameLabel',
+      'username',
+    ]) {
+      const value = properties[key]
+      if (value !== undefined && value !== server[key]) {
+        // if value is falseish pass undefined to the model to delete this property
+        server[key] = value || undefined
+        hasChanged = true
+      }
     }
 
-    if (enabled !== undefined) {
-      server.enabled = enabled
-    }
-
-    if (readOnly !== undefined) {
+    // special handling for readOnly
+    const { readOnly } = properties
+    if (readOnly !== undefined && readOnly !== server.readOnly) {
       server.readOnly = readOnly
       if (xapi !== undefined) {
         xapi.readOnly = readOnly
       }
     }
 
-    if (allowUnauthorized !== undefined) {
-      server.allowUnauthorized = allowUnauthorized
+    if (hasChanged) {
+      await this._servers.update(server)
     }
-
-    if (httpProxy !== undefined) {
-      // if value is null, pass undefined to the model , so it will delete this optional property from the Server object
-      server.httpProxy = httpProxy === null ? undefined : httpProxy
-    }
-    await this._servers.update(server)
   }
 
   async getXenServerWithCredentials(id) {
@@ -229,30 +214,7 @@ export default class XenServers {
     const objects = this._app._objects
 
     const serverIdsByPool = this._serverIdsByPool
-
-    const updatePoolServer = async (xapiObject, xapiId) => {
-      const serverId = serverIdsByPool[xapiId]
-      const xenServer = await this.getXenServer(serverId)
-
-      // check if some properties need to be updated
-      const serverPropertiesUpdate = {}
-      if (
-        xapiObject.name_label !== xenServer.poolNameLabel &&
-        !(xapiObject.name_label === '' && xenServer.poolNameLabel === undefined)
-      ) {
-        serverPropertiesUpdate.poolNameLabel = xapiObject.name_label
-      }
-      if (
-        xapiObject.name_description !== xenServer.poolNameDescription &&
-        !(xapiObject.name_description === '' && xenServer.poolNameDescription === undefined)
-      ) {
-        serverPropertiesUpdate.poolNameDescription = xapiObject.name_description
-      }
-
-      if (!isEmpty(serverPropertiesUpdate)) {
-        return this.updateXenServer(serverIdsByPool[xapiId], serverPropertiesUpdate)
-      }
-    }
+    const self = this
 
     forEach(newXapiObjects, function handleObject(xapiObject, xapiId) {
       // handle pool UUID change
@@ -264,7 +226,12 @@ export default class XenServers {
 
       // save pool name and description in server properties
       if (xapiObject.$type === 'pool') {
-        updatePoolServer(xapiObject, xapiId)::ignoreErrors()
+        self
+          .updateXenServer(serverIdsByPool[xapiId], {
+            poolNameDescription: xapiObject.name_description,
+            poolNameLabel: xapiObject.name_label,
+          })
+          ::ignoreErrors()
       }
 
       const { $ref } = xapiObject

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -177,6 +177,7 @@ export default class XenServers {
       if (xapi !== undefined) {
         xapi.readOnly = readOnly
       }
+      hasChanged = true
     }
 
     if (hasChanged) {

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -354,12 +354,6 @@ export default class XenServers {
       if (serverIdsByPool[poolId] !== undefined) {
         throw new PoolAlreadyConnected(poolId, serverIdsByPool[poolId], server.id)
       }
-      if (xapi.pool.name_label !== undefined || xapi.pool.name_description !== undefined) {
-        await this.updateXenServer(id, {
-          poolNameLabel: xapi.pool.name_label,
-          poolNameDescription: xapi.pool.name_description,
-        })
-      }
 
       serverIdsByPool[poolId] = server.id
 

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -164,7 +164,7 @@ export default class XenServers {
     ]) {
       // if value is falseish pass undefined to the model to delete this property
       const value = properties[key] || undefined
-      if (value !== undefined && value !== server[key]) {
+      if (value !== server[key]) {
         server[key] = value
         hasChanged = true
       }

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -162,10 +162,10 @@ export default class XenServers {
       'poolNameLabel',
       'username',
     ]) {
-      const value = properties[key]
+      // if value is falseish pass undefined to the model to delete this property
+      const value = properties[key] || undefined
       if (value !== undefined && value !== server[key]) {
-        // if value is falseish pass undefined to the model to delete this property
-        server[key] = value || undefined
+        server[key] = value
         hasChanged = true
       }
     }

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -236,7 +236,10 @@ export default class XenServers {
 
       // check if some properties need to be updated
       const serverPropertiesUpdate = {}
-      if (xapiObject.name_label !== xenServer.poolNameLabel) {
+      if (
+        xapiObject.name_label !== xenServer.poolNameLabel &&
+        !(xapiObject.name_label === '' && xenServer.poolNameLabel === undefined)
+      ) {
         serverPropertiesUpdate.poolNameLabel = xapiObject.name_label
       }
       if (


### PR DESCRIPTION
### Description

Remember server's pool name and description, and display the pool name as server default label. The server label can be deleted (since 81e7e0731220cf17d58245d508582aa6c5534531) to get back to the default pool name value.

We did multiple commits to keep the original changes around, but I would advise not to review by commit.

[XO-437](https://project.vates.tech/vates-global/projects/70ab2907-1ac3-4e7d-831f-a8752c36474d/issues/473e6228-1a1d-40f4-87d6-9669b406faf5)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
