### PR TITLE
feat(xo-lite): add topology field in vm creation

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [Host/Header] Add master host icon on host header (PR [#8512](https://github.com/vatesfr/xen-orchestra/pull/8512))
 - [Host] Add dashboard view (PR [#8504](https://github.com/vatesfr/xen-orchestra/pull/8504))
+- [VM/New] Add topology field in VM creation (PR [#8491](https://github.com/vatesfr/xen-orchestra/pull/8491))
 
 ## **0.9.1** (2025-04-02)
 

--- a/@xen-orchestra/lite/src/libs/xen-api/operations/vm-operations.ts
+++ b/@xen-orchestra/lite/src/libs/xen-api/operations/vm-operations.ts
@@ -108,11 +108,12 @@ export function createVmOperations(xenApi: XenApi) {
     setCopyBiosString: (vmRefs: VmRefs, hostRef: XenApiHost['$ref']) =>
       Promise.all(toArray(vmRefs).map(vmRef => xenApi.call('VM.set_copy_bios_string', [vmRef, hostRef]))),
 
-    setCorePerSocket: async (vmRef: XenApiVm['$ref'], corePerSocket: string | null) => {
-      await Promise.all([
-        xenApi.call('VM.remove_from_platform', [vmRef, 'cores-per-socket']),
-        xenApi.call('VM.add_to_platform', [vmRef, 'cores-per-socket', String(corePerSocket) ?? null]),
-      ])
+    setCoresPerSocket: async (vmRef: XenApiVm['$ref'], coresPerSocket: number | null) => {
+      await xenApi.call('VM.remove_from_platform', [vmRef, 'cores-per-socket'])
+
+      if (coresPerSocket !== null) {
+        await xenApi.call('VM.add_to_platform', [vmRef, 'cores-per-socket', coresPerSocket ?? null])
+      }
     },
 
     setCpuMask: (vmRefs: VmRefs, mask: string[] | null) =>

--- a/@xen-orchestra/lite/src/libs/xen-api/operations/vm-operations.ts
+++ b/@xen-orchestra/lite/src/libs/xen-api/operations/vm-operations.ts
@@ -105,6 +105,16 @@ export function createVmOperations(xenApi: XenApi) {
 
     setAutoPowerOn: (vmRef: XenApiVm['$ref'], value: boolean) => setOtherConfig(vmRef, 'auto_poweron', value),
 
+    setCopyBiosString: (vmRefs: VmRefs, hostRef: XenApiHost['$ref']) =>
+      Promise.all(toArray(vmRefs).map(vmRef => xenApi.call('VM.set_copy_bios_string', [vmRef, hostRef]))),
+
+    setCorePerSocket: async (vmRef: XenApiVm['$ref'], corePerSocket: string | null) => {
+      await Promise.all([
+        xenApi.call('VM.remove_from_platform', [vmRef, 'cores-per-socket']),
+        xenApi.call('VM.add_to_platform', [vmRef, 'cores-per-socket', String(corePerSocket) ?? null]),
+      ])
+    },
+
     setCpuMask: (vmRefs: VmRefs, mask: string[] | null) =>
       Promise.all(
         toArray(vmRefs).map(vmRef => xenApi.call('VM.set_VCPUs_params', [vmRef, 'mask', mask?.join(',') ?? '']))
@@ -114,9 +124,6 @@ export function createVmOperations(xenApi: XenApi) {
       Promise.all(
         toArray(vmRefs).map(vmRef => xenApi.call('VM.set_VCPUs_params', [vmRef, 'weight', weight?.toString() ?? '']))
       ),
-
-    setCopyBiosString: (vmRefs: VmRefs, hostRef: XenApiHost['$ref']) =>
-      Promise.all(toArray(vmRefs).map(vmRef => xenApi.call('VM.set_copy_bios_string', [vmRef, hostRef]))),
 
     setHvmBootFirmware: async (vmRef: XenApiVm['$ref'], firmware: string) => {
       await Promise.all([
@@ -165,11 +172,6 @@ export function createVmOperations(xenApi: XenApi) {
     setNameLabel: (vmRefs: VmRefs, nameLabel: string) =>
       Promise.all(toArray(vmRefs).map(vmRef => xenApi.call('VM.set_name_label', [vmRef, nameLabel]))),
 
-    setVCpuCap: (vmRefs: VmRefs, cap: number | null) =>
-      Promise.all(
-        toArray(vmRefs).map(vmRef => xenApi.call('VM.set_VCPUs_params', [vmRef, 'cap', cap?.toString() ?? '']))
-      ),
-
     setVCPUsAtStartup: (vmRefs: VmRefs, count: number) =>
       Promise.all(toArray(vmRefs).map(vmRef => xenApi.call('VM.set_VCPUs_at_startup', [vmRef, count]))),
 
@@ -178,6 +180,11 @@ export function createVmOperations(xenApi: XenApi) {
 
     setVCPUsNumberLive: (vmRefs: VmRefs, count: number) =>
       Promise.all(toArray(vmRefs).map(vmRef => xenApi.call('VM.set_VCPUs_number_live', [vmRef, String(count)]))),
+
+    setVCpuCap: (vmRefs: VmRefs, cap: number | null) =>
+      Promise.all(
+        toArray(vmRefs).map(vmRef => xenApi.call('VM.set_VCPUs_params', [vmRef, 'cap', cap?.toString() ?? '']))
+      ),
 
     setVirtualizationMode: (vmRefs: XenApiVm['$ref'], virtualizationMode: 'pv' | 'hvm') => {
       if (virtualizationMode !== 'pv' && virtualizationMode !== 'hvm') {
@@ -196,6 +203,11 @@ export function createVmOperations(xenApi: XenApi) {
     shutdown: (vmRefs: VmRefs, force = false) =>
       Promise.all(toArray(vmRefs).map(vmRef => xenApi.call(`VM.${force ? 'hard' : 'clean'}_shutdown`, [vmRef]))),
 
+    snapshot: (vmRefsToSnapshot: VmRefsWithNameLabel) => {
+      const vmRefs = Object.keys(vmRefsToSnapshot) as XenApiVm['$ref'][]
+      return Promise.all(vmRefs.map(vmRef => xenApi.call('VM.snapshot', [vmRef, vmRefsToSnapshot[vmRef]])))
+    },
+
     start: (vmRefs: VmRefs) =>
       Promise.all(toArray(vmRefs).map(vmRef => xenApi.call('VM.start', [vmRef, false, false]))),
 
@@ -203,10 +215,5 @@ export function createVmOperations(xenApi: XenApi) {
       Promise.all(toArray(vmRefs).map(vmRef => xenApi.call('VM.start_on', [vmRef, hostRef, false, false]))),
 
     suspend: (vmRefs: VmRefs) => Promise.all(toArray(vmRefs).map(vmRef => xenApi.call('VM.suspend', [vmRef]))),
-
-    snapshot: (vmRefsToSnapshot: VmRefsWithNameLabel) => {
-      const vmRefs = Object.keys(vmRefsToSnapshot) as XenApiVm['$ref'][]
-      return Promise.all(vmRefs.map(vmRef => xenApi.call('VM.snapshot', [vmRef, vmRefsToSnapshot[vmRef]])))
-    },
   }
 }

--- a/@xen-orchestra/lite/src/libs/xen-api/operations/vm-operations.ts
+++ b/@xen-orchestra/lite/src/libs/xen-api/operations/vm-operations.ts
@@ -112,7 +112,7 @@ export function createVmOperations(xenApi: XenApi) {
       await xenApi.call('VM.remove_from_platform', [vmRef, 'cores-per-socket'])
 
       if (coresPerSocket !== null) {
-        await xenApi.call('VM.add_to_platform', [vmRef, 'cores-per-socket', coresPerSocket ?? null])
+        await xenApi.call('VM.add_to_platform', [vmRef, 'cores-per-socket', String(coresPerSocket)])
       }
     },
 

--- a/@xen-orchestra/lite/src/libs/xen-api/xen-api.types.ts
+++ b/@xen-orchestra/lite/src/libs/xen-api/xen-api.types.ts
@@ -103,6 +103,7 @@ export type RawXenApiRecord<T extends XenApiRecord<ObjectType>> = Omit<T, '$ref'
 
 export interface XenApiPool extends XenApiRecord<'pool'> {
   cpu_info: {
+    socket_count: string
     cpu_count: string
   }
   master: XenApiHost['$ref']

--- a/@xen-orchestra/lite/src/types/new-vm.ts
+++ b/@xen-orchestra/lite/src/types/new-vm.ts
@@ -33,7 +33,7 @@ export interface VmState {
   vCPU: number
   VCPUs_max: number
   ram: number
-  topology: null
+  topology: number | null
   copyHostBiosStrings: boolean
   sshKeys: string[]
   existingVdis: Vdi[]

--- a/@xen-orchestra/lite/src/types/new-vm.ts
+++ b/@xen-orchestra/lite/src/types/new-vm.ts
@@ -33,7 +33,7 @@ export interface VmState {
   vCPU: number
   VCPUs_max: number
   ram: number
-  topology: string
+  topology: null
   copyHostBiosStrings: boolean
   sshKeys: string[]
   existingVdis: Vdi[]

--- a/@xen-orchestra/lite/src/views/new-vm/NewVmView.vue
+++ b/@xen-orchestra/lite/src/views/new-vm/NewVmView.vue
@@ -566,7 +566,7 @@ const coresPerSocket = computed(() => {
     if (vmState.vCPU % cores === 0) {
       options.push({
         // TODO Need to improve pluralization
-        label: t('vm-sockets-with-cores-per-socket', {
+        label: t('sockets-with-cores-per-socket', {
           nSockets: vmState.vCPU / cores,
           nCores: cores,
         }),

--- a/@xen-orchestra/lite/src/views/new-vm/NewVmView.vue
+++ b/@xen-orchestra/lite/src/views/new-vm/NewVmView.vue
@@ -565,6 +565,7 @@ const coresPerSocket = computed(() => {
   for (cores; cores >= minCores; cores--) {
     if (vmState.vCPU % cores === 0) {
       options.push({
+        // TODO Need to improve pluralization
         label: t('vmSocketsWithCoresPerSocket', {
           nSockets: vmState.vCPU / cores,
           nCores: cores,

--- a/@xen-orchestra/lite/src/views/new-vm/NewVmView.vue
+++ b/@xen-orchestra/lite/src/views/new-vm/NewVmView.vue
@@ -164,7 +164,14 @@
                 <UiInput v-model="ramFormatted" accent="brand" />
               </VtsInputWrapper>
               <VtsInputWrapper :label="$t('topology')">
-                <UiInput v-model="vmState.topology" accent="brand" disabled />
+                <div class="topology">
+                  <FormSelect v-model="vmState.topology">
+                    <option :value="null">{{ $t('default-behavior') }}</option>
+                    <option v-for="core in coresPerSocket" :key="core.value" :value="core.value">
+                      {{ core.label }}
+                    </option>
+                  </FormSelect>
+                </div>
               </VtsInputWrapper>
             </div>
             <!-- NETWORK SECTION -->
@@ -480,7 +487,7 @@ const vmState = reactive<VmState>({
   vCPU: 0,
   VCPUs_max: 0,
   ram: 0,
-  topology: '',
+  topology: null,
   copyHostBiosStrings: false,
   sshKeys: [],
   existingVdis: [],
@@ -536,6 +543,39 @@ const deleteItem = <T,>(array: T[], index: number) => {
 }
 
 const poolName = computed(() => pool.value?.name_label)
+
+const poolCpuInfo = computed(() => {
+  return {
+    cpus: {
+      cores: pool.value?.cpu_info && +pool.value.cpu_info.cpu_count,
+      sockets: pool.value?.cpu_info && +pool.value.cpu_info.socket_count,
+    },
+  }
+})
+
+const coresPerSocket = computed(() => {
+  // https://github.com/xcp-ng/xenadmin/blob/0160cd0119fae3b871eef656c23e2b76fcc04cb5/XenModel/XenAPI-Extensions/VM.cs#L62
+  const MAX_VM_SOCKETS = 16
+  const minCores = vmState.vCPU / MAX_VM_SOCKETS
+  const options = []
+  let cores = poolCpuInfo.value.cpus.cores
+
+  if (cores === undefined || vmState.vCPU === undefined) return []
+
+  for (cores; cores >= minCores; cores--) {
+    if (vmState.vCPU % cores === 0) {
+      options.push({
+        label: t('vmSocketsWithCoresPerSocket', {
+          nSockets: vmState.vCPU / cores,
+          nCores: cores,
+        }),
+        value: cores,
+      })
+    }
+  }
+
+  return options
+})
 
 const hostMasterRef = computed(() => pool.value?.master)
 
@@ -720,6 +760,7 @@ const vmCreationParams = computed(() => ({
   bootAfterCreate: vmState.boot_vm,
   copyHostBiosStrings: vmState.boot_firmware !== 'uefi' && !templateHasBiosStrings.value && vmState.copyHostBiosStrings,
   hvmBootFirmware: vmState.boot_firmware,
+  coresPerSocket: vmState.topology,
   tags: vmState.tags,
   cloudConfig: '',
 }))
@@ -772,9 +813,10 @@ const _createVm = async ($defer: Defer) => {
       xapi.vm.setNameLabel(vmRefs, vmCreationParams.value.name_label),
       xapi.vm.setNameDescription(vmRefs, vmCreationParams.value.name_description),
       xapi.vm.setMemory(vmRefs, vmCreationParams.value.memory),
-      xapi.vm.setVCPUsAtStartup(vmRefs, vmCreationParams.value.cpus),
-      xapi.vm.setHvmBootFirmware(vmRefs[0], vmCreationParams.value.hvmBootFirmware),
       xapi.vm.setAutoPowerOn(vmRefs[0], vmCreationParams.value.autoPoweron),
+      xapi.vm.setCorePerSocket(vmRefs[0], vmCreationParams.value.coresPerSocket),
+      xapi.vm.setHvmBootFirmware(vmRefs[0], vmCreationParams.value.hvmBootFirmware),
+      xapi.vm.setVCPUsAtStartup(vmRefs, vmCreationParams.value.cpus),
     ])
 
     // INSTALL SETTINGS
@@ -987,6 +1029,10 @@ const createVM = defer(_createVm)
     .memory-container {
       display: flex;
       gap: 10.8rem;
+
+      .topology {
+        width: 32rem;
+      }
     }
 
     thead tr th:last-child {

--- a/@xen-orchestra/web-core/lib/locales/en.json
+++ b/@xen-orchestra/web-core/lib/locales/en.json
@@ -119,6 +119,7 @@
   "dark-mode.disable": "Disable dark mode",
   "dark-mode.enable": "Enable dark mode",
   "dashboard": "Dashboard",
+  "default-behavior": "Default behavior",
   "default-locking-mode": "Default locking mode",
   "delete": "Delete",
   "delete-vms": "Delete 1 VM | Delete {n} VMs",

--- a/@xen-orchestra/web-core/lib/locales/en.json
+++ b/@xen-orchestra/web-core/lib/locales/en.json
@@ -480,7 +480,7 @@
   "vm-is-running": "The VM is running",
   "vm.active": "Active",
   "vm.inactive": "Inactive",
-  "vmSocketsWithCoresPerSocket": "{nSockets} sockets × {nCores} cores/socket",
+  "vm-sockets-with-cores-per-socket": "{nSockets} sockets × {nCores} cores/socket",
   "vms": "VM | VMs",
   "vms-status": "VMs status",
   "vms-status.halted": "Halted",

--- a/@xen-orchestra/web-core/lib/locales/en.json
+++ b/@xen-orchestra/web-core/lib/locales/en.json
@@ -480,7 +480,7 @@
   "vm-is-running": "The VM is running",
   "vm.active": "Active",
   "vm.inactive": "Inactive",
-  "vm-sockets-with-cores-per-socket": "{nSockets} sockets × {nCores} cores/socket",
+  "vmSocketsWithCoresPerSocket": "{nSockets} sockets × {nCores} cores/socket",
   "vms": "VM | VMs",
   "vms-status": "VMs status",
   "vms-status.halted": "Halted",

--- a/@xen-orchestra/web-core/lib/locales/fr.json
+++ b/@xen-orchestra/web-core/lib/locales/fr.json
@@ -480,7 +480,7 @@
   "vm-is-running": "La VM est en cours d'exécution",
   "vm.active": "Active | Active | Actives",
   "vm.inactive": "Inactive | Inactive | Inactives",
-  "vm-sockets-with-cores-per-socket": "{nSockets} sockets × {nCores} cœurs/socket",
+  "vmSocketsWithCoresPerSocket": "{nSockets} sockets × {nCores} cœurs/socket",
   "vms": "VM | VMs",
   "vms-status": "Statut des VMs",
   "vms-status.halted": "Éteintes",

--- a/@xen-orchestra/web-core/lib/locales/fr.json
+++ b/@xen-orchestra/web-core/lib/locales/fr.json
@@ -119,6 +119,7 @@
   "dark-mode.disable": "Désactiver le mode sombre",
   "dark-mode.enable": "Activer le mode sombre",
   "dashboard": "Tableau de bord",
+  "default-behavior": "Comportement par défaut",
   "default-locking-mode": "Mode de verrouillage par défaut",
   "delete": "Supprimer",
   "delete-vms": "Supprimer 1 VM | Supprimer {n} VMs",

--- a/@xen-orchestra/web-core/lib/locales/fr.json
+++ b/@xen-orchestra/web-core/lib/locales/fr.json
@@ -480,7 +480,7 @@
   "vm-is-running": "La VM est en cours d'exécution",
   "vm.active": "Active | Active | Actives",
   "vm.inactive": "Inactive | Inactive | Inactives",
-  "vmSocketsWithCoresPerSocket": "{nSockets} sockets × {nCores} cœurs/socket",
+  "vm-sockets-with-cores-per-socket": "{nSockets} sockets × {nCores} cœurs/socket",
   "vms": "VM | VMs",
   "vms-status": "Statut des VMs",
   "vms-status.halted": "Éteintes",


### PR DESCRIPTION
### Description

add topology field in vm creation, method in vm operations and translation

### Screenshoots 

Light:
![image](https://github.com/user-attachments/assets/096c3ae5-c569-4e93-86f8-268e97909845)
Dark:
![image](https://github.com/user-attachments/assets/ef20ceae-45ff-4e87-92e0-e05fda2005b4)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
