### PR TITLE
fix(@xen-orchestra/rest-api): fix null values not displayed as nullable

### DIFF
--- a/@xen-orchestra/rest-api/tsoa.json
+++ b/@xen-orchestra/rest-api/tsoa.json
@@ -21,5 +21,8 @@
     "basePath": "/rest/v0",
     "authenticationModule": "./src/middlewares/authentication.middleware.mts",
     "iocModule": "./src/ioc/ioc.mts"
+  },
+  "compilerOptions": {
+    "strictNullChecks": true
   }
 }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,4 +31,6 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/rest-api patch
+
 <!--packages-end-->


### PR DESCRIPTION
### Description

This option is required to not loose the `nullable` option on `null` properties when using dynamic type.
E.g.
```ts
type WithFoo <T> = T {foo: string} 
```
```ts
WithFoo<{bar: null | string}> 
```
Will return this openapi spec: 
```
type: object,
properties: {
   bar: {
     type: string
   },
   foo: {
     type: string
   }
}
```

With this option enabled, it will generate a spec like:
```
type: object,
properties: {
   bar: {
     type: string,
     nullable: true
   },
   foo: {
     type: string
   }
}
```


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
