### PR TITLE
fix(xo-lite/xo-6): issue with status in pool network table

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -8,7 +8,7 @@
 - [Console]: Adding a border when console is focused (PR [#8235](https://github.com/vatesfr/xen-orchestra/pull/8235))
 - [Pool/Network]: Display networks and host internal networks lists in pool view (PR [#8147](https://github.com/vatesfr/xen-orchestra/pull/8147))
 - [Host/Network]: Display pifs list in host view (PR [#8180](https://github.com/vatesfr/xen-orchestra/pull/8180))
-- [Pool/Network]: Fix issue with network status (PR[#8284](https://github.com/vatesfr/xen-orchestra/pull/8284))
+- [Pool/Network]: Fix issue with network status (PR [#8284](https://github.com/vatesfr/xen-orchestra/pull/8284))
 
 ## **0.6.0** (2024-11-29)
 

--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [Console]: Adding a border when console is focused (PR [#8235](https://github.com/vatesfr/xen-orchestra/pull/8235))
 - [Pool/Network]: Display networks and host internal networks lists in pool view (PR [#8147](https://github.com/vatesfr/xen-orchestra/pull/8147))
 - [Host/Network]: Display pifs list in host view (PR [#8180](https://github.com/vatesfr/xen-orchestra/pull/8180))
+- [Pool/Network]: Fix issue with network status (PR[#8284](https://github.com/vatesfr/xen-orchestra/pull/8284))
 
 ## **0.6.0** (2024-11-29)
 

--- a/@xen-orchestra/lite/src/components/pool/network/PoolNetworksTable.vue
+++ b/@xen-orchestra/lite/src/components/pool/network/PoolNetworksTable.vue
@@ -121,6 +121,7 @@
 import useMultiSelect from '@/composables/multi-select.composable'
 import type { XenApiNetwork } from '@/libs/xen-api/xen-api.types'
 import { useNetworkStore } from '@/stores/xen-api/network.store'
+import { usePifMetricsStore } from '@/stores/xen-api/pif-metrics.store'
 import { usePifStore } from '@/stores/xen-api/pif.store'
 import VtsConnectionStatus from '@core/components/connection-status/VtsConnectionStatus.vue'
 import VtsDataTable from '@core/components/data-table/VtsDataTable.vue'
@@ -155,6 +156,7 @@ import { useI18n } from 'vue-i18n'
 
 const { networksWithPifs: networks, isReady, hasError } = useNetworkStore().subscribe()
 const { records: pifs } = usePifStore().subscribe()
+const { getPifCarrier } = usePifMetricsStore().subscribe()
 
 const { t } = useI18n()
 const searchQuery = ref('')
@@ -193,12 +195,12 @@ const getNetworkStatus = (network: XenApiNetwork) => {
     return 'disconnected'
   }
 
-  const currentlyAttached = networkPIFs.map(pif => pif.currently_attached)
-  if (currentlyAttached.every(Boolean)) {
+  const isConnected = networkPIFs.map(pif => pif.currently_attached && getPifCarrier(pif))
+  if (isConnected.every(Boolean)) {
     return 'connected'
   }
 
-  if (currentlyAttached.some(Boolean)) {
+  if (isConnected.some(Boolean)) {
     return 'partially-connected'
   }
 

--- a/@xen-orchestra/web/src/components/pool/PoolNetworksTable.vue
+++ b/@xen-orchestra/web/src/components/pool/PoolNetworksTable.vue
@@ -199,12 +199,12 @@ const getNetworkStatus = (network: XoNetwork) => {
     return 'disconnected'
   }
 
-  const currentlyAttached = networkPIFs.map(pif => pif.attached)
-  if (currentlyAttached.every(Boolean)) {
+  const isConnected = networkPIFs.map(pif => pif.attached && pif.carrier)
+  if (isConnected.every(Boolean)) {
     return 'connected'
   }
 
-  if (currentlyAttached.some(Boolean)) {
+  if (isConnected.some(Boolean)) {
     return 'partially-connected'
   }
   return 'disconnected'
@@ -250,6 +250,7 @@ const headerIcon: Record<NetworkHeader, IconDefinition> = {
 
 .pool-networks-table {
   gap: 2.4rem;
+
   .container,
   .table-actions {
     gap: 0.8rem;

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,8 @@
 
 ### Bug fixes
 
-- [Pool/Network]: Fix issue with network status (PR[#8284](https://github.com/vatesfr/xen-orchestra/pull/8284))
+- **XO 6**:
+	- [Pool/Network] Fix issue with network status (PR [#8284](https://github.com/vatesfr/xen-orchestra/pull/8284))
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,8 @@
 
 ### Bug fixes
 
+- [Pool/Network]: Fix issue with network status (PR[#8284](https://github.com/vatesfr/xen-orchestra/pull/8284))
+
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 ### Packages to release


### PR DESCRIPTION
### Description

Fix issue with how status is calculated in pool table

### Screenshot
Before : 
![image](https://github.com/user-attachments/assets/2c1b5864-de77-4d34-9342-99eb3946276c)

After : 
![image](https://github.com/user-attachments/assets/3e39b4b2-bdd8-455b-8848-bce2f6da8eee)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
