### PR TITLE
feat(xo-server-audit): audit import

### DIFF
--- a/@xen-orchestra/audit-core/index.js
+++ b/@xen-orchestra/audit-core/index.js
@@ -99,12 +99,14 @@ class AuditCore {
   }
 
   async _importRecord(record) {
-    // TODO: we should check the chain continuity, but then we can't import separate chains of logs
-    if (record.id !== createHash(record)) {
-      throw new Error('Unhealthy chain import')
+    if (!record.id || !record.previousId) {
+      throw new Error('Invalid record')
     }
     await this._storage.put(record)
-    return record.id
+    return {
+      id: record.id,
+      isValid: record.id === createHash(record),
+    }
   }
 
   async checkIntegrity(oldest, newest) {

--- a/@xen-orchestra/audit-core/index.js
+++ b/@xen-orchestra/audit-core/index.js
@@ -98,6 +98,15 @@ class AuditCore {
     return record
   }
 
+  async _importRecord(record) {
+    // TODO: we should check the chain continuity, but then we can't import separate chains of logs
+    if (record.id !== createHash(record)) {
+      throw new Error('Unhealthy chain import')
+    }
+    await this._storage.put(record)
+    return record.id
+  }
+
   async checkIntegrity(oldest, newest) {
     const storage = this._storage
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@
 - [REST API] Expose `/rest/v0/schedules` and `/rest/v0/schedules/<schedule-id>` enpoints (PR [#8477](https://github.com/vatesfr/xen-orchestra/pull/8477))
 - [REST API] Expose the possibility to run a schedule `/rest/v0/schedules/<schedule-id>/actions/run` (PR [#8477](https://github.com/vatesfr/xen-orchestra/pull/8477))
 - [Host/Networks] PIFs can now be filtered by network names
+- [Plugins/audit] Add an option to import audit logs from an XOA to another (PR [#8474](https://github.com/vatesfr/xen-orchestra/pull/8474))
 
 ### Bug fixes
 
@@ -55,12 +56,14 @@
 <!--packages-start-->
 
 - @vates/types minor
+- @xen-orchestra/audit-core minor
 - @xen-orchestra/backups minor
 - @xen-orchestra/fs minor
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
 - xo-server patch
+- xo-server-audit minor
 - xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-server-audit/package.json
+++ b/packages/xo-server-audit/package.json
@@ -44,13 +44,16 @@
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {
+    "@vates/decorate-with": "^2.1.0",
     "@xen-orchestra/audit-core": "^0.3.1",
     "@xen-orchestra/cron": "^1.0.6",
     "@xen-orchestra/log": "^0.7.1",
     "async-iterator-to-stream": "^1.1.0",
     "complex-matcher": "^0.7.1",
+    "golike-defer": "^0.5.1",
+    "ndjson": "^2.0.0",
     "promise-toolbox": "^0.21.0",
-    "readable-stream": "^4.1.0",
+    "readable-stream": "^4.7.0",
     "xo-common": "^0.8.0"
   },
   "private": true

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2793,6 +2793,13 @@ const messages = {
   noAuditRecordAvailable: 'No audit record available',
   refreshAuditRecordsList: 'Refresh records list',
   auditInactiveUserActionsRecord: 'User actions recording is currently inactive',
+  importAuditRecords: 'Import records',
+  importRecordsTip: 'Try dropping a .ndjson.gz or .ndjson file here or click to select a file.',
+  importAuditRecordsCleanList: 'Reset',
+  importButtonAuditRecords: 'Import',
+  importAuditRecordsSuccess: 'Audit records successfully imported',
+  importAuditRecordsError: 'Error while importing audit records',
+  noAuditRecordsFile: 'No audit records file selected',
 
   // Licenses
   allHostsMustBeBound: 'All hosts must be bound to a license',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2796,9 +2796,12 @@ const messages = {
   importAuditRecords: 'Import records',
   importRecordsTip: 'Try dropping a .ndjson.gz or .ndjson file here or click to select a file.',
   importAuditRecordsCleanList: 'Reset',
-  importButtonAuditRecords: 'Import',
+  importAuditRecordsButton: 'Import',
+  importAuditRecordsTooltip: 'Import audit record from another XOA. Audit log database must be empty.',
   importAuditRecordsSuccess: 'Audit records successfully imported',
-  importAuditRecordsError: 'Error while importing audit records',
+  importAuditRecordsSuccessWithProblems:
+    "Audit records successfully imported, but {nInvalid} invalid records were imported and at least {nMissing} records were missing. Logs prior to the missing entries will not appear. The oldest visible log's ID is {lastLogId}",
+  importAuditRecordsError: 'Error while importing audit records: {importError}',
   noAuditRecordsFile: 'No audit records file selected',
 
   // Licenses

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -2800,7 +2800,7 @@ const messages = {
   importAuditRecordsTooltip: 'Import audit record from another XOA. Audit log database must be empty.',
   importAuditRecordsSuccess: 'Audit records successfully imported',
   importAuditRecordsSuccessWithProblems:
-    "Audit records successfully imported, but {nInvalid} invalid records were imported and at least {nMissing} records were missing. Logs prior to the missing entries will not appear. The oldest visible log's ID is {lastLogId}",
+    "Audit records successfully imported, but {nInvalidRecords} invalid records were imported and at least {nMissingRecords} records were missing. Logs prior to the missing entries will not appear. The oldest visible log's ID is {lastLogId}",
   importAuditRecordsError: 'Error while importing audit records: {importError}',
   noAuditRecordsFile: 'No audit records file selected',
 

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -4240,6 +4240,13 @@ export const exportAuditRecords = () =>
     window.open(`.${url}`)
   })
 
+export const importAuditRecords = recordsFile =>
+  _call('audit.importRecords', { zipped: recordsFile.type === 'application/gzip' }).then(({ $sendTo }) =>
+    post($sendTo, recordsFile).then(response => {
+      return response.status === 200
+    })
+  )
+
 export const checkAuditRecordsIntegrity = (oldest, newest) => _call('audit.checkIntegrity', { oldest, newest })
 
 export const generateAuditFingerprint = oldest => _call('audit.generateFingerprint', { oldest })

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -4249,16 +4249,10 @@ export const importAuditRecords = async recordsFile => {
     throw new Error(text)
   }
 
-  let body
   try {
-    body = JSON.parse(text)
+    return JSON.parse(text)
   } catch (error) {
     throw new Error(`Body is not a JSON, original message is : ${text}`)
-  }
-  return {
-    nInvalid: body.invalidRecords.length,
-    nMissing: body.missingRecords.length,
-    lastLogId: body.chainLastLog?.id,
   }
 }
 

--- a/packages/xo-web/src/xo-app/settings/audit/index.js
+++ b/packages/xo-web/src/xo-app/settings/audit/index.js
@@ -4,6 +4,7 @@ import Button from 'button'
 import Copiable from 'copiable'
 import CopyToClipboard from 'react-copy-to-clipboard'
 import decorate from 'apply-decorators'
+import Dropzone from 'dropzone'
 import Icon from 'icon'
 import Link from 'link'
 import NoObjects from 'no-objects'
@@ -17,7 +18,7 @@ import { injectIntl } from 'react-intl'
 import { get } from '@xen-orchestra/defined'
 import { injectState, provideState } from 'reaclette'
 import { noop, startCase } from 'lodash'
-import { NumericDate } from 'utils'
+import { NumericDate, formatSize } from 'utils'
 import { PREMIUM } from 'xoa-plans'
 import { User } from 'render-xo-item'
 import {
@@ -26,6 +27,7 @@ import {
   fetchAuditRecords,
   generateAuditFingerprint,
   getPlugin,
+  importAuditRecords,
 } from 'xo'
 import RichText from 'rich-text'
 
@@ -171,6 +173,21 @@ const displayRecord = record =>
     <RichText copiable message={JSON.stringify(record, null, 2)} />
   )
 
+const renderImportStatus = ({ recordsFile, importStatus }) => {
+  switch (importStatus) {
+    case 'noFile':
+      return _('noAuditRecordsFile')
+    case 'selectedFile':
+      return <span>{`${recordsFile?.name} (${formatSize(recordsFile?.size)})`}</span>
+    case 'start':
+      return <Icon icon='loading' />
+    case 'end':
+      return <span className='text-success'>{_('importAuditRecordsSuccess')}</span>
+    case 'importError':
+      return <span className='text-danger'>{_('importAuditRecordsError')}</span>
+  }
+}
+
 const INDIVIDUAL_ACTIONS = [
   {
     handler: displayRecord,
@@ -252,7 +269,10 @@ export default decorate([
       _records: undefined,
       checkedRecords: {},
       goTo: undefined,
+      importStatus: 'noFile',
       missingRecord: undefined,
+      recordsFile: undefined,
+      showImportDropzone: false,
     }),
     effects: {
       initialize({ fetchRecords }) {
@@ -260,6 +280,37 @@ export default decorate([
       },
       async fetchRecords() {
         this.state._records = await fetchAuditRecords()
+      },
+      showImportDropzone() {
+        this.state.showImportDropzone = !this.state.showImportDropzone
+      },
+      startImportRecords() {
+        this.state.importStatus = 'start'
+
+        return importAuditRecords(this.state.recordsFile)
+          .then(
+            imported => {
+              if (imported !== false) {
+                this.state.recordsFile = undefined
+                this.state.importStatus = 'end'
+              } else {
+                this.state.importStatus = 'selectedFile'
+              }
+            },
+            () => {
+              this.state.recordsFile = undefined
+              this.state.importStatus = 'importError'
+            }
+          )
+          .finally(this.effects.fetchRecords)
+      },
+      handleDrop(_, files) {
+        this.state.recordsFile = files && files[0]
+        this.state.importStatus = 'selectedFile'
+      },
+      unselectFile() {
+        this.state.recordsFile = undefined
+        this.state.importStatus = 'noFile'
       },
       handleRef(_, ref) {
         if (ref !== null) {
@@ -339,8 +390,38 @@ export default decorate([
             size='large'
           >
             {_('auditCheckIntegrity')}
+          </ActionButton>{' '}
+          <ActionButton
+            btnStyle='warning'
+            handler={effects.showImportDropzone}
+            icon='upload'
+            size='large'
+            disabled={!state.isUserActionsRecordInactive || state.records?.length > 0}
+          >
+            {_('importAuditRecords')}
           </ActionButton>
         </div>
+
+        {!!state.showImportDropzone && (
+          <div>
+            <Dropzone onDrop={effects.handleDrop} message={_('importRecordsTip')} />
+            {renderImportStatus(state)}
+            <div className='form-group pull-right'>
+              <ActionButton
+                btnStyle='primary'
+                className='mr-1'
+                disabled={!state.recordsFile}
+                handler={effects.startImportRecords}
+                icon='import'
+                type='submit'
+              >
+                {_('importButtonAuditRecords')}
+              </ActionButton>
+              <Button onClick={effects.unselectFile}>{_('importAuditRecordsCleanList')}</Button>
+            </div>
+          </div>
+        )}
+
         {state.isUserActionsRecordInactive && (
           <p>
             <Link

--- a/packages/xo-web/src/xo-app/settings/audit/index.js
+++ b/packages/xo-web/src/xo-app/settings/audit/index.js
@@ -176,7 +176,7 @@ const displayRecord = record =>
 const renderImportStatus = ({
   recordsFile,
   importError,
-  importResults: { nInvalid, nMissing, lastLogId } = {},
+  importResults: { nInvalidRecords, nMissingRecords, lastLogId } = {},
   importStatus,
 }) => {
   switch (importStatus) {
@@ -187,12 +187,12 @@ const renderImportStatus = ({
     case 'start':
       return <Icon icon='loading' />
     case 'end':
-      if (nInvalid === 0 && nMissing === 0) {
+      if (nInvalidRecords === 0 && nMissingRecords === 0) {
         return <span className='text-success'>{_('importAuditRecordsSuccess')}</span>
       } else {
         return (
           <span className='text-warning'>
-            {_('importAuditRecordsSuccessWithProblems', { nInvalid, nMissing, lastLogId })}
+            {_('importAuditRecordsSuccessWithProblems', { nInvalidRecords, nMissingRecords, lastLogId })}
           </span>
         )
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17700,7 +17700,7 @@ read-pkg@^3.0.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-"readable-stream@>= 0.3.0", readable-stream@^4.1.0, readable-stream@^4.5.2:
+"readable-stream@>= 0.3.0", readable-stream@^4.1.0, readable-stream@^4.5.2, readable-stream@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.7.0.tgz#cedbd8a1146c13dfff8dab14068028d58c15ac91"
   integrity sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==


### PR DESCRIPTION
### Description

![image](https://github.com/user-attachments/assets/d9d8c7de-1f10-46cf-8c89-cc32a8b35aa6)

Add a way to import audit logs, after exporting it with the UI. The import is possible only if the audit log database is empty.

[XO-823](https://project.vates.tech/vates-global/browse/XO-823/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
