### PR TITLE
feat(web-core): don't force collection properties to be computed

### DIFF
--- a/@xen-orchestra/web-core/lib/packages/collection/build-item.ts
+++ b/@xen-orchestra/web-core/lib/packages/collection/build-item.ts
@@ -1,11 +1,11 @@
-import type { CollectionItem, CollectionOptions, FlagRegistry } from '@core/packages/collection/types.ts'
-import type { ComputedRef, UnwrapRef } from 'vue'
+import type { CollectionItem, CollectionOptions, FlagRegistry } from '@core/packages/collection'
+import { unref, type UnwrapRef } from 'vue'
 
 export function buildItem<
   TSource,
   TId extends PropertyKey,
   TFlag extends string,
-  TProperties extends Record<string, ComputedRef>,
+  TProperties extends Record<string, unknown>,
 >(
   source: TSource,
   options: CollectionOptions<TSource, TId, TFlag, TProperties>,
@@ -38,7 +38,7 @@ export function buildItem<
         return properties !== undefined && prop in properties
       },
       get(target, prop: Extract<keyof TProperties, string>) {
-        return properties?.[prop].value
+        return unref(properties?.[prop])
       },
     }),
   }

--- a/@xen-orchestra/web-core/lib/packages/collection/create-collection.ts
+++ b/@xen-orchestra/web-core/lib/packages/collection/create-collection.ts
@@ -1,4 +1,4 @@
-import type { CollectionItem, FlagRegistry } from '@core/packages/collection/types.ts'
+import type { CollectionItem, FlagRegistry } from '@core/packages/collection'
 import { useArrayFilter, useArrayMap } from '@vueuse/core'
 import { computed, type ComputedRef } from 'vue'
 

--- a/@xen-orchestra/web-core/lib/packages/collection/index.ts
+++ b/@xen-orchestra/web-core/lib/packages/collection/index.ts
@@ -1,0 +1,5 @@
+export * from './build-item.ts'
+export * from './create-collection.ts'
+export * from './types.ts'
+export * from './use-collection.ts'
+export * from './use-flag-registry.ts'

--- a/@xen-orchestra/web-core/lib/packages/collection/types.ts
+++ b/@xen-orchestra/web-core/lib/packages/collection/types.ts
@@ -1,5 +1,4 @@
-import type { useFlagRegistry } from '@core/packages/collection/use-flag-registry.ts'
-import type { ComputedRef } from 'vue'
+import type { useFlagRegistry } from '@core/packages/collection'
 
 export type FlagsConfig<TFlag extends string> = TFlag[] | { [K in TFlag]: { multiple?: boolean } }
 
@@ -7,7 +6,7 @@ export type CollectionOptions<
   TSource,
   TId extends PropertyKey,
   TFlag extends string,
-  TProperties extends Record<string, ComputedRef>,
+  TProperties extends Record<string, unknown>,
 > = {
   identifier: (source: TSource) => TId
   properties?: (source: TSource) => TProperties

--- a/@xen-orchestra/web-core/lib/packages/collection/use-collection.ts
+++ b/@xen-orchestra/web-core/lib/packages/collection/use-collection.ts
@@ -1,14 +1,11 @@
-import { buildItem } from '@core/packages/collection/build-item.ts'
-import { createCollection } from '@core/packages/collection/create-collection.ts'
-import type { CollectionOptions } from '@core/packages/collection/types.ts'
-import { useFlagRegistry } from '@core/packages/collection/use-flag-registry.ts'
-import { computed, type ComputedRef, type MaybeRefOrGetter, toValue } from 'vue'
+import { buildItem, type CollectionOptions, createCollection, useFlagRegistry } from '@core/packages/collection'
+import { computed, type MaybeRefOrGetter, toValue } from 'vue'
 
 export function useCollection<
   TSource,
   TId extends PropertyKey,
   TFlag extends string,
-  TProperties extends Record<string, ComputedRef>,
+  TProperties extends Record<string, unknown>,
 >(sources: MaybeRefOrGetter<TSource[]>, options: CollectionOptions<TSource, TId, TFlag, TProperties>) {
   const flagRegistry = useFlagRegistry<TFlag>(options.flags)
 


### PR DESCRIPTION
### Description

Allow non-computed properties on collection items.

```ts
useCollection(items, {
  identifier: item => item.id,
  properties: item => ({
    doSomething: () => ...
  })
})
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
