### PR TITLE
fix(xo-web/acls): disable ACL feature on plans <Enterprise

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,4 +31,6 @@
 
 <!--packages-start-->
 
+- xo-web patch
+
 <!--packages-end-->

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -145,6 +145,7 @@ const messages = {
   addCustomField: 'Add custom field',
   advancedTagCreation: 'Advanced tag creation',
   availableXoaPremium: 'Available in XOA Premium',
+  availableXoaPlan: 'Available in XOA {plan}',
   detach: 'Detach',
   editCustomField: 'Edit custom field',
   deleteCustomField: 'Delete custom field',

--- a/packages/xo-web/src/xo-app/new-vm/index.js
+++ b/packages/xo-web/src/xo-app/new-vm/index.js
@@ -91,6 +91,7 @@ import {
   getResolvedResourceSets,
   getUser,
 } from 'selectors'
+import { CURRENT as XOA_PLAN, ENTERPRISE } from 'xoa-plans'
 
 import styles from './index.css'
 
@@ -1914,10 +1915,15 @@ export default class NewVm extends BaseComponent {
                     <span className='mr-1'>{_('vmAcls')}</span>
                     <ActionButton
                       btnStyle='primary'
+                      disabled={XOA_PLAN.value < ENTERPRISE.value}
                       handler={this._addAcls}
                       icon='add'
                       size='small'
-                      tooltip={_('vmAddAcls')}
+                      tooltip={
+                        XOA_PLAN.value < ENTERPRISE.value
+                          ? _('availableXoaPlan', { plan: ENTERPRISE.name })
+                          : _('vmAddAcls')
+                      }
                     />
                   </Col>
                 </Row>

--- a/packages/xo-web/src/xo-app/vm/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/vm/tab-advanced.js
@@ -65,7 +65,7 @@ import {
   XEN_VIDEORAM_VALUES,
 } from 'xo'
 import { createGetObject, createGetObjectsOfType, createSelector, isAdmin } from 'selectors'
-import { getXoaPlan, PREMIUM } from 'xoa-plans'
+import { getXoaPlan, CURRENT as XOA_PLAN, ENTERPRISE, PREMIUM } from 'xoa-plans'
 import { SelectSuspendSr } from 'select-suspend-sr'
 
 import BootOrder from './boot-order'
@@ -505,7 +505,16 @@ const Acls = decorate([
       )}
       <Row>
         <Col>
-          <ActionButton btnStyle='primary' handler={effects.addAcls} icon='add' size='small' tooltip={_('vmAddAcls')} />
+          <ActionButton
+            btnStyle='primary'
+            disabled={XOA_PLAN.value < ENTERPRISE.value}
+            handler={effects.addAcls}
+            icon='add'
+            size='small'
+            tooltip={
+              XOA_PLAN.value < ENTERPRISE.value ? _('availableXoaPlan', { plan: ENTERPRISE.name }) : _('vmAddAcls')
+            }
+          />
         </Col>
       </Row>
     </Container>


### PR DESCRIPTION
Introduced by #3774
Introduced by #8412

### Description

ACLs feature is only available for XOA plans Enterprise and Premium. The feature is properly disabled on the main ACL config page but was still available from a VM's Advanced page and from the VM creation form.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
