### PR TITLE
feat(web-core): create VtsInputWrapper component

### DIFF
--- a/@xen-orchestra/lite/src/stories/web-core/input-wrapper/vts-input-wrapper.story.md
+++ b/@xen-orchestra/lite/src/stories/web-core/input-wrapper/vts-input-wrapper.story.md
@@ -1,0 +1,3 @@
+```ts
+type InputWrapperMessage = MaybeArray<string | { content: string; accent?: InfoAccent }>
+```

--- a/@xen-orchestra/lite/src/stories/web-core/input-wrapper/vts-input-wrapper.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/input-wrapper/vts-input-wrapper.story.vue
@@ -1,0 +1,82 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties }"
+    :params="[
+      prop('label').str().preset('Some label').widget(),
+      prop('learnMoreUrl').str().widget(),
+      iconProp(),
+      prop('message').type('InputWrapperMessage').widget(object()).preset([]).help('See presets'),
+      slot(),
+      slot('label').help('Can be used in place of label prop'),
+    ]"
+    :presets
+  >
+    <VtsInputWrapper v-bind="properties">
+      <div class="placeholder">Input will be placed here</div>
+    </VtsInputWrapper>
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import { iconProp, prop, slot } from '@/libs/story/story-param.ts'
+import { object } from '@/libs/story/story-widget.ts'
+import VtsInputWrapper from '@core/components/input-wrapper/VtsInputWrapper.vue'
+
+const withInfo = ['Info ']
+
+const withSuccess = [
+  ...withInfo,
+  {
+    content: 'Success',
+    accent: 'success',
+  },
+]
+const withWarning = [
+  ...withSuccess,
+  {
+    content: 'Warning',
+    accent: 'warning',
+  },
+]
+const withDanger = [
+  ...withWarning,
+  {
+    content: 'Danger',
+    accent: 'danger',
+  },
+]
+
+const presets = {
+  'With "info" message': {
+    props: {
+      message: withInfo,
+    },
+  },
+  '\u21B3 and "success" message': {
+    props: {
+      message: withSuccess,
+    },
+  },
+  '\u00A0\u00A0\u21B3 and "warning" message': {
+    props: {
+      message: withWarning,
+    },
+  },
+  '\u00A0\u00A0\u00A0\u00A0\u21B3 and "danger" message': {
+    props: {
+      message: withDanger,
+    },
+  },
+}
+</script>
+
+<style lang="postcss" scoped>
+.placeholder {
+  border: 1px dashed var(--color-neutral-border);
+  border-radius: 0.4rem;
+  padding: 0.8rem 1.6rem;
+  color: var(--color-neutral-txt-secondary);
+  font-style: italic;
+}
+</style>

--- a/@xen-orchestra/web-core/lib/components/input-wrapper/VtsInputWrapper.vue
+++ b/@xen-orchestra/web-core/lib/components/input-wrapper/VtsInputWrapper.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="vts-input-wrapper">
+    <UiLabel
+      :accent="labelAccent"
+      :for="id"
+      :href="learnMoreUrl"
+      :icon
+      :required="wrapperController.required"
+      class="label"
+    >
+      <slot name="label">{{ label }}</slot>
+    </UiLabel>
+    <slot />
+    <UiInfo v-for="{ content, accent } of messages" :key="content" :accent="accent">
+      {{ content }}
+    </UiInfo>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import UiInfo, { type InfoAccent } from '@core/components/ui/info/UiInfo.vue'
+import UiLabel, { type LabelAccent } from '@core/components/ui/label/UiLabel.vue'
+import { useMapper } from '@core/composables/mapper.composable'
+import { useRanked } from '@core/composables/ranked.composable.ts'
+import type { MaybeArray } from '@core/types/utility.type'
+import { IK_INPUT_WRAPPER_CONTROLLER } from '@core/utils/injection-keys.util'
+import { toArray } from '@core/utils/to-array.utils'
+import type { IconDefinition } from '@fortawesome/fontawesome-common-types'
+import { useArrayMap } from '@vueuse/core'
+import { provide, reactive, useId } from 'vue'
+
+export type InputWrapperMessage = MaybeArray<string | { content: string; accent?: InfoAccent }>
+
+export type InputWrapperController = {
+  id: string
+  labelAccent: LabelAccent
+  required: boolean
+}
+
+const { message: _message } = defineProps<{
+  label?: string
+  learnMoreUrl?: string
+  icon?: IconDefinition
+  message?: InputWrapperMessage
+}>()
+
+defineSlots<{
+  default(): any
+  label?(): any
+}>()
+
+const id = useId()
+
+const unsortedMessages = useArrayMap(
+  () => toArray(_message),
+  item => ({
+    content: typeof item === 'object' ? item.content : item,
+    accent: typeof item === 'object' ? (item.accent ?? 'info') : 'info',
+  })
+)
+
+const messages = useRanked(unsortedMessages, ({ accent }) => accent, ['danger', 'warning', 'success', 'info'])
+
+const labelAccent = useMapper<InfoAccent, LabelAccent>(
+  () => messages.value[0]?.accent,
+  {
+    info: 'neutral',
+    success: 'neutral',
+    warning: 'warning',
+    danger: 'danger',
+  },
+  'neutral'
+)
+
+const wrapperController = reactive({
+  id,
+  labelAccent,
+  required: false,
+}) satisfies InputWrapperController
+
+provide(IK_INPUT_WRAPPER_CONTROLLER, wrapperController)
+</script>
+
+<style lang="postcss" scoped>
+.vts-input-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+
+  .label {
+    min-height: 2.4rem;
+  }
+}
+</style>

