### PR TITLE
fix(xo-server/rest-api): return 404 if backup log do not exist

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,9 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [REST API] Correctly return a 404 not found error when trying to get a backup log that does not exist
+
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -36,5 +39,7 @@
 
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+- xo-server-backup-reports patch
+- xo-server patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,8 +18,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [REST API] Correctly return a 404 not found error when trying to get a backup log that does not exist
-
+- [REST API] Correctly return a 404 not found error when trying to get a backup log that does not exist (PR [#8457](https://github.com/vatesfr/xen-orchestra/pull/8457))
 
 ### Packages to release
 

--- a/packages/xo-server-backup-reports/src/index.js
+++ b/packages/xo-server-backup-reports/src/index.js
@@ -122,8 +122,10 @@ class BackupReportsXoPlugin {
     }
     const xo = this._xo
 
-    const log = await xo.getBackupNgLogs(runJobId)
-    if (log === undefined) {
+    let log
+    try {
+      log = await xo.getBackupNgLogs(runJobId)
+    } catch (error) {
       throw new Error(`no log found with runId=${JSON.stringify(runJobId)}`)
     }
 

--- a/packages/xo-server/src/xo-mixins/backups-ng-logs.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng-logs.mjs
@@ -3,6 +3,7 @@ import isEmpty from 'lodash/isEmpty.js'
 import iteratee from 'lodash/iteratee.js'
 import ms from 'ms'
 import sortedIndexBy from 'lodash/sortedIndexBy.js'
+import { noSuchObject } from 'xo-common/api-errors.js'
 
 import { debounceWithKey } from '../_pDebounceWithKey.mjs'
 
@@ -178,7 +179,14 @@ export default {
       forEach(restoreLogs, handleLog)
       forEach(restoreMetadataLogs, handleLog)
 
-      return runId === undefined ? consolidated : consolidated[runId]
+      if (runId !== undefined) {
+        if (consolidated[runId] === undefined) {
+          /* throw */ noSuchObject(runId, 'backup-ng-log')
+        }
+        return consolidated[runId]
+      }
+
+      return consolidated
     },
     10e3,
     function keyFn(runId) {

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -1248,7 +1248,7 @@ export default class RestApi {
         ['/backup/logs/:id', '/restore/logs/:id'],
         wrap(async (req, res) => {
           res.json(await app.getBackupNgLogs(req.params.id))
-        })
+        }, true)
       )
 
     api


### PR DESCRIPTION
### Description

If a `runId` is passed and no backup log was found, undefined was returned.
Now throw `no such object`

See zammad#36647 and [mm](https://team.vates.fr/vates/pl/4nm591y6g78kxgum8opf8kc76r)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
