### PR TITLE
feat(xo-core): update VtsIcon component brand color

### DIFF
--- a/@xen-orchestra/lite/src/components/infra/InfraHostItem.vue
+++ b/@xen-orchestra/lite/src/components/infra/InfraHostItem.vue
@@ -3,7 +3,7 @@
     <UiTreeItemLabel :icon="faServer" :route="{ name: 'host.console', params: { uuid: host.uuid } }" @toggle="toggle()">
       {{ host.name_label || '(Host)' }}
       <template #addons>
-        <UiIcon v-if="isPoolMaster" v-tooltip="$t('master')" :icon="faStar" accent="warning" />
+        <VtsIcon v-if="isPoolMaster" v-tooltip="$t('master')" :icon="faStar" accent="warning" />
         <UiCounter
           v-if="isReady"
           v-tooltip="$t('running-vm', { count: vmCount })"
@@ -28,7 +28,7 @@ import type { XenApiHost } from '@/libs/xen-api/xen-api.types'
 import { useHostStore } from '@/stores/xen-api/host.store'
 import { usePoolStore } from '@/stores/xen-api/pool.store'
 import { useVmStore } from '@/stores/xen-api/vm.store'
-import UiIcon from '@core/components/icon/VtsIcon.vue'
+import VtsIcon from '@core/components/icon/VtsIcon.vue'
 import VtsTreeItem from '@core/components/tree/VtsTreeItem.vue'
 import VtsTreeList from '@core/components/tree/VtsTreeList.vue'
 import UiCounter from '@core/components/ui/counter/UiCounter.vue'

--- a/@xen-orchestra/lite/src/stories/web-core/icon/vts-icon.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/icon/vts-icon.story.vue
@@ -2,7 +2,11 @@
   <ComponentStory
     v-slot="{ properties }"
     :params="[
-      prop('accent').enum('current', 'info', 'success', 'warning', 'danger').required().preset('current').widget(),
+      prop('accent')
+        .enum('current', 'brand', 'info', 'success', 'warning', 'danger')
+        .required()
+        .preset('current')
+        .widget(),
       iconProp().preset(faCheck),
       prop('overlay-icon')
         .type('IconDefinition')

--- a/@xen-orchestra/lite/src/stories/web-core/ui/link/ui-link.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/link/ui-link.story.vue
@@ -13,11 +13,11 @@
     <UiLink v-bind="properties">This is a link</UiLink>
 
     <div v-if="!properties.to && !properties.href" class="info">
-      <VtsIcon :icon="faInfoCircle" accent="brand" />
+      <VtsIcon :icon="faInfoCircle" accent="info" />
       Link is disabled because no `href` or `to` is provided
     </div>
     <div v-else-if="properties.to && properties.href" class="info">
-      <VtsIcon :icon="faExclamationTriangle" accent="brand" />
+      <VtsIcon :icon="faExclamationTriangle" accent="info" />
       `to` is ignored when `href` is provided
     </div>
   </ComponentStory>

--- a/@xen-orchestra/web-core/docs/guidelines/best-practices.md
+++ b/@xen-orchestra/web-core/docs/guidelines/best-practices.md
@@ -142,7 +142,7 @@ The component would look like this:
 <template>
   <div>
     <slot name="icon">
-      <UiIcon :icon />
+      <VtsIcon :icon />
     </slot>
     <!--  rest of the code  -->
   </div>
