### PR TITLE
docs(manage_infrastructure): add link to the V2V section of the XCP-ng doc

### DIFF
--- a/docs/docs/manage_infrastructure.md
+++ b/docs/docs/manage_infrastructure.md
@@ -462,6 +462,14 @@ To prevent a virtual machine from migrating:
 
 When this option is enabled, the VM won't be able to migrate to another host.
 
+## Migrating from VMware with V2V
+
+XCP-ng is a type 1 hypervisor, similar to VMware ESXi.
+
+You can migrate your VM from VMware vSphere to a Vates environment (Xen Orchestra and XCP-ng), directly from Xen Orchestra. For this, we use V2V ("VMware to Vates").
+
+To know more on using V2V in Xen Orchestra to migrate your environment from VMware, refer to the [XO V2V section in the XCP-ng documentation](https://docs.xcp-ng.org/installation/migrate-to-xcp-ng/#xo-v2v).
+
 
 ## Hosts management
 


### PR DESCRIPTION
The XCP-ng documentation was recently updated (see [PR #334](https://github.com/xcp-ng/xcp-ng-org/pull/334)) to include [more details](https://docs.xcp-ng.org/installation/migrate-to-xcp-ng/#xo-v2v) on migrating from VMware to a Vates environment, including various methods such as V2V via Xen Orchestra.

As a result, the [XO documentation](https://docs.xen-orchestra.com/manage_infrastructure) now includes a mention of V2V, with a link to the relevant section in the XCP-ng docs.