### PR TITLE
fix(xo-web): empty list of options in selects

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@
 - [V2V] Fix `fail to power off vm vm-XXXXXX, state:queued.` when powering down source VM (PR [#8328](https://github.com/vatesfr/xen-orchestra/pull/8328))
 - [V2] Fix `Cannot read properties of undefined (reading 'map')` with empty datastore (PR [#8311](https://github.com/vatesfr/xen-orchestra/pull/8311))
 - [Plugin/audit] Do not log call to `host.getBiosInfo` and `host.getMdadmHealth`
+- Fix empty list of options in selectors [#8361](https://github.com/vatesfr/xen-orchestra/issues/8361) (`TypeError: p.createRef is not a function`)
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,7 +26,6 @@
 - [V2V] Fix `fail to power off vm vm-XXXXXX, state:queued.` when powering down source VM (PR [#8328](https://github.com/vatesfr/xen-orchestra/pull/8328))
 - [V2] Fix `Cannot read properties of undefined (reading 'map')` with empty datastore (PR [#8311](https://github.com/vatesfr/xen-orchestra/pull/8311))
 - [Plugin/audit] Do not log call to `host.getBiosInfo` and `host.getMdadmHealth`
-- Fix empty list of options in selectors [#8361](https://github.com/vatesfr/xen-orchestra/issues/8361) (`TypeError: p.createRef is not a function`)
 
 ### Packages to release
 

--- a/packages/xo-web/package.json
+++ b/packages/xo-web/package.json
@@ -117,7 +117,7 @@
     "react-shortcuts": "^2.0.0",
     "react-sparklines": "1.6.0",
     "react-test-renderer": "^15.6.2",
-    "react-virtualized": "^9.15.0",
+    "react-virtualized": "9.22.5",
     "readable-stream": "^3.0.2",
     "redux": "^4.0.0",
     "redux-thunk": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4529,14 +4529,7 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^20.2.3":
-  version "20.17.19"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.19.tgz#0f2869555719bef266ca6e1827fcdca903c1a697"
-  integrity sha512-LEwC7o1ifqg/6r2gn9Dns0f1rhK+fPFDoMiceTJ6kWmVk6bgXBI/9IOWfVan4WiAavK9pIVWdX0/e3J+eEUh5A==
-  dependencies:
-    undici-types "~6.19.2"
-
-"@types/node@^20.6":
+"@types/node@^20.2.3", "@types/node@^20.6":
   version "20.17.19"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.19.tgz#0f2869555719bef266ca6e1827fcdca903c1a697"
   integrity sha512-LEwC7o1ifqg/6r2gn9Dns0f1rhK+fPFDoMiceTJ6kWmVk6bgXBI/9IOWfVan4WiAavK9pIVWdX0/e3J+eEUh5A==
@@ -17277,7 +17270,7 @@ react-transition-group@^2.2.0:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react-virtualized@^9.15.0:
+react-virtualized@9.22.5:
   version "9.22.5"
   resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.5.tgz#bfb96fed519de378b50d8c0064b92994b3b91620"
   integrity sha512-YqQMRzlVANBv1L/7r63OHa2b0ZsAaDp1UhVNEdUaXI8A5u6hTpA5NYtUueLH2rFuY/27mTGIBl7ZhqFKzw18YQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -17278,9 +17278,9 @@ react-transition-group@^2.2.0:
     react-lifecycles-compat "^3.0.4"
 
 react-virtualized@^9.15.0:
-  version "9.22.6"
-  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.6.tgz#3ae2aa69eca61cf3af332e2f9d6b4aa5638786d5"
-  integrity sha512-U5j7KuUQt3AaMatlMJ0UJddqSiX+Km0YJxSqbAzIiGw5EmNz0khMyqP2hzgu4+QUtm+QPIrxzUX4raJxmVJnHg==
+  version "9.22.5"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.5.tgz#bfb96fed519de378b50d8c0064b92994b3b91620"
+  integrity sha512-YqQMRzlVANBv1L/7r63OHa2b0ZsAaDp1UhVNEdUaXI8A5u6hTpA5NYtUueLH2rFuY/27mTGIBl7ZhqFKzw18YQ==
   dependencies:
     "@babel/runtime" "^7.7.2"
     clsx "^1.0.4"


### PR DESCRIPTION
Introduced by a386680d90bee4fe9987aebc8fb8001a08f240d2
Fixes #8361
See https://github.com/bvaughn/react-virtualized/issues/1871

### Description

react-virtualized@9.22.6 seems to be breaking old versions of React
Error in browser console: `TypeError: p.createRef is not a function`

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
