### PR TITLE
feat(xo-6): dashboard mobile layout

### DIFF
--- a/@xen-orchestra/web/src/pages/index.vue
+++ b/@xen-orchestra/web/src/pages/index.vue
@@ -66,4 +66,19 @@ import VmsStatus from '@/components/site/dashboard/VmsStatus.vue'
 .patches {
   grid-area: patches;
 }
+
+@media (--mobile) {
+  .site-dashboard {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'pools-status'
+      'hosts-status'
+      'vms-status'
+      'resources-overview'
+      'backups'
+      'backup-issues'
+      'repositories'
+      'patches';
+  }
+}
 </style>

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,8 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - [Plugin/backup-reports] Add VM Description to the backup report. (contribution made by [@truongtx8](https://github.com/truongtx8)) (PR [#8253](https://github.com/vatesfr/xen-orchestra/pull/8253))
+- **XO6**:
+  - [Dashboard] Adding a mobile layout (PR [#8268](https://github.com/vatesfr/xen-orchestra/pull/8268))
 
 ### Bug fixes
 
@@ -34,6 +36,7 @@
 <!--packages-start-->
 
 - @vates/types major
+- @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
 - xo-server-auth-oidc patch
 - xo-server-backup-reports minor


### PR DESCRIPTION
### Description

Handle dashboard cards for mobile layout
based on figma break down mockup
https://www.figma.com/design/pMLRMaoFwo7CBpTfgt8djo/2.-Vates---Xen-Orchestra-6-MVP

### Screenshot

<img width="742" alt="Capture d’écran 2025-01-24 à 11 08 31" src="https://github.com/user-attachments/assets/c157d5a3-733a-49f0-9b96-dc863d7b2a95" />

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
