### PR TITLE
feat(@xen-orchestra/rest-api): expose get servers and get server

### DIFF
--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -230,6 +230,22 @@ export type XoPool = BaseXapiXo & {
   type: 'pool'
 }
 
+export type XoServer = {
+  allowUnauthorized: boolean
+  enabled: boolean
+  error?: Record<string, unknown>
+  host: string
+  httpProxy?: string
+  id: Branded<'server'>
+  label?: string
+  poolId?: XoPool['id']
+  poolNameDescription?: string
+  poolNameLabel?: string
+  readOnly: boolean
+  status: 'connected' | 'disconnected' | 'connecting'
+  username: string
+}
+
 export type XoSr = BaseXapiXo & {
   $PBDs: XoPbd['id'][]
 
@@ -382,4 +398,6 @@ export type XapiXoRecord =
   | XoVmTemplate
   | XoVtpm
 
-export type XoRecord = XapiXoRecord | XoGroup | XoUser
+export type NonXapiXoRecord = XoGroup | XoServer | XoUser
+
+export type XoRecord = XapiXoRecord | NonXapiXoRecord

--- a/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
@@ -1,0 +1,26 @@
+import { Controller } from 'tsoa'
+import { Request } from 'express'
+import { XoRecord } from '@vates/types'
+
+import { RestApi } from '../rest-api/rest-api.mjs'
+import { makeObjectMapper } from '../helpers/object-wrapper.helper.mjs'
+import type { WithHref } from '../helpers/helper.type.mjs'
+
+export abstract class BaseController<T extends XoRecord, IsSync extends boolean> extends Controller {
+  abstract getObjects(): IsSync extends false ? Promise<Record<T['id'], T>> : Record<T['id'], T>
+  abstract getObject(id: T['id']): IsSync extends false ? Promise<T> : T
+
+  restApi: RestApi
+
+  constructor(restApi: RestApi) {
+    super()
+    this.restApi = restApi
+  }
+
+  sendObjects(objects: T[], req: Request): string[] | WithHref<T>[] | WithHref<Partial<T>>[] {
+    const mapper = makeObjectMapper(req)
+    const mappedObjects = objects.map(mapper) as string[] | WithHref<T>[] | WithHref<Partial<T>>[]
+
+    return mappedObjects
+  }
+}

--- a/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
@@ -1,10 +1,13 @@
-import { Controller } from 'tsoa'
+import { Controller, HttpStatusCodeLiteral } from 'tsoa'
 import { Request } from 'express'
-import { XoRecord } from '@vates/types'
+import { XoRecord } from '@vates/types/xo'
 
+import { BASE_URL } from '../index.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { makeObjectMapper } from '../helpers/object-wrapper.helper.mjs'
 import type { WithHref } from '../helpers/helper.type.mjs'
+
+const noop = () => {}
 
 export abstract class BaseController<T extends XoRecord, IsSync extends boolean> extends Controller {
   abstract getObjects(): IsSync extends false ? Promise<Record<T['id'], T>> : Record<T['id'], T>
@@ -22,5 +25,40 @@ export abstract class BaseController<T extends XoRecord, IsSync extends boolean>
     const mappedObjects = objects.map(mapper) as string[] | WithHref<T>[] | WithHref<Partial<T>>[]
 
     return mappedObjects
+  }
+
+  /**
+   * statusCode must represent the status code in case of a synchronous request. Default 200
+   */
+  async createAction<CbType>(
+    cb: () => CbType,
+    {
+      statusCode = 200,
+      sync = false,
+      taskProperties,
+    }: {
+      statusCode?: HttpStatusCodeLiteral
+      sync?: boolean
+      taskProperties: { name: string; objectId: T['id']; args?: Record<string, unknown>; [key: string]: unknown }
+    }
+  ) {
+    taskProperties.name = 'REST API: ' + taskProperties.name
+    taskProperties.type = 'xo:rest-api:action'
+
+    const task = this.restApi.tasks.create(taskProperties)
+    const pResult = task.run(cb)
+
+    if (sync) {
+      this.setStatus(statusCode)
+      return pResult
+    } else {
+      pResult.catch(noop)
+      const location = `${BASE_URL}/tasks/${task.id}`
+      this.setStatus(202)
+      this.setHeader('Location', location)
+      this.setHeader('Content-Type', 'text/plain')
+
+      return location
+    }
   }
 }

