### PR TITLE
fix(netbox/name-dedup): perform a case-insensitive name comparison

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,6 +32,8 @@
 - [Plugins/Perf-alert] Fixing alert email notifications to be resent every minute for no reason [Forum#9658](https://xcp-ng.org/forum/topic/9658/lots-of-performance-alerts-after-upgrading-xo-to-commit-aa490) [Forum#10447](https://xcp-ng.org/forum/topic/10447/perf-alert-plugin-lots-of-alerts-but-no-option-to-exclude-sr) (PR [#8408](https://github.com/vatesfr/xen-orchestra/pull/8408))
 - [Netbox] Fix synchronization not working if `checkNetboxVersion` is disabled in the config (PR [#8416](https://github.com/vatesfr/xen-orchestra/pull/8416))
 - [Continuous replication]: Fix `"Expected "actual" to be strictly unequal to: undefined"` when adding a new disk to an already replicated VM (PR [#8400](https://github.com/vatesfr/xen-orchestra/pull/8400))
+- [Netbox] Fix `500 Internal Server Error` when 2 VMs have the same name but different case (PR [#8413](https://github.com/vatesfr/xen-orchestra/pull/8413))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/packages/xo-server-netbox/src/name-dedup.js
+++ b/packages/xo-server-netbox/src/name-dedup.js
@@ -23,7 +23,8 @@ export function indexName(name, index) {
 export function deduplicateName(name, usedNames) {
   let index = 1
   let uniqName = name
-  while (index < 1e3 && usedNames.includes(uniqName)) {
+  usedNames = usedNames.map(usedName => usedName.toLowerCase())
+  while (index < 1e3 && usedNames.includes(uniqName.toLowerCase())) {
     uniqName = indexName(name, index++, NAME_MAX_LENGTH)
   }
   if (index === 1e3) {
@@ -46,5 +47,5 @@ export function compareNames(original, copy) {
   }
 
   const match = copy.match(/.* \((\d+)\)$/)
-  return match !== null && indexName(original, match[1], NAME_MAX_LENGTH) === copy
+  return match !== null && indexName(original, match[1], NAME_MAX_LENGTH).toLowerCase() === copy.toLowerCase()
 }


### PR DESCRIPTION
### Description

Netbox doesn't allow 2 VM names to be equal within the same cluster even if they don't have the same case.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
