### PR TITLE
fix(xo-web/SelectTag): list SR tags

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Home/SR] On the tags selector, add the possibility to add an existing tag (PR [#8251](https://github.com/vatesfr/xen-orchestra/pull/8251))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -35,5 +37,6 @@
 <!--packages-start-->
 
 - @xen-orchestra/web-core minor
+- xo-web minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,7 +18,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [Home/SR] On the tags selector, add the possibility to add an existing tag (PR [#8251](https://github.com/vatesfr/xen-orchestra/pull/8251))
+- Fix SR tags not being listed in tag selectors (PR [#8251](https://github.com/vatesfr/xen-orchestra/pull/8251))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,6 +37,6 @@
 <!--packages-start-->
 
 - @xen-orchestra/web-core minor
-- xo-web minor
+- xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-web/src/common/selectors.js
+++ b/packages/xo-web/src/common/selectors.js
@@ -412,7 +412,12 @@ export const createGetObjectsOfType = type => {
 
 export const createGetTags = collectionSelectors => {
   if (!collectionSelectors) {
-    collectionSelectors = [createGetObjectsOfType('host'), createGetObjectsOfType('pool'), createGetObjectsOfType('VM')]
+    collectionSelectors = [
+      createGetObjectsOfType('host'),
+      createGetObjectsOfType('pool'),
+      createGetObjectsOfType('VM'),
+      createGetObjectsOfType('SR'),
+    ]
   }
 
   const getTags = create(collectionSelectors, (...collections) => {


### PR DESCRIPTION
See https://xcp-ng.org/forum/topic/9953

### Description

Previously, only VM tags were filtered on the selector

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
