### PR TITLE
fix(xo-server): fix videoram not correctly parsed if defined in platform

### DIFF
--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/vm-template.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/vm-template.oa-example.mts
@@ -72,7 +72,7 @@ export const vmTemplate = {
   $VGPUs: [],
   xenStoreData: {},
   vga: 'std',
-  videoram: '8',
+  videoram: 8,
   id: 'b7569d99-30f8-178a-7d94-801de3e29b5b-f873abe0-b138-4995-8f6f-498b423d234d',
   isDefaultTemplate: true,
   template_info: {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,4 +31,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/rest-api patch
+- xo-server patch
+
 <!--packages-end-->

--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -482,7 +482,9 @@ const TRANSFORMS = {
     }
 
     if (isHvm) {
-      ;({ vga: vm.vga = 'cirrus', videoram: vm.videoram = 4 } = obj.platform)
+      const { vga, videoram } = obj.platform
+      vm.vga = vga ?? 'cirrus'
+      vm.videoram = +(videoram ?? 4)
     }
 
     const coresPerSocket = obj.platform['cores-per-socket']


### PR DESCRIPTION
### Description

As reported by @UnelDev, sometime `vm.videoram` is a number, and sometimes a string.
This was because the value was not parsed into a number in case the value existed in the `vm.platform.videoram`

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
