### PR TITLE
docs(backups): long term retention (GFS)

### DIFF
--- a/docs/docs/backups.md
+++ b/docs/docs/backups.md
@@ -390,7 +390,7 @@ Xen Orchestra supports the **Grandfather-Father-Son (GFS)** backup retention str
 The start of the week is computed with the timezone set in the schedule.
 - **What GFS isn't:**\
 GFS in Xen Orchestra stands for Grandfather-Father-Son. It's a backup strategy, and is not related to the file system called GFS2 (or Global File System 2), supported by XenServer.
-- GFS backups are defined per schedule. For example, if a backup has two schedules, two independent GFS backups will be created.
+- GFS retention is defined per schedule. For example, if a backup has two schedules, two independent GFS backups will be created.
 :::
 
 #### Enabling GFS Retention

--- a/docs/docs/backups.md
+++ b/docs/docs/backups.md
@@ -370,6 +370,50 @@ It is often a good idea to configure retention of older backups with decreasing 
 
 Again, all of these can be assigned to the same backup job. Note that if you do a weekly and a monthly backup, at some point, these will fall on the same day. Xen Orchestra is designed to fail gracefully (with an error message) if a backup job for a VM is already running. For this reason, you will want to set the time on the monthly job to run before the weekly job so that if one fails, it will be the weekly rather than the monthly one; if the weekly one fails, the monthly will be there for that spot in the retention plan; if the monthly one fails, the weekly one will only be retained for 4 weeks, and then there will be a gap in the monthly retention.
 
+### Long-term Backup Retention with GFS Strategy
+
+Xen Orchestra supports the **Grandfather-Father-Son (GFS)** backup retention strategy, providing an efficient way to manage long-term backups. Backups are organized into daily, weekly, and monthly intervals, optimizing storage while keeping important recovery points over time.
+
+#### FAQ
+
+- **What happens if I change my GFS retention policy?**\
+  Excess backups will be deleted during the next job execution to match the updated retention settings.
+
+- **Is GFS retention applied globally or per repository?**\
+  GFS retention is applied on a per-repository basis, allowing you to manage retention independently for different storage locations.
+
+- **How does Xen Orchestra decide which backups to retain?**\
+  The oldest backup within each retention period (daily, weekly, or monthly) is preserved. For example, the first backup of the week is saved as the weekly backup.
+
+:::warning
+- **Definition of a week:**\
+The start of the week is computed with the timezone set in the schedule.
+- **What GFS isn't:**\
+GFS in Xen Orchestra stands for Grandfather-Father-Son. It's a backup strategy, and is not related to the file system called GFS2 (or Global File System 2), supported by XenServer.
+- GFS backups are defined per schedule. For example, if a backup has two schedules, two independent GFS backups will be created.
+:::
+
+#### Enabling GFS Retention
+
+To enable GFS retention:
+
+1. Go to the **Backup** menu.
+2. Create a new backup job or open an existing one.
+3. Click the **Delta Backup** button.\
+The section called **Long-term retention of backups** appears.
+4. In that section, you can define the following:
+- **Daily backups**: The number of daily backups to keep.
+- **Weekly backups** (Son): The number of weekly backups to keep.
+- **Monthly backups** (Father): The number of monthly backups to keep.
+- **Yearly backups** (Grandfather): The number of monthly backups to keep.
+5. Click the **Save** button.
+
+During each backup run, Xen Orchestra evaluates existing backups and removes any excess backups based on the configured policy.
+
+### Implementation in Xen Orchestra
+
+To enable GFS retention, configure the settings in the backup job's "Retention" section. During each backup run, Xen Orchestra evaluates existing backups and removes any excess backups based on the configured policy.
+
 ## Backup Health Check
 
 Backup health check ensures the backups are ready to be restored.


### PR DESCRIPTION
As announced in the [5.101 release note](https://xen-orchestra.com/blog/xen-orchestra-5-101/), Xen Orchestra now supports the GFS (Grandfather-Father-Son) backup strategy. 

The XO documentation is updated to reflect this new feature and explain how to use it.

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
