### PR TITLE
fix(usage-report): avoid report failure when previous stats are invalid

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - Fix SR tags not being listed in tag selectors (PR [#8251](https://github.com/vatesfr/xen-orchestra/pull/8251))
+- [Plugins/usage-report] Prevent the report creation from failing over and over when previous stats file is empty or incorrect (PR [#8240](https://github.com/vatesfr/xen-orchestra/pull/8240))
 
 ### Packages to release
 
@@ -40,6 +41,7 @@
 - @xen-orchestra/backups patch
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+- xo-server-usage-report patch
 - xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-server-usage-report/src/index.js
+++ b/packages/xo-server-usage-report/src/index.js
@@ -546,7 +546,14 @@ async function storeStats({ data, storedStatsPath }) {
 
 async function computeEvolution({ storedStatsPath, ...newStats }) {
   try {
-    const oldStats = JSON.parse(await pReadFile(storedStatsPath, 'utf8'))
+    const fileContent = await pReadFile(storedStatsPath, 'utf8')
+    let oldStats
+    try {
+      oldStats = JSON.parse(fileContent)
+    } catch {
+      log.warn('Invalid or empty json stats file')
+      return
+    }
     const newStatsVms = newStats.vms
     const oldStatsVms = oldStats.global.vms
     const newStatsHosts = newStats.hosts


### PR DESCRIPTION
### Description

The usage report plugin ended up failing to send reports over and over if the stored stats file was an empty file (or an incorrect json) at some point.
This change makes the plugin consider that previous stats don't exist if the json file cannot be parsed, which makes it able to send the report (without the "evolution" part) and rewrite the stats file.

https://help.vates.tech/#ticket/zoom/33177

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
