### PR TITLE
feat(xo-server/rest-api): ability to update group's name

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
 - **XO6**:
   - [Dashboard] Adding a mobile layout (PR [#8268](https://github.com/vatesfr/xen-orchestra/pull/8268))
 - [REST API] Swagger interface available on `/rest/v0/docs` endpoint. Endpoint documentation will be added step by step (PR [#8316](https://github.com/vatesfr/xen-orchestra/pull/8316))
-- [REST API] Ability to update a group's name and its users (PR [#8278](https://github.com/vatesfr/xen-orchestra/pull/8278))
+- [REST API] Allow updating a group's name (PR [#8278](https://github.com/vatesfr/xen-orchestra/pull/8278))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 - **XO6**:
   - [Dashboard] Adding a mobile layout (PR [#8268](https://github.com/vatesfr/xen-orchestra/pull/8268))
 - [REST API] Swagger interface available on `/rest/v0/docs` endpoint. Endpoint documentation will be added step by step (PR [#8316](https://github.com/vatesfr/xen-orchestra/pull/8316))
+- [REST API] Ability to update a group's name and its users (PR [#8278](https://github.com/vatesfr/xen-orchestra/pull/8278))
 
 ### Bug fixes
 
@@ -40,6 +41,7 @@
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+- xo-server minor
 - xo-server-auth-oidc patch
 - xo-server-backup-reports minor
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -1373,7 +1373,7 @@ export default class RestApi {
         if (name === null) {
           return res.status(400).json({ error: 'name cannot be removed' })
         }
-        if (typeof name !== 'string') {
+        if (name !== undefined && typeof name !== 'string') {
           return res.status(400).json({ error: 'name must be a string' })
         }
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -1533,15 +1533,6 @@ export default class RestApi {
       })
     )
 
-    api.patch(
-      '/groups/update/:id',
-      json(),
-      wrap(async (req, res) => {
-        await collections.groups.actions.update(req.body, req)
-        res.sendStatus(200)
-      })
-    )
-
     setupRestApi(express)
   }
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -1356,7 +1356,8 @@ export default class RestApi {
 
       res.json(result)
     })
-    // Generic route captures all PATCH requests, preventing group/update from being executed so patch/groups must be placed before patch/object
+
+    // should go before routes /:collection/:object because they will match before
     api.patch(
       '/:collection(groups)/:id',
       json(),
@@ -1364,14 +1365,17 @@ export default class RestApi {
         const { id } = req.params
         const { name } = req.body
 
-        await app.getGroup(id)
+        const group = await app.getGroup(id)
+        if (group.provider !== undefined) {
+          return res.status(403).json({ message: 'Cannot edit synchronized group' })
+        }
 
-        if (name === undefined || name === null) {
-          return res.status(400).json({ message: 'Name is required' })
+        if (name == null) {
+          return res.status(400).json({ message: 'name is required' })
         }
 
         await app.updateGroup(id, { name })
-        res.sendStatus(200)
+        res.sendStatus(204)
       }, true)
     )
     api

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -1367,15 +1367,25 @@ export default class RestApi {
 
         const group = await app.getGroup(id)
         if (group.provider !== undefined) {
-          return res.status(403).json({ message: 'Cannot edit synchronized group' })
+          return res.status(403).json({ error: 'Cannot edit synchronized group' })
         }
 
-        if (name == null) {
-          return res.status(400).json({ message: 'name is required' })
+        if (name === null) {
+          return res.status(400).json({ error: 'name cannot be removed' })
+        }
+        if (typeof name !== 'string') {
+          return res.status(400).json({ error: 'name must be a string' })
         }
 
-        await app.updateGroup(id, { name })
-        res.sendStatus(204)
+        try {
+          await app.updateGroup(id, { name })
+          res.sendStatus(204)
+        } catch (error) {
+          if (error.message === `the group ${name} already exists`) {
+            return res.status(400).json({ error: error.message })
+          }
+          throw error
+        }
       }, true)
     )
     api
@@ -1549,6 +1559,10 @@ export default class RestApi {
         if (name == null) {
           return res.status(400).json({ error: 'name is required' })
         }
+        if (typeof name !== 'string') {
+          return res.status(400).json({ message: 'name must be a string' })
+        }
+
         try {
           const group = await app.createGroup({ name })
           res.status(201).end(group.id)


### PR DESCRIPTION
### Description

```
PATCH rest/v0/groups/:id
request body :
{
  name?: string
}
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
