### PR TITLE
fix(xo-web): do not show VM creator when user is not admin

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,7 +23,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [OpenAPI spec] Fixed some required properties being marked as optional (PR [#8480](https://github.com/vatesfr/xen-orchestra/pull/8480))
-- [VM/Advanced] Do not show VM creator to non-admins [#8463](https://github.com/vatesfr/xen-orchestra/issues/8463)
+- [VM/Advanced] Do not show VM creator to non-admins [#8463](https://github.com/vatesfr/xen-orchestra/issues/8463) (PR [#8503](https://github.com/vatesfr/xen-orchestra/pull/8503))
 - **XO 6:**
   - [VM/Create] Fix TS type-check errors (PR [#8472](https://github.com/vatesfr/xen-orchestra/pull/8472))
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [OpenAPI spec] Fixed some required properties being marked as optional (PR [#8480](https://github.com/vatesfr/xen-orchestra/pull/8480))
+- [VM/Advanced] Do not show VM creator to non-admins [#8463](https://github.com/vatesfr/xen-orchestra/issues/8463)
 - **XO 6:**
   - [VM/Create] Fix TS type-check errors (PR [#8472](https://github.com/vatesfr/xen-orchestra/pull/8472))
 

--- a/packages/xo-web/src/xo-app/vm/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/vm/tab-advanced.js
@@ -1519,12 +1519,14 @@ export default class TabAdvanced extends Component {
                     </td>
                   </tr>
                 )}
-                <tr>
-                  <th>{_('vmCreator')}</th>
-                  <td>
-                    <SelectUser onChange={this._updateUser} value={vm.creation?.user} />
-                  </td>
-                </tr>
+                {isAdmin && (
+                  <tr>
+                    <th>{_('vmCreator')}</th>
+                    <td>
+                      <SelectUser onChange={this._updateUser} value={vm.creation?.user} />
+                    </td>
+                  </tr>
+                )}
               </tbody>
             </table>
           </Col>


### PR DESCRIPTION
Fixes #8463
Introduced by #7276

### Screenshots

Before:

![Capture_2025-04-11_15:40:51](https://github.com/user-attachments/assets/468c9b98-f30d-40e5-9149-d543714719b7)

After:

![Capture_2025-04-11_15:41:20](https://github.com/user-attachments/assets/7df21577-6e9a-4304-85f9-e4728b433439)

### Description

Non-admin users should not see the VM's creator.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
