### PR TITLE
feat(xo-server/xostor): handle XOSTOR on RPU process

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,6 @@
   - [Host] Add dashboard view (PR [#8398](https://github.com/vatesfr/xen-orchestra/pull/8398))
 - [RPU] Allows to perform an RPU even if an XOSTOR is present on the pool (PR [#8455](https://github.com/vatesfr/xen-orchestra/pull/8455))
 
-
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -40,8 +39,8 @@
 
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
-- xo-server-backup-reports patch
 - xo-server minor
-- xo-web
+- xo-server-backup-reports patch
+- xo-web patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,8 @@
 
 - **XO 6:**
   - [Host] Add dashboard view (PR [#8398](https://github.com/vatesfr/xen-orchestra/pull/8398))
+- [RPU] Enable to do RPU even if a XOSTOR is present on the pool
+
 
 ### Bug fixes
 
@@ -39,6 +41,7 @@
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
 - xo-server-backup-reports patch
-- xo-server patch
+- xo-server minor
+- xo-web
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 
 - **XO 6:**
   - [Host] Add dashboard view (PR [#8398](https://github.com/vatesfr/xen-orchestra/pull/8398))
-- [RPU] Enable to do RPU even if a XOSTOR is present on the pool (PR [#8455](https://github.com/vatesfr/xen-orchestra/pull/8455))
+- [RPU] Allows to perform an RPU even if an XOSTOR is present on the pool (PR [#8455](https://github.com/vatesfr/xen-orchestra/pull/8455))
 
 
 ### Bug fixes

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 
 - **XO 6:**
   - [Host] Add dashboard view (PR [#8398](https://github.com/vatesfr/xen-orchestra/pull/8398))
-- [RPU] Enable to do RPU even if a XOSTOR is present on the pool
+- [RPU] Enable to do RPU even if a XOSTOR is present on the pool (PR [#8455](https://github.com/vatesfr/xen-orchestra/pull/8455))
 
 
 ### Bug fixes

--- a/packages/xo-server/src/xapi/mixins/patching.mjs
+++ b/packages/xo-server/src/xapi/mixins/patching.mjs
@@ -678,10 +678,26 @@ const methods = {
     /* throw */ notImplemented()
   },
 
+  async _updateLinstorPackages() {
+    const hosts = Object.values(this.objects.indexes.type.host)
+
+    async function callPluginOnAllHost(plugin, fn, args) {
+      for (const host of hosts) {
+        await this.call('host.call_plugin', host.$ref, plugin, fn, args)
+      }
+    }
+
+    return Task.run({ name: 'Updating LINSTOR packages' }, async () => {
+      await callPluginOnAllHost('updater.py', 'update', { packages: 'xcp-ng-xapi-plugins' })
+      await callPluginOnAllHost('updater.py', 'update', { packages: 'xcp-ng-linstor' })
+      await callPluginOnAllHost('service.py', 'stop_service', { service: 'linstor-controller' })
+      await callPluginOnAllHost('service.py', 'restart_service', { service: 'linstor-satellite' })
+    })
+  },
+
   async rollingPoolUpdate($defer, parentTask, { xsCredentials, force = false, rebootVm = force } = {}) {
-    // Temporary workaround until XCP-ng finds a way to update linstor packages
     if (some(this.objects.indexes.type.SR, { type: 'linstor' })) {
-      throw new Error('rolling pool update not possible since there is a linstor SR in the pool')
+      await this._updateLinstorPackages()
     }
 
     const master = this.pool.$master

--- a/packages/xo-server/src/xapi/mixins/patching.mjs
+++ b/packages/xo-server/src/xapi/mixins/patching.mjs
@@ -681,15 +681,14 @@ const methods = {
   async _updateLinstorPackages() {
     const hosts = Object.values(this.objects.indexes.type.host)
 
-    async function callPluginOnAllHost(plugin, fn, args) {
+    const callPluginOnAllHost = async (plugin, fn, args) => {
       for (const host of hosts) {
         await this.call('host.call_plugin', host.$ref, plugin, fn, args)
       }
     }
 
-    return Task.run({ name: 'Updating LINSTOR packages' }, async () => {
-      await callPluginOnAllHost('updater.py', 'update', { packages: 'xcp-ng-xapi-plugins' })
-      await callPluginOnAllHost('updater.py', 'update', { packages: 'xcp-ng-linstor' })
+    return Task.run({ properties: { name: 'Updating LINSTOR packages' } }, async () => {
+      await callPluginOnAllHost('updater.py', 'update', { packages: 'xcp-ng-xapi-plugins,xcp-ng-linstor' })
       await callPluginOnAllHost('service.py', 'stop_service', { service: 'linstor-controller' })
       await callPluginOnAllHost('service.py', 'restart_service', { service: 'linstor-satellite' })
     })

--- a/packages/xo-web/src/common/intl/locales/ja.js
+++ b/packages/xo-web/src/common/intl/locales/ja.js
@@ -3178,9 +3178,6 @@ export default {
   // Original text: 'This will automatically restart the toolstack on every host. Running VMs will not be affected. Are you sure you want to continue and install all the patches on this pool?'
   confirmPoolPatch: undefined,
 
-  // Original text: 'RPU is disabled because a XOSTOR storage is present in the pool'
-  rollingPoolUpdateDisabledBecauseXostorOnPool: undefined,
-
   // Original text: 'Rolling pool update'
   rollingPoolUpdate: undefined,
 

--- a/packages/xo-web/src/common/intl/locales/ja.js
+++ b/packages/xo-web/src/common/intl/locales/ja.js
@@ -7068,9 +7068,6 @@ export default {
   // Original text: 'Resource list'
   resourceList: undefined,
 
-  // Original text: 'As long as a XOSTOR storage is present in the pool, Rolling Pool Update will not be available'
-  rpuNoLongerAvailableIfXostor: undefined,
-
   // Original text: 'Select disk(s)…'
   selectDisks: undefined,
 

--- a/packages/xo-web/src/common/intl/locales/ru.js
+++ b/packages/xo-web/src/common/intl/locales/ru.js
@@ -3147,9 +3147,6 @@ export default {
   // Original text: 'This will automatically restart the toolstack on every host. Running VMs will not be affected. Are you sure you want to continue and install all the patches on this pool?'
   confirmPoolPatch: undefined,
 
-  // Original text: 'RPU is disabled because a XOSTOR storage is present in the pool'
-  rollingPoolUpdateDisabledBecauseXostorOnPool: undefined,
-
   // Original text: 'Rolling pool update'
   rollingPoolUpdate: undefined,
 

--- a/packages/xo-web/src/common/intl/locales/ru.js
+++ b/packages/xo-web/src/common/intl/locales/ru.js
@@ -6977,9 +6977,6 @@ export default {
   // Original text: 'Resource list'
   resourceList: undefined,
 
-  // Original text: 'As long as a XOSTOR storage is present in the pool, Rolling Pool Update will not be available'
-  rpuNoLongerAvailableIfXostor: undefined,
-
   // Original text: 'Select disk(s)…'
   selectDisks: undefined,
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1224,7 +1224,6 @@ const messages = {
   installPoolPatches: 'Install pool patches',
   confirmPoolPatch:
     'This will automatically restart the toolstack on every host. Running VMs will not be affected. Are you sure you want to continue and install all the patches on this pool?',
-  rollingPoolUpdateDisabledBecauseXostorOnPool: 'RPU is disabled because a XOSTOR storage is present in the pool',
   rollingPoolUpdate: 'Rolling pool update',
   rollingPoolUpdateMessage:
     'Are you sure you want to start a rolling pool update? Running VMs will be migrated back and forth and this can take a while. Scheduled backups that may concern this pool will be disabled.',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2712,8 +2712,6 @@ const messages = {
   replication: 'Replication',
   replicationCountHigherThanHostsWithDisks: 'Replication count is higher than number of hosts with disks',
   resourceList: 'Resource list',
-  rpuNoLongerAvailableIfXostor:
-    'As long as a XOSTOR storage is present in the pool, Rolling Pool Update will not be available',
   rpuRequireVmsReboot: 'To fully apply the patches, some VMs will reboot. Are you sure you want to continue?',
   selectDisks: 'Select disk(s)…',
   selectedDiskTypeIncompatibleXostor: 'Only disks of type "Disk" and "Raid" are accepted. Selected disk type: {type}.',

--- a/packages/xo-web/src/xo-app/pool/tab-patches.js
+++ b/packages/xo-web/src/xo-app/pool/tab-patches.js
@@ -217,11 +217,6 @@ export default class TabPatches extends Component {
       ).length
   )
 
-  hasAXostor = createSelector(
-    () => this.props.poolSrs,
-    poolSrs => some(poolSrs, { SR_type: 'linstor' })
-  )
-
   render() {
     const {
       hostPatches,

--- a/packages/xo-web/src/xo-app/pool/tab-patches.js
+++ b/packages/xo-web/src/xo-app/pool/tab-patches.js
@@ -238,7 +238,6 @@ export default class TabPatches extends Component {
 
     const isSingleHost = size(poolHosts) < 2
 
-    const hasAXostor = this.hasAXostor()
     const hasMultipleVmsRunningOnLocalStorage = this.getNVmsRunningOnLocalStorage() > 0
 
     return (
@@ -249,23 +248,19 @@ export default class TabPatches extends Component {
               {ROLLING_POOL_UPDATES_AVAILABLE && (
                 <TabButton
                   btnStyle='primary'
-                  disabled={
-                    hasAXostor || isEmpty(missingPatches) || hasMultipleVmsRunningOnLocalStorage || isSingleHost
-                  }
+                  disabled={isEmpty(missingPatches) || hasMultipleVmsRunningOnLocalStorage || isSingleHost}
                   handler={rollingPoolUpdate}
                   handlerParam={pool.id}
                   icon='pool-rolling-update'
                   labelId='rollingPoolUpdate'
                   tooltip={
-                    hasAXostor
-                      ? _('rollingPoolUpdateDisabledBecauseXostorOnPool')
-                      : hasMultipleVmsRunningOnLocalStorage
-                        ? _('nVmsRunningOnLocalStorage', {
-                            nVms: this.getNVmsRunningOnLocalStorage(),
-                          })
-                        : isSingleHost
-                          ? _('multiHostPoolUpdate')
-                          : undefined
+                    hasMultipleVmsRunningOnLocalStorage
+                      ? _('nVmsRunningOnLocalStorage', {
+                          nVms: this.getNVmsRunningOnLocalStorage(),
+                        })
+                      : isSingleHost
+                        ? _('multiHostPoolUpdate')
+                        : undefined
                   }
                 />
               )}

--- a/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
+++ b/packages/xo-web/src/xo-app/xostor/new-xostor-form.js
@@ -232,11 +232,6 @@ const PoolCard = decorate([
               <Icon icon='info' /> {_('xostorPackagesWillBeInstalled')}
             </em>
           </div>
-          <div className='text-warning'>
-            <em>
-              <Icon icon='alarm' /> {_('rpuNoLongerAvailableIfXostor')}
-            </em>
-          </div>
         </div>
       </CardBlock>
     </Card>


### PR DESCRIPTION
### Description

Tested on `.83` pool.

We update the LINSTOR package on all hosts, then shut down the controller and reboot the satellite on each host before starting the RPU

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
