### PR TITLE
docs(xoa): NTP synchronization with systemd-timesyncd

### DIFF
--- a/docs/docs/xoa.md
+++ b/docs/docs/xoa.md
@@ -250,7 +250,7 @@ $ xoa network ntp
 ? NTP servers (space separated)
 ```
 
-For changes to take effect, you will need to restart NTP: `systemctl restart systemd-timesyncd.service `.
+For changes to take effect, you will need to restart NTP: `systemctl restart systemd-timesyncd.service`.
 
 ## Restart the service
 

--- a/docs/docs/xoa.md
+++ b/docs/docs/xoa.md
@@ -245,7 +245,7 @@ You will need to be root to edit this file (or use `sudo`). We recommend adding 
 
 If you'd like to simply change NTP servers, use the `xoa network ntp` command:
 
-```
+```console
 $ xoa network ntp
 ? NTP servers (space separated)
 ```

--- a/docs/docs/xoa.md
+++ b/docs/docs/xoa.md
@@ -239,9 +239,16 @@ pool 2.debian.pool.ntp.org iburst
 pool 3.debian.pool.ntp.org iburst
 ```
 
-If you'd like to use your own NTP server or another pool, you can make the changes directly in `/etc/systemd/timesyncd.conf`.
+If you'd like to use another pool, you can make the changes directly in `/etc/systemd/timesyncd.conf`.
 
-You will need to be root to edit this file (or use `sudo`). We recommend adding your custom server to the top of the list, leaving the debian server entries if possible.
+You will need to be root to edit this file (or use `sudo`). We recommend adding your custom server to the top of the list, leaving the Debian server entries if possible.
+
+If you'd like to simply change NTP servers, use the `xoa network ntp` command:
+
+```
+$ xoa network ntp
+? NTP servers (space separated)
+```
 
 For changes to take effect, you will need to restart NTP: `systemctl restart systemd-timesyncd.service `.
 

--- a/docs/docs/xoa.md
+++ b/docs/docs/xoa.md
@@ -230,7 +230,7 @@ You can verify that your time is correctly set with the `date` command. To set X
 
 ## Setting a custom NTP server
 
-By default, XOA is configured to use the standard Debian NTP servers:
+By default, XOA is configured to use the `systemd-timesyncd` daemon, along with the standard Debian NTP servers:
 
 ```
 pool 0.debian.pool.ntp.org iburst
@@ -239,11 +239,11 @@ pool 2.debian.pool.ntp.org iburst
 pool 3.debian.pool.ntp.org iburst
 ```
 
-If you'd like to use your own NTP server or another pool, you can make the changes directly in `/etc/ntp.conf`.
+If you'd like to use your own NTP server or another pool, you can make the changes directly in `/etc/systemd/timesyncd.conf`.
 
 You will need to be root to edit this file (or use `sudo`). We recommend adding your custom server to the top of the list, leaving the debian server entries if possible.
 
-For changes to take effect, you will need to restart NTP: `sudo systemctl restart ntp.service`.
+For changes to take effect, you will need to restart NTP: `systemctl restart systemd-timesyncd.service `.
 
 ## Restart the service
 


### PR DESCRIPTION
### Description

This PR updates the Xen Orchestra documentation to reflect the changes in NTP synchronization, as outlined in this forum discussion: [XOA / XCP-ng NTP?](https://xcp-ng.org/forum/topic/9920/xoa-xcp-ng-ntp?_=1735802120407) . 

Starting with recent versions of XOA, the system now uses **systemd-timesyncd** for time synchronization instead of ntp(d) or even chrony.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
