### PR TITLE
feat(@xen-orchestra/rest-api): ability to add a server

### DIFF
--- a/@xen-orchestra/rest-api/.USAGE.md
+++ b/@xen-orchestra/rest-api/.USAGE.md
@@ -30,6 +30,7 @@ class Foo extends Controller {
  @Example(['foo', 'bar'])
  @Get('{id}')
  @Security('*')
+ @Middlewares(json())
  @SuccessResponse(202)
  @Response(404)
  getFoo(@Path() id: string) {

--- a/@xen-orchestra/rest-api/README.md
+++ b/@xen-orchestra/rest-api/README.md
@@ -48,6 +48,7 @@ class Foo extends Controller {
  @Example(['foo', 'bar'])
  @Get('{id}')
  @Security('*')
+ @Middlewares(json())
  @SuccessResponse(202)
  @Response(404)
  getFoo(@Path() id: string) {

--- a/@xen-orchestra/rest-api/src/middlewares/generic-error-handler.middleware.mts
+++ b/@xen-orchestra/rest-api/src/middlewares/generic-error-handler.middleware.mts
@@ -6,6 +6,7 @@ import {
   invalidParameters,
   noSuchObject,
   notImplemented,
+  objectAlreadyExists,
   unauthorized,
 } from 'xo-common/api-errors.js'
 import { NextFunction, Request, Response } from 'express'
@@ -28,6 +29,8 @@ export default function genericErrorHandler(error: unknown, req: Request, res: R
     res.status(403)
   } else if (invalidCredentials.is(error)) {
     res.status(401)
+  } else if (objectAlreadyExists.is(error)) {
+    res.status(409)
   } else if (invalidParameters.is(error)) {
     res.status(422)
   } else if (notImplemented.is(error)) {

--- a/@xen-orchestra/rest-api/src/open-api/common/response.common.mts
+++ b/@xen-orchestra/rest-api/src/open-api/common/response.common.mts
@@ -13,6 +13,10 @@ export type Unbrand<T> = {
         : T[K]
 }
 
+export const createdResp = {
+  status: 201,
+  description: 'Resource created',
+}
 export const actionAsyncroneResp = {
   status: 202,
   description: 'Action executed asynchronously',
@@ -42,4 +46,14 @@ export const noContentResp = {
 export const internalServerErrorResp = {
   status: 500,
   description: 'Internal server error, XenServer/XCP-ng error',
+} as const
+
+export const resourceAlreadyExists = {
+  status: 409,
+  description: 'Resource already exists',
+} as const
+
+export const invalidParameters = {
+  status: 422,
+  description: 'Invalid parameters',
 } as const

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/server.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/server.oa-example.mts
@@ -1,3 +1,5 @@
+export const serverId = { id: '38068475-3a1d-4a64-95df-8782cdea02ac' }
+
 export const serverIds = [
   '/rest/v0/servers/f07ab729-c0e8-721c-45ec-f11276377030',
   '/rest/v0/servers/d5d1c4a3-4c5e-ca7b-6be8-33c824f87571',

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -16,6 +16,8 @@ import type {
 } from '@vates/types/xen-api'
 import type { XoHost, XoServer, XoUser, XapiXoRecord, XoVm, XoSchedule, XoJob, XoGroup } from '@vates/types/xo'
 
+import type { InsertableXoServer } from '../servers/server.type.mjs'
+
 type XapiRecordByXapiXoRecord = {
   host: XenApiHostWrapped
   message: XenApiMessage
@@ -63,6 +65,8 @@ export type XoApp = {
   getXapiObject: <T extends XapiXoRecord>(maybeId: T['id'] | T, type: T['type']) => XapiRecordByXapiXoRecord[T['type']]
   getXapiVmStats: (vmId: XoVm['id'], granularity?: XapiStatsGranularity) => Promise<XapiVmStats>
   getXenServer(id: XoServer['id']): Promise<XoServer>
+  /** Allow to add a new server in the DB (XCP-ng/XenServer) */
+  registerXenServer(body: InsertableXoServer): Promise<XoServer>
   runJob(job: XoJob, schedule: XoSchedule): void
   runWithApiContext: (user: XoUser, fn: () => void) => Promise<unknown>
 }

--- a/@xen-orchestra/rest-api/src/servers/server.controller.mts
+++ b/@xen-orchestra/rest-api/src/servers/server.controller.mts
@@ -1,10 +1,33 @@
-import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
-import { Request as ExRequest } from 'express'
+import {
+  Body,
+  Example,
+  Get,
+  Middlewares,
+  Path,
+  Post,
+  Query,
+  Request,
+  Response,
+  Route,
+  Security,
+  SuccessResponse,
+  Tags,
+} from 'tsoa'
+import { type Request as ExRequest, json } from 'express'
 import { provide } from 'inversify-binding-decorators'
 import type { XoServer } from '@vates/types'
 
-import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
-import { partialServers, server, serverIds } from '../open-api/oa-examples/server.oa-example.mjs'
+import type { InsertableXoServer } from './server.type.mjs'
+
+import {
+  createdResp,
+  invalidParameters,
+  notFoundResp,
+  resourceAlreadyExists,
+  unauthorizedResp,
+  type Unbrand,
+} from '../open-api/common/response.common.mjs'
+import { partialServers, server, serverId, serverIds } from '../open-api/oa-examples/server.oa-example.mjs'
 import type { WithHref } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
 
@@ -47,5 +70,25 @@ export class ServerController extends XoController<XoServer> {
   @Response(notFoundResp.status, notFoundResp.description)
   getServer(@Path() id: string): Promise<Unbrand<XoServer>> {
     return this.getObject(id as XoServer['id'])
+  }
+
+  /**
+   * @example body {
+   *   "allowUnauthorized": true,
+   *   "host": "192.168.1.10",
+   *   "label": "Example server",
+   *   "username": "root",
+   *   "password": "awes0meP4ssword"
+   * }
+   */
+  @Example(serverId)
+  @Post('')
+  @Middlewares(json())
+  @SuccessResponse(createdResp.status, createdResp.description)
+  @Response(resourceAlreadyExists.status, resourceAlreadyExists.description)
+  @Response(invalidParameters.status, invalidParameters.description)
+  async addServer(@Body() body: InsertableXoServer): Promise<{ id: string }> {
+    const server = await this.restApi.xoApp.registerXenServer(body)
+    return { id: server.id }
   }
 }

--- a/@xen-orchestra/rest-api/src/servers/server.type.mts
+++ b/@xen-orchestra/rest-api/src/servers/server.type.mts
@@ -1,0 +1,7 @@
+import { XoServer } from '@vates/types'
+
+export interface InsertableXoServer extends Pick<XoServer, 'host' | 'httpProxy' | 'label' | 'username'> {
+  allowUnauthorized?: XoServer['allowUnauthorized']
+  password: string
+  readOnly?: XoServer['readOnly']
+}

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [REST] Ability to add a new server `POST rest/v0/servers`
+- [REST] Ability to add a new server `POST rest/v0/servers` (PR [#8564](https://github.com/vatesfr/xen-orchestra/pull/8564))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [REST] Ability to add a new server `POST rest/v0/servers`
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -30,5 +32,8 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- @xen-orchestra/rest-api minor
+- xo-server patch
 
 <!--packages-end-->

--- a/packages/xo-server/src/models/server.mjs
+++ b/packages/xo-server/src/models/server.mjs
@@ -1,6 +1,6 @@
+import { objectAlreadyExists } from 'xo-common/api-errors.js'
 import Collection from '../collection/redis.mjs'
 import { serializeError } from '../utils.mjs'
-import { objectAlreadyExists } from 'xo-common/api-errors.js'
 
 import { parseProp } from './utils.mjs'
 

--- a/packages/xo-server/src/models/server.mjs
+++ b/packages/xo-server/src/models/server.mjs
@@ -1,5 +1,6 @@
 import Collection from '../collection/redis.mjs'
 import { serializeError } from '../utils.mjs'
+import { objectAlreadyExists } from 'xo-common/api-errors.js'
 
 import { parseProp } from './utils.mjs'
 
@@ -34,7 +35,11 @@ export class Servers extends Collection {
     const { host } = params
 
     if (await this.exists({ host })) {
-      throw new Error('server already exists')
+      const _host = await this.get({ host })
+      /* throw */ objectAlreadyExists({
+        objectId: _host.id,
+        objectType: 'server',
+      })
     }
 
     return /* await */ this.add(params)


### PR DESCRIPTION
### Screenshot

![Capture d’écran de 2025-05-06 16-23-41](https://github.com/user-attachments/assets/9484a75e-a5d0-4dec-bfa8-ddd314d068db)

### Description

In the JSON RPC API, `servers.add` allow the possibility to connect the newly created server directly.
I intentionally did not implement this part to try to keep as much as possible single responsibility per endpoint (except for endpoints with a lot of business logic such as the VM creation).

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
