### PR TITLE
feat(vhd-lib): handle broken vhd directory named as aliases

### DIFF
--- a/@xen-orchestra/backups/_cleanVm.mjs
+++ b/@xen-orchestra/backups/_cleanVm.mjs
@@ -142,6 +142,7 @@ export async function checkAliases(
         continue
       }
       logWarn('unhandled error while checking alias', { alias, err })
+      continue
     }
 
     if (target === '') {

--- a/@xen-orchestra/backups/_cleanVm.mjs
+++ b/@xen-orchestra/backups/_cleanVm.mjs
@@ -129,9 +129,26 @@ export async function checkAliases(
         logWarn('missing target of alias', { alias })
         if (remove) {
           logInfo('removing alias and non VHD target', { alias, target })
-          await handler.unlink(target)
           await handler.unlink(alias)
         }
+        continue
+      }
+      if (err.code === 'EISDIR') {
+        logWarn('alias is a vhd directory', { alias })
+        if (remove) {
+          logInfo('removing vhd directory named as alias', { alias, target })
+          await VhdAbstract.unlink(handler, alias)
+        }
+        continue
+      }
+      logWarn('unhandled error while checking alias', { alias, err })
+    }
+
+    if (target === '') {
+      logWarn('empty target for alias ', { alias })
+      if (remove) {
+        logInfo('removing alias and non VHD target', { alias, target })
+        await handler.unlink(alias)
       }
       continue
     }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,6 +34,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
 - @xen-orchestra/web minor
 - xo-server patch
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,6 +36,7 @@
 
 - @xen-orchestra/backups patch
 - @xen-orchestra/web minor
+- vhd-lib patch
 - xo-server patch
 
 <!--packages-end-->

--- a/packages/vhd-lib/Vhd/VhdAbstract.js
+++ b/packages/vhd-lib/Vhd/VhdAbstract.js
@@ -202,7 +202,15 @@ exports.VhdAbstract = class VhdAbstract {
   }
 
   static async unlink(handler, path) {
-    const resolved = await resolveVhdAlias(handler, path)
+    let resolved = path
+    try {
+      resolved = await resolveVhdAlias(handler, path)
+    } catch (err) {
+      // broken vhd directory must be unlinkable
+      if (err.code !== 'EISDIR') {
+        throw err
+      }
+    }
     try {
       await handler.unlink(resolved)
     } catch (err) {

--- a/packages/vhd-lib/Vhd/VhdAbstract.js
+++ b/packages/vhd-lib/Vhd/VhdAbstract.js
@@ -19,9 +19,11 @@ const {
 const assert = require('assert')
 const path = require('path')
 const asyncIteratorToStream = require('async-iterator-to-stream')
+const { createLogger } = require('@xen-orchestra/log')
 const { checksumStruct, fuFooter, fuHeader } = require('../_structs')
 const { isVhdAlias, resolveVhdAlias } = require('../aliases')
 
+const { warn } = createLogger('vhd-lib:VhdAbstract')
 exports.VhdAbstract = class VhdAbstract {
   get bitmapSize() {
     return sectorsToBytes(this.sectorsOfBitmap)
@@ -210,6 +212,7 @@ exports.VhdAbstract = class VhdAbstract {
       if (err.code !== 'EISDIR') {
         throw err
       }
+      warn('Deleting directly a VhdDirectory', { path, err })
     }
     try {
       await handler.unlink(resolved)


### PR DESCRIPTION
### Description

cleanvm fails is vhd ddirectory are used directly, without alias

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
