### PR TITLE
feat(web-core): update UiInfo component

### DIFF
--- a/@xen-orchestra/lite/src/stories/web-core/icon/vts-icon.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/icon/vts-icon.story.vue
@@ -3,7 +3,7 @@
     v-slot="{ properties }"
     :params="[
       prop('accent')
-        .enum('current', 'brand', 'info', 'success', 'warning', 'danger')
+        .enum('current', 'brand', 'info', 'success', 'warning', 'danger', 'muted')
         .required()
         .preset('current')
         .widget(),

--- a/@xen-orchestra/lite/src/stories/web-core/ui/info/ui-info.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/info/ui-info.story.vue
@@ -2,7 +2,7 @@
   <ComponentStory
     v-slot="{ properties, settings }"
     :params="[
-      prop('accent').enum('info', 'success', 'warning', 'danger').required().preset('info').widget(),
+      prop('accent').enum('info', 'success', 'warning', 'danger', 'muted').required().preset('info').widget(),
       prop('wrap').bool().help('Choose if the text should wrap if too long').widget(),
       slot(),
       setting('defaultSlot').widget(text()).preset('message'),

--- a/@xen-orchestra/web-core/lib/components/icon/VtsIcon.vue
+++ b/@xen-orchestra/web-core/lib/components/icon/VtsIcon.vue
@@ -13,7 +13,7 @@ import UiLoader from '@core/components/ui/loader/UiLoader.vue'
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
-export type IconAccent = 'current' | 'brand' | 'info' | 'success' | 'warning' | 'danger'
+export type IconAccent = 'current' | 'brand' | 'info' | 'success' | 'warning' | 'danger' | 'muted'
 
 defineProps<{
   accent: IconAccent
@@ -86,6 +86,14 @@ defineProps<{
 
     .overlay-icon {
       color: var(--color-danger-txt-item);
+    }
+  }
+
+  &.muted {
+    color: var(--color-neutral-background-disabled);
+
+    .overlay-icon {
+      color: var(--color-neutral-txt-secondary);
     }
   }
 }

--- a/@xen-orchestra/web-core/lib/components/input-wrapper/VtsInputWrapper.vue
+++ b/@xen-orchestra/web-core/lib/components/input-wrapper/VtsInputWrapper.vue
@@ -68,6 +68,7 @@ const labelAccent = useMapper<InfoAccent, LabelAccent>(
     success: 'neutral',
     warning: 'warning',
     danger: 'danger',
+    muted: 'neutral',
   },
   'neutral'
 )

--- a/@xen-orchestra/web-core/lib/components/ui/info/UiInfo.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/info/UiInfo.vue
@@ -1,4 +1,4 @@
-<!-- v3 -->
+<!-- v4 -->
 <template>
   <div class="ui-info">
     <VtsIcon :accent class="icon" :icon="faCircle" :overlay-icon="icon" />
@@ -16,12 +16,13 @@ import {
   faCircle,
   faExclamation,
   faInfo,
+  faMinus,
   faXmark,
   type IconDefinition,
 } from '@fortawesome/free-solid-svg-icons'
 import { computed } from 'vue'
 
-export type InfoAccent = 'info' | 'success' | 'warning' | 'danger'
+export type InfoAccent = 'info' | 'success' | 'warning' | 'danger' | 'muted'
 
 const { accent } = defineProps<{
   accent: InfoAccent
@@ -37,6 +38,7 @@ const iconByAccent: Record<InfoAccent, IconDefinition> = {
   success: faCheck,
   warning: faExclamation,
   danger: faXmark,
+  muted: faMinus,
 }
 
 const icon = computed(() => iconByAccent[accent])

--- a/@xen-orchestra/web-core/lib/components/ui/info/UiInfo.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/info/UiInfo.vue
@@ -1,8 +1,8 @@
-<!-- v2 -->
+<!-- v3 -->
 <template>
   <div class="ui-info">
     <VtsIcon :accent class="icon" :icon="faCircle" :overlay-icon="icon" />
-    <p v-tooltip="!wrap" class="typo-form-info" :class="{ 'text-ellipsis': !wrap }">
+    <p v-tooltip="!wrap" class="typo-body-regular-small" :class="{ 'text-ellipsis': !wrap }">
       <slot />
     </p>
   </div>


### PR DESCRIPTION
### Description

Adding muted variant for `UiInfo` component

### Screenshot

<img width="262" alt="Capture d’écran 2025-04-16 à 16 48 51" src="https://github.com/user-attachments/assets/c0099f53-be8a-4f94-b53c-1045e3b6e1bd" />

<img width="256" alt="Capture d’écran 2025-04-16 à 16 52 59" src="https://github.com/user-attachments/assets/593f72a9-5e12-400c-bf11-538cf9fb0117" />

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