@@ -161,7 +161,7 @@ defineSlots<{
 </script>
 ```
 
-In this case, you can use the `icon` prop for simple uses, and keep the flexibility of using the slot when needed, as the `UiIcon` component is overwritten when the slot is used.
+In this case, you can use the `icon` prop for simple uses, and keep the flexibility of using the slot when needed, as the `VtsIcon` component is overwritten when the slot is used.
 
 ## Component MUST use inline handler or inline function for event handling
 

--- a/@xen-orchestra/web-core/docs/icons.md
+++ b/@xen-orchestra/web-core/docs/icons.md
@@ -2,7 +2,7 @@
 
 XO Lite / 6 / Core projects are using Font Awesome 6 Free.
 
-Icons can be displayed with the `UiIcon` component.
+Icons can be displayed with the `VtsIcon` component.
 
 The component takes an `icon` prop that should be an icon object imported from `@fortawesome/free-solid-svg-icons` or `@fortawesome/free-regular-svg-icons`.
 
@@ -20,7 +20,7 @@ Use the `busy` prop to display a loader icon.
 </template>
 
 <script lang="ts" setup>
-import UiIcon from '@/components/ui/icon/UiIcon.vue'
+import VtsIcon from '@core/components/icon/VtsIcon.vue'
 import { faDisplay } from '@fortawesome/free-solid-svg-icons'
 </script>
 ```

--- a/@xen-orchestra/web-core/lib/components/dropdown/DropdownItem.vue
+++ b/@xen-orchestra/web-core/lib/components/dropdown/DropdownItem.vue
@@ -8,7 +8,7 @@
       <slot />
     </div>
     <div v-if="info" class="info-text p3 italic">{{ info }}</div>
-    <VtsIcon v-if="arrow" :accent="disabled ? 'current' : 'info'" :icon="faAngleRight" class="right-icon" />
+    <VtsIcon v-if="arrow" :accent="disabled ? 'current' : 'brand'" :icon="faAngleRight" class="right-icon" />
   </div>
 </template>
 

--- a/@xen-orchestra/web-core/lib/components/icon/VtsIcon.vue
+++ b/@xen-orchestra/web-core/lib/components/icon/VtsIcon.vue
@@ -50,10 +50,10 @@ defineProps<{
   }
 
   &.brand {
-    color: var(--color-info-item-base);
+    color: var(--color-brand-item-base);
 
     .overlay-icon {
-      color: var(--color-info-txt-item);
+      color: var(--color-brand-txt-item);
     }
   }
 

--- a/@xen-orchestra/web-core/lib/components/ui/checkbox/UiCheckbox.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/checkbox/UiCheckbox.vue
@@ -10,7 +10,7 @@
       v-bind="attrs"
     />
     <span class="fake-checkbox">
-      <VtsIcon :icon accent="info" class="icon" />
+      <VtsIcon :icon accent="current" class="icon" />
     </span>
     <span v-if="slots.default" class="typo p1-regular">
       <slot />

--- a/@xen-orchestra/web-core/lib/components/ui/input/UiInput.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/input/UiInput.vue
@@ -11,7 +11,7 @@
         v-if="!attrs.disabled && modelValue && clearable"
         :icon="faXmark"
         class="after"
-        accent="info"
+        accent="brand"
         @click="modelValue = ''"
       />
     </div>

--- a/@xen-orchestra/web-core/lib/components/ui/legend/UiLegend.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/legend/UiLegend.vue
@@ -1,9 +1,9 @@
 <!-- v3 -->
 <template>
   <li :class="classNames" class="ui-legend">
-    <VtsIcon :icon="faCircle" accent="brand" class="circle-icon" />
+    <VtsIcon :icon="faCircle" accent="current" class="circle-icon" />
     <span class="label typo p3-regular"><slot /></span>
-    <VtsIcon v-if="tooltip" v-tooltip="tooltip" :icon="faCircleInfo" class="tooltip-icon" accent="info" />
+    <VtsIcon v-if="tooltip" v-tooltip="tooltip" :icon="faCircleInfo" class="tooltip-icon" accent="brand" />
     <span v-if="valueLabel" class="value-and-unit typo c3-semi-bold">{{ valueLabel }}</span>
   </li>
 </template>

--- a/@xen-orchestra/web-core/lib/components/ui/object-link/UiObjectLink.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/object-link/UiObjectLink.vue
@@ -3,7 +3,7 @@
   <RouterLink v-if="route && !disabled" :to="route" class="ui-object-link is-link typo p3-regular-underline">
     <span class="icon">
       <slot name="icon">
-        <UiIcon :icon accent="current" />
+        <VtsIcon :icon accent="current" />
       </slot>
     </span>
     <span v-tooltip class="content text-ellipsis">
@@ -13,7 +13,7 @@
   <span v-else :class="{ disabled }" class="ui-object-link typo p3-regular-underline">
     <span class="icon">
       <slot name="icon">
-        <UiIcon :icon accent="current" />
+        <VtsIcon :icon accent="current" />
       </slot>
     </span>
     <slot />
@@ -21,7 +21,7 @@
 </template>
 
 <script lang="ts" setup>
-import UiIcon from '@core/components/icon/VtsIcon.vue'
+import VtsIcon from '@core/components/icon/VtsIcon.vue'
 import { vTooltip } from '@core/directives/tooltip.directive'
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types'
 import { type RouteLocationRaw } from 'vue-router'

--- a/@xen-orchestra/web-core/lib/components/ui/tree-item-label/UiTreeItemLabel.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/tree-item-label/UiTreeItemLabel.vue
@@ -27,7 +27,7 @@
       <div v-else class="h-line" />
       <a v-tooltip="{ selector: '.text' }" :href class="link typo p2-medium" @click="navigate">
         <slot name="icon">
-          <UiIcon :icon accent="current" class="icon" />
+          <VtsIcon :icon accent="current" class="icon" />
         </slot>
         <div class="text text-ellipsis">
           <slot />
@@ -39,7 +39,7 @@
 </template>
 
 <script lang="ts" setup>
-import UiIcon from '@core/components/icon/VtsIcon.vue'
+import VtsIcon from '@core/components/icon/VtsIcon.vue'
 import VtsTreeLine from '@core/components/tree/VtsTreeLine.vue'
 import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import { vTooltip } from '@core/directives/tooltip.directive'

--- a/@xen-orchestra/web/src/components/tree/HostTreeItem.vue
+++ b/@xen-orchestra/web/src/components/tree/HostTreeItem.vue
@@ -11,7 +11,7 @@
         />
       </template>
       <template #addons>
-        <UiIcon v-if="isMaster" v-tooltip="$t('master')" :icon="faStar" accent="warning" />
+        <VtsIcon v-if="isMaster" v-tooltip="$t('master')" :icon="faStar" accent="warning" />
         <UiCounter
           v-tooltip="$t('running-vm', runningVmsCount)"
           :value="runningVmsCount"
@@ -35,7 +35,7 @@ import { useHostStore } from '@/stores/xo-rest-api/host.store'
 import { useVmStore } from '@/stores/xo-rest-api/vm.store'
 import type { HostBranch } from '@/types/tree.type'
 import type { HostState } from '@core/types/object-icon.type'
-import UiIcon from '@core/components/icon/VtsIcon.vue'
+import VtsIcon from '@core/components/icon/VtsIcon.vue'
 import VtsTreeItem from '@core/components/tree/VtsTreeItem.vue'
 import VtsTreeList from '@core/components/tree/VtsTreeList.vue'
 import UiCounter from '@core/components/ui/counter/UiCounter.vue'


### PR DESCRIPTION
### Description

- Use the correct `--color-brand-*` CSS variables when using the CSS class `brand`, instead of `--color-info-*`.
- Add missing `brand` variant in story component.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
