### PR TITLE
feat(web-core): update vtsLoadingHero Component

### DIFF
--- a/@xen-orchestra/lite/src/stories/web-core/state-hero/vts-loading-hero.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/state-hero/vts-loading-hero.story.vue
@@ -1,14 +1,24 @@
 <template>
   <ComponentStory
-    v-slot="{ properties }"
-    :params="[prop('type').required().enum('page', 'card', 'table', 'panel').preset('card').widget()]"
+    v-slot="{ properties, settings }"
+    :params="[
+      prop('type').required().enum('page', 'card', 'table', 'panel').preset('card').widget(),
+      slot('title').help('Meant to receive title'),
+      slot('text').help('Meant to receive text'),
+      setting('title').preset('Please wait').widget(text()),
+      setting('text').preset('This is a loading text').widget(text()),
+    ]"
   >
-    <VtsLoadingHero v-bind="properties" />
+    <VtsLoadingHero v-bind="properties">
+      <template #title> {{ settings.title }}</template>
+      <template #text> {{ settings.text }}</template>
+    </VtsLoadingHero>
   </ComponentStory>
 </template>
 
 <script lang="ts" setup>
 import ComponentStory from '@/components/component-story/ComponentStory.vue'
-import { prop } from '@/libs/story/story-param'
+import { prop, setting, slot } from '@/libs/story/story-param'
+import { text } from '@/libs/story/story-widget.ts'
 import VtsLoadingHero from '@core/components/state-hero/VtsLoadingHero.vue'
 </script>

--- a/@xen-orchestra/lite/src/stories/web-core/state-hero/vts-loading-hero.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/state-hero/vts-loading-hero.story.vue
@@ -5,13 +5,14 @@
       prop('type').required().enum('page', 'card', 'table', 'panel').preset('card').widget(),
       slot('title').help('Meant to receive title'),
       slot('text').help('Meant to receive text'),
-      setting('title').preset('Please wait').widget(text()),
-      setting('text').preset('This is a loading text').widget(text()),
+      setting('title').preset('').widget(text()),
+      setting('text').preset('').widget(text()),
     ]"
+    :presets
   >
     <VtsLoadingHero v-bind="properties">
-      <template #title> {{ settings.title }}</template>
-      <template #text> {{ settings.text }}</template>
+      <template v-if="settings.title" #title>{{ settings.title }}</template>
+      <template v-if="settings.text" #text>{{ settings.text }}</template>
     </VtsLoadingHero>
   </ComponentStory>
 </template>
@@ -21,4 +22,19 @@ import ComponentStory from '@/components/component-story/ComponentStory.vue'
 import { prop, setting, slot } from '@/libs/story/story-param'
 import { text } from '@/libs/story/story-widget.ts'
 import VtsLoadingHero from '@core/components/state-hero/VtsLoadingHero.vue'
+
+const presets = {
+  'with text': {
+    settings: {
+      title: 'Please wait',
+      text: 'This is a loading text',
+    },
+  },
+  'without text': {
+    settings: {
+      title: '',
+      text: '',
+    },
+  },
+}
 </script>

--- a/@xen-orchestra/web-core/lib/components/state-hero/VtsLoadingHero.vue
+++ b/@xen-orchestra/web-core/lib/components/state-hero/VtsLoadingHero.vue
@@ -1,13 +1,51 @@
 <template>
-  <VtsStateHero :type busy>
-    {{ $t('loading-in-progress') }}
-  </VtsStateHero>
+  <div class="vts-loading-hero">
+    <VtsStateHero :type busy>
+      {{ $t('loading-in-progress') }}
+    </VtsStateHero>
+    <div class="content">
+      <div v-if="slots.title" class="title" :class="typoClass">
+        <slot name="title" />
+      </div>
+      <div v-if="slots.text" class="text typo-body-bold">
+        <slot name="text" />
+      </div>
+    </div>
+  </div>
 </template>
 
 <script lang="ts" setup>
 import VtsStateHero, { type StateHeroType } from '@core/components/state-hero/VtsStateHero.vue'
+import { computed } from 'vue'
 
-defineProps<{
+const props = defineProps<{
   type: StateHeroType
 }>()
+
+const slots = defineSlots<{
+  title(): string
+  text(): string
+}>()
+
+const typoClass = computed(() => (props.type === 'page' ? 'typo-h1' : 'typo-h2'))
 </script>
+
+<style lang="postcss" scoped>
+.vts-loading-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: 2.4rem;
+    text-align: center;
+    .title {
+      color: var(--color-neutral-txt-primary);
+    }
+    .text {
+      color: var(--color-neutral-txt-secondary);
+    }
+  }
+}
+</style>

--- a/@xen-orchestra/web-core/lib/components/state-hero/VtsLoadingHero.vue
+++ b/@xen-orchestra/web-core/lib/components/state-hero/VtsLoadingHero.vue
@@ -3,8 +3,8 @@
     <VtsStateHero :type busy>
       {{ $t('loading-in-progress') }}
     </VtsStateHero>
-    <div class="content">
-      <div v-if="slots.title" class="title" :class="typoClass">
+    <div v-if="slots.title || slots.text" class="content">
+      <div v-if="slots.title" class="title" :class="className">
         <slot name="title" />
       </div>
       <div v-if="slots.text" class="text typo-body-bold">
@@ -18,16 +18,16 @@
 import VtsStateHero, { type StateHeroType } from '@core/components/state-hero/VtsStateHero.vue'
 import { computed } from 'vue'
 
-const props = defineProps<{
+const { type } = defineProps<{
   type: StateHeroType
 }>()
 
 const slots = defineSlots<{
-  title(): string
-  text(): string
+  title?(): any
+  text?(): any
 }>()
 
-const typoClass = computed(() => (props.type === 'page' ? 'typo-h1' : 'typo-h2'))
+const className = computed(() => (type === 'page' ? 'typo-h1' : 'typo-h2'))
 </script>
 
 <style lang="postcss" scoped>
@@ -35,14 +35,17 @@ const typoClass = computed(() => (props.type === 'page' ? 'typo-h1' : 'typo-h2')
   display: flex;
   flex-direction: column;
   gap: 1.6rem;
+
   .content {
     display: flex;
     flex-direction: column;
     gap: 2.4rem;
     text-align: center;
+
     .title {
       color: var(--color-neutral-txt-primary);
     }
+
     .text {
       color: var(--color-neutral-txt-secondary);
     }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -41,6 +41,7 @@
 - @xen-orchestra/backups patch
 - @xen-orchestra/fs patch
 - @xen-orchestra/rest-api minor
+- @xen-orchestra/web-core minor
 - xo-server patch
 - xo-server-auth-oidc patch
 - xo-server-perf-alert patch


### PR DESCRIPTION
### Description

Update `VtsLoadingHero` component to handle text displaying

### Screenshot
<img width="719" alt="Capture d’écran 2025-05-06 à 09 38 22" src="https://github.com/user-attachments/assets/a7570b59-808c-475a-a2d8-9cc5f6a3e54b" />


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
