### PR TITLE
feat(xo-core): update treeview components colors

### DIFF
--- a/@xen-orchestra/lite/src/components/infra/InfraHostItem.vue
+++ b/@xen-orchestra/lite/src/components/infra/InfraHostItem.vue
@@ -3,7 +3,7 @@
     <UiTreeItemLabel :icon="faServer" :route="{ name: 'host.console', params: { uuid: host.uuid } }" @toggle="toggle()">
       {{ host.name_label || '(Host)' }}
       <template #addons>
-        <VtsIcon v-if="isPoolMaster" v-tooltip="$t('master')" :icon="faStar" accent="warning" />
+        <VtsIcon v-if="isPoolMaster" v-tooltip="$t('master')" accent="info" :icon="faCircle" :overlay-icon="faStar" />
         <UiCounter
           v-if="isReady"
           v-tooltip="$t('running-vm', { count: vmCount })"
@@ -34,7 +34,7 @@ import VtsTreeList from '@core/components/tree/VtsTreeList.vue'
 import UiCounter from '@core/components/ui/counter/UiCounter.vue'
 import UiTreeItemLabel from '@core/components/ui/tree-item-label/UiTreeItemLabel.vue'
 import { vTooltip } from '@core/directives/tooltip.directive'
-import { faServer, faStar } from '@fortawesome/free-solid-svg-icons'
+import { faCircle, faServer, faStar } from '@fortawesome/free-solid-svg-icons'
 import { useToggle } from '@vueuse/shared'
 import { computed } from 'vue'
 

--- a/@xen-orchestra/web-core/lib/components/tree/VtsTreeLine.vue
+++ b/@xen-orchestra/web-core/lib/components/tree/VtsTreeLine.vue
@@ -22,7 +22,7 @@ defineProps<{
 
   .tree-line-vertical {
     width: 0.1rem;
-    background: var(--color-info-txt-base);
+    background: var(--color-brand-txt-base);
     height: calc(100% + 0.7rem);
     transform: translateY(calc(0.7rem * -1));
   }
@@ -33,7 +33,7 @@ defineProps<{
     background: transparent;
 
     &.right {
-      background: var(--color-info-txt-base);
+      background: var(--color-brand-txt-base);
     }
   }
 }

--- a/@xen-orchestra/web-core/lib/components/tree/VtsTreeLoadingItem.vue
+++ b/@xen-orchestra/web-core/lib/components/tree/VtsTreeLoadingItem.vue
@@ -44,7 +44,7 @@ const depth = inject(IK_TREE_LIST_DEPTH, 0)
     .loader {
       flex: 1;
       animation: pulse alternate 1s infinite;
-      background-color: var(--color-info-background-selected);
+      background-color: var(--color-brand-background-selected);
     }
   }
 

--- a/@xen-orchestra/web-core/lib/components/ui/tree-item-label/UiTreeItemLabel.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/tree-item-label/UiTreeItemLabel.vue
@@ -1,4 +1,4 @@
-<!-- v2 -->
+<!-- v3 -->
 <template>
   <RouterLink v-slot="{ isExactActive, isActive, href, navigate }" :to="route" custom>
     <div
@@ -114,22 +114,22 @@ const depth = inject(IK_TREE_LIST_DEPTH, 0)
 
   .h-line {
     width: 2rem;
-    border-bottom: 0.1rem solid var(--color-info-txt-base);
+    border-bottom: 0.1rem solid var(--color-brand-txt-base);
     margin-left: -0.4rem;
   }
 
   /* INTERACTION VARIANTS */
 
   &:is(.exact-active, .active) {
-    background-color: var(--color-info-background-selected);
+    background-color: var(--color-brand-background-selected);
   }
 
   &:hover {
-    background-color: var(--color-info-background-hover);
+    background-color: var(--color-brand-background-hover);
   }
 
   &:active {
-    background-color: var(--color-info-background-active);
+    background-color: var(--color-brand-background-active);
   }
 }
 </style>

--- a/@xen-orchestra/web/src/components/tree/HostTreeItem.vue
+++ b/@xen-orchestra/web/src/components/tree/HostTreeItem.vue
@@ -11,7 +11,7 @@
         />
       </template>
       <template #addons>
-        <VtsIcon v-if="isMaster" v-tooltip="$t('master')" :icon="faStar" accent="warning" />
+        <VtsIcon v-if="isMaster" v-tooltip="$t('master')" accent="info" :icon="faCircle" :overlay-icon="faStar" />
         <UiCounter
           v-tooltip="$t('running-vm', runningVmsCount)"
           :value="runningVmsCount"
@@ -42,7 +42,7 @@ import UiCounter from '@core/components/ui/counter/UiCounter.vue'
 import UiObjectIcon from '@core/components/ui/object-icon/UiObjectIcon.vue'
 import UiTreeItemLabel from '@core/components/ui/tree-item-label/UiTreeItemLabel.vue'
 import { vTooltip } from '@core/directives/tooltip.directive'
-import { faServer, faStar } from '@fortawesome/free-solid-svg-icons'
+import { faCircle, faServer, faStar } from '@fortawesome/free-solid-svg-icons'
 import { computed } from 'vue'
 
 const props = defineProps<{


### PR DESCRIPTION
### Description

- Update treeview components colors: change CSS variables from `--color-info-*` to `--color-brand-*`
- Update the "primary host" icon and icon color

Font sizes don’t match the ones used in the DS. They’re updated in PR #8320 but it is not blocking.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
