### PR TITLE
fix(xo-server/getAllUnhealthyVdiChainsLength): better handling of vdi not in cache

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,6 +34,7 @@
 - [V2V] Improve compatiblity whith VSphere handling multiple vSAN storages (PR [#8243](https://github.com/vatesfr/xen-orchestra/pull/8243))
 - [Backup/LTR] Fix computation for the last week of the year (PR [#8269](https://github.com/vatesfr/xen-orchestra/pull/8269))
 - [New/Storage] Correctly display error if storage detection failed for HBA or ZFS (PR [#8250](https://github.com/vatesfr/xen-orchestra/pull/8250))
+- Fix error `sr.getAllUnhealthyVdiChainsLength(...) [36ms] =!> TypeError: Cannot read properties of undefined (reading 'managed')` (PR [#8273](https://github.com/vatesfr/xen-orchestra/pull/8273))
 
 ### Packages to release
 

--- a/packages/xo-server/src/xapi/mixins/storage.mjs
+++ b/packages/xo-server/src/xapi/mixins/storage.mjs
@@ -81,6 +81,9 @@ const methods = {
 
     const cache = { __proto__: null }
     forEach(vdis, vdi => {
+      if (vdi !== undefined) {
+        return
+      }
       if (vdi.managed && !vdi.is_a_snapshot) {
         const { uuid } = vdi
         const { unhealthyLength, missingParent } = this._getVdiChainsInfo(uuid, children, cache, resultContainer)

--- a/packages/xo-server/src/xapi/mixins/storage.mjs
+++ b/packages/xo-server/src/xapi/mixins/storage.mjs
@@ -81,7 +81,7 @@ const methods = {
 
     const cache = { __proto__: null }
     forEach(vdis, vdi => {
-      if (vdi !== undefined) {
+      if (vdi === undefined) {
         return
       }
       if (vdi.managed && !vdi.is_a_snapshot) {


### PR DESCRIPTION
### Description

from https://help.vates.tech/#ticket/zoom/32912 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
