### PR TITLE
feat(xo-server/rest-api): ability to remove user from a group

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,8 @@
 - [REST API] Swagger interface available on `/rest/v0/docs` endpoint. Endpoint documentation will be added step by step (PR [#8316](https://github.com/vatesfr/xen-orchestra/pull/8316))
 - [REST API] Implement CRUD for `groups` (PRs [#8276](https://github.com/vatesfr/xen-orchestra/pull/8276), [#8277](https://github.com/vatesfr/xen-orchestra/pull/8277), [#8278](https://github.com/vatesfr/xen-orchestra/pull/8278), [#8334](https://github.com/vatesfr/xen-orchestra/pull/8334), [#8334](https://github.com/vatesfr/xen-orchestra/pull/8334), [#8336](https://github.com/vatesfr/xen-orchestra/pull/8336))
 
+- [REST API] Ability to remove a user from a group (PR [#8336](https://github.com/vatesfr/xen-orchestra/pull/8336))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,9 +15,7 @@
 - **XO6**:
   - [Dashboard] Adding a mobile layout (PR [#8268](https://github.com/vatesfr/xen-orchestra/pull/8268))
 - [REST API] Swagger interface available on `/rest/v0/docs` endpoint. Endpoint documentation will be added step by step (PR [#8316](https://github.com/vatesfr/xen-orchestra/pull/8316))
-- [REST API] Implement CRUD for `groups` (PRs [#8276](https://github.com/vatesfr/xen-orchestra/pull/8276), [#8277](https://github.com/vatesfr/xen-orchestra/pull/8277), [#8278](https://github.com/vatesfr/xen-orchestra/pull/8278), [#8334](https://github.com/vatesfr/xen-orchestra/pull/8334), [#8334](https://github.com/vatesfr/xen-orchestra/pull/8334), [#8336](https://github.com/vatesfr/xen-orchestra/pull/8336))
-
-- [REST API] Ability to remove a user from a group (PR [#8336](https://github.com/vatesfr/xen-orchestra/pull/8336))
+- [REST API] Implement CRUD for `groups` (PRs [#8276](https://github.com/vatesfr/xen-orchestra/pull/8276), [#8277](https://github.com/vatesfr/xen-orchestra/pull/8277), [#8278](https://github.com/vatesfr/xen-orchestra/pull/8278), [#8334](https://github.com/vatesfr/xen-orchestra/pull/8334), [#8336](https://github.com/vatesfr/xen-orchestra/pull/8336))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -1558,6 +1558,22 @@ export default class RestApi {
         res.sendStatus(204)
       }, true)
     )
+    api.delete(
+      '/:collection(groups)/:groupid/users/:userid',
+      json(),
+      wrap(async (req, res) => {
+        const { groupid, userid } = req.params
+        const group = await app.getGroup(groupid)
+        await app.getUser(userid)
+
+        if (!group.users.includes(userid)) {
+          return res.status(409).json({ message: 'User not found in this group' })
+        }
+        await app.removeUserFromGroup(userid, groupid)
+
+        res.sendStatus(204)
+      }, true)
+    )
 
     api.delete(
       '/:collection(groups)/:id',

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -1558,6 +1558,7 @@ export default class RestApi {
         res.sendStatus(204)
       }, true)
     )
+
     api.delete(
       '/:collection(groups)/:id/users/:userId',
       wrap(async (req, res) => {

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -1559,17 +1559,16 @@ export default class RestApi {
       }, true)
     )
     api.delete(
-      '/:collection(groups)/:groupid/users/:userid',
-      json(),
+      '/:collection(groups)/:id/users/:userId',
       wrap(async (req, res) => {
-        const { groupid, userid } = req.params
-        const group = await app.getGroup(groupid)
-        await app.getUser(userid)
+        const { id, userId } = req.params
+        const group = await app.getGroup(id)
 
-        if (!group.users.includes(userid)) {
-          return res.status(409).json({ message: 'User not found in this group' })
+        if (group.provider !== undefined) {
+          return res.status(403).json({ message: 'cannot remove user from synchronized group' })
         }
-        await app.removeUserFromGroup(userid, groupid)
+
+        await app.removeUserFromGroup(userId, id)
 
         res.sendStatus(204)
       }, true)


### PR DESCRIPTION
### Description

``` DELETE rest/v0/groups/:id/users/:id ```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
