### PR TITLE
feat(web-core): create useMapper composable

### DIFF
--- a/@xen-orchestra/web-core/lib/composables/mapper.composable.md
+++ b/@xen-orchestra/web-core/lib/composables/mapper.composable.md
@@ -1,0 +1,74 @@
+# `useMapper` composable
+
+This composable maps values from one type to another using a mapping record. It takes a source value, a mapping object, and a default value to use when the source value is undefined or not found in the mapping.
+
+## Usage
+
+```ts
+const mappedValue = useMapper(sourceValue, mapping, defaultValue)
+```
+
+|                | Required | Type                      | Default |                                                                                   |
+| -------------- | :------: | ------------------------- | ------- | --------------------------------------------------------------------------------- |
+| `sourceValue`  |    ✓     | `MaybeRefOrGetter<TFrom>` |         | The source value to be mapped. Can be a ref, a getter function, or a raw value    |
+| `mapping`      |    ✓     | `Record<TFrom, TTo>`      |         | An object mapping source values to destination values                             |
+| `defaultValue` |    ✓     | `MaybeRefOrGetter<TTo>`   |         | The default value to use when the source is undefined or not found in the mapping |
+
+## Return value
+
+|               | Type               |                                                  |
+| ------------- | ------------------ | ------------------------------------------------ |
+| `mappedValue` | `ComputedRef<TTo>` | A computed reference containing the mapped value |
+
+## Example
+
+```vue
+<template>
+  <div>
+    <p>Selected car color: {{ carColor }}</p>
+    <p>Recommended wall color: {{ wallColor }}</p>
+
+    <button @click="carColor = 'red'">Red Car</button>
+    <button @click="carColor = 'blue'">Blue Car</button>
+    <button @click="carColor = 'black'">Black Car</button>
+    <button @click="carColor = 'green'">Green Car</button>
+    <button @click="carColor = 'silver'">Silver Car</button>
+    <button @click="carColor = undefined">No Car</button>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { useMapper } from '@/composables/mapper'
+import { ref } from 'vue'
+
+// Source type
+type CarColor = 'red' | 'blue' | 'black' | 'green' | 'silver'
+
+// Destination type
+type WallColor = 'beige' | 'lightGray' | 'cream' | 'white'
+
+// Create a ref for the source value
+const carColor = ref<CarColor | undefined>(undefined)
+
+// Create a computed property that maps car color to wall color
+const wallColor = useMapper<CarColor, WallColor>(
+  carColor,
+  {
+    red: 'beige',
+    blue: 'lightGray',
+    black: 'cream',
+    green: 'beige',
+    silver: 'lightGray',
+  },
+  'white'
+)
+</script>
+```
+
+In this example:
+
+- When `carColor.value` is `'red'` or `'green'`, `wallColor.value` will be `'beige'`
+- When `carColor.value` is `'blue'` or `'silver'`, `wallColor.value` will be `'lightGray'`
+- When `carColor.value` is `'black'`, `wallColor.value` will be `'cream'`
+- When `carColor.value` is `undefined` or any value not in the mapping, `wallColor.value` will be
+  `'white'` (the default value)

--- a/@xen-orchestra/web-core/lib/composables/mapper.composable.ts
+++ b/@xen-orchestra/web-core/lib/composables/mapper.composable.ts
@@ -1,0 +1,18 @@
+import { computed, type ComputedRef, type MaybeRefOrGetter, toValue } from 'vue'
+
+export function useMapper<TFrom extends string | number, TTo>(
+  _source: MaybeRefOrGetter<TFrom | undefined>,
+  mapping: Record<TFrom, TTo>,
+  _defaultValue: MaybeRefOrGetter<TTo>
+): ComputedRef<TTo> {
+  return computed(() => {
+    const source = toValue(_source)
+    const defaultValue = toValue(_defaultValue)
+
+    if (source === undefined) {
+      return defaultValue
+    }
+
+    return Object.prototype.hasOwnProperty.call(mapping, source) ? mapping[source] : defaultValue
+  })
+}


### PR DESCRIPTION
### Description

Simple composable to map a reactive value to another one.

Will be mainly used to map incompatible accents between components.

```ts
const from = ref()

const to = useMapper(from, {
  A: 'X',
  B: undefined,
  C: 'Y',
}, 'Default')

from.value = undefined // to.value === 'Default'
from.value = 'A'       // to.value === 'X'
from.value = 'B'       // to.value === undefined
from.value = 'C'       // to.value === 'Y'
from.value = 'Invalid' // to.value === 'Default'
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
