### PR TITLE
fix(@xen-orchestra/rest-api): remove mutualization of query params

### DIFF
--- a/@xen-orchestra/rest-api/src/hosts/host.controller.mts
+++ b/@xen-orchestra/rest-api/src/hosts/host.controller.mts
@@ -1,4 +1,4 @@
-import { Example, Get, Path, Queries, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
 import type { Request as ExRequest } from 'express'
 import { inject } from 'inversify'
 import { provide } from 'inversify-binding-decorators'

--- a/@xen-orchestra/rest-api/src/hosts/host.controller.mts
+++ b/@xen-orchestra/rest-api/src/hosts/host.controller.mts
@@ -14,7 +14,6 @@ import {
   unauthorizedResp,
   type Unbrand,
 } from '../open-api/common/response.common.mjs'
-import type { CollectionQueryParams } from '../open-api/common/request.common.mjs'
 
 @Route('hosts')
 @Security('*')
@@ -36,9 +35,10 @@ export class HostController extends XapiXoController<XoHost> {
   @Get('')
   getHosts(
     @Request() req: ExRequest,
-    @Queries() queries: CollectionQueryParams
+    @Query() fields?: string,
+    @Query() filter?: string,
+    @Query() limit?: number
   ): string[] | WithHref<Unbrand<XoHost>>[] | WithHref<Partial<Unbrand<XoHost>>>[] {
-    const { filter, limit } = queries
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/open-api/common/request.common.mts
+++ b/@xen-orchestra/rest-api/src/open-api/common/request.common.mts
@@ -1,5 +1,0 @@
-export interface CollectionQueryParams {
-  fields?: string
-  filter?: string
-  limit?: number
-}

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -1,24 +1,10 @@
-import {
-  Example,
-  Get,
-  Path,
-  Post,
-  Queries,
-  Query,
-  Request,
-  Response,
-  Route,
-  Security,
-  Tags,
-  SuccessResponse,
-} from 'tsoa'
+import { Example, Get, Path, Post, Query, Request, Response, Route, Security, Tags, SuccessResponse } from 'tsoa'
 import { Request as ExRequest } from 'express'
 import { inject } from 'inversify'
 import { incorrectState, invalidParameters } from 'xo-common/api-errors.js'
 import { provide } from 'inversify-binding-decorators'
 import type { XapiStatsGranularity, XapiVmStats, XoVm } from '@vates/types'
 
-import { CollectionQueryParams } from '../open-api/common/request.common.mjs'
 import {
   actionAsyncroneResp,
   internalServerErrorResp,
@@ -56,9 +42,10 @@ export class VmController extends XapiXoController<XoVm> {
   @Get('')
   getVms(
     @Request() req: ExRequest,
-    @Queries() queries: CollectionQueryParams
+    @Query() fields?: string,
+    @Query() filter?: string,
+    @Query() limit?: number
   ): string[] | WithHref<Unbrand<XoVm>>[] | WithHref<Partial<Unbrand<XoVm>>>[] {
-    const { filter, limit } = queries
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 


### PR DESCRIPTION
### Description

Mutualiztion of query params require to also mutualize examples.
Introduced by 0951d56

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
