### PR TITLE
feat(web-core): inverse the logic of border props in MenuList.vue

### DIFF
--- a/@xen-orchestra/lite/src/components/account-menu/AccountMenu.vue
+++ b/@xen-orchestra/lite/src/components/account-menu/AccountMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <MenuList placement="bottom-end" border>
+  <MenuList placement="bottom-end">
     <template #trigger="{ open, isOpen }">
       <UiAccountMenuButton
         v-tooltip="isOpen ? false : { content: $t('settings'), placement: 'left' }"

--- a/@xen-orchestra/lite/src/components/component-story/ComponentStory.vue
+++ b/@xen-orchestra/lite/src/components/component-story/ComponentStory.vue
@@ -13,7 +13,7 @@
     </TabItem>
     <TabItem v-bind="tab(TAB.SLOTS, slotParams)">Slots</TabItem>
     <TabItem v-bind="tab(TAB.SETTINGS, settingParams)">Settings</TabItem>
-    <MenuList placement="bottom" border>
+    <MenuList placement="bottom">
       <template #trigger="{ open, isOpen }">
         <TabItem :active="isOpen" :disabled="presets === undefined" class="preset-tab" @click="open">
           <UiIcon :icon="faSliders" />

--- a/@xen-orchestra/lite/src/components/vm/VmHeader.vue
+++ b/@xen-orchestra/lite/src/components/vm/VmHeader.vue
@@ -2,7 +2,7 @@
   <TitleBar :icon="faDisplay">
     {{ name }}
     <template #actions>
-      <MenuList v-if="vm !== undefined" placement="bottom-end" border>
+      <MenuList v-if="vm !== undefined" placement="bottom-end">
         <template #trigger="{ open, isOpen }">
           <UiButton
             size="medium"
@@ -18,7 +18,7 @@
         </template>
         <VmActionPowerStateItems :vm-refs="[vm.$ref]" />
       </MenuList>
-      <MenuList v-if="vm !== undefined" placement="bottom-end" border>
+      <MenuList v-if="vm !== undefined" placement="bottom-end">
         <template #trigger="{ open, isOpen }">
           <UiButtonIcon
             v-tooltip="{

--- a/@xen-orchestra/lite/src/components/vm/VmsActionsBar.vue
+++ b/@xen-orchestra/lite/src/components/vm/VmsActionsBar.vue
@@ -2,7 +2,7 @@
   <MenuList
     :disabled="selectedRefs.length === 0"
     :horizontal="!isMobile"
-    :border="isMobile"
+    :no-border="!isMobile"
     class="vms-actions-bar"
     placement="bottom-end"
   >

--- a/@xen-orchestra/web-core/lib/components/menu/MenuItem.vue
+++ b/@xen-orchestra/web-core/lib/components/menu/MenuItem.vue
@@ -11,7 +11,7 @@
     >
       <slot />
     </MenuTrigger>
-    <MenuList v-else :disabled="isDisabled" border>
+    <MenuList v-else :disabled="isDisabled">
       <template #trigger="{ open, isOpen }">
         <MenuTrigger :active="isOpen" :busy="isBusy" :disabled="isDisabled" :icon @click="open">
           <slot />

--- a/@xen-orchestra/web-core/lib/components/menu/MenuList.vue
+++ b/@xen-orchestra/web-core/lib/components/menu/MenuList.vue
@@ -2,7 +2,13 @@
 <template>
   <slot :is-open="isOpen" :open="open" name="trigger" />
   <Teleport :disabled="!shouldTeleport" to="body">
-    <ul v-if="!hasTrigger || isOpen" ref="menu" :class="{ horizontal, border }" class="menu-list" v-bind="$attrs">
+    <ul
+      v-if="!hasTrigger || isOpen"
+      ref="menu"
+      :class="{ horizontal, border: !noBorder }"
+      class="menu-list"
+      v-bind="$attrs"
+    >
       <slot />
     </ul>
   </Teleport>
@@ -21,7 +27,7 @@ defineOptions({
 
 const props = defineProps<{
   horizontal?: boolean
-  border?: boolean
+  noBorder?: boolean
   disabled?: boolean
   placement?: Options['placement']
 }>()

--- a/@xen-orchestra/web-core/lib/components/table/ColumnTitle.vue
+++ b/@xen-orchestra/web-core/lib/components/table/ColumnTitle.vue
@@ -1,6 +1,6 @@
 <!-- v1.0 -->
 <template>
-  <MenuList :disabled placement="bottom-start" border>
+  <MenuList :disabled placement="bottom-start">
     <template #trigger="{ open, isOpen }">
       <th
         :class="{ interactive, disabled, focus: isOpen }"

--- a/@xen-orchestra/web/src/components/account-menu/AccountMenu.vue
+++ b/@xen-orchestra/web/src/components/account-menu/AccountMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <MenuList border :disabled placement="bottom-end">
+  <MenuList :disabled placement="bottom-end">
     <template #trigger="{ isOpen, open }">
       <UiAccountMenuButton
         v-tooltip="isOpen ? false : { content: $t('account-organization-more'), placement: 'bottom-end' }"


### PR DESCRIPTION
### Description

inverse the logic of border props in MenuList component by passing no-border if we don't need border and keep borders by default without define a props default

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
