### PR TITLE
feat(xo-core): update UiCardTitle and UiCardSubtitle components

### DIFF
--- a/@xen-orchestra/web-core/lib/components/ui/card-subtitle/UiCardSubtitle.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/card-subtitle/UiCardSubtitle.vue
@@ -15,8 +15,8 @@ const slots = defineSlots<{
 
 <style lang="postcss" scoped>
 .ui-card-subtitle {
-  color: var(--color-info-txt-base);
-  border-bottom: 0.1rem solid var(--color-info-txt-base);
+  color: var(--color-brand-txt-base);
+  border-bottom: 0.1rem solid var(--color-brand-txt-base);
   display: flex;
   justify-content: space-between;
   gap: 0.8rem;

--- a/@xen-orchestra/web-core/lib/components/ui/card-title/UiCardTitle.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/card-title/UiCardTitle.vue
@@ -46,7 +46,7 @@ const slots = defineSlots<{
     display: flex;
     align-items: center;
     gap: 0.8rem;
-    color: var(--color-info-txt-base);
+    color: var(--color-brand-txt-base);
   }
 
   .description {


### PR DESCRIPTION
### Description

- Update `UiCardTitle`:
  - use `--color-brand-*` CSS variable instead of `--color-info-*` for "info" section

- Update `UiCardSubtitle`:
  - use `--color-brand-*` CSS variables instead of `--color-info-*`

Font sizes don’t match the ones used in the DS. They’re updated in PR #8320 but it is not blocking.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
