### PR TITLE
feat(@xen-orchestra/rest-api): expose get user and get users

### DIFF
--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -343,7 +343,7 @@ export type XoUser = {
   email: string
   groups: XoGroup['id'][]
   id: Branded<'user'>
-  name: string
+  name?: string
   permission: string
   pw_hash?: string
   preferences: Record<string, string>

--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -345,7 +345,7 @@ export type XoUser = {
   id: Branded<'user'>
   name: string
   permission: string
-  pw_hash: string
+  pw_hash?: string
   preferences: Record<string, string>
 }
 

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/user.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/user.oa-example.mts
@@ -1,6 +1,6 @@
 export const userIds = [
-  '/rest/v0/users/722d17b9-699b-49d2-8193-be1ac573d3de',
   '/rest/v0/users/088124f3-41b6-4258-9653-6eedc7b46111',
+  '/rest/v0/users/a8715f02-20e7-4881-8b02-28ce2260c39d',
 ]
 
 export const partialUsers = [

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/user.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/user.oa-example.mts
@@ -5,23 +5,18 @@ export const userIds = [
 
 export const partialUsers = [
   {
-    email: 'admin@admin.net',
+    permission: 'admin',
+    name: 'admin@admin.net',
     id: '722d17b9-699b-49d2-8193-be1ac573d3de',
     href: '/rest/v0/users/722d17b9-699b-49d2-8193-be1ac573d3de',
-  },
-  {
-    email: 'testName',
-    id: '088124f3-41b6-4258-9653-6eedc7b46111',
-    href: '/rest/v0/users/088124f3-41b6-4258-9653-6eedc7b46111',
   },
 ]
 
 export const user = {
   email: 'admin@admin.net',
   permission: 'admin',
-  pw_hash: '$argon2id$v=19$m=65536,t=3,p=4$219jr9Zx2wh+WXseO2QxDw$s30eQm8MMvtWtMnw8XBZzgGoErIxPMkkkwbD9oNfs3I',
-  groups: [],
+  groups: ['7d98fee4-3357-41a7-ac3f-9124212badb7', '7981ba62-c395-4546-bfa4-d1261653a77f'],
+  name: 'admin@admin.net',
   preferences: {},
   id: '722d17b9-699b-49d2-8193-be1ac573d3de',
-  name: 'admin@admin.net',
 }

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/user.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/user.oa-example.mts
@@ -10,11 +10,18 @@ export const partialUsers = [
     id: '722d17b9-699b-49d2-8193-be1ac573d3de',
     href: '/rest/v0/users/722d17b9-699b-49d2-8193-be1ac573d3de',
   },
+  {
+    permission: 'none',
+    name: 'testName',
+    id: '088124f3-41b6-4258-9653-6eedc7b46111',
+    href: '/rest/v0/users/088124f3-41b6-4258-9653-6eedc7b46111',
+  },
 ]
 
 export const user = {
   email: 'admin@admin.net',
   permission: 'admin',
+  pw_hash: '***obfuscated***',
   groups: ['7d98fee4-3357-41a7-ac3f-9124212badb7', '7981ba62-c395-4546-bfa4-d1261653a77f'],
   name: 'admin@admin.net',
   preferences: {},

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/user.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/user.oa-example.mts
@@ -1,0 +1,27 @@
+export const userIds = [
+  '/rest/v0/users/722d17b9-699b-49d2-8193-be1ac573d3de',
+  '/rest/v0/users/088124f3-41b6-4258-9653-6eedc7b46111',
+]
+
+export const partialUsers = [
+  {
+    email: 'admin@admin.net',
+    id: '722d17b9-699b-49d2-8193-be1ac573d3de',
+    href: '/rest/v0/users/722d17b9-699b-49d2-8193-be1ac573d3de',
+  },
+  {
+    email: 'testName',
+    id: '088124f3-41b6-4258-9653-6eedc7b46111',
+    href: '/rest/v0/users/088124f3-41b6-4258-9653-6eedc7b46111',
+  },
+]
+
+export const user = {
+  email: 'admin@admin.net',
+  permission: 'admin',
+  pw_hash: '$argon2id$v=19$m=65536,t=3,p=4$219jr9Zx2wh+WXseO2QxDw$s30eQm8MMvtWtMnw8XBZzgGoErIxPMkkkwbD9oNfs3I',
+  groups: [],
+  preferences: {},
+  id: '722d17b9-699b-49d2-8193-be1ac573d3de',
+  name: 'admin@admin.net',
+}

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/user.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/user.oa-example.mts
@@ -5,16 +5,15 @@ export const userIds = [
 
 export const partialUsers = [
   {
-    permission: 'admin',
-    name: 'admin@admin.net',
-    id: '722d17b9-699b-49d2-8193-be1ac573d3de',
-    href: '/rest/v0/users/722d17b9-699b-49d2-8193-be1ac573d3de',
-  },
-  {
     permission: 'none',
     name: 'testName',
     id: '088124f3-41b6-4258-9653-6eedc7b46111',
     href: '/rest/v0/users/088124f3-41b6-4258-9653-6eedc7b46111',
+  },
+  {
+    permission: 'none',
+    id: 'a8715f02-20e7-4881-8b02-28ce2260c39d',
+    href: '/rest/v0/users/a8715f02-20e7-4881-8b02-28ce2260c39d',
   },
 ]
 

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -47,6 +47,7 @@ export type XoApp = {
     opts?: { bypassOtp?: boolean }
   ) => Promise<{ bypassOtp: boolean; expiration: number; user: XoUser }>
   getAllSchedules(): Promise<XoSchedule[]>
+  getAllUsers(): Promise<XoUser[]>
   getAllXenServers(): Promise<XoServer[]>
   getJob(id: XoJob['id']): Promise<XoJob>
   getObject: <T extends XapiXoRecord>(id: T['id'], type?: T['type']) => T
@@ -55,6 +56,7 @@ export type XoApp = {
     opts?: { filter?: string | ((obj: T) => boolean); limit?: number }
   ) => Record<T['id'], T>
   getSchedule(id: XoSchedule['id']): Promise<XoSchedule>
+  getUser: (id: XoUser['id']) => Promise<XoUser>
   getXapiHostStats: (hostId: XoHost['id'], granularity?: XapiStatsGranularity) => Promise<XapiHostStats>
   getXapiObject: <T extends XapiXoRecord>(maybeId: T['id'] | T, type: T['type']) => XapiRecordByXapiXoRecord[T['type']]
   getXapiVmStats: (vmId: XoVm['id'], granularity?: XapiStatsGranularity) => Promise<XapiVmStats>

--- a/@xen-orchestra/rest-api/src/users/user.controller.mts
+++ b/@xen-orchestra/rest-api/src/users/user.controller.mts
@@ -1,10 +1,10 @@
 import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
-import { Request as ExRequest } from 'express'
+import type { Request as ExRequest } from 'express'
 import { provide } from 'inversify-binding-decorators'
-import { notFoundResp, unauthorizedResp, Unbrand } from '../open-api/common/response.common.mjs'
+import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
 import type { WithHref } from '../helpers/helper.type.mjs'
-import { XoUser } from '@vates/types'
+import type { XoUser } from '@vates/types'
 import { partialUsers, user, userIds } from '../open-api/oa-examples/user.oa-example.mjs'
 
 @Route('users')
@@ -22,7 +22,7 @@ export class UserController extends XoController<XoUser> {
   }
 
   /**
-   * @example fields "email,id"
+   * @example fields "permission,name,id"
    * @example filter "permission:admin"
    * @example limit 42
    */

--- a/@xen-orchestra/rest-api/src/users/user.controller.mts
+++ b/@xen-orchestra/rest-api/src/users/user.controller.mts
@@ -15,8 +15,8 @@ import { partialUsers, user, userIds } from '../open-api/oa-examples/user.oa-exa
 export class UserController extends XoController<XoUser> {
   // --- abstract methods
   async getAllCollectionObjects(): Promise<XoUser[]> {
-    const users = this.restApi.xoApp.getAllUsers()
-    return (await users).map(user => this.sanitizeUser(user))
+    const users = await this.restApi.xoApp.getAllUsers()
+    return users.map(user => this.sanitizeUser(user))
   }
 
   async getCollectionObject(id: XoUser['id']): Promise<XoUser> {
@@ -24,7 +24,7 @@ export class UserController extends XoController<XoUser> {
     return this.sanitizeUser(user)
   }
 
-  private sanitizeUser(user: XoUser): XoUser {
+  sanitizeUser(user: XoUser): XoUser {
     const sanitizedUser = { ...user }
 
     if (sanitizedUser.pw_hash !== undefined) {
@@ -36,7 +36,7 @@ export class UserController extends XoController<XoUser> {
 
   /**
    * @example fields "permission,name,id"
-   * @example filter "permission:admin"
+   * @example filter "permission:none"
    * @example limit 42
    */
   @Example(userIds)
@@ -47,7 +47,7 @@ export class UserController extends XoController<XoUser> {
     @Query() fields?: string,
     @Query() filter?: string,
     @Query() limit?: number
-  ): Promise<string[] | WithHref<XoUser>[] | WithHref<Partial<XoUser>>[]> {
+  ): Promise<string[] | WithHref<Partial<Unbrand<XoUser>>>[]> {
     const users = Object.values(await this.getObjects({ filter, limit }))
     return this.sendObjects(users, req)
   }

--- a/@xen-orchestra/rest-api/src/users/user.controller.mts
+++ b/@xen-orchestra/rest-api/src/users/user.controller.mts
@@ -1,0 +1,50 @@
+import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import { Request as ExRequest } from 'express'
+import { provide } from 'inversify-binding-decorators'
+import { notFoundResp, unauthorizedResp, Unbrand } from '../open-api/common/response.common.mjs'
+import { XoController } from '../abstract-classes/xo-controller.mjs'
+import type { WithHref } from '../helpers/helper.type.mjs'
+import { XoUser } from '@vates/types'
+import { partialUsers, user, userIds } from '../open-api/oa-examples/user.oa-example.mjs'
+
+@Route('users')
+@Security('*')
+@Response(unauthorizedResp.status, unauthorizedResp.description)
+@Tags('users')
+@provide(UserController)
+export class UserController extends XoController<XoUser> {
+  // --- abstract methods
+  getAllCollectionObjects(): Promise<XoUser[]> {
+    return this.restApi.xoApp.getAllUsers()
+  }
+  getCollectionObject(id: XoUser['id']): Promise<XoUser> {
+    return this.restApi.xoApp.getUser(id)
+  }
+
+  /**
+   * @example fields "email,id"
+   * @example filter "permission:admin"
+   * @example limit 42
+   */
+  @Example(userIds)
+  @Example(partialUsers)
+  @Get('')
+  async getUsers(
+    @Request() req: ExRequest,
+    @Query() fields?: string,
+    @Query() filter?: string,
+    @Query() limit?: number
+  ): Promise<string[] | WithHref<Partial<Unbrand<XoUser>>>[]> {
+    return this.sendObjects(Object.values(await this.getObjects()), req)
+  }
+
+  /**
+   * @example id "722d17b9-699b-49d2-8193-be1ac573d3de"
+   */
+  @Example(user)
+  @Get('{id}')
+  @Response(notFoundResp.status, notFoundResp.description)
+  getUser(@Path() id: string): Promise<Unbrand<XoUser>> {
+    return this.getObject(id as XoUser['id'])
+  }
+}

--- a/@xen-orchestra/rest-api/src/users/user.controller.mts
+++ b/@xen-orchestra/rest-api/src/users/user.controller.mts
@@ -35,7 +35,7 @@ export class UserController extends XoController<XoUser> {
     @Query() filter?: string,
     @Query() limit?: number
   ): Promise<string[] | WithHref<Partial<Unbrand<XoUser>>>[]> {
-    return this.sendObjects(Object.values(await this.getObjects()), req)
+    return this.sendObjects(Object.values(await this.getObjects({ filter, limit })), req)
   }
 
   /**

--- a/@xen-orchestra/rest-api/src/users/user.controller.mts
+++ b/@xen-orchestra/rest-api/src/users/user.controller.mts
@@ -1,11 +1,12 @@
 import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import type { Request as ExRequest } from 'express'
+import { provide } from 'inversify-binding-decorators'
+import type { XoUser } from '@vates/types'
+
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { partialUsers, user, userIds } from '../open-api/oa-examples/user.oa-example.mjs'
-import { provide } from 'inversify-binding-decorators'
-import type { Request as ExRequest } from 'express'
 import type { WithHref } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
-import type { XoUser } from '@vates/types'
 
 @Route('users')
 @Security('*')
@@ -16,15 +17,15 @@ export class UserController extends XoController<XoUser> {
   // --- abstract methods
   async getAllCollectionObjects(): Promise<XoUser[]> {
     const users = await this.restApi.xoApp.getAllUsers()
-    return users.map(user => this.sanitizeUser(user))
+    return users.map(user => this.#sanitizeUser(user))
   }
 
   async getCollectionObject(id: XoUser['id']): Promise<XoUser> {
     const user = await this.restApi.xoApp.getUser(id)
-    return this.sanitizeUser(user)
+    return this.#sanitizeUser(user)
   }
 
-  sanitizeUser(user: XoUser): XoUser {
+  #sanitizeUser(user: XoUser): XoUser {
     const sanitizedUser = { ...user }
 
     if (sanitizedUser.pw_hash !== undefined) {
@@ -60,6 +61,6 @@ export class UserController extends XoController<XoUser> {
   @Response(notFoundResp.status, notFoundResp.description)
   async getUser(@Path() id: string): Promise<Unbrand<XoUser>> {
     const user = await this.getObject(id as XoUser['id'])
-    return this.sanitizeUser(user)
+    return this.#sanitizeUser(user)
   }
 }

--- a/@xen-orchestra/rest-api/src/users/user.controller.mts
+++ b/@xen-orchestra/rest-api/src/users/user.controller.mts
@@ -1,11 +1,11 @@
 import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
-import type { Request as ExRequest } from 'express'
-import { provide } from 'inversify-binding-decorators'
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
-import { XoController } from '../abstract-classes/xo-controller.mjs'
-import type { WithHref } from '../helpers/helper.type.mjs'
-import type { XoUser } from '@vates/types'
 import { partialUsers, user, userIds } from '../open-api/oa-examples/user.oa-example.mjs'
+import { provide } from 'inversify-binding-decorators'
+import type { Request as ExRequest } from 'express'
+import type { WithHref } from '../helpers/helper.type.mjs'
+import { XoController } from '../abstract-classes/xo-controller.mjs'
+import type { XoUser } from '@vates/types'
 
 @Route('users')
 @Security('*')

--- a/@xen-orchestra/rest-api/src/users/user.controller.mts
+++ b/@xen-orchestra/rest-api/src/users/user.controller.mts
@@ -21,6 +21,13 @@ export class UserController extends XoController<XoUser> {
     return this.restApi.xoApp.getUser(id)
   }
 
+  partialUser(user: XoUser): Partial<Unbrand<XoUser>> {
+    return {
+      ...user,
+      pw_hash: '***obfuscated***',
+    }
+  }
+
   /**
    * @example fields "permission,name,id"
    * @example filter "permission:admin"
@@ -35,7 +42,8 @@ export class UserController extends XoController<XoUser> {
     @Query() filter?: string,
     @Query() limit?: number
   ): Promise<string[] | WithHref<Partial<Unbrand<XoUser>>>[]> {
-    return this.sendObjects(Object.values(await this.getObjects({ filter, limit })), req)
+    const users = Object.values(await this.getObjects({ filter, limit })).map(this.partialUser)
+    return this.sendObjects(users as XoUser[], req)
   }
 
   /**
@@ -44,7 +52,8 @@ export class UserController extends XoController<XoUser> {
   @Example(user)
   @Get('{id}')
   @Response(notFoundResp.status, notFoundResp.description)
-  getUser(@Path() id: string): Promise<Unbrand<XoUser>> {
-    return this.getObject(id as XoUser['id'])
+  async getUser(@Path() id: string): Promise<Partial<Unbrand<XoUser>>> {
+    const user = await this.getObject(id as XoUser['id'])
+    return this.partialUser(user)
   }
 }

--- a/@xen-orchestra/rest-api/src/users/user.controller.mts
+++ b/@xen-orchestra/rest-api/src/users/user.controller.mts
@@ -59,8 +59,7 @@ export class UserController extends XoController<XoUser> {
   @Example(user)
   @Get('{id}')
   @Response(notFoundResp.status, notFoundResp.description)
-  async getUser(@Path() id: string): Promise<Unbrand<XoUser>> {
-    const user = await this.getObject(id as XoUser['id'])
-    return this.#sanitizeUser(user)
+  getUser(@Path() id: string): Promise<Unbrand<XoUser>> {
+    return this.getObject(id as XoUser['id'])
   }
 }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,8 @@
   - [Host/Header] Add master host icon on host header (PR [#8512](https://github.com/vatesfr/xen-orchestra/pull/8512))
 - Hub recipe
   - Upgrade Pyrgos/Kubernetes recipe to use MicroK8s
+  - `/rest/v0/users` (PR [#8494](https://github.com/vatesfr/xen-orchestra/pull/8494))
+  - `/rest/v0/users/<user-id>` (PR [#8494](https://github.com/vatesfr/xen-orchestra/pull/8494))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -40,7 +40,7 @@
 
 - @vates/node-vsphere-soap patch
 - @xen-orchestra/immutable-backups patch
-- @xen-orchestra/rest-api patch
+- @xen-orchestra/rest-api minor
 - @xen-orchestra/vmware-explorer patch
 - @xen-orchestra/web minor
 - xo-server patch

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
   - [Host/Header] Add master host icon on host header (PR [#8512](https://github.com/vatesfr/xen-orchestra/pull/8512))
 - Hub recipe
   - Upgrade Pyrgos/Kubernetes recipe to use MicroK8s
+- **Migrated REST API endpoints**:
   - `/rest/v0/users` (PR [#8494](https://github.com/vatesfr/xen-orchestra/pull/8494))
   - `/rest/v0/users/<user-id>` (PR [#8494](https://github.com/vatesfr/xen-orchestra/pull/8494))
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -608,6 +608,7 @@ export default class RestApi {
       docs: {},
       messages: {},
       pools: {},
+      users: {},
       vifs: {},
       vms: {
         actions: {
@@ -1002,12 +1003,6 @@ export default class RestApi {
       },
     }
     collections.users = {
-      getObject(id) {
-        return app.getUser(id).then(getUserPublicProperties)
-      },
-      async getObjects(filter, limit) {
-        return handleArray(await app.getAllUsers(), filter, limit)
-      },
       routes: {
         async authentication_tokens(req, res) {
           const { filter, limit } = req.query


### PR DESCRIPTION
### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
