### PR TITLE
fix(@vates/task): ensure compatibility between library versions

### DIFF
--- a/@vates/task/index.js
+++ b/@vates/task/index.js
@@ -66,7 +66,8 @@ class Task {
   }
 
   // These two properties should not be used outside the class
-  // For compatibility reasons they are kept public, to always allow a task to read its parent properties
+  //
+  // To ensure compatibility between multiple versions of this lib, they are kept public for now
   _abortController = new AbortController()
   _onProgress
 

--- a/@vates/task/index.js
+++ b/@vates/task/index.js
@@ -82,6 +82,14 @@ class Task {
     return this.#status
   }
 
+  get abortSignal() {
+    return this.#abortController.signal
+  }
+
+  get onProgress() {
+    return this.#onProgress
+  }
+
   constructor({ properties, onProgress } = {}) {
     this.#startData = { properties }
 
@@ -90,12 +98,11 @@ class Task {
     } else {
       const parent = getTask()
       if (parent !== undefined) {
-        const { signal } = parent.#abortController
-        signal.addEventListener('abort', () => {
-          this.#abortController.abort(signal.reason)
+        parent.abortSignal.addEventListener('abort', () => {
+          this.#abortController.abort(parent.abortSignal.reason)
         })
 
-        this.#onProgress = parent.#onProgress
+        this.#onProgress = parent.onProgress
         this.#startData.parentId = parent.id
       } else {
         this.#onProgress = noop

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -44,6 +44,7 @@
 <!--packages-start-->
 
 - @vates/generator-toolbox major
+- @vates/task patch
 - @vates/types major
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/vmware-explorer patch


### PR DESCRIPTION
### Description

Using different versions of `@vates/task` could lead to errors: `TypeError: Cannot read private member #abortSignal whose class did not declare it` when a task and its parent were not created with the same version of the library, because then they were not part of the exact same class.

According to [this commentary](https://github.com/vatesfr/xen-orchestra/blob/987e9691030d0953bc59b028b513668bbdaca73a/%40vates/task/index.js#L22), ensuring compatibility between various versions of the library is important to us.

Introduced by 3c7d316b3cb3e949316e4a93f74da954df81a65f

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
