### PR TITLE
feat(xo-core): add UiProgressBar component

### DIFF
--- a/@xen-orchestra/lite/src/stories/web-core/ui/progress-bar/ui-progress-bar.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/progress-bar/ui-progress-bar.story.vue
@@ -5,7 +5,7 @@
       prop('legend').preset('Legend').required().widget(),
       prop('value').preset(25).required().widget(),
       prop('max').num().widget(),
-      prop('steps').arr('number').help('Meant to display steps values under the progress bar. See Presets.').widget(),
+      prop('showSteps').bool().help('Meant to display steps values under the progress bar. See Presets.').widget(),
     ]"
     :presets
   >
@@ -19,32 +19,23 @@ import { prop } from '@/libs/story/story-param'
 import UiProgressBar from '@core/components/ui/progress-bar/UiProgressBar.vue'
 
 const presets = {
-  '>= 80': {
+  'Warning >= 80%': {
     props: {
       legend: 'Ram usage',
       value: 80,
-      steps: undefined,
     },
   },
-  '>= 90': {
+  'Danger >= 90%': {
     props: {
       legend: 'Ram usage',
       value: 95,
-      steps: undefined,
     },
   },
   'With steps': {
     props: {
       legend: 'Ram usage',
-      value: 50,
-      steps: [0, 100, 200],
-    },
-  },
-  'With steps >= 80': {
-    props: {
-      legend: 'Ram usage',
-      value: 160,
-      steps: [0, 100, 200],
+      value: 250,
+      max: 200,
     },
   },
 }

--- a/@xen-orchestra/lite/src/stories/web-core/ui/progress-bar/ui-progress-bar.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/progress-bar/ui-progress-bar.story.vue
@@ -1,0 +1,51 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties }"
+    :params="[
+      prop('legend').preset('Legend').required().widget(),
+      prop('value').preset(25).required().widget(),
+      prop('max').num().widget(),
+      prop('steps').arr('number').help('Meant to display steps values under the progress bar. See Presets.').widget(),
+    ]"
+    :presets
+  >
+    <UiProgressBar v-bind="properties" />
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import { prop } from '@/libs/story/story-param'
+import UiProgressBar from '@core/components/ui/progress-bar/UiProgressBar.vue'
+
+const presets = {
+  '>= 80': {
+    props: {
+      legend: 'Ram usage',
+      value: 80,
+      steps: undefined,
+    },
+  },
+  '>= 90': {
+    props: {
+      legend: 'Ram usage',
+      value: 95,
+      steps: undefined,
+    },
+  },
+  'With steps': {
+    props: {
+      legend: 'Ram usage',
+      value: 50,
+      steps: [0, 100, 200],
+    },
+  },
+  'With steps >= 80': {
+    props: {
+      legend: 'Ram usage',
+      value: 160,
+      steps: [0, 100, 200],
+    },
+  },
+}
+</script>

--- a/@xen-orchestra/web-core/lib/components/ui/progress-bar/UiProgressBar.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/progress-bar/UiProgressBar.vue
@@ -1,0 +1,111 @@
+<!-- v2 -->
+<template>
+  <div class="ui-progress-bar" :class="accentClass">
+    <div class="progress-bar">
+      <div class="segment" :style="{ width: `${percentage}%` }" />
+    </div>
+    <div v-if="steps" class="steps typo-body-regular-small">
+      <span>{{ $n(steps[0] / 100, 'percent') }}</span>
+      <span>{{ $n(steps[1] / 100, 'percent') }}</span>
+      <span>{{ $n(steps[2] / 100, 'percent') }}</span>
+    </div>
+    <VtsLegendList class="legend">
+      <UiLegend :accent :value="rawPercentage" unit="%">{{ legend }}</UiLegend>
+    </VtsLegendList>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import VtsLegendList from '@core/components/legend-list/VtsLegendList.vue'
+import UiLegend from '@core/components/ui/legend/UiLegend.vue'
+import { toVariants } from '@core/utils/to-variants.util'
+import { computed } from 'vue'
+
+const {
+  value,
+  max = 100,
+  steps,
+} = defineProps<{
+  legend: string
+  value: number
+  max?: number
+  steps?: [min: number, half: number, max: number]
+}>()
+
+const rawPercentage = computed(() => Math.round((value / max) * 1000) / 10)
+
+const percentage = computed(() => {
+  if (!steps) {
+    return rawPercentage.value
+  }
+
+  const relativeValue = (value / max) * 100
+
+  return Math.min(100, Math.round(relativeValue * steps?.[1]) / steps?.[2])
+})
+
+const accent = computed(() => {
+  if (percentage.value >= 90) {
+    return 'danger'
+  }
+
+  if (percentage.value >= 80) {
+    return 'warning'
+  }
+
+  return 'info'
+})
+
+const accentClass = computed(() => toVariants({ accent: accent.value }))
+</script>
+
+<style lang="postcss" scoped>
+.ui-progress-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+
+  .progress-bar {
+    width: 100%;
+    height: 1.2rem;
+    border-radius: 0.4rem;
+    overflow: hidden;
+    background-color: var(--color-neutral-background-disabled);
+
+    .segment {
+      height: 100%;
+      transition: width 0.25s ease-in-out;
+    }
+  }
+
+  .steps {
+    color: var(--color-neutral-txt-secondary);
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .legend {
+    margin-inline-start: auto;
+  }
+
+  /* ACCENT */
+
+  &.accent--info {
+    .segment {
+      background-color: var(--color-info-item-base);
+    }
+  }
+
+  &.accent--warning {
+    .segment {
+      background-color: var(--color-warning-item-base);
+    }
+  }
+
+  &.accent--danger {
+    .segment {
+      background-color: var(--color-danger-item-base);
+    }
+  }
+}
+</style>

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -57,6 +57,7 @@
 - @xen-orchestra/backups patch
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/vmware-explorer patch
+- @xen-orchestra/web-core minor
 - @xen-orchestra/xapi patch
 - xo-server minor
 - xo-server-audit minor


### PR DESCRIPTION
### Description

Add `UiProgressBar` component.

The steps’ display behavior is as follows:
- when the prop `showSteps` is set to `true`, the values `0%` and `100%` are displayed for percentages under 100
- when the prop `showSteps` is set to `true` or percentage exceeds 100, the steps are always shown and updated according to the current percentage (see examples in the screenshot below)

### Screenshots

![ui-progress-bar](https://github.com/user-attachments/assets/0f776c12-8fb3-4d88-8526-524fbee31015)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
