### PR TITLE
fix(xo-web): better handling of free and trial users

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,9 @@
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
-- [Licence]: better handling of trial and free users 
+
+- [Licence]: better handling of trial and free users (PR [#8557](https://github.com/vatesfr/xen-orchestra/pull/8557))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -30,5 +32,6 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
 - xo-web patch
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
-- [xo-web]: better handling of trial and free users 
+- [Licence]: better handling of trial and free users 
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
-
+- [xo-web]: better handling of trial and free users 
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -30,5 +30,5 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
-
+- xo-web patch
 <!--packages-end-->

--- a/packages/xo-web/src/common/xoa-updater.js
+++ b/packages/xo-web/src/common/xoa-updater.js
@@ -40,12 +40,12 @@ export function getLicenseNearExpiration(licenses, trial) {
   const plan = getXoaPlan()
   // user does not have a licence for free or source version
   // also don't crash the app if the licence is in unexpected state
-  if(![PREMIUM, ENTERPRISE,STARTER ].includes(plan)){
-    return 
+  if (![PREMIUM, ENTERPRISE, STARTER].includes(plan)) {
+    return
   }
   // user under trial are not expected to have licences
-  if(isTrialRunning(trial)){
-    return 
+  if (isTrialRunning(trial)) {
+    return
   }
   // got a unlimited license bound to this XO nothing can expires
   if (licenses.find(({ expires }) => expires === undefined) !== undefined) {

--- a/packages/xo-web/src/common/xoa-updater.js
+++ b/packages/xo-web/src/common/xoa-updater.js
@@ -11,6 +11,7 @@ import {
   setXoaUpdaterLog,
   setXoaUpdaterState,
 } from 'store/actions'
+import { ENTERPRISE, getXoaPlan, PREMIUM, STARTER } from './xoa-plans'
 
 // ===================================================================
 
@@ -35,7 +36,18 @@ export function blockXoaAccess(xoaState) {
   return block
 }
 
-export function getLicenseNearExpiration(licenses) {
+export function getLicenseNearExpiration(licenses, trial) {
+  const plan = getXoaPlan()
+  // user does not have a licence for free or source version
+  // also don't crash the app if the licence is in unexpected state
+  if(![PREMIUM, ENTERPRISE,STARTER ].includes(plan)){
+    return 
+  }
+  // user under trial are not expected to have licences
+  if(isTrialRunning(trial)){
+    return 
+  }
+  // got a unlimited license bound to this XO nothing can expires
   if (licenses.find(({ expires }) => expires === undefined) !== undefined) {
     return
   }

--- a/packages/xo-web/src/xo-app/index.js
+++ b/packages/xo-web/src/xo-app/index.js
@@ -444,7 +444,9 @@ export default class XoApp extends Component {
     const licenseNearExpiration = this.props.selfLicences && getLicenseNearExpiration(this.props.selfLicences, trial)
     // If we are under expired or unstable trial (signed up only)
     const blocked =
-      signedUp &&( blockXoaAccess(trial) || licenseNearExpiration?.blocked === true)&& !(pathname.startsWith('/xoa/') || pathname === '/backup/restore')
+      signedUp &&
+      (blockXoaAccess(trial) || licenseNearExpiration?.blocked === true) &&
+      !(pathname.startsWith('/xoa/') || pathname === '/backup/restore')
     const plan = getXoaPlan()
     return (
       <IntlProvider>
@@ -492,7 +494,7 @@ export default class XoApp extends Component {
                   </button>
                 </div>
               )}
-              {licenseNearExpiration  && (
+              {licenseNearExpiration && (
                 <div className={`alert alert-info mb-0 ${licenseNearExpiration.popupClass ?? 'alert-info'}`}>
                   {_(licenseNearExpiration.strCode, {
                     duration: licenseNearExpiration.textDuration,

--- a/packages/xo-web/src/xo-app/index.js
+++ b/packages/xo-web/src/xo-app/index.js
@@ -441,7 +441,7 @@ export default class XoApp extends Component {
   render() {
     const { signedUp, trial, registerNeeded } = this.props
     const { pathname } = this.context.router.location
-    const licenseNearExpiration = this.props.selfLicences && getLicenseNearExpiration(this.props.selfLicences)
+    const licenseNearExpiration = this.props.selfLicences && getLicenseNearExpiration(this.props.selfLicences, trial)
     // If we are under expired or unstable trial (signed up only)
     const blocked =
       signedUp &&( blockXoaAccess(trial) || licenseNearExpiration?.blocked === true)&& !(pathname.startsWith('/xoa/') || pathname === '/backup/restore')


### PR DESCRIPTION
* don't check licence for users with a running trial
* don't check licence for users with a free of from source plan

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
3. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   4. The _junior reviewer_ assigns the _senior reviewer_.
   5. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
