### PR TITLE
fix(lite/host): improve console retrieval

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## **next**
+
+- [Host/Console] Fix console sometimes not correctly displayed (PR [#8305](https://github.com/vatesfr/xen-orchestra/pull/8305))
+
 ## **0.7.0** (2025-01-30)
 
 - Fix persistent scrollbar on the right (PR [#8191](https://github.com/vatesfr/xen-orchestra/pull/8191))

--- a/@xen-orchestra/lite/src/views/host/HostConsoleView.vue
+++ b/@xen-orchestra/lite/src/views/host/HostConsoleView.vue
@@ -56,7 +56,7 @@ const { records: controlDomains } = useControlDomainStore().subscribe()
 
 const {
   isReady: isConsoleReady,
-  getByOpaqueRef: getConsoleByOpaqueRef,
+  getByOpaqueRefs: getConsolesByOpaqueRefs,
   hasError: hasConsoleError,
 } = useConsoleStore().subscribe()
 
@@ -71,11 +71,11 @@ const controlDomain = computed(() => {
     : undefined
 })
 
-const hostConsole = computed(() => {
-  const hostConsoles = controlDomain.value?.consoles.map(consoleRef => getConsoleByOpaqueRef(consoleRef))
-
-  return hostConsoles?.find(console => console?.location !== undefined && console?.protocol === 'rfb')
-})
+const hostConsole = computed(() =>
+  getConsolesByOpaqueRefs(controlDomain.value?.consoles ?? []).find(
+    console => console.location !== undefined && console.protocol === 'rfb'
+  )
+)
 
 const isReady = computed(() => isHostReady.value && isConsoleReady.value && controlDomain.value)
 

--- a/@xen-orchestra/lite/src/views/host/HostConsoleView.vue
+++ b/@xen-orchestra/lite/src/views/host/HostConsoleView.vue
@@ -72,8 +72,9 @@ const controlDomain = computed(() => {
 })
 
 const hostConsole = computed(() => {
-  const consoleOpaqueRef = controlDomain.value?.consoles[0]
-  return consoleOpaqueRef ? getConsoleByOpaqueRef(consoleOpaqueRef) : undefined
+  const hostConsoles = controlDomain.value?.consoles.map(consoleRef => getConsoleByOpaqueRef(consoleRef))
+
+  return hostConsoles?.find(console => console?.location !== undefined && console?.protocol === 'rfb')
 })
 
 const isReady = computed(() => isHostReady.value && isConsoleReady.value && controlDomain.value)
@@ -83,12 +84,14 @@ const isHostRunning = computed(() => {
 })
 
 const url = computed(() => {
-  if (xenApiStore.currentSessionId == null) {
+  if (xenApiStore.currentSessionId == null || hostConsole.value === undefined) {
     return
   }
+
   const _url = new URL(hostConsole.value!.location)
   _url.protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
   _url.searchParams.set('session_id', xenApiStore.currentSessionId)
+
   return _url
 })
 


### PR DESCRIPTION
### Description

**Introduced by 904273f**

Forum issue: https://xcp-ng.org/forum/topic/10376/xo-lite-not-loading-on-host-screen

Fix the way we retrieve the correct console object from a host.
A host can have multiple consoles, with different protocols. We weren’t handling this case correctly.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
