### PR TITLE
fix(xo-server/rest-api): do not show route twice

### DIFF
--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -1144,7 +1144,10 @@ export default class RestApi {
 
     api.get(
       '/',
-      wrap((req, res) => sendObjects([...Object.values(collections), ...swaggerEndpoints], req, res))
+      wrap((req, res) => {
+        const endpoints = new Set([...Object.keys(collections), ...swaggerEndpoints])
+        return sendObjects(endpoints, req, res)
+      })
     )
 
     // For compatibility redirect from /backups* to /backup


### PR DESCRIPTION
### Screenshot
#### Before


![Capture d’écran de 2025-02-24 15-22-28](https://github.com/user-attachments/assets/a472c25c-5f87-498b-8dee-96962e7a067a)

#### After
![Capture d’écran de 2025-02-24 15-21-35](https://github.com/user-attachments/assets/bf3f6729-eb68-4b71-b452-ace0e1e07a65)

### Description

If a collection was present in both the OpenAPI REST API and the legacy REST API, it displayed both. Use a Set to ensure unique values

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
