### PR TITLE
fix(xo-server): throw when remote uses encryption without data blocks

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - Fix SR tags not being listed in tag selectors (PR [#8251](https://github.com/vatesfr/xen-orchestra/pull/8251))
+- [Settings/Remotes] Disallow using encryption without using data block storage, which was a source of errors (PR [#8244](https://github.com/vatesfr/xen-orchestra/pull/8244))
 
 ### Packages to release
 
@@ -40,6 +41,7 @@
 - @xen-orchestra/backups patch
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+- xo-server patch
 - xo-web patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,7 +20,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - Fix SR tags not being listed in tag selectors (PR [#8251](https://github.com/vatesfr/xen-orchestra/pull/8251))
-- [Settings/Remotes] Disallow using encryption without using data block storage, which was a source of errors (PR [#8244](https://github.com/vatesfr/xen-orchestra/pull/8244))
+- [Settings/Remotes] Only allow using encryption when using data block storage to prevent errors during backups (PR [#8244](https://github.com/vatesfr/xen-orchestra/pull/8244))
 
 ### Packages to release
 

--- a/packages/xo-server/src/xo-mixins/remotes.mjs
+++ b/packages/xo-server/src/xo-mixins/remotes.mjs
@@ -47,7 +47,7 @@ function validateUrl(url) {
   const hasEncryption = encryptionKey !== undefined
   const hasVhdDirectory = useVhdDirectory === true
   if (hasEncryption && !hasVhdDirectory) {
-    throw invalidParameters('Encryption must not be used without using VHD directory (data blocks)')
+    throw invalidParameters('Encryption must be used with VHD directory (data blocks)')
   }
 }
 

--- a/packages/xo-server/src/xo-mixins/remotes.mjs
+++ b/packages/xo-server/src/xo-mixins/remotes.mjs
@@ -32,7 +32,7 @@ const INVALID_URL_PARAMS = ['benchmarks', 'id', 'info', 'name', 'proxy', 'enable
 function validateUrl(url) {
   const parsedUrl = parse(url)
 
-  const { path } = parsedUrl
+  const { path, encryptionKey, useVhdDirectory } = parsedUrl
   if (path !== undefined && basename(path) === 'xo-vm-backups') {
     throw invalidParameters('remote url should not end with xo-vm-backups')
   }
@@ -42,6 +42,12 @@ function validateUrl(url) {
       // log with stack trace
       warn(new Error('invalid remote URL param ' + param))
     }
+  }
+
+  const hasEncryption = encryptionKey !== undefined
+  const hasVhdDirectory = useVhdDirectory === true
+  if (hasEncryption && !hasVhdDirectory) {
+    throw invalidParameters('Encryption must not be used without using VHD directory (data blocks)')
   }
 }
 


### PR DESCRIPTION
### Description

Prevent remotes from using encryption when not using VHD blocks (at creation or edition), which lead to strange errors.

[XO-564](https://project.vates.tech/vates-global/projects/70ab2907-1ac3-4e7d-831f-a8752c36474d/issues/6c125089-1691-4ff6-8e48-81ee6e1dd15f/)

from https://help.vates.tech/#ticket/zoom/32574

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