--- a/@xen-orchestra/web-core/lib/components/input-wrapper/VtsInputWrapper.vue
+++ b/@xen-orchestra/web-core/lib/components/input-wrapper/VtsInputWrapper.vue
@@ -11,7 +11,7 @@
       <slot name="label">{{ label }}</slot>
     </UiLabel>
     <slot />
-    <UiInfo v-for="{ content, accent } of messages" :key="content" :accent="accent">
+    <UiInfo v-for="{ content, accent } of messages" :key="content" :accent>
       {{ content }}
     </UiInfo>
   </div>

--- a/@xen-orchestra/web-core/lib/components/ui/label/UiLabel.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/label/UiLabel.vue
@@ -15,8 +15,10 @@ import UiLink from '@core/components/ui/link/UiLink.vue'
 import { toVariants } from '@core/utils/to-variants.util'
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types'
 
+export type LabelAccent = 'neutral' | 'warning' | 'danger'
+
 const { for: htmlFor } = defineProps<{
-  accent: 'neutral' | 'warning' | 'danger'
+  accent: LabelAccent
   for?: string
   icon?: IconDefinition
   required?: boolean

--- a/@xen-orchestra/web-core/lib/utils/if-else.utils.ts
+++ b/@xen-orchestra/web-core/lib/utils/if-else.utils.ts
@@ -2,7 +2,7 @@ import type { MaybeArray, VoidFunction } from '@core/types/utility.type'
 import { toArray } from '@core/utils/to-array.utils'
 import { watch, type WatchOptions, type WatchSource } from 'vue'
 
-export interface IfElseOptions extends Pick<WatchOptions, 'immediate'> {}
+export interface IfElseOptions extends Pick<WatchOptions, 'immediate' | 'flush'> {}
 
 export function ifElse(
   source: WatchSource<boolean>,

--- a/@xen-orchestra/web-core/lib/utils/injection-keys.util.ts
+++ b/@xen-orchestra/web-core/lib/utils/injection-keys.util.ts
@@ -1,3 +1,4 @@
+import type { InputWrapperController } from '@core/components/input-wrapper/VtsInputWrapper.vue'
 import type { ValueFormatter } from '@core/types/chart'
 import type { ComputedRef, InjectionKey, Ref } from 'vue'
 
@@ -18,3 +19,5 @@ export const IK_CLOSE_MENU = Symbol('IK_CLOSE_MENU') as InjectionKey<() => void>
 export const IK_MENU_TELEPORTED = Symbol('IK_MENU_TELEPORTED') as InjectionKey<boolean>
 
 export const IK_DISABLED = Symbol('IK_DISABLED') as InjectionKey<ComputedRef<boolean>>
+
+export const IK_INPUT_WRAPPER_CONTROLLER = Symbol('IK_INPUT_WRAPPER_CONTROLLER') as InjectionKey<InputWrapperController>


### PR DESCRIPTION
### Description

This component is an extract of the common part around different inputs (existing or incoming)

![VtsInputWrapper](https://github.com/user-attachments/assets/2f1313ad-3074-4393-a3af-33f5940dfbab)


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
