### PR TITLE
fix(backups): disable CBT when CBT is unusable

### DIFF
--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -158,6 +158,28 @@ class Vdi {
     return Buffer.from(encoded, 'base64')
   }
 
+  /**
+   * will disable CBT on the VDI, all its ancestor and will purge
+   * snapshots of type cbt_metadata of this chain
+   *
+   * @param {OpaqueRef} vdiRef
+   */
+  async disableCbtOnChain(vdiRef) {
+    const smConfig = await this.getField('VDI', vdiRef, 'sm-config')
+    if (smConfig['vhd-parent']) {
+      await this.VDI_disableCbtOnChain(smConfig['vhd-parent'])
+    }
+    const snapshotRefs = await this.getField('VDI', vdiRef, 'snapshots')
+    for (const snapshotRef of snapshotRefs) {
+      const type = await this.getField('VDI', snapshotRef, 'type')
+      if (type === 'cbt_metadata') {
+        await this.VDI_destroy(snapshotRef)
+      }
+      await this.callAsync('VDI.disable_cbt', snapshotRef)
+    }
+    await this.callAsync('VDI.disable_cbt', vdiRef)
+  }
+
   async disconnectFromControlDomain(vdiRef) {
     let vbdRefs
     try {
@@ -206,11 +228,12 @@ class Vdi {
       vdi: ref,
     }
 
-    const [cbt_enabled, size, uuid, vdiName] = await Promise.all([
+    const [cbt_enabled, size, snapshotOf, uuid, vdiName] = await Promise.all([
       this.getField('VDI', ref, 'cbt_enabled').catch(() => {
         /* on XS < 7.3 cbt is not supported */
       }),
       this.getField('VDI', ref, 'virtual_size'),
+      this.getField('VDI', ref, 'snapshot_of'),
       this.getField('VDI', ref, 'uuid'),
       this.getField('VDI', ref, 'name_label'),
     ])
@@ -275,8 +298,10 @@ class Vdi {
     // a CBT export can only work if we have a NBD client and changed blocks
     if (changedBlocks === undefined || nbdClient === undefined) {
       if (baseParentType === 'cbt_metadata') {
+        await this.VDI_disableCbtOnChain(snapshotOf)
         const e = new Error(`can't create a stream from a metadata VDI, fall back to a base `)
         e.code = 'VDI_CANT_DO_DELTA'
+        // CBt is not usable: reset it
         throw e
       }
 

--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -312,7 +312,7 @@ class Vdi {
         await this.VDI_disableCbtOnChain(snapshotOf)
         const e = new Error(`can't create a stream from a metadata VDI, fall back to a base `)
         e.code = 'VDI_CANT_DO_DELTA'
-        // CBt is not usable: reset it
+        // CBT is not usable: reset it
         throw e
       }
 

--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -181,7 +181,7 @@ class Vdi {
         }
       }
       /**
-       * xapi can't disable CBT on a snapshot OPERATION_NOT_ALLOWED(VDI is a snapshot )
+       * xapi can't disable CBT on a snapshot OPERATION_NOT_ALLOWED(VDI is a snapshot)
        */
     }
     try {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 - **XO6**:
   - [Pool/Network]: Display networks and host internal networks information in side panel (PR [#8286](https://github.com/vatesfr/xen-orchestra/pull/8286))
-
+- [Changed Block Tracking] Disabling CBT now cleanup the full disk and snapshot chains (PR [#8313](https://github.com/vatesfr/xen-orchestra/pull/8313))
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 ### Bug fixes

--- a/packages/xo-server/src/api/vdi.mjs
+++ b/packages/xo-server/src/api/vdi.mjs
@@ -67,8 +67,11 @@ export const set = defer(async function ($defer, params) {
     await xapi.resizeVdi(ref, size)
   }
   if ('cbt' in params) {
-    const method = params.cbt ? 'VDI.enable_cbt' : 'VDI.disable_cbt'
-    await xapi.callAsync(method, ref)
+    if (params.cbt) {
+      await xapi.callAsync('VDI.enable_cbt', ref)
+    } else {
+      await xapi.VDI_disableCbtOnChain(ref)
+    }
   }
 
   // Other fields.


### PR DESCRIPTION
### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
