### PR TITLE
fix(xo-server-perf-alert): fix configuration schema

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@
 - [Backups] mirror full backup bigger han 50GB from encrypted source (PR [#8570](https://github.com/vatesfr/xen-orchestra/pull/8570))
 - [ACLs] Fix ACLs not being assigned properly when resource set is assigned to a VM (PR [#8571](https://github.com/vatesfr/xen-orchestra/pull/8571))
 - [Plugins/Perf-alert] Fixing plugin configuration error happening while editing config [Forum#9658](https://xcp-ng.org/forum/post/90573) (PR [#8561](https://github.com/vatesfr/xen-orchestra/pull/8561))
+- [Plugins/Perf-alert] Prevent non-running VMs and hosts to be monitored in specific cases [Forum#10802](https://xcp-ng.org/forum/topic/10802/performance-alerts-fail-when-turning-on-all-running-hosts-all-running-vm-s-etc) (PR [#8561](https://github.com/vatesfr/xen-orchestra/pull/8561))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
 
 - [Backups] mirror full backup bigger han 50GB from encrypted source (PR [#8570](https://github.com/vatesfr/xen-orchestra/pull/8570))
 - [ACLs] Fix ACLs not being assigned properly when resource set is assigned to a VM (PR [#8571](https://github.com/vatesfr/xen-orchestra/pull/8571))
+- [Plugins/Perf-alert] Fixing plugin configuration error happening while editing config [Forum#9658](https://xcp-ng.org/forum/post/90573) (PR [#8561](https://github.com/vatesfr/xen-orchestra/pull/8561))
 
 ### Packages to release
 
@@ -41,5 +42,6 @@
 - @xen-orchestra/rest-api minor
 - xo-server patch
 - xo-server-auth-oidc patch
+- xo-server-perf-alert patch
 
 <!--packages-end-->

--- a/packages/xo-server-perf-alert/src/index.js
+++ b/packages/xo-server-perf-alert/src/index.js
@@ -9,7 +9,7 @@ const logger = createLogger('xo:xo-server-perf-alert')
 const PARAMS_JSON_SCHEMA = [
   {
     properties: {
-      uuids: {},
+      uuids: { minItems: 1 },
       smartMode: { anyOf: [{ not: {} }, { const: false }] },
       excludeUuids: { anyOf: [{ not: {} }, { const: true }, { const: false }] },
     },
@@ -19,13 +19,14 @@ const PARAMS_JSON_SCHEMA = [
   {
     properties: {
       smartMode: { const: true },
-      uuids: { not: {} },
+      // after being edited, uuids will be an empty list instead of undefined
+      uuids: { anyOf: [{ not: {} }, { maxItems: 0 }] },
     },
     required: ['smartMode'],
   },
   {
     properties: {
-      uuids: {},
+      uuids: { minItems: 1 },
       smartMode: { const: true },
       excludeUuids: { const: true },
     },
@@ -204,6 +205,8 @@ export const configurationSchema = {
             type: 'boolean',
           },
           uuids: {
+            description:
+              'List of hosts to monitor if "All running hosts" is disabled, or to not monitor if "Exclude hosts" is enabled.',
             title: 'Hosts',
             type: 'array',
             items: {
@@ -260,6 +263,8 @@ export const configurationSchema = {
             type: 'boolean',
           },
           uuids: {
+            description:
+              'List of VMs to monitor if "All running VMs" is disabled, or to not monitor if "Exclude VMs" is enabled.',
             title: 'Virtual Machines',
             type: 'array',
             items: {
@@ -316,6 +321,8 @@ export const configurationSchema = {
             type: 'boolean',
           },
           uuids: {
+            description:
+              'List of SRs to monitor if "All SRs" is disabled, or to not monitor if "Exclude SRs" is enabled.',
             title: 'SRs',
             type: 'array',
             items: {

--- a/packages/xo-server-perf-alert/src/index.js
+++ b/packages/xo-server-perf-alert/src/index.js
@@ -11,6 +11,7 @@ const PARAMS_JSON_SCHEMA = [
     properties: {
       uuids: { minItems: 1 },
       smartMode: { anyOf: [{ not: {} }, { const: false }] },
+      // we allow smartMode=false with excludeUuids=true because UI is not very clear, and we can't enforce smartMode value when excludeUuids=true
       excludeUuids: { anyOf: [{ not: {} }, { const: true }, { const: false }] },
     },
     required: ['uuids'],
@@ -509,7 +510,7 @@ ${monitorBodies.join('\n')}`
                   }
 
                   if (
-                    definition.smartMode &&
+                    (definition.smartMode || definition.excludeUuids) &&
                     (objectType === 'VM' || objectType === 'host') &&
                     obj.power_state !== 'Running'
                   ) {


### PR DESCRIPTION
### Description

**Review by commit, do not squash**

- first commit: allow users to clear the "Virtual machines" field of the configuration without getting an error (same for the "Hosts" and "SRs" fields) [XO-814](https://project.vates.tech/vates-global/browse/XO-814/). Also add a description to a configuration field
- second commit: preventing non-running hosts and VMs to be monitored when the monitor is configured with "Exclude VMs"/"Exclude hosts" option but not "All running VMs"/"All running hosts"
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
