### PR TITLE
fix(xo-6/vm-creation): remove TS errors from type-check

### DIFF
--- a/@xen-orchestra/web/src/pages/vm/new.vue
+++ b/@xen-orchestra/web/src/pages/vm/new.vue
@@ -772,10 +772,6 @@ function getExistingVdisDiff(vdi1: Vdi, vdi2: Vdi) {
   for (const _key in vdi1) {
     const key = _key as keyof Vdi
 
-    if (!Object.prototype.hasOwnProperty.call(vdi1, key) || !Object.prototype.hasOwnProperty.call(vdi2, key)) {
-      continue
-    }
-
     if (vdi1[key] !== vdi2[key]) {
       hasChanged = true
       changes[key] = vdi2[key]
@@ -786,13 +782,16 @@ function getExistingVdisDiff(vdi1: Vdi, vdi2: Vdi) {
 }
 
 const modifiedExistingVdis = computed(() => {
-  return vmState.existingVdis.flatMap((vdi, index) => {
+  return vmState.existingVdis.reduce((acc, vdi, index) => {
     const defaultVdi = defaultExistingVdis.value[index]
-
     const changes = getExistingVdisDiff(defaultVdi, vdi)
 
-    return changes ? { ...changes, userdevice: vdi.userdevice } : []
-  })
+    if (changes) {
+      acc.push({ ...changes, userdevice: vdi.userdevice })
+    }
+
+    return acc
+  }, [] as Partial<Vdi>[])
 })
 
 const vmData = computed(() => {

--- a/@xen-orchestra/web/src/pages/vm/new.vue
+++ b/@xen-orchestra/web/src/pages/vm/new.vue
@@ -419,7 +419,7 @@ import { useVdiStore } from '@/stores/xo-rest-api/vdi.store'
 import { useVifStore } from '@/stores/xo-rest-api/vif.store'
 import { useVmTemplateStore } from '@/stores/xo-rest-api/vm-template.store'
 import type { XoNetwork } from '@/types/xo/network.type.ts'
-import { type NetworkInterface, type Vdi, type VmState } from '@/types/xo/new-vm.type'
+import type { NetworkInterface, Vdi, VmState } from '@/types/xo/new-vm.type'
 import type { XoVdi } from '@/types/xo/vdi.type.ts'
 import type { XoVmTemplate } from '@/types/xo/vm-template.type'
 import type { Branded } from '@core/types/utility.type'
@@ -609,7 +609,7 @@ const filteredSrs = computed(() => {
   return srs.value.filter(sr => sr.content_type !== 'iso' && sr.physical_usage > 0 && sr.$pool === vmState.pool?.id)
 })
 
-const getVdis = (template: XoVmTemplate) =>
+const getVmTemplateVdis = (template: XoVmTemplate) =>
   (template.template_info?.disks ?? []).map((disk, index) => ({
     name_label: `${vmState?.name || 'disk'}_${index}_${generateRandomString(4)}`,
     name_description: 'Created by XO',
@@ -717,7 +717,7 @@ const addNetworkInterface = () => {
 }
 
 // const allVdisHaveSr = computed(() => {
-//   const existingVDIs = getVdis(vmState.new_vm_template)
+//   const existingVDIs = getVmTemplateVdis(vmState.new_vm_template)
 //   return existingVDIs.every(vdi => vdi.sr.length > 0)
 // })
 
@@ -762,7 +762,7 @@ const onTemplateChange = () => {
     ram: memory.dynamic[1],
     tags,
     vCPU: CPUs.number,
-    vdis: getVdis(template),
+    vdis: getVmTemplateVdis(template),
     existingVdis: getExistingVdis(template),
     networkInterfaces: getExistingInterface(template),
   })

--- a/@xen-orchestra/web/src/pages/vm/new.vue
+++ b/@xen-orchestra/web/src/pages/vm/new.vue
@@ -794,7 +794,7 @@ const vmData = computed(() => {
     name_description: vmState.description,
     name_label: vmState.name,
     template: vmState.new_vm_template?.uuid,
-    vdis: vmState.vdis.map(vdi => ({
+    vdis: [...vmState.vdis, ...vmState.existingVdis].map(vdi => ({
       ...vdi,
       size: giBToBytes(vdi.size),
     })),

--- a/@xen-orchestra/web/src/pages/vm/new.vue
+++ b/@xen-orchestra/web/src/pages/vm/new.vue
@@ -23,7 +23,7 @@
             <!--        // Todo: Replace by the new select component -->
             <div class="custom-select">
               <select v-model="vmState.new_vm_template" @change="onTemplateChange()">
-                <option v-for="template in vmsTemplates" :key="template.uuid" :value="template" class="template-option">
+                <option v-for="template in vmsTemplates" :key="template.id" :value="template" class="template-option">
                   {{ `${template.name_label} - ${vmState.pool.name_label}` }}
                 </option>
               </select>

--- a/@xen-orchestra/web/src/pages/vm/new.vue
+++ b/@xen-orchestra/web/src/pages/vm/new.vue
@@ -758,6 +758,8 @@ const onTemplateChange = () => {
     vdis: getVmTemplateVdis(template),
     existingVdis: getExistingVdis(template),
     networkInterfaces: getExistingInterface(template),
+    selectedVdi: undefined,
+    installMode: undefined,
   })
 }
 
@@ -782,7 +784,7 @@ function getExistingVdisDiff(vdi1: Vdi, vdi2: Vdi) {
 }
 
 const modifiedExistingVdis = computed(() => {
-  return vmState.existingVdis.reduce((acc, vdi, index) => {
+  return vmState.existingVdis.reduce<Partial<Vdi>[]>((acc, vdi, index) => {
     const defaultVdi = defaultExistingVdis.value[index]
     const changes = getExistingVdisDiff(defaultVdi, vdi)
 
@@ -791,7 +793,7 @@ const modifiedExistingVdis = computed(() => {
     }
 
     return acc
-  }, [] as Partial<Vdi>[])
+  }, [])
 })
 
 const vmData = computed(() => {
@@ -805,7 +807,10 @@ const vmData = computed(() => {
     vdisToSend.length > 0 && { vdis: vdisToSend },
     vmState.affinity_host && { affinity: vmState.affinity_host },
     vmState.installMode !== 'no-config' && {
-      install: { method: vmState.installMode, repository: vmState.selectedVdi },
+      install: {
+        method: vmState.installMode,
+        repository: vmState.installMode === 'network' ? ' ' : vmState.selectedVdi,
+      },
     }
     // TODO: uncomment when radio will be implemented
     // ...(vmState.installMode === 'custom_config' && {

--- a/@xen-orchestra/web/src/pages/vm/new.vue
+++ b/@xen-orchestra/web/src/pages/vm/new.vue
@@ -33,100 +33,85 @@
           <div v-if="vmState.new_vm_template" class="form-container">
             <!-- INSTALL SETTINGS SECTION -->
             <UiTitle>{{ $t('install-settings') }}</UiTitle>
-            <div>
-              <div v-if="isDiskTemplate" class="install-settings-container">
-                <div class="radio-container">
+            <div class="install-settings-container">
+              <div class="radio-container">
+                <template v-if="isDiskTemplate">
                   <UiRadioButton v-model="vmState.installMode" accent="brand" value="no-config">
                     {{ $t('no-config') }}
                   </UiRadioButton>
                   <UiRadioButton v-model="vmState.installMode" accent="brand" value="cdrom">
                     {{ $t('iso-dvd') }}
                   </UiRadioButton>
-
-                  <!-- TODO need to be add later after confirmation -->
-                  <!--
-                    <UiRadioButton v-model="vmState.installMode" accent="brand" value="ssh-key">
-                      {{ $t('ssh-key') }}
-                    </UiRadioButton>
-                    <UiRadioButton v-model="vmState.installMode" accent="brand" value="custom_config">
-                      {{ $t('custom-config') }}
-                    </UiRadioButton>
-                  -->
-                </div>
-                <div v-if="vmState.installMode === 'cdrom'" class="custom-select">
-                  <select v-model="vmState.selectedVdi">
-                    <template v-for="(vdis, srName) in filteredVDIs" :key="srName">
-                      <optgroup :label="srName">
-                        <option v-for="vdi in vdis" :key="vdi.id" :value="vdi.id">
-                          {{ vdi.name_label }}
-                        </option>
-                      </optgroup>
-                    </template>
-                  </select>
-                  <FontAwesomeIcon class="icon" :icon="faAngleDown" />
-                </div>
-                <!-- TODO need to be add later after confirmation -->
-                <!--
-                 <div v-if="vmState.installMode === 'SSH'" class="install-ssh-key-container">
-                    <div class="install-chips">
-                      <UiChip v-for="(key, index) in vmState.sshKeys" :key="index" accent="info" @remove="removeSshKey(index)">
-                        {{ key }}
-                      </UiChip>
-                    </div>
-                    <div class="install-ssh-key">
-                      <UiInput v-model="vmState.ssh_key" placeholder="Paste public key" accent="brand" />
-                      <UiButton accent="brand" size="medium" variant="primary" @click="addSshKey()">
-                        {{ $t('add') }}
-                      </UiButton>
-                    </div>
-                  </div>
-                  <div v-if="vmState.installMode === 'custom_config'" class="install-custom-config">
-                    <div>
-                      <UiTextarea v-model="vmState.cloudConfig" placeholder="Write configurations" accent="brand" href="''">
-                        {{ $t('user-config') }}
-                      </UiTextarea>
-                      <span class="typo p3-regular-italic">
-                        Available template variables <br />
-                        - {name}: the VM's name. - It must not contain "_" <br />
-                        - {index}: the VM's index,<br />
-                        it will take 0 in case of single VM Tip: escape any variable with a preceding backslash (\)
-                      </span>
-                    </div>
-                    <div>
-                      <UiTextarea v-model="vmState.networkConfig" placeholder="Write configurations" accent="brand" href="''">
-                        {{ $t('network-config') }}
-                      </UiTextarea>
-                      <span class="typo p3-regular-italic">
-                        Network configuration is only compatible with the NoCloud datasource. <br />
-
-                        See Network config documentation.
-                      </span>
-                    </div>
-                  </div>
-                  -->
-              </div>
-              <div v-else class="install-settings-container">
-                <div class="radio-container">
+                </template>
+                <template v-else>
                   <UiRadioButton v-model="vmState.installMode" accent="brand" value="cdrom">
                     {{ t('iso-dvd') }}
                   </UiRadioButton>
                   <UiRadioButton v-model="vmState.installMode" accent="brand" value="network">
                     {{ t('pxe') }}
                   </UiRadioButton>
-                </div>
-                <div v-if="vmState.installMode === 'cdrom'" class="custom-select">
-                  <select v-model="vmState.selectedVdi">
-                    <template v-for="(vdis, srName) in filteredVDIs" :key="srName">
-                      <optgroup :label="srName">
-                        <option v-for="vdi in vdis" :key="vdi.id" :value="vdi.id">
-                          {{ vdi.name_label }}
-                        </option>
-                      </optgroup>
-                    </template>
-                  </select>
-                  <FontAwesomeIcon class="icon" :icon="faAngleDown" />
-                </div>
+                </template>
+                <!-- TODO need to be add later after confirmation -->
+                <!--
+                  <UiRadioButton v-model="vmState.installMode" accent="brand" value="ssh-key">
+                    {{ $t('ssh-key') }}
+                  </UiRadioButton>
+                  <UiRadioButton v-model="vmState.installMode" accent="brand" value="custom_config">
+                    {{ $t('custom-config') }}
+                  </UiRadioButton>
+                -->
               </div>
+              <div v-if="vmState.installMode === 'cdrom'" class="custom-select">
+                <select v-model="vmState.selectedVdi">
+                  <template v-for="(vdis, srName) in filteredVDIs" :key="srName">
+                    <optgroup :label="srName">
+                      <option v-for="vdi in vdis" :key="vdi.id" :value="vdi.id">
+                        {{ vdi.name_label }}
+                      </option>
+                    </optgroup>
+                  </template>
+                </select>
+                <FontAwesomeIcon class="icon" :icon="faAngleDown" />
+              </div>
+              <!-- TODO need to be add later after confirmation -->
+              <!--
+               <div v-if="vmState.installMode === 'SSH'" class="install-ssh-key-container">
+                  <div class="install-chips">
+                    <UiChip v-for="(key, index) in vmState.sshKeys" :key="index" accent="info" @remove="removeSshKey(index)">
+                      {{ key }}
+                    </UiChip>
+                  </div>
+                  <div class="install-ssh-key">
+                    <UiInput v-model="vmState.ssh_key" placeholder="Paste public key" accent="brand" />
+                    <UiButton accent="brand" size="medium" variant="primary" @click="addSshKey()">
+                      {{ $t('add') }}
+                    </UiButton>
+                  </div>
+                </div>
+                <div v-if="vmState.installMode === 'custom_config'" class="install-custom-config">
+                  <div>
+                    <UiTextarea v-model="vmState.cloudConfig" placeholder="Write configurations" accent="brand" href="''">
+                      {{ $t('user-config') }}
+                    </UiTextarea>
+                    <span class="typo p3-regular-italic">
+                      Available template variables <br />
+                      - {name}: the VM's name. - It must not contain "_" <br />
+                      - {index}: the VM's index,<br />
+                      it will take 0 in case of single VM Tip: escape any variable with a preceding backslash (\)
+                    </span>
+                  </div>
+                  <div>
+                    <UiTextarea v-model="vmState.networkConfig" placeholder="Write configurations" accent="brand" href="''">
+                      {{ $t('network-config') }}
+                    </UiTextarea>
+                    <span class="typo p3-regular-italic">
+                      Network configuration is only compatible with the NoCloud datasource. <br />
+
+                      See Network config documentation.
+                    </span>
+                  </div>
+                </div>
+                -->
             </div>
             <!-- SYSTEM SECTION -->
             <UiTitle>{{ $t('system') }}</UiTitle>

--- a/@xen-orchestra/web/src/types/xo/new-vm.type.ts
+++ b/@xen-orchestra/web/src/types/xo/new-vm.type.ts
@@ -10,6 +10,7 @@ export interface Vdi {
   name_description: string
   size: number
   sr: XoSr['id'] | undefined
+  userdevice?: string | null
 }
 
 export interface NetworkInterface {
@@ -17,10 +18,12 @@ export interface NetworkInterface {
   macAddress: string
 }
 
+export type InstallMode = 'no-config' | 'ssh-key' | 'custom_config' | 'cdrom' | 'network' | undefined
+
 export interface VmState {
   affinity_host?: XoHost['id']
   auto_poweron: boolean
-  installMode?: string
+  installMode?: InstallMode
   boot_firmware: string
   boot_vm: boolean
   clone: boolean

--- a/@xen-orchestra/web/src/types/xo/new-vm.type.ts
+++ b/@xen-orchestra/web/src/types/xo/new-vm.type.ts
@@ -9,26 +9,26 @@ export interface Vdi {
   name_label: string
   name_description: string
   size: number
-  sr: XoSr['id'] | undefined
+  sr: XoSr['id']
 }
 
 export interface NetworkInterface {
-  interface: XoNetwork['id'] | undefined
+  interface: XoNetwork['id']
   macAddress: string
 }
 
 export interface VmState {
-  affinity_host: XoHost['id'] | undefined
+  affinity_host?: XoHost['id']
   auto_poweron: boolean
-  installMode: string
+  installMode?: string
   boot_firmware: string
   boot_vm: boolean
   clone: boolean
-  cloudConfig: string
+  cloudConfig?: string
   copyHostBiosStrings: boolean
   defaultNetwork: NetworkInterface | undefined
   isDiskTemplateSelected: boolean
-  networkConfig: string
+  networkConfig?: string
   networkInterfaces: NetworkInterface[]
   new_vm_template: XoVmTemplate | undefined
   pool: XoPool | undefined

--- a/@xen-orchestra/web/src/types/xo/new-vm.type.ts
+++ b/@xen-orchestra/web/src/types/xo/new-vm.type.ts
@@ -13,7 +13,7 @@ export interface Vdi {
 }
 
 export interface NetworkInterface {
-  interface: XoNetwork['id']
+  interface: XoNetwork['id'] | undefined
   macAddress: string
 }
 
@@ -40,7 +40,7 @@ export interface VmState {
   topology: string
   vCPU: number
   selectedVcpu: number
-  vdis: string[]
+  vdis: Vdi[]
   description: string
   existingVdis: Vdi[]
   name: string

--- a/@xen-orchestra/web/src/types/xo/new-vm.type.ts
+++ b/@xen-orchestra/web/src/types/xo/new-vm.type.ts
@@ -9,7 +9,7 @@ export interface Vdi {
   name_label: string
   name_description: string
   size: number
-  sr: XoSr['id']
+  sr: XoSr['id'] | undefined
 }
 
 export interface NetworkInterface {

--- a/@xen-orchestra/web/src/types/xo/new-vm.type.ts
+++ b/@xen-orchestra/web/src/types/xo/new-vm.type.ts
@@ -10,7 +10,7 @@ export interface Vdi {
   name_description: string
   size: number
   sr: XoSr['id'] | undefined
-  userdevice?: string | null
+  userdevice?: string
 }
 
 export interface NetworkInterface {

--- a/@xen-orchestra/web/src/types/xo/pool.type.ts
+++ b/@xen-orchestra/web/src/types/xo/pool.type.ts
@@ -10,5 +10,5 @@ export type XoPool = {
   name_description: string
   name_label: string
   _xapiRef: string
-  default_SR: XoSr['id']
+  default_SR?: XoSr['id']
 }

--- a/@xen-orchestra/web/src/types/xo/vbd.type.ts
+++ b/@xen-orchestra/web/src/types/xo/vbd.type.ts
@@ -2,6 +2,7 @@ import type { XoVdi } from '@/types/xo/vdi.type'
 import type { Branded } from '@core/types/utility.type'
 
 export type XoVbd = {
+  device: string | null
   id: Branded<'vbd'>
   name_label: string
   name_description: string

--- a/@xen-orchestra/web/src/types/xo/vbd.type.ts
+++ b/@xen-orchestra/web/src/types/xo/vbd.type.ts
@@ -8,4 +8,5 @@ export type XoVbd = {
   name_description: string
   VDI: XoVdi['id']
   is_cd_drive: boolean
+  position: string
 }

--- a/@xen-orchestra/web/src/types/xo/vbd.type.ts
+++ b/@xen-orchestra/web/src/types/xo/vbd.type.ts
@@ -2,7 +2,6 @@ import type { XoVdi } from '@/types/xo/vdi.type'
 import type { Branded } from '@core/types/utility.type'
 
 export type XoVbd = {
-  device: string | null
   id: Branded<'vbd'>
   name_label: string
   name_description: string

--- a/@xen-orchestra/web/src/types/xo/vbd.type.ts
+++ b/@xen-orchestra/web/src/types/xo/vbd.type.ts
@@ -6,4 +6,5 @@ export type XoVbd = {
   name_label: string
   name_description: string
   VDI: XoVdi['id']
+  is_cd_drive: boolean
 }

--- a/@xen-orchestra/web/src/utils/xo-api-definition.util.ts
+++ b/@xen-orchestra/web/src/utils/xo-api-definition.util.ts
@@ -60,7 +60,7 @@ export const xoApiDefinition = {
   vbd: {
     type: 'collection',
     path: 'vbds',
-    fields: 'id,name_label,name_description,VDI,is_cd_drive',
+    fields: 'id,name_label,name_description,VDI,is_cd_drive,position',
     handler: (record: XoVbd) => record,
   },
   vdi: {

--- a/@xen-orchestra/web/src/utils/xo-api-definition.util.ts
+++ b/@xen-orchestra/web/src/utils/xo-api-definition.util.ts
@@ -60,7 +60,7 @@ export const xoApiDefinition = {
   vbd: {
     type: 'collection',
     path: 'vbds',
-    fields: 'id,name_label,name_description,VDI',
+    fields: 'id,name_label,name_description,VDI,is_cd_drive',
     handler: (record: XoVbd) => record,
   },
   vdi: {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,8 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [OpenAPI spec] Fixed some required properties being marked as optional (PR [#8480](https://github.com/vatesfr/xen-orchestra/pull/8480))
+- **XO 6:**
+  - [VM/Create] Fix TS type-check errors (PR [#8472](https://github.com/vatesfr/xen-orchestra/pull/8472))
 
 ### Packages to release
 
@@ -39,6 +41,7 @@
 
 - @vates/types minor
 - @xen-orchestra/rest-api minor
+- @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
 - xo-server patch
 - xo-web patch


### PR DESCRIPTION
### Description

- Updated VM creation code to match the TS typing and remove errors in `type-check`
- Refactored code
- Simplified and improved business logic
- Improved naming

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
