### PR TITLE
fix(xo-server-backup-reports): fix undefined function in partial

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Plugin/backup-reports] Backup reports were not sent on failure with storage issue on remote (PR [#8229](https://github.com/vatesfr/xen-orchestra/pull/8229))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -30,5 +32,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- xo-server-backup-reports patch
 
 <!--packages-end-->

--- a/packages/xo-server-backup-reports/templates/markdown/partials/vmFailure.hbs
+++ b/packages/xo-server-backup-reports/templates/markdown/partials/vmFailure.hbs
@@ -9,7 +9,7 @@
 
 - **UUID**: {{{uuid}}}
 - **Type**: {{{taskLog.data.type}}}
-{{>reportTemporalDataMd end=taskLog.end start=taskLog.start}}
+{{>reportTemporalDataMd end=taskLog.end start=taskLog.start formatDate=../formatDate}}
 {{>reportWarningsMd task=taskLog}}
 - **Error**: {{{taskLog.result.message}}}
 {{else}}

--- a/packages/xo-server-backup-reports/templates/mjml/partials/vmFailure.hbs
+++ b/packages/xo-server-backup-reports/templates/mjml/partials/vmFailure.hbs
@@ -16,7 +16,7 @@
           <ul>
             <li><span style="font-weight: bold">UUID</span>: {{uuid}}</li>
             <li><span style="font-weight: bold">Type</span>: {{taskLog.data.type}}</li>
-            {{>reportTemporalDataMjml end=taskLog.end start=taskLog.start}}
+            {{>reportTemporalDataMjml end=taskLog.end start=taskLog.start formatDate=../formatDate}}
             {{>reportWarningsMjml task=taskLog}}
             <li><span style="font-weight: bold">Error</span>: {{taskLog.result.message}}</li>
           </ul>


### PR DESCRIPTION
### Description

In some failure cases, backup reports were not sent because of an error during handlebars compilation.
The `formatDate` function was incorrectly passed from partial to partial causing the `executeFunction` helper to execute `undefined` as a function (the `vmFailure` helper used default `formatDate=./formatDate` instead of `formatDate=../formatDate`, the `..` being necessary because of the `#each` loop)

[XO-571](https://project.vates.tech/vates-global/projects/70ab2907-1ac3-4e7d-831f-a8752c36474d/issues/71af806d-f821-4055-a937-1d98c0dab0c2)

Introduced by https://github.com/vatesfr/xen-orchestra/commit/aa9c49ce6ae4d93b4b95e7e1b47d0206cd302a58

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
