### PR TITLE
fix(xo-server/Redis): properly delete IDs from Redis when multiple are removed

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [ACLs] Fix ACLs not being assigned properly when resource set is assigned to a VM
+- [ACLs] Fix ACLs not being assigned properly when resource set is assigned to a VM (PR [#8571](https://github.com/vatesfr/xen-orchestra/pull/8571))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [ACLs] Fix ACLs not being assigned properly when resource set is assigned to a VM
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/packages/xo-server/src/collection/redis.mjs
+++ b/packages/xo-server/src/collection/redis.mjs
@@ -277,7 +277,7 @@ export default class Redis extends Collection {
     const { indexes, prefix, redis } = this
 
     // update main index
-    let promise = redis.sRem(prefix + '_ids', ...ids)
+    let promise = redis.sRem(prefix + '_ids', ids)
 
     // update other indexes
     if (indexes.length !== 0) {


### PR DESCRIPTION
Fixes Zammad#37604
Introduced by 36b94f745d7a678b60e393bd8f8377f17dcd681b

### Description

Steps to reproduce:
1. Create a resource set with multiple users and with option "Share VMs by default" enabled
2. Go to a VM that is not in a resource set
3. Assign the resource set to the VM → ACLs get assigned to the VM for all the users
4. Unassign the resource set from the VM → ACLs are removed
5. Re-assign the same resource set to the VM → ACLs are not properly re-assigned

The issue is in step 4, when XO removes multiple ACL entries and its corresponding IDs from Redis' index: since version 4, Redis' Node library doesn't support passing multiple flat arguments to its methods to perform an action on multiple entries. It expects an array instead.

This change doesn't seem to be very documented but Redis' code is clear:
- v3: https://github.com/redis/node-redis/blob/v3.1.2/lib/commands.js#L35-L45
- v4: https://github.com/redis/node-redis/blob/v4.0.0-next.0/lib/commands/SREM.ts#L5

Since the IDs were not properly deleted (only the first one was deleted), when the resource set is assigned the 2nd time, the ACLs entries are detected as already existing when they are compared to the index.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
