### PR TITLE
fix(@xen-orchestra/lite): fix JSONRPC request type

### DIFF
--- a/@xen-orchestra/lite/src/libs/xen-api/xen-api.ts
+++ b/@xen-orchestra/lite/src/libs/xen-api/xen-api.ts
@@ -77,11 +77,11 @@ export default class XenApi {
     this.fromToken = undefined
   }
 
-  private request<T>(method: string, args: any[] = []): PromiseLike<T> {
-    return this.client.request(method, args)
+  private request<T>(method: string, args: unknown[] = []) {
+    return this.client.request(method, args) as Promise<T>
   }
 
-  call = <T>(method: string, args: any[] = []): PromiseLike<T> => {
+  call = <T>(method: string, args: unknown[] = []): Promise<T> => {
     return this.request(method, [this.sessionId, ...args])
   }
 


### PR DESCRIPTION
### Description

`client.request` is typed as `PromiseLike` in the `json-rpc-2.0` lib. But in our use, `client.request` is always a `Promise`.
Also use `unknown` instead of `any`

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
