### PR TITLE
fix(fs/s3): mirror full backup bigger han 50GB from encrypted source

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/FullRemote.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/FullRemote.mjs
@@ -26,6 +26,7 @@ export const FullRemote = class FullRemoteVmBackupRunner extends AbstractRemote 
             stream: forkStreamUnpipe(stream),
             // stream will be forked and transformed, it's not safe to attach additionnal properties to it
             streamLength: stream.length,
+            maxStreamLength: stream.maxStreamLength, // on encrypted source
             timestamp: metadata.timestamp,
             vm: metadata.vm,
             vmSnapshot: metadata.vmSnapshot,

--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -165,14 +165,18 @@ export default class RemoteHandlerAbstract {
 
     if (this.isEncrypted) {
       stream = this.#encryptor.decryptStream(stream)
-    } else {
-      // try to add the length prop if missing and not a range stream
-      if (stream.length === undefined && options.end === undefined && options.start === undefined) {
-        try {
+    }
+
+    // try to add the length prop if missing and not a range stream
+    if (stream.length === undefined && options.end === undefined && options.start === undefined) {
+      try {
+        if (this.isEncrypted) {
+          stream.maxStreamLength = await this.getSizeOnDisk(file)
+        } else {
           stream.length = await this._getSize(file)
-        } catch (error) {
-          // ignore errors
         }
+      } catch (error) {
+        // ignore errors
       }
     }
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Backups] mirror full backup bigger han 50GB from encrypted source (PR [#8570](https://github.com/vatesfr/xen-orchestra/pull/8570))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -33,7 +35,8 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
+- @xen-orchestra/fs patch
 - @xen-orchestra/rest-api minor
 - xo-server patch
-
 <!--packages-end-->


### PR DESCRIPTION
we must compute a relevant partSize when uploading a file bigger than 50G
bigger partSize means more memory consumption, but we are limited to
upload 10K chunk of partSize bytes

this commit will ensure there is an estimate of the size from encrpted remote
and pass this estimate to the FullRemoteWriter

from ticket 38031

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
