### PR TITLE
docs(fuse-vhd): document cli file restoration

### DIFF
--- a/@vates/fuse-vhd/.USAGE.md
+++ b/@vates/fuse-vhd/.USAGE.md
@@ -13,7 +13,7 @@ await mount(handler, diskId, mountPoint)
 
 ### cli
 
-From the install folder :
+From the install folder:
 
 ```
 cli.mjs <remoteUrl> <vhdPathInRemote> <mountPoint>
@@ -25,4 +25,23 @@ After installing the package
 xo-fuse-vhd <remoteUrl> <vhdPathInRemote> <mountPoint>
 ```
 
-remoteUrl can be found by using cli in `@xen-orchestra/fs` , for example a local remote will have a url like `file:///path/to/remote/root`
+The `remoteUrl` can be found using the following command from the XOA CLI, and then picking the right `url` property:
+
+`xo-server-db ls remote`
+
+## Restore a file from a VHD using `fuse-vhd` CLI
+
+1. Mount a VHD to the Filesystem (see **Usage**).
+2. Verify the VHD is Correctly Mounted:
+
+`mount | grep fuse`
+
+3. Get the `START` and `SIZE` of the disk whose file you want to restore. Multiply `START` by 512 (block size) to get the offset value. (`mountedVhdPath` is the `mountPoint` value from earlier, followed by `/vhd0`, for example). Depending on the partition type, you may need to do some additional setup to discover the partitions.
+
+`partx --bytes --output=NR,START,SIZE,NAME,UUID,TYPE --pairs <mountedVhdPath>`
+
+4.  Mount the disk. Depending on the partition type, you may need to add some additionnal options. The `norecovery` option is used for ext3/ext4/xfs file systems, otherwise remove this option.
+
+`mount --options=loop,ro,norecovery,sizelimit=<SIZE>,offset=<START*512>  --source=<mountedVhdPath> --target=<diskMountPoint>`
+
+5. Copy Your Files from the mounted partition and then unmount the partition.

--- a/@vates/fuse-vhd/.USAGE.md
+++ b/@vates/fuse-vhd/.USAGE.md
@@ -29,6 +29,8 @@ The `remoteUrl` can be found using the following command from the XOA CLI, and t
 
 `xo-server-db ls remote`
 
