### PR TITLE
fix(xen-api): obfuscate password for pool.join{,_force}

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -7,6 +7,8 @@
 
 > Security fixes and new features should go in this section
 
+- Ensure password is not logged in error messages when adding hosts to a pool (PR [#8369](https://github.com/vatesfr/xen-orchestra/pull/8369))
+
 ### Enhancements
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
@@ -36,6 +38,7 @@
 <!--packages-start-->
 
 - @vates/types patch
+- xen-api patch
 - xo-cli patch
 - xo-server minor
 

--- a/packages/xen-api/index.mjs
+++ b/packages/xen-api/index.mjs
@@ -809,6 +809,10 @@ export class Xapi extends EventEmitter {
       obfuscated[0] = '* session id *'
     }
 
+    if (method === 'pool.join' || method === 'pool.join_force') {
+      obfuscated[3] = '* obfuscated *'
+    }
+
     const callId = Math.random().toString(36).slice(2)
     const startTime = Date.now()
     debug(`${this._humanId}: ${method} started`, { callId, args: obfuscated })

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -168,15 +168,7 @@ export default class Xapi extends XapiBase {
   // =================================================================
 
   async joinPool(masterAddress, masterUsername, masterPassword, force = false) {
-    try {
-      await this.call(force ? 'pool.join_force' : 'pool.join', masterAddress, masterUsername, masterPassword)
-    } catch (error) {
-      const params = error?.call?.params
-      if (Array.isArray(params)) {
-        params[2] = '* obfuscated *'
-      }
-      throw error
-    }
+    await this.call(force ? 'pool.join_force' : 'pool.join', masterAddress, masterUsername, masterPassword)
   }
 
   // =================================================================


### PR DESCRIPTION
### Description

**DO NOT SQUASH**

Fixes zammad#35148

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
