### PR TITLE
Doc: Explain what 'Prevent migration' does

### DIFF
--- a/docs/docs/manage_infrastructure.md
+++ b/docs/docs/manage_infrastructure.md
@@ -457,7 +457,7 @@ To prevent a virtual machine from migrating:
 
 1. Go to the VM's configuration page.
 2. Go to the **Advanced** tab.
-3. Activate the **Block migration** toggle switch. 
+3. Activate the **Disable migration** toggle switch. 
 
 > Note: Here, "block" means "disable," not a literal block.
 

--- a/docs/docs/manage_infrastructure.md
+++ b/docs/docs/manage_infrastructure.md
@@ -451,6 +451,19 @@ VM migration with storage motion allows you to migrate a VM from one host to ano
 - Migrating a VM that has VDIs on a shared SR from host A to host B using a particular network must trigger a "VM Migration with Storage Motion" without moving its VDIs.
 - Migrating a VM from host A to host B with a destination SR must trigger a "VM Migration with Storage Motion" and move VDIs to the destination SR, regardless of where the VDIs were stored.
 
+### Disabling VM migration
+
+To prevent a virtual machine from migrating:
+
+1. Go to the VM's configuration page.
+2. Go to the **Advanced** tab.
+3. Activate the **Block migration** toggle switch. 
+
+> Note: Here, "block" means "disable," not a literal block.
+
+When this option is enabled, the VM won't be able to migrate to another host.
+
+
 ## Hosts management
 
 Outside updates (see next section), you can also do host management via Xen Orchestra. Basic operations are supported, like reboot, shutdown and so on.

--- a/docs/docs/manage_infrastructure.md
+++ b/docs/docs/manage_infrastructure.md
@@ -451,13 +451,13 @@ VM migration with storage motion allows you to migrate a VM from one host to ano
 - Migrating a VM that has VDIs on a shared SR from host A to host B using a particular network must trigger a "VM Migration with Storage Motion" without moving its VDIs.
 - Migrating a VM from host A to host B with a destination SR must trigger a "VM Migration with Storage Motion" and move VDIs to the destination SR, regardless of where the VDIs were stored.
 
-### Disabling VM migration
+### Preventing VM migration
 
 To prevent a virtual machine from migrating:
 
 1. Go to the VM's configuration page.
 2. Go to the **Advanced** tab.
-3. Activate the **Disable migration** toggle switch. 
+3. Activate the **Prevent migration** toggle switch. 
 
 
 When this option is enabled, the VM won't be able to migrate to another host.

--- a/docs/docs/manage_infrastructure.md
+++ b/docs/docs/manage_infrastructure.md
@@ -459,7 +459,6 @@ To prevent a virtual machine from migrating:
 2. Go to the **Advanced** tab.
 3. Activate the **Disable migration** toggle switch. 
 
-> Note: Here, "block" means "disable," not a literal block.
 
 When this option is enabled, the VM won't be able to migrate to another host.
 


### PR DESCRIPTION
[Some users](https://xcp-ng.org/forum/topic/10206/block-migraton-option-on-the-vm-s-advanced-tab) weren't sure what a 'block migration' was. This PR updates the Xen Orchestra documentation to explain that 'Block migration' is an imperative phrase and that enabling this option will prevent the VM from migrating to another host. 

Hopefully this will prevent any further confusion till we update the actual button label.

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
