### PR TITLE
feat(xo-core): update UiLink component

### DIFF
--- a/@xen-orchestra/web-core/lib/components/ui/link/UiLink.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/link/UiLink.vue
@@ -1,14 +1,9 @@
-<!-- v2 -->
+<!-- v3 -->
 <template>
   <component :is="component" :class="classes" class="ui-link" v-bind="attributes">
     <VtsIcon :icon accent="current" />
     <slot />
-    <VtsIcon
-      v-if="attributes.target === '_blank'"
-      :icon="faArrowUpRightFromSquare"
-      accent="current"
-      class="external-icon"
-    />
+    <VtsIcon v-if="attributes.target === '_blank'" :icon="faUpRightFromSquare" accent="current" class="external-icon" />
   </component>
 </template>
 
@@ -16,7 +11,7 @@
 import VtsIcon from '@core/components/icon/VtsIcon.vue'
 import { type LinkOptions, useLinkComponent } from '@core/composables/link-component.composable'
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types'
-import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons'
+import { faUpRightFromSquare } from '@fortawesome/free-solid-svg-icons'
 import { computed } from 'vue'
 
 const props = defineProps<
@@ -41,14 +36,14 @@ const classes = computed(() => [typoClasses[props.size], { disabled: isDisabled.
   display: inline-flex;
   align-items: center;
   gap: 0.8rem;
-  color: var(--color-info-txt-base);
+  color: var(--color-brand-txt-base);
 
   &:hover {
-    color: var(--color-info-txt-hover);
+    color: var(--color-brand-txt-hover);
   }
 
   &:active {
-    color: var(--color-info-txt-active);
+    color: var(--color-brand-txt-active);
   }
 
   &:focus-visible {
@@ -57,7 +52,7 @@ const classes = computed(() => [typoClasses[props.size], { disabled: isDisabled.
     &::before {
       content: '';
       position: absolute;
-      inset: -0.6rem;
+      inset: -0.4rem;
       border: 0.2rem solid var(--color-info-txt-base);
       border-radius: 0.4rem;
     }


### PR DESCRIPTION
### Description

Update `UiLink` component:
- use `--color-brand-*`  CSS variables instead of `--color-info-*`
- update "external link" icon
- update `:focus-visible` spacing

Font sizes don’t match the ones used in the DS. They’re updated in PR #8320 but it is not blocking.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
