### PR TITLE
feat(backups): add encryption chacha20, allow file larger than 64GB on encrypted remote

### DIFF
--- a/@xen-orchestra/fs/src/_encryptor.js
+++ b/@xen-orchestra/fs/src/_encryptor.js
@@ -3,8 +3,10 @@ const { readChunk } = require('@vates/read-chunk')
 const crypto = require('crypto')
 
 const CHACHA20 = 'chacha20-poly1305'
+const AES256 = 'aes-256-gcm'
 export const DEFAULT_ENCRYPTION_ALGORITHM = CHACHA20
 export const UNENCRYPTED_ALGORITHM = 'none'
+export const SUPPORTED_ALGORITHM = new Set([UNENCRYPTED_ALGORITHM, AES256, CHACHA20, DEFAULT_ENCRYPTION_ALGORITHM])
 
 export function isLegacyEncryptionAlgorithm(algorithm) {
   return algorithm !== UNENCRYPTED_ALGORITHM && algorithm !== DEFAULT_ENCRYPTION_ALGORITHM
@@ -34,8 +36,7 @@ function getEncryptor(algorithm = DEFAULT_ENCRYPTION_ALGORITHM, key) {
     throw error
   }
   const { ivLength, mode } = info
-  const authTagLength = ['gcm', 'ccm', 'ocb'].includes(mode) || algorithm === CHACHA20
-    ? 16 : 0
+  const authTagLength = ['gcm', 'ccm', 'ocb'].includes(mode) || algorithm === CHACHA20 ? 16 : 0
 
   function encryptStream(input) {
     return pipeline(

--- a/@xen-orchestra/fs/src/_encryptor.js
+++ b/@xen-orchestra/fs/src/_encryptor.js
@@ -2,7 +2,8 @@ const { pipeline } = require('node:stream')
 const { readChunk } = require('@vates/read-chunk')
 const crypto = require('crypto')
 
-export const DEFAULT_ENCRYPTION_ALGORITHM = 'aes-256-gcm'
+const CHACHA20 = 'chacha20-poly1305'
+export const DEFAULT_ENCRYPTION_ALGORITHM = CHACHA20
 export const UNENCRYPTED_ALGORITHM = 'none'
 
 export function isLegacyEncryptionAlgorithm(algorithm) {
@@ -33,7 +34,8 @@ function getEncryptor(algorithm = DEFAULT_ENCRYPTION_ALGORITHM, key) {
     throw error
   }
   const { ivLength, mode } = info
-  const authTagLength = ['gcm', 'ccm', 'ocb'].includes(mode) ? 16 : 0
+  const authTagLength = ['gcm', 'ccm', 'ocb'].includes(mode) || algorithm === CHACHA20
+    ? 16 : 0
 
   function encryptStream(input) {
     return pipeline(

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
   - [Console]: Displays a loader when the console is loading (PR [#8226](https://github.com/vatesfr/xen-orchestra/pull/8226))
   - [i18n] Add Spanish translation (contribution made by [@DSJ2](https://github.com/DSJ2)) (PR [#8220](https://github.com/vatesfr/xen-orchestra/pull/8220))
   - [Console]: Add Ctrl+Alt+Del functionality to console (PR [#8239](https://github.com/vatesfr/xen-orchestra/pull/8239))
-- [Backup] New chacha20 encryption for remotes, allow encrypted files larger than 64GB (PR [#8237](https://github.com/vatesfr/xen-orchestra/pull/8237))
+- [Backup] New [ChaCha20-Poly1305](https://en.wikipedia.org/wiki/ChaCha20-Poly1305) encryption for remotes, allow encrypted files larger than 64GB (PR [#8237](https://github.com/vatesfr/xen-orchestra/pull/8237))
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,9 @@
   - [Console]: Displays a loader when the console is loading (PR [#8226](https://github.com/vatesfr/xen-orchestra/pull/8226))
   - [i18n] Add Spanish translation (contribution made by [@DSJ2](https://github.com/DSJ2)) (PR [#8220](https://github.com/vatesfr/xen-orchestra/pull/8220))
   - [Console]: Add Ctrl+Alt+Del functionality to console (PR [#8239](https://github.com/vatesfr/xen-orchestra/pull/8239))
+- [Backup] New chacha20 encryption for remotes, allow encrypted files larger than 64GB (PR [#8237](https://github.com/vatesfr/xen-orchestra/pull/8237))
+
+> Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 ### Bug fixes
 
@@ -42,6 +45,7 @@
 <!--packages-start-->
 
 - @xen-orchestra/backups patch
+- @xen-orchestra/fs minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
 - xo-server patch


### PR DESCRIPTION
### Description

Fixed "attempted to add data in unsupported state" error on encrypted files larger than 64GB, enabled by using new chacha20 encryption

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
