### PR TITLE
feat(@xen-orchestra/rest-api): mutualize code for better qol

### DIFF
--- a/@xen-orchestra/rest-api/src/helpers/helper.type.mts
+++ b/@xen-orchestra/rest-api/src/helpers/helper.type.mts
@@ -1,16 +1,1 @@
-import { Branded } from '@vates/types'
-
-// Required because Branded<string> is not a primitive type
-// and TSOA is not able to correctly convert Branded when generating
-// the openapi specification
-export type Unbrand<T> = {
-  [K in keyof T]: T[K] extends Branded<string> | undefined
-    ? string | undefined
-    : T[K] extends Branded<string>[]
-      ? string[]
-      : T[K] extends Branded<string>
-        ? string
-        : T[K]
-}
-
 export type WithHref<T> = T & { href: string }

--- a/@xen-orchestra/rest-api/src/hosts/host.controller.mts
+++ b/@xen-orchestra/rest-api/src/hosts/host.controller.mts
@@ -1,4 +1,4 @@
-import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import { Example, Get, Path, Queries, Query, Request, Response, Route, Security, Tags } from 'tsoa'
 import type { Request as ExRequest } from 'express'
 import { inject } from 'inversify'
 import { provide } from 'inversify-binding-decorators'
@@ -14,6 +14,7 @@ import {
   unauthorizedResp,
   type Unbrand,
 } from '../open-api/common/response.common.mjs'
+import type { CollectionQueryParams } from '../open-api/common/request.common.mjs'
 
 @Route('hosts')
 @Security('*')
@@ -35,10 +36,9 @@ export class HostController extends XapiXoController<XoHost> {
   @Get('')
   getHosts(
     @Request() req: ExRequest,
-    @Query() fields?: string,
-    @Query() filter?: string,
-    @Query() limit?: number
+    @Queries() queries: CollectionQueryParams
   ): string[] | WithHref<Unbrand<XoHost>>[] | WithHref<Partial<Unbrand<XoHost>>>[] {
+    const { filter, limit } = queries
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/hosts/host.controller.mts
+++ b/@xen-orchestra/rest-api/src/hosts/host.controller.mts
@@ -6,12 +6,18 @@ import type { XapiHostStats, XapiStatsGranularity, XoHost } from '@vates/types'
 
 import { host, hostIds, hostStats, partialHosts } from '../open-api/oa-examples/host.oa-example.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
-import type { Unbrand, WithHref } from '../helpers/helper.type.mjs'
+import type { WithHref } from '../helpers/helper.type.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
+import {
+  internalServerErrorResp,
+  notFoundResp,
+  unauthorizedResp,
+  type Unbrand,
+} from '../open-api/common/response.common.mjs'
 
 @Route('hosts')
 @Security('*')
-@Response(401, 'Authentication required')
+@Response(unauthorizedResp.status, unauthorizedResp.description)
 @Tags('hosts')
 @provide(HostController)
 export class HostController extends XapiXoController<XoHost> {
@@ -41,7 +47,7 @@ export class HostController extends XapiXoController<XoHost> {
    */
   @Example(host)
   @Get('{id}')
-  @Response(404, 'Host not found')
+  @Response(notFoundResp.status, notFoundResp.description)
   getHost(@Path() id: string): Unbrand<XoHost> {
     return this.getObject(id as XoHost['id'])
   }
@@ -52,9 +58,9 @@ export class HostController extends XapiXoController<XoHost> {
    */
   @Example(hostStats)
   @Get('{id}/stats')
-  @Response(404, 'Host not found')
+  @Response(notFoundResp.status, notFoundResp.description)
   @Response(422, 'Invalid granularity')
-  @Response(500, 'Internal server error, XenServer/XCP-ng error')
+  @Response(internalServerErrorResp.status, internalServerErrorResp.description)
   getHostStats(@Path() id: string, @Query() granularity?: XapiStatsGranularity): Promise<XapiHostStats> {
     return this.restApi.xoApp.getXapiHostStats(id as XoHost['id'], granularity)
   }

--- a/@xen-orchestra/rest-api/src/open-api/common/request.common.mts
+++ b/@xen-orchestra/rest-api/src/open-api/common/request.common.mts
@@ -1,0 +1,5 @@
+export interface CollectionQueryParams {
+  fields?: string
+  filter?: string
+  limit?: number
+}

--- a/@xen-orchestra/rest-api/src/open-api/common/response.common.mts
+++ b/@xen-orchestra/rest-api/src/open-api/common/response.common.mts
@@ -1,0 +1,29 @@
+import { Branded } from '@vates/types'
+
+// Required because Branded<string> is not a primitive type
+// and TSOA is not able to correctly convert Branded when generating
+// the openapi specification
+export type Unbrand<T> = {
+  [K in keyof T]: T[K] extends Branded<string> | undefined
+    ? string | undefined
+    : T[K] extends Branded<string>[]
+      ? string[]
+      : T[K] extends Branded<string>
+        ? string
+        : T[K]
+}
+
+export const unauthorizedResp = {
+  status: 401,
+  description: 'Authentication required',
+} as const
+
+export const notFoundResp = {
+  status: 404,
+  description: 'Resource not found',
+} as const
+
+export const internalServerErrorResp = {
+  status: 500,
+  description: 'Internal server error, XenServer/XCP-ng error',
+} as const

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -1,4 +1,4 @@
-import { Example, Get, Path, Queries, Request, Response, Route, Security, Tags } from 'tsoa'
+import { Example, Get, Path, Queries, Query, Request, Response, Route, Security, Tags } from 'tsoa'
 import { Request as ExRequest } from 'express'
 import { inject } from 'inversify'
 import { incorrectState, invalidParameters } from 'xo-common/api-errors.js'
@@ -60,7 +60,7 @@ export class VmController extends XapiXoController<XoVm> {
    */
   @Example(vmStatsExample)
   @Get('{id}/stats')
-  @Response(404, 'VM not found')
+  @Response(notFoundResp.status, notFoundResp.description)
   @Response(422, 'Invalid granularity, VM is halted or host could not be found')
   async getVmStats(@Path() id: string, @Query() granularity?: XapiStatsGranularity): Promise<XapiVmStats> {
     try {


### PR DESCRIPTION
### Description

- Created a const for common response documentation
- Moved Unbrand type to `open-api/response.commont.mts` as it should only be used on API responses for open-api documentation
- Created a `CollectionQueryParams` to avoid code duplication every time we create a get<Collections> endpoint

~~Wait for #8359, #8372~~ 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
