### PR TITLE
fix(xo-server): fix possible race condition at VIF level on VM creation

### DIFF
--- a/packages/xo-server/src/xapi/mixins/vm.mjs
+++ b/packages/xo-server/src/xapi/mixins/vm.mjs
@@ -289,24 +289,23 @@ const methods = {
       })
 
       await Promise.all(_vifsToDestroy.map(vif => this._deleteVif(vif)))
-      await Promise.all(
-        _vifsToCreate.map(vif =>
-          this.VIF_create(
-            {
-              ipv4_allowed: vif.ipv4_allowed,
-              ipv6_allowed: vif.ipv6_allowed,
-              device: vif.device,
-              locking_mode: isEmpty(vif.ipv4_allowed) && isEmpty(vif.ipv6_allowed) ? 'network_default' : 'locked',
-              MTU: vif.mtu,
-              network: this.getObject(vif.network).$ref,
-              VM: vm.$ref,
-            },
-            {
-              MAC: vif.mac,
-            }
-          )
+
+      for (const vif of _vifsToCreate) {
+        await this.VIF_create(
+          {
+            ipv4_allowed: vif.ipv4_allowed,
+            ipv6_allowed: vif.ipv6_allowed,
+            device: vif.device,
+            locking_mode: isEmpty(vif.ipv4_allowed) && isEmpty(vif.ipv6_allowed) ? 'network_default' : 'locked',
+            MTU: vif.mtu,
+            network: this.getObject(vif.network).$ref,
+            VM: vm.$ref,
+          },
+          {
+            MAC: vif.mac,
+          }
         )
-      )
+      }
     }
 
     if (vgpuType !== undefined && gpuGroup !== undefined) {


### PR DESCRIPTION
### Description

In case the user want to create multiple VIFs, it can lead to `userdevice already exist`.
Use `forof` to avoid this issue

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