+The `vhdPathInRemote` follows a file structure described [here](https://github.com/vatesfr/xen-orchestra/blob/master/%40xen-orchestra/backups/docs/VM%20backups/README.md).
+
 ## Restore a file from a VHD using `fuse-vhd` CLI
 
 1. Mount a VHD to the Filesystem (see **Usage**).

--- a/@vates/fuse-vhd/.USAGE.md
+++ b/@vates/fuse-vhd/.USAGE.md
@@ -46,4 +46,4 @@ The `vhdPathInRemote` follows a file structure described [here](https://github.c
 
 `mount --options=loop,ro,norecovery,sizelimit=<SIZE>,offset=<START*512>  --source=<mountedVhdPath> --target=<diskMountPoint>`
 
-5. Copy Your Files from the mounted partition and then unmount the partition.
+5. Copy your files from the mounted partition, then unmount the partition.

--- a/@vates/fuse-vhd/README.md
+++ b/@vates/fuse-vhd/README.md
@@ -29,7 +29,7 @@ await mount(handler, diskId, mountPoint)
 
 ### cli
 
-From the install folder :
+From the install folder:
 
 ```
 cli.mjs <remoteUrl> <vhdPathInRemote> <mountPoint>
@@ -41,7 +41,35 @@ After installing the package
 xo-fuse-vhd <remoteUrl> <vhdPathInRemote> <mountPoint>
 ```
 
-remoteUrl can be found by using cli in `@xen-orchestra/fs` , for example a local remote will have a url like `file:///path/to/remote/root`
+remoteUrl can be found by using cli in `@xen-orchestra/fs` , for example a local remote will have a url like `file:///path/to/remote/root`, or with command:
+
+```
+xo-server-db ls remote
+```
+
+## Restore a file from a VHD using `fuse-vhd` CLI
+
+- Mount a VHD to filesystem (see "Usage")
+
+- Check that your VHD is correctly mounted:
+
+```
+mount | grep fuse
+```
+
+- Get the `START` and `SIZE` of the disk whose file you want to restore. Multiply `START` by 512 (block size) to get an offset value. (`mountedVhdPath` is the `mountPoint` value from earlier followed by `/vhd0` for example)
+
+```
+partx --bytes --output=NR,START,SIZE,NAME,UUID,TYPE --pairs <mountedVhdPath>
+```
+
+- Mount the disk:
+
+```
+mount --options=loop,ro,norecovery,sizelimit=<SIZE>,offset=<START*512>  --source=<mountedVhdPath> --target=<diskMountPoint>
+```
+
+- You can now copy your files from the mounted partition and unmount the partition.
 
 ## Contributions
 

--- a/@vates/fuse-vhd/README.md
+++ b/@vates/fuse-vhd/README.md
@@ -49,6 +49,22 @@ xo-server-db ls remote
 
 ## Restore a file from a VHD using `fuse-vhd` CLI
 
+1. Mount a VHD to the Filesystem (see **Usage**).
+2. Verify the VHD is Correctly Mounted:
+
+`mount | grep fuse`
+
+3. Get the `START` and `SIZE` of the disk whose file you want to restore. Multiply `START` by 512 (block size) to get the offset value. (`mountedVhdPath` is the `mountPoint` value from earlier, followed by `/vhd0`, for example).
+
+`partx --bytes --output=NR,START,SIZE,NAME,UUID,TYPE --pairs <mountedVhdPath>`
+
+4.  Mount the disk:
+
+`mount --options=loop,ro,norecovery,sizelimit=<SIZE>,offset=<START*512>  --source=<mountedVhdPath> --target=<diskMountPoint>`
+
+5. Copy Your Files from the mounted partition and then unmount the partition.
+
+
 - Mount a VHD to filesystem (see "Usage")
 
 - Check that your VHD is correctly mounted:

--- a/@vates/fuse-vhd/README.md
+++ b/@vates/fuse-vhd/README.md
@@ -41,11 +41,9 @@ After installing the package
 xo-fuse-vhd <remoteUrl> <vhdPathInRemote> <mountPoint>
 ```
 
-remoteUrl can be found by using cli in `@xen-orchestra/fs` , for example a local remote will have a url like `file:///path/to/remote/root`, or with command:
+The `remoteUrl` can be found using the following command from the XOA CLI, and then picking the right `url` property:
 
-```
-xo-server-db ls remote
-```
+`xo-server-db ls remote`
 
 ## Restore a file from a VHD using `fuse-vhd` CLI
 
@@ -54,38 +52,15 @@ xo-server-db ls remote
 
 `mount | grep fuse`
 
-3. Get the `START` and `SIZE` of the disk whose file you want to restore. Multiply `START` by 512 (block size) to get the offset value. (`mountedVhdPath` is the `mountPoint` value from earlier, followed by `/vhd0`, for example).
+3. Get the `START` and `SIZE` of the disk whose file you want to restore. Multiply `START` by 512 (block size) to get the offset value. (`mountedVhdPath` is the `mountPoint` value from earlier, followed by `/vhd0`, for example). Depending on the partition type, you may need to do some additional setup to discover the partitions.
 
 `partx --bytes --output=NR,START,SIZE,NAME,UUID,TYPE --pairs <mountedVhdPath>`
 
-4.  Mount the disk:
+4.  Mount the disk. Depending on the partition type, you may need to add some additionnal options.
 
 `mount --options=loop,ro,norecovery,sizelimit=<SIZE>,offset=<START*512>  --source=<mountedVhdPath> --target=<diskMountPoint>`
 
 5. Copy Your Files from the mounted partition and then unmount the partition.
-
-
-- Mount a VHD to filesystem (see "Usage")
-
-- Check that your VHD is correctly mounted:
-
-```
-mount | grep fuse
-```
-
-- Get the `START` and `SIZE` of the disk whose file you want to restore. Multiply `START` by 512 (block size) to get an offset value. (`mountedVhdPath` is the `mountPoint` value from earlier followed by `/vhd0` for example)
-
-```
-partx --bytes --output=NR,START,SIZE,NAME,UUID,TYPE --pairs <mountedVhdPath>
-```
-
-- Mount the disk:
-
-```
-mount --options=loop,ro,norecovery,sizelimit=<SIZE>,offset=<START*512>  --source=<mountedVhdPath> --target=<diskMountPoint>
-```
-
-- You can now copy your files from the mounted partition and unmount the partition.
 
 ## Contributions
 

--- a/@vates/fuse-vhd/README.md
+++ b/@vates/fuse-vhd/README.md
@@ -62,7 +62,7 @@ The `vhdPathInRemote` follows a file structure described [here](https://github.c
 
 `mount --options=loop,ro,norecovery,sizelimit=<SIZE>,offset=<START*512>  --source=<mountedVhdPath> --target=<diskMountPoint>`
 
-5. Copy Your Files from the mounted partition and then unmount the partition.
+5. Copy your files from the mounted partition, then unmount the partition.
 
 ## Contributions
 

--- a/@vates/fuse-vhd/README.md
+++ b/@vates/fuse-vhd/README.md
@@ -56,7 +56,7 @@ The `remoteUrl` can be found using the following command from the XOA CLI, and t
 
 `partx --bytes --output=NR,START,SIZE,NAME,UUID,TYPE --pairs <mountedVhdPath>`
 
-4.  Mount the disk. Depending on the partition type, you may need to add some additionnal options.
+4.  Mount the disk. Depending on the partition type, you may need to add some additionnal options. The `norecovery` option is used for ext3/ext4/xfs file systems, otherwise remove this option.
 
 `mount --options=loop,ro,norecovery,sizelimit=<SIZE>,offset=<START*512>  --source=<mountedVhdPath> --target=<diskMountPoint>`
 

--- a/@vates/fuse-vhd/README.md
+++ b/@vates/fuse-vhd/README.md
@@ -45,6 +45,8 @@ The `remoteUrl` can be found using the following command from the XOA CLI, and t
 
 `xo-server-db ls remote`
 
+The `vhdPathInRemote` follows a file structure described [here](https://github.com/vatesfr/xen-orchestra/blob/master/%40xen-orchestra/backups/docs/VM%20backups/README.md).
+
 ## Restore a file from a VHD using `fuse-vhd` CLI
 
 1. Mount a VHD to the Filesystem (see **Usage**).


### PR DESCRIPTION
### Description

Document how to restore a file from a VHD with `fuse-vhd` CLI.
This will allow users to restore by themselves large files that make the restore fail when done from the UI.

While reviewing, try to make sure:
- the explanations look clear
- there is no mistake or bad wording in the explanation

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
