### PR TITLE
fix(@xen-orchestra/rest-api): remove unused return type

### DIFF
--- a/@xen-orchestra/rest-api/src/hosts/host.controller.mts
+++ b/@xen-orchestra/rest-api/src/hosts/host.controller.mts
@@ -38,7 +38,7 @@ export class HostController extends XapiXoController<XoHost> {
     @Query() fields?: string,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Unbrand<XoHost>>[] | WithHref<Partial<Unbrand<XoHost>>>[] {
+  ): string[] | WithHref<Partial<Unbrand<XoHost>>>[] {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/srs/sr.controller.mts
+++ b/@xen-orchestra/rest-api/src/srs/sr.controller.mts
@@ -33,7 +33,7 @@ export class SrController extends XapiXoController<XoSr> {
     @Query() fields?: string,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Unbrand<XoSr>>[] | WithHref<Partial<Unbrand<XoSr>>>[] {
+  ): string[] | WithHref<Partial<Unbrand<XoSr>>>[] {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/vbds/vbd.controller.mts
+++ b/@xen-orchestra/rest-api/src/vbds/vbd.controller.mts
@@ -34,7 +34,7 @@ export class VbdController extends XapiXoController<XoVbd> {
     @Query() fields?: string,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Unbrand<XoVbd>>[] | WithHref<Partial<Unbrand<XoVbd>>>[] {
+  ): string[] | WithHref<Partial<Unbrand<XoVbd>>>[] {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -45,7 +45,7 @@ export class VmController extends XapiXoController<XoVm> {
     @Query() fields?: string,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Unbrand<XoVm>>[] | WithHref<Partial<Unbrand<XoVm>>>[] {
+  ): string[] | WithHref<Partial<Unbrand<XoVm>>>[] {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 


### PR DESCRIPTION
### Description

See [comment](https://github.com/vatesfr/xen-orchestra/pull/8385#discussion_r2010114860)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
