### PR TITLE
fix(xo-6/host): ram usage progress bar not handling values properly

### DIFF
--- a/@xen-orchestra/web/src/components/host/dashboard/HostDashboadRamUsage.vue
+++ b/@xen-orchestra/web/src/components/host/dashboard/HostDashboadRamUsage.vue
@@ -3,7 +3,7 @@
     <UiCardTitle>{{ $t('ram-usage') }}</UiCardTitle>
     <VtsLoadingHero v-if="!isReady" type="card" />
     <template v-else>
-      <UiProgressBar :value="ramUsage.used?.value ?? 0" :max="ramUsage.total?.value" :legend="host.name_label" />
+      <UiProgressBar :value="host.memory.usage" :max="host.memory.size" :legend="host.name_label" />
       <div class="total">
         <UiCardNumbers
           :label="$t('total-used')"


### PR DESCRIPTION
### Description

Introduced by d77b195

RAM usage progress bar display was broken when memory used and total units were different.
Fixed by using raw values for progress bar props instead of computed ones.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