--- a/@xen-orchestra/rest-api/src/abstract-classes/xapi-xo-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/xapi-xo-controller.mts
@@ -1,23 +1,19 @@
 import * as CM from 'complex-matcher'
-import { Controller, HttpStatusCodeLiteral } from 'tsoa'
-import { Request } from 'express'
+import { HttpStatusCodeLiteral } from 'tsoa'
 import type { XapiXoRecord } from '@vates/types/xo'
 
 import { BASE_URL } from '../index.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
-import { makeObjectMapper } from '../helpers/object-wrapper.helper.mjs'
-import type { WithHref } from '../helpers/helper.type.mjs'
+import { BaseController } from './base-controller.mjs'
 
 const noop = () => {}
 
-export abstract class XapiXoController<T extends XapiXoRecord> extends Controller {
+export abstract class XapiXoController<T extends XapiXoRecord> extends BaseController<T, true> {
   #type: T['type']
-  restApi: RestApi
 
   constructor(type: T['type'], restApi: RestApi) {
-    super()
+    super(restApi)
     this.#type = type
-    this.restApi = restApi
   }
 
   getObjects({ filter, limit }: { filter?: string; limit?: number } = {}): Record<T['id'], T> {
@@ -29,13 +25,6 @@ export abstract class XapiXoController<T extends XapiXoRecord> extends Controlle
 
   getObject(id: T['id']): T {
     return this.restApi.getObject<T>(id, this.#type)
-  }
-
-  sendObjects(objects: T[], req: Request): string[] | WithHref<T>[] | WithHref<Partial<T>>[] {
-    const mapper = makeObjectMapper(req)
-    const mappedObjects = objects.map(mapper) as string[] | WithHref<T>[] | WithHref<Partial<T>>[]
-
-    return mappedObjects
   }
 
   getXapiObject(maybeId: T['id'] | T) {

--- a/@xen-orchestra/rest-api/src/abstract-classes/xapi-xo-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/xapi-xo-controller.mts
@@ -1,12 +1,8 @@
 import * as CM from 'complex-matcher'
-import { HttpStatusCodeLiteral } from 'tsoa'
 import type { XapiXoRecord } from '@vates/types/xo'
 
-import { BASE_URL } from '../index.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { BaseController } from './base-controller.mjs'
-
-const noop = () => {}
 
 export abstract class XapiXoController<T extends XapiXoRecord> extends BaseController<T, true> {
   #type: T['type']
@@ -29,40 +25,5 @@ export abstract class XapiXoController<T extends XapiXoRecord> extends BaseContr
 
   getXapiObject(maybeId: T['id'] | T) {
     return this.restApi.getXapiObject<T>(maybeId, this.#type)
-  }
-
-  /**
-   * statusCode must represent the status code in case of a synchronous request. Default 200
-   */
-  async createAction<CbType>(
-    cb: () => CbType,
-    {
-      statusCode = 200,
-      sync = false,
-      taskProperties,
-    }: {
-      statusCode?: HttpStatusCodeLiteral
-      sync?: boolean
-      taskProperties: { name: string; objectId: T['id']; args?: Record<string, unknown>; [key: string]: unknown }
-    }
-  ) {
-    taskProperties.name = 'REST API: ' + taskProperties.name
-    taskProperties.type = 'xo:rest-api:action'
-
-    const task = this.restApi.tasks.create(taskProperties)
-    const pResult = task.run(cb)
-
-    if (sync) {
-      this.setStatus(statusCode)
-      return pResult
-    } else {
-      pResult.catch(noop)
-      const location = `${BASE_URL}/tasks/${task.id}`
-      this.setStatus(202)
-      this.setHeader('Location', location)
-      this.setHeader('Content-Type', 'text/plain')
-
-      return location
-    }
   }
 }

--- a/@xen-orchestra/rest-api/src/abstract-classes/xo-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/xo-controller.mts
@@ -7,8 +7,8 @@ import { BaseController } from './base-controller.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 
 export abstract class XoController<T extends NonXapiXoRecord> extends BaseController<T, false> {
-  abstract _getObjects(): Promise<T[]>
-  abstract _getObject(id: T['id']): Promise<T>
+  abstract getAllCollectionObjects(): Promise<T[]>
+  abstract getCollectionObject(id: T['id']): Promise<T>
 
   constructor(@inject(RestApi) restApi: RestApi) {
     super(restApi)
@@ -17,7 +17,7 @@ export abstract class XoController<T extends NonXapiXoRecord> extends BaseContro
   async getObjects({ filter, limit = Infinity }: { filter?: string; limit?: number } = {}): Promise<
     Record<T['id'], T>
   > {
-    let objects = await this._getObjects()
+    let objects = await this.getAllCollectionObjects()
 
     if (filter !== undefined) {
       const predicate = CM.parse(filter).createPredicate()
@@ -38,6 +38,6 @@ export abstract class XoController<T extends NonXapiXoRecord> extends BaseContro
   }
 
   async getObject(id: T['id']): Promise<T> {
-    return this._getObject(id)
+    return this.getCollectionObject(id)
   }
 }

--- a/@xen-orchestra/rest-api/src/abstract-classes/xo-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/xo-controller.mts
@@ -1,0 +1,47 @@
+import * as CM from 'complex-matcher'
+import type { NonXapiXoRecord } from '@vates/types/xo'
+
+import { BaseController } from './base-controller.mjs'
+
+import { RestApi } from '../rest-api/rest-api.mjs'
+
+export abstract class XoController<T extends NonXapiXoRecord> extends BaseController<T, false> {
+  abstract _abstractGetObjects(): Promise<T[]>
+  abstract _abstractGetObject(id: T['id']): Promise<T>
+
+  constructor(restApi: RestApi) {
+    super(restApi)
+  }
+
+  async getObjects({
+    filter,
+    limit,
+  }: {
+    filter?: string
+    limit?: number
+  } = {}): Promise<Record<T['id'], T>> {
+    const _limit = limit ?? Infinity
+    let objects = await this._abstractGetObjects()
+
+    if (filter !== undefined) {
+      const predicate = CM.parse(filter).createPredicate()
+      objects = objects.filter(predicate)
+    }
+
+    if (_limit < objects.length) {
+      objects.length = _limit
+    }
+
+    const objectById = {} as Record<T['id'], T>
+
+    objects.forEach(obj => {
+      objectById[obj.id] = obj
+    })
+
+    return objectById
+  }
+
+  async getObject(id: T['id']): Promise<T> {
+    return this._abstractGetObject(id)
+  }
+}

--- a/@xen-orchestra/rest-api/src/helpers/object-wrapper.helper.mts
+++ b/@xen-orchestra/rest-api/src/helpers/object-wrapper.helper.mts
@@ -1,13 +1,13 @@
 import path from 'node:path'
 import pick from 'lodash/pick.js'
 import { Request } from 'express'
-import type { XapiXoRecord } from '@vates/types'
+import type { XoRecord } from '@vates/types'
 
 import type { WithHref } from './helper.type.mjs'
 
 const { join } = path.posix
 
-export function makeObjectMapper<T extends XapiXoRecord>(req: Request, path = req.path) {
+export function makeObjectMapper<T extends XoRecord>(req: Request, path = req.path) {
   const makeUrl = ({ id }: T) => join(path, typeof id === 'number' ? String(id) : id)
   let objectMapper: (object: T) => string | WithHref<Partial<T>> | WithHref<T>
 

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/server.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/server.oa-example.mts
@@ -1,0 +1,28 @@
+export const serverIds = [
+  '/rest/v0/servers/f07ab729-c0e8-721c-45ec-f11276377030',
+  '/rest/v0/servers/d5d1c4a3-4c5e-ca7b-6be8-33c824f87571',
+]
+
+export const partialServers = [
+  {
+    status: 'connected',
+    href: '/rest/v0/servers/63375ed4-6d71-4fce-91b0-0a98921b1f9f',
+  },
+  {
+    status: 'connected',
+    href: '/rest/v0/servers/7202d2b7-913a-473b-b6d1-39447a51643f',
+  },
+]
+
+export const server = {
+  host: '192.168.1.2',
+  label: 'MRA local',
+  username: 'root',
+  allowUnauthorized: true,
+  poolNameLabel: 'MRA local',
+  enabled: true,
+  readOnly: false,
+  id: '63375ed4-6d71-4fce-91b0-0a98921b1f9f',
+  status: 'connected',
+  poolId: 'b7569d99-30f8-178a-7d94-801de3e29b5b',
+}

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/server.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/server.oa-example.mts
@@ -5,10 +5,12 @@ export const serverIds = [
 
 export const partialServers = [
   {
+    id: '63375ed4-6d71-4fce-91b0-0a98921b1f9f',
     status: 'connected',
     href: '/rest/v0/servers/63375ed4-6d71-4fce-91b0-0a98921b1f9f',
   },
   {
+    id: '7202d2b7-913a-473b-b6d1-39447a51643f',
     status: 'connected',
     href: '/rest/v0/servers/7202d2b7-913a-473b-b6d1-39447a51643f',
   },

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
@@ -21,6 +21,10 @@ export class RestApi {
     return this.#xoApp.authenticateUser(...args)
   }
 
+  getAllXenServers() {
+    return this.#xoApp.getAllXenServers()
+  }
+
   getObject<T extends XapiXoRecord>(id: T['id'], type: T['type']) {
     return this.#xoApp.getObject(id, type)
   }
@@ -31,6 +35,11 @@ export class RestApi {
 
   getXapiObject<T extends XapiXoRecord>(maybeId: T['id'] | T, type: T['type']) {
     return this.#xoApp.getXapiObject<T>(maybeId, type)
+  }
+
+  // todo: do not expose this
+  getXenServer(...args: Parameters<XoApp['getXenServer']>) {
+    return this.#xoApp.getXenServer(...args)
   }
 
   runWithApiContext(...args: Parameters<XoApp['runWithApiContext']>) {

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
@@ -21,10 +21,6 @@ export class RestApi {
     return this.#xoApp.authenticateUser(...args)
   }
 
-  getAllXenServers() {
-    return this.#xoApp.getAllXenServers()
-  }
-
   getObject<T extends XapiXoRecord>(id: T['id'], type: T['type']) {
     return this.#xoApp.getObject(id, type)
   }
@@ -35,11 +31,6 @@ export class RestApi {
 
   getXapiObject<T extends XapiXoRecord>(maybeId: T['id'] | T, type: T['type']) {
     return this.#xoApp.getXapiObject<T>(maybeId, type)
-  }
-
-  // todo: do not expose this
-  getXenServer(...args: Parameters<XoApp['getXenServer']>) {
-    return this.#xoApp.getXenServer(...args)
   }
 
   runWithApiContext(...args: Parameters<XoApp['runWithApiContext']>) {

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -12,7 +12,7 @@ import type {
   XenApiVmWrapped,
   XenApiVtpmWrapped,
 } from '@vates/types/xen-api'
-import type { XoHost, XoUser, XapiXoRecord, XoVm } from '@vates/types/xo'
+import type { XoHost, XoServer, XoUser, XapiXoRecord, XoVm } from '@vates/types/xo'
 
 type XapiRecordByXapiXoRecord = {
   host: XenApiHostWrapped
@@ -42,6 +42,7 @@ export type XoApp = {
     userData?: { ip?: string },
     opts?: { bypassOtp?: boolean }
   ) => Promise<{ bypassOtp: boolean; expiration: number; user: XoUser }>
+  getAllXenServers(): Promise<XoServer[]>
   getObject: <T extends XapiXoRecord>(id: T['id'], type: T['type']) => T
   getObjectsByType: <T extends XapiXoRecord>(
     type: T['type'],
@@ -50,5 +51,6 @@ export type XoApp = {
   getXapiHostStats: (hostId: XoHost['id'], granularity?: XapiStatsGranularity) => Promise<XapiHostStats>
   getXapiObject: <T extends XapiXoRecord>(maybeId: T['id'] | T, type: T['type']) => XapiRecordByXapiXoRecord[T['type']]
   getXapiVmStats: (vmId: XoVm['id'], granularity?: XapiStatsGranularity) => Promise<XapiVmStats>
+  getXenServer(id: XoServer['id']): Promise<XoServer>
   runWithApiContext: (user: XoUser, fn: () => void) => Promise<unknown>
 }

--- a/@xen-orchestra/rest-api/src/servers/server.controller.mts
+++ b/@xen-orchestra/rest-api/src/servers/server.controller.mts
@@ -1,4 +1,4 @@
-import { Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
 import { Request as ExRequest } from 'express'
 import { inject } from 'inversify'
 import { provide } from 'inversify-binding-decorators'
@@ -7,19 +7,20 @@ import type { XoServer } from '@vates/types'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import type { Unbrand, WithHref } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
+import { partialServers, server, serverIds } from '../open-api/oa-examples/server.oa-example.mjs'
 
 @Route('servers')
 @Security('*')
-@Response(401)
+@Response(401, 'Authentication required')
 @Tags('servers')
 @provide(ServerController)
 export class ServerController extends XoController<XoServer> {
   // --- abstract methods
   _abstractGetObjects(): Promise<XoServer[]> {
-    return this.restApi.getAllXenServers()
+    return this.restApi.xoApp.getAllXenServers()
   }
   _abstractGetObject(id: XoServer['id']): Promise<XoServer> {
-    return this.restApi.getXenServer(id)
+    return this.restApi.xoApp.getXenServer(id)
   }
 
   constructor(@inject(RestApi) restApi: RestApi) {
@@ -31,6 +32,8 @@ export class ServerController extends XoController<XoServer> {
    * @example filter "status:/^connected$/"
    * @example limit 42
    */
+  @Example(serverIds)
+  @Example(partialServers)
   @Get('')
   async getServers(
     @Request() req: ExRequest,
@@ -38,15 +41,16 @@ export class ServerController extends XoController<XoServer> {
     @Query() filter?: string,
     @Query() limit?: number
   ): Promise<string[] | WithHref<Unbrand<XoServer>>[] | WithHref<Partial<Unbrand<XoServer>>>[]> {
-    const servers = Object.values(await this.getObjects({ filter, limit }))
-    return this.sendObjects(servers, req)
+    return this.sendObjects(Object.values(await this.getObjects({ filter, limit })), req)
   }
 
   /**
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    */
+  @Example(server)
   @Get('{id}')
-  getServer(@Path() id: string) {
+  @Response(404, 'Server not found')
+  getServer(@Path() id: string): Promise<Unbrand<XoServer>> {
     return this.getObject(id as XoServer['id'])
   }
 }

--- a/@xen-orchestra/rest-api/src/servers/server.controller.mts
+++ b/@xen-orchestra/rest-api/src/servers/server.controller.mts
@@ -1,12 +1,10 @@
 import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
 import { Request as ExRequest } from 'express'
-import { inject } from 'inversify'
 import { provide } from 'inversify-binding-decorators'
 import type { XoServer } from '@vates/types'
 
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { partialServers, server, serverIds } from '../open-api/oa-examples/server.oa-example.mjs'
-import { RestApi } from '../rest-api/rest-api.mjs'
 import type { WithHref } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
 
@@ -17,15 +15,11 @@ import { XoController } from '../abstract-classes/xo-controller.mjs'
 @provide(ServerController)
 export class ServerController extends XoController<XoServer> {
   // --- abstract methods
-  _abstractGetObjects(): Promise<XoServer[]> {
+  _getObjects(): Promise<XoServer[]> {
     return this.restApi.xoApp.getAllXenServers()
   }
-  _abstractGetObject(id: XoServer['id']): Promise<XoServer> {
+  _getObject(id: XoServer['id']): Promise<XoServer> {
     return this.restApi.xoApp.getXenServer(id)
-  }
-
-  constructor(@inject(RestApi) restApi: RestApi) {
-    super(restApi)
   }
 
   /**
@@ -41,7 +35,7 @@ export class ServerController extends XoController<XoServer> {
     @Query() fields?: string,
     @Query() filter?: string,
     @Query() limit?: number
-  ): Promise<string[] | WithHref<Unbrand<XoServer>>[] | WithHref<Partial<Unbrand<XoServer>>>[]> {
+  ): Promise<string[] | WithHref<Partial<Unbrand<XoServer>>>[]> {
     return this.sendObjects(Object.values(await this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/servers/server.controller.mts
+++ b/@xen-orchestra/rest-api/src/servers/server.controller.mts
@@ -29,7 +29,7 @@ export class ServerController extends XoController<XoServer> {
   }
 
   /**
-   * @example fields "status,uuid"
+   * @example fields "status,id"
    * @example filter "status:/^connected$/"
    * @example limit 42
    */

--- a/@xen-orchestra/rest-api/src/servers/server.controller.mts
+++ b/@xen-orchestra/rest-api/src/servers/server.controller.mts
@@ -4,14 +4,15 @@ import { inject } from 'inversify'
 import { provide } from 'inversify-binding-decorators'
 import type { XoServer } from '@vates/types'
 
-import { RestApi } from '../rest-api/rest-api.mjs'
-import type { Unbrand, WithHref } from '../helpers/helper.type.mjs'
-import { XoController } from '../abstract-classes/xo-controller.mjs'
+import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { partialServers, server, serverIds } from '../open-api/oa-examples/server.oa-example.mjs'
+import { RestApi } from '../rest-api/rest-api.mjs'
+import type { WithHref } from '../helpers/helper.type.mjs'
+import { XoController } from '../abstract-classes/xo-controller.mjs'
 
 @Route('servers')
 @Security('*')
-@Response(401, 'Authentication required')
+@Response(unauthorizedResp.status, unauthorizedResp.description)
 @Tags('servers')
 @provide(ServerController)
 export class ServerController extends XoController<XoServer> {
@@ -49,7 +50,7 @@ export class ServerController extends XoController<XoServer> {
    */
   @Example(server)
   @Get('{id}')
-  @Response(404, 'Server not found')
+  @Response(notFoundResp.status, notFoundResp.description)
   getServer(@Path() id: string): Promise<Unbrand<XoServer>> {
     return this.getObject(id as XoServer['id'])
   }

--- a/@xen-orchestra/rest-api/src/servers/server.controller.mts
+++ b/@xen-orchestra/rest-api/src/servers/server.controller.mts
@@ -1,0 +1,52 @@
+import { Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import { Request as ExRequest } from 'express'
+import { inject } from 'inversify'
+import { provide } from 'inversify-binding-decorators'
+import type { XoServer } from '@vates/types'
+
+import { RestApi } from '../rest-api/rest-api.mjs'
+import type { Unbrand, WithHref } from '../helpers/helper.type.mjs'
+import { XoController } from '../abstract-classes/xo-controller.mjs'
+
+@Route('servers')
+@Security('*')
+@Response(401)
+@Tags('servers')
+@provide(ServerController)
+export class ServerController extends XoController<XoServer> {
+  // --- abstract methods
+  _abstractGetObjects(): Promise<XoServer[]> {
+    return this.restApi.getAllXenServers()
+  }
+  _abstractGetObject(id: XoServer['id']): Promise<XoServer> {
+    return this.restApi.getXenServer(id)
+  }
+
+  constructor(@inject(RestApi) restApi: RestApi) {
+    super(restApi)
+  }
+
+  /**
+   * @example fields "status,uuid"
+   * @example filter "status:/^connected$/"
+   * @example limit 42
+   */
+  @Get('')
+  async getServers(
+    @Request() req: ExRequest,
+    @Query() fields?: string,
+    @Query() filter?: string,
+    @Query() limit?: number
+  ): Promise<string[] | WithHref<Unbrand<XoServer>>[] | WithHref<Partial<Unbrand<XoServer>>>[]> {
+    const servers = Object.values(await this.getObjects({ filter, limit }))
+    return this.sendObjects(servers, req)
+  }
+
+  /**
+   * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
+   */
+  @Get('{id}')
+  getServer(@Path() id: string) {
+    return this.getObject(id as XoServer['id'])
+  }
+}

--- a/@xen-orchestra/rest-api/src/servers/server.controller.mts
+++ b/@xen-orchestra/rest-api/src/servers/server.controller.mts
@@ -15,10 +15,10 @@ import { XoController } from '../abstract-classes/xo-controller.mjs'
 @provide(ServerController)
 export class ServerController extends XoController<XoServer> {
   // --- abstract methods
-  _getObjects(): Promise<XoServer[]> {
+  getAllCollectionObjects(): Promise<XoServer[]> {
     return this.restApi.xoApp.getAllXenServers()
   }
-  _getObject(id: XoServer['id']): Promise<XoServer> {
+  getCollectionObject(id: XoServer['id']): Promise<XoServer> {
     return this.restApi.xoApp.getXenServer(id)
   }
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,6 +29,8 @@
   - `/rest/v0/vdis/<vdi-id>` (PR [#8427](https://github.com/vatesfr/xen-orchestra/pull/8427))
   - `/rest/v0/vdi-snapshots` (PR [#8427](https://github.com/vatesfr/xen-orchestra/pull/8427))
   - `/rest/v0/vdi-snapshots/<vdi-snapshot-id>` (PR [#8427](https://github.com/vatesfr/xen-orchestra/pull/8427))
+  - `/rest/v0/servers` (PR [#8385](https://github.com/vatesfr/xen-orchestra/pull/8385))
+  - `/rest/v0/servers/<server-id>` (PR [#8385](https://github.com/vatesfr/xen-orchestra/pull/8385))
 - [New VM] Configure ACLs directly from VM creation form [#6996](https://github.com/vatesfr/xen-orchestra/issues/6996) (PR [#8412](https://github.com/vatesfr/xen-orchestra/pull/8412))
 - [Netbox] Support version 4.2.x (PR [#8417](https://github.com/vatesfr/xen-orchestra/pull/8417))
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -617,6 +617,7 @@ export default class RestApi {
       vbds: {},
       vdis: {},
       'vdi-snapshots': {},
+      servers: {},
     }
 
     const withParams = (fn, paramsSchema) => {
@@ -992,14 +993,6 @@ export default class RestApi {
           app.tasks.off('update', onUpdate).off('remove', onRemove)
         })
         return stream[Symbol.asyncIterator]()
-      },
-    }
-    collections.servers = {
-      getObject(id) {
-        return app.getXenServer(id)
-      },
-      async getObjects(filter, limit) {
-        return handleArray(await app.getAllXenServers(), filter, limit)
       },
     }
     collections.users = {


### PR DESCRIPTION
### Description

Implement the mecanism to expose non XAPI object endpoints:

- Added a new type, `NonXapiXoRecord`, which represents all XO objects that are not XAPI objects (e.g., users, servers, groups, etc.).
- Split `XapiXoController` to create `BaseController`, allowing code reuse between `XapiXoController` and the new `XoController`.
- `BaseController` exposes `sendObjects` and `createAction` (unchanged) and enforces subclasses to define the `getObject` and `getObjects` methods.
- `XoController` requires subclasses to implement `getAllCollectionObjects` and `getCollectionObject`, as these are used in its `getObjects` and `getObject` methods.
- `filter` and `limit` are handled by xo-server for XAPI objects. `XoController` implements its own filter and limit mechanisms for all non XAPI object in `getObjects`

And finally expose `/rest/v0/servers` and `/rest/v0/servers/<server-id>`🥳

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
