### PR TITLE
feat(xo-server): calculate size replication in sr

### DIFF
--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -294,9 +294,7 @@ async function _getDashboardStats(app) {
         if (isReplicaVm(vmObject)) {
           return true
         }
-      } catch (err) {
-        console.error(err.message)
-      }
+      } catch (err) {}
     }
     return false
   }
@@ -311,7 +309,6 @@ async function _getDashboardStats(app) {
       vdiObject = app.getObject(vdi, ['VDI', 'VDI-snapshot', 'VDI-unmanaged'])
       cache.set(vdi, vdiObject)
     } catch (err) {
-      console.error(err.message)
       return 0
     }
 
@@ -333,20 +330,19 @@ async function _getDashboardStats(app) {
 
       return {
         replicated: acc.replicated + replicated,
-        other: acc.other + sr.size - replicated,
         total: acc.total + sr.size,
         used: acc.used + sr.physical_usage,
       }
     },
     {
       replicated: 0,
-      other: 0,
       total: 0,
       used: 0,
     }
   )
 
   storageRepositoriesSize.available = storageRepositoriesSize.total - storageRepositoriesSize.used
+  storageRepositoriesSize.other = storageRepositoriesSize.total - storageRepositoriesSize.replicated
   resourcesOverview.srSize = storageRepositoriesSize.total
 
   dashboard.storageRepositories = { size: storageRepositoriesSize }


### PR DESCRIPTION
### Description

XO-108
[REST API/Dashboard/SR] calculate the size that XO replications take within SRs

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
