### PR TITLE
fix(web-core): sidebar z-index

### DIFF
--- a/@xen-orchestra/web-core/lib/components/layout/VtsLayoutSidebar.vue
+++ b/@xen-orchestra/web-core/lib/components/layout/VtsLayoutSidebar.vue
@@ -58,7 +58,7 @@ const ui = useUiStore()
   background-color: var(--color-neutral-background-secondary);
   border-right: 0.1rem solid var(--color-neutral-border);
   width: v-bind('sidebar.cssWidth');
-  z-index: 1001;
+  z-index: 1010;
   transition:
     margin-left 0.25s,
     transform 0.25s;


### PR DESCRIPTION
### Description

The `z-index` of `VtsBackdrop.vue` has been updated but this makes the access to the sidebar content impossible when it's not pinned.

This PR fix the `z-index` of the sidebar.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
