### PR TITLE
fix(@vates/types): enhance xen-api and xo types

### DIFF
--- a/@vates/types/src/common.mts
+++ b/@vates/types/src/common.mts
@@ -645,6 +645,10 @@ export const CERTIFICATE_TYPE = {
 
 export type CERTIFICATE_TYPE = (typeof CERTIFICATE_TYPE)[keyof typeof CERTIFICATE_TYPE]
 
+export const OPAQUE_REF = { EMPTY: 'OpaqueRef:NULL' } as const
+
+export type OPAQUE_REF_NULL = (typeof OPAQUE_REF)['EMPTY']
+
 // ----- XAPI Stats
 
 type XapiStatsResponse<T> = {

--- a/@vates/types/src/xen-api.mts
+++ b/@vates/types/src/xen-api.mts
@@ -23,6 +23,7 @@ import type {
   ON_CRASH_BEHAVIOUR,
   ON_NORMAL_EXIT,
   ON_SOFTREBOOT_BEHAVIOR,
+  OPAQUE_REF_NULL,
   PERSISTENCE_BACKEND,
   PGPU_DOM0_ACCESS,
   PIF_IGMP_STATUS,
@@ -88,16 +89,16 @@ export interface XenApiSession {
   auth_user_sid: string
   client_certificate?: boolean
   is_local_superuser: boolean
-  last_active?: string
+  last_active: string
   originator: string
   other_config: Record<string, string>
-  parent?: XenApiSession['$ref']
-  pool?: boolean
+  parent: XenApiSession['$ref'] | OPAQUE_REF_NULL
+  pool: boolean
   rbac_permissions: string[]
-  subject?: XenApiSubject['$ref']
+  subject: XenApiSubject['$ref'] | OPAQUE_REF_NULL
   tasks: XenApiTask['$ref'][]
-  this_host?: XenApiHost['$ref']
-  this_user?: XenApiUser['$ref']
+  this_host: XenApiHost['$ref']
+  this_user: XenApiUser['$ref']
   uuid: string
   validation_time: string
 }
@@ -127,32 +128,32 @@ export interface XenApiTask {
   $ref: Branded<'task'>
   allowed_operations: TASK_ALLOWED_OPERATIONS[]
   backtrace: string
-  created?: string
+  created: string
   current_operations: Record<string, TASK_ALLOWED_OPERATIONS>
   error_info: string[]
-  finished?: string
+  finished: string
   name_description: string
   name_label: string
   other_config: Record<string, string>
-  progress?: number
-  resident_on?: XenApiHost['$ref']
-  result?: string
-  status?: TASK_STATUS_TYPE
-  subtask_of?: XenApiTask['$ref']
+  progress: number
+  resident_on: XenApiHost['$ref']
+  result: string
+  status: TASK_STATUS_TYPE
+  subtask_of: XenApiTask['$ref'] | OPAQUE_REF_NULL
   subtasks: XenApiTask['$ref'][]
-  type?: string
+  type: string
   uuid: string
 }
 
 export interface XenApiEvent {
   $ref: Branded<'event'>
-  class?: string
-  id?: number
+  class: string
+  id: number
   /** @deprecated */
   obj_uuid?: string
-  operation?: EVENT_OPERATION
-  ref?: string
-  snapshot?: object
+  operation: EVENT_OPERATION
+  ref: string
+  snapshot: object
   /** @deprecated */
   timestamp?: string
 }
@@ -165,10 +166,10 @@ export interface XenApiPool {
   client_certificate_auth_name?: string
   coordinator_bias: boolean
   cpu_info: Record<string, string>
-  crash_dump_SR?: XenApiSr['$ref']
+  crash_dump_SR: XenApiSr['$ref'] | OPAQUE_REF_NULL
   current_operations: Record<string, POOL_ALLOWED_OPERATIONS>
   custom_uefi_certificates?: string
-  default_SR?: XenApiSr['$ref']
+  default_SR: XenApiSr['$ref'] | OPAQUE_REF_NULL
   ext_auth_max_threads?: number
   guest_agent_config: Record<string, string>
   gui_config: Record<string, string>
@@ -186,25 +187,25 @@ export interface XenApiPool {
   last_update_sync?: string
   live_patching_disabled?: boolean
   local_auth_max_threads?: number
-  master?: XenApiHost['$ref']
+  master: XenApiHost['$ref']
   metadata_VDIs: XenApiVdi['$ref'][]
   migration_compression?: boolean
-  name_description?: string
-  name_label?: string
-  other_config?: Record<string, string>
+  name_description: string
+  name_label: string
+  other_config: Record<string, string>
   policy_no_vendor_device: boolean
   redo_log_enabled: boolean
-  redo_log_vdi?: XenApiVdi['$ref']
+  redo_log_vdi: XenApiVdi['$ref'] | OPAQUE_REF_NULL
   repositories?: XenApiRepository['$ref'][]
-  repository_proxy_password?: XenApiSecret['$ref']
+  repository_proxy_password?: XenApiSecret['$ref'] | OPAQUE_REF_NULL
   repository_proxy_url?: string
   repository_proxy_username?: string
   restrictions: Record<string, string>
-  suspend_image_SR?: XenApiSr['$ref']
+  suspend_image_SR: XenApiSr['$ref'] | OPAQUE_REF_NULL
   tags: string[]
   telemetry_frequency?: TELEMETRY_FREQUENCY
   telemetry_next_collection?: string
-  telemetry_uuid?: XenApiSecret['$ref']
+  telemetry_uuid?: XenApiSecret['$ref'] | OPAQUE_REF_NULL
   tls_verification_enabled?: boolean
   uefi_certificates?: string
   update_sync_day?: number
@@ -221,6 +222,7 @@ export interface XenApiPool {
 }
 export type XenApiPoolWrapped = WrapperXenApi<XenApiPool, 'pool'>
 
+/** @deprecated */
 export interface XenApiPoolPatch {
   $ref: Branded<'pool_patch'>
   after_apply_guidance: AFTER_APPLY_GUIDANCE[]
@@ -229,7 +231,7 @@ export interface XenApiPoolPatch {
   name_label: string
   other_config: Record<string, string>
   pool_applied: boolean
-  pool_update?: XenApiPoolUpdate['$ref']
+  pool_update?: XenApiPoolUpdate['$ref'] | OPAQUE_REF_NULL
   size: number
   uuid: string
   version: string
@@ -246,7 +248,7 @@ export interface XenApiPoolUpdate {
   name_label: string
   other_config?: Record<string, string>
   uuid: string
-  vdi?: XenApiVdi['$ref']
+  vdi: XenApiVdi['$ref']
   version?: string
 }
 
@@ -255,13 +257,13 @@ type XenApiVmCallMethods = {
 }
 export interface XenApiVm {
   $ref: Branded<'VM'>
-  actions_after_crash?: ON_CRASH_BEHAVIOUR
-  actions_after_reboot?: ON_NORMAL_EXIT
-  actions_after_shutdown?: ON_NORMAL_EXIT
+  actions_after_crash: ON_CRASH_BEHAVIOUR
+  actions_after_reboot: ON_NORMAL_EXIT
+  actions_after_shutdown: ON_NORMAL_EXIT
   actions_after_softreboot?: ON_SOFTREBOOT_BEHAVIOR
-  affinity?: XenApiHost['$ref']
+  affinity: XenApiHost['$ref'] | OPAQUE_REF_NULL
   allowed_operations: VM_OPERATIONS[]
-  appliance?: XenApiVmAppliance['$ref']
+  appliance: XenApiVmAppliance['$ref'] | OPAQUE_REF_NULL
   attached_PCIs: XenApiPci['$ref'][]
   bios_strings: Record<string, string>
   blobs: Record<string, XenApiBlob['$ref']>
@@ -271,80 +273,80 @@ export interface XenApiVm {
   crash_dumps: XenApiCrashdump['$ref'][]
   current_operations: Record<string, VM_OPERATIONS>
   domain_type?: DOMAIN_TYPE
-  domarch?: string
-  domid?: number
+  domarch: string
+  domid: number
   generation_id: string
-  guest_metrics?: XenApiVmGuestMetrics['$ref']
+  guest_metrics: XenApiVmGuestMetrics['$ref'] | OPAQUE_REF_NULL
   /** @deprecated */
   ha_always_run?: boolean
   ha_restart_priority: string
   hardware_platform_version: number
   has_vendor_device: boolean
-  HVM_boot_params?: Record<string, string>
+  HVM_boot_params: Record<string, string>
   /** @deprecated */
   HVM_boot_policy?: string
   HVM_shadow_multiplier: number
   is_a_snapshot: boolean
-  is_a_template?: boolean
-  is_control_domain?: boolean
+  is_a_template: boolean
+  is_control_domain: boolean
   is_default_template?: boolean
   /** @deprecated */
   is_snapshot_from_vmpp?: boolean
   is_vmss_snapshot?: boolean
   last_boot_CPU_flags: Record<string, string>
   last_booted_record: string
-  memory_dynamic_max?: number
-  memory_dynamic_min?: number
+  memory_dynamic_max: number
+  memory_dynamic_min: number
   memory_overhead: number
-  memory_static_max?: number
-  memory_static_min?: number
+  memory_static_max: number
+  memory_static_min: number
   /** @deprecated */
   memory_target?: number
-  metrics?: XenApiVmMetrics['$ref']
+  metrics: XenApiVmMetrics['$ref']
   name_description: string
   name_label: string
   NVRAM?: Record<string, string>
   order: number
-  other_config?: Record<string, string>
-  parent?: XenApiVm['$ref']
+  other_config: Record<string, string>
+  parent: XenApiVm['$ref'] | OPAQUE_REF_NULL
   /** @deprecated */
   PCI_bus?: string
   pending_guidances_full?: UPDATE_GUIDANCES[]
   pending_guidances_recommended?: UPDATE_GUIDANCES[]
   pending_guidances?: UPDATE_GUIDANCES[]
-  platform?: Record<string, string>
+  platform: Record<string, string>
   power_state: VM_POWER_STATE
   /** @deprecated */
-  protection_policy?: XenApiVmpp['$ref']
-  PV_args?: string
-  PV_bootloader_args?: string
-  PV_bootloader?: string
-  PV_kernel?: string
-  PV_legacy_args?: string
-  PV_ramdisk?: string
-  recommendations?: string
+  protection_policy?: XenApiVmpp['$ref'] | OPAQUE_REF_NULL
+  PV_args: string
+  PV_bootloader_args: string
+  PV_bootloader: string
+  PV_kernel: string
+  PV_legacy_args: string
+  PV_ramdisk: string
+  recommendations: string
   reference_label?: string
   requires_reboot?: boolean
-  resident_on?: XenApiHost['$ref']
-  scheduled_to_be_resident_on?: XenApiHost['$ref']
+  resident_on: XenApiHost['$ref'] | OPAQUE_REF_NULL
+  scheduled_to_be_resident_on: XenApiHost['$ref'] | OPAQUE_REF_NULL
   shutdown_delay: number
   snapshot_info: Record<string, string>
   snapshot_metadata: string
-  snapshot_of?: XenApiVm['$ref']
-  snapshot_schedule?: XenApiVmss['$ref']
+  snapshot_of: XenApiVm['$ref'] | OPAQUE_REF_NULL
+  snapshot_schedule?: XenApiVmss['$ref'] | OPAQUE_REF_NULL
   snapshot_time: string
   snapshots: XenApiVm['$ref'][]
   start_delay: number
-  suspend_SR?: XenApiSr['$ref']
-  suspend_VDI?: XenApiVdi['$ref']
+  suspend_SR: XenApiSr['$ref'] | OPAQUE_REF_NULL
+  suspend_VDI: XenApiVdi['$ref'] | OPAQUE_REF_NULL
   tags: string[]
   transportable_snapshot_id: string
-  user_version?: number
+  user_version: number
   uuid: string
   VBDs: XenApiVbd['$ref'][]
-  VCPUs_at_startup?: number
-  VCPUs_max?: number
-  VCPUs_params?: Record<string, string>
+  VCPUs_at_startup: number
+  VCPUs_max: number
+  VCPUs_params: Record<string, string>
   version: number
   VGPUs: XenApiVgpu['$ref'][]
   VIFs: XenApiVif['$ref'][]
@@ -358,19 +360,19 @@ export interface XenApiVmMetrics {
   $ref: Branded<'VM_metrics'>
   current_domain_type?: DOMAIN_TYPE
   hvm?: boolean
-  install_time?: string
-  last_updated?: string
-  memory_actual?: number
+  install_time: string
+  last_updated: string
+  memory_actual: number
   nested_virt?: boolean
   nomigrate?: boolean
   other_config: Record<string, string>
-  start_time?: string
+  start_time: string
   state: string[]
   uuid: string
-  VCPUs_CPU?: Record<number, number>
-  VCPUs_flags?: Record<number, string[]>
-  VCPUs_number?: number
-  VCPUs_params?: Record<string, string>
+  VCPUs_CPU: Record<number, number>
+  VCPUs_flags: Record<number, string[]>
+  VCPUs_number: number
+  VCPUs_params: Record<string, string>
   /** @deprecated */
   VCPUs_utilisation?: Record<number, number>
 }
@@ -381,21 +383,22 @@ export interface XenApiVmGuestMetrics {
   can_use_hotplug_vif: TRISTATE_TYPE
   /** @deprecated */
   disks?: Record<string, string>
-  last_updated?: string
+  last_updated: string
   live: boolean
   /** @deprecated */
   memory?: Record<string, string>
-  networks?: Record<string, string>
-  os_version?: Record<string, string>
+  networks: Record<string, string>
+  os_version: Record<string, string>
   other_config: Record<string, string>
-  other?: Record<string, string>
+  other: Record<string, string>
   PV_drivers_detected: boolean
   /** @deprecated */
   PV_drivers_up_to_date?: boolean
-  PV_drivers_version?: Record<string, string>
+  PV_drivers_version: Record<string, string>
   uuid: string
 }
 
+/** @deprecated */
 export interface XenApiVmpp {
   $ref: Branded<'VMPP'>
   /** @deprecated */
@@ -433,7 +436,7 @@ export interface XenApiVmpp {
   /** @deprecated */
   recent_alerts?: string[]
   /** @deprecated */
-  uuid: string
+  uuid?: string
   /** @deprecated */
   VMs?: XenApiVm['$ref'][]
 }
@@ -441,13 +444,13 @@ export interface XenApiVmpp {
 export interface XenApiVmss {
   $ref: Branded<'VMSS'>
   enabled: boolean
-  frequency?: VMSS_FREQUENCY
+  frequency: VMSS_FREQUENCY
   last_run_time: string
   name_description: string
   name_label: string
   retained_snapshots: number
   schedule: Record<string, string>
-  type?: VMSS_TYPE
+  type: VMSS_TYPE
   uuid: string
   VMs: XenApiVm['$ref'][]
 }
@@ -470,27 +473,27 @@ export interface XenApiDrTask {
 
 export interface XenApiHost {
   $ref: Branded<'host'>
-  address?: string
+  address: string
   allowed_operations: HOST_ALLOWED_OPERATIONS[]
-  API_version_major?: number
-  API_version_minor?: number
-  API_version_vendor_implementation?: Record<string, string>
-  API_version_vendor?: string
+  API_version_major: number
+  API_version_minor: number
+  API_version_vendor_implementation: Record<string, string>
+  API_version_vendor: string
   bios_strings: Record<string, string>
   blobs: Record<string, XenApiBlob['$ref']>
   capabilities: string[]
   certificates?: XenApiCertificate['$ref'][]
   chipset_info: Record<string, string>
-  control_domain?: XenApiVm['$ref']
-  cpu_configuration?: Record<string, string>
+  control_domain?: XenApiVm['$ref'] | OPAQUE_REF_NULL
+  cpu_configuration: Record<string, string>
   cpu_info: Record<string, string>
-  crash_dump_sr?: XenApiSr['$ref']
+  crash_dump_sr: XenApiSr['$ref'] | OPAQUE_REF_NULL
   crashdumps: XenApiHostCrashdump['$ref'][]
   current_operations: Record<string, HOST_ALLOWED_OPERATIONS>
   display: HOST_DISPLAY
   edition: string
   editions?: string[]
-  enabled?: boolean
+  enabled: boolean
   external_auth_configuration: Record<string, string>
   external_auth_service_name: string
   external_auth_type: string
@@ -499,23 +502,23 @@ export interface XenApiHost {
   ha_network_peers: string[]
   ha_statefiles: string[]
   host_CPUs: XenApiHostCpu['$ref'][]
-  hostname?: string
+  hostname: string
   https_only?: boolean
   iscsi_iqn?: string
   last_software_update?: string
   last_update_hash?: string
   latest_synced_updates_applied?: LATEST_SYNCED_UPDATES_APPLIED_STATE
-  license_params?: Record<string, string>
+  license_params: Record<string, string>
   license_server: Record<string, string>
-  local_cache_sr?: XenApiSr['$ref']
-  logging?: Record<string, string>
+  local_cache_sr: XenApiSr['$ref'] | OPAQUE_REF_NULL
+  logging: Record<string, string>
   memory_overhead: number
-  metrics?: XenApiHostMetrics['$ref']
+  metrics: XenApiHostMetrics['$ref']
   multipathing?: boolean
   name_description: string
   name_label: string
   numa_affinity_policy?: HOST_NUMA_AFFINITY_POLICY
-  other_config?: Record<string, string>
+  other_config: Record<string, string>
   /** @deprecated */
   patches?: XenApiHostPatch['$ref'][]
   PBDs: XenApiPbd['$ref'][]
@@ -529,12 +532,12 @@ export interface XenApiHost {
   power_on_mode: string
   PUSBs?: XenApiPusb['$ref'][]
   resident_VMs: XenApiVm['$ref'][]
-  sched_policy?: string
-  software_version?: Record<string, string>
+  sched_policy: string
+  software_version: Record<string, string>
   /** @deprecated */
   ssl_legacy?: boolean
   supported_bootloaders: string[]
-  suspend_image_sr?: XenApiSr['$ref']
+  suspend_image_sr: XenApiSr['$ref'] | OPAQUE_REF_NULL
   tags: string[]
   tls_verification_enabled?: boolean
   /** @deprecated */
@@ -548,53 +551,55 @@ export type XenApiHostWrapped = WrapperXenApi<XenApiHost, 'host'>
 
 export interface XenApiHostCrashdump {
   $ref: Branded<'host_crashdump'>
-  host?: XenApiHost['$ref']
+  host: XenApiHost['$ref']
   other_config: Record<string, string>
-  size?: number
-  timestamp?: string
+  size: number
+  timestamp: string
   uuid: string
 }
 
+/** @deprecated */
 export interface XenApiHostPatch {
   $ref: Branded<'host_patch'>
-  applied?: boolean
-  host?: XenApiHost['$ref']
+  applied: boolean
+  host: XenApiHost['$ref']
   name_description: string
   name_label: string
   other_config: Record<string, string>
-  pool_patch?: XenApiPoolPatch['$ref']
-  size?: number
-  timestamp_applied?: string
+  pool_patch: XenApiPoolPatch['$ref'] | OPAQUE_REF_NULL
+  size: number
+  timestamp_applied: string
   uuid: string
-  version?: string
+  version: string
 }
 
 export interface XenApiHostMetrics {
   $ref: Branded<'host_metrics'>
-  last_updated?: string
-  live?: boolean
+  last_updated: string
+  live: boolean
   /** @deprecated */
   memory_free?: number
-  memory_total?: number
+  memory_total: number
   other_config: Record<string, string>
   uuid: string
 }
 
+/** @deprecated */
 export interface XenApiHostCpu {
   $ref: Branded<'host_cpu'>
-  family?: number
-  features?: string
-  flags?: string
-  host?: XenApiHost['$ref']
-  model?: number
-  modelname?: string
-  number?: number
+  family: number
+  features: string
+  flags: string
+  host: XenApiHost['$ref']
+  model: number
+  modelname: string
+  number: number
   other_config: Record<string, string>
-  speed?: number
-  stepping?: string
-  utilisation?: number
+  speed: number
+  stepping: string
+  utilisation: number
   uuid: string
-  vendor?: string
+  vendor: string
 }
 
 export interface XenApiNetwork {
@@ -609,7 +614,7 @@ export interface XenApiNetwork {
   MTU: number
   name_description: string
   name_label: string
-  other_config?: Record<string, string>
+  other_config: Record<string, string>
   PIFs: XenApiPif['$ref'][]
   purpose?: NETWORK_PURPOSE[]
   tags: string[]
@@ -622,7 +627,7 @@ export interface XenApiVif {
   allowed_operations: VIF_OPERATIONS[]
   current_operations: Record<string, VIF_OPERATIONS>
   currently_attached: boolean
-  device?: string
+  device: string
   ipv4_addresses: string[]
   ipv4_allowed: string[]
   ipv4_configuration_mode: VIF_IPV4_CONFIGURATION_MODE
@@ -633,30 +638,31 @@ export interface XenApiVif {
   ipv6_gateway: string
   locking_mode: VIF_LOCKING_MODE
   MAC_autogenerated: boolean
-  MAC?: string
+  MAC: string
   /** @deprecated */
-  metrics?: XenApiVifMetrics['$ref']
-  MTU?: number
-  network?: XenApiNetwork['$ref']
-  other_config?: Record<string, string>
-  qos_algorithm_params?: Record<string, string>
-  qos_algorithm_type?: string
+  metrics?: XenApiVifMetrics['$ref'] | OPAQUE_REF_NULL
+  MTU: number
+  network: XenApiNetwork['$ref']
+  other_config: Record<string, string>
+  qos_algorithm_params: Record<string, string>
+  qos_algorithm_type: string
   qos_supported_algorithms: string[]
-  runtime_properties?: Record<string, string>
-  status_code?: number
-  status_detail?: string
+  runtime_properties: Record<string, string>
+  status_code: number
+  status_detail: string
   uuid: string
-  VM?: XenApiVm['$ref']
+  VM: XenApiVm['$ref']
 }
 export type XenApiVifWrapped = WrapperXenApi<XenApiVif, 'VIF'>
 
+/** @deprecated */
 export interface XenApiVifMetrics {
   $ref: Branded<'VIF_metrics'>
   /** @deprecated */
   io_read_kbs?: number
   /** @deprecated */
   io_write_kbs?: number
-  last_updated?: string
+  last_updated: string
   other_config: Record<string, string>
   uuid: string
 }
@@ -664,29 +670,29 @@ export interface XenApiVifMetrics {
 export interface XenApiPif {
   $ref: Branded<'PIF'>
   bond_master_of: XenApiBond['$ref'][]
-  bond_slave_of?: XenApiBond['$ref']
+  bond_slave_of: XenApiBond['$ref'] | OPAQUE_REF_NULL
   capabilities: string[]
   currently_attached: boolean
-  device?: string
+  device: string
   disallow_unplug: boolean
   DNS: string
   gateway: string
-  host?: XenApiHost['$ref']
+  host: XenApiHost['$ref']
   igmp_snooping_status?: PIF_IGMP_STATUS
   ip_configuration_mode: IP_CONFIGURATION_MODE
   IP: string
   ipv6_configuration_mode: IPV6_CONFIGURATION_MODE
   ipv6_gateway: string
   IPv6: string[]
-  MAC?: string
+  MAC: string
   managed: boolean
   management: boolean
-  metrics?: XenApiPifMetrics['$ref']
-  MTU?: number
+  metrics: XenApiPifMetrics['$ref']
+  MTU: number
   netmask: string
-  network?: XenApiNetwork['$ref']
+  network: XenApiNetwork['$ref']
   other_config: Record<string, string>
-  PCI?: XenApiPci['$ref']
+  PCI?: XenApiPci['$ref'] | OPAQUE_REF_NULL
   physical: boolean
   primary_address_type: PRIMARY_ADDRESS_TYPE
   properties: Record<string, string>
@@ -695,38 +701,38 @@ export interface XenApiPif {
   tunnel_access_PIF_of: XenApiTunnel['$ref'][]
   tunnel_transport_PIF_of: XenApiTunnel['$ref'][]
   uuid: string
-  VLAN_master_of?: XenApiVlan['$ref']
+  VLAN_master_of: XenApiVlan['$ref'] | OPAQUE_REF_NULL
   VLAN_slave_of: XenApiVlan['$ref'][]
-  VLAN?: number
+  VLAN: number
 }
 
 export interface XenApiPifMetrics {
   $ref: Branded<'PIF_metrics'>
-  carrier?: boolean
-  device_id?: string
-  device_name?: string
-  duplex?: boolean
+  carrier: boolean
+  device_id: string
+  device_name: string
+  duplex: boolean
   /** @deprecated */
   io_read_kbs?: number
   /** @deprecated */
   io_write_kbs?: number
-  last_updated?: string
+  last_updated: string
   other_config: Record<string, string>
-  pci_bus_path?: string
-  speed?: number
+  pci_bus_path: string
+  speed: number
   uuid: string
-  vendor_id?: string
-  vendor_name?: string
+  vendor_id: string
+  vendor_name: string
 }
 
 export interface XenApiBond {
   $ref: Branded<'Bond'>
   auto_update_mac?: boolean
   links_up: number
-  master?: XenApiPif['$ref']
+  master: XenApiPif['$ref'] | OPAQUE_REF_NULL
   mode: BOND_MODE
   other_config: Record<string, string>
-  primary_slave?: XenApiPif['$ref']
+  primary_slave: XenApiPif['$ref'] | OPAQUE_REF_NULL
   properties: Record<string, string>
   slaves: XenApiPif['$ref'][]
   uuid: string
@@ -736,8 +742,8 @@ export interface XenApiVlan {
   $ref: Branded<'VLAN'>
   other_config: Record<string, string>
   tag: number
-  tagged_PIF?: XenApiPif['$ref']
-  untagged_PIF?: XenApiPif['$ref']
+  tagged_PIF: XenApiPif['$ref'] | OPAQUE_REF_NULL
+  untagged_PIF: XenApiPif['$ref'] | OPAQUE_REF_NULL
   uuid: string
 }
 
@@ -745,19 +751,19 @@ export interface XenApiSm {
   $ref: Branded<'SM'>
   /** @deprecated */
   capabilities?: string[]
-  configuration?: Record<string, string>
-  copyright?: string
+  configuration: Record<string, string>
+  copyright: string
   driver_filename: string
   features: Record<string, number>
   name_description: string
   name_label: string
   other_config: Record<string, string>
-  required_api_version?: string
+  required_api_version: string
   required_cluster_stack: string[]
-  type?: string
+  type: string
   uuid: string
-  vendor?: string
-  version?: string
+  vendor: string
+  version: string
 }
 
 export interface XenApiSr {
@@ -765,24 +771,24 @@ export interface XenApiSr {
   allowed_operations: STORAGE_OPERATIONS[]
   blobs: Record<string, XenApiBlob['$ref']>
   clustered: boolean
-  content_type?: string
+  content_type: string
   current_operations: Record<string, STORAGE_OPERATIONS>
-  introduced_by?: XenApiDrTask['$ref']
+  introduced_by: XenApiDrTask['$ref'] | OPAQUE_REF_NULL
   is_tools_sr: boolean
   local_cache_enabled: boolean
   name_description: string
   name_label: string
-  other_config?: Record<string, string>
+  other_config: Record<string, string>
   PBDs: XenApiPbd['$ref'][]
-  physical_size?: number
-  physical_utilisation?: number
-  shared?: boolean
+  physical_size: number
+  physical_utilisation: number
+  shared: boolean
   sm_config: Record<string, string>
   tags: string[]
-  type?: string
+  type: string
   uuid: string
   VDIs: XenApiVdi['$ref'][]
-  virtual_allocation?: number
+  virtual_allocation: number
 }
 export type XenApiSrWrapped = WrapperXenApi<XenApiSr, 'SR'>
 
@@ -794,7 +800,7 @@ export interface XenApiSrStat {
   name_description?: string
   name_label?: string
   total_space?: number
-  uuid: unknown
+  uuid?: unknown
 }
 
 export interface XenApiProbeResult {
@@ -820,30 +826,30 @@ export interface XenApiVdi {
   is_a_snapshot: boolean
   is_tools_iso: boolean
   location: string
-  managed?: boolean
+  managed: boolean
   metadata_latest: boolean
-  metadata_of_pool?: XenApiPool['$ref']
-  missing?: boolean
+  metadata_of_pool: XenApiPool['$ref'] | OPAQUE_REF_NULL
+  missing: boolean
   name_description: string
   name_label: string
   on_boot: ON_BOOT
-  other_config?: Record<string, string>
+  other_config: Record<string, string>
   /** @deprecated */
-  parent?: XenApiVdi['$ref']
-  physical_utilisation?: number
-  read_only?: boolean
-  sharable?: boolean
+  parent?: OPAQUE_REF_NULL
+  physical_utilisation: number
+  read_only: boolean
+  sharable: boolean
   sm_config: Record<string, string>
-  snapshot_of?: XenApiVdi['$ref']
+  snapshot_of: XenApiVdi['$ref'] | OPAQUE_REF_NULL
   snapshot_time: string
   snapshots: XenApiVdi['$ref'][]
-  SR?: XenApiSr['$ref']
-  storage_lock?: boolean
+  SR: XenApiSr['$ref']
+  storage_lock: boolean
   tags: string[]
-  type?: VDI_TYPE
+  type: VDI_TYPE
   uuid: string
   VBDs: XenApiVbd['$ref'][]
-  virtual_size?: number
+  virtual_size: number
   xenstore_data: Record<string, string>
 }
 export type XenApiVdiWrapped = WrapperXenApi<XenApiVdi, 'VDI'>
@@ -851,31 +857,32 @@ export type XenApiVdiWrapped = WrapperXenApi<XenApiVdi, 'VDI'>
 export interface XenApiVbd {
   $ref: Branded<'VBD'>
   allowed_operations: VBD_OPERATIONS[]
-  bootable?: boolean
+  bootable: boolean
   current_operations: Record<string, VBD_OPERATIONS>
   currently_attached: boolean
   device: string
-  empty?: boolean
+  empty: boolean
   /** @deprecated */
-  metrics?: XenApiVbdMetrics['$ref']
-  mode?: VBD_MODE
-  other_config?: Record<string, string>
-  qos_algorithm_params?: Record<string, string>
-  qos_algorithm_type?: string
+  metrics?: XenApiVbdMetrics['$ref'] | OPAQUE_REF_NULL
+  mode: VBD_MODE
+  other_config: Record<string, string>
+  qos_algorithm_params: Record<string, string>
+  qos_algorithm_type: string
   qos_supported_algorithms: string[]
-  runtime_properties?: Record<string, string>
-  status_code?: number
-  status_detail?: string
-  storage_lock?: boolean
-  type?: VBD_TYPE
+  runtime_properties: Record<string, string>
+  status_code: number
+  status_detail: string
+  storage_lock: boolean
+  type: VBD_TYPE
   unpluggable: boolean
-  userdevice?: string
+  userdevice: string
   uuid: string
-  VDI?: XenApiVdi['$ref']
-  VM?: XenApiVm['$ref']
+  VDI: XenApiVdi['$ref']
+  VM: XenApiVm['$ref']
 }
 export type XenApiVbdWrapped = WrapperXenApi<XenApiVbd, 'VBD'>
 
+/** @deprecated */
 export interface XenApiVbdMetrics {
   $ref: Branded<'VBD_metrics'>
   /** @deprecated */
@@ -891,83 +898,85 @@ export interface XenApiVbdMetrics {
 
 export interface XenApiPbd {
   $ref: Branded<'PBD'>
-  currently_attached?: boolean
-  device_config?: Record<string, string>
-  host?: XenApiHost['$ref']
+  currently_attached: boolean
+  device_config: Record<string, string>
+  host: XenApiHost['$ref']
   other_config: Record<string, string>
-  SR?: XenApiSr['$ref']
+  SR: XenApiSr['$ref']
   uuid: string
 }
 
+/** @deprecated */
 export interface XenApiCrashdump {
   $ref: Branded<'crashdump'>
   other_config: Record<string, string>
   uuid: string
-  VDI?: XenApiVdi['$ref']
-  VM?: XenApiVm['$ref']
+  VDI: XenApiVdi['$ref']
+  VM: XenApiVm['$ref']
 }
 
 export interface XenApiVtpm {
   $ref: Branded<'VTPM'>
   allowed_operations: VTPM_OPERATIONS[]
-  backend?: XenApiVm['$ref']
+  backend: XenApiVm['$ref'] | OPAQUE_REF_NULL
   current_operations: Record<string, VTPM_OPERATIONS>
   is_protected?: boolean
   is_unique?: boolean
   persistence_backend?: PERSISTENCE_BACKEND
   uuid: string
-  VM?: XenApiVm['$ref']
+  VM: XenApiVm['$ref']
 }
 export type XenApiVtpmWrapped = WrapperXenApi<XenApiVtpm, 'VTPM'>
 
 export interface XenApiConsole {
   $ref: Branded<'console'>
-  location?: string
-  other_config?: Record<string, string>
-  protocol?: CONSOLE_PROTOCOL
+  location: string
+  other_config: Record<string, string>
+  protocol: CONSOLE_PROTOCOL
   uuid: string
-  VM?: XenApiVm['$ref']
+  VM: XenApiVm['$ref']
 }
 
+/** @deprecated */
 export interface XenApiUser {
   $ref: Branded<'user'>
-  fullname?: string
+  fullname: string
   other_config: Record<string, string>
-  short_name?: string
+  short_name: string
   uuid: string
 }
 
 export interface XenApiDataSource {
   $ref: Branded<'data_source'>
-  enabled?: boolean
-  max?: number
-  min?: number
+  enabled: boolean
+  max: number
+  min: number
   name_description: string
   name_label: string
-  standard?: boolean
-  units?: string
-  value?: number
+  standard: boolean
+  units: string
+  value: number
 }
 
 export interface XenApiBlob {
   $ref: Branded<'blob'>
-  last_updated?: string
-  mime_type?: string
+  last_updated: string
+  mime_type: string
   name_description: string
   name_label: string
   public: boolean
-  size?: number
+  size: number
   uuid: string
 }
 
 export interface XenApiMessage {
   $ref: Branded<'message'>
-  body?: string
-  cls?: CLS
-  name?: string
-  obj_uuid?: string
-  priority?: number
-  timestamp?: string
+  body: string
+  cls: CLS
+  name: string
+  obj_uuid: string
+  priority: number
+  timestamp: string
   uuid: string
 }
 
@@ -975,24 +984,24 @@ export interface XenApiSecret {
   $ref: Branded<'secret'>
   other_config: Record<string, string>
   uuid: string
-  value?: string
+  value: string
 }
 
 export interface XenApiTunnel {
   $ref: Branded<'tunnel'>
-  access_PIF?: XenApiPif['$ref']
+  access_PIF: XenApiPif['$ref'] | OPAQUE_REF_NULL
   other_config: Record<string, string>
   protocol?: TUNNEL_PROTOCOL
   status: Record<string, string>
-  transport_PIF?: XenApiPif['$ref']
+  transport_PIF: XenApiPif['$ref'] | OPAQUE_REF_NULL
   uuid: string
 }
 
 export interface XenApiNetworkSriov {
   $ref: Branded<'network_sriov'>
   configuration_mode?: SRIOV_CONFIGURATION_MODE
-  logical_PIF?: XenApiPif['$ref']
-  physical_PIF?: XenApiPif['$ref']
+  logical_PIF?: XenApiPif['$ref'] | OPAQUE_REF_NULL
+  physical_PIF?: XenApiPif['$ref'] | OPAQUE_REF_NULL
   requires_reboot?: boolean
   uuid: string
 }
@@ -1003,7 +1012,7 @@ export interface XenApiPci {
   dependencies: XenApiPci['$ref'][]
   device_name: string
   driver_name?: string
-  host?: XenApiHost['$ref']
+  host: XenApiHost['$ref'] | OPAQUE_REF_NULL
   other_config: Record<string, string>
   pci_id: string
   subsystem_device_name?: string
@@ -1017,11 +1026,11 @@ export interface XenApiPgpu {
   compatibility_metadata?: Record<string, string>
   dom0_access: PGPU_DOM0_ACCESS
   enabled_VGPU_types: XenApiVgpuType['$ref'][]
-  GPU_group?: XenApiGpuGroup['$ref']
-  host?: XenApiHost['$ref']
+  GPU_group: XenApiGpuGroup['$ref'] | OPAQUE_REF_NULL
+  host: XenApiHost['$ref'] | OPAQUE_REF_NULL
   is_system_display_device: boolean
   other_config: Record<string, string>
-  PCI?: XenApiPci['$ref']
+  PCI: XenApiPci['$ref'] | OPAQUE_REF_NULL
   resident_VGPUs: XenApiVgpu['$ref'][]
   supported_VGPU_max_capacities: Record<XenApiVgpuType['$ref'], number>
   supported_VGPU_types: XenApiVgpuType['$ref'][]
@@ -1048,14 +1057,14 @@ export interface XenApiVgpu {
   currently_attached: boolean
   device: string
   extra_args?: string
-  GPU_group?: XenApiGpuGroup['$ref']
+  GPU_group: XenApiGpuGroup['$ref']
   other_config: Record<string, string>
-  PCI?: XenApiPci['$ref']
-  resident_on?: XenApiPgpu['$ref']
-  scheduled_to_be_resident_on?: XenApiPgpu['$ref']
-  type?: XenApiVgpuType['$ref']
+  PCI?: XenApiPci['$ref'] | OPAQUE_REF_NULL
+  resident_on: XenApiPgpu['$ref'] | OPAQUE_REF_NULL
+  scheduled_to_be_resident_on: XenApiPgpu['$ref'] | OPAQUE_REF_NULL
+  type: XenApiVgpuType['$ref'] | OPAQUE_REF_NULL
   uuid: string
-  VM?: XenApiVm['$ref']
+  VM: XenApiVm['$ref']
 }
 export type XenApiVgpuWrapped = WrapperXenApi<XenApiVgpu, 'VGPU'>
 
@@ -1087,7 +1096,7 @@ export interface XenApiPvsSite {
   proxies?: XenApiPvsProxy['$ref'][]
   PVS_uuid?: string
   servers?: XenApiPvsServer['$ref'][]
-  uuid: string
+  uuid?: string
 }
 
 export interface XenApiPvsServer {
@@ -1095,27 +1104,27 @@ export interface XenApiPvsServer {
   addresses?: string[]
   first_port?: number
   last_port?: number
-  site?: XenApiPvsSite['$ref']
-  uuid: string
+  site?: XenApiPvsSite['$ref'] | OPAQUE_REF_NULL
+  uuid?: string
 }
 
 export interface XenApiPvsProxy {
   $ref: Branded<'PVS_proxy'>
   currently_attached?: boolean
-  site?: XenApiPvsSite['$ref']
+  site?: XenApiPvsSite['$ref'] | OPAQUE_REF_NULL
   status?: PVS_PROXY_STATUS
-  uuid: string
-  VIF?: XenApiVif['$ref']
+  uuid?: string
+  VIF?: XenApiVif['$ref'] | OPAQUE_REF_NULL
 }
 
 export interface XenApiPvsCacheStorage {
   $ref: Branded<'PVS_cache_storage'>
-  host?: XenApiHost['$ref']
-  site?: XenApiPvsSite['$ref']
+  host?: XenApiHost['$ref'] | OPAQUE_REF_NULL
+  site?: XenApiPvsSite['$ref'] | OPAQUE_REF_NULL
   size?: number
-  SR?: XenApiSr['$ref']
-  uuid: string
-  VDI?: XenApiVdi['$ref']
+  SR?: XenApiSr['$ref'] | OPAQUE_REF_NULL
+  uuid?: string
+  VDI?: XenApiVdi['$ref'] | OPAQUE_REF_NULL
 }
 
 export interface XenApiFeature {
@@ -1125,7 +1134,7 @@ export interface XenApiFeature {
   host?: XenApiHost['$ref']
   name_description: string
   name_label: string
-  uuid: string
+  uuid?: string
   version?: string
 }
 
@@ -1134,7 +1143,7 @@ export interface XenApiSdnController {
   address?: string
   port?: number
   protocol?: SDN_CONTROLLER_PROTOCOL
-  uuid: string
+  uuid?: string
 }
 
 export interface XenApiVdiNbdServerInfo {
@@ -1149,7 +1158,7 @@ export interface XenApiVdiNbdServerInfo {
 export interface XenApiPusb {
   $ref: Branded<'PUSB'>
   description?: string
-  host?: XenApiHost['$ref']
+  host?: XenApiHost['$ref'] | OPAQUE_REF_NULL
   other_config?: Record<string, string>
   passthrough_enabled?: boolean
   path?: string
@@ -1157,8 +1166,8 @@ export interface XenApiPusb {
   product_id?: string
   serial?: string
   speed?: number
-  USB_group?: XenApiUsbGroup['$ref']
-  uuid: string
+  USB_group?: XenApiUsbGroup['$ref'] | OPAQUE_REF_NULL
+  uuid?: string
   vendor_desc?: string
   vendor_id?: string
   version?: string
@@ -1170,7 +1179,7 @@ export interface XenApiUsbGroup {
   name_label?: string
   other_config?: Record<string, string>
   PUSBs?: XenApiPusb['$ref'][]
-  uuid: string
+  uuid?: string
   VUSBs?: XenApiVusb['$ref'][]
 }
 
@@ -1181,7 +1190,7 @@ export interface XenApiVusb {
   currently_attached: boolean
   other_config?: Record<string, string>
   USB_group?: XenApiUsbGroup['$ref']
-  uuid: string
+  uuid?: string
   VM?: XenApiVm['$ref']
 }
 
@@ -1201,33 +1210,33 @@ export interface XenApiCluster {
   quorum?: number
   token_timeout_coefficient?: number
   token_timeout?: number
-  uuid: string
+  uuid?: string
 }
 
 export interface XenApiClusterHost {
   $ref: Branded<'Cluster_host'>
   allowed_operations: CLUSTER_HOST_OPERATION[]
-  cluster?: XenApiCluster['$ref']
+  cluster?: XenApiCluster['$ref'] | OPAQUE_REF_NULL
   current_operations: Record<string, CLUSTER_HOST_OPERATION>
   enabled?: boolean
-  host?: XenApiHost['$ref']
+  host?: XenApiHost['$ref'] | OPAQUE_REF_NULL
   joined?: boolean
   last_update_live?: string
   live?: boolean
   other_config?: Record<string, string>
-  PIF?: XenApiPif['$ref']
-  uuid: string
+  PIF?: XenApiPif['$ref'] | OPAQUE_REF_NULL
+  uuid?: string
 }
 
 export interface XenApiCertificate {
   $ref: Branded<'Certificate'>
   fingerprint?: string
-  host?: XenApiHost['$ref']
+  host?: XenApiHost['$ref'] | OPAQUE_REF_NULL
   name?: string
   not_after?: string
   not_before?: string
   type?: CERTIFICATE_TYPE
-  uuid: string
+  uuid?: string
 }
 
 export interface XenApiRepository {
@@ -1241,7 +1250,7 @@ export interface XenApiRepository {
   /** @deprecated */
   up_to_date?: boolean
   update?: boolean
-  uuid: string
+  uuid?: string
 }
 
 export interface XenApiObserver {
@@ -1253,7 +1262,7 @@ export interface XenApiObserver {
   hosts?: XenApiHost['$ref'][]
   name_description: string
   name_label: string
-  uuid: string
+  uuid?: string
 }
 
 export type XenApiRecord =

--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -45,22 +45,23 @@ type BaseXoVm = BaseXapiXo & {
   blockedOperations: Record<VM_OPERATIONS, string>
   boot: Record<string, string>
   coresPerSocket?: number
-  cpuCap?: number | null
-  cpuMask?: (number | null)[]
-  cpuWeight?: number | null
+  cpuCap?: number
+  cpuMask?: number[]
+  cpuWeight?: number
   creation: Record<string, string>
   current_operations: Record<string, VM_OPERATIONS>
   docker?: {
     containers?: string[]
     enabled: boolean
     info?: string
+    /** @deprecated */
     process?: string
     version?: string
   }
   expNestedHvm: boolean
   hasVendorDevice: boolean
   high_availability: string
-  installTime?: number | null
+  installTime?: number
   isFirmwareSupported: boolean
   memory: {
     dynamic: number[]
@@ -86,7 +87,7 @@ type BaseXoVm = BaseXapiXo & {
   secureBoot: boolean
   snapshots: XoVmSnapshot['id'][]
   startDelay: number
-  startTime?: number | null
+  startTime?: number
   suspendSr?: XoSr['id']
   tags: string[]
   vga?: string
@@ -126,32 +127,32 @@ export type XoHost = BaseXapiXo & {
    */
   CPUs: Record<string, string>
 
-  address?: string
+  address: string
   agentStartTime: null | number
   bios_string: Record<string, string>
   build: string
   certificates?: {
     fingerprint: string
     notAfter: number
-  }
+  }[]
   chipset_info: {
     iommu?: boolean
   }
   controlDomain?: XoVm['id']
   cpus: {
-    cores?: null | number
-    sockets?: null | number
+    cores?: number
+    sockets?: number
   }
   current_operations: Record<string, HOST_ALLOWED_OPERATIONS>
   enabled: boolean
-  hostname?: string
+  hostname: string
   hvmCapable: boolean
   id: Branded<'host'>
   iscsiIqn: string
   license_expiry: null | number
   license_params: Record<string, string>
   license_server: Record<string, string>
-  logging?: Record<string, string>
+  logging: Record<string, string>
   memory: {
     size: number
     /**
@@ -235,7 +236,7 @@ export type XoSr = BaseXapiXo & {
   VDIs: XoVdi['id'][]
 
   allocationStrategy: 'thin' | 'thick' | 'unknown'
-  content_type?: string
+  content_type: string
   current_operations: Record<string, STORAGE_OPERATIONS>
   id: Branded<'SR'>
   inMaintenanceMode: boolean
@@ -246,10 +247,10 @@ export type XoSr = BaseXapiXo & {
   shared: boolean
   size: number | null
   sm_config: Record<string, string>
-  SR_type?: string
+  SR_type: string
   tags: string[]
   type: 'SR'
-  usage: number | null
+  usage: number
 }
 
 export type XoUser = {
@@ -269,7 +270,7 @@ export type XoVbd = BaseXapiXo & {
   device: string | null
   id: Branded<'VBD'>
   is_cd_drive: boolean
-  position?: string
+  position: string
   read_only: boolean
   type: 'VBD'
   VDI: XoVdi['id']


### PR DESCRIPTION
### Description

Updating `@vates/types` library after updating [xapi-generator](https://github.com/vatesfr/xen-orchestra/tree/wip-xapi-types-generator/%40xen-orchestra/xapi-generator)

The changes have been:
- only consider a property as optional if:
  - released after the version 7. `dundee`
  - Not published (deprecated, removed, prototype,...)
- Added OpaqueRef:NULL
- Added deprecated interface
- Added an enum for OPAQUE_REF

XO types have been updated accordingly.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
