### PR TITLE
fix(xo-server/test): use mock.timers for getFromAsyncCache test

### DIFF
--- a/packages/xo-server/src/utils.test.mjs
+++ b/packages/xo-server/src/utils.test.mjs
@@ -189,13 +189,28 @@ describe('parseSize()', function () {
 
 // ===================================================================
 
-const cacheTest = new Map()
-const cacheTimeout = 500
-const cacheExpiresIn = 1000
-const cacheTestOps = { timeout: cacheTimeout, expiresIn: cacheExpiresIn }
-const sleep = times => new Promise(resolve => setTimeout(resolve, times))
-
 describe('getFromAsyncCache()', function () {
+  const cacheTest = new Map()
+  const cacheTimeout = 500
+  const cacheExpiresIn = 1000
+  const cacheTestOps = { timeout: cacheTimeout, expiresIn: cacheExpiresIn }
+  const sleep = times => new Promise(resolve => setTimeout(resolve, times))
+
+  // start the promise, advance time and return the promise
+  const _getFromAsyncCache = async (t, ms, cache, key, fn, opts) => {
+    const p = getFromAsyncCache(cache, key, fn, opts)
+    t.mock.timers.tick(ms)
+    return p
+  }
+
+  it('Ensure the callback is called', async t => {
+    const cb = t.mock.fn(async () => {})
+
+    assert.equal(cb.mock.callCount(), 0)
+    await getFromAsyncCache(cacheTest, 'simpleTest', cb)
+    assert.equal(cb.mock.callCount(), 1)
+  })
+
   it('Returns the computed value', async function () {
     const result = await getFromAsyncCache(cacheTest, 'simpleTest', async () => 'foo')
     assert.equal(result.value, 'foo')
@@ -213,52 +228,54 @@ describe('getFromAsyncCache()', function () {
     assert.equal(result.value, 'baz')
   })
 
-  it('Returns undefined if the fn takes too long to execute, then returns the computed value when the promise is resolved', async function () {
-    const result = await getFromAsyncCache(
-      cacheTest,
-      'timeout',
-      async () => {
-        await sleep(cacheTimeout * 2.5)
-        return 'foo'
-      },
-      cacheTestOps
-    )
+  it('Returns undefined if the fn takes too long to execute, then returns the computed value when the promise is resolved', async function (t) {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+    const cb = async () => {
+      await sleep(cacheTimeout * 2.5)
+      return 'foo'
+    }
+
+    const result = await _getFromAsyncCache(t, cacheTimeout, cacheTest, 'timeout', cb, cacheTestOps)
     assert.equal(result.value, undefined)
 
-    const secondResult = await getFromAsyncCache(cacheTest, 'timeout', undefined, cacheTestOps)
+    const secondResult = await _getFromAsyncCache(t, cacheTimeout, cacheTest, 'timeout', undefined, cacheTestOps)
     assert.equal(secondResult.value, undefined)
+
+    t.mock.timers.tick(cacheTimeout)
 
     const thirdResult = await getFromAsyncCache(cacheTest, 'timeout', undefined, cacheTestOps)
     assert.equal(thirdResult.value, 'foo')
   })
 
-  it('If cached value is expired, returns the new computed value', async function () {
+  it('If cached value is expired, returns the new computed value', async function (t) {
+    t.mock.timers.enable({ apis: ['Date'], now: 0 })
+
     const result = await getFromAsyncCache(cacheTest, 'expired', async () => 'foo', cacheTestOps)
     assert.equal(result.value, 'foo')
 
-    await sleep(cacheExpiresIn + 10)
+    t.mock.timers.setTime(cacheExpiresIn * 2)
 
     const secondResult = await getFromAsyncCache(cacheTest, 'expired', async () => 'bar', cacheTestOps)
     assert.equal(secondResult.value, 'bar')
   })
 
-  it('If cached value is expired and the fn takes too long time to execute, returns the expired cached value with "isExpired" property and updates the cache when the promise is resolved', async function () {
+  it('If cached value is expired and the fn takes too long time to execute, returns the expired cached value with "isExpired" property and updates the cache when the promise is resolved', async function (t) {
+    t.mock.timers.enable({ apis: ['Date', 'setTimeout'], now: 0 })
+    const cb = async () => {
+      await sleep(cacheTimeout * 1.5)
+      return 'bar'
+    }
+
     const result = await getFromAsyncCache(cacheTest, 'expiredAndTimeout', async () => 'foo', cacheTestOps)
     assert.equal(result.value, 'foo')
 
-    await sleep(cacheExpiresIn + 1)
+    t.mock.timers.setTime(cacheExpiresIn * 2)
 
-    const secondResult = await getFromAsyncCache(
-      cacheTest,
-      'expiredAndTimeout',
-      async () => {
-        await sleep(cacheTimeout + 1)
-        return 'bar'
-      },
-      cacheTestOps
-    )
+    const secondResult = await _getFromAsyncCache(t, cacheTimeout, cacheTest, 'expiredAndTimeout', cb, cacheTestOps)
     assert.equal(secondResult.value, 'foo')
     assert.equal(secondResult.isExpired, true)
+
+    t.mock.timers.tick(cacheTimeout)
 
     const thirdResult = await getFromAsyncCache(cacheTest, 'expiredAndTimeout', undefined, cacheTestOps)
     assert.equal(thirdResult.value, 'bar')


### PR DESCRIPTION
### Description

introduced by 1eeff13

use `mock.timers` to avoid false negative.
https://nodejs.org/dist/v23.6.1/docs/api/test.html#timers

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
