### PR TITLE
feat(web-core): add loading state on console

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## **next**
 
 - Fix persistent scrollbar on the right (PR [#8191](https://github.com/vatesfr/xen-orchestra/pull/8191))
+- [Console]: Displays a loader when the console is loading (PR [#8226](https://github.com/vatesfr/xen-orchestra/pull/8226))
 
 ## **0.6.0** (2024-11-29)
 

--- a/@xen-orchestra/lite/src/components/RemoteConsole.vue
+++ b/@xen-orchestra/lite/src/components/RemoteConsole.vue
@@ -129,7 +129,6 @@ defineExpose({
     }
 
     /* Required because the library adds "margin: auto" to the canvas which makes the canvas centered in space and not aligned to the rest of the layout */
-
     :deep(canvas) {
       margin: 0 auto !important;
     }

--- a/@xen-orchestra/lite/src/components/RemoteConsole.vue
+++ b/@xen-orchestra/lite/src/components/RemoteConsole.vue
@@ -1,9 +1,13 @@
 <template>
-  <div ref="vmConsoleContainer" class="vm-console" />
+  <div class="remote-console">
+    <VtsLoadingHero :disabled="isReady" type="panel" />
+    <div ref="vmConsoleContainer" class="vm-console" />
+  </div>
 </template>
 
 <script lang="ts" setup>
 import { useXenApiStore } from '@/stores/xen-api.store'
+import VtsLoadingHero from '@core/components/state-hero/VtsLoadingHero.vue'
 import VncClient from '@novnc/novnc/lib/rfb'
 import { promiseTimeout } from '@vueuse/shared'
 import { fibonacci } from 'iterable-backoff'
@@ -18,6 +22,8 @@ const N_TOTAL_TRIES = 8
 const FIBONACCI_MS_ARRAY: number[] = Array.from(fibonacci().toMs().take(N_TOTAL_TRIES))
 
 const vmConsoleContainer = ref<HTMLDivElement>()
+const isReady = ref(false)
+
 const xenApiStore = useXenApiStore()
 const url = computed(() => {
   if (xenApiStore.currentSessionId == null) {
@@ -54,9 +60,11 @@ function handleDisconnectionEvent() {
 
 function handleConnectionEvent() {
   nConnectionAttempts = 0
+  isReady.value = true
 }
 
 function clearVncClient() {
+  isReady.value = false
   if (vncClient === undefined) {
     return
   }
@@ -109,17 +117,22 @@ defineExpose({
 </script>
 
 <style lang="postcss" scoped>
-.vm-console {
-  flex: 1;
+.remote-console {
+  flex-grow: 1;
   max-width: 100%;
 
-  & > :deep(div) {
-    background-color: transparent !important;
-  }
+  .vm-console {
+    height: 100%;
 
-  /* Required because the library adds "margin: auto" to the canvas which makes the canvas centered in space and not aligned to the rest of the layout */
-  :deep(canvas) {
-    margin: 0 auto !important;
+    & > :deep(div) {
+      background-color: transparent !important;
+    }
+
+    /* Required because the library adds "margin: auto" to the canvas which makes the canvas centered in space and not aligned to the rest of the layout */
+
+    :deep(canvas) {
+      margin: 0 auto !important;
+    }
   }
 }
 </style>

--- a/@xen-orchestra/web-core/lib/components/console/VtsRemoteConsole.vue
+++ b/@xen-orchestra/web-core/lib/components/console/VtsRemoteConsole.vue
@@ -1,10 +1,12 @@
 <template>
   <div :class="uiStore.isMobile ? 'mobile' : undefined" class="vts-remote-console">
+    <VtsLoadingHero v-if="!isReady" class="loading-state" type="card" />
     <div ref="consoleContainer" class="console" />
   </div>
 </template>
 
 <script lang="ts" setup>
+import VtsLoadingHero from '@core/components/state-hero/VtsLoadingHero.vue'
 import { useUiStore } from '@core/stores/ui.store'
 import VncClient from '@novnc/novnc/lib/rfb'
 import { promiseTimeout } from '@vueuse/shared'
@@ -19,11 +21,13 @@ const N_TOTAL_TRIES = 8
 const FIBONACCI_MS_ARRAY: number[] = Array.from(fibonacci().toMs().take(N_TOTAL_TRIES))
 
 const consoleContainer = ref<HTMLDivElement | null>(null)
+const isReady = ref(false)
 
 let vncClient: VncClient | undefined
 let nConnectionAttempts = 0
 
 function handleDisconnectionEvent() {
+  isReady.value = false
   clearVncClient()
 
   nConnectionAttempts++
@@ -43,6 +47,7 @@ function handleDisconnectionEvent() {
 
 function handleConnectionEvent() {
   nConnectionAttempts = 0
+  isReady.value = true
 }
 
 function clearVncClient() {
@@ -53,6 +58,7 @@ function clearVncClient() {
   vncClient.removeEventListener('disconnect', handleDisconnectionEvent)
   vncClient.removeEventListener('connect', handleConnectionEvent)
   vncClient.disconnect()
+  isReady.value = false
 
   vncClient = undefined
 }
@@ -106,11 +112,16 @@ const uiStore = useUiStore()
     width: 95vw;
   }
 
+  .loading-state {
+    margin-top: 15rem;
+  }
+
   .console {
     height: 100%;
   }
 
   /* Required because the library adds "margin: auto" to the canvas which makes the canvas centered in space and not aligned to the rest of the layout */
+
   :deep(canvas) {
     margin: 0 auto !important;
   }

--- a/@xen-orchestra/web-core/lib/components/console/VtsRemoteConsole.vue
+++ b/@xen-orchestra/web-core/lib/components/console/VtsRemoteConsole.vue
@@ -116,7 +116,6 @@ const uiStore = useUiStore()
   }
 
   /* Required because the library adds "margin: auto" to the canvas which makes the canvas centered in space and not aligned to the rest of the layout */
-
   :deep(canvas) {
     margin: 0 auto !important;
   }

--- a/@xen-orchestra/web-core/lib/components/console/VtsRemoteConsole.vue
+++ b/@xen-orchestra/web-core/lib/components/console/VtsRemoteConsole.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="uiStore.isMobile ? 'mobile' : undefined" class="vts-remote-console">
-    <VtsLoadingHero v-if="!isReady" class="loading-state" type="card" />
+    <VtsLoadingHero :disabled="isReady" type="panel" />
     <div ref="consoleContainer" class="console" />
   </div>
 </template>
@@ -112,16 +112,11 @@ const uiStore = useUiStore()
     width: 95vw;
   }
 
-  .loading-state {
-    margin-top: 15rem;
-  }
-
   .console {
     height: 100%;
   }
 
   /* Required because the library adds "margin: auto" to the canvas which makes the canvas centered in space and not aligned to the rest of the layout */
-
   :deep(canvas) {
     margin: 0 auto !important;
   }

--- a/@xen-orchestra/web-core/lib/components/console/VtsRemoteConsole.vue
+++ b/@xen-orchestra/web-core/lib/components/console/VtsRemoteConsole.vue
@@ -27,7 +27,6 @@ let vncClient: VncClient | undefined
 let nConnectionAttempts = 0
 
 function handleDisconnectionEvent() {
-  isReady.value = false
   clearVncClient()
 
   nConnectionAttempts++
@@ -51,6 +50,7 @@ function handleConnectionEvent() {
 }
 
 function clearVncClient() {
+  isReady.value = false
   if (vncClient === undefined) {
     return
   }
@@ -58,7 +58,6 @@ function clearVncClient() {
   vncClient.removeEventListener('disconnect', handleDisconnectionEvent)
   vncClient.removeEventListener('connect', handleConnectionEvent)
   vncClient.disconnect()
-  isReady.value = false
 
   vncClient = undefined
 }
@@ -117,6 +116,7 @@ const uiStore = useUiStore()
   }
 
   /* Required because the library adds "margin: auto" to the canvas which makes the canvas centered in space and not aligned to the rest of the layout */
+
   :deep(canvas) {
     margin: 0 auto !important;
   }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -9,6 +9,14 @@
 
 ### Enhancements
 
+**XO 6**:
+
+- [Console]: Displays a loader when the console is loading (PR [#8226](https://github.com/vatesfr/xen-orchestra/pull/8226))
+
+**XO Lite**:
+
+- [Console]: Displays a loader when the console is loading (PR [#8226](https://github.com/vatesfr/xen-orchestra/pull/8226))
+
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 ### Bug fixes

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,4 +31,6 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/web-core minor
+
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -9,13 +9,8 @@
 
 ### Enhancements
 
-**XO 6**:
-
-- [Console]: Displays a loader when the console is loading (PR [#8226](https://github.com/vatesfr/xen-orchestra/pull/8226))
-
-**XO Lite**:
-
-- [Console]: Displays a loader when the console is loading (PR [#8226](https://github.com/vatesfr/xen-orchestra/pull/8226))
+- **XO 6**:
+  - [Console]: Displays a loader when the console is loading (PR [#8226](https://github.com/vatesfr/xen-orchestra/pull/8226))
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 


### PR DESCRIPTION
### Description

Add a loading state to console window, much visible with a 3G throttling

### Screenshot

<img width="1459" alt="Capture d’écran 2025-01-08 à 11 02 52 (2)" src="https://github.com/user-attachments/assets/89a9df11-b896-4421-8810-c860a988a68d" />


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
