### PR TITLE
feat(xo-web/vm/disks): allow Self Service users to attach disks to their VMs

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Self Service] Allow Self Service users to attach disks to their VMs
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -30,5 +32,8 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- xo-server minor
+- xo-web minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [Self Service] Allow Self Service users to attach disks to their VMs
+- [Self Service] Allow Self Service users to attach disks to their VMs (PR [#8384](https://github.com/vatesfr/xen-orchestra/pull/8384))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/api/vbd.mjs
+++ b/packages/xo-server/src/api/vbd.mjs
@@ -2,6 +2,14 @@
 
 async function delete_({ vbd }) {
   await this.getXapiObject(vbd).$destroy()
+
+  const vdi = this.getObject(vbd.VDI)
+  const vm = this.getObject(vbd.VM)
+
+  const { resourceSet } = vm
+  if (resourceSet != null) {
+    await this.releaseLimitsInResourceSet({ disk: vdi.size }, resourceSet)
+  }
 }
 
 delete_.params = {

--- a/packages/xo-web/src/xo-app/vm/tab-disks.js
+++ b/packages/xo-web/src/xo-app/vm/tab-disks.js
@@ -621,19 +621,6 @@ export default class TabDisks extends Component {
     }, noop)
   }
 
-  _getIsVmAdmin = createSelector(
-    () => this.props.checkPermissions,
-    () => this.props.vm && this.props.vm.id,
-    (check, vmId) => check(vmId, 'administrate')
-  )
-
-  _getAttachDiskPredicate = createSelector(
-    () => this.props.isAdmin,
-    () => this.props.vm.resourceSet,
-    this._getIsVmAdmin,
-    (isAdmin, resourceSet, isVmAdmin) => isAdmin || (resourceSet == null && isVmAdmin)
-  )
-
   _getRequiredHost = createSelector(
     this._areSrsOnSameHost,
     this._getVdiSrs,
@@ -744,14 +731,12 @@ export default class TabDisks extends Component {
               icon='add'
               labelId='vbdCreateDeviceButton'
             />
-            {this._getAttachDiskPredicate() && (
-              <TabButton
-                btnStyle={attachDisk ? 'info' : 'primary'}
-                handler={this._toggleAttachDisk}
-                icon='disk'
-                labelId='vdiAttachDevice'
-              />
-            )}
+            <TabButton
+              btnStyle={attachDisk ? 'info' : 'primary'}
+              handler={this._toggleAttachDisk}
+              icon='disk'
+              labelId='vdiAttachDevice'
+            />
           </Col>
         </Row>
         <Row>


### PR DESCRIPTION
See Zammad#30630

### Screenshots

![Capture_2025-03-26_09:19:31](https://github.com/user-attachments/assets/daeb8e52-ed87-4738-8ddb-4317ce1b8596)

### Description

A Self Service user is now allowed to attach VDIs to their VMs, as long as they have enough disk space left in the resource set and permissions on the SR that contains the VDI.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
