### PR TITLE
chore(backups): convert cleanvm to typescript

### DIFF
--- a/@xen-orchestra/async-map/index.d.ts
+++ b/@xen-orchestra/async-map/index.d.ts
@@ -1,0 +1,2 @@
+export function asyncMap<Item, This>(iterable: Iterable<Item>, mapFn: (this: This, item: Item) => Item | PromiseLike<Item>, thisArg?: This): Promise<Item[]>;
+export function asyncMapSettled<Item, This>(iterable: Iterable<Item>, mapFn: (this: This, item: Item) => Item | PromiseLike<Item>, thisArg?: This): Promise<Item[]>;

--- a/@xen-orchestra/backups/Task.d.mts
+++ b/@xen-orchestra/backups/Task.d.mts
@@ -1,0 +1,28 @@
+export class Task {
+    static get cancelToken(): any;
+    static run(opts: any, fn: any): any;
+    static wrapFn(opts: any, fn: any): (...args: any[]) => any;
+    constructor({ name, data, onLog }: {
+        name: any;
+        data: any;
+        onLog: any;
+    });
+    cancel: any;
+    failure(error: any): void;
+    info(message: any, data: any): void;
+    /**
+     * Run a function in the context of this task
+     *
+     * In case of error, the task will be failed.
+     *
+     * @typedef Result
+     * @param {() => Result} fn
+     * @param {boolean} last - Whether the task should succeed if there is no error
+     * @returns Result
+     */
+    run(fn: () => any, last?: boolean): any;
+    success(value: any): void;
+    warning(message: any, data: any): void;
+    wrapFn(fn: any, last: any): () => any;
+    #private;
+}

--- a/@xen-orchestra/backups/_backupType.d.mts
+++ b/@xen-orchestra/backups/_backupType.d.mts
@@ -1,0 +1,4 @@
+export function isMetadataFile(filename: string): boolean;
+export function isVhdFile(filename: string): boolean;
+export function isXvaFile(filename: string): boolean;
+export function isXvaSumFile(filename: string): boolean;

