### PR TITLE
feat(@xen-orchestra/rest-api): expose get pifs and get pifs/:id

### DIFF
--- a/@vates/types/src/xen-api.mts
+++ b/@vates/types/src/xen-api.mts
@@ -705,6 +705,7 @@ export interface XenApiPif {
   VLAN_slave_of: XenApiVlan['$ref'][]
   VLAN: number
 }
+export type XenApiPifWrapped = WrapperXenApi<XenApiPif, 'PIF'>
 
 export interface XenApiPifMetrics {
   $ref: Branded<'PIF_metrics'>
@@ -1336,6 +1337,7 @@ export type XenApiRecord =
 
 export type WrappedXenApiRecord =
   | XenApiHostWrapped
+  | XenApiPifWrapped
   | XenApiPoolWrapped
   | XenApiSrWrapped
   | XenApiVbdWrapped

--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -5,8 +5,11 @@ import type {
   DOMAIN_TYPE,
   HOST_ALLOWED_OPERATIONS,
   HOST_POWER_STATE,
+  IP_CONFIGURATION_MODE,
+  IPV6_CONFIGURATION_MODE,
   NETWORK_OPERATIONS,
   POOL_ALLOWED_OPERATIONS,
+  PRIMARY_ADDRESS_TYPE,
   STORAGE_OPERATIONS,
   VDI_OPERATIONS,
   VDI_TYPE,
@@ -271,8 +274,34 @@ export type XoPgpu = BaseXapiXo & {
 }
 
 export type XoPif = BaseXapiXo & {
+  $host: XoHost['id']
+  $network: XoNetwork['id']
+
+  attached: boolean
+  bondMaster?: XoPif['id']
+  bondSalves?: XoPif['id'][]
+  carrier: boolean
+  device: string
+  deviceName?: string
+  disallowUnplug: boolean
+  dns: string
+  gateway: string
   id: Branded<'PIF'>
+  ip: string
+  ipv6: string[]
+  ipv6Mode: IPV6_CONFIGURATION_MODE
+  isBondMaster: boolean
+  isBondSlave: boolean
+  mac: string
+  management: boolean
+  mode: IP_CONFIGURATION_MODE
+  mtu: number
+  netmask: string
+  physical: boolean
+  primaryAddressType: PRIMARY_ADDRESS_TYPE
+  speed?: number
   type: 'PIF'
+  vlan: number
 }
 
 export type XoPool = BaseXapiXo & {
@@ -488,6 +517,7 @@ export type XapiXoRecord =
   | XoHost
   | XoMessage
   | XoNetwork
+  | XoPif
   | XoPool
   | XoSr
   | XoVbd

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/pif.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/pif.oa-example.mts
@@ -1,0 +1,53 @@
+export const pifIds = [
+  '/rest/v0/pifs/d9e42451-3794-089f-de81-4ee0e6137bee',
+  '/rest/v0/pifs/3f258258-ffd9-7bf2-2b47-74a0af2ea3b3',
+]
+
+export const partialPifs = [
+  {
+    attached: true,
+    device: 'eth0',
+    deviceName: 'MT27520 Family [ConnectX-3 Pro]',
+    id: 'd9e42451-3794-089f-de81-4ee0e6137bee',
+    href: '/rest/v0/pifs/d9e42451-3794-089f-de81-4ee0e6137bee',
+  },
+  {
+    attached: true,
+    device: 'eth1',
+    deviceName: 'MT27520 Family [ConnectX-3 Pro]',
+    id: '3f258258-ffd9-7bf2-2b47-74a0af2ea3b3',
+    href: '/rest/v0/pifs/3f258258-ffd9-7bf2-2b47-74a0af2ea3b3',
+  },
+]
+
+export const pif = {
+  type: 'PIF',
+  attached: true,
+  isBondMaster: false,
+  isBondSlave: false,
+  device: 'eth0',
+  deviceName: 'MT27520 Family [ConnectX-3 Pro]',
+  dns: '',
+  disallowUnplug: false,
+  gateway: '',
+  ip: '',
+  ipv6: [],
+  mac: 'ec:eb:b8:8e:d1:12',
+  management: false,
+  carrier: true,
+  mode: 'None',
+  ipv6Mode: 'None',
+  mtu: 1500,
+  netmask: '',
+  physical: true,
+  primaryAddressType: 'IPv4',
+  vlan: -1,
+  speed: 10000,
+  $host: 'b61a5c92-700e-4966-a13b-00633f03eea8',
+  $network: 'ac9b098e-df7f-50d3-b013-95d4cd550c61',
+  id: 'd9e42451-3794-089f-de81-4ee0e6137bee',
+  uuid: 'd9e42451-3794-089f-de81-4ee0e6137bee',
+  $pool: 'b7569d99-30f8-178a-7d94-801de3e29b5b',
+  $poolId: 'b7569d99-30f8-178a-7d94-801de3e29b5b',
+  _xapiRef: 'OpaqueRef:d94c0e13-ce19-c545-bcf2-c4cbbd3d43b8',
+}

--- a/@xen-orchestra/rest-api/src/pifs/pif.controller.mts
+++ b/@xen-orchestra/rest-api/src/pifs/pif.controller.mts
@@ -1,0 +1,51 @@
+import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import { inject } from 'inversify'
+import { provide } from 'inversify-binding-decorators'
+import type { Request as ExRequest } from 'express'
+import type { XoPif } from '@vates/types'
+
+import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
+import { partialPifs, pif, pifIds } from '../open-api/oa-examples/pif.oa-example.mjs'
+import { RestApi } from '../rest-api/rest-api.mjs'
+import type { WithHref } from '../helpers/helper.type.mjs'
+import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
+
+type UnbrandedXoPif = Unbrand<XoPif>
+
+@Route('pifs')
+@Security('*')
+@Response(unauthorizedResp.status, unauthorizedResp.description)
+@Tags('pifs')
+@provide(PifController)
+export class PifController extends XapiXoController<XoPif> {
+  constructor(@inject(RestApi) restApi: RestApi) {
+    super('PIF', restApi)
+  }
+
+  /**
+   * @example fields "attached,device,deviceName,id"
+   * @example filter "attached?"
+   * @example limit 42
+   */
+  @Example(pifIds)
+  @Example(partialPifs)
+  @Get('')
+  getPifs(
+    @Request() req: ExRequest,
+    @Query() fields?: string,
+    @Query() filter?: string,
+    @Query() limit?: number
+  ): string[] | WithHref<Partial<UnbrandedXoPif>>[] {
+    return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
+  }
+
+  /**
+   * @example id "d9e42451-3794-089f-de81-4ee0e6137bee"
+   */
+  @Example(pif)
+  @Get('{id}')
+  @Response(notFoundResp.status, notFoundResp.description)
+  getPif(@Path() id: string): UnbrandedXoPif {
+    return this.getObject(id as XoPif['id'])
+  }
+}

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -5,6 +5,7 @@ import type {
   XenApiHostWrapped,
   XenApiMessage,
   XenApiNetwork,
+  XenApiPifWrapped,
   XenApiPoolWrapped,
   XenApiSrWrapped,
   XenApiVbdWrapped,
@@ -20,6 +21,7 @@ type XapiRecordByXapiXoRecord = {
   host: XenApiHostWrapped
   message: XenApiMessage
   network: XenApiNetwork
+  PIF: XenApiPifWrapped
   pool: XenApiPoolWrapped
   SR: XenApiSrWrapped
   VBD: XenApiVbdWrapped

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,10 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- **Migrated REST API endpoints**:
+  - `/rest/v0/pifs` (PR [#8569](https://github.com/vatesfr/xen-orchestra/pull/8569))
+  - `/rest/v0/pifs/<pif-id>` (PR [#8569](https://github.com/vatesfr/xen-orchestra/pull/8569))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -32,5 +36,7 @@
 <!--packages-start-->
 
 - @vates/types minor
-- @xen-orchestra/rest-api patch
+- @xen-orchestra/rest-api minor
+- xo-server patch
+
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,4 +31,6 @@
 
 <!--packages-start-->
 
+- @vates/types minor
+- @xen-orchestra/rest-api patch
 <!--packages-end-->

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -608,6 +608,7 @@ export default class RestApi {
       docs: {},
       messages: {},
       networks: {},
+      pifs: {},
       pools: {},
       groups: {},
       users: {},


### PR DESCRIPTION
### Screenshot

![Capture d’écran de 2025-05-07 15-39-44](https://github.com/user-attachments/assets/6370cfe0-de1b-4aaa-9f16-f6f354a03f87)

### Description

**Review by commits**
**Do not squash**

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
