### PR TITLE
feat(xo-6/treeview): collapse treeview when pool/host/vm is clicked

### DIFF
--- a/@xen-orchestra/web-core/lib/components/tree/VtsTreeItem.vue
+++ b/@xen-orchestra/web-core/lib/components/tree/VtsTreeItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <li class="vts-tree-item" @click="handleClick">
+  <li class="vts-tree-item" @click="handleClick()">
     <slot />
     <slot v-if="expanded" name="sublist" />
   </li>

--- a/@xen-orchestra/web-core/lib/components/tree/VtsTreeItem.vue
+++ b/@xen-orchestra/web-core/lib/components/tree/VtsTreeItem.vue
@@ -1,11 +1,12 @@
 <template>
-  <li class="vts-tree-item">
+  <li class="vts-tree-item" @click="handleClick">
     <slot />
     <slot v-if="expanded" name="sublist" />
   </li>
 </template>
 
 <script lang="ts" setup>
+import { useSidebarStore } from '@core/stores/sidebar.store'
 import { IK_TREE_ITEM_EXPANDED, IK_TREE_ITEM_HAS_CHILDREN } from '@core/utils/injection-keys.util'
 import { onBeforeMount, onBeforeUpdate, provide, ref, toRef, useSlots } from 'vue'
 
@@ -18,11 +19,18 @@ defineSlots<{
   sublist?(): any
 }>()
 
+const sidebar = useSidebarStore()
 const hasChildren = ref(false)
 
 const updateHasChildren = () => {
   const { sublist } = useSlots()
   hasChildren.value = sublist !== undefined
+}
+
+const handleClick = () => {
+  if (!hasChildren.value) {
+    sidebar.toggleExpand()
+  }
 }
 
 onBeforeMount(() => updateHasChildren())

--- a/@xen-orchestra/web-core/lib/components/tree/VtsTreeItem.vue
+++ b/@xen-orchestra/web-core/lib/components/tree/VtsTreeItem.vue
@@ -7,6 +7,7 @@
 
 <script lang="ts" setup>
 import { useSidebarStore } from '@core/stores/sidebar.store'
+import { useUiStore } from '@core/stores/ui.store'
 import { IK_TREE_ITEM_EXPANDED, IK_TREE_ITEM_HAS_CHILDREN } from '@core/utils/injection-keys.util'
 import { onBeforeMount, onBeforeUpdate, provide, ref, toRef, useSlots } from 'vue'
 
@@ -20,6 +21,7 @@ defineSlots<{
 }>()
 
 const sidebar = useSidebarStore()
+const uiStore = useUiStore()
 const hasChildren = ref(false)
 
 const updateHasChildren = () => {
@@ -28,7 +30,7 @@ const updateHasChildren = () => {
 }
 
 const handleClick = () => {
-  if (!hasChildren.value) {
+  if (!hasChildren.value && uiStore.isMobile) {
     sidebar.toggleExpand()
   }
 }

--- a/@xen-orchestra/web-core/lib/components/tree/VtsTreeItem.vue
+++ b/@xen-orchestra/web-core/lib/components/tree/VtsTreeItem.vue
@@ -30,8 +30,8 @@ const updateHasChildren = () => {
 }
 
 const handleClick = () => {
-  if (!hasChildren.value && uiStore.isMobile) {
-    sidebar.toggleExpand()
+  if (uiStore.isMobile) {
+    sidebar.toggleExpand(false)
   }
 }
 

--- a/@xen-orchestra/web-core/lib/stores/sidebar.store.ts
+++ b/@xen-orchestra/web-core/lib/stores/sidebar.store.ts
@@ -2,7 +2,7 @@ import { useUiStore } from '@core/stores/ui.store'
 import { ifElse } from '@core/utils/if-else.utils'
 import { useLocalStorage, useRafFn, useStyleTag, useToggle } from '@vueuse/core'
 import { defineStore } from 'pinia'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 export const useSidebarStore = defineStore('layout', () => {
   const uiStore = useUiStore()
@@ -48,6 +48,13 @@ export const useSidebarStore = defineStore('layout', () => {
   )
 
   ifElse(isResizing, [load, resume], [pause, unload])
+
+  watch(
+    () => uiStore.isMobile,
+    isMobile => {
+      isExpanded.value = !isMobile
+    }
+  )
 
   return {
     isExpanded,

--- a/@xen-orchestra/web-core/lib/stores/sidebar.store.ts
+++ b/@xen-orchestra/web-core/lib/stores/sidebar.store.ts
@@ -54,7 +54,10 @@ export const useSidebarStore = defineStore('layout', () => {
     () => uiStore.isMobile,
     isMobile => {
       // keep the state of desktop expention
-      if (isMobile) desktopState = isExpanded.value
+      if (isMobile) {
+        desktopState = isExpanded.value
+      }
+
       isExpanded.value = desktopState && !isMobile
     }
   )

--- a/@xen-orchestra/web-core/lib/stores/sidebar.store.ts
+++ b/@xen-orchestra/web-core/lib/stores/sidebar.store.ts
@@ -12,6 +12,7 @@ export const useSidebarStore = defineStore('layout', () => {
   const toggleExpand = useToggle(isExpanded)
   const toggleLock = useToggle(isLocked)
   const isResizing = ref(false)
+  let desktopState = false
 
   let initialX: number
   let initialWidth: number
@@ -52,7 +53,9 @@ export const useSidebarStore = defineStore('layout', () => {
   watch(
     () => uiStore.isMobile,
     isMobile => {
-      isExpanded.value = !isMobile
+      // keep the state of desktop expention
+      if (isMobile) desktopState = isExpanded.value
+      isExpanded.value = desktopState && !isMobile
     }
   )
 


### PR DESCRIPTION
### Description

Adding a click handler to collapse the sidebar on mobile devices if you click on the Pool, Host, or vm button in the sidebar.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
