### PR TITLE
docs(users): using Google for SAML auth

### DIFF
--- a/docs/docs/users.md
+++ b/docs/docs/users.md
@@ -123,7 +123,7 @@ Use the screenshots below as a reference as how to setup SAML with Google Worksp
 
 > Note: Right now even when the authorization is successfull, you will be redirected to the `https://xo.company.net/signin` page. However, just browse directly into the bare URL `https://xo.company.net`, and you'll now be logged in and can use the XO-dashboard.
 
-> If you get a certificate error. Try and add a newline at the bottom of the Certificate field in Xen-Orchestra.
+> If you get a certificate error. Try to add a newline at the bottom of the Certificate field in Xen Orchestra.
 
 The first login will create the user inside XO, as a non-privileged user. An administrator then has to promote the user to the apropriate group. (XO: Settings/Users).
 

--- a/docs/docs/users.md
+++ b/docs/docs/users.md
@@ -114,8 +114,15 @@ Save the configuration and then activate the plugin (button on top).
 ##### Google Workspace - SAML [support.google.com](https://support.google.com/a/answer/6087519?hl=en#zippy=)
 
 Use the screenshots below as a reference as how to setup SAML with Google Workspace.
+1. Sign-in to your Google Workspace Admin Dashboard [https://admin.google.com](https://admin.google.com).
+2. Go-to: Apps/Web and mobile apps
+3. *Add app*. Choose *Add Custom SAML app*.
+4. Give it a name and optionally a description.
+5. Use the screenshots below to see what fields pair with what.
 
 > Note: Right now even when the authorization is successfull, you will be redirected to the `https://xo.company.net/signin` page. However, just browse directly into the bare URL `https://xo.company.net`, and you'll now be logged in and can use the XO-dashboard.
+
+> If you get a certificate error. Try and add a newline at the bottom of the Certificate field in Xen-Orchestra.
 
 The first login will create the user inside XO, as a non-privileged user. An administrator then has to promote the user to the apropriate group. (XO: Settings/Users).
 

--- a/docs/docs/users.md
+++ b/docs/docs/users.md
@@ -114,6 +114,7 @@ Save the configuration and then activate the plugin (button on top).
 ##### Google Workspace - SAML [support.google.com](https://support.google.com/a/answer/6087519?hl=en#zippy=)
 
 Use the screenshots below as a reference as how to setup SAML with Google Workspace.
+
 1. Sign in to your [Google Workspace Admin Dashboard](https://admin.google.com).
 2. Go to **Apps/Web and mobile apps**
 3. Click **Add app** and select **Add custom SAML app**.

--- a/docs/docs/users.md
+++ b/docs/docs/users.md
@@ -114,11 +114,11 @@ Save the configuration and then activate the plugin (button on top).
 ##### Google Workspace - SAML [support.google.com](https://support.google.com/a/answer/6087519?hl=en#zippy=)
 
 Use the screenshots below as a reference as how to setup SAML with Google Workspace.
-1. Sign-in to your Google Workspace Admin Dashboard [https://admin.google.com](https://admin.google.com).
-2. Go-to: Apps/Web and mobile apps
-3. *Add app*. Choose *Add Custom SAML app*.
-4. Give it a name and optionally a description.
-5. Use the screenshots below to see what fields pair with what.
+1. Sign in to your [Google Workspace Admin Dashboard](https://admin.google.com).
+2. Go to **Apps/Web and mobile apps**
+3. Click **Add app** and select **Add custom SAML app**.
+4. Give your app a name and optionally a description.
+5. To see how the fields should be filled out, refer to the screenshots below.
 
 > Note: Right now even when the authorization is successfull, you will be redirected to the `https://xo.company.net/signin` page. However, just browse directly into the bare URL `https://xo.company.net`, and you'll now be logged in and can use the XO-dashboard.
 


### PR DESCRIPTION
I noticed that the SAML-docs I wrote, could use some tweaking. To make it more helpfull. So I added a few points to better point to where to find this inside Googles admin dashboard.

Also. Added a small note about a potential certificate error, if there isn't a newline at the bottom of the certificate field.

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
