### PR TITLE
docs: fix links to cloud-init

### DIFF
--- a/docs/docs/manage_infrastructure.md
+++ b/docs/docs/manage_infrastructure.md
@@ -285,7 +285,7 @@ These templates will use PV configuration in order to boot: either from the righ
 
 Because there is already disks installed, you shouldn't have "Install settings" _per se_. But you can use our `config drive` setup if your template already has CloudInit installed!
 
-Please refer to the [XCP-ng CloudInit section](advanced.md#cloud-init) for more.
+Please refer to the [XCP-ng CloudInit section](vm-templates.md#cloud-init) for more.
 
 #### Interfaces
 

--- a/docs/docs/users.md
+++ b/docs/docs/users.md
@@ -446,7 +446,7 @@ Finally, if a user has been granted access to multiple resource sets, they can b
 
 ### Toward the Cloud
 
-Self-service is a major step in the Cloud. Combine it with our [Cloudinit compatible VM creation](advanced.md#cloud-init) for a full experience:
+Self-service is a major step in the Cloud. Combine it with our [Cloudinit compatible VM creation](vm-templates.md#cloud-init) for a full experience:
 
 - create a Cloud ready template
 - create a set and put Cloud templates inside

--- a/docs/docs/vm-templates.md
+++ b/docs/docs/vm-templates.md
@@ -90,9 +90,9 @@ Before deleting a template, make sure to find and remove any attached disks. Oth
 
 If you want VMs to set themselves up automatically after deployment, **Cloud-Init** (for Linux) and **Cloudbase-Init** (for Windows) can help.
 
-### Cloud-init (Linux)
+### Cloud-init
 
-Cloud-init is a program that handles the early initialization of a cloud instance.
+Cloud-init is a program that handles the early initialization of a cloud instance of Linux.
 In other words, on a "Cloud-init-ready" VM template, you can pass a lot of data at first boot, such as:
 
 - Set the host name


### PR DESCRIPTION
### Description

_Cloud-init was moved, update refs to match._

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