--- a/@xen-orchestra/backups/_cleanVm.mjs
+++ b/@xen-orchestra/backups/_cleanVm.mjs
@@ -1,607 +1,535 @@
-import * as UUID from 'uuid'
-import sum from 'lodash/sum.js'
-import { asyncMap } from '@xen-orchestra/async-map'
-import { Constants, openVhd, VhdAbstract, VhdFile } from 'vhd-lib'
-import { isVhdAlias, resolveVhdAlias } from 'vhd-lib/aliases.js'
-import { basename, dirname, resolve } from 'node:path'
-import { isMetadataFile, isVhdFile, isXvaFile, isXvaSumFile } from './_backupType.mjs'
-import { limitConcurrency } from 'limit-concurrency-decorator'
-import { mergeVhdChain } from 'vhd-lib/merge.js'
-
-import { Task } from './Task.mjs'
-import { Disposable } from 'promise-toolbox'
-import handlerPath from '@xen-orchestra/fs/path'
-
-const { DISK_TYPES } = Constants
-
+import * as UUID from 'uuid';
+import sum from 'lodash/sum.js';
+import { asyncMap } from '@xen-orchestra/async-map';
+import { Constants, openVhd, VhdAbstract, VhdFile } from 'vhd-lib';
+import { isVhdAlias, resolveVhdAlias } from 'vhd-lib/aliases.js';
+import { basename, dirname, resolve } from 'node:path';
+import { isMetadataFile, isVhdFile, isXvaFile, isXvaSumFile } from './_backupType.mjs';
+import { limitConcurrency } from 'limit-concurrency-decorator';
+import { mergeVhdChain } from 'vhd-lib/merge.js';
+import { Task } from './Task.mjs';
+import { Disposable } from 'promise-toolbox';
+import * as handlerPath from '@xen-orchestra/fs/path';
+const { DISK_TYPES } = Constants;
 // checking the size of a vhd directory is costly
 // 1 Http Query per 1000 blocks
 // we only check size of all the vhd are VhdFiles
 function shouldComputeVhdsSize(handler, vhds) {
-  if (handler.isEncrypted) {
-    return false
-  }
-  return vhds.every(vhd => vhd instanceof VhdFile)
-}
-
-const computeVhdsSize = (handler, vhdPaths) =>
-  Disposable.use(
-    vhdPaths.map(vhdPath => openVhd(handler, vhdPath)),
-    async vhds => {
-      if (shouldComputeVhdsSize(handler, vhds)) {
-        const sizes = await asyncMap(vhds, vhd => vhd.getSize())
-        return sum(sizes)
-      }
+    if (handler.isEncrypted) {
+        return false;
     }
-  )
-
+    return vhds.every(vhd => vhd instanceof VhdFile);
+}
+const computeVhdsSize = (handler, vhdPaths) => Disposable.use(vhdPaths.map(vhdPath => openVhd(handler, vhdPath)), async (vhds) => {
+    if (shouldComputeVhdsSize(handler, vhds)) {
+        const sizes = await asyncMap(vhds, vhd => vhd.getSize());
+        return sum(sizes);
+    }
+});
 // chain is [ ancestor, child_1, ..., child_n ]
 async function _mergeVhdChain(handler, chain, { logInfo, remove, mergeBlockConcurrency }) {
-  logInfo(`merging VHD chain`, { chain })
-
-  let done, total
-  const handle = setInterval(() => {
-    if (done !== undefined) {
-      logInfo('merge in progress', {
-        done,
-        parent: chain[0],
-        progress: Math.round((100 * done) / total),
-        total,
-      })
+    logInfo(`merging VHD chain`, { chain });
+    let done, total;
+    const handle = setInterval(() => {
+        if (done !== undefined) {
+            logInfo('merge in progress', {
+                done,
+                parent: chain[0],
+                progress: Math.round((100 * done) / total),
+                total,
+            });
+        }
+    }, 10e3);
+    try {
+        return await mergeVhdChain(handler, chain, {
+            logInfo,
+            mergeBlockConcurrency,
+            onProgress({ done: d, total: t }) {
+                done = d;
+                total = t;
+            },
+            removeUnused: remove,
+        });
     }
-  }, 10e3)
-  try {
-    return await mergeVhdChain(handler, chain, {
-      logInfo,
-      mergeBlockConcurrency,
-      onProgress({ done: d, total: t }) {
-        done = d
-        total = t
-      },
-      removeUnused: remove,
-    })
-  } finally {
-    clearInterval(handle)
-  }
+    finally {
+        clearInterval(handle);
+    }
 }
-
-const noop = Function.prototype
-
-const INTERRUPTED_VHDS_REG = /^\.(.+)\.merge.json$/
+const noop = Function.prototype;
+const INTERRUPTED_VHDS_REG = /^\.(.+)\.merge.json$/;
 const listVhds = async (handler, vmDir, logWarn) => {
-  const vhds = new Set()
-  const aliases = {}
-  const interruptedVhds = new Map()
-
-  await asyncMap(
-    await handler.list(`${vmDir}/vdis`, {
-      ignoreMissing: true,
-      prependDir: true,
-    }),
-    async jobDir =>
-      asyncMap(
-        await handler.list(jobDir, {
-          prependDir: true,
-        }),
-        async vdiDir => {
-          const list = await handler.list(vdiDir, {
+    const vhds = new Set();
+    const aliases = {};
+    const interruptedVhds = new Map();
+    await asyncMap(await handler.list(`${vmDir}/vdis`, {
+        ignoreMissing: true,
+        prependDir: true,
+    }), async (jobDir) => asyncMap(await handler.list(jobDir, {
+        prependDir: true,
+    }), async (vdiDir) => {
+        const list = await handler.list(vdiDir, {
             filter: file => isVhdFile(file) || INTERRUPTED_VHDS_REG.test(file),
-          })
-          aliases[vdiDir] = list.filter(vhd => isVhdAlias(vhd)).map(file => `${vdiDir}/${file}`)
-
-          await asyncMap(list, async file => {
-            const res = INTERRUPTED_VHDS_REG.exec(file)
+        });
+        aliases[vdiDir] = list.filter(vhd => isVhdAlias(vhd)).map(file => `${vdiDir}/${file}`);
+        await asyncMap(list, async (file) => {
+            const res = INTERRUPTED_VHDS_REG.exec(file);
             if (res === null) {
-              vhds.add(`${vdiDir}/${file}`)
-            } else {
-              try {
-                const mergeState = JSON.parse(await handler.readFile(`${vdiDir}/${file}`))
-                interruptedVhds.set(`${vdiDir}/${res[1]}`, {
-                  statePath: `${vdiDir}/${file}`,
-                  chain: mergeState.chain,
-                })
-              } catch (error) {
-                // fall back to a non resuming merge
-                vhds.add(`${vdiDir}/${file}`)
-                logWarn('failed to read existing merge state', { path: file, error })
-              }
+                vhds.add(`${vdiDir}/${file}`);
             }
-          })
-        }
-      )
-  )
-
-  return { vhds, interruptedVhds, aliases }
-}
-
-export async function checkAliases(
-  aliasPaths,
-  targetDataRepository,
-  { handler, logInfo = noop, logWarn = console.warn, remove = false }
-) {
-  const aliasFound = []
-  for (const alias of aliasPaths) {
-    let target
-    try {
-      target = await resolveVhdAlias(handler, alias)
-    } catch (err) {
-      if (err.code === 'ENOENT') {
-        logWarn('missing target of alias', { alias })
-        if (remove) {
-          logInfo('removing alias and non VHD target', { alias, target })
-          await handler.unlink(target)
-          await handler.unlink(alias)
-        }
-      }
-    }
-
-    if (!isVhdFile(target)) {
-      logWarn('alias references non VHD target', { alias, target })
-      if (remove) {
-        logInfo('removing alias and non VHD target', { alias, target })
-        await handler.unlink(target)
-        await handler.unlink(alias)
-      }
-      continue
-    }
-
-    try {
-      const { dispose } = await openVhd(handler, target)
-      try {
-        await dispose()
-      } catch (e) {
-        // error during dispose should not trigger a deletion
-      }
-    } catch (error) {
-      logWarn('missing or broken alias target', { alias, target, error })
-      if (remove) {
+            else {
+                try {
+                    const mergeState = JSON.parse(await handler.readFile(`${vdiDir}/${file}`));
+                    interruptedVhds.set(`${vdiDir}/${res[1]}`, {
+                        statePath: `${vdiDir}/${file}`,
+                        chain: mergeState.chain,
+                    });
+                }
+                catch (error) {
+                    // fall back to a non resuming merge
+                    vhds.add(`${vdiDir}/${file}`);
+                    logWarn('failed to read existing merge state', { path: file, error });
+                }
+            }
+        });
+    }));
+    return { vhds, interruptedVhds, aliases };
+};
+export async function checkAliases(aliasPaths, targetDataRepository, { handler, logInfo = noop, logWarn = console.warn, remove = false }) {
+    const aliasFound = [];
+    for (const alias of aliasPaths) {
+        let target;
         try {
-          await VhdAbstract.unlink(handler, alias)
-        } catch (error) {
-          if (error.code !== 'ENOENT') {
-            logWarn('error deleting alias target', { alias, target, error })
-          }
+            target = await resolveVhdAlias(handler, alias);
         }
-      }
-      continue
+        catch (err) {
+            if (err.code === 'ENOENT') {
+                logWarn('missing target of alias', { alias });
+                if (remove) {
+                    logInfo('removing alias and non VHD target', { alias, target });
+                    await handler.unlink(target);
+                    await handler.unlink(alias);
+                }
+            }
+        }
+        if (!isVhdFile(target)) {
+            logWarn('alias references non VHD target', { alias, target });
+            if (remove) {
+                logInfo('removing alias and non VHD target', { alias, target });
+                await handler.unlink(target);
+                await handler.unlink(alias);
+            }
+            continue;
+        }
+        try {
+            const { dispose } = await openVhd(handler, target);
+            try {
+                await dispose();
+            }
+            catch (e) {
+                // error during dispose should not trigger a deletion
+            }
+        }
+        catch (error) {
+            logWarn('missing or broken alias target', { alias, target, error });
+            if (remove) {
+                try {
+                    await VhdAbstract.unlink(handler, alias);
+                }
+                catch (error) {
+                    if (error.code !== 'ENOENT') {
+                        logWarn('error deleting alias target', { alias, target, error });
+                    }
+                }
+            }
+            continue;
+        }
+        aliasFound.push(resolve('/', target));
     }
-
-    aliasFound.push(resolve('/', target))
-  }
-
-  const vhds = await handler.list(targetDataRepository, {
-    ignoreMissing: true,
-    prependDir: true,
-  })
-
-  await asyncMap(vhds, async path => {
-    if (!aliasFound.includes(path)) {
-      logWarn('no alias references VHD', { path })
-      if (remove) {
-        logInfo('deleting unused VHD', { path })
-        await VhdAbstract.unlink(handler, path)
-      }
-    }
-  })
+    const vhds = await handler.list(targetDataRepository, {
+        ignoreMissing: true,
+        prependDir: true,
+    });
+    await asyncMap(vhds, async (path) => {
+        if (!aliasFound.includes(path)) {
+            logWarn('no alias references VHD', { path });
+            if (remove) {
+                logInfo('deleting unused VHD', { path });
+                await VhdAbstract.unlink(handler, path);
+            }
+        }
+    });
 }
-
-const defaultMergeLimiter = limitConcurrency(1)
-
-export async function cleanVm(
-  vmDir,
-  {
-    fixMetadata,
-    remove = false,
-    removeTmp = remove,
-    merge,
-    mergeBlockConcurrency,
-    mergeLimiter = defaultMergeLimiter,
-    logInfo = noop,
-    logWarn = console.warn,
-  }
-) {
-  const limitedMergeVhdChain = mergeLimiter(_mergeVhdChain)
-
-  const handler = this._handler
-
-  const vhdsToJSons = new Set()
-  const vhdById = new Map()
-  const vhdParents = { __proto__: null }
-  const vhdChildren = { __proto__: null }
-
-  const { vhds, interruptedVhds, aliases } = await listVhds(handler, vmDir, logWarn)
-
-  // remove broken VHDs
-  await asyncMap(vhds, async path => {
-    if (removeTmp && basename(path)[0] === '.') {
-      logInfo('deleting temporary VHD', { path })
-      return VhdAbstract.unlink(handler, path)
-    }
-    try {
-      await Disposable.use(openVhd(handler, path, { checkSecondFooter: !interruptedVhds.has(path) }), vhd => {
-        if (vhd.footer.diskType === DISK_TYPES.DIFFERENCING) {
-          const parent = resolve('/', dirname(path), vhd.header.parentUnicodeName)
-          vhdParents[path] = parent
-          if (parent in vhdChildren) {
-            const error = new Error('this script does not support multiple VHD children')
-            error.parent = parent
-            error.child1 = vhdChildren[parent]
-            error.child2 = path
-            throw error // should we throw?
-          }
-          vhdChildren[parent] = path
+const defaultMergeLimiter = limitConcurrency(1);
+export async function cleanVm(vmDir, { fixMetadata, remove = false, removeTmp = remove, merge, mergeBlockConcurrency, mergeLimiter = defaultMergeLimiter, logInfo = noop, logWarn = console.warn, }) {
+    const limitedMergeVhdChain = mergeLimiter(_mergeVhdChain);
+    const handler = this._handler;
+    const vhdsToJSons = new Set();
+    const vhdById = new Map();
+    const vhdParents = { __proto__: null };
+    const vhdChildren = { __proto__: null };
+    const { vhds, interruptedVhds, aliases } = await listVhds(handler, vmDir, logWarn);
+    // remove broken VHDs
+    await asyncMap(vhds, async (path) => {
+        if (removeTmp && basename(path)[0] === '.') {
+            logInfo('deleting temporary VHD', { path });
+            return VhdAbstract.unlink(handler, path);
         }
-        // Detect VHDs with the same UUIDs
-        //
-        // Due to a bug introduced in a1bcd35e2
-        const duplicate = vhdById.get(UUID.stringify(vhd.footer.uuid))
-        let vhdKept = vhd
-        if (duplicate !== undefined) {
-          logWarn('uuid is duplicated', { uuid: UUID.stringify(vhd.footer.uuid) })
-          if (duplicate.containsAllDataOf(vhd)) {
-            logWarn(`should delete ${path}`)
-            vhdKept = duplicate
-            vhds.delete(path)
-          } else if (vhd.containsAllDataOf(duplicate)) {
-            logWarn(`should delete ${duplicate._path}`)
-            vhds.delete(duplicate._path)
-          } else {
-            logWarn('same ids but different content')
-          }
+        try {
+            await Disposable.use(openVhd(handler, path, { checkSecondFooter: !interruptedVhds.has(path) }), vhd => {
+                if (vhd.footer.diskType === DISK_TYPES.DIFFERENCING) {
+                    const parent = resolve('/', dirname(path), vhd.header.parentUnicodeName);
+                    vhdParents[path] = parent;
+                    if (parent in vhdChildren) {
+                        const error = new Error('this script does not support multiple VHD children');
+                        error.parent = parent;
+                        error.child1 = vhdChildren[parent];
+                        error.child2 = path;
+                        throw error; // should we throw?
+                    }
+                    vhdChildren[parent] = path;
+                }
+                // Detect VHDs with the same UUIDs
+                //
+                // Due to a bug introduced in a1bcd35e2
+                const duplicate = vhdById.get(UUID.stringify(vhd.footer.uuid));
+                let vhdKept = vhd;
+                if (duplicate !== undefined) {
+                    logWarn('uuid is duplicated', { uuid: UUID.stringify(vhd.footer.uuid) });
+                    if (duplicate.containsAllDataOf(vhd)) {
+                        logWarn(`should delete ${path}`);
+                        vhdKept = duplicate;
+                        vhds.delete(path);
+                    }
+                    else if (vhd.containsAllDataOf(duplicate)) {
+                        logWarn(`should delete ${duplicate._path}`);
+                        vhds.delete(duplicate._path);
+                    }
+                    else {
+                        logWarn('same ids but different content');
+                    }
+                }
+                vhdById.set(UUID.stringify(vhdKept.footer.uuid), vhdKept);
+            });
         }
-        vhdById.set(UUID.stringify(vhdKept.footer.uuid), vhdKept)
-      })
-    } catch (error) {
-      vhds.delete(path)
-      logWarn('VHD check error', { path, error })
-      if (error?.code === 'ERR_ASSERTION' && remove) {
-        logInfo('deleting broken VHD', { path })
-        return VhdAbstract.unlink(handler, path)
-      }
-    }
-  })
-
-  // remove interrupted merge states for missing VHDs
-  for (const interruptedVhd of interruptedVhds.keys()) {
-    if (!vhds.has(interruptedVhd)) {
-      const { statePath } = interruptedVhds.get(interruptedVhd)
-      interruptedVhds.delete(interruptedVhd)
-
-      logWarn('orphan merge state', {
-        mergeStatePath: statePath,
-        missingVhdPath: interruptedVhd,
-      })
-      if (remove) {
-        logInfo('deleting orphan merge state', { statePath })
-        await handler.unlink(statePath)
-      }
-    }
-  }
-
-  // check if alias are correct
-  // check if all vhd in data subfolder have a corresponding alias
-  await asyncMap(Object.keys(aliases), async dir => {
-    await checkAliases(aliases[dir], `${dir}/data`, { handler, logInfo, logWarn, remove })
-  })
-
-  // remove VHDs with missing ancestors
-  {
-    const deletions = []
-
-    // return true if the VHD has been deleted or is missing
-    const deleteIfOrphan = vhdPath => {
-      const parent = vhdParents[vhdPath]
-      if (parent === undefined) {
-        return
-      }
-
-      // no longer needs to be checked
-      delete vhdParents[vhdPath]
-
-      deleteIfOrphan(parent)
-
-      if (!vhds.has(parent)) {
-        vhds.delete(vhdPath)
-
-        logWarn('parent VHD is missing', { parent, child: vhdPath })
-        if (remove) {
-          logInfo('deleting orphan VHD', { path: vhdPath })
-          deletions.push(VhdAbstract.unlink(handler, vhdPath))
+        catch (error) {
+            vhds.delete(path);
+            logWarn('VHD check error', { path, error });
+            if (error?.code === 'ERR_ASSERTION' && remove) {
+                logInfo('deleting broken VHD', { path });
+                return VhdAbstract.unlink(handler, path);
+            }
         }
-      }
+    });
+    // remove interrupted merge states for missing VHDs
+    for (const interruptedVhd of interruptedVhds.keys()) {
+        if (!vhds.has(interruptedVhd)) {
+            const { statePath } = interruptedVhds.get(interruptedVhd);
+            interruptedVhds.delete(interruptedVhd);
+            logWarn('orphan merge state', {
+                mergeStatePath: statePath,
+                missingVhdPath: interruptedVhd,
+            });
+            if (remove) {
+                logInfo('deleting orphan merge state', { statePath });
+                await handler.unlink(statePath);
+            }
+        }
     }
-
-    // > A property that is deleted before it has been visited will not be
-    // > visited later.
-    // >
-    // > -- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in#Deleted_added_or_modified_properties
-    for (const child in vhdParents) {
-      deleteIfOrphan(child)
+    // check if alias are correct
+    // check if all vhd in data subfolder have a corresponding alias
+    await asyncMap(Object.keys(aliases), async (dir) => {
+        await checkAliases(aliases[dir], `${dir}/data`, { handler, logInfo, logWarn, remove });
+    });
+    // remove VHDs with missing ancestors
+    {
+        const deletions = [];
+        // return true if the VHD has been deleted or is missing
+        const deleteIfOrphan = vhdPath => {
+            const parent = vhdParents[vhdPath];
+            if (parent === undefined) {
+                return;
+            }
+            // no longer needs to be checked
+            delete vhdParents[vhdPath];
+            deleteIfOrphan(parent);
+            if (!vhds.has(parent)) {
+                vhds.delete(vhdPath);
+                logWarn('parent VHD is missing', { parent, child: vhdPath });
+                if (remove) {
+                    logInfo('deleting orphan VHD', { path: vhdPath });
+                    deletions.push(VhdAbstract.unlink(handler, vhdPath));
+                }
+            }
+        };
+        // > A property that is deleted before it has been visited will not be
+        // > visited later.
+        // >
+        // > -- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in#Deleted_added_or_modified_properties
+        for (const child in vhdParents) {
+            deleteIfOrphan(child);
+        }
+        await Promise.all(deletions);
     }
-
-    await Promise.all(deletions)
-  }
-
-  const jsons = new Set()
-  const xvas = new Set()
-  const xvaSums = []
-  const entries = await handler.list(vmDir, {
-    prependDir: true,
-  })
-  entries.forEach(path => {
-    if (isMetadataFile(path)) {
-      jsons.add(path)
-    } else if (isXvaFile(path)) {
-      xvas.add(path)
-    } else if (isXvaSumFile(path)) {
-      xvaSums.push(path)
+    const jsons = new Set();
+    const xvas = new Set();
+    const xvaSums = [];
+    const entries = await handler.list(vmDir, {
+        prependDir: true,
+    });
+    entries.forEach(path => {
+        if (isMetadataFile(path)) {
+            jsons.add(path);
+        }
+        else if (isXvaFile(path)) {
+            xvas.add(path);
+        }
+        else if (isXvaSumFile(path)) {
+            xvaSums.push(path);
+        }
+    });
+    const cachePath = vmDir + '/cache.json.gz';
+    let mustRegenerateCache;
+    {
+        const cache = await this._readCache(cachePath);
+        const actual = cache === undefined ? 0 : Object.keys(cache).length;
+        const expected = jsons.size;
+        mustRegenerateCache = actual !== expected;
+        if (mustRegenerateCache) {
+            logWarn('unexpected number of entries in backup cache', { path: cachePath, actual, expected });
+        }
     }
-  })
-
-  const cachePath = vmDir + '/cache.json.gz'
-
-  let mustRegenerateCache
-  {
-    const cache = await this._readCache(cachePath)
-    const actual = cache === undefined ? 0 : Object.keys(cache).length
-    const expected = jsons.size
-
-    mustRegenerateCache = actual !== expected
+    await asyncMap(xvas, async (path) => {
+        // check is not good enough to delete the file, the best we can do is report
+        // it
+        if (!(await this.isValidXva(path))) {
+            logWarn('XVA might be broken', { path });
+        }
+    });
+    const unusedVhds = new Set(vhds);
+    const unusedXvas = new Set(xvas);
+    const backups = new Map();
+    // compile the list of unused XVAs and VHDs, and remove backup metadata which
+    // reference a missing XVA/VHD
+    await asyncMap(jsons, async (json) => {
+        let metadata;
+        try {
+            metadata = JSON.parse(await handler.readFile(json));
+        }
+        catch (error) {
+            logWarn('failed to read backup metadata', { path: json, error });
+            jsons.delete(json);
+            return;
+        }
+        let isBackupComplete;
+        const { mode } = metadata;
+        if (mode === 'full') {
+            const linkedXva = resolve('/', vmDir, metadata.xva);
+            isBackupComplete = xvas.has(linkedXva);
+            if (isBackupComplete) {
+                unusedXvas.delete(linkedXva);
+            }
+            else {
+                logWarn('the XVA linked to the backup is missing', { backup: json, xva: linkedXva });
+            }
+        }
+        else if (mode === 'delta') {
+            const linkedVhds = (() => {
+                const { vhds } = metadata;
+                return Object.keys(vhds).map(key => resolve('/', vmDir, vhds[key]));
+            })();
+            const missingVhds = linkedVhds.filter(_ => !vhds.has(_));
+            isBackupComplete = missingVhds.length === 0;
+            // FIXME: find better approach by keeping as much of the backup as
+            // possible (existing disks) even if one disk is missing
+            if (isBackupComplete) {
+                linkedVhds.forEach(_ => unusedVhds.delete(_));
+                linkedVhds.forEach(path => {
+                    vhdsToJSons[path] = json;
+                });
+            }
+            else {
+                logWarn('some VHDs linked to the backup are missing', { backup: json, missingVhds });
+            }
+        }
+        if (isBackupComplete) {
+            backups.set(json, metadata);
+        }
+        else {
+            jsons.delete(json);
+            if (remove) {
+                logInfo('deleting incomplete backup', { backup: json });
+                mustRegenerateCache = true;
+                await handler.unlink(json);
+            }
+        }
+    });
+    // TODO: parallelize by vm/job/vdi
+    const unusedVhdsDeletion = [];
+    const toMerge = [];
+    {
+        // VHD chains (as list from oldest to most recent) to merge indexed by most recent
+        // ancestor
+        const vhdChainsToMerge = { __proto__: null };
+        const toCheck = new Set(unusedVhds);
+        const getUsedChildChainOrDelete = vhd => {
+            if (vhd in vhdChainsToMerge) {
+                const chain = vhdChainsToMerge[vhd];
+                delete vhdChainsToMerge[vhd];
+                return chain;
+            }
+            if (!unusedVhds.has(vhd)) {
+                return [vhd];
+            }
+            // no longer needs to be checked
+            toCheck.delete(vhd);
+            const child = vhdChildren[vhd];
+            if (child !== undefined) {
+                const chain = getUsedChildChainOrDelete(child);
+                if (chain !== undefined) {
+                    chain.unshift(vhd);
+                    return chain;
+                }
+            }
+            // no warning because a VHD can be unused for perfectly good reasons,
+            // e.g. the corresponding backup (metadata file) has been deleted
+            if (remove) {
+                logInfo('deleting unused VHD', { path: vhd });
+                unusedVhdsDeletion.push(VhdAbstract.unlink(handler, vhd));
+            }
+        };
+        toCheck.forEach(vhd => {
+            vhdChainsToMerge[vhd] = getUsedChildChainOrDelete(vhd);
+        });
+        // merge interrupted VHDs
+        for (const parent of interruptedVhds.keys()) {
+            // before #6349 the chain wasn't in the mergeState
+            const { chain, statePath } = interruptedVhds.get(parent);
+            if (chain === undefined) {
+                vhdChainsToMerge[parent] = [parent, vhdChildren[parent]];
+            }
+            else {
+                vhdChainsToMerge[parent] = chain.map(vhdPath => handlerPath.resolveFromFile(statePath, vhdPath));
+            }
+        }
+        Object.values(vhdChainsToMerge).forEach(chain => {
+            if (chain !== undefined) {
+                toMerge.push(chain);
+            }
+        });
+    }
+    const metadataWithMergedVhd = {};
+    const doMerge = async () => {
+        await asyncMap(toMerge, async (chain) => {
+            const { finalVhdSize } = await limitedMergeVhdChain(handler, chain, {
+                logInfo,
+                logWarn,
+                remove,
+                mergeBlockConcurrency,
+            });
+            const metadataPath = vhdsToJSons[chain[chain.length - 1]]; // all the chain should have the same metada file
+            metadataWithMergedVhd[metadataPath] = (metadataWithMergedVhd[metadataPath] ?? 0) + finalVhdSize;
+        });
+    };
+    await Promise.all([
+        ...unusedVhdsDeletion,
+        toMerge.length !== 0 && (merge ? Task.run({ name: 'merge' }, doMerge) : () => Promise.resolve()),
+        asyncMap(unusedXvas, path => {
+            logWarn('unused XVA', { path });
+            if (remove) {
+                logInfo('deleting unused XVA', { path });
+                return handler.unlink(path);
+            }
+        }),
+        asyncMap(xvaSums, path => {
+            // no need to handle checksums for XVAs deleted by the script, they will be handled by `unlink()`
+            if (!xvas.has(path.slice(0, -'.checksum'.length))) {
+                logInfo('unused XVA checksum', { path });
+                if (remove) {
+                    logInfo('deleting unused XVA checksum', { path });
+                    return handler.unlink(path);
+                }
+            }
+        }),
+    ]);
+    await asyncMap(jsons, async (metadataPath) => {
+        const metadata = backups.get(metadataPath);
+        let fileSystemSize;
+        const mergedSize = metadataWithMergedVhd[metadataPath];
+        const { mode, size, vhds, xva } = metadata;
+        try {
+            if (mode === 'full') {
+                // a full backup : check size
+                const linkedXva = resolve('/', vmDir, xva);
+                try {
+                    fileSystemSize = await handler.getSize(linkedXva);
+                    if (fileSystemSize !== size && fileSystemSize !== undefined) {
+                        logWarn('cleanVm: incorrect backup size in metadata', {
+                            path: metadataPath,
+                            actual: size ?? 'none',
+                            expected: fileSystemSize,
+                        });
+                    }
+                }
+                catch (error) {
+                    // can fail with encrypted remote
+                }
+            }
+            else if (mode === 'delta') {
+                // don't warn if the size has changed after a merge
+                if (mergedSize === undefined) {
+                    const linkedVhds = Object.keys(vhds).map(key => resolve('/', vmDir, vhds[key]));
+                    fileSystemSize = await computeVhdsSize(handler, linkedVhds);
+                    // the size is not computed in some cases (e.g. VhdDirectory)
+                    if (fileSystemSize !== undefined && fileSystemSize !== size) {
+                        logWarn('cleanVm: incorrect backup size in metadata', {
+                            path: metadataPath,
+                            actual: size ?? 'none',
+                            expected: fileSystemSize,
+                        });
+                    }
+                }
+            }
+        }
+        catch (error) {
+            logWarn('failed to get backup size', { backup: metadataPath, error });
+            return;
+        }
+        // systematically update size and differentials after a merge
+        // @todo : after 2024-04-01 remove the fixmetadata options since the size computation is fixed
+        console.log({ /* metadata, */ vdis: metadata.vdis, isVhdDifferencing: metadata.isVhdDifferencing, parent: metadata.vmSnapshot.parent, mergedSize, fixMetadata, fileSystemSize, size });
+        if (mergedSize || (fixMetadata && fileSystemSize !== size)) {
+            metadata.size = mergedSize ?? fileSystemSize ?? size;
+            if (mergedSize) {
+                // all disks are now key disk
+                metadata.isVhdDifferencing = {};
+                for (const vdi of Object.values(metadata.vdis ?? {})) {
+                    const uuid = vdi.uuid;
+                    console.log({ uuid });
+                    metadata.isVhdDifferencing[`${uuid}.vhd`] = false;
+                }
+            }
+            mustRegenerateCache = true;
+            try {
+                await handler.writeFile(metadataPath, JSON.stringify(metadata), { flags: 'w' });
+            }
+            catch (error) {
+                logWarn('failed to update backup size in metadata', { path: metadataPath, error });
+            }
+        }
+    });
     if (mustRegenerateCache) {
-      logWarn('unexpected number of entries in backup cache', { path: cachePath, actual, expected })
-    }
-  }
-
-  await asyncMap(xvas, async path => {
-    // check is not good enough to delete the file, the best we can do is report
-    // it
-    if (!(await this.isValidXva(path))) {
-      logWarn('XVA might be broken', { path })
-    }
-  })
-
-  const unusedVhds = new Set(vhds)
-  const unusedXvas = new Set(xvas)
-
-  const backups = new Map()
-
-  // compile the list of unused XVAs and VHDs, and remove backup metadata which
-  // reference a missing XVA/VHD
-  await asyncMap(jsons, async json => {
-    let metadata
-    try {
-      metadata = JSON.parse(await handler.readFile(json))
-    } catch (error) {
-      logWarn('failed to read backup metadata', { path: json, error })
-      jsons.delete(json)
-      return
-    }
-
-    let isBackupComplete
-
-    const { mode } = metadata
-    if (mode === 'full') {
-      const linkedXva = resolve('/', vmDir, metadata.xva)
-      isBackupComplete = xvas.has(linkedXva)
-      if (isBackupComplete) {
-        unusedXvas.delete(linkedXva)
-      } else {
-        logWarn('the XVA linked to the backup is missing', { backup: json, xva: linkedXva })
-      }
-    } else if (mode === 'delta') {
-      const linkedVhds = (() => {
-        const { vhds } = metadata
-        return Object.keys(vhds).map(key => resolve('/', vmDir, vhds[key]))
-      })()
-
-      const missingVhds = linkedVhds.filter(_ => !vhds.has(_))
-      isBackupComplete = missingVhds.length === 0
-
-      // FIXME: find better approach by keeping as much of the backup as
-      // possible (existing disks) even if one disk is missing
-      if (isBackupComplete) {
-        linkedVhds.forEach(_ => unusedVhds.delete(_))
-        linkedVhds.forEach(path => {
-          vhdsToJSons[path] = json
-        })
-      } else {
-        logWarn('some VHDs linked to the backup are missing', { backup: json, missingVhds })
-      }
-    }
-
-    if (isBackupComplete) {
-      backups.set(json, metadata)
-    } else {
-      jsons.delete(json)
-      if (remove) {
-        logInfo('deleting incomplete backup', { backup: json })
-        mustRegenerateCache = true
-        await handler.unlink(json)
-      }
-    }
-  })
-
-  // TODO: parallelize by vm/job/vdi
-  const unusedVhdsDeletion = []
-  const toMerge = []
-  {
-    // VHD chains (as list from oldest to most recent) to merge indexed by most recent
-    // ancestor
-    const vhdChainsToMerge = { __proto__: null }
-
-    const toCheck = new Set(unusedVhds)
-
-    const getUsedChildChainOrDelete = vhd => {
-      if (vhd in vhdChainsToMerge) {
-        const chain = vhdChainsToMerge[vhd]
-        delete vhdChainsToMerge[vhd]
-        return chain
-      }
-
-      if (!unusedVhds.has(vhd)) {
-        return [vhd]
-      }
-
-      // no longer needs to be checked
-      toCheck.delete(vhd)
-
-      const child = vhdChildren[vhd]
-      if (child !== undefined) {
-        const chain = getUsedChildChainOrDelete(child)
-        if (chain !== undefined) {
-          chain.unshift(vhd)
-          return chain
+        const cache = {};
+        for (const [path, content] of backups.entries()) {
+            cache[path] = {
+                _filename: path,
+                id: path,
+                ...content,
+            };
         }
-      }
-
-      // no warning because a VHD can be unused for perfectly good reasons,
-      // e.g. the corresponding backup (metadata file) has been deleted
-      if (remove) {
-        logInfo('deleting unused VHD', { path: vhd })
-        unusedVhdsDeletion.push(VhdAbstract.unlink(handler, vhd))
-      }
+        await this._writeCache(cachePath, cache);
     }
-
-    toCheck.forEach(vhd => {
-      vhdChainsToMerge[vhd] = getUsedChildChainOrDelete(vhd)
-    })
-
-    // merge interrupted VHDs
-    for (const parent of interruptedVhds.keys()) {
-      // before #6349 the chain wasn't in the mergeState
-      const { chain, statePath } = interruptedVhds.get(parent)
-      if (chain === undefined) {
-        vhdChainsToMerge[parent] = [parent, vhdChildren[parent]]
-      } else {
-        vhdChainsToMerge[parent] = chain.map(vhdPath => handlerPath.resolveFromFile(statePath, vhdPath))
-      }
-    }
-
-    Object.values(vhdChainsToMerge).forEach(chain => {
-      if (chain !== undefined) {
-        toMerge.push(chain)
-      }
-    })
-  }
-
-  const metadataWithMergedVhd = {}
-  const doMerge = async () => {
-    await asyncMap(toMerge, async chain => {
-      const { finalVhdSize } = await limitedMergeVhdChain(handler, chain, {
-        logInfo,
-        logWarn,
-        remove,
-        mergeBlockConcurrency,
-      })
-      const metadataPath = vhdsToJSons[chain[chain.length - 1]] // all the chain should have the same metada file
-      metadataWithMergedVhd[metadataPath] = (metadataWithMergedVhd[metadataPath] ?? 0) + finalVhdSize
-    })
-  }
-
-  await Promise.all([
-    ...unusedVhdsDeletion,
-    toMerge.length !== 0 && (merge ? Task.run({ name: 'merge' }, doMerge) : () => Promise.resolve()),
-    asyncMap(unusedXvas, path => {
-      logWarn('unused XVA', { path })
-      if (remove) {
-        logInfo('deleting unused XVA', { path })
-        return handler.unlink(path)
-      }
-    }),
-    asyncMap(xvaSums, path => {
-      // no need to handle checksums for XVAs deleted by the script, they will be handled by `unlink()`
-      if (!xvas.has(path.slice(0, -'.checksum'.length))) {
-        logInfo('unused XVA checksum', { path })
-        if (remove) {
-          logInfo('deleting unused XVA checksum', { path })
-          return handler.unlink(path)
-        }
-      }
-    }),
-  ])
-
-  // update size for delta metadata with merged VHD
-  // check for the other that the size is the same as the real file size
-  await asyncMap(jsons, async metadataPath => {
-    const metadata = backups.get(metadataPath)
-
-    let fileSystemSize
-    const mergedSize = metadataWithMergedVhd[metadataPath]
-
-    const { mode, size, vhds, xva } = metadata
-
-    try {
-      if (mode === 'full') {
-        // a full backup : check size
-        const linkedXva = resolve('/', vmDir, xva)
-        try {
-          fileSystemSize = await handler.getSize(linkedXva)
-          if (fileSystemSize !== size && fileSystemSize !== undefined) {
-            logWarn('cleanVm: incorrect backup size in metadata', {
-              path: metadataPath,
-              actual: size ?? 'none',
-              expected: fileSystemSize,
-            })
-          }
-        } catch (error) {
-          // can fail with encrypted remote
-        }
-      } else if (mode === 'delta') {
-        // don't warn if the size has changed after a merge
-        if (mergedSize === undefined) {
-          const linkedVhds = Object.keys(vhds).map(key => resolve('/', vmDir, vhds[key]))
-          fileSystemSize = await computeVhdsSize(handler, linkedVhds)
-          // the size is not computed in some cases (e.g. VhdDirectory)
-          if (fileSystemSize !== undefined && fileSystemSize !== size) {
-            logWarn('cleanVm: incorrect backup size in metadata', {
-              path: metadataPath,
-              actual: size ?? 'none',
-              expected: fileSystemSize,
-            })
-          }
-        }
-      }
-    } catch (error) {
-      logWarn('failed to get backup size', { backup: metadataPath, error })
-      return
-    }
-
-    // systematically update size and differentials after a merge
-
-    // @todo : after 2024-04-01 remove the fixmetadata options since the size computation is fixed
-    if (mergedSize || (fixMetadata && fileSystemSize !== size)) {
-      metadata.size = mergedSize ?? fileSystemSize ?? size
-
-      if (mergedSize) {
-        // all disks are now key disk
-        metadata.isVhdDifferencing = {}
-        for (const id of Object.values(metadata.vdis ?? {})) {
-          metadata.isVhdDifferencing[`${id}.vhd`] = false
-        }
-      }
-      mustRegenerateCache = true
-      try {
-        await handler.writeFile(metadataPath, JSON.stringify(metadata), { flags: 'w' })
-      } catch (error) {
-        logWarn('failed to update backup size in metadata', { path: metadataPath, error })
-      }
-    }
-  })
-
-  if (mustRegenerateCache) {
-    const cache = {}
-    for (const [path, content] of backups.entries()) {
-      cache[path] = {
-        _filename: path,
-        id: path,
-        ...content,
-      }
-    }
-    await this._writeCache(cachePath, cache)
-  }
-
-  return {
-    // boolean whether some VHDs were merged (or should be merged)
-    merge: toMerge.length !== 0,
-  }
+    return {
+        // boolean whether some VHDs were merged (or should be merged)
+        merge: toMerge.length !== 0,
+    };
 }

--- a/@xen-orchestra/backups/_cleanVm.mjs
+++ b/@xen-orchestra/backups/_cleanVm.mjs
@@ -1,535 +1,548 @@
-import * as UUID from 'uuid';
-import sum from 'lodash/sum.js';
-import { asyncMap } from '@xen-orchestra/async-map';
-import { Constants, openVhd, VhdAbstract, VhdFile } from 'vhd-lib';
-import { isVhdAlias, resolveVhdAlias } from 'vhd-lib/aliases.js';
-import { basename, dirname, resolve } from 'node:path';
-import { isMetadataFile, isVhdFile, isXvaFile, isXvaSumFile } from './_backupType.mjs';
-import { limitConcurrency } from 'limit-concurrency-decorator';
-import { mergeVhdChain } from 'vhd-lib/merge.js';
-import { Task } from './Task.mjs';
-import { Disposable } from 'promise-toolbox';
-import * as handlerPath from '@xen-orchestra/fs/path';
-const { DISK_TYPES } = Constants;
+import * as UUID from 'uuid'
+import sum from 'lodash/sum.js'
+import { asyncMap } from '@xen-orchestra/async-map'
+import { Constants, openVhd, VhdAbstract, VhdFile } from 'vhd-lib'
+import { isVhdAlias, resolveVhdAlias } from 'vhd-lib/aliases.js'
+import { basename, dirname, resolve } from 'node:path'
+import { isMetadataFile, isVhdFile, isXvaFile, isXvaSumFile } from './_backupType.mjs'
+import { limitConcurrency } from 'limit-concurrency-decorator'
+import { mergeVhdChain } from 'vhd-lib/merge.js'
+import { Task } from './Task.mjs'
+import { Disposable } from 'promise-toolbox'
+import * as handlerPath from '@xen-orchestra/fs/path'
+const { DISK_TYPES } = Constants
 // checking the size of a vhd directory is costly
 // 1 Http Query per 1000 blocks
 // we only check size of all the vhd are VhdFiles
 function shouldComputeVhdsSize(handler, vhds) {
-    if (handler.isEncrypted) {
-        return false;
-    }
-    return vhds.every(vhd => vhd instanceof VhdFile);
+  if (handler.isEncrypted) {
+    return false
+  }
+  return vhds.every(vhd => vhd instanceof VhdFile)
 }
-const computeVhdsSize = (handler, vhdPaths) => Disposable.use(vhdPaths.map(vhdPath => openVhd(handler, vhdPath)), async (vhds) => {
-    if (shouldComputeVhdsSize(handler, vhds)) {
-        const sizes = await asyncMap(vhds, vhd => vhd.getSize());
-        return sum(sizes);
+const computeVhdsSize = (handler, vhdPaths) =>
+  Disposable.use(
+    vhdPaths.map(vhdPath => openVhd(handler, vhdPath)),
+    async vhds => {
+      if (shouldComputeVhdsSize(handler, vhds)) {
+        const sizes = await asyncMap(vhds, vhd => vhd.getSize())
+        return sum(sizes)
+      }
     }
-});
+  )
 // chain is [ ancestor, child_1, ..., child_n ]
 async function _mergeVhdChain(handler, chain, { logInfo, remove, mergeBlockConcurrency }) {
-    logInfo(`merging VHD chain`, { chain });
-    let done, total;
-    const handle = setInterval(() => {
-        if (done !== undefined) {
-            logInfo('merge in progress', {
-                done,
-                parent: chain[0],
-                progress: Math.round((100 * done) / total),
-                total,
-            });
-        }
-    }, 10e3);
-    try {
-        return await mergeVhdChain(handler, chain, {
-            logInfo,
-            mergeBlockConcurrency,
-            onProgress({ done: d, total: t }) {
-                done = d;
-                total = t;
-            },
-            removeUnused: remove,
-        });
+  logInfo(`merging VHD chain`, { chain })
+  let done, total
+  const handle = setInterval(() => {
+    if (done !== undefined) {
+      logInfo('merge in progress', {
+        done,
+        parent: chain[0],
+        progress: Math.round((100 * done) / total),
+        total,
+      })
     }
-    finally {
-        clearInterval(handle);
-    }
+  }, 10e3)
+  try {
+    return await mergeVhdChain(handler, chain, {
+      logInfo,
+      mergeBlockConcurrency,
+      onProgress({ done: d, total: t }) {
+        done = d
+        total = t
+      },
+      removeUnused: remove,
+    })
+  } finally {
+    clearInterval(handle)
+  }
 }
-const noop = Function.prototype;
-const INTERRUPTED_VHDS_REG = /^\.(.+)\.merge.json$/;
+const noop = Function.prototype
+const INTERRUPTED_VHDS_REG = /^\.(.+)\.merge.json$/
 const listVhds = async (handler, vmDir, logWarn) => {
-    const vhds = new Set();
-    const aliases = {};
-    const interruptedVhds = new Map();
-    await asyncMap(await handler.list(`${vmDir}/vdis`, {
-        ignoreMissing: true,
-        prependDir: true,
-    }), async (jobDir) => asyncMap(await handler.list(jobDir, {
-        prependDir: true,
-    }), async (vdiDir) => {
-        const list = await handler.list(vdiDir, {
+  const vhds = new Set()
+  const aliases = {}
+  const interruptedVhds = new Map()
+  await asyncMap(
+    await handler.list(`${vmDir}/vdis`, {
+      ignoreMissing: true,
+      prependDir: true,
+    }),
+    async jobDir =>
+      asyncMap(
+        await handler.list(jobDir, {
+          prependDir: true,
+        }),
+        async vdiDir => {
+          const list = await handler.list(vdiDir, {
             filter: file => isVhdFile(file) || INTERRUPTED_VHDS_REG.test(file),
-        });
-        aliases[vdiDir] = list.filter(vhd => isVhdAlias(vhd)).map(file => `${vdiDir}/${file}`);
-        await asyncMap(list, async (file) => {
-            const res = INTERRUPTED_VHDS_REG.exec(file);
+          })
+          aliases[vdiDir] = list.filter(vhd => isVhdAlias(vhd)).map(file => `${vdiDir}/${file}`)
+          await asyncMap(list, async file => {
+            const res = INTERRUPTED_VHDS_REG.exec(file)
             if (res === null) {
-                vhds.add(`${vdiDir}/${file}`);
+              vhds.add(`${vdiDir}/${file}`)
+            } else {
+              try {
+                const mergeState = JSON.parse(await handler.readFile(`${vdiDir}/${file}`))
+                interruptedVhds.set(`${vdiDir}/${res[1]}`, {
+                  statePath: `${vdiDir}/${file}`,
+                  chain: mergeState.chain,
+                })
+              } catch (error) {
+                // fall back to a non resuming merge
+                vhds.add(`${vdiDir}/${file}`)
+                logWarn('failed to read existing merge state', { path: file, error })
+              }
             }
-            else {
-                try {
-                    const mergeState = JSON.parse(await handler.readFile(`${vdiDir}/${file}`));
-                    interruptedVhds.set(`${vdiDir}/${res[1]}`, {
-                        statePath: `${vdiDir}/${file}`,
-                        chain: mergeState.chain,
-                    });
-                }
-                catch (error) {
-                    // fall back to a non resuming merge
-                    vhds.add(`${vdiDir}/${file}`);
-                    logWarn('failed to read existing merge state', { path: file, error });
-                }
-            }
-        });
-    }));
-    return { vhds, interruptedVhds, aliases };
-};
-export async function checkAliases(aliasPaths, targetDataRepository, { handler, logInfo = noop, logWarn = console.warn, remove = false }) {
-    const aliasFound = [];
-    for (const alias of aliasPaths) {
-        let target;
-        try {
-            target = await resolveVhdAlias(handler, alias);
+          })
         }
-        catch (err) {
-            if (err.code === 'ENOENT') {
-                logWarn('missing target of alias', { alias });
-                if (remove) {
-                    logInfo('removing alias and non VHD target', { alias, target });
-                    await handler.unlink(target);
-                    await handler.unlink(alias);
-                }
-            }
-        }
-        if (!isVhdFile(target)) {
-            logWarn('alias references non VHD target', { alias, target });
-            if (remove) {
-                logInfo('removing alias and non VHD target', { alias, target });
-                await handler.unlink(target);
-                await handler.unlink(alias);
-            }
-            continue;
-        }
-        try {
-            const { dispose } = await openVhd(handler, target);
-            try {
-                await dispose();
-            }
-            catch (e) {
-                // error during dispose should not trigger a deletion
-            }
-        }
-        catch (error) {
-            logWarn('missing or broken alias target', { alias, target, error });
-            if (remove) {
-                try {
-                    await VhdAbstract.unlink(handler, alias);
-                }
-                catch (error) {
-                    if (error.code !== 'ENOENT') {
-                        logWarn('error deleting alias target', { alias, target, error });
-                    }
-                }
-            }
-            continue;
-        }
-        aliasFound.push(resolve('/', target));
-    }
-    const vhds = await handler.list(targetDataRepository, {
-        ignoreMissing: true,
-        prependDir: true,
-    });
-    await asyncMap(vhds, async (path) => {
-        if (!aliasFound.includes(path)) {
-            logWarn('no alias references VHD', { path });
-            if (remove) {
-                logInfo('deleting unused VHD', { path });
-                await VhdAbstract.unlink(handler, path);
-            }
-        }
-    });
+      )
+  )
+  return { vhds, interruptedVhds, aliases }
 }
-const defaultMergeLimiter = limitConcurrency(1);
-export async function cleanVm(vmDir, { fixMetadata, remove = false, removeTmp = remove, merge, mergeBlockConcurrency, mergeLimiter = defaultMergeLimiter, logInfo = noop, logWarn = console.warn, }) {
-    const limitedMergeVhdChain = mergeLimiter(_mergeVhdChain);
-    const handler = this._handler;
-    const vhdsToJSons = new Set();
-    const vhdById = new Map();
-    const vhdParents = { __proto__: null };
-    const vhdChildren = { __proto__: null };
-    const { vhds, interruptedVhds, aliases } = await listVhds(handler, vmDir, logWarn);
-    // remove broken VHDs
-    await asyncMap(vhds, async (path) => {
-        if (removeTmp && basename(path)[0] === '.') {
-            logInfo('deleting temporary VHD', { path });
-            return VhdAbstract.unlink(handler, path);
+export async function checkAliases(
+  aliasPaths,
+  targetDataRepository,
+  { handler, logInfo = noop, logWarn = console.warn, remove = false }
+) {
+  const aliasFound = []
+  for (const alias of aliasPaths) {
+    let target
+    try {
+      target = await resolveVhdAlias(handler, alias)
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        logWarn('missing target of alias', { alias })
+        if (remove) {
+          logInfo('removing alias and non VHD target', { alias, target })
+          await handler.unlink(target)
+          await handler.unlink(alias)
         }
+      }
+    }
+    if (!isVhdFile(target)) {
+      logWarn('alias references non VHD target', { alias, target })
+      if (remove) {
+        logInfo('removing alias and non VHD target', { alias, target })
+        await handler.unlink(target)
+        await handler.unlink(alias)
+      }
+      continue
+    }
+    try {
+      const { dispose } = await openVhd(handler, target)
+      try {
+        await dispose()
+      } catch (e) {
+        // error during dispose should not trigger a deletion
+      }
+    } catch (error) {
+      logWarn('missing or broken alias target', { alias, target, error })
+      if (remove) {
         try {
-            await Disposable.use(openVhd(handler, path, { checkSecondFooter: !interruptedVhds.has(path) }), vhd => {
-                if (vhd.footer.diskType === DISK_TYPES.DIFFERENCING) {
-                    const parent = resolve('/', dirname(path), vhd.header.parentUnicodeName);
-                    vhdParents[path] = parent;
-                    if (parent in vhdChildren) {
-                        const error = new Error('this script does not support multiple VHD children');
-                        error.parent = parent;
-                        error.child1 = vhdChildren[parent];
-                        error.child2 = path;
-                        throw error; // should we throw?
-                    }
-                    vhdChildren[parent] = path;
-                }
-                // Detect VHDs with the same UUIDs
-                //
-                // Due to a bug introduced in a1bcd35e2
-                const duplicate = vhdById.get(UUID.stringify(vhd.footer.uuid));
-                let vhdKept = vhd;
-                if (duplicate !== undefined) {
-                    logWarn('uuid is duplicated', { uuid: UUID.stringify(vhd.footer.uuid) });
-                    if (duplicate.containsAllDataOf(vhd)) {
-                        logWarn(`should delete ${path}`);
-                        vhdKept = duplicate;
-                        vhds.delete(path);
-                    }
-                    else if (vhd.containsAllDataOf(duplicate)) {
-                        logWarn(`should delete ${duplicate._path}`);
-                        vhds.delete(duplicate._path);
-                    }
-                    else {
-                        logWarn('same ids but different content');
-                    }
-                }
-                vhdById.set(UUID.stringify(vhdKept.footer.uuid), vhdKept);
-            });
+          await VhdAbstract.unlink(handler, alias)
+        } catch (error) {
+          if (error.code !== 'ENOENT') {
+            logWarn('error deleting alias target', { alias, target, error })
+          }
         }
-        catch (error) {
-            vhds.delete(path);
-            logWarn('VHD check error', { path, error });
-            if (error?.code === 'ERR_ASSERTION' && remove) {
-                logInfo('deleting broken VHD', { path });
-                return VhdAbstract.unlink(handler, path);
-            }
-        }
-    });
-    // remove interrupted merge states for missing VHDs
-    for (const interruptedVhd of interruptedVhds.keys()) {
-        if (!vhds.has(interruptedVhd)) {
-            const { statePath } = interruptedVhds.get(interruptedVhd);
-            interruptedVhds.delete(interruptedVhd);
-            logWarn('orphan merge state', {
-                mergeStatePath: statePath,
-                missingVhdPath: interruptedVhd,
-            });
-            if (remove) {
-                logInfo('deleting orphan merge state', { statePath });
-                await handler.unlink(statePath);
-            }
-        }
+      }
+      continue
     }
-    // check if alias are correct
-    // check if all vhd in data subfolder have a corresponding alias
-    await asyncMap(Object.keys(aliases), async (dir) => {
-        await checkAliases(aliases[dir], `${dir}/data`, { handler, logInfo, logWarn, remove });
-    });
-    // remove VHDs with missing ancestors
-    {
-        const deletions = [];
-        // return true if the VHD has been deleted or is missing
-        const deleteIfOrphan = vhdPath => {
-            const parent = vhdParents[vhdPath];
-            if (parent === undefined) {
-                return;
-            }
-            // no longer needs to be checked
-            delete vhdParents[vhdPath];
-            deleteIfOrphan(parent);
-            if (!vhds.has(parent)) {
-                vhds.delete(vhdPath);
-                logWarn('parent VHD is missing', { parent, child: vhdPath });
-                if (remove) {
-                    logInfo('deleting orphan VHD', { path: vhdPath });
-                    deletions.push(VhdAbstract.unlink(handler, vhdPath));
-                }
-            }
-        };
-        // > A property that is deleted before it has been visited will not be
-        // > visited later.
-        // >
-        // > -- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in#Deleted_added_or_modified_properties
-        for (const child in vhdParents) {
-            deleteIfOrphan(child);
-        }
-        await Promise.all(deletions);
+    aliasFound.push(resolve('/', target))
+  }
+  const vhds = await handler.list(targetDataRepository, {
+    ignoreMissing: true,
+    prependDir: true,
+  })
+  await asyncMap(vhds, async path => {
+    if (!aliasFound.includes(path)) {
+      logWarn('no alias references VHD', { path })
+      if (remove) {
+        logInfo('deleting unused VHD', { path })
+        await VhdAbstract.unlink(handler, path)
+      }
     }
-    const jsons = new Set();
-    const xvas = new Set();
-    const xvaSums = [];
-    const entries = await handler.list(vmDir, {
-        prependDir: true,
-    });
-    entries.forEach(path => {
-        if (isMetadataFile(path)) {
-            jsons.add(path);
-        }
-        else if (isXvaFile(path)) {
-            xvas.add(path);
-        }
-        else if (isXvaSumFile(path)) {
-            xvaSums.push(path);
-        }
-    });
-    const cachePath = vmDir + '/cache.json.gz';
-    let mustRegenerateCache;
-    {
-        const cache = await this._readCache(cachePath);
-        const actual = cache === undefined ? 0 : Object.keys(cache).length;
-        const expected = jsons.size;
-        mustRegenerateCache = actual !== expected;
-        if (mustRegenerateCache) {
-            logWarn('unexpected number of entries in backup cache', { path: cachePath, actual, expected });
-        }
+  })
+}
+const defaultMergeLimiter = limitConcurrency(1)
+export async function cleanVm(
+  vmDir,
+  {
+    fixMetadata,
+    remove = false,
+    removeTmp = remove,
+    merge,
+    mergeBlockConcurrency,
+    mergeLimiter = defaultMergeLimiter,
+    logInfo = noop,
+    logWarn = console.warn,
+  }
+) {
+  const limitedMergeVhdChain = mergeLimiter(_mergeVhdChain)
+  const handler = this._handler
+  const vhdsToJSons = new Set()
+  const vhdById = new Map()
+  const vhdParents = { __proto__: null }
+  const vhdChildren = { __proto__: null }
+  const { vhds, interruptedVhds, aliases } = await listVhds(handler, vmDir, logWarn)
+  // remove broken VHDs
+  await asyncMap(vhds, async path => {
+    if (removeTmp && basename(path)[0] === '.') {
+      logInfo('deleting temporary VHD', { path })
+      return VhdAbstract.unlink(handler, path)
     }
-    await asyncMap(xvas, async (path) => {
-        // check is not good enough to delete the file, the best we can do is report
-        // it
-        if (!(await this.isValidXva(path))) {
-            logWarn('XVA might be broken', { path });
+    try {
+      await Disposable.use(openVhd(handler, path, { checkSecondFooter: !interruptedVhds.has(path) }), vhd => {
+        if (vhd.footer.diskType === DISK_TYPES.DIFFERENCING) {
+          const parent = resolve('/', dirname(path), vhd.header.parentUnicodeName)
+          vhdParents[path] = parent
+          if (parent in vhdChildren) {
+            const error = new Error('this script does not support multiple VHD children')
+            error.parent = parent
+            error.child1 = vhdChildren[parent]
+            error.child2 = path
+            throw error // should we throw?
+          }
+          vhdChildren[parent] = path
         }
-    });
-    const unusedVhds = new Set(vhds);
-    const unusedXvas = new Set(xvas);
-    const backups = new Map();
-    // compile the list of unused XVAs and VHDs, and remove backup metadata which
-    // reference a missing XVA/VHD
-    await asyncMap(jsons, async (json) => {
-        let metadata;
-        try {
-            metadata = JSON.parse(await handler.readFile(json));
+        // Detect VHDs with the same UUIDs
+        //
+        // Due to a bug introduced in a1bcd35e2
+        const duplicate = vhdById.get(UUID.stringify(vhd.footer.uuid))
+        let vhdKept = vhd
+        if (duplicate !== undefined) {
+          logWarn('uuid is duplicated', { uuid: UUID.stringify(vhd.footer.uuid) })
+          if (duplicate.containsAllDataOf(vhd)) {
+            logWarn(`should delete ${path}`)
+            vhdKept = duplicate
+            vhds.delete(path)
+          } else if (vhd.containsAllDataOf(duplicate)) {
+            logWarn(`should delete ${duplicate._path}`)
+            vhds.delete(duplicate._path)
+          } else {
+            logWarn('same ids but different content')
+          }
         }
-        catch (error) {
-            logWarn('failed to read backup metadata', { path: json, error });
-            jsons.delete(json);
-            return;
-        }
-        let isBackupComplete;
-        const { mode } = metadata;
-        if (mode === 'full') {
-            const linkedXva = resolve('/', vmDir, metadata.xva);
-            isBackupComplete = xvas.has(linkedXva);
-            if (isBackupComplete) {
-                unusedXvas.delete(linkedXva);
-            }
-            else {
-                logWarn('the XVA linked to the backup is missing', { backup: json, xva: linkedXva });
-            }
-        }
-        else if (mode === 'delta') {
-            const linkedVhds = (() => {
-                const { vhds } = metadata;
-                return Object.keys(vhds).map(key => resolve('/', vmDir, vhds[key]));
-            })();
-            const missingVhds = linkedVhds.filter(_ => !vhds.has(_));
-            isBackupComplete = missingVhds.length === 0;
-            // FIXME: find better approach by keeping as much of the backup as
-            // possible (existing disks) even if one disk is missing
-            if (isBackupComplete) {
-                linkedVhds.forEach(_ => unusedVhds.delete(_));
-                linkedVhds.forEach(path => {
-                    vhdsToJSons[path] = json;
-                });
-            }
-            else {
-                logWarn('some VHDs linked to the backup are missing', { backup: json, missingVhds });
-            }
-        }
-        if (isBackupComplete) {
-            backups.set(json, metadata);
-        }
-        else {
-            jsons.delete(json);
-            if (remove) {
-                logInfo('deleting incomplete backup', { backup: json });
-                mustRegenerateCache = true;
-                await handler.unlink(json);
-            }
-        }
-    });
-    // TODO: parallelize by vm/job/vdi
-    const unusedVhdsDeletion = [];
-    const toMerge = [];
-    {
-        // VHD chains (as list from oldest to most recent) to merge indexed by most recent
-        // ancestor
-        const vhdChainsToMerge = { __proto__: null };
-        const toCheck = new Set(unusedVhds);
-        const getUsedChildChainOrDelete = vhd => {
-            if (vhd in vhdChainsToMerge) {
-                const chain = vhdChainsToMerge[vhd];
-                delete vhdChainsToMerge[vhd];
-                return chain;
-            }
-            if (!unusedVhds.has(vhd)) {
-                return [vhd];
-            }
-            // no longer needs to be checked
-            toCheck.delete(vhd);
-            const child = vhdChildren[vhd];
-            if (child !== undefined) {
-                const chain = getUsedChildChainOrDelete(child);
-                if (chain !== undefined) {
-                    chain.unshift(vhd);
-                    return chain;
-                }
-            }
-            // no warning because a VHD can be unused for perfectly good reasons,
-            // e.g. the corresponding backup (metadata file) has been deleted
-            if (remove) {
-                logInfo('deleting unused VHD', { path: vhd });
-                unusedVhdsDeletion.push(VhdAbstract.unlink(handler, vhd));
-            }
-        };
-        toCheck.forEach(vhd => {
-            vhdChainsToMerge[vhd] = getUsedChildChainOrDelete(vhd);
-        });
-        // merge interrupted VHDs
-        for (const parent of interruptedVhds.keys()) {
-            // before #6349 the chain wasn't in the mergeState
-            const { chain, statePath } = interruptedVhds.get(parent);
-            if (chain === undefined) {
-                vhdChainsToMerge[parent] = [parent, vhdChildren[parent]];
-            }
-            else {
-                vhdChainsToMerge[parent] = chain.map(vhdPath => handlerPath.resolveFromFile(statePath, vhdPath));
-            }
-        }
-        Object.values(vhdChainsToMerge).forEach(chain => {
-            if (chain !== undefined) {
-                toMerge.push(chain);
-            }
-        });
+        vhdById.set(UUID.stringify(vhdKept.footer.uuid), vhdKept)
+      })
+    } catch (error) {
+      vhds.delete(path)
+      logWarn('VHD check error', { path, error })
+      if (error?.code === 'ERR_ASSERTION' && remove) {
+        logInfo('deleting broken VHD', { path })
+        return VhdAbstract.unlink(handler, path)
+      }
     }
-    const metadataWithMergedVhd = {};
-    const doMerge = async () => {
-        await asyncMap(toMerge, async (chain) => {
-            const { finalVhdSize } = await limitedMergeVhdChain(handler, chain, {
-                logInfo,
-                logWarn,
-                remove,
-                mergeBlockConcurrency,
-            });
-            const metadataPath = vhdsToJSons[chain[chain.length - 1]]; // all the chain should have the same metada file
-            metadataWithMergedVhd[metadataPath] = (metadataWithMergedVhd[metadataPath] ?? 0) + finalVhdSize;
-        });
-    };
-    await Promise.all([
-        ...unusedVhdsDeletion,
-        toMerge.length !== 0 && (merge ? Task.run({ name: 'merge' }, doMerge) : () => Promise.resolve()),
-        asyncMap(unusedXvas, path => {
-            logWarn('unused XVA', { path });
-            if (remove) {
-                logInfo('deleting unused XVA', { path });
-                return handler.unlink(path);
-            }
-        }),
-        asyncMap(xvaSums, path => {
-            // no need to handle checksums for XVAs deleted by the script, they will be handled by `unlink()`
-            if (!xvas.has(path.slice(0, -'.checksum'.length))) {
-                logInfo('unused XVA checksum', { path });
-                if (remove) {
-                    logInfo('deleting unused XVA checksum', { path });
-                    return handler.unlink(path);
-                }
-            }
-        }),
-    ]);
-    await asyncMap(jsons, async (metadataPath) => {
-        const metadata = backups.get(metadataPath);
-        let fileSystemSize;
-        const mergedSize = metadataWithMergedVhd[metadataPath];
-        const { mode, size, vhds, xva } = metadata;
-        try {
-            if (mode === 'full') {
-                // a full backup : check size
-                const linkedXva = resolve('/', vmDir, xva);
-                try {
-                    fileSystemSize = await handler.getSize(linkedXva);
-                    if (fileSystemSize !== size && fileSystemSize !== undefined) {
-                        logWarn('cleanVm: incorrect backup size in metadata', {
-                            path: metadataPath,
-                            actual: size ?? 'none',
-                            expected: fileSystemSize,
-                        });
-                    }
-                }
-                catch (error) {
-                    // can fail with encrypted remote
-                }
-            }
-            else if (mode === 'delta') {
-                // don't warn if the size has changed after a merge
-                if (mergedSize === undefined) {
-                    const linkedVhds = Object.keys(vhds).map(key => resolve('/', vmDir, vhds[key]));
-                    fileSystemSize = await computeVhdsSize(handler, linkedVhds);
-                    // the size is not computed in some cases (e.g. VhdDirectory)
-                    if (fileSystemSize !== undefined && fileSystemSize !== size) {
-                        logWarn('cleanVm: incorrect backup size in metadata', {
-                            path: metadataPath,
-                            actual: size ?? 'none',
-                            expected: fileSystemSize,
-                        });
-                    }
-                }
-            }
+  })
+  // remove interrupted merge states for missing VHDs
+  for (const interruptedVhd of interruptedVhds.keys()) {
+    if (!vhds.has(interruptedVhd)) {
+      const { statePath } = interruptedVhds.get(interruptedVhd)
+      interruptedVhds.delete(interruptedVhd)
+      logWarn('orphan merge state', {
+        mergeStatePath: statePath,
+        missingVhdPath: interruptedVhd,
+      })
+      if (remove) {
+        logInfo('deleting orphan merge state', { statePath })
+        await handler.unlink(statePath)
+      }
+    }
+  }
+  // check if alias are correct
+  // check if all vhd in data subfolder have a corresponding alias
+  await asyncMap(Object.keys(aliases), async dir => {
+    await checkAliases(aliases[dir], `${dir}/data`, { handler, logInfo, logWarn, remove })
+  })
+  // remove VHDs with missing ancestors
+  {
+    const deletions = []
+    // return true if the VHD has been deleted or is missing
+    const deleteIfOrphan = vhdPath => {
+      const parent = vhdParents[vhdPath]
+      if (parent === undefined) {
+        return
+      }
+      // no longer needs to be checked
+      delete vhdParents[vhdPath]
+      deleteIfOrphan(parent)
+      if (!vhds.has(parent)) {
+        vhds.delete(vhdPath)
+        logWarn('parent VHD is missing', { parent, child: vhdPath })
+        if (remove) {
+          logInfo('deleting orphan VHD', { path: vhdPath })
+          deletions.push(VhdAbstract.unlink(handler, vhdPath))
         }
-        catch (error) {
-            logWarn('failed to get backup size', { backup: metadataPath, error });
-            return;
-        }
-        // systematically update size and differentials after a merge
-        // @todo : after 2024-04-01 remove the fixmetadata options since the size computation is fixed
-        console.log({ /* metadata, */ vdis: metadata.vdis, isVhdDifferencing: metadata.isVhdDifferencing, parent: metadata.vmSnapshot.parent, mergedSize, fixMetadata, fileSystemSize, size });
-        if (mergedSize || (fixMetadata && fileSystemSize !== size)) {
-            metadata.size = mergedSize ?? fileSystemSize ?? size;
-            if (mergedSize) {
-                // all disks are now key disk
-                metadata.isVhdDifferencing = {};
-                for (const vdi of Object.values(metadata.vdis ?? {})) {
-                    const uuid = vdi.uuid;
-                    console.log({ uuid });
-                    metadata.isVhdDifferencing[`${uuid}.vhd`] = false;
-                }
-            }
-            mustRegenerateCache = true;
-            try {
-                await handler.writeFile(metadataPath, JSON.stringify(metadata), { flags: 'w' });
-            }
-            catch (error) {
-                logWarn('failed to update backup size in metadata', { path: metadataPath, error });
-            }
-        }
-    });
+      }
+    }
+    // > A property that is deleted before it has been visited will not be
+    // > visited later.
+    // >
+    // > -- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in#Deleted_added_or_modified_properties
+    for (const child in vhdParents) {
+      deleteIfOrphan(child)
+    }
+    await Promise.all(deletions)
+  }
+  const jsons = new Set()
+  const xvas = new Set()
+  const xvaSums = []
+  const entries = await handler.list(vmDir, {
+    prependDir: true,
+  })
+  entries.forEach(path => {
+    if (isMetadataFile(path)) {
+      jsons.add(path)
+    } else if (isXvaFile(path)) {
+      xvas.add(path)
+    } else if (isXvaSumFile(path)) {
+      xvaSums.push(path)
+    }
+  })
+  const cachePath = vmDir + '/cache.json.gz'
+  let mustRegenerateCache
+  {
+    const cache = await this._readCache(cachePath)
+    const actual = cache === undefined ? 0 : Object.keys(cache).length
+    const expected = jsons.size
+    mustRegenerateCache = actual !== expected
     if (mustRegenerateCache) {
-        const cache = {};
-        for (const [path, content] of backups.entries()) {
-            cache[path] = {
-                _filename: path,
-                id: path,
-                ...content,
-            };
-        }
-        await this._writeCache(cachePath, cache);
+      logWarn('unexpected number of entries in backup cache', { path: cachePath, actual, expected })
     }
-    return {
-        // boolean whether some VHDs were merged (or should be merged)
-        merge: toMerge.length !== 0,
-    };
+  }
+  await asyncMap(xvas, async path => {
+    // check is not good enough to delete the file, the best we can do is report
+    // it
+    if (!(await this.isValidXva(path))) {
+      logWarn('XVA might be broken', { path })
+    }
+  })
+  const unusedVhds = new Set(vhds)
+  const unusedXvas = new Set(xvas)
+  const backups = new Map()
+  // compile the list of unused XVAs and VHDs, and remove backup metadata which
+  // reference a missing XVA/VHD
+  await asyncMap(jsons, async json => {
+    let metadata
+    try {
+      metadata = JSON.parse(await handler.readFile(json))
+    } catch (error) {
+      logWarn('failed to read backup metadata', { path: json, error })
+      jsons.delete(json)
+      return
+    }
+    let isBackupComplete
+    const { mode } = metadata
+    if (mode === 'full') {
+      const linkedXva = resolve('/', vmDir, metadata.xva)
+      isBackupComplete = xvas.has(linkedXva)
+      if (isBackupComplete) {
+        unusedXvas.delete(linkedXva)
+      } else {
+        logWarn('the XVA linked to the backup is missing', { backup: json, xva: linkedXva })
+      }
+    } else if (mode === 'delta') {
+      const linkedVhds = (() => {
+        const { vhds } = metadata
+        return Object.keys(vhds).map(key => resolve('/', vmDir, vhds[key]))
+      })()
+      const missingVhds = linkedVhds.filter(_ => !vhds.has(_))
+      isBackupComplete = missingVhds.length === 0
+      // FIXME: find better approach by keeping as much of the backup as
+      // possible (existing disks) even if one disk is missing
+      if (isBackupComplete) {
+        linkedVhds.forEach(_ => unusedVhds.delete(_))
+        linkedVhds.forEach(path => {
+          vhdsToJSons[path] = json
+        })
+      } else {
+        logWarn('some VHDs linked to the backup are missing', { backup: json, missingVhds })
+      }
+    }
+    if (isBackupComplete) {
+      backups.set(json, metadata)
+    } else {
+      jsons.delete(json)
+      if (remove) {
+        logInfo('deleting incomplete backup', { backup: json })
+        mustRegenerateCache = true
+        await handler.unlink(json)
+      }
+    }
+  })
+  // TODO: parallelize by vm/job/vdi
+  const unusedVhdsDeletion = []
+  const toMerge = []
+  {
+    // VHD chains (as list from oldest to most recent) to merge indexed by most recent
+    // ancestor
+    const vhdChainsToMerge = { __proto__: null }
+    const toCheck = new Set(unusedVhds)
+    const getUsedChildChainOrDelete = vhd => {
+      if (vhd in vhdChainsToMerge) {
+        const chain = vhdChainsToMerge[vhd]
+        delete vhdChainsToMerge[vhd]
+        return chain
+      }
+      if (!unusedVhds.has(vhd)) {
+        return [vhd]
+      }
+      // no longer needs to be checked
+      toCheck.delete(vhd)
+      const child = vhdChildren[vhd]
+      if (child !== undefined) {
+        const chain = getUsedChildChainOrDelete(child)
+        if (chain !== undefined) {
+          chain.unshift(vhd)
+          return chain
+        }
+      }
+      // no warning because a VHD can be unused for perfectly good reasons,
+      // e.g. the corresponding backup (metadata file) has been deleted
+      if (remove) {
+        logInfo('deleting unused VHD', { path: vhd })
+        unusedVhdsDeletion.push(VhdAbstract.unlink(handler, vhd))
+      }
+    }
+    toCheck.forEach(vhd => {
+      vhdChainsToMerge[vhd] = getUsedChildChainOrDelete(vhd)
+    })
+    // merge interrupted VHDs
+    for (const parent of interruptedVhds.keys()) {
+      // before #6349 the chain wasn't in the mergeState
+      const { chain, statePath } = interruptedVhds.get(parent)
+      if (chain === undefined) {
+        vhdChainsToMerge[parent] = [parent, vhdChildren[parent]]
+      } else {
+        vhdChainsToMerge[parent] = chain.map(vhdPath => handlerPath.resolveFromFile(statePath, vhdPath))
+      }
+    }
+    Object.values(vhdChainsToMerge).forEach(chain => {
+      if (chain !== undefined) {
+        toMerge.push(chain)
+      }
+    })
+  }
+  const metadataWithMergedVhd = {}
+  const doMerge = async () => {
+    await asyncMap(toMerge, async chain => {
+      const { finalVhdSize } = await limitedMergeVhdChain(handler, chain, {
+        logInfo,
+        logWarn,
+        remove,
+        mergeBlockConcurrency,
+      })
+      const metadataPath = vhdsToJSons[chain[chain.length - 1]] // all the chain should have the same metada file
+      metadataWithMergedVhd[metadataPath] = (metadataWithMergedVhd[metadataPath] ?? 0) + finalVhdSize
+    })
+  }
+  await Promise.all([
+    ...unusedVhdsDeletion,
+    toMerge.length !== 0 && (merge ? Task.run({ name: 'merge' }, doMerge) : () => Promise.resolve()),
+    asyncMap(unusedXvas, path => {
+      logWarn('unused XVA', { path })
+      if (remove) {
+        logInfo('deleting unused XVA', { path })
+        return handler.unlink(path)
+      }
+    }),
+    asyncMap(xvaSums, path => {
+      // no need to handle checksums for XVAs deleted by the script, they will be handled by `unlink()`
+      if (!xvas.has(path.slice(0, -'.checksum'.length))) {
+        logInfo('unused XVA checksum', { path })
+        if (remove) {
+          logInfo('deleting unused XVA checksum', { path })
+          return handler.unlink(path)
+        }
+      }
+    }),
+  ])
+  await asyncMap(jsons, async metadataPath => {
+    const metadata = backups.get(metadataPath)
+    let fileSystemSize
+    const mergedSize = metadataWithMergedVhd[metadataPath]
+    const { mode, size, vhds, xva } = metadata
+    try {
+      if (mode === 'full') {
+        // a full backup : check size
+        const linkedXva = resolve('/', vmDir, xva)
+        try {
+          fileSystemSize = await handler.getSize(linkedXva)
+          if (fileSystemSize !== size && fileSystemSize !== undefined) {
+            logWarn('cleanVm: incorrect backup size in metadata', {
+              path: metadataPath,
+              actual: size ?? 'none',
+              expected: fileSystemSize,
+            })
+          }
+        } catch (error) {
+          // can fail with encrypted remote
+        }
+      } else if (mode === 'delta') {
+        // don't warn if the size has changed after a merge
+        if (mergedSize === undefined) {
+          const linkedVhds = Object.keys(vhds).map(key => resolve('/', vmDir, vhds[key]))
+          fileSystemSize = await computeVhdsSize(handler, linkedVhds)
+          // the size is not computed in some cases (e.g. VhdDirectory)
+          if (fileSystemSize !== undefined && fileSystemSize !== size) {
+            logWarn('cleanVm: incorrect backup size in metadata', {
+              path: metadataPath,
+              actual: size ?? 'none',
+              expected: fileSystemSize,
+            })
+          }
+        }
+      }
+    } catch (error) {
+      logWarn('failed to get backup size', { backup: metadataPath, error })
+      return
+    }
+    // systematically update size and differentials after a merge
+    // @todo : after 2024-04-01 remove the fixmetadata options since the size computation is fixed
+    console.log({
+      /* metadata, */ vdis: metadata.vdis,
+      isVhdDifferencing: metadata.isVhdDifferencing,
+      parent: metadata.vmSnapshot.parent,
+      mergedSize,
+      fixMetadata,
+      fileSystemSize,
+      size,
+    })
+    if (mergedSize || (fixMetadata && fileSystemSize !== size)) {
+      metadata.size = mergedSize ?? fileSystemSize ?? size
+      if (mergedSize) {
+        // all disks are now key disk
+        metadata.isVhdDifferencing = {}
+        for (const vdi of Object.values(metadata.vdis ?? {})) {
+          const uuid = vdi.uuid
+          console.log({ uuid })
+          metadata.isVhdDifferencing[`${uuid}.vhd`] = false
+        }
+      }
+      mustRegenerateCache = true
+      try {
+        await handler.writeFile(metadataPath, JSON.stringify(metadata), { flags: 'w' })
+      } catch (error) {
+        logWarn('failed to update backup size in metadata', { path: metadataPath, error })
+      }
+    }
+  })
+  if (mustRegenerateCache) {
+    const cache = {}
+    for (const [path, content] of backups.entries()) {
+      cache[path] = {
+        _filename: path,
+        id: path,
+        ...content,
+      }
+    }
+    await this._writeCache(cachePath, cache)
+  }
+  return {
+    // boolean whether some VHDs were merged (or should be merged)
+    merge: toMerge.length !== 0,
+  }
 }

--- a/@xen-orchestra/backups/_cleanVm.mts
+++ b/@xen-orchestra/backups/_cleanVm.mts
@@ -1,0 +1,736 @@
+import * as UUID from 'uuid'
+import sum from 'lodash/sum.js'
+import { asyncMap } from '@xen-orchestra/async-map'
+import { Constants, openVhd, VhdAbstract, VhdFile } from 'vhd-lib'
+import { isVhdAlias, resolveVhdAlias } from 'vhd-lib/aliases.js'
+import { basename, dirname, resolve } from 'node:path'
+import { isMetadataFile, isVhdFile, isXvaFile, isXvaSumFile } from './_backupType.mjs'
+import { limitConcurrency } from 'limit-concurrency-decorator'
+import { mergeVhdChain } from 'vhd-lib/merge.js'
+
+import { Task } from './Task.mjs'
+import { Disposable } from 'promise-toolbox'
+import * as handlerPath from '@xen-orchestra/fs/path'
+import RemoteHandlerAbstract from '@xen-orchestra/fs/abstract'
+
+const { DISK_TYPES } = Constants
+
+// checking the size of a vhd directory is costly
+// 1 Http Query per 1000 blocks
+// we only check size of all the vhd are VhdFiles
+function shouldComputeVhdsSize(handler, vhds) {
+  if (handler.isEncrypted) {
+    return false
+  }
+  return vhds.every(vhd => vhd instanceof VhdFile)
+}
+
+const computeVhdsSize = (handler: unknown, vhdPaths: string[]): number | void =>
+  Disposable.use(
+    vhdPaths.map(vhdPath => openVhd(handler, vhdPath)),
+    async vhds => {
+      if (shouldComputeVhdsSize(handler, vhds)) {
+        const sizes = await asyncMap(vhds, vhd => vhd.getSize())
+        return sum(sizes) as number
+      }
+    }
+  )
+
+
+// chain is [ ancestor, child_1, ..., child_n ]
+async function _mergeVhdChain(handler, chain, { logInfo, remove, mergeBlockConcurrency }) {
+  logInfo(`merging VHD chain`, { chain })
+
+  let done, total
+  const handle = setInterval(() => {
+    if (done !== undefined) {
+      logInfo('merge in progress', {
+        done,
+        parent: chain[0],
+        progress: Math.round((100 * done) / total),
+        total,
+      })
+    }
+  }, 10e3)
+  try {
+    return await mergeVhdChain(handler, chain, {
+      logInfo,
+      mergeBlockConcurrency,
+      onProgress({ done: d, total: t }) {
+        done = d
+        total = t
+      },
+      removeUnused: remove,
+    })
+  } finally {
+    clearInterval(handle)
+  }
+}
+
+const noop = Function.prototype
+
+const INTERRUPTED_VHDS_REG = /^\.(.+)\.merge.json$/
+const listVhds = async (handler, vmDir, logWarn) => {
+  const vhds = new Set()
+  const aliases = {}
+  const interruptedVhds = new Map()
+
+  await asyncMap(
+    await handler.list(`${vmDir}/vdis`, {
+      ignoreMissing: true,
+      prependDir: true,
+    }),
+    async jobDir =>
+      asyncMap(
+        await handler.list(jobDir, {
+          prependDir: true,
+        }),
+        async vdiDir => {
+          const list = await handler.list(vdiDir, {
+            filter: file => isVhdFile(file) || INTERRUPTED_VHDS_REG.test(file),
+          })
+          aliases[vdiDir] = list.filter(vhd => isVhdAlias(vhd)).map(file => `${vdiDir}/${file}`)
+
+          await asyncMap(list, async file => {
+            const res = INTERRUPTED_VHDS_REG.exec(file)
+            if (res === null) {
+              vhds.add(`${vdiDir}/${file}`)
+            } else {
+              try {
+                const mergeState = JSON.parse(await handler.readFile(`${vdiDir}/${file}`))
+                interruptedVhds.set(`${vdiDir}/${res[1]}`, {
+                  statePath: `${vdiDir}/${file}`,
+                  chain: mergeState.chain,
+                })
+              } catch (error) {
+                // fall back to a non resuming merge
+                vhds.add(`${vdiDir}/${file}`)
+                logWarn('failed to read existing merge state', { path: file, error })
+              }
+            }
+          })
+        }
+      )
+  )
+
+  return { vhds, interruptedVhds, aliases }
+}
+
+export async function checkAliases(
+  aliasPaths,
+  targetDataRepository,
+  { handler, logInfo = noop, logWarn = console.warn, remove = false }
+) {
+  const aliasFound = []
+  for (const alias of aliasPaths) {
+    let target
+    try {
+      target = await resolveVhdAlias(handler, alias)
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        logWarn('missing target of alias', { alias })
+        if (remove) {
+          logInfo('removing alias and non VHD target', { alias, target })
+          await handler.unlink(target)
+          await handler.unlink(alias)
+        }
+      }
+    }
+
+    if (!isVhdFile(target)) {
+      logWarn('alias references non VHD target', { alias, target })
+      if (remove) {
+        logInfo('removing alias and non VHD target', { alias, target })
+        await handler.unlink(target)
+        await handler.unlink(alias)
+      }
+      continue
+    }
+
+    try {
+      const { dispose } = await openVhd(handler, target)
+      try {
+        await dispose()
+      } catch (e) {
+        // error during dispose should not trigger a deletion
+      }
+    } catch (error) {
+      logWarn('missing or broken alias target', { alias, target, error })
+      if (remove) {
+        try {
+          await VhdAbstract.unlink(handler, alias)
+        } catch (error) {
+          if (error.code !== 'ENOENT') {
+            logWarn('error deleting alias target', { alias, target, error })
+          }
+        }
+      }
+      continue
+    }
+
+    aliasFound.push(resolve('/', target))
+  }
+
+  const vhds = await handler.list(targetDataRepository, {
+    ignoreMissing: true,
+    prependDir: true,
+  })
+
+  await asyncMap(vhds, async path => {
+    if (!aliasFound.includes(path)) {
+      logWarn('no alias references VHD', { path })
+      if (remove) {
+        logInfo('deleting unused VHD', { path })
+        await VhdAbstract.unlink(handler, path)
+      }
+    }
+  })
+}
+
+const defaultMergeLimiter = limitConcurrency(1)
+
+export async function cleanVm(
+  vmDir: string,
+  {
+    fixMetadata,
+    remove = false,
+    removeTmp = remove,
+    merge,
+    mergeBlockConcurrency,
+    mergeLimiter = defaultMergeLimiter,
+    logInfo = noop,
+    logWarn = console.warn,
+  }: {
+    fixMetadata: boolean,
+    remove: boolean,
+    removeTmp: boolean,
+    merge: Function,
+    mergeBlockConcurrency: number,
+    mergeLimiter: Function,
+    logInfo: Function,
+    logWarn: Function,
+  }
+) {
+  const limitedMergeVhdChain = mergeLimiter(_mergeVhdChain)
+
+  const handler: RemoteHandlerAbstract = this._handler
+
+  const vhdsToJSons = new Set()
+  const vhdById = new Map()
+  const vhdParents = { __proto__: null }
+  const vhdChildren = { __proto__: null }
+
+  const { vhds, interruptedVhds, aliases } = await listVhds(handler, vmDir, logWarn)
+
+  // remove broken VHDs
+  await asyncMap(vhds, async path => {
+    if (removeTmp && basename(path)[0] === '.') {
+      logInfo('deleting temporary VHD', { path })
+      return VhdAbstract.unlink(handler, path)
+    }
+    try {
+      await Disposable.use(openVhd(handler, path, { checkSecondFooter: !interruptedVhds.has(path) }), vhd => {
+        if (vhd.footer.diskType === DISK_TYPES.DIFFERENCING) {
+          const parent = resolve('/', dirname(path), vhd.header.parentUnicodeName)
+          vhdParents[path] = parent
+          if (parent in vhdChildren) {
+            const error = new Error('this script does not support multiple VHD children')
+            error.parent = parent
+            error.child1 = vhdChildren[parent]
+            error.child2 = path
+            throw error // should we throw?
+          }
+          vhdChildren[parent] = path
+        }
+        // Detect VHDs with the same UUIDs
+        //
+        // Due to a bug introduced in a1bcd35e2
+        const duplicate = vhdById.get(UUID.stringify(vhd.footer.uuid))
+        let vhdKept = vhd
+        if (duplicate !== undefined) {
+          logWarn('uuid is duplicated', { uuid: UUID.stringify(vhd.footer.uuid) })
+          if (duplicate.containsAllDataOf(vhd)) {
+            logWarn(`should delete ${path}`)
+            vhdKept = duplicate
+            vhds.delete(path)
+          } else if (vhd.containsAllDataOf(duplicate)) {
+            logWarn(`should delete ${duplicate._path}`)
+            vhds.delete(duplicate._path)
+          } else {
+            logWarn('same ids but different content')
+          }
+        }
+        vhdById.set(UUID.stringify(vhdKept.footer.uuid), vhdKept)
+      })
+    } catch (error) {
+      vhds.delete(path)
+      logWarn('VHD check error', { path, error })
+      if (error?.code === 'ERR_ASSERTION' && remove) {
+        logInfo('deleting broken VHD', { path })
+        return VhdAbstract.unlink(handler, path)
+      }
+    }
+  })
+
+  // remove interrupted merge states for missing VHDs
+  for (const interruptedVhd of interruptedVhds.keys()) {
+    if (!vhds.has(interruptedVhd)) {
+      const { statePath } = interruptedVhds.get(interruptedVhd)
+      interruptedVhds.delete(interruptedVhd)
+
+      logWarn('orphan merge state', {
+        mergeStatePath: statePath,
+        missingVhdPath: interruptedVhd,
+      })
+      if (remove) {
+        logInfo('deleting orphan merge state', { statePath })
+        await handler.unlink(statePath)
+      }
+    }
+  }
+
+  // check if alias are correct
+  // check if all vhd in data subfolder have a corresponding alias
+  await asyncMap(Object.keys(aliases), async dir => {
+    await checkAliases(aliases[dir], `${dir}/data`, { handler, logInfo, logWarn, remove })
+  })
+
+  // remove VHDs with missing ancestors
+  {
+    const deletions = []
+
+    // return true if the VHD has been deleted or is missing
+    const deleteIfOrphan = vhdPath => {
+      const parent = vhdParents[vhdPath]
+      if (parent === undefined) {
+        return
+      }
+
+      // no longer needs to be checked
+      delete vhdParents[vhdPath]
+
+      deleteIfOrphan(parent)
+
+      if (!vhds.has(parent)) {
+        vhds.delete(vhdPath)
+
+        logWarn('parent VHD is missing', { parent, child: vhdPath })
+        if (remove) {
+          logInfo('deleting orphan VHD', { path: vhdPath })
+          deletions.push(VhdAbstract.unlink(handler, vhdPath))
+        }
+      }
+    }
+
+    // > A property that is deleted before it has been visited will not be
+    // > visited later.
+    // >
+    // > -- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in#Deleted_added_or_modified_properties
+    for (const child in vhdParents) {
+      deleteIfOrphan(child)
+    }
+
+    await Promise.all(deletions)
+  }
+
+  const jsons = new Set()
+  const xvas = new Set()
+  const xvaSums = []
+  const entries = await handler.list(vmDir, {
+    prependDir: true,
+  })
+  entries.forEach(path => {
+    if (isMetadataFile(path)) {
+      jsons.add(path)
+    } else if (isXvaFile(path)) {
+      xvas.add(path)
+    } else if (isXvaSumFile(path)) {
+      xvaSums.push(path)
+    }
+  })
+
+  const cachePath = vmDir + '/cache.json.gz'
+
+  let mustRegenerateCache
+  {
+    const cache = await this._readCache(cachePath)
+    const actual = cache === undefined ? 0 : Object.keys(cache).length
+    const expected = jsons.size
+
+    mustRegenerateCache = actual !== expected
+    if (mustRegenerateCache) {
+      logWarn('unexpected number of entries in backup cache', { path: cachePath, actual, expected })
+    }
+  }
+
+  await asyncMap(xvas, async path => {
+    // check is not good enough to delete the file, the best we can do is report
+    // it
+    if (!(await this.isValidXva(path))) {
+      logWarn('XVA might be broken', { path })
+    }
+  })
+
+  const unusedVhds = new Set(vhds)
+  const unusedXvas = new Set(xvas)
+
+  const backups = new Map()
+
+  // compile the list of unused XVAs and VHDs, and remove backup metadata which
+  // reference a missing XVA/VHD
+  await asyncMap(jsons, async json => {
+    let metadata
+    try {
+      metadata = JSON.parse(await handler.readFile(json))
+    } catch (error) {
+      logWarn('failed to read backup metadata', { path: json, error })
+      jsons.delete(json)
+      return
+    }
+
+    let isBackupComplete
+
+    const { mode } = metadata
+    if (mode === 'full') {
+      const linkedXva = resolve('/', vmDir, metadata.xva)
+      isBackupComplete = xvas.has(linkedXva)
+      if (isBackupComplete) {
+        unusedXvas.delete(linkedXva)
+      } else {
+        logWarn('the XVA linked to the backup is missing', { backup: json, xva: linkedXva })
+      }
+    } else if (mode === 'delta') {
+      const linkedVhds = (() => {
+        const { vhds } = metadata
+        return Object.keys(vhds).map(key => resolve('/', vmDir, vhds[key]))
+      })()
+
+      const missingVhds = linkedVhds.filter(_ => !vhds.has(_))
+      isBackupComplete = missingVhds.length === 0
+
+      // FIXME: find better approach by keeping as much of the backup as
+      // possible (existing disks) even if one disk is missing
+      if (isBackupComplete) {
+        linkedVhds.forEach(_ => unusedVhds.delete(_))
+        linkedVhds.forEach(path => {
+          vhdsToJSons[path] = json
+        })
+      } else {
+        logWarn('some VHDs linked to the backup are missing', { backup: json, missingVhds })
+      }
+    }
+
+    if (isBackupComplete) {
+      backups.set(json, metadata)
+    } else {
+      jsons.delete(json)
+      if (remove) {
+        logInfo('deleting incomplete backup', { backup: json })
+        mustRegenerateCache = true
+        await handler.unlink(json)
+      }
+    }
+  })
+
+  // TODO: parallelize by vm/job/vdi
+  const unusedVhdsDeletion = []
+  const toMerge = []
+  {
+    // VHD chains (as list from oldest to most recent) to merge indexed by most recent
+    // ancestor
+    const vhdChainsToMerge = { __proto__: null }
+
+    const toCheck = new Set(unusedVhds)
+
+    const getUsedChildChainOrDelete = vhd => {
+      if (vhd in vhdChainsToMerge) {
+        const chain = vhdChainsToMerge[vhd]
+        delete vhdChainsToMerge[vhd]
+        return chain
+      }
+
+      if (!unusedVhds.has(vhd)) {
+        return [vhd]
+      }
+
+      // no longer needs to be checked
+      toCheck.delete(vhd)
+
+      const child = vhdChildren[vhd]
+      if (child !== undefined) {
+        const chain = getUsedChildChainOrDelete(child)
+        if (chain !== undefined) {
+          chain.unshift(vhd)
+          return chain
+        }
+      }
+
+      // no warning because a VHD can be unused for perfectly good reasons,
+      // e.g. the corresponding backup (metadata file) has been deleted
+      if (remove) {
+        logInfo('deleting unused VHD', { path: vhd })
+        unusedVhdsDeletion.push(VhdAbstract.unlink(handler, vhd))
+      }
+    }
+
+    toCheck.forEach(vhd => {
+      vhdChainsToMerge[vhd] = getUsedChildChainOrDelete(vhd)
+    })
+
+    // merge interrupted VHDs
+    for (const parent of interruptedVhds.keys()) {
+      // before #6349 the chain wasn't in the mergeState
+      const { chain, statePath } = interruptedVhds.get(parent)
+      if (chain === undefined) {
+        vhdChainsToMerge[parent] = [parent, vhdChildren[parent]]
+      } else {
+        vhdChainsToMerge[parent] = chain.map(vhdPath => handlerPath.resolveFromFile(statePath, vhdPath))
+      }
+    }
+
+    Object.values(vhdChainsToMerge).forEach(chain => {
+      if (chain !== undefined) {
+        toMerge.push(chain)
+      }
+    })
+  }
+
+  const metadataWithMergedVhd = {}
+  const doMerge = async () => {
+    await asyncMap(toMerge, async chain => {
+      const { finalVhdSize } = await limitedMergeVhdChain(handler, chain, {
+        logInfo,
+        logWarn,
+        remove,
+        mergeBlockConcurrency,
+      })
+      const metadataPath: string = vhdsToJSons[chain[chain.length - 1]] // all the chain should have the same metada file
+      metadataWithMergedVhd[metadataPath] = (metadataWithMergedVhd[metadataPath] ?? 0) + finalVhdSize
+    })
+  }
+
+  await Promise.all([
+    ...unusedVhdsDeletion,
+    toMerge.length !== 0 && (merge ? Task.run({ name: 'merge' }, doMerge) : () => Promise.resolve()),
+    asyncMap(unusedXvas, path => {
+      logWarn('unused XVA', { path })
+      if (remove) {
+        logInfo('deleting unused XVA', { path })
+        return handler.unlink(path)
+      }
+    }),
+    asyncMap(xvaSums, path => {
+      // no need to handle checksums for XVAs deleted by the script, they will be handled by `unlink()`
+      if (!xvas.has(path.slice(0, -'.checksum'.length))) {
+        logInfo('unused XVA checksum', { path })
+        if (remove) {
+          logInfo('deleting unused XVA checksum', { path })
+          return handler.unlink(path)
+        }
+      }
+    }),
+  ])
+
+  // update size for delta metadata with merged VHD
+  // check for the other that the size is the same as the real file size
+  type OpaqueRef = `OpaqueRef:${string}`;
+  await asyncMap(jsons, async metadataPath => {
+    const metadata: {
+      isVhdDifferencing: {
+        [key: OpaqueRef | string]: boolean;
+      };
+      jobId: string;
+      mode: "delta" | "full";
+      scheduleId: string;
+      size: number;
+      timestamp: number;
+      vbds: {
+        [key: OpaqueRef]: {
+          VDI: OpaqueRef;
+          VM: OpaqueRef;
+          allowed_operations: string[];
+          bootable: boolean;
+          current_operations: Object;
+          currently_attached: boolean;
+          device: "xvda" | string;
+          empty: boolean;
+          metrics: OpaqueRef;
+          mode: "RW" | "RO" | string;
+          other_config: Object;
+          qos_algorithm_params: Object;
+          qos_algorithm_type: string;
+          qos_supported_algorithms: string[];
+          runtime_properties: Object;
+          status_code: number;
+          status_detail: string;
+          storage_lock: boolean;
+          type: "Disk" | string;
+          unpluggable: boolean;
+          userdevice: "0" | string;
+          uuid: string
+        }
+      };
+      vdis: {
+        [key: OpaqueRef]: {
+          $SR$uuid: string;
+          $snapshot_of$uuid: string;
+          SR: OpaqueRef;
+          VBDs: OpaqueRef[];
+          allow_caching: boolean;
+          allowed_operations: boolean;
+          cbt_enabled: boolean;
+          crash_dumps: string[];
+          current_operations: Object;
+          is_a_snapshot: boolean;
+          is_tools_iso: boolean;
+          location: string;
+          managed: string;
+          metadata_latest: boolean;
+          metadata_of_pool: OpaqueRef;
+          missing: boolean;
+          name_description: string;
+          name_label: string;
+          on_boot: string;
+          other_config: Object;
+          parent: OpaqueRef;
+          physical_utilisation: number;
+          read_only: boolean;
+          sharable: boolean;
+          sm_config: {
+            'vhd-parent': string
+          };
+          snapshot_of: OpaqueRef;
+          snapshot_time: string;
+          snapshots: Object[];
+          storage_lock: boolean;
+          tags: string[];
+          type: string;
+          uuid: string;
+          virtual_size: number;
+          xenstore_data: Object
+        };
+      };
+      version: "2.0.0" | string;
+      vhds: {
+        [key: OpaqueRef]: string
+      };
+      vifs: {
+        [key: OpaqueRef]: {
+          $network$VLAN: number;
+          $network$name_label: string;
+          $network$uuid: string;
+          MAC: string;
+          MAC_autogenerated: string;
+          MTU: number;
+          VM: OpaqueRef;
+          allowed_operations: string[];
+          current_operations: Object;
+          currently_attached: boolean;
+          device: "0" | string;
+          ipv6_addresses: string[];
+          ipv6_allowed: string[];
+          ipv6_configuration_mode: "None" | string;
+          ipv6_gateway: string;
+          locking_mode: "network_default" | string;
+          metrics: OpaqueRef;
+          network: OpaqueRef;
+          other_config: Object;
+          qos_algorithm_params: Object;
+          qos_algorithm_type: string;
+          qos_supported_algorithms: string[];
+          runtime_properties: Object;
+          status_code: number;
+          status_detail: string;
+          uuid: string
+        }
+      };
+      vm: Object;
+      vmSnapshot: Object;
+      vtpms: Object[];
+      xva?: string
+    } = backups.get(metadataPath)
+
+    let fileSystemSize: number | undefined
+    const mergedSize: number | undefined = metadataWithMergedVhd[metadataPath]
+
+    const { mode, size, vhds, xva } = metadata
+
+    try {
+      if (mode === 'full') {
+        // a full backup : check size
+        const linkedXva = resolve('/', vmDir, xva as string)
+        try {
+          fileSystemSize = await handler.getSize(linkedXva)
+          if (fileSystemSize !== size && fileSystemSize !== undefined) {
+            logWarn('cleanVm: incorrect backup size in metadata', {
+              path: metadataPath,
+              actual: size ?? 'none',
+              expected: fileSystemSize,
+            })
+          }
+        } catch (error) {
+          // can fail with encrypted remote
+        }
+      } else if (mode === 'delta') {
+        // don't warn if the size has changed after a merge
+        if (mergedSize === undefined) {
+          const linkedVhds = Object.keys(vhds).map(key => resolve('/', vmDir, vhds[key]))
+          fileSystemSize = await computeVhdsSize(handler, linkedVhds)
+          // the size is not computed in some cases (e.g. VhdDirectory)
+          if (fileSystemSize !== undefined && fileSystemSize !== size) {
+            logWarn('cleanVm: incorrect backup size in metadata', {
+              path: metadataPath,
+              actual: size ?? 'none',
+              expected: fileSystemSize,
+            })
+          }
+        }
+      }
+    } catch (error) {
+      logWarn('failed to get backup size', { backup: metadataPath, error })
+      return
+    }
+
+    // systematically update size and differentials after a merge
+
+    // @todo : after 2024-04-01 remove the fixmetadata options since the size computation is fixed
+    console.log({/* metadata, */ vdis: metadata.vdis, isVhdDifferencing: metadata.isVhdDifferencing, parent: metadata.vmSnapshot.parent, mergedSize, fixMetadata, fileSystemSize, size })
+    if (mergedSize || (fixMetadata && fileSystemSize !== size)) {
+      metadata.size = mergedSize ?? fileSystemSize ?? size
+
+      if (mergedSize) {
+        // all disks are now key disk
+        metadata.isVhdDifferencing = {}
+
+        for (const vdi of Object.values(metadata.vdis ?? {})) {
+          const uuid = vdi.uuid
+          console.log({ uuid })
+          metadata.isVhdDifferencing[`${uuid}.vhd`] = false
+        }
+      }
+      mustRegenerateCache = true
+      try {
+        await handler.writeFile(metadataPath, JSON.stringify(metadata), { flags: 'w' })
+      } catch (error) {
+        logWarn('failed to update backup size in metadata', { path: metadataPath, error })
+      }
+    }
+  })
+
+  if (mustRegenerateCache) {
+    const cache = {}
+    for (const [path, content] of backups.entries()) {
+      cache[path] = {
+        _filename: path,
+        id: path,
+        ...content,
+      }
+    }
+    await this._writeCache(cachePath, cache)
+  }
+
+  return {
+    // boolean whether some VHDs were merged (or should be merged)
+    merge: toMerge.length !== 0,
+  }
+}

--- a/@xen-orchestra/backups/_cleanVm.mts
+++ b/@xen-orchestra/backups/_cleanVm.mts
@@ -11,14 +11,14 @@ import { mergeVhdChain } from 'vhd-lib/merge.js'
 import { Task } from './Task.mjs'
 import { Disposable } from 'promise-toolbox'
 import * as handlerPath from '@xen-orchestra/fs/path'
-import RemoteHandlerAbstract from '@xen-orchestra/fs/abstract'
+import RemoteHandlerAbstract from '@xen-orchestra/fs/'
 
 const { DISK_TYPES } = Constants
 
 // checking the size of a vhd directory is costly
 // 1 Http Query per 1000 blocks
 // we only check size of all the vhd are VhdFiles
-function shouldComputeVhdsSize(handler, vhds) {
+function shouldComputeVhdsSize(handler: RemoteHandlerAbstract, vhds: object[]) {
   if (handler.isEncrypted) {
     return false
   }

--- a/@xen-orchestra/backups/global.d.ts
+++ b/@xen-orchestra/backups/global.d.ts
@@ -1,0 +1,2 @@
+declare module "limit-concurrency-decorator";
+declare module "promise-toolbox";

--- a/@xen-orchestra/backups/global.d.ts
+++ b/@xen-orchestra/backups/global.d.ts
@@ -1,2 +1,7 @@
 declare module "limit-concurrency-decorator";
 declare module "promise-toolbox";
+declare module '@xen-orchestra/fs/abstract' {
+  export default class RemoteHandlerAbstract {
+    // Types ici
+  }
+}

--- a/@xen-orchestra/backups/package.json
+++ b/@xen-orchestra/backups/package.json
@@ -13,6 +13,9 @@
     "node": ">=14.18"
   },
   "scripts": {
+    "build": "npx tsc && npm run prettify",
+    "dev": "npx tsc -w",
+    "prettify": "prettier --write '*.mjs'",
     "postversion": "npm publish --access public",
     "test-integration": "node --test *.integ.mjs"
   },

--- a/@xen-orchestra/backups/runBackupWorker.mjs
+++ b/@xen-orchestra/backups/runBackupWorker.mjs
@@ -7,7 +7,11 @@ const PATH = new URL('_backupWorker.mjs', import.meta.url).pathname
 
 export function runBackupWorker(params, onLog) {
   return new Promise((resolve, reject) => {
-    const worker = fork(PATH)
+    const inspectArg = process.execArgv.find(arg => arg.startsWith('--inspect'))
+    const execArgv = inspectArg
+      ? [inspectArg.replace(/^(--inspect)(=.*)?$/, (_, prefix) => `${prefix}=localhost:9230`)]
+      : []
+    const worker = fork(PATH, [], { execArgv })
 
     worker.on('exit', (code, signal) => reject(new Error(`worker exited with code ${code} and signal ${signal}`)))
     worker.on('error', reject)

--- a/@xen-orchestra/backups/tsconfig.json
+++ b/@xen-orchestra/backups/tsconfig.json
@@ -1,0 +1,109 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "NodeNext",                                /* Specify what module code is generated. */
+    "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "moduleResolution": "nodenext",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}

--- a/@xen-orchestra/backups/tsconfig.json
+++ b/@xen-orchestra/backups/tsconfig.json
@@ -76,7 +76,7 @@
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */

--- a/@xen-orchestra/fs/cli.d.ts
+++ b/@xen-orchestra/fs/cli.d.ts
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+export {};

--- a/@xen-orchestra/fs/src/_encryptor.d.ts
+++ b/@xen-orchestra/fs/src/_encryptor.d.ts
@@ -1,0 +1,3 @@
+export function isLegacyEncryptionAlgorithm(algorithm: any): boolean;
+export const DEFAULT_ENCRYPTION_ALGORITHM: "aes-256-gcm";
+export const UNENCRYPTED_ALGORITHM: "none";

--- a/@xen-orchestra/fs/src/abstract.d.ts
+++ b/@xen-orchestra/fs/src/abstract.d.ts
@@ -1,0 +1,147 @@
+export default class RemoteHandlerAbstract {
+    constructor(remote: any, options?: {});
+    _remote: any;
+    _timeout: any;
+    closeFile: any;
+    copy: any;
+    getInfo(): Promise<any>;
+    getSizeOnDisk(file: any): Promise<any>;
+    list: any;
+    mkdir: any;
+    openFile: any;
+    outputFile(file: any, data: any, { dirMode, flags }?: {
+        dirMode: any;
+        flags?: string;
+    }): Promise<void>;
+    read(file: any, buffer: any, position: any): Promise<void>;
+    readFile: any;
+    rename: any;
+    rmdir(dir: any): Promise<void>;
+    truncate(file: any, len: any): Promise<void>;
+    unlink: any;
+    write(file: any, buffer: any, position: any): Promise<void>;
+    writeFile: any;
+    _forget(): Promise<void>;
+    _sync(): Promise<void>;
+    get type(): void;
+    addPrefix(prefix: any): PrefixWrapper | this;
+    createReadStream(file: any, { checksum, ignoreMissingChecksum, ...options }?: {
+        checksum?: boolean;
+        ignoreMissingChecksum?: boolean;
+    }): Promise<any>;
+    /**
+     * write a stream to a file using a temporary file
+     *
+     * @param {string} path
+     * @param {ReadableStream} input
+     * @param {object} [options]
+     * @param {boolean} [options.checksum]
+     * @param {number} [options.dirMode]
+     * @param {(this: RemoteHandlerAbstract, path: string) => Promise<undefined>} [options.validator] Function that will be called before the data is commited to the remote, if it fails, file should not exist
+     */
+    outputStream(path: string, input: ReadableStream, { checksum, dirMode, maxStreamLength, streamLength, validator }?: {
+        checksum?: boolean;
+        dirMode?: number;
+        validator?: (this: RemoteHandlerAbstract, path: string) => Promise<undefined>;
+    }): Promise<void>;
+    forget(): Promise<void>;
+    getSize(file: any): Promise<any>;
+    __list(dir: any, { filter, ignoreMissing, prependDir }?: {
+        filter: any;
+        ignoreMissing?: boolean;
+        prependDir?: boolean;
+    }): Promise<any>;
+    lock(path: any): Promise<{
+        dispose: () => Promise<void>;
+    }>;
+    mktree(dir: any, { mode }?: {
+        mode: any;
+    }): Promise<void>;
+    __readFile(file: any, { flags }?: {
+        flags?: string;
+    }): Promise<any>;
+    __rename(oldPath: any, newPath: any, { checksum }?: {
+        checksum?: boolean;
+    }): any;
+    __copy(oldPath: any, newPath: any, { checksum }?: {
+        checksum?: boolean;
+    }): Promise<any>;
+    rmtree(dir: any): Promise<void>;
+    sync(): Promise<void>;
+    test(): Promise<{
+        success: boolean;
+        writeRate: number;
+        readRate: number;
+        step?: undefined;
+        file?: undefined;
+        error?: undefined;
+    } | {
+        success: boolean;
+        step: string;
+        file: any;
+        error: any;
+        writeRate?: undefined;
+        readRate?: undefined;
+    }>;
+    __unlink(file: any, { checksum }?: {
+        checksum?: boolean;
+    }): Promise<void>;
+    __writeFile(file: any, data: any, { flags }?: {
+        flags?: string;
+    }): Promise<void>;
+    __closeFile(fd: any): Promise<void>;
+    __mkdir(dir: any, { mode }?: {
+        mode: any;
+    }): Promise<void>;
+    __openFile(path: any, flags: any): Promise<{
+        fd: any;
+        path: any;
+    }>;
+    useVhdDirectory(): any;
+    _closeFile(fd: any): Promise<void>;
+    _createOutputStream(file: any, { dirMode, ...options }?: {
+        dirMode: any;
+    }): any;
+    _createReadStream(file: any, options: any): Promise<void>;
+    _createWriteStream(file: any, options: any): Promise<void>;
+    _getInfo(): Promise<{}>;
+    _lock(path: any): Promise<() => Promise<void>>;
+    _getSize(file: any): Promise<void>;
+    _list(dir: any): Promise<void>;
+    _mkdir(dir: any): Promise<void>;
+    _mktree(dir: any, { mode }?: {
+        mode: any;
+    }): any;
+    _openFile(path: any, flags: any): Promise<void>;
+    _outputFile(file: any, data: any, { dirMode, flags }: {
+        dirMode: any;
+        flags: any;
+    }): any;
+    _outputStream(path: any, input: any, { dirMode, validator }: {
+        dirMode: any;
+        validator: any;
+    }): Promise<void>;
+    _read(file: any, buffer: any, position: any): void;
+    _readFile(file: any, options: any): Promise<void>;
+    _rename(oldPath: any, newPath: any): Promise<void>;
+    _copy(oldPath: any, newPath: any): Promise<void>;
+    _rmdir(dir: any): Promise<void>;
+    _rmtree(dir: any): any;
+    _unlink(file: any): Promise<void>;
+    _write(file: any, buffer: any, position: any): Promise<void>;
+    _writeFd(fd: any, buffer: any, position: any): Promise<void>;
+    _writeFile(file: any, data: any, options: any): Promise<void>;
+    get isEncrypted(): boolean;
+    get encryptionAlgorithm(): any;
+    #private;
+}
+declare class PrefixWrapper {
+    constructor(handler: any, prefix: any);
+    _handler: any;
+    get type(): any;
+    list(dir: any, opts: any): Promise<any>;
+    rename(oldPath: any, newPath: any): any;
+    _resolve(path: any): any;
+    #private;
+}
+export {};

--- a/@xen-orchestra/fs/src/checksum.d.ts
+++ b/@xen-orchestra/fs/src/checksum.d.ts
@@ -1,0 +1,2 @@
+export function createChecksumStream(algorithm?: string): any;
+export function validChecksumOfReadStream(stream: any, expectedChecksum: any): any;

--- a/@xen-orchestra/fs/src/path.d.ts
+++ b/@xen-orchestra/fs/src/path.d.ts
@@ -1,0 +1,7 @@
+export function split(path: any): any;
+export function normalize(path: any): any;
+export function relativeFromFile(file: any, path: any): any;
+export function resolveFromFile(file: any, path: any): any;
+export const basename: any;
+export const dirname: any;
+export const join: any;

--- a/packages/vhd-lib/Vhd/VhdAbstract.d.ts
+++ b/packages/vhd-lib/Vhd/VhdAbstract.d.ts
@@ -1,0 +1,112 @@
+export class VhdAbstract {
+    /**
+     * instantiate a Vhd
+     *
+     * @returns {AbstractVhd}
+     */
+    static open(): AbstractVhd;
+    static unlink(handler: any, path: any): Promise<void>;
+    static createAlias(handler: any, aliasPath: any, targetPath: any): Promise<void>;
+    get bitmapSize(): number;
+    get fullBlockSize(): any;
+    get sectorsOfBitmap(): number;
+    get sectorsPerBlock(): number;
+    get header(): void;
+    get footer(): void;
+    /**
+     * Check if this vhd contains a block with id blockId
+     * Must be called after readBlockAllocationTable
+     *
+     * @param {number} blockId
+     * @returns {boolean}
+     *
+     */
+    containsBlock(blockId: number): boolean;
+    /**
+     * Read the header and the footer
+     * check their integrity
+     * if checkSecondFooter also checks that the footer at the end is equal to the one at the beginning
+     *
+     * @param {boolean} checkSecondFooter
+     */
+    readHeaderAndFooter(checkSecondFooter?: boolean): void;
+    readBlockAllocationTable(): void;
+    /**
+     * @typedef {Object} BitmapBlock
+     * @property {number} id
+     * @property {Buffer} bitmap
+     *
+     * @typedef {Object} FullBlock
+     * @property {number} id
+     * @property {Buffer} bitmap
+     * @property {Buffer} data
+     * @property {Buffer} buffer - bitmap + data
+     *
+     * @param {number} blockId
+     * @param {boolean} onlyBitmap
+     * @returns {Promise<BitmapBlock | FullBlock>}
+     */
+    readBlock(blockId: number, onlyBitmap?: boolean): Promise<{
+        id: number;
+        bitmap: Buffer;
+    } | {
+        id: number;
+        bitmap: Buffer;
+        data: Buffer;
+        /**
+         * - bitmap + data
+         */
+        buffer: Buffer;
+    }>;
+    /**
+     * coalesce the block with id blockId from the child vhd into
+     * this vhd
+     *
+     * @param {AbstractVhd} child
+     * @param {number} blockId
+     *
+     * @returns {number} the merged data size
+     */
+    mergeBlock(child: AbstractVhd, blockId: number): number;
+    /**
+     * ensure the bat size can store at least entries block
+     * move blocks if needed
+     * @param {number} entries
+     */
+    ensureBatSize(entries: number): void;
+    writeFooter(onlyEndFooter?: boolean): void;
+    writeHeader(): void;
+    _writeParentLocatorData(parentLocatorId: any, platformDataOffset: any, data: any): void;
+    _readParentLocatorData(parentLocatorId: any, platformDataOffset: any, platformDataSpace: any): void;
+    get batSize(): number;
+    writeParentLocator({ id, platformCode, data }: {
+        id: any;
+        platformCode?: number;
+        data?: Buffer;
+    }): Promise<void>;
+    readParentLocator(id: any): Promise<{
+        platformCode: any;
+        id: any;
+        data: void;
+    }>;
+    setUniqueParentLocator(fileNameString: any): Promise<void>;
+    blocks(): AsyncGenerator<{
+        id: number;
+        bitmap: Buffer;
+    } | {
+        id: number;
+        bitmap: Buffer;
+        data: Buffer;
+        /**
+         * - bitmap + data
+         */
+        buffer: Buffer;
+    }, void, unknown>;
+    streamSize(): number;
+    stream({ onProgress }?: {
+        onProgress: any;
+    }): any;
+    rawContent(): any;
+    containsAllDataOf(child: any): Promise<boolean>;
+    readRawData(start: any, length: any, cache: any, buf: any): Promise<number>;
+}

--- a/packages/vhd-lib/Vhd/VhdDirectory.d.ts
+++ b/packages/vhd-lib/Vhd/VhdDirectory.d.ts
@@ -1,0 +1,47 @@
+export class VhdDirectory extends VhdAbstract {
+    static open(handler: any, path: any, { flags }?: {
+        flags?: string;
+    }): Promise<{
+        dispose: () => void;
+        value: VhdDirectory;
+    }>;
+    static create(handler: any, path: any, { flags, compression }?: {
+        flags?: string;
+        compression: any;
+    }): Promise<{
+        dispose: () => void;
+        value: VhdDirectory;
+    }>;
+    constructor(handler: any, path: any, opts: any);
+    footer: any;
+    get compressionType(): any;
+    set header(arg: any);
+    get header(): any;
+    _handler: any;
+    _path: any;
+    _opts: any;
+    writeBlockAllocationTable(): Promise<any>;
+    readBlockAllocationTable(): Promise<void>;
+    containsBlock(blockId: any): boolean;
+    _readChunk(partName: any): Promise<{
+        buffer: any;
+    }>;
+    _writeChunk(partName: any, buffer: any): Promise<any>;
+    _getFullBlockPath(blockId: any): string;
+    readHeaderAndFooter(): Promise<void>;
+    readBlock(blockId: any, onlyBitmap?: boolean): Promise<{
+        id: any;
+        bitmap: any;
+        data: any;
+        buffer: any;
+    }>;
+    ensureBatSize(): void;
+    writeFooter(): Promise<void>;
+    writeHeader(): Promise<void>;
+    mergeBlock(child: any, blockId: any, isResumingMerge?: boolean): Promise<number>;
+    writeEntireBlock(block: any): Promise<void>;
+    _readParentLocatorData(id: any): Promise<any>;
+    _writeParentLocatorData(id: any, data: any): Promise<void>;
+    #private;
+}
+import { VhdAbstract } from "./VhdAbstract";

--- a/packages/vhd-lib/Vhd/VhdFile.d.ts
+++ b/packages/vhd-lib/Vhd/VhdFile.d.ts
@@ -1,0 +1,57 @@
+export class VhdFile extends VhdAbstract {
+    static open(handler: any, path: any, { flags, checkSecondFooter }?: {
+        flags: any;
+        checkSecondFooter?: boolean;
+    }): Promise<{
+        dispose: () => any;
+        value: VhdFile;
+    }>;
+    static create(handler: any, path: any, { flags }?: {
+        flags: any;
+    }): Promise<{
+        dispose: () => any;
+        value: VhdFile;
+    }>;
+    constructor(handler: any, path: any);
+    footer: any;
+    set header(arg: any);
+    get header(): any;
+    _handler: any;
+    _path: any;
+    _read(start: any, n: any): Promise<any>;
+    _getEndOfHeaders(): number;
+    _getBatEntry(blockId: any): any;
+    _getEndOfData(): number;
+    containsBlock(id: any): boolean;
+    readHeaderAndFooter(checkSecondFooter?: boolean): Promise<void>;
+    readBlockAllocationTable(): Promise<void>;
+    readBlock(blockId: any, onlyBitmap?: boolean): Promise<{
+        id: any;
+        bitmap: any;
+        data?: undefined;
+        buffer?: undefined;
+    } | {
+        id: any;
+        bitmap: any;
+        data: any;
+        buffer: any;
+    }>;
+    _write(data: any, offset: any): Promise<any>;
+    _freeFirstBlockSpace(spaceNeededBytes: any): any;
+    ensureBatSize(entries: any): Promise<void>;
+    _setBatEntry(block: any, blockSector: any): Promise<any>;
+    _createBlock(blockId: any): Promise<number>;
+    _writeBlockBitmap(blockAddr: any, bitmap: any): Promise<void>;
+    writeEntireBlock(block: any): Promise<void>;
+    _writeBlockSectors(block: any, beginSectorId: any, endSectorId: any, parentBitmap: any): Promise<void>;
+    writeFooter(onlyEndFooter?: boolean): Promise<void>;
+    writeHeader(): Promise<any>;
+    writeBlockAllocationTable(): Promise<any>;
+    writeData(offsetSectors: any, buffer: any): Promise<void>;
+    _ensureSpaceForParentLocators(neededSectors: any): Promise<number>;
+    _readParentLocatorData(parentLocatorId: any): Promise<any>;
+    _writeParentLocatorData(parentLocatorId: any, data: any): Promise<void>;
+    getSize(): Promise<any>;
+    #private;
+}
+import { VhdAbstract } from "./VhdAbstract";

--- a/packages/vhd-lib/Vhd/VhdNegative.d.ts
+++ b/packages/vhd-lib/Vhd/VhdNegative.d.ts
@@ -1,0 +1,18 @@
+/**
+ * Build an incremental VHD which can be applied to a child to revert to the state of its parent.
+ * @param {*} parent
+ * @param {*} descendant
+ */
+export class VhdNegative extends VhdAbstract {
+    constructor(parent: any, child: any);
+    get header(): any;
+    get footer(): any;
+    readBlockAllocationTable(): Promise<[any, any]>;
+    containsBlock(blockId: any): any;
+    readHeaderAndFooter(): Promise<[any, any]>;
+    readBlock(blockId: any, onlyBitmap?: boolean): Promise<any>;
+    mergeBlock(child: any, blockId: any): void;
+    _readParentLocatorData(id: any): any;
+    #private;
+}
+import { VhdAbstract } from "./VhdAbstract";

--- a/packages/vhd-lib/Vhd/VhdSynthetic.d.ts
+++ b/packages/vhd-lib/Vhd/VhdSynthetic.d.ts
@@ -1,0 +1,61 @@
+export const VhdSynthetic: {
+    new (vhds: Array<VhdAbstract>): {
+        "__#4@#vhds": any[];
+        readonly header: any;
+        readonly footer: any;
+        readonly compressionType: any;
+        readBlockAllocationTable(): Promise<void>;
+        containsBlock(blockId: any): boolean;
+        readHeaderAndFooter(): Promise<void>;
+        "__#4@#getVhdWithBlock"(blockId: any): any;
+        readBlock(blockId: any, onlyBitmap?: boolean): Promise<any>;
+        mergeBlock(child: any, blockId: any): Promise<void>;
+        _readParentLocatorData(id: any): any;
+        _getFullBlockPath(blockId: any): any;
+        checkVhdsClass(cls: any): boolean;
+        readonly bitmapSize: number;
+        readonly fullBlockSize: any;
+        readonly sectorsOfBitmap: number;
+        readonly sectorsPerBlock: number;
+        ensureBatSize(entries: number): void;
+        writeFooter(onlyEndFooter?: boolean): void;
+        writeHeader(): void;
+        _writeParentLocatorData(parentLocatorId: any, platformDataOffset: any, data: any): void;
+        readonly batSize: number;
+        writeParentLocator({ id, platformCode, data }: {
+            id: any;
+            platformCode?: number;
+            data?: Buffer;
+        }): Promise<void>;
+        readParentLocator(id: any): Promise<{
+            platformCode: any;
+            id: any;
+            data: void;
+        }>;
+        setUniqueParentLocator(fileNameString: any): Promise<void>;
+        blocks(): AsyncGenerator<{
+            id: number;
+            bitmap: Buffer;
+        } | {
+            id: number;
+            bitmap: Buffer;
+            data: Buffer;
+            /**
+             * - bitmap + data
+             */
+            buffer: Buffer;
+        }, void, unknown>;
+        streamSize(): number;
+        stream({ onProgress }?: {
+            onProgress: any;
+        }): any;
+        rawContent(): any;
+        containsAllDataOf(child: any): Promise<boolean>;
+        readRawData(start: any, length: any, cache: any, buf: any): Promise<number>;
+    };
+    fromVhdChain: any;
+    open: any;
+    unlink(handler: any, path: any): Promise<void>;
+    createAlias(handler: any, aliasPath: any, targetPath: any): Promise<void>;
+};
+import { VhdAbstract } from "./VhdAbstract";

--- a/packages/vhd-lib/Vhd/_utils.d.ts
+++ b/packages/vhd-lib/Vhd/_utils.d.ts
@@ -1,0 +1,11 @@
+export function unpackHeader(bufHeader: Buffer, footer: any): any;
+export function unpackFooter(bufFooter: any): any;
+export function computeBatSize(entries: any): number;
+export function computeSectorsPerBlock(blockSize: any): number;
+export function computeBlockBitmapSize(blockSize: any): number;
+export function computeFullBlockSize(blockSize: any): any;
+export function computeSectorOfBitmap(blockSize: any): number;
+export function sectorsRoundUpNoZero(bytes: any): number;
+export function sectorsToBytes(sectors: any): number;
+export function assertChecksum(name: any, buf: any, struct: any): void;
+export const BUF_BLOCK_UNUSED: Buffer;

--- a/packages/vhd-lib/_bitmap.d.ts
+++ b/packages/vhd-lib/_bitmap.d.ts
@@ -1,0 +1,2 @@
+export function set(map: any, bit: any): void;
+export function test(map: any, bit: any): boolean;

--- a/packages/vhd-lib/_checkHeader.d.ts
+++ b/packages/vhd-lib/_checkHeader.d.ts
@@ -1,0 +1,2 @@
+declare function _exports(header: any, footer: any): void;
+export = _exports;

--- a/packages/vhd-lib/_computeGeometryForSize.d.ts
+++ b/packages/vhd-lib/_computeGeometryForSize.d.ts
@@ -1,0 +1,7 @@
+declare function _exports(size: any): {
+    cylinders: number;
+    heads: number;
+    sectorsPerTrackCylinder: number;
+    actualSize: number;
+};
+export = _exports;

--- a/packages/vhd-lib/_constants.d.ts
+++ b/packages/vhd-lib/_constants.d.ts
@@ -1,0 +1,29 @@
+export const BLOCK_UNUSED: 4294967295;
+export const CREATOR_APPLICATION: "xo  ";
+export const FOOTER_SIZE: 512;
+export const HEADER_SIZE: 1024;
+export const SECTOR_SIZE: 512;
+export const DEFAULT_BLOCK_SIZE: 2097152;
+export const FOOTER_COOKIE: "conectix";
+export const HEADER_COOKIE: "cxsparse";
+export namespace DISK_TYPES {
+    let __proto__: any;
+    let FIXED: number;
+    let DYNAMIC: number;
+    let DIFFERENCING: number;
+}
+export const PARENT_LOCATOR_ENTRIES: 8;
+export namespace PLATFORMS {
+    let __proto___1: any;
+    export { __proto___1 as __proto__ };
+    export let NONE: number;
+    export let WI2R: number;
+    export let WI2K: number;
+    export let W2RU: number;
+    export let W2KU: number;
+    export let MAC: number;
+    export let MACX: number;
+}
+export const FILE_FORMAT_VERSION: number;
+export const HEADER_VERSION: number;
+export const ALIAS_MAX_PATH_LENGTH: 1024;

--- a/packages/vhd-lib/_createFooterHeader.d.ts
+++ b/packages/vhd-lib/_createFooterHeader.d.ts
@@ -1,0 +1,2 @@
+export function createFooter(size: any, timestamp: any, geometry: any, dataOffset: any, diskType?: number): any;
+export function createHeader(maxTableEntries: any, tableOffset?: number, blockSize?: 2097152): any;

--- a/packages/vhd-lib/_getFirstAndLastBlocks.d.ts
+++ b/packages/vhd-lib/_getFirstAndLastBlocks.d.ts
@@ -1,0 +1,7 @@
+declare function _exports(bat: any): {
+    first: number;
+    firstSector: any;
+    last: number;
+    lastSector: any;
+};
+export = _exports;

--- a/packages/vhd-lib/_noop.d.ts
+++ b/packages/vhd-lib/_noop.d.ts
@@ -1,0 +1,2 @@
+declare const _exports: Function;
+export = _exports;

--- a/packages/vhd-lib/_resolveRelativeFromFile.d.ts
+++ b/packages/vhd-lib/_resolveRelativeFromFile.d.ts
@@ -1,0 +1,2 @@
+export = resolveRelativeFromFile;
+declare function resolveRelativeFromFile(file: any, path: any): string;

--- a/packages/vhd-lib/_structs.d.ts
+++ b/packages/vhd-lib/_structs.d.ts
@@ -1,0 +1,5 @@
+export function unpackField(field: any, buf: any): any;
+export function checksumStruct(buf: any, struct: any): number;
+export const fuFooter: any;
+export const fuHeader: any;
+export function packField(field: any, value: any, buf: any): void;

--- a/packages/vhd-lib/aliases.d.ts
+++ b/packages/vhd-lib/aliases.d.ts
@@ -1,0 +1,2 @@
+export function resolveVhdAlias(handler: any, filename: any): Promise<any>;
+export function isVhdAlias(filename: any): any;

--- a/packages/vhd-lib/chain.d.ts
+++ b/packages/vhd-lib/chain.d.ts
@@ -1,0 +1,2 @@
+declare function _exports(parentHandler: any, parentPath: any, childHandler: any, childPath: any, force?: boolean): Promise<void>;
+export = _exports;

--- a/packages/vhd-lib/checkChain.d.ts
+++ b/packages/vhd-lib/checkChain.d.ts
@@ -1,0 +1,2 @@
+declare function _exports(handler: any, path: any): Promise<void>;
+export = _exports;

--- a/packages/vhd-lib/checkFooter.d.ts
+++ b/packages/vhd-lib/checkFooter.d.ts
@@ -1,0 +1,2 @@
+declare function _exports(footer: any): void;
+export = _exports;

--- a/packages/vhd-lib/createReadableSparseStream.d.ts
+++ b/packages/vhd-lib/createReadableSparseStream.d.ts
@@ -1,0 +1,2 @@
+declare function _exports(diskSize: any, fragmentSize: any, fragmentLogicAddressList: any, fragmentIterator: any): Promise<Function>;
+export = _exports;

--- a/packages/vhd-lib/createVhdDirectoryFromStream.d.ts
+++ b/packages/vhd-lib/createVhdDirectoryFromStream.d.ts
@@ -1,0 +1,5 @@
+export function createVhdDirectoryFromStream(handler: any, path: any, inputStream: any, { validator, concurrency, compression }?: {
+    validator: any;
+    concurrency?: number;
+    compression: any;
+}): Promise<any>;

--- a/packages/vhd-lib/createVhdStreamWithLength.d.ts
+++ b/packages/vhd-lib/createVhdStreamWithLength.d.ts
@@ -1,0 +1,10 @@
+declare function _exports(stream: any): Promise<EndCutterStream>;
+export = _exports;
+declare class EndCutterStream {
+    constructor(footerOffset: any, footerBuffer: any);
+    _footerOffset: any;
+    _footerBuffer: any;
+    _position: number;
+    _done: boolean;
+    _transform(data: any, encoding: any, callback: any): void;
+}

--- a/packages/vhd-lib/index.d.ts
+++ b/packages/vhd-lib/index.d.ts
@@ -1,0 +1,129 @@
+export const chainVhd: (parentHandler: any, parentPath: any, childHandler: any, childPath: any, force?: boolean) => Promise<void>;
+export const checkFooter: (footer: any) => void;
+export const checkVhdChain: (handler: any, path: any) => Promise<void>;
+export const createReadableSparseStream: (diskSize: any, fragmentSize: any, fragmentLogicAddressList: any, fragmentIterator: any) => Promise<Function>;
+export const createVhdStreamWithLength: (stream: any) => Promise<{
+    _footerOffset: any;
+    _footerBuffer: any;
+    _position: number;
+    _done: boolean;
+    _transform(data: any, encoding: any, callback: any): void;
+}>;
+export const createVhdDirectoryFromStream: (handler: any, path: any, inputStream: any, { validator, concurrency, compression }?: {
+    validator: any;
+    concurrency?: number;
+    compression: any;
+}) => Promise<any>;
+export const isVhdDifferencingDisk: (stream: any) => Promise<boolean>;
+export const peekFooterFromVhdStream: (stream: any) => Promise<any>;
+export const openVhd: (handler: any, path: any, opts: any) => Promise<{
+    dispose: () => void;
+    value: import("./Vhd/VhdDirectory").VhdDirectory;
+} | {
+    dispose: () => any;
+    value: import("./Vhd/VhdFile").VhdFile;
+}>;
+export const VhdAbstract: {
+    new (): import("./Vhd/VhdAbstract").VhdAbstract;
+    open(): AbstractVhd;
+    unlink(handler: any, path: any): Promise<void>;
+    createAlias(handler: any, aliasPath: any, targetPath: any): Promise<void>;
+};
+export const VhdDirectory: {
+    new (handler: any, path: any, opts: any): import("./Vhd/VhdDirectory").VhdDirectory;
+    open(handler: any, path: any, { flags }?: {
+        flags?: string;
+    }): Promise<{
+        dispose: () => void;
+        value: import("./Vhd/VhdDirectory").VhdDirectory;
+    }>;
+    create(handler: any, path: any, { flags, compression }?: {
+        flags?: string;
+        compression: any;
+    }): Promise<{
+        dispose: () => void;
+        value: import("./Vhd/VhdDirectory").VhdDirectory;
+    }>;
+    unlink(handler: any, path: any): Promise<void>;
+    createAlias(handler: any, aliasPath: any, targetPath: any): Promise<void>;
+};
+export const VhdFile: {
+    new (handler: any, path: any): import("./Vhd/VhdFile").VhdFile;
+    open(handler: any, path: any, { flags, checkSecondFooter }?: {
+        flags: any;
+        checkSecondFooter?: boolean;
+    }): Promise<{
+        dispose: () => any;
+        value: import("./Vhd/VhdFile").VhdFile;
+    }>;
+    create(handler: any, path: any, { flags }?: {
+        flags: any;
+    }): Promise<{
+        dispose: () => any;
+        value: import("./Vhd/VhdFile").VhdFile;
+    }>;
+    unlink(handler: any, path: any): Promise<void>;
+    createAlias(handler: any, aliasPath: any, targetPath: any): Promise<void>;
+};
+export const VhdSynthetic: {
+    new (vhds: import("./Vhd/VhdAbstract").VhdAbstract[]): {
+        "__#4@#vhds": any[];
+        readonly header: any;
+        readonly footer: any;
+        readonly compressionType: any;
+        readBlockAllocationTable(): Promise<void>;
+        containsBlock(blockId: any): boolean;
+        readHeaderAndFooter(): Promise<void>;
+        "__#4@#getVhdWithBlock"(blockId: any): any;
+        readBlock(blockId: any, onlyBitmap?: boolean): Promise<any>;
+        mergeBlock(child: any, blockId: any): Promise<void>;
+        _readParentLocatorData(id: any): any;
+        _getFullBlockPath(blockId: any): any;
+        checkVhdsClass(cls: any): boolean;
+        readonly bitmapSize: number;
+        readonly fullBlockSize: any;
+        readonly sectorsOfBitmap: number;
+        readonly sectorsPerBlock: number;
+        ensureBatSize(entries: number): void;
+        writeFooter(onlyEndFooter?: boolean): void;
+        writeHeader(): void;
+        _writeParentLocatorData(parentLocatorId: any, platformDataOffset: any, data: any): void;
+        readonly batSize: number;
+        writeParentLocator({ id, platformCode, data }: {
+            id: any;
+            platformCode?: number;
+            data?: Buffer;
+        }): Promise<void>;
+        readParentLocator(id: any): Promise<{
+            platformCode: any;
+            id: any;
+            data: void;
+        }>;
+        setUniqueParentLocator(fileNameString: any): Promise<void>;
+        blocks(): AsyncGenerator<{
+            id: number;
+            bitmap: Buffer;
+        } | {
+            id: number;
+            bitmap: Buffer;
+            data: Buffer;
+            /**
+             * - bitmap + data
+             */
+            buffer: Buffer;
+        }, void, unknown>;
+        streamSize(): number;
+        stream({ onProgress }?: {
+            onProgress: any;
+        }): any;
+        rawContent(): any;
+        containsAllDataOf(child: any): Promise<boolean>;
+        readRawData(start: any, length: any, cache: any, buf: any): Promise<number>;
+    };
+    fromVhdChain: any;
+    open: any;
+    unlink(handler: any, path: any): Promise<void>;
+    createAlias(handler: any, aliasPath: any, targetPath: any): Promise<void>;
+};
+export const VhdNegative: typeof import("./Vhd/VhdNegative").VhdNegative;
+export const Constants: typeof import("./_constants");

--- a/packages/vhd-lib/isVhdDifferencingDisk.d.ts
+++ b/packages/vhd-lib/isVhdDifferencingDisk.d.ts
@@ -1,0 +1,2 @@
+declare function _exports(stream: any): Promise<boolean>;
+export = _exports;

--- a/packages/vhd-lib/merge.d.ts
+++ b/packages/vhd-lib/merge.d.ts
@@ -1,0 +1,1 @@
+export const mergeVhdChain: any;

--- a/packages/vhd-lib/openVhd.d.ts
+++ b/packages/vhd-lib/openVhd.d.ts
@@ -1,0 +1,9 @@
+export function openVhd(handler: any, path: any, opts: any): Promise<{
+    dispose: () => void;
+    value: VhdDirectory;
+} | {
+    dispose: () => any;
+    value: VhdFile;
+}>;
+import { VhdDirectory } from "./Vhd/VhdDirectory.js";
+import { VhdFile } from "./Vhd/VhdFile.js";

--- a/packages/vhd-lib/parseVhdStream.d.ts
+++ b/packages/vhd-lib/parseVhdStream.d.ts
@@ -1,0 +1,1 @@
+export function parseVhdStream(stream: any): AsyncGenerator<any, void, unknown>;

--- a/packages/vhd-lib/peekFooterFromVhdStream.d.ts
+++ b/packages/vhd-lib/peekFooterFromVhdStream.d.ts
@@ -1,0 +1,2 @@
+declare function _exports(stream: any): Promise<any>;
+export = _exports;


### PR DESCRIPTION
### Description

WIP

This is the _cleanVm.mjs built from the .mts.
This allows to see with the diff that _the resulting mjs file is the same_, except for the empty lines that were deleted by TSC. (not configurable)

I only executed `prettier --write *.mjs` to remove the ";" at end of lines. (not configurable too)

Dependencies are only partially typed at the moment.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
