### PR TITLE
fix(xo-lite): issue with wording in host pif table

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [Console]: Adding a border when console is focused (PR [#8235](https://github.com/vatesfr/xen-orchestra/pull/8235))
 - [Pool/Network]: Display networks and host internal networks lists in pool view (PR [#8147](https://github.com/vatesfr/xen-orchestra/pull/8147))
 - [Host/Network]: Display pifs list in host view (PR [#8180](https://github.com/vatesfr/xen-orchestra/pull/8180))
+- [Host/Network]: Fix issue with wording in host pif table (PR [8285](https://github.com/vatesfr/xen-orchestra/pull/8285))
 
 ## **0.6.0** (2024-11-29)
 

--- a/@xen-orchestra/lite/src/components/host/network/HostPifTable.vue
+++ b/@xen-orchestra/lite/src/components/host/network/HostPifTable.vue
@@ -212,15 +212,15 @@ const getPifStatus = (pif: XenApiPif) => {
   const carrier = getPifCarrier(pif)
   const isCurrentlyAttached = pif.currently_attached
 
-  if (isCurrentlyAttached && carrier) {
-    return 'connected'
+  if (!isCurrentlyAttached) {
+    return 'disconnected'
   }
 
-  if (isCurrentlyAttached && !carrier) {
-    return 'partially-connected'
+  if (!carrier) {
+    return 'disconnected-from-physical-device'
   }
 
-  return 'disconnected'
+  return 'connected'
 }
 
 const { visibleColumns, rows } = useTable('pifs', filteredPifs, {


### PR DESCRIPTION
### Description

Fix issue with wording in table

### Screenshot
Before: 
![image](https://github.com/user-attachments/assets/7e188249-422f-4178-bb1b-cd9f8b8722de)

After:
![image](https://github.com/user-attachments/assets/088e91f3-35ea-473c-96f7-b75bfee5879a)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
