### PR TITLE
feat(sdn-controller): use host plugin 

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,8 +17,7 @@
   - [Site/Backups] Add side panel to backup jobs view (PR [#8966](https://github.com/vatesfr/xen-orchestra/pull/8966))
   - [VM/Backups] Add side panel to VM backup jobs view (PR [#8978](https://github.com/vatesfr/xen-orchestra/pull/8978))
 
-
-- [sdn-controller] Use the Xapi plugin instead of a direct channel to drive openflow (PR [#8488](https://github.com/vatesfr/xen-orchestra/pull/8488))
+- [sdn-controller] Use the XCP-ng plugin instead of a direct channel to drive openflow (PR [#8488](https://github.com/vatesfr/xen-orchestra/pull/8488))
 
 ### Bug fixes
 
@@ -26,6 +25,7 @@
 
 - **XO 6:**
   - [VM/New] Fix `auto_poweron is an excess property and therefore is not allowed` during VM creation (PR [#8998](https://github.com/vatesfr/xen-orchestra/pull/8998))
+  - [sdn-controller] Remove port for ICMP filtering (PR [#8488](https://github.com/vatesfr/xen-orchestra/pull/8488))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,9 @@
   - [Site/Backups] Add side panel to backup jobs view (PR [#8966](https://github.com/vatesfr/xen-orchestra/pull/8966))
   - [VM/Backups] Add side panel to VM backup jobs view (PR [#8978](https://github.com/vatesfr/xen-orchestra/pull/8978))
 
+
+- [sdn-controller] Use the Xapi plugin instead of a direct channel to drive openflow (PR [#8488](https://github.com/vatesfr/xen-orchestra/pull/8488))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -42,5 +45,6 @@
 
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+- xo-server-sdn-controller minor
 
 <!--packages-end-->

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -380,9 +380,9 @@ class SDNController extends EventEmitter {
     addRule.params = {
       allow: { type: 'boolean' },
       direction: { type: 'string' },
-      ipRange: { type: 'string', optional: true },
+      ipRange: { type: 'string' },
       port: { type: 'integer', optional: true },
-      protocol: { type: 'string', optional: true },
+      protocol: { type: 'string' },
       vifId: { type: 'string' },
     }
     addRule.permission = 'admin'
@@ -391,9 +391,9 @@ class SDNController extends EventEmitter {
     deleteRule.description = 'Delete an ACL rule from a VIF'
     deleteRule.params = {
       direction: { type: 'string' },
-      ipRange: { type: 'string', optional: true },
+      ipRange: { type: 'string' },
       port: { type: 'integer', optional: true },
-      protocol: { type: 'string', optional: true },
+      protocol: { type: 'string' },
       vifId: { type: 'string' },
     }
     deleteRule.permission = 'admin'
@@ -403,8 +403,8 @@ class SDNController extends EventEmitter {
     addNetworkRule.params = {
       allow: { type: 'boolean' },
       direction: { type: 'string' },
-      ipRange: { type: 'string', optional: true },
-      port: { type: 'integer', optional: true },
+      ipRange: { type: 'string' },
+      port: { type: 'integer' },
       protocol: { type: 'string', optional: true },
       networkId: { type: 'string' },
     }
@@ -414,9 +414,9 @@ class SDNController extends EventEmitter {
     deleteNetworkRule.description = 'Delete an ACL rule from a network'
     deleteNetworkRule.params = {
       direction: { type: 'string' },
-      ipRange: { type: 'string', optional: true },
+      ipRange: { type: 'string' },
       port: { type: 'integer', optional: true },
-      protocol: { type: 'string', optional: true },
+      protocol: { type: 'string' },
       networkId: { type: 'string' },
     }
     deleteNetworkRule.permission = 'admin'

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -251,6 +251,7 @@ function isControllerNeeded(xapi) {
 // =============================================================================
 
 class SDNController extends EventEmitter {
+  #staticConfig
   /*
   Attributes on created networks:
   - `other_config`:
@@ -272,9 +273,9 @@ class SDNController extends EventEmitter {
     - `xo:sdn-controller:of-rules`: A list of openflow entries to apply to this VIF
   */
 
-  constructor({ xo, getDataDir }) {
+  constructor({ xo, getDataDir, staticConfig }) {
     super()
-
+    this.#staticConfig = staticConfig
     this._xo = xo
     this._getDataDir = getDataDir
 
@@ -1355,7 +1356,7 @@ class SDNController extends EventEmitter {
     let channel = this.ofChannels[host.$ref]
     if (channel === undefined) {
       // this ensure only one channel is create in parallel
-      channel = this.ofChannels[host.$ref] = instantiateController(host)
+      channel = this.ofChannels[host.$ref] = instantiateController(host, this._tlsHelper, this.#staticConfig)
     }
     if (this.ofChannels[host.$ref].then) {
       this.ofChannels[host.$ref] = await this.ofChannels[host.$ref]

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -1354,9 +1354,12 @@ class SDNController extends EventEmitter {
   async _getOrCreateOfChannel(host) {
     let channel = this.ofChannels[host.$ref]
     if (channel === undefined) {
+      // this ensure only one channel is create in parallel
       channel = this.ofChannels[host.$ref] = instantiateController(host)
     }
-    await channel
+    if (this.ofChannels[host.$ref].then) {
+      this.ofChannels[host.$ref] = await this.ofChannels[host.$ref]
+    }
     return channel
   }
 }

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -404,8 +404,8 @@ class SDNController extends EventEmitter {
       allow: { type: 'boolean' },
       direction: { type: 'string' },
       ipRange: { type: 'string' },
-      port: { type: 'integer' },
-      protocol: { type: 'string', optional: true },
+      port: { type: 'integer', optional: true },
+      protocol: { type: 'string' },
       networkId: { type: 'string' },
     }
     addNetworkRule.permission = 'admin'
@@ -415,8 +415,8 @@ class SDNController extends EventEmitter {
     deleteNetworkRule.params = {
       direction: { type: 'string' },
       ipRange: { type: 'string' },
-      port: { type: 'integer', optional: true },
-      protocol: { type: 'string' },
+      port: { type: 'integer' },
+      protocol: { type: 'string', optional: true },
       networkId: { type: 'string' },
     }
     deleteNetworkRule.permission = 'admin'

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -641,7 +641,7 @@ class SDNController extends EventEmitter {
   async _addNetworkRule({ networkId, allow, direction, ipRange = '', port, protocol }) {
     try {
       const network = this._xo.getXapiObject(this._xo.getObject(networkId, 'network'))
-      assert(network.PIFs.length > 0, 'Network needs to be plugged to delete  rule')
+      assert(network.PIFs.length > 0, 'Network needs to be plugged to delete a rule')
       const channel = this._getOrCreateOfChannel(network.PIFs[0].host)
       await channel.addNetworkRule(network, allow, protocol, port, ipRange, direction)
       const networkRules = network.other_config['xo:sdn-controller:of-rules']
@@ -721,7 +721,7 @@ class SDNController extends EventEmitter {
   async _deleteNetworkOfRule({ direction, ipRange = '', port, protocol, networkId }, updateOtherConfig = true) {
     try {
       let network = this._xo.getXapiObject(this._xo.getObject(networkId, 'network'))
-      assert(network.PIFs.length > 0, 'Network needs to be plugged to delete  rule')
+      assert(network.PIFs.length > 0, 'Network needs to be plugged to delete a rule')
 
       const channel = await this._getOrCreateOfChannel(network.PIFs[0].host)
       await channel.deleteNetworkRule({ network, protocol, port, ipRange, direction })

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -643,7 +643,8 @@ class SDNController extends EventEmitter {
     try {
       const network = this._xo.getXapiObject(this._xo.getObject(networkId, 'network'))
       assert(network.$PIFs.length > 0, 'Network needs to be plugged to add a rule')
-      const channel = await this._getOrCreateOfChannel(network.$PIFs[0].$host)
+      const host = this._xo.getXapiObject(this._xo.getObject(network.$PIFs[0].host, 'host'))
+      const channel = await this._getOrCreateOfChannel(host)
       await channel.addNetworkRule({ network, allow, protocol, port, ipRange, direction })
       const networkRules = network.other_config['xo:sdn-controller:of-rules']
       const newNetworkRules = networkRules !== undefined ? JSON.parse(networkRules) : []
@@ -724,7 +725,8 @@ class SDNController extends EventEmitter {
       let network = this._xo.getXapiObject(this._xo.getObject(networkId, 'network'))
       assert(network.$PIFs.length > 0, 'Network needs to be plugged to delete a rule')
 
-      const channel = await this._getOrCreateOfChannel(network.$PIFs[0].$host)
+      const host = this._xo.getXapiObject(this._xo.getObject(network.$PIFs[0].host, 'host'))
+      const channel = await this._getOrCreateOfChannel(host)
       await channel.deleteNetworkRule({ network, protocol, port, ipRange, direction })
       if (!updateOtherConfig) {
         return

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -643,7 +643,7 @@ class SDNController extends EventEmitter {
     try {
       const network = this._xo.getXapiObject(this._xo.getObject(networkId, 'network'))
       assert(network.$PIFs.length > 0, 'Network needs to be plugged to add a rule')
-      const channel = await this._getOrCreateOfChannel(network.$PIFs[0].host)
+      const channel = await this._getOrCreateOfChannel(network.$PIFs[0].$host)
       await channel.addNetworkRule({ network, allow, protocol, port, ipRange, direction })
       const networkRules = network.other_config['xo:sdn-controller:of-rules']
       const newNetworkRules = networkRules !== undefined ? JSON.parse(networkRules) : []
@@ -724,7 +724,7 @@ class SDNController extends EventEmitter {
       let network = this._xo.getXapiObject(this._xo.getObject(networkId, 'network'))
       assert(network.$PIFs.length > 0, 'Network needs to be plugged to delete a rule')
 
-      const channel = await this._getOrCreateOfChannel(network.$PIFs[0].host)
+      const channel = await this._getOrCreateOfChannel(network.$PIFs[0].$host)
       await channel.deleteNetworkRule({ network, protocol, port, ipRange, direction })
       if (!updateOtherConfig) {
         return

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -415,8 +415,8 @@ class SDNController extends EventEmitter {
     deleteNetworkRule.params = {
       direction: { type: 'string' },
       ipRange: { type: 'string' },
-      port: { type: 'integer' },
-      protocol: { type: 'string', optional: true },
+      port: { type: 'integer', optional: true },
+      protocol: { type: 'string' },
       networkId: { type: 'string' },
     }
     deleteNetworkRule.permission = 'admin'

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -641,8 +641,8 @@ class SDNController extends EventEmitter {
   async _addNetworkRule({ networkId, allow, direction, ipRange = '', port, protocol }) {
     try {
       const network = this._xo.getXapiObject(this._xo.getObject(networkId, 'network'))
-      assert(network.PIFs.length > 0, 'Network needs to be plugged to delete a rule')
-      const channel = this._getOrCreateOfChannel(network.PIFs[0].host)
+      assert(network.$PIFs.length > 0, 'Network needs to be plugged to delete a rule')
+      const channel = this._getOrCreateOfChannel(network.$PIFs[0].host)
       await channel.addNetworkRule(network, allow, protocol, port, ipRange, direction)
       const networkRules = network.other_config['xo:sdn-controller:of-rules']
       const newNetworkRules = networkRules !== undefined ? JSON.parse(networkRules) : []
@@ -721,9 +721,9 @@ class SDNController extends EventEmitter {
   async _deleteNetworkOfRule({ direction, ipRange = '', port, protocol, networkId }, updateOtherConfig = true) {
     try {
       let network = this._xo.getXapiObject(this._xo.getObject(networkId, 'network'))
-      assert(network.PIFs.length > 0, 'Network needs to be plugged to delete a rule')
+      assert(network.$PIFs.length > 0, 'Network needs to be plugged to delete a rule')
 
-      const channel = await this._getOrCreateOfChannel(network.PIFs[0].host)
+      const channel = await this._getOrCreateOfChannel(network.$PIFs[0].host)
       await channel.deleteNetworkRule({ network, protocol, port, ipRange, direction })
       if (!updateOtherConfig) {
         return

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -642,9 +642,9 @@ class SDNController extends EventEmitter {
   async _addNetworkRule({ networkId, allow, direction, ipRange = '', port, protocol }) {
     try {
       const network = this._xo.getXapiObject(this._xo.getObject(networkId, 'network'))
-      assert(network.$PIFs.length > 0, 'Network needs to be plugged to delete a rule')
+      assert(network.$PIFs.length > 0, 'Network needs to be plugged to add a rule')
       const channel = this._getOrCreateOfChannel(network.$PIFs[0].host)
-      await channel.addNetworkRule(network, allow, protocol, port, ipRange, direction)
+      await channel.addNetworkRule({ network, allow, protocol, port, ipRange, direction })
       const networkRules = network.other_config['xo:sdn-controller:of-rules']
       const newNetworkRules = networkRules !== undefined ? JSON.parse(networkRules) : []
       const stringRule = JSON.stringify({

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -9,10 +9,10 @@ import { fromCallback, promisify } from 'promise-toolbox'
 import { join } from 'path'
 import { v4 as uuidv4 } from 'uuid'
 
-import { OpenFlowChannel } from './protocol/openflow-channel'
 import { OvsdbClient } from './protocol/ovsdb-client'
 import { PrivateNetwork } from './private-network/private-network'
 import { TlsHelper } from './utils/tls-helper'
+import { instantiateController } from './openflow-controller'
 
 // =============================================================================
 
@@ -467,7 +467,7 @@ class SDNController extends EventEmitter {
       const hosts = filter(xapi.objects.all, { $type: 'host' })
       for (const host of hosts) {
         this._getOrCreateOvsdbClient(host)
-        this._getOrCreateOfChannel(host)
+        await this._getOrCreateOfChannel(host)
       }
 
       // Add already existing private networks
@@ -582,9 +582,9 @@ class SDNController extends EventEmitter {
       await this._setPoolControllerIfNeeded(vif.$pool)
 
       const client = this._getOrCreateOvsdbClient(vif.$VM.$resident_on)
-      const channel = this._getOrCreateOfChannel(vif.$VM.$resident_on)
+      const channel = await this._getOrCreateOfChannel(vif.$VM.$resident_on)
       const ofport = await client.getOfPortForVif(vif)
-      await channel.addRule(vif, allow, protocol, port, ipRange, direction, ofport)
+      await channel.addRule({ vif, allow, protocol, port, ipRange, direction, ofport })
       const vifRules = vif.other_config['xo:sdn-controller:of-rules']
       const newVifRules = vifRules !== undefined ? JSON.parse(vifRules) : []
       const stringRule = JSON.stringify({
@@ -618,9 +618,9 @@ class SDNController extends EventEmitter {
       await this._setPoolControllerIfNeeded(vif.$pool)
 
       const client = this._getOrCreateOvsdbClient(vif.$VM.$resident_on)
-      const channel = this._getOrCreateOfChannel(vif.$VM.$resident_on)
+      const channel = await this._getOrCreateOfChannel(vif.$VM.$resident_on)
       const ofport = await client.getOfPortForVif(vif)
-      await channel.deleteRule(vif, protocol, port, ipRange, direction, ofport)
+      await channel.deleteRule({ vif, protocol, port, ipRange, direction, ofport })
       if (!updateOtherConfig) {
         return
       }
@@ -726,7 +726,7 @@ class SDNController extends EventEmitter {
         const hostPif = host.$PIFs.find(_pif => _pif.network === pif.network)
         await createTunnel(host, createdNetwork, hostPif)
         this._getOrCreateOvsdbClient(host)
-        this._getOrCreateOfChannel(host)
+        await this._getOrCreateOfChannel(host)
       })
       await this._setPoolControllerIfNeeded(pool)
 
@@ -776,7 +776,7 @@ class SDNController extends EventEmitter {
           this._newHosts.push(object)
         }
         this._getOrCreateOvsdbClient(object)
-        this._getOrCreateOfChannel(object)
+        await this._getOrCreateOfChannel(object)
       } else if ($type === 'PIF') {
         log.debug('New PIF', {
           device: object.device,
@@ -973,7 +973,7 @@ class SDNController extends EventEmitter {
         value === 'hard_shutdown' ||
         value === 'clean_shutdown'
       ) {
-        await this._cleanOfRules(vm)
+        await this._cleanOfVmRules(vm)
       }
 
       await vm.$xapi.watchTask(key).catch(noop)
@@ -1239,13 +1239,12 @@ class SDNController extends EventEmitter {
     return client
   }
 
-  _getOrCreateOfChannel(host) {
+  async _getOrCreateOfChannel(host) {
     let channel = this.ofChannels[host.$ref]
     if (channel === undefined) {
-      channel = new OpenFlowChannel(host, this._tlsHelper)
-      this.ofChannels[host.$ref] = channel
+      channel = this.ofChannels[host.$ref] = instantiateController(host)
     }
-
+    await channel
     return channel
   }
 }

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -643,7 +643,7 @@ class SDNController extends EventEmitter {
     try {
       const network = this._xo.getXapiObject(this._xo.getObject(networkId, 'network'))
       assert(network.$PIFs.length > 0, 'Network needs to be plugged to add a rule')
-      const channel = this._getOrCreateOfChannel(network.$PIFs[0].host)
+      const channel = await this._getOrCreateOfChannel(network.$PIFs[0].host)
       await channel.addNetworkRule({ network, allow, protocol, port, ipRange, direction })
       const networkRules = network.other_config['xo:sdn-controller:of-rules']
       const newNetworkRules = networkRules !== undefined ? JSON.parse(networkRules) : []

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -602,7 +602,7 @@ class SDNController extends EventEmitter {
       log.error('Error while adding OF rule', {
         error,
         vif: vif.uuid,
-        host: vif.$VM.$resident_on.uuid,
+        host: vif.$VM.$resident_on?.uuid,
         allow,
         protocol,
         port,
@@ -651,7 +651,7 @@ class SDNController extends EventEmitter {
       log.error('Error while adding OF rule', {
         error,
         vif: vif.uuid,
-        host: vif.$VM.$resident_on.uuid,
+        host: vif.$VM.$resident_on?.uuid,
         protocol,
         port,
         ipRange,
@@ -818,8 +818,8 @@ class SDNController extends EventEmitter {
   _objectsRemoved(xapi, objects) {
     forOwn(objects, async (object, id) => {
       try {
-        this.ovsdbClients = omitBy(this.ovsdbClients, client => client.host.$id === id)
-        this.ofChannels = omitBy(this.ofChannels, channel => channel.host.$id === id)
+        this.ovsdbClients = omitBy(this.ovsdbClients, client => client.host?.$id === id)
+        this.ofChannels = omitBy(this.ofChannels, channel => channel.host?.$id === id)
 
         // If a Star center host is removed: re-elect a new center where needed
         const starCenterRef = this._starCenters.get(id)

--- a/packages/xo-server-sdn-controller/src/openflow-controller.js
+++ b/packages/xo-server-sdn-controller/src/openflow-controller.js
@@ -1,0 +1,16 @@
+import { OpenFlowPlugin } from './openflow-plugin'
+import { OpenFlowChannel } from './protocol/openflow-channel'
+
+export async function instantiateController(host, tlsHelper) {
+  try {
+    const controller = new OpenFlowPlugin(host)
+    await controller.check(host)
+    return controller
+  } catch (error) {
+    if (error.code === 'XENAPI_MISSING_PLUGIN' /* || error.code === 'UNKNOWN_XENAPI_PLUGIN_FUNCTION' */) {
+      return new OpenFlowChannel(host, tlsHelper)
+    } else {
+      throw error
+    }
+  }
+}

--- a/packages/xo-server-sdn-controller/src/openflow-controller.js
+++ b/packages/xo-server-sdn-controller/src/openflow-controller.js
@@ -5,9 +5,11 @@ export async function instantiateController(host, tlsHelper) {
   try {
     const controller = new OpenFlowPlugin(host)
     await controller.check(host)
+    console.log('USE OPENFLOW')
     return controller
   } catch (error) {
     if (error.code === 'XENAPI_MISSING_PLUGIN') {
+      console.log('FALL BACK TO DIRECT',{error})
       return new OpenFlowChannel(host, tlsHelper)
     } else {
       throw error

--- a/packages/xo-server-sdn-controller/src/openflow-controller.js
+++ b/packages/xo-server-sdn-controller/src/openflow-controller.js
@@ -1,15 +1,17 @@
+import { createLogger } from '@xen-orchestra/log'
 import { OpenFlowPlugin } from './openflow-plugin'
 import { OpenFlowChannel } from './protocol/openflow-channel'
 
+const log = createLogger('xo:sdn-controller:openflowcontroller')
 export async function instantiateController(host, tlsHelper) {
   try {
     const controller = new OpenFlowPlugin(host)
     await controller.check(host)
-    console.log('USE OPENFLOW')
+    log.info('use xapi plugin')
     return controller
   } catch (error) {
     if (error.code === 'XENAPI_MISSING_PLUGIN') {
-      console.log('FALL BACK TO DIRECT',{error})
+      log.info('use direct poenflow channel')
       return new OpenFlowChannel(host, tlsHelper)
     } else {
       throw error

--- a/packages/xo-server-sdn-controller/src/openflow-controller.js
+++ b/packages/xo-server-sdn-controller/src/openflow-controller.js
@@ -3,18 +3,14 @@ import { OpenFlowPlugin } from './openflow-plugin'
 import { OpenFlowChannel } from './protocol/openflow-channel'
 
 const log = createLogger('xo:sdn-controller:openflowcontroller')
-export async function instantiateController(host, tlsHelper) {
-  try {
+export async function instantiateController(host, tlsHelper, config) {
+  if (config.useDirectChannel) {
+    log.info('use direct openflow channel')
+    return new OpenFlowChannel(host, tlsHelper)
+  } else {
     const controller = new OpenFlowPlugin(host)
     await controller.check(host)
     log.info('use xapi plugin')
     return controller
-  } catch (error) {
-    if (error.code === 'XENAPI_MISSING_PLUGIN') {
-      log.info('use direct openflow channel')
-      return new OpenFlowChannel(host, tlsHelper)
-    } else {
-      throw error
-    }
   }
 }

--- a/packages/xo-server-sdn-controller/src/openflow-controller.js
+++ b/packages/xo-server-sdn-controller/src/openflow-controller.js
@@ -7,7 +7,7 @@ export async function instantiateController(host, tlsHelper) {
     await controller.check(host)
     return controller
   } catch (error) {
-    if (error.code === 'XENAPI_MISSING_PLUGIN' /* || error.code === 'UNKNOWN_XENAPI_PLUGIN_FUNCTION' */) {
+    if (error.code === 'XENAPI_MISSING_PLUGIN') {
       return new OpenFlowChannel(host, tlsHelper)
     } else {
       throw error

--- a/packages/xo-server-sdn-controller/src/openflow-controller.js
+++ b/packages/xo-server-sdn-controller/src/openflow-controller.js
@@ -11,7 +11,7 @@ export async function instantiateController(host, tlsHelper) {
     return controller
   } catch (error) {
     if (error.code === 'XENAPI_MISSING_PLUGIN') {
-      log.info('use direct poenflow channel')
+      log.info('use direct openflow channel')
       return new OpenFlowChannel(host, tlsHelper)
     } else {
       throw error

--- a/packages/xo-server-sdn-controller/src/openflow-plugin.js
+++ b/packages/xo-server-sdn-controller/src/openflow-plugin.js
@@ -1,0 +1,48 @@
+import { asyncEach } from '@vates/async-each'
+
+const PLUGIN_NAME = 'open-vswitch.py'
+
+export class OpenFlowPlugin {
+  #getBridge(network) {
+    return network.bridge // following discussion with David, it may not be the right bridge
+    // the plugin may need the bridge name on dom0 side
+  }
+
+  async #callPluginOnAllNetwork(network, method, parameters) {
+    const bridge = this.#getBridge(network)
+    return asyncEach(network.PIFs, async PIF => {
+      const host = PIF.host
+      return host.$xapi.call('host.call_plugin', host.$ref, PLUGIN_NAME, method, { ...parameters, bridge })
+    })
+  }
+
+  async addRule({ vif, allow, protocol, ipRange, direction, port }) {
+    const network = vif.$network
+    const mac = vif.MAC
+    return this.#callPluginOnAllNetwork(network, 'add-flow', {
+      mac,
+      allow: allow ? 'true' : 'false',
+      protocol,
+      ipRange,
+      direction,
+      port,
+    })
+  }
+
+  async deleteRule({ vif, allow, protocol, ipRange, direction, port }) {
+    const network = vif.$network
+    const mac = vif.MAC
+    return this.#callPluginOnAllNetwork(network, 'del-flow', {
+      mac,
+      allow: allow ? 'true' : 'false',
+      protocol,
+      ipRange,
+      direction,
+      port,
+    })
+  }
+
+  async check(host) {
+    return host.$xapi.call('host.call_plugin', host.$ref, PLUGIN_NAME, 'dump-flows', { IHAVEPARAMZ: 'true' })
+  }
+}

--- a/packages/xo-server-sdn-controller/src/openflow-plugin.js
+++ b/packages/xo-server-sdn-controller/src/openflow-plugin.js
@@ -23,6 +23,7 @@ export class OpenFlowPlugin {
     if (port) {
       port = String(port)
     }
+    allow = String(allow)
     log.debug('addRule', { vif, allow, protocol, ipRange, direction, port })
     return this.#callPluginOnAllNetwork(vif.$network, 'add-rule', {
       mac: vif.MAC,
@@ -53,6 +54,7 @@ export class OpenFlowPlugin {
     if (port) {
       port = String(port)
     }
+    allow = String(allow)
     log.debug('addNetworkRule', { network, allow, protocol, ipRange, direction, port })
     return this.#callPluginOnAllNetwork(network, 'add-rule', { allow, protocol, ipRange, direction, port })
   }

--- a/packages/xo-server-sdn-controller/src/openflow-plugin.js
+++ b/packages/xo-server-sdn-controller/src/openflow-plugin.js
@@ -20,6 +20,9 @@ export class OpenFlowPlugin {
   }
 
   async addRule({ vif, allow, protocol, ipRange, direction, port }) {
+    if (port) {
+      port = String(port)
+    }
     log.debug('addRule', { vif, allow, protocol, ipRange, direction, port })
     return this.#callPluginOnAllNetwork(vif.$network, 'add-rule', {
       mac: vif.MAC,
@@ -32,6 +35,9 @@ export class OpenFlowPlugin {
   }
 
   async deleteRule({ vif, allow, protocol, ipRange, direction, port }) {
+    if (port) {
+      port = String(port)
+    }
     log.debug('deleteRule', { vif, allow, protocol, ipRange, direction, port })
     return this.#callPluginOnAllNetwork(vif.$network, 'del-rule', {
       mac: vif.MAC,
@@ -44,10 +50,16 @@ export class OpenFlowPlugin {
   }
 
   async addNetworkRule({ network, allow, protocol, ipRange, direction, port }) {
+    if (port) {
+      port = String(port)
+    }
     log.debug('addNetworkRule', { network, allow, protocol, ipRange, direction, port })
     return this.#callPluginOnAllNetwork(network, 'add-rule', { allow, protocol, ipRange, direction, port })
   }
   async deleteNetworkRule({ network, allow, protocol, ipRange, direction, port }) {
+    if (port) {
+      port = String(port)
+    }
     log.debug('deleteNetworkRule', { network, allow, protocol, ipRange, direction, port })
     return this.#callPluginOnAllNetwork(network, 'del-rule', { allow, protocol, ipRange, direction, port })
   }

--- a/packages/xo-server-sdn-controller/src/openflow-plugin.js
+++ b/packages/xo-server-sdn-controller/src/openflow-plugin.js
@@ -17,6 +17,7 @@ export class OpenFlowPlugin {
   }
 
   async addRule({ vif, allow, protocol, ipRange, direction, port }) {
+    console.log('addRule',{ vif, allow, protocol, ipRange, direction, port })
     return this.#callPluginOnAllNetwork(vif.$network, 'add-rule', {
       mac: vif.MAC,
       allow: allow ? 'true' : 'false',
@@ -28,6 +29,7 @@ export class OpenFlowPlugin {
   }
 
   async deleteRule({ vif, allow, protocol, ipRange, direction, port }) {
+    console.log('deleteRule',{ vif, allow, protocol, ipRange, direction, port })
     return this.#callPluginOnAllNetwork(vif.$network, 'del-rule', {
       mac: vif.MAC,
       allow: allow ? 'true' : 'false',
@@ -39,12 +41,15 @@ export class OpenFlowPlugin {
   }
 
   async addNetworkRule({ network, allow, protocol, ipRange, direction, port }) {
+    console.log('addNetworkRule',{ network, allow, protocol, ipRange, direction, port })
     return this.#callPluginOnAllNetwork(network, 'add-rule', { allow, protocol, ipRange, direction, port })
   }
   async deleteNetworkRule({ network, allow, protocol, ipRange, direction, port }) {
+    console.log('deleteNetworkRule',{ network, allow, protocol, ipRange, direction, port })
     return this.#callPluginOnAllNetwork(network, 'del-rule', { allow, protocol, ipRange, direction, port })
   }
   async check(host) {
+    console.log('check',{ host })
     await Promise.all(
       host.$PIFs.map(async ({ $network }) => {
         const response = await host.$xapi.call('host.call_plugin', host.$ref, PLUGIN_NAME, 'dump-flows', {

--- a/packages/xo-server-sdn-controller/src/openflow-plugin.js
+++ b/packages/xo-server-sdn-controller/src/openflow-plugin.js
@@ -23,7 +23,6 @@ export class OpenFlowPlugin {
     if (port) {
       port = String(port)
     }
-    allow = String(allow)
     log.debug('addRule', { vif, allow, protocol, ipRange, direction, port })
     return this.#callPluginOnAllNetwork(vif.$network, 'add-rule', {
       mac: vif.MAC,
@@ -54,16 +53,27 @@ export class OpenFlowPlugin {
     if (port) {
       port = String(port)
     }
-    allow = String(allow)
     log.debug('addNetworkRule', { network, allow, protocol, ipRange, direction, port })
-    return this.#callPluginOnAllNetwork(network, 'add-rule', { allow, protocol, ipRange, direction, port })
+    return this.#callPluginOnAllNetwork(network, 'add-rule', {
+      allow: allow ? 'true' : 'false',
+      protocol,
+      ipRange,
+      direction,
+      port,
+    })
   }
   async deleteNetworkRule({ network, allow, protocol, ipRange, direction, port }) {
     if (port) {
       port = String(port)
     }
     log.debug('deleteNetworkRule', { network, allow, protocol, ipRange, direction, port })
-    return this.#callPluginOnAllNetwork(network, 'del-rule', { allow, protocol, ipRange, direction, port })
+    return this.#callPluginOnAllNetwork(network, 'del-rule', {
+      allow: allow ? 'true' : 'false',
+      protocol,
+      ipRange,
+      direction,
+      port,
+    })
   }
 
   async check(host) {

--- a/packages/xo-server-sdn-controller/src/openflow-plugin.js
+++ b/packages/xo-server-sdn-controller/src/openflow-plugin.js
@@ -17,10 +17,8 @@ export class OpenFlowPlugin {
   }
 
   async addRule({ vif, allow, protocol, ipRange, direction, port }) {
-    const network = vif.$network
-    const mac = vif.MAC
-    return this.#callPluginOnAllNetwork(network, 'add-flow', {
-      mac,
+    return this.#callPluginOnAllNetwork(vif.$network, 'add-flow', {
+      mac: vif.MAC,
       allow: allow ? 'true' : 'false',
       protocol,
       ipRange,
@@ -30,10 +28,8 @@ export class OpenFlowPlugin {
   }
 
   async deleteRule({ vif, allow, protocol, ipRange, direction, port }) {
-    const network = vif.$network
-    const mac = vif.MAC
-    return this.#callPluginOnAllNetwork(network, 'del-flow', {
-      mac,
+    return this.#callPluginOnAllNetwork(vif.$network, 'del-flow', {
+      mac: vif.MAC,
       allow: allow ? 'true' : 'false',
       protocol,
       ipRange,

--- a/packages/xo-server-sdn-controller/src/openflow-plugin.js
+++ b/packages/xo-server-sdn-controller/src/openflow-plugin.js
@@ -51,7 +51,7 @@ export class OpenFlowPlugin {
           bridge: $network.bridge,
         })
         const json = JSON.parse(response)
-        strictEqual(json.returncode, 0, `plugin check should have a return code of 0 to succeed, got ${response}`)
+        strictEqual(json.returncode, 0, `plugin check should have a return code of 0 to succeed, got ${json.returncode}`)
       })
     )
   }

--- a/packages/xo-server-sdn-controller/src/openflow-plugin.js
+++ b/packages/xo-server-sdn-controller/src/openflow-plugin.js
@@ -11,7 +11,7 @@ export class OpenFlowPlugin {
   async #callPluginOnAllNetwork(network, method, parameters) {
     const bridge = this.#getBridge(network)
     return asyncEach(network.PIFs, async PIF => {
-      const host = PIF.host
+      const host = PIF.$host
       return host.$xapi.call('host.call_plugin', host.$ref, PLUGIN_NAME, method, { ...parameters, bridge })
     })
   }

--- a/packages/xo-server-sdn-controller/src/openflow-plugin.js
+++ b/packages/xo-server-sdn-controller/src/openflow-plugin.js
@@ -8,12 +8,12 @@ const log = createLogger('xo:sdn-controller:openflowplugin')
 export class OpenFlowPlugin {
   #getBridge(network) {
     return network.bridge // following discussion with David, it may not be the right bridge
-    // the plugin may need the bridge name on dom0 side
+    // the plugin may need the bridge name on dom0 sides
   }
 
   async #callPluginOnAllNetwork(network, method, parameters) {
     const bridge = this.#getBridge(network)
-    return asyncEach(network.PIFs, async PIF => {
+    return asyncEach(network.$PIFs, async PIF => {
       const host = PIF.$host
       return host.$xapi.call('host.call_plugin', host.$ref, PLUGIN_NAME, method, { ...parameters, bridge })
     })

--- a/packages/xo-server-sdn-controller/src/openflow-plugin.js
+++ b/packages/xo-server-sdn-controller/src/openflow-plugin.js
@@ -76,7 +76,7 @@ export class OpenFlowPlugin {
           // plugin is not installed , no need to test other networks
           throw error
         }
-        log('error while checking if the host has the sdn plugin', error)
+        log.error('error while checking if the host has the sdn plugin', error)
         // track at least
         lastError = error
       }

--- a/packages/xo-server-sdn-controller/src/openflow-plugin.js
+++ b/packages/xo-server-sdn-controller/src/openflow-plugin.js
@@ -42,6 +42,12 @@ export class OpenFlowPlugin {
     })
   }
 
+  async addNetworkRule({ network, allow, protocol, ipRange, direction, port }) {
+    return this.#callPluginOnAllNetwork(network, 'add-flow', { allow, protocol, ipRange, direction, port })
+  }
+  async deleteNetworkRule({ network, allow, protocol, ipRange, direction, port }) {
+    return this.#callPluginOnAllNetwork(network, 'del-flow', { allow, protocol, ipRange, direction, port })
+  }
   async check(host) {
     return host.$xapi.call('host.call_plugin', host.$ref, PLUGIN_NAME, 'dump-flows', { IHAVEPARAMZ: 'true' })
   }

--- a/packages/xo-server-sdn-controller/src/openflow-plugin.js
+++ b/packages/xo-server-sdn-controller/src/openflow-plugin.js
@@ -2,7 +2,7 @@ import { asyncEach } from '@vates/async-each'
 import { createLogger } from '@xen-orchestra/log'
 import { strictEqual } from 'node:assert'
 
-const PLUGIN_NAME = 'sdn-controller.py'
+const PLUGIN_NAME = 'sdncontroller.py'
 
 const log = createLogger('xo:sdn-controller:openflowplugin')
 export class OpenFlowPlugin {

--- a/packages/xo-server-sdn-controller/src/private-network/private-network.js
+++ b/packages/xo-server-sdn-controller/src/private-network/private-network.js
@@ -60,7 +60,6 @@ export class PrivateNetwork {
 
     const transportPif = await this.getTransportPif(network)
     const centerTransportPif = await this.getTransportPif(centerNetwork)
-
     const hostPif = host.$PIFs.find(pif => pif.network === transportPif.network)
     const centerPif = this.center.$PIFs.find(pif => pif.network === centerTransportPif.network)
 

--- a/packages/xo-server-sdn-controller/src/private-network/private-network.js
+++ b/packages/xo-server-sdn-controller/src/private-network/private-network.js
@@ -60,6 +60,7 @@ export class PrivateNetwork {
 
     const transportPif = await this.getTransportPif(network)
     const centerTransportPif = await this.getTransportPif(centerNetwork)
+
     const hostPif = host.$PIFs.find(pif => pif.network === transportPif.network)
     const centerPif = this.center.$PIFs.find(pif => pif.network === centerTransportPif.network)
 

--- a/packages/xo-server-sdn-controller/src/protocol/openflow-channel.js
+++ b/packages/xo-server-sdn-controller/src/protocol/openflow-channel.js
@@ -89,7 +89,7 @@ export class OpenFlowChannel extends EventEmitter {
 
   // ---------------------------------------------------------------------------
 
-  async addRule(vif, allow, protocol, port, ipRange, direction, ofport) {
+  async addRule({ vif, allow, protocol, port, ipRange, direction, ofport }) {
     log.info('Adding OF rule', {
       allow,
       protocol,
@@ -178,7 +178,7 @@ export class OpenFlowChannel extends EventEmitter {
     }
   }
 
-  async deleteRule(vif, protocol, port, ipRange, direction, ofport) {
+  async deleteRule({ vif, protocol, port, ipRange, direction, ofport }) {
     log.info('Deleting OF rule', {
       protocol,
       port,

--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -179,6 +179,9 @@ checkNetboxVersion = true
 [plugins]
 lookupPaths = ['./node_modules', '../', '/usr/local/lib/node_modules']
 
+[plugins.sdn-controller]
+useDirectChannel = true
+
 [remoteOptions]
 mountsDir = '/run/xo-server/mounts'
 

--- a/packages/xo-web/src/xo-app/vm/tab-network.js
+++ b/packages/xo-web/src/xo-app/vm/tab-network.js
@@ -473,7 +473,7 @@ const openAdvancedSettingsModal = async vif => {
 
 // -----------------------------------------------------------------------------
 
-const USABLE_PORT_PROTOCOL = ['TCP', 'ICMP', 'UDP']
+const USABLE_PORT_PROTOCOL = ['TCP', 'UDP']
 class NewAclRuleForm extends BaseComponent {
   state = {
     allow: true,


### PR DESCRIPTION
### Description

to enable the use of plugin, add this in a config file 

[plugins.sdn-controller]
useDirectChannel = false 

Includes this fix : https://github.com/vatesfr/xen-orchestra/pull/9000

plugin is here : https://github.com/xcp-ng/xcp-ng-xapi-plugins/blob/dml-traffic-rules-fixing/SOURCES/etc/xapi.d/plugins/sdncontroller.py

method can be called by xo-cli : sdnController.addRule and sdnController.deleteRule 

and 2 new methods : sdnController.addNetworkRule ans sdnController.deleteNetworkRule that take the same parameter as addRule and deleteRule but with a networkId instead of a vifId . **This 2 methods will fail on the direct (legacy) approach. They will only work in coordination with the plugin**


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
