### PR TITLE
fix(xapi): VDI_destroyCloudInitConfig wait 5 minutes before removing the VDI

### DIFF
--- a/@xen-orchestra/xapi/index.mjs
+++ b/@xen-orchestra/xapi/index.mjs
@@ -1,5 +1,6 @@
 import assert from 'assert'
 import pRetry from 'promise-toolbox/retry'
+import { parseDuration } from '@vates/parse-duration'
 import { utcFormat, utcParse } from 'd3-time-format'
 import { Xapi as Base } from 'xen-api'
 import { createLogger } from '@xen-orchestra/log'
@@ -151,6 +152,7 @@ export class Xapi extends Base {
     syncHookSecret,
     syncHookTimeout,
     vdiDestroyRetryWhenInUse = { delay: 5e3, tries: 10 },
+    vdiDelayBeforeRemovingCloudConfigDrive = 1000 * 60 * 5,
     ...opts
   }) {
     super(opts)
@@ -169,6 +171,7 @@ export class Xapi extends Base {
       onRetry: disconnectBeforeRetry,
       when: { code: 'VDI_IN_USE' },
     }
+    this._vdiDelayBeforeRemovingCloudConfigDrive = parseDuration(vdiDelayBeforeRemovingCloudConfigDrive)
 
     const genericWatchers = (this._genericWatchers = new Set())
     const objectWatchers = (this._objectWatchers = { __proto__: null })

--- a/@xen-orchestra/xapi/index.mjs
+++ b/@xen-orchestra/xapi/index.mjs
@@ -152,7 +152,7 @@ export class Xapi extends Base {
     syncHookSecret,
     syncHookTimeout,
     vdiDestroyRetryWhenInUse = { delay: 5e3, tries: 10 },
-    vdiDelayBeforeRemovingCloudConfigDrive = 1000 * 60 * 5,
+    vdiDelayBeforeRemovingCloudConfigDrive = '5 min',
     ...opts
   }) {
     super(opts)

--- a/@xen-orchestra/xapi/package.json
+++ b/@xen-orchestra/xapi/package.json
@@ -26,6 +26,7 @@
     "@vates/async-each": "^1.0.0",
     "@vates/decorate-with": "^2.1.0",
     "@vates/nbd-client": "^3.1.2",
+    "@vates/parse-duration": "^0.1.1",
     "@vates/read-chunk": "^1.2.0",
     "@vates/task": "^0.6.0",
     "@xen-orchestra/async-map": "^0.1.2",

--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -67,7 +67,7 @@ class Vdi {
     })
 
     const vm = await this.getRecord('VM', vmRef)
-    const gm = await this.waitObjectState(vm.guest_metrics, gm => gm?.PV_drivers_detected, {
+    await this.waitObjectState(vm.guest_metrics, gm => gm?.PV_drivers_detected, {
       timeout: timeLimit - Date.now(),
     }).catch(error => {
       warn('failed to wait guest metrics, consider VM as started', {
@@ -76,10 +76,8 @@ class Vdi {
       })
     })
 
-    if (gm?.PV_drivers_detected) {
-      // It may happen that `PV_drivers_detected` returns `true` too quickly, and thus we destroy the cloudConfig VDI before the first boot
-      await new Promise(resolve => setTimeout(resolve, 1000 * 30))
-    }
+    // See https://github.com/vatesfr/xen-orchestra/issues/8219
+    await new Promise(resolve => setTimeout(resolve, this._vdiDelayBeforeRemovingCloudConfigDrive))
 
     await this.VBD_unplug(vbdRef)
     await this.VDI_destroy(vdiRef)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,6 +28,7 @@
 - [Backups/Logs] Display mirror backup transfer size (PR [#8224](https://github.com/vatesfr/xen-orchestra/pull/8224))
 - [Settings/Remotes] Only allow using encryption when using data block storage to prevent errors during backups (PR [#8244](https://github.com/vatesfr/xen-orchestra/pull/8244))
 - Fix _Rolling Pool Update_ and _Install Patches_ for XenServer >= 8.4 [Forum#9550](https://xcp-ng.org/forum/topic/9550/xenserver-8-patching/27?_=1736774010376) (PR [#8241](https://github.com/vatesfr/xen-orchestra/pull/8241))
+- [New/VM] Fix premature destruction of the cloudConfig VDI when using the option _destroyCloudConfigVdiAfterBoot_ [#8219](https://github.com/vatesfr/xen-orchestra/issues/8219) (PR [#8247](https://github.com/vatesfr/xen-orchestra/pull/8247))
 
 ### Packages to release
 

--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -193,7 +193,7 @@ vdiExportConcurrency = 12
 vmEvacuationConcurrency = 3
 vmExportConcurrency = 2
 vmSnapshotConcurrency = 2
-vdiDelayBeforeRemovingCloudConfigDrive = '5 minutes'
+vdiDelayBeforeRemovingCloudConfigDrive = '5 min'
 
 poolMarkingInterval = '6 hours'
 poolMarkingMaxAge = '48 hours'

--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -193,6 +193,7 @@ vdiExportConcurrency = 12
 vmEvacuationConcurrency = 3
 vmExportConcurrency = 2
 vmSnapshotConcurrency = 2
+vdiDelayBeforeRemovingCloudConfigDrive = '5 minutes'
 
 poolMarkingInterval = '6 hours'
 poolMarkingMaxAge = '48 hours'


### PR DESCRIPTION
### Description

See #8219

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
