### PR TITLE
docs(sdn_controller): remove XCP-ng 8.0 and prior (obsolete)

### DIFF
--- a/docs/docs/sdn_controller.md
+++ b/docs/docs/sdn_controller.md
@@ -55,22 +55,14 @@ The plugin's configuration contains:
 
 ### VxLAN
 
-- On XCP-ng prior to 7.6:
-  - To be able to use `VxLAN`, the following line needs to be added, if not already present, in `/etc/sysconfig/iptables` of all the hosts where `VxLAN` is wanted: `-A xapi-INPUT -p udp -m conntrack --ctstate NEW -m udp --dport 4789 -j ACCEPT`
-
 ### Encryption
 
-:::warning
-Encryption is not available prior to XCP-ng 8.0.
-:::
-
-- On XCP-ng 8.0:
-  - To be able to encrypt the networks, `openvswitch-ipsec` package must be installed on all the hosts:
-    - `yum install openvswitch-ipsec --enablerepo=xcp-ng-testing`
-    - `systemctl enable ipsec`
-    - `systemctl enable openvswitch-ipsec`
-    - `systemctl start ipsec`
-    - `systemctl start openvswitch-ipsec`
+- To be able to encrypt the networks, `openvswitch-ipsec` package must be installed on all the hosts:
+  - `yum install openvswitch-ipsec --enablerepo=xcp-ng-testing`
+  - `systemctl enable ipsec`
+  - `systemctl enable openvswitch-ipsec`
+  - `systemctl start ipsec`
+  - `systemctl start openvswitch-ipsec`
 
 ## OpenFlow rules
 
@@ -101,6 +93,3 @@ In the VM network tab a new column has been added: _Network rules_.
 ### Requirements
 
 ### Openflow
-
-- On XCP-ng prior to 8.0:
-  - To be able to use `OpenFlow`, the following line needs to be added, if not already present, in `/etc/sysconfig/iptables` of all the hosts where `OpenFlow` is wanted: `-A xapi-INPUT -p udp -m conntrack --ctstate NEW -m tcp --dport 6653 -j ACCEPT`


### PR DESCRIPTION
XCP-ng 8.0 and 7.6 are referenced in multiple sections of the [SDN Controller article](https://docs.xen-orchestra.com/sdn_controller). 

These versions are obsolete, nobody should be using SDN Controller on anything older than XCP-ng 8.2.
As a result, references to XCP-ng 8.0 and older can be removed safely.