### PR TITLE
REST: Expose get alarms/messages and get alarm/message

### DIFF
--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -115,6 +115,18 @@ type BaseXoVm = BaseXapiXo & {
       }
 }
 
+export type XoAlarm = Omit<XoMessage, '$object' | 'body'> & {
+  body: {
+    value: string
+    name: string
+  }
+  object: {
+    type: XapiXoRecord['type'] | 'unknown'
+    uuid: XapiXoRecord['uuid']
+    href?: string
+  }
+}
+
 export type XoGroup = {
   id: Branded<'group'>
   name: string
@@ -209,6 +221,16 @@ export type XoHost = BaseXapiXo & {
 export type XoHostPatch = BaseXapiXo & {
   id: Branded<'host_patch'>
   type: 'host_patch'
+}
+
+export type XoMessage = BaseXapiXo & {
+  $object: XapiXoRecord['id']
+
+  body: string
+  id: Branded<'message'>
+  name: string
+  time: number
+  type: 'message'
 }
 
 export type XoNetwork = BaseXapiXo & {
@@ -445,7 +467,9 @@ export type XoVtpm = BaseXapiXo & {
 }
 
 export type XapiXoRecord =
+  | XoAlarm
   | XoHost
+  | XoMessage
   | XoNetwork
   | XoPool
   | XoSr

--- a/@xen-orchestra/rest-api/src/abstract-classes/xapi-xo-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/xapi-xo-controller.mts
@@ -12,11 +12,11 @@ export abstract class XapiXoController<T extends XapiXoRecord> extends BaseContr
     this.#type = type
   }
 
-  getObjects({ filter, limit }: { filter?: string; limit?: number } = {}): Record<T['id'], T> {
-    if (filter !== undefined) {
+  getObjects({ filter, limit }: { filter?: string | ((obj: T) => boolean); limit?: number } = {}): Record<T['id'], T> {
+    if (filter !== undefined && typeof filter === 'string') {
       filter = CM.parse(filter).createPredicate()
     }
-    return this.restApi.getObjectsByType<T>(this.#type, { filter, limit })
+    return this.restApi.getObjectsByType<T>(this.#type, { filter: filter as (obj: XapiXoRecord) => boolean, limit })
   }
 
   getObject(id: T['id']): T {

--- a/@xen-orchestra/rest-api/src/alarms/alarm.controller.mts
+++ b/@xen-orchestra/rest-api/src/alarms/alarm.controller.mts
@@ -1,0 +1,130 @@
+import * as CM from 'complex-matcher'
+import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import type { Request as ExRequest } from 'express'
+import { inject } from 'inversify'
+import { noSuchObject } from 'xo-common/api-errors.js'
+import { provide } from 'inversify-binding-decorators'
+import type { XapiXoRecord, XoAlarm, XoMessage } from '@vates/types'
+
+import { alarm, alarmIds, partialAlarms } from '../open-api/oa-examples/alarm.oa-example.mjs'
+import { BASE_URL } from '../index.mjs'
+import { notFoundResp, unauthorizedResp, Unbrand } from '../open-api/common/response.common.mjs'
+import { RestApi } from '../rest-api/rest-api.mjs'
+import { WithHref } from '../helpers/helper.type.mjs'
+import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
+
+// E.g: 'value: 0.6\nconfig:\n<variable>\n<name value="cpu_usage"/>\n<alarm_trigger_level value="0.4"/>\n<alarm_trigger_period value ="60"/>\n</variable>';
+const ALARM_BODY_REGEX = /^value:\s*(Infinity|NaN|-Infinity|\d+(?:\.\d+)?)\s*config:\s*<variable>\s*<name value="(.*?)"/
+const ALARM_NAMES = ['ALARM', 'BOND_STATUS_CHANGED', 'MULTIPATH_PERIODIC_ALERT']
+export const alarmPredicate = CM.parse(`name:|(${ALARM_NAMES.join(' ')})`).createPredicate()
+
+type UnbrandedXoAlarm = Unbrand<XoAlarm>
+
+@Route('alarms')
+@Security('*')
+@Response(unauthorizedResp.status, unauthorizedResp.description)
+@Tags('alarms')
+@provide(AlarmController)
+export class AlarmController extends XapiXoController<XoAlarm> {
+  constructor(@inject(RestApi) restApi: RestApi) {
+    super('message', restApi)
+  }
+
+  #parseAlarm({ $object, body, ...alarm }: XoMessage): XoAlarm {
+    let object: XapiXoRecord | { type: 'unknown'; uuid: XapiXoRecord['uuid'] }
+    try {
+      object = this.restApi.getObject<XapiXoRecord>($object)
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (err) {
+      object = {
+        type: 'unknown',
+        uuid: $object,
+      }
+    }
+
+    let href: string | undefined
+    if (object.type !== 'unknown') {
+      href = `${BASE_URL}/${object.type.toLowerCase() + 's'}/${object.uuid}`
+    }
+
+    const [, value, name] = body.match(ALARM_BODY_REGEX) ?? []
+    return {
+      ...alarm,
+      body: {
+        value, // Keep the value as a string because NaN, Infinity, -Infinity is not valid JSON
+        name: name ?? body, // for 'BOND_STATUS_CHANGED' and 'MULTIPATH_PERIODIC_ALERT', body is a non-xml string. ("body": "The status of the eth0+eth1 bond is: 1/2 up")
+      },
+      object: {
+        type: object.type,
+        uuid: object.uuid,
+        href,
+      },
+    }
+  }
+
+  /**
+   * Override parent getObjects in order to only get `ALARM` messages
+   */
+  getObjects({ filter, limit = Infinity }: { filter?: string; limit?: number } = {}): Record<XoAlarm['id'], XoAlarm> {
+    const rawAlarms = this.restApi.getObjectsByType<XoMessage>('message', {
+      filter: alarmPredicate,
+    })
+
+    let userFilter: (obj: XoAlarm) => boolean = () => true
+    if (filter !== undefined) {
+      userFilter = CM.parse(filter).createPredicate()
+    }
+    const alarms: Record<XoAlarm['id'], XoAlarm> = {}
+    for (const id in rawAlarms) {
+      if (limit === 0) {
+        break
+      }
+      const alarm = this.#parseAlarm(rawAlarms[id])
+      if (userFilter(alarm)) {
+        alarms[id] = alarm
+        limit--
+      }
+    }
+    return alarms
+  }
+
+  /**
+   * Override parent getObject in order to only get `ALARM` message
+   */
+  getObject(id: XoAlarm['id']): XoAlarm {
+    const maybeAlarm = this.restApi.getObject<XoMessage>(id, 'message')
+
+    if (!alarmPredicate(maybeAlarm)) {
+      /* throw */ noSuchObject(id, 'alarm')
+    }
+
+    return this.#parseAlarm(maybeAlarm)
+  }
+
+  /**
+   * @example fields "body,id,object"
+   * @example filter "body:name:physical_utilisation"
+   * @example limit 42
+   */
+  @Example(alarmIds)
+  @Example(partialAlarms)
+  @Get('')
+  getAlarms(
+    @Request() req: ExRequest,
+    @Query() fields?: string,
+    @Query() filter?: string,
+    @Query() limit?: number
+  ): string[] | WithHref<Partial<UnbrandedXoAlarm>>[] {
+    return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
+  }
+
+  /**
+   * @example id "0c98c71c-2f9c-d5c2-b9b6-2c8371730eab"
+   */
+  @Example(alarm)
+  @Get('{id}')
+  @Response(notFoundResp.status, notFoundResp.description)
+  getAlarm(@Path() id: string): UnbrandedXoAlarm {
+    return this.getObject(id as XoAlarm['id'])
+  }
+}

--- a/@xen-orchestra/rest-api/src/messages/message.controller.mts
+++ b/@xen-orchestra/rest-api/src/messages/message.controller.mts
@@ -1,0 +1,83 @@
+import * as CM from 'complex-matcher'
+import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import type { Request as ExRequest } from 'express'
+import { inject } from 'inversify'
+import { noSuchObject } from 'xo-common/api-errors.js'
+import { provide } from 'inversify-binding-decorators'
+import type { XoMessage } from '@vates/types'
+
+import { alarmPredicate } from '../alarms/alarm.controller.mjs'
+import { message, messageIds, partialMessages } from '../open-api/oa-examples/message.oa-example.mjs'
+import { RestApi } from '../rest-api/rest-api.mjs'
+import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
+import type { WithHref } from '../helpers/helper.type.mjs'
+import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
+
+type UnbrandedXoMessage = Unbrand<XoMessage>
+
+@Route('messages')
+@Security('*')
+@Response(unauthorizedResp.status, unauthorizedResp.description)
+@Tags('message')
+@provide(MessageController)
+export class MessageController extends XapiXoController<XoMessage> {
+  constructor(@inject(RestApi) restapi: RestApi) {
+    super('message', restapi)
+  }
+
+  /**
+   * Override parent getObjects in order to exclude `ALARM` messages
+   */
+  getObjects({ filter, limit = Infinity }: { filter?: string; limit?: number } = {}): Record<
+    XoMessage['id'],
+    XoMessage
+  > {
+    let userfilter: (obj: XoMessage) => boolean = () => true
+    if (filter !== undefined) {
+      userfilter = CM.parse(filter).createPredicate()
+    }
+    const messagePredicate = (obj: XoMessage) => !alarmPredicate(obj) && userfilter(obj)
+
+    return super.getObjects({ filter: messagePredicate, limit })
+  }
+
+  /**
+   * Override parent getObject in order to exclude`ALARM` message
+   */
+  getObject(id: XoMessage['id']): XoMessage {
+    const message = super.getObject(id)
+
+    if (alarmPredicate(message)) {
+      /* throw */ noSuchObject(id, 'message')
+    }
+
+    return message
+  }
+
+  /**
+   * @example fields "name,body,id,$object"
+   * @example filter "name:VM_STARTED"
+   * @example limit 42
+   */
+  @Example(messageIds)
+  @Example(partialMessages)
+  @Get('')
+  getMessages(
+    @Request() req: ExRequest,
+    @Query() fields?: string,
+    @Query() filter?: string,
+    @Query() limit?: number
+  ): string[] | WithHref<Partial<UnbrandedXoMessage>>[] {
+    return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
+  }
+
+  /**
+   * @example id "f775eaeb-abe5-94e0-9682-14c37c3a1dfe"
+   */
+  @Example(message)
+  @Get('{id}')
+  @Response(notFoundResp.status, notFoundResp.description)
+  getMessage(@Path() id: string): UnbrandedXoMessage {
+    return this.getObject(id as XoMessage['id'])
+  }
+}

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/alarm.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/alarm.oa-example.mts
@@ -1,0 +1,51 @@
+export const alarmIds = [
+  '/rest/v0/alarms/0c98c71c-2f9c-d5c2-b9b6-2c8371730eab',
+  '/rest/v0/alarms/6a4cc401-6cba-0d41-3b02-b848c5017343',
+]
+
+export const partialAlarms = [
+  {
+    body: {
+      value: '0.0',
+      name: 'physical_utilisation',
+    },
+    id: '0c98c71c-2f9c-d5c2-b9b6-2c8371730eab',
+    object: {
+      type: 'unknown',
+      uuid: '3f607494-26f1-b328-b626-d81cf007de37',
+    },
+    href: '/rest/v0/alarms/0c98c71c-2f9c-d5c2-b9b6-2c8371730eab',
+  },
+  {
+    body: {
+      value: '0.2',
+      name: 'physical_utilisation',
+    },
+    id: '6a4cc401-6cba-0d41-3b02-b848c5017343',
+    object: {
+      type: 'SR',
+      uuid: '8aa2fb4a-143e-c2bc-05d4-c68bbb101d41',
+      href: '/rest/v0/srs/8aa2fb4a-143e-c2bc-05d4-c68bbb101d41',
+    },
+    href: '/rest/v0/alarms/6a4cc401-6cba-0d41-3b02-b848c5017343',
+  },
+]
+
+export const alarm = {
+  name: 'ALARM',
+  time: 1724862780,
+  type: 'message',
+  uuid: '0c98c71c-2f9c-d5c2-b9b6-2c8371730eab',
+  $pool: 'b7569d99-30f8-178a-7d94-801de3e29b5b',
+  $poolId: 'b7569d99-30f8-178a-7d94-801de3e29b5b',
+  _xapiRef: 'OpaqueRef:87ccf385-4197-11aa-3ca0-32213c4cb56d',
+  id: '0c98c71c-2f9c-d5c2-b9b6-2c8371730eab',
+  body: {
+    value: '0.0',
+    name: 'physical_utilisation',
+  },
+  object: {
+    type: 'unknown',
+    uuid: '3f607494-26f1-b328-b626-d81cf007de37',
+  },
+}

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/message.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/message.oa-example.mts
@@ -1,0 +1,34 @@
+export const messageIds = [
+  '/rest/v0/messages/f775eaeb-abe5-94e0-9682-14c37c3a1dfe',
+  '/rest/v0/messages/ed2d1623-3e65-8d39-7a14-4eb69274c5e3',
+]
+
+export const partialMessages = [
+  {
+    name: 'VM_STARTED',
+    body: "VM 'Alpine MRA' (uuid: cef5f68c-61ae-3831-d2e6-1590d4934acf) started on host: XCP 8.3.0 master (uuid: b61a5c92-700e-4966-a13b-00633f03eea8)",
+    id: 'f775eaeb-abe5-94e0-9682-14c37c3a1dfe',
+    $object: 'cef5f68c-61ae-3831-d2e6-1590d4934acf',
+    href: '/rest/v0/messages/f775eaeb-abe5-94e0-9682-14c37c3a1dfe',
+  },
+  {
+    name: 'VM_STARTED',
+    body: "VM 'Alpine MRA' (uuid: cef5f68c-61ae-3831-d2e6-1590d4934acf) started on host: XCP 8.3.0 master (uuid: b61a5c92-700e-4966-a13b-00633f03eea8)",
+    id: 'ed2d1623-3e65-8d39-7a14-4eb69274c5e3',
+    $object: 'cef5f68c-61ae-3831-d2e6-1590d4934acf',
+    href: '/rest/v0/messages/ed2d1623-3e65-8d39-7a14-4eb69274c5e3',
+  },
+]
+
+export const message = {
+  body: "VM 'Alpine MRA' (uuid: cef5f68c-61ae-3831-d2e6-1590d4934acf) started on host: XCP 8.3.0 master (uuid: b61a5c92-700e-4966-a13b-00633f03eea8)",
+  name: 'VM_STARTED',
+  time: 1709908890,
+  $object: 'cef5f68c-61ae-3831-d2e6-1590d4934acf',
+  id: 'f775eaeb-abe5-94e0-9682-14c37c3a1dfe',
+  type: 'message',
+  uuid: 'f775eaeb-abe5-94e0-9682-14c37c3a1dfe',
+  $pool: 'b7569d99-30f8-178a-7d94-801de3e29b5b',
+  $poolId: 'b7569d99-30f8-178a-7d94-801de3e29b5b',
+  _xapiRef: 'OpaqueRef:7544478e-84d3-2381-69e7-b0698ab45d9b',
+}

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
@@ -21,7 +21,7 @@ export class RestApi {
     return this.#xoApp.authenticateUser(...args)
   }
 
-  getObject<T extends XapiXoRecord>(id: T['id'], type: T['type']) {
+  getObject<T extends XapiXoRecord>(id: T['id'], type?: T['type']) {
     return this.#xoApp.getObject(id, type)
   }
 

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -49,10 +49,10 @@ export type XoApp = {
   getAllSchedules(): Promise<XoSchedule[]>
   getAllXenServers(): Promise<XoServer[]>
   getJob(id: XoJob['id']): Promise<XoJob>
-  getObject: <T extends XapiXoRecord>(id: T['id'], type: T['type']) => T
+  getObject: <T extends XapiXoRecord>(id: T['id'], type?: T['type']) => T
   getObjectsByType: <T extends XapiXoRecord>(
     type: T['type'],
-    opts?: { filter?: string; limit?: number }
+    opts?: { filter?: string | ((obj: T) => boolean); limit?: number }
   ) => Record<T['id'], T>
   getSchedule(id: XoSchedule['id']): Promise<XoSchedule>
   getXapiHostStats: (hostId: XoHost['id'], granularity?: XapiStatsGranularity) => Promise<XapiHostStats>

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -3,6 +3,7 @@ import type { Task } from '@vates/types/lib/vates/task'
 import type { XapiHostStats, XapiVmStats, XapiStatsGranularity } from '@vates/types/common'
 import type {
   XenApiHostWrapped,
+  XenApiMessage,
   XenApiNetwork,
   XenApiPoolWrapped,
   XenApiSrWrapped,
@@ -17,6 +18,7 @@ import type { XoHost, XoServer, XoUser, XapiXoRecord, XoVm, XoSchedule, XoJob } 
 
 type XapiRecordByXapiXoRecord = {
   host: XenApiHostWrapped
+  message: XenApiMessage
   network: XenApiNetwork
   pool: XenApiPoolWrapped
   SR: XenApiSrWrapped

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,8 @@
   - `/rest/v0/pools/<pool-id>` (PR [#8490](https://github.com/vatesfr/xen-orchestra/pull/8490))
   - `/rest/v0/alarms` (PR [#8485](https://github.com/vatesfr/xen-orchestra/pull/8485))
   - `/rest/v0/alarms/<alarm-id>` (PR [#8485](https://github.com/vatesfr/xen-orchestra/pull/8485))
+  - `/rest/v0/messages` (PR [#8485](https://github.com/vatesfr/xen-orchestra/pull/8485))
+  - `/rest/v0/messages/<message-id>` (PR [#8485](https://github.com/vatesfr/xen-orchestra/pull/8485))
 
 - [VM/Advanced] Rename `Block migration` to `Prevent migration` (PR [#8500](https://github.com/vatesfr/xen-orchestra/pull/8500))
 - [Dashboard/Health] Display snapshots older than 30 days for which no schedules are enabled (PR [#8487](https://github.com/vatesfr/xen-orchestra/pull/8487))

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,8 @@
   - `/rest/v0/vifs/<vif-id>` (PR [#8483](https://github.com/vatesfr/xen-orchestra/pull/8483))
   - `/rest/v0/pools` (PR [#8490](https://github.com/vatesfr/xen-orchestra/pull/8490))
   - `/rest/v0/pools/<pool-id>` (PR [#8490](https://github.com/vatesfr/xen-orchestra/pull/8490))
+  - `/rest/v0/alarms` (PR [#8485](https://github.com/vatesfr/xen-orchestra/pull/8485))
+  - `/rest/v0/alarms/<alarm-id>` (PR [#8485](https://github.com/vatesfr/xen-orchestra/pull/8485))
 
 - [VM/Advanced] Rename `Block migration` to `Prevent migration` (PR [#8500](https://github.com/vatesfr/xen-orchestra/pull/8500))
 - [Dashboard/Health] Display snapshots older than 30 days for which no schedules are enabled (PR [#8487](https://github.com/vatesfr/xen-orchestra/pull/8487))

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -606,6 +606,7 @@ export default class RestApi {
     const swaggerEndpoints = {
       alarms: {},
       docs: {},
+      messages: {},
       pools: {},
       vifs: {},
       vms: {
@@ -1037,26 +1038,6 @@ export default class RestApi {
       },
     }
     collections.dashboard = {}
-    collections.messages = {
-      getObject(id) {
-        const message = app.getObject(id, 'message')
-        if (isAlarm(message)) {
-          throw noSuchObject(id, 'message')
-        }
-
-        return message
-      },
-      getObjects(filter, limit) {
-        return handleArray(
-          Object.values(
-            app.getObjects({
-              filter: every(keepNonAlarmMessages, filter),
-              limit,
-            })
-          )
-        )
-      },
-    }
 
     // normalize collections
     for (const id of Object.keys(collections)) {

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -31,8 +31,6 @@ import {
 import { compileXoJsonSchema } from './_xoJsonSchema.mjs'
 import { createPredicate } from 'value-matcher'
 
-// E.g: 'value: 0.6\nconfig:\n<variable>\n<name value="cpu_usage"/>\n<alarm_trigger_level value="0.4"/>\n<alarm_trigger_period value ="60"/>\n</variable>';
-const ALARM_BODY_REGEX = /^value:\s*(Infinity|NaN|-Infinity|\d+(?:\.\d+)?)\s*config:\s*<variable>\s*<name value="(.*?)"/
 const DASHBOARD_CACHE = new Map()
 
 const { join } = path.posix
@@ -606,6 +604,7 @@ export default class RestApi {
     const collections = { __proto__: null }
     // add migrated collections to maintain their discoverability
     const swaggerEndpoints = {
+      alarms: {},
       docs: {},
       pools: {},
       vifs: {},
@@ -1052,53 +1051,6 @@ export default class RestApi {
           Object.values(
             app.getObjects({
               filter: every(keepNonAlarmMessages, filter),
-              limit,
-            })
-          )
-        )
-      },
-    }
-    collections.alarms = {
-      getObject(id, req) {
-        const alarm = app.getObject(id, 'message')
-        if (!isAlarm(alarm)) {
-          throw noSuchObject(id, 'alarm')
-        }
-
-        const { $object, body } = alarm
-        let object = {}
-        try {
-          object = app.getObject($object)
-        } catch (error) {
-          object = {
-            type: 'unknown',
-            uuid: $object,
-          }
-        }
-
-        const { baseUrl } = req
-        const objType = object.type.toLowerCase() + 's'
-        const href = collections[objType] === undefined ? undefined : `${baseUrl}/${objType}/${object.uuid}`
-        const [, value, name] = body.match(ALARM_BODY_REGEX) ?? []
-
-        return {
-          ...alarm,
-          body: {
-            value, // Keep the value as a string because NaN, Infinity, -Infinity is not valid JSON
-            name: name ?? body, // for 'BOND_STATUS_CHANGED' and 'MULTIPATH_PERIODIC_ALERT', body is a non-xml string. ("body": "The status of the eth0+eth1 bond is: 1/2 up")
-          },
-          object: {
-            type: object.type,
-            uuid: object.uuid,
-            href,
-          },
-        }
-      },
-      getObjects(filter, limit) {
-        return handleArray(
-          Object.values(
-            app.getObjects({
-              filter: every(isAlarm, filter),
               limit,
             })
           )


### PR DESCRIPTION
### Description

Alarms and messages are very similar, but we need to separate them.
Messages are "everything and nothing," and alarms are "useful messages."
We decided to create a dedicated alarm endpoint to avoid clients having to fetch and filter all the messages.

To do this, we need to create two separate controllers and override the `getObjects/getObject` methods for each.

The message controller simply filters alarm messages.
The alarm controller only retrieves alarm messages and parses their body.
 
Previously, the REST API only parsed the alarm body when querying a single alarm. Now it parses the alarm even when querying the entire collection and allows filtering on the parsed body! 
E.g. `filter=body:name:physical_utilisation`

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
