### PR TITLE
feat(hub/recipes): update kubernetes version list to use Microk8s version

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,8 @@
 
 - **XO6**:
   - [Host/Header] Add master host icon on host header (PR [#8512](https://github.com/vatesfr/xen-orchestra/pull/8512))
+- Hub recipe
+  - Upgrade Pyrgos/Kubernetes recipe to use MicroK8s
 
 ### Bug fixes
 

--- a/packages/xo-web/src/xo-app/hub/recipes/recipe-form.js
+++ b/packages/xo-web/src/xo-app/hub/recipes/recipe-form.js
@@ -140,7 +140,7 @@ export default decorate([
         sr =>
           sr.$pool === get(() => value.pool.id) && isSrWritable(sr),
       versionList: async () => {
-        const res = await fetch('https://api.github.com/repos/kubernetes/kubernetes/releases')
+        const res = await fetch('https://api.github.com/repos/canonical/microk8s/releases')
         if (res.ok) {
           const rawList = await res.json()
           const versionList = rawList


### PR DESCRIPTION
### Description

For the project Pyrgos, we changed the kubernetes hub recipe to use Microk8s solution.

This PR is to list the available version for Microk8s instead of Kubernetes (actually it's a subset of k8s minor versions).

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
