### PR TITLE
fix(@xen-orchestra/rest-api): fix unbrand type

### DIFF
--- a/@xen-orchestra/rest-api/src/open-api/common/response.common.mts
+++ b/@xen-orchestra/rest-api/src/open-api/common/response.common.mts
@@ -4,12 +4,12 @@ import { Branded } from '@vates/types'
 // and TSOA is not able to correctly convert Branded when generating
 // the openapi specification
 export type Unbrand<T> = {
-  [K in keyof T]: T[K] extends Branded<string> | undefined
-    ? string | undefined
+  [K in keyof T]: T[K] extends Branded<string>
+    ? string
     : T[K] extends Branded<string>[]
       ? string[]
-      : T[K] extends Branded<string>
-        ? string
+      : T[K] extends Branded<string> | undefined
+        ? string | undefined
         : T[K]
 }
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [OpenAPI spec] Fixed some required properties being marked as optional
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -30,5 +32,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- @xen-orchestra/rest-api patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [OpenAPI spec] Fixed some required properties being marked as optional
+- [OpenAPI spec] Fixed some required properties being marked as optional (PR [#8480](https://github.com/vatesfr/xen-orchestra/pull/8480))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

Reverse the order condition because its looks like `"foo" extends string | undefined` return true so all `Branded<'*'>` became optional.

#### Example
```ts
// TS type
{
  poolId: Branded<'pool'>,
  affinityHost?: Branded<'host'>,
  name_description: string
}
```

#### OpenAPI spec before

```json
"properties": {
	"poolId": {
		"type": "string"
	},
	"affinityHost": {
		"type": "string"
	},
	"name_description": {
		"type": "string"
	}
},
"required": [
	"name_description"
]
```


#### OpenAPI spec after
**poolId** become required

```json
"properties": {
	"poolId": {
		"type": "string"
	},
	"affinityHost": {
		"type": "string"
	},
	"name_description": {
		"type": "string"
	}
},
"required": [
	"poolId",
	"name_description"
],
```

 
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
