### PR TITLE
feat(web-core/xo-6/xo-lite): add pagination in data tables

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## **next**
 
+- [Table] add pagination on table (PR [#8573](https://github.com/vatesfr/xen-orchestra/pull/8573))
 - [Pool/system] Display pool information in pool/system tab (PR [#8660](https://github.com/vatesfr/xen-orchestra/pull/8660))
 - [VM/Dashboard] Display VM information in dashboard tab (PR [#8529](https://github.com/vatesfr/xen-orchestra/pull/8529))
 - [Tab/Network] Updated side panel in tab network behavior for mobile view (PR [#8688](https://github.com/vatesfr/xen-orchestra/pull/8688))

--- a/@xen-orchestra/lite/src/components/host/network/HostPifsTable.vue
+++ b/@xen-orchestra/lite/src/components/host/network/HostPifsTable.vue
@@ -40,7 +40,9 @@
             {{ t('delete') }}
           </UiButton>
         </UiTableActions>
-        <UiTopBottomTable :selected-items="0" :total-items="0" />
+        <UiTopBottomTable :selected-items="0" :total-items="0">
+          <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+        </UiTopBottomTable>
       </div>
       <VtsDataTable :is-ready :has-error :no-data-message="pifs.length === 0 ? t('no-pif-detected') : undefined">
         <template #thead>
@@ -65,7 +67,7 @@
         </template>
         <template #tbody>
           <tr
-            v-for="row of rows"
+            v-for="row of vifRowRecords"
             :key="row.id"
             :class="{ selected: selectedPifId === row.id }"
             @click="selectedPifId = row.id"
@@ -124,7 +126,9 @@
       <VtsStateHero v-if="searchQuery && filteredPifs.length === 0" type="table" image="no-result">
         <div>{{ t('no-result') }}</div>
       </VtsStateHero>
-      <UiTopBottomTable :selected-items="0" :total-items="0" />
+      <UiTopBottomTable :selected-items="0" :total-items="0">
+        <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+      </UiTopBottomTable>
     </div>
   </div>
 </template>
@@ -143,8 +147,10 @@ import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiCheckbox from '@core/components/ui/checkbox/UiCheckbox.vue'
 import UiQuerySearchBar from '@core/components/ui/query-search-bar/UiQuerySearchBar.vue'
 import UiTableActions from '@core/components/ui/table-actions/UiTableActions.vue'
+import UiTablePagination from '@core/components/ui/table-pagination/UiTablePagination.vue'
 import UiTitle from '@core/components/ui/title/UiTitle.vue'
 import UiTopBottomTable from '@core/components/ui/top-bottom-table/UiTopBottomTable.vue'
+import { usePagination } from '@core/composables/pagination.composable'
 import { useRouteQuery } from '@core/composables/route-query.composable'
 import { useTable } from '@core/composables/table.composable'
 import { vTooltip } from '@core/directives/tooltip.directive'
@@ -237,6 +243,8 @@ const { visibleColumns, rows } = useTable('pifs', filteredPifs, {
     define('more', noop, { label: '', isHideable: false }),
   ],
 })
+
+const { pageRecords: vifRowRecords, paginationBindings } = usePagination('pifRow', rows)
 
 type PifHeader = 'network' | 'device' | 'status' | 'VLAN' | 'IP' | 'MAC' | 'ip_configuration_mode'
 

--- a/@xen-orchestra/lite/src/components/host/network/HostPifsTable.vue
+++ b/@xen-orchestra/lite/src/components/host/network/HostPifsTable.vue
@@ -67,7 +67,7 @@
         </template>
         <template #tbody>
           <tr
-            v-for="row of vifRowRecords"
+            v-for="row of pifsRecords"
             :key="row.id"
             :class="{ selected: selectedPifId === row.id }"
             @click="selectedPifId = row.id"
@@ -244,7 +244,7 @@ const { visibleColumns, rows } = useTable('pifs', filteredPifs, {
   ],
 })
 
-const { pageRecords: vifRowRecords, paginationBindings } = usePagination('pifRow', rows)
+const { pageRecords: pifsRecords, paginationBindings } = usePagination('pifs', rows)
 
 type PifHeader = 'network' | 'device' | 'status' | 'VLAN' | 'IP' | 'MAC' | 'ip_configuration_mode'
 

--- a/@xen-orchestra/lite/src/components/pool/network/PoolHostInternalNetworksTable.vue
+++ b/@xen-orchestra/lite/src/components/pool/network/PoolHostInternalNetworksTable.vue
@@ -40,7 +40,9 @@
             {{ t('delete') }}
           </UiButton>
         </UiTableActions>
-        <UiTopBottomTable :selected-items="0" :total-items="0" @toggle-select-all="toggleSelect" />
+        <UiTopBottomTable :selected-items="0" :total-items="0" @toggle-select-all="toggleSelect">
+          <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+        </UiTopBottomTable>
       </div>
       <VtsDataTable
         :is-ready
@@ -69,7 +71,7 @@
         </template>
         <template #tbody>
           <tr
-            v-for="row of rows"
+            v-for="row of networksRecords"
             :key="row.id"
             :class="{ selected: selectedNetworkId === row.id }"
             @click="selectedNetworkId = row.id"
@@ -101,7 +103,9 @@
       <VtsStateHero v-if="searchQuery && filteredNetworks.length === 0" type="table" image="no-result">
         <div>{{ t('no-result') }}</div>
       </VtsStateHero>
-      <UiTopBottomTable :selected-items="0" :total-items="0" @toggle-select-all="toggleSelect" />
+      <UiTopBottomTable :selected-items="0" :total-items="0" @toggle-select-all="toggleSelect">
+        <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+      </UiTopBottomTable>
     </div>
   </div>
 </template>
@@ -118,8 +122,10 @@ import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiCheckbox from '@core/components/ui/checkbox/UiCheckbox.vue'
 import UiQuerySearchBar from '@core/components/ui/query-search-bar/UiQuerySearchBar.vue'
 import UiTableActions from '@core/components/ui/table-actions/UiTableActions.vue'
+import UiTablePagination from '@core/components/ui/table-pagination/UiTablePagination.vue'
 import UiTitle from '@core/components/ui/title/UiTitle.vue'
 import UiTopBottomTable from '@core/components/ui/top-bottom-table/UiTopBottomTable.vue'
+import { usePagination } from '@core/composables/pagination.composable'
 import { useRouteQuery } from '@core/composables/route-query.composable'
 import { useTable } from '@core/composables/table.composable'
 import { vTooltip } from '@core/directives/tooltip.directive'
@@ -184,6 +190,8 @@ const { visibleColumns, rows } = useTable('networks', filteredNetworks, {
     define('more', noop, { label: '', isHideable: false }),
   ],
 })
+
+const { pageRecords: networksRecords, paginationBindings } = usePagination('networks', rows)
 
 type NetworkHeader = 'name_label' | 'name_description' | 'MTU' | 'default_locking_mode'
 

--- a/@xen-orchestra/lite/src/components/pool/network/PoolHostInternalNetworksTable.vue
+++ b/@xen-orchestra/lite/src/components/pool/network/PoolHostInternalNetworksTable.vue
@@ -191,7 +191,7 @@ const { visibleColumns, rows } = useTable('networks', filteredNetworks, {
   ],
 })
 
-const { pageRecords: networksRecords, paginationBindings } = usePagination('networks', rows)
+const { pageRecords: networksRecords, paginationBindings } = usePagination('internal-networks', rows)
 
 type NetworkHeader = 'name_label' | 'name_description' | 'MTU' | 'default_locking_mode'
 

--- a/@xen-orchestra/lite/src/components/pool/network/PoolNetworksTable.vue
+++ b/@xen-orchestra/lite/src/components/pool/network/PoolNetworksTable.vue
@@ -74,7 +74,7 @@
         </template>
         <template #tbody>
           <tr
-            v-for="row of networkRowRecords"
+            v-for="row of networksRecords"
             :key="row.id"
             :class="{ selected: selectedNetworkId === row.id }"
             @click="selectedNetworkId = row.id"
@@ -231,7 +231,7 @@ const { visibleColumns, rows } = useTable('networks', filteredNetworks, {
   ],
 })
 
-const { pageRecords: networkRowRecords, paginationBindings } = usePagination('pifRow', rows)
+const { pageRecords: networksRecords, paginationBindings } = usePagination('networks', rows)
 
 type NetworkHeader = 'name_label' | 'name_description' | 'status' | 'vlan' | 'MTU' | 'default_locking_mode'
 

--- a/@xen-orchestra/lite/src/components/pool/network/PoolNetworksTable.vue
+++ b/@xen-orchestra/lite/src/components/pool/network/PoolNetworksTable.vue
@@ -43,7 +43,9 @@
             {{ t('delete') }}
           </UiButton>
         </UiTableActions>
-        <UiTopBottomTable :selected-items="0" :total-items="0" @toggle-select-all="toggleSelect" />
+        <UiTopBottomTable :selected-items="0" :total-items="0" @toggle-select-all="toggleSelect">
+          <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+        </UiTopBottomTable>
       </div>
       <VtsDataTable
         :is-ready
@@ -72,7 +74,7 @@
         </template>
         <template #tbody>
           <tr
-            v-for="row of rows"
+            v-for="row of networkRowRecords"
             :key="row.id"
             :class="{ selected: selectedNetworkId === row.id }"
             @click="selectedNetworkId = row.id"
@@ -105,7 +107,9 @@
       <VtsStateHero v-if="searchQuery && filteredNetworks.length === 0" type="table" image="no-result">
         <div>{{ t('no-result') }}</div>
       </VtsStateHero>
-      <UiTopBottomTable :selected-items="0" :total-items="0" @toggle-select-all="toggleSelect" />
+      <UiTopBottomTable :selected-items="0" :total-items="0" @toggle-select-all="toggleSelect">
+        <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+      </UiTopBottomTable>
     </div>
   </div>
 </template>
@@ -126,8 +130,10 @@ import UiCheckbox from '@core/components/ui/checkbox/UiCheckbox.vue'
 import UiDropdownButton from '@core/components/ui/dropdown-button/UiDropdownButton.vue'
 import UiQuerySearchBar from '@core/components/ui/query-search-bar/UiQuerySearchBar.vue'
 import UiTableActions from '@core/components/ui/table-actions/UiTableActions.vue'
+import UiTablePagination from '@core/components/ui/table-pagination/UiTablePagination.vue'
 import UiTitle from '@core/components/ui/title/UiTitle.vue'
 import UiTopBottomTable from '@core/components/ui/top-bottom-table/UiTopBottomTable.vue'
+import { usePagination } from '@core/composables/pagination.composable'
 import { useRouteQuery } from '@core/composables/route-query.composable'
 import { useTable } from '@core/composables/table.composable'
 import { vTooltip } from '@core/directives/tooltip.directive'
@@ -224,6 +230,8 @@ const { visibleColumns, rows } = useTable('networks', filteredNetworks, {
     define('more', noop, { label: '', isHideable: false }),
   ],
 })
+
+const { pageRecords: networkRowRecords, paginationBindings } = usePagination('pifRow', rows)
 
 type NetworkHeader = 'name_label' | 'name_description' | 'status' | 'vlan' | 'MTU' | 'default_locking_mode'
 

--- a/@xen-orchestra/lite/src/components/vm/network/VmVifsTable.vue
+++ b/@xen-orchestra/lite/src/components/vm/network/VmVifsTable.vue
@@ -50,7 +50,9 @@
             {{ t('delete') }}
           </UiButton>
         </UiTableActions>
-        <UiTopBottomTable :selected-items="0" :total-items="0" />
+        <UiTopBottomTable :selected-items="0" :total-items="0">
+          <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+        </UiTopBottomTable>
       </div>
       <VtsDataTable :is-ready :has-error :no-data-message="vifs.length === 0 ? t('no-vif-detected') : undefined">
         <template #thead>
@@ -75,7 +77,7 @@
         </template>
         <template #tbody>
           <tr
-            v-for="row of rows"
+            v-for="row of vifRowRecords"
             :key="row.id"
             :class="{ selected: selectedVifId === row.id }"
             @click="selectedVifId = row.id"
@@ -127,7 +129,9 @@
       <VtsStateHero v-if="searchQuery && filteredVifs.length === 0" type="table" image="no-result">
         <div>{{ t('no-result') }}</div>
       </VtsStateHero>
-      <UiTopBottomTable :selected-items="0" :total-items="0" />
+      <UiTopBottomTable :selected-items="0" :total-items="0">
+        <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+      </UiTopBottomTable>
     </div>
   </div>
 </template>
@@ -148,8 +152,10 @@ import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiCheckbox from '@core/components/ui/checkbox/UiCheckbox.vue'
 import UiQuerySearchBar from '@core/components/ui/query-search-bar/UiQuerySearchBar.vue'
 import UiTableActions from '@core/components/ui/table-actions/UiTableActions.vue'
+import UiTablePagination from '@core/components/ui/table-pagination/UiTablePagination.vue'
 import UiTitle from '@core/components/ui/title/UiTitle.vue'
 import UiTopBottomTable from '@core/components/ui/top-bottom-table/UiTopBottomTable.vue'
+import { usePagination } from '@core/composables/pagination.composable'
 import { useRouteQuery } from '@core/composables/route-query.composable'
 import { useTable } from '@core/composables/table.composable'
 import { vTooltip } from '@core/directives/tooltip.directive'
@@ -230,6 +236,8 @@ const { visibleColumns, rows } = useTable('vifs', filteredVifs, {
     define('more', noop, { label: '', isHideable: false }),
   ],
 })
+
+const { pageRecords: vifRowRecords, paginationBindings } = usePagination('vifRow', rows)
 
 type VifHeader = 'network' | 'device' | 'status' | 'IP' | 'MAC' | 'MTU' | 'locking_mode'
 

--- a/@xen-orchestra/lite/src/components/vm/network/VmVifsTable.vue
+++ b/@xen-orchestra/lite/src/components/vm/network/VmVifsTable.vue
@@ -77,7 +77,7 @@
         </template>
         <template #tbody>
           <tr
-            v-for="row of vifRowRecords"
+            v-for="row of vifsRecords"
             :key="row.id"
             :class="{ selected: selectedVifId === row.id }"
             @click="selectedVifId = row.id"
@@ -237,7 +237,7 @@ const { visibleColumns, rows } = useTable('vifs', filteredVifs, {
   ],
 })
 
-const { pageRecords: vifRowRecords, paginationBindings } = usePagination('vifRow', rows)
+const { pageRecords: vifsRecords, paginationBindings } = usePagination('vifs', rows)
 
 type VifHeader = 'network' | 'device' | 'status' | 'IP' | 'MAC' | 'MTU' | 'locking_mode'
 

--- a/@xen-orchestra/lite/src/stories/web-core/ui/table-pagination/ui-table-pagination.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/table-pagination/ui-table-pagination.story.vue
@@ -3,12 +3,12 @@
     v-slot="{ properties }"
     :params="[
       prop('from').required().num().widget().preset(1),
-      prop('to').required().num().widget().preset(50),
+      prop('to').required().num().widget().preset(24),
       prop('total').required().num().widget().preset(137),
       prop('isFirstPage').required().bool().widget().preset(true),
       prop('isLastPage').required().bool().widget(),
       model('showBy')
-        .preset('50')
+        .preset('24')
         .prop(p => p.num())
         .required(),
       event('first'),
@@ -31,17 +31,17 @@ const presets = {
   'First page': {
     props: {
       from: 1,
-      to: 50,
+      to: 24,
       total: 137,
       isFirstPage: true,
       isLastPage: false,
-      showBy: 50,
+      showBy: 24,
     },
   },
   'Intermediate page': {
     props: {
-      from: 51,
-      to: 100,
+      from: 25,
+      to: 49,
       total: 137,
       isFirstPage: false,
       isLastPage: false,
@@ -49,7 +49,7 @@ const presets = {
   },
   'Last page': {
     props: {
-      from: 101,
+      from: 113,
       to: 137,
       total: 137,
       isFirstPage: false,

--- a/@xen-orchestra/web-core/lib/components/data-table/VtsDataTable.vue
+++ b/@xen-orchestra/web-core/lib/components/data-table/VtsDataTable.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="table-container">
-    <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
     <VtsLoadingHero v-if="!isReady" type="table" />
     <VtsErrorNoDataHero v-else-if="hasError" type="table" />
     <VtsNoDataHero v-else-if="noDataMessage" type="table" />
@@ -9,9 +8,7 @@
         <slot name="thead" />
       </thead>
       <tbody>
-        <template v-for="(vnode, index) in pageRecords" :key="index">
-          <component :is="vnode" />
-        </template>
+        <slot name="tbody" />
       </tbody>
     </VtsTable>
   </div>
@@ -22,8 +19,6 @@ import VtsErrorNoDataHero from '@core/components/state-hero/VtsErrorNoDataHero.v
 import VtsLoadingHero from '@core/components/state-hero/VtsLoadingHero.vue'
 import VtsNoDataHero from '@core/components/state-hero/VtsNoDataHero.vue'
 import VtsTable from '@core/components/table/VtsTable.vue'
-import { usePagination } from '@core/composables/pagination.composable'
-import UiTablePagination from '../ui/table-pagination/UiTablePagination.vue'
 
 defineProps<{
   isReady?: boolean
@@ -31,31 +26,10 @@ defineProps<{
   noDataMessage?: string
 }>()
 
-const slots = defineSlots<{
+defineSlots<{
   thead(): any
   tbody(): any
 }>()
-
-const vnodes = slots.tbody?.() || []
-const rowElement = new Array<any>()
-
-function countRow(vnodes: any[]): number {
-  let count = 0
-
-  for (const vnode of vnodes) {
-    if (vnode.type === 'tr') {
-      count++
-      rowElement.push(vnode)
-    } else if (Array.isArray(vnode.children)) {
-      count += countRow(vnode.children)
-    }
-  }
-  return count
-}
-
-countRow(vnodes)
-
-const { pageRecords, paginationBindings } = usePagination('items', rowElement)
 </script>
 
 <style lang="postcss" scoped>

--- a/@xen-orchestra/web-core/lib/components/ui/table-pagination/UiTablePagination.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/table-pagination/UiTablePagination.vue
@@ -13,7 +13,7 @@
     <span class="typo-body-regular-small label show">{{ t('core.pagination.show-by') }}</span>
     <div class="dropdown-wrapper">
       <select v-model="showBy" class="dropdown typo-body-regular-small">
-        <option v-for="option in [10, 20, 40, 80, -1]" :key="option" :value="option" class="typo-body-bold-small">
+        <option v-for="option in [50, 100, 150, 200, -1]" :key="option" :value="option" class="typo-body-bold-small">
           {{ option === -1 ? t('core.pagination.all') : option }}
         </option>
       </select>
@@ -49,7 +49,7 @@ const emit = defineEmits<{
   last: []
 }>()
 
-const showBy = defineModel<number>('showBy', { default: 10 })
+const showBy = defineModel<number>('showBy', { default: 50 })
 
 const { t } = useI18n()
 </script>

--- a/@xen-orchestra/web-core/lib/components/ui/table-pagination/UiTablePagination.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/table-pagination/UiTablePagination.vue
@@ -13,7 +13,7 @@
     <span class="typo-body-regular-small label show">{{ t('core.pagination.show-by') }}</span>
     <div class="dropdown-wrapper">
       <select v-model="showBy" class="dropdown typo-body-regular-small">
-        <option v-for="option in [10, 20, 30, 50, -1]" :key="option" :value="option" class="typo-body-bold-small">
+        <option v-for="option in [12, 24, 48, -1]" :key="option" :value="option" class="typo-body-bold-small">
           {{ option === -1 ? t('core.pagination.all') : option }}
         </option>
       </select>
@@ -49,7 +49,7 @@ const emit = defineEmits<{
   last: []
 }>()
 
-const showBy = defineModel<number>('showBy', { default: 10 })
+const showBy = defineModel<number>('showBy', { default: 24 })
 
 const { t } = useI18n()
 </script>

--- a/@xen-orchestra/web-core/lib/components/ui/table-pagination/UiTablePagination.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/table-pagination/UiTablePagination.vue
@@ -13,7 +13,7 @@
     <span class="typo-body-regular-small label show">{{ t('core.pagination.show-by') }}</span>
     <div class="dropdown-wrapper">
       <select v-model="showBy" class="dropdown typo-body-regular-small">
-        <option v-for="option in [50, 100, 150, 200, -1]" :key="option" :value="option" class="typo-body-bold-small">
+        <option v-for="option in [10, 20, 40, 80, -1]" :key="option" :value="option" class="typo-body-bold-small">
           {{ option === -1 ? t('core.pagination.all') : option }}
         </option>
       </select>
@@ -49,7 +49,7 @@ const emit = defineEmits<{
   last: []
 }>()
 
-const showBy = defineModel<number>('showBy', { default: 50 })
+const showBy = defineModel<number>('showBy', { default: 10 })
 
 const { t } = useI18n()
 </script>

--- a/@xen-orchestra/web-core/lib/components/ui/table-pagination/UiTablePagination.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/table-pagination/UiTablePagination.vue
@@ -13,7 +13,7 @@
     <span class="typo-body-regular-small label show">{{ t('core.pagination.show-by') }}</span>
     <div class="dropdown-wrapper">
       <select v-model="showBy" class="dropdown typo-body-regular-small">
-        <option v-for="option in [50, 100, 150, 200, -1]" :key="option" :value="option" class="typo-body-bold-small">
+        <option v-for="option in [10, 20, 30, 50, -1]" :key="option" :value="option" class="typo-body-bold-small">
           {{ option === -1 ? t('core.pagination.all') : option }}
         </option>
       </select>
@@ -49,7 +49,7 @@ const emit = defineEmits<{
   last: []
 }>()
 
-const showBy = defineModel<number>('showBy', { default: 50 })
+const showBy = defineModel<number>('showBy', { default: 10 })
 
 const { t } = useI18n()
 </script>

--- a/@xen-orchestra/web-core/lib/composables/pagination.composable.ts
+++ b/@xen-orchestra/web-core/lib/composables/pagination.composable.ts
@@ -5,7 +5,7 @@ import { computed, type MaybeRefOrGetter, toValue } from 'vue'
 export function usePagination<T>(id: string, _records: MaybeRefOrGetter<T[]>) {
   const records = computed(() => toValue(_records))
 
-  const showBy = useLocalStorage(`${id}.per-page`, 10)
+  const showBy = useLocalStorage(`${id}.per-page`, 24)
 
   const pageSize = computed({
     get: () => (showBy.value === -1 ? Number.MAX_SAFE_INTEGER : showBy.value),

--- a/@xen-orchestra/web-core/lib/composables/pagination.composable.ts
+++ b/@xen-orchestra/web-core/lib/composables/pagination.composable.ts
@@ -5,7 +5,7 @@ import { computed, type MaybeRefOrGetter, toValue } from 'vue'
 export function usePagination<T>(id: string, _records: MaybeRefOrGetter<T[]>) {
   const records = computed(() => toValue(_records))
 
-  const showBy = useLocalStorage(`${id}.per-page`, 50)
+  const showBy = useLocalStorage(`${id}.per-page`, 10)
 
   const pageSize = computed({
     get: () => (showBy.value === -1 ? Number.MAX_SAFE_INTEGER : showBy.value),

--- a/@xen-orchestra/web/src/components/host/network/HostPifTable.vue
+++ b/@xen-orchestra/web/src/components/host/network/HostPifTable.vue
@@ -40,7 +40,9 @@
             {{ t('delete') }}
           </UiButton>
         </UiTableActions>
-        <UiTopBottomTable :selected-items="0" :total-items="0" />
+        <UiTopBottomTable :selected-items="0" :total-items="0">
+          <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+        </UiTopBottomTable>
       </div>
       <VtsDataTable :is-ready :has-error :no-data-message="pifs.length === 0 ? t('no-pif-detected') : undefined">
         <template #thead>
@@ -65,7 +67,7 @@
         </template>
         <template #tbody>
           <tr
-            v-for="row of rows"
+            v-for="row of pifRowRecords"
             :key="row.id"
             :class="{ selected: selectedPifId === row.id }"
             @click="selectedPifId = row.id"
@@ -124,7 +126,9 @@
       <VtsStateHero v-if="searchQuery && filteredPifs.length === 0" type="table" image="no-result">
         <div>{{ t('no-result') }}</div>
       </VtsStateHero>
-      <UiTopBottomTable :selected-items="0" :total-items="0" />
+      <UiTopBottomTable :selected-items="0" :total-items="0">
+        <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+      </UiTopBottomTable>
     </div>
   </div>
 </template>
@@ -142,8 +146,10 @@ import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiCheckbox from '@core/components/ui/checkbox/UiCheckbox.vue'
 import UiQuerySearchBar from '@core/components/ui/query-search-bar/UiQuerySearchBar.vue'
 import UiTableActions from '@core/components/ui/table-actions/UiTableActions.vue'
+import UiTablePagination from '@core/components/ui/table-pagination/UiTablePagination.vue'
 import UiTitle from '@core/components/ui/title/UiTitle.vue'
 import UiTopBottomTable from '@core/components/ui/top-bottom-table/UiTopBottomTable.vue'
+import { usePagination } from '@core/composables/pagination.composable'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
 import useMultiSelect from '@core/composables/table/multi-select.composable.ts'
 import { useTable } from '@core/composables/table.composable.ts'
@@ -230,6 +236,8 @@ const { visibleColumns, rows } = useTable('pifs', filteredPifs, {
     define('more', noop, { label: '', isHideable: false }),
   ],
 })
+
+const { pageRecords: pifRowRecords, paginationBindings } = usePagination('pifRow', rows)
 
 type pifHeader = 'network' | 'device' | 'status' | 'vlan' | 'ip' | 'mac' | 'mode' | 'more'
 

--- a/@xen-orchestra/web/src/components/host/network/HostPifTable.vue
+++ b/@xen-orchestra/web/src/components/host/network/HostPifTable.vue
@@ -67,7 +67,7 @@
         </template>
         <template #tbody>
           <tr
-            v-for="row of pifRowRecords"
+            v-for="row of pifsRecords"
             :key="row.id"
             :class="{ selected: selectedPifId === row.id }"
             @click="selectedPifId = row.id"
@@ -237,7 +237,7 @@ const { visibleColumns, rows } = useTable('pifs', filteredPifs, {
   ],
 })
 
-const { pageRecords: pifRowRecords, paginationBindings } = usePagination('pifRow', rows)
+const { pageRecords: pifsRecords, paginationBindings } = usePagination('pifs', rows)
 
 type pifHeader = 'network' | 'device' | 'status' | 'vlan' | 'ip' | 'mac' | 'mode' | 'more'
 

--- a/@xen-orchestra/web/src/components/pool/network/PoolHostInternalNetworksTable.vue
+++ b/@xen-orchestra/web/src/components/pool/network/PoolHostInternalNetworksTable.vue
@@ -189,7 +189,7 @@ const { visibleColumns, rows } = useTable('networks', filteredNetworks, {
   ],
 })
 
-const { pageRecords: networksRecords, paginationBindings } = usePagination('networks', rows)
+const { pageRecords: networksRecords, paginationBindings } = usePagination('internal-networks', rows)
 
 type NetworkHeader = 'name_label' | 'name_description' | 'MTU' | 'default_locking_mode'
 

--- a/@xen-orchestra/web/src/components/pool/network/PoolHostInternalNetworksTable.vue
+++ b/@xen-orchestra/web/src/components/pool/network/PoolHostInternalNetworksTable.vue
@@ -40,7 +40,9 @@
             {{ t('delete') }}
           </UiButton>
         </UiTableActions>
-        <UiTopBottomTable :selected-items="0" :total-items="0" @toggle-select-all="toggleSelect" />
+        <UiTopBottomTable :selected-items="0" :total-items="0" @toggle-select-all="toggleSelect">
+          <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+        </UiTopBottomTable>
       </div>
       <VtsDataTable
         :is-ready
@@ -69,7 +71,7 @@
         </template>
         <template #tbody>
           <tr
-            v-for="row of rows"
+            v-for="row of networkRowRecords"
             :key="row.id"
             :class="{ selected: selectedNetworkId === row.id }"
             @click="selectedNetworkId = row.id"
@@ -101,7 +103,9 @@
       <VtsStateHero v-if="searchQuery && filteredNetworks.length === 0" type="table" image="no-result">
         <div>{{ t('no-result') }}</div>
       </VtsStateHero>
-      <UiTopBottomTable :selected-items="0" :total-items="0" @toggle-select-all="toggleSelect" />
+      <UiTopBottomTable :selected-items="0" :total-items="0" @toggle-select-all="toggleSelect">
+        <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+      </UiTopBottomTable>
     </div>
   </div>
 </template>
@@ -117,8 +121,10 @@ import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiCheckbox from '@core/components/ui/checkbox/UiCheckbox.vue'
 import UiQuerySearchBar from '@core/components/ui/query-search-bar/UiQuerySearchBar.vue'
 import UiTableActions from '@core/components/ui/table-actions/UiTableActions.vue'
+import UiTablePagination from '@core/components/ui/table-pagination/UiTablePagination.vue'
 import UiTitle from '@core/components/ui/title/UiTitle.vue'
 import UiTopBottomTable from '@core/components/ui/top-bottom-table/UiTopBottomTable.vue'
+import { usePagination } from '@core/composables/pagination.composable'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
 import useMultiSelect from '@core/composables/table/multi-select.composable.ts'
 import { useTable } from '@core/composables/table.composable.ts'
@@ -182,6 +188,8 @@ const { visibleColumns, rows } = useTable('networks', filteredNetworks, {
     define('more', noop, { label: '', isHideable: false }),
   ],
 })
+
+const { pageRecords: networkRowRecords, paginationBindings } = usePagination('hostRow', rows)
 
 type NetworkHeader = 'name_label' | 'name_description' | 'MTU' | 'default_locking_mode'
 

--- a/@xen-orchestra/web/src/components/pool/network/PoolHostInternalNetworksTable.vue
+++ b/@xen-orchestra/web/src/components/pool/network/PoolHostInternalNetworksTable.vue
@@ -71,7 +71,7 @@
         </template>
         <template #tbody>
           <tr
-            v-for="row of networkRowRecords"
+            v-for="row of networksRecords"
             :key="row.id"
             :class="{ selected: selectedNetworkId === row.id }"
             @click="selectedNetworkId = row.id"
@@ -189,7 +189,7 @@ const { visibleColumns, rows } = useTable('networks', filteredNetworks, {
   ],
 })
 
-const { pageRecords: networkRowRecords, paginationBindings } = usePagination('hostRow', rows)
+const { pageRecords: networksRecords, paginationBindings } = usePagination('networks', rows)
 
 type NetworkHeader = 'name_label' | 'name_description' | 'MTU' | 'default_locking_mode'
 

--- a/@xen-orchestra/web/src/components/pool/network/PoolNetworksTable.vue
+++ b/@xen-orchestra/web/src/components/pool/network/PoolNetworksTable.vue
@@ -74,7 +74,7 @@
         </template>
         <template #tbody>
           <tr
-            v-for="row of networkRowRecords"
+            v-for="row of networksRecords"
             :key="row.id"
             :class="{ selected: selectedNetworkId === row.id }"
             @click="selectedNetworkId = row.id"
@@ -231,7 +231,7 @@ const { visibleColumns, rows } = useTable('networks', filteredNetworks, {
   ],
 })
 
-const { pageRecords: networkRowRecords, paginationBindings } = usePagination('networkRow', rows)
+const { pageRecords: networksRecords, paginationBindings } = usePagination('networks', rows)
 
 type NetworkHeader = 'name_label' | 'name_description' | 'status' | 'vlan' | 'MTU' | 'default_locking_mode'
 

--- a/@xen-orchestra/web/src/components/pool/network/PoolNetworksTable.vue
+++ b/@xen-orchestra/web/src/components/pool/network/PoolNetworksTable.vue
@@ -43,7 +43,9 @@
             {{ t('delete') }}
           </UiButton>
         </UiTableActions>
-        <UiTopBottomTable :selected-items="0" :total-items="0" @toggle-select-all="toggleSelect" />
+        <UiTopBottomTable :selected-items="0" :total-items="0" @toggle-select-all="toggleSelect">
+          <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+        </UiTopBottomTable>
       </div>
       <VtsDataTable
         :is-ready
@@ -72,7 +74,7 @@
         </template>
         <template #tbody>
           <tr
-            v-for="row of rows"
+            v-for="row of networkRowRecords"
             :key="row.id"
             :class="{ selected: selectedNetworkId === row.id }"
             @click="selectedNetworkId = row.id"
@@ -105,7 +107,9 @@
       <VtsStateHero v-if="searchQuery && filteredNetworks.length === 0" type="table" image="no-result">
         <div>{{ t('no-result') }}</div>
       </VtsStateHero>
-      <UiTopBottomTable :selected-items="0" :total-items="0" @toggle-select-all="toggleSelect" />
+      <UiTopBottomTable :selected-items="0" :total-items="0" @toggle-select-all="toggleSelect">
+        <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+      </UiTopBottomTable>
     </div>
   </div>
 </template>
@@ -124,8 +128,10 @@ import UiCheckbox from '@core/components/ui/checkbox/UiCheckbox.vue'
 import UiDropdownButton from '@core/components/ui/dropdown-button/UiDropdownButton.vue'
 import UiQuerySearchBar from '@core/components/ui/query-search-bar/UiQuerySearchBar.vue'
 import UiTableActions from '@core/components/ui/table-actions/UiTableActions.vue'
+import UiTablePagination from '@core/components/ui/table-pagination/UiTablePagination.vue'
 import UiTitle from '@core/components/ui/title/UiTitle.vue'
 import UiTopBottomTable from '@core/components/ui/top-bottom-table/UiTopBottomTable.vue'
+import { usePagination } from '@core/composables/pagination.composable'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
 import useMultiSelect from '@core/composables/table/multi-select.composable.ts'
 import { useTable } from '@core/composables/table.composable.ts'
@@ -224,6 +230,8 @@ const { visibleColumns, rows } = useTable('networks', filteredNetworks, {
     define('more', noop, { label: '', isHideable: false }),
   ],
 })
+
+const { pageRecords: networkRowRecords, paginationBindings } = usePagination('networkRow', rows)
 
 type NetworkHeader = 'name_label' | 'name_description' | 'status' | 'vlan' | 'MTU' | 'default_locking_mode'
 

--- a/@xen-orchestra/web/src/components/vm/network/VmVifsTable.vue
+++ b/@xen-orchestra/web/src/components/vm/network/VmVifsTable.vue
@@ -51,7 +51,9 @@
           </UiButton>
         </UiTableActions>
 
-        <UiTopBottomTable :selected-items="0" :total-items="0" />
+        <UiTopBottomTable :selected-items="0" :total-items="0">
+          <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+        </UiTopBottomTable>
       </div>
       <VtsDataTable :is-ready :has-error :no-data-message="vifs.length === 0 ? t('no-vif-detected') : undefined">
         <template #thead>
@@ -74,7 +76,7 @@
         </template>
         <template #tbody>
           <tr
-            v-for="row of rows"
+            v-for="row of vifRowRecords"
             :key="row.id"
             :class="{ selected: selectedVifId === row.id }"
             @click="selectedVifId = row.id"
@@ -123,7 +125,9 @@
           </tr>
         </template>
       </VtsDataTable>
-      <UiTopBottomTable :selected-items="0" :total-items="0" />
+      <UiTopBottomTable :selected-items="0" :total-items="0">
+        <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+      </UiTopBottomTable>
     </div>
   </div>
 </template>
@@ -141,8 +145,10 @@ import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiCheckbox from '@core/components/ui/checkbox/UiCheckbox.vue'
 import UiQuerySearchBar from '@core/components/ui/query-search-bar/UiQuerySearchBar.vue'
 import UiTableActions from '@core/components/ui/table-actions/UiTableActions.vue'
+import UiTablePagination from '@core/components/ui/table-pagination/UiTablePagination.vue'
 import UiTitle from '@core/components/ui/title/UiTitle.vue'
 import UiTopBottomTable from '@core/components/ui/top-bottom-table/UiTopBottomTable.vue'
+import { usePagination } from '@core/composables/pagination.composable'
 import { useRouteQuery } from '@core/composables/route-query.composable'
 import useMultiSelect from '@core/composables/table/multi-select.composable'
 import { useTable } from '@core/composables/table.composable'
@@ -214,6 +220,8 @@ const { visibleColumns, rows } = useTable('vifs', filteredVifs, {
     define('more', noop, { label: '', isHideable: false }),
   ],
 })
+
+const { pageRecords: vifRowRecords, paginationBindings } = usePagination('vifRow', rows)
 
 type VifHeader = 'network' | 'device' | 'status' | 'ip' | 'MAC' | 'MTU' | 'lockingMode' | 'more'
 

--- a/@xen-orchestra/web/src/components/vm/network/VmVifsTable.vue
+++ b/@xen-orchestra/web/src/components/vm/network/VmVifsTable.vue
@@ -76,7 +76,7 @@
         </template>
         <template #tbody>
           <tr
-            v-for="row of vifRowRecords"
+            v-for="row of vifsRecords"
             :key="row.id"
             :class="{ selected: selectedVifId === row.id }"
             @click="selectedVifId = row.id"
@@ -221,7 +221,7 @@ const { visibleColumns, rows } = useTable('vifs', filteredVifs, {
   ],
 })
 
-const { pageRecords: vifRowRecords, paginationBindings } = usePagination('vifRow', rows)
+const { pageRecords: vifsRecords, paginationBindings } = usePagination('vifs', rows)
 
 type VifHeader = 'network' | 'device' | 'status' | 'ip' | 'MAC' | 'MTU' | 'lockingMode' | 'more'
 

--- a/@xen-orchestra/web/src/pages/host/[id]/vms.vue
+++ b/@xen-orchestra/web/src/pages/host/[id]/vms.vue
@@ -1,8 +1,11 @@
 <template>
   <VtsLoadingHero v-if="!isReady" type="page" />
   <UiCard v-else class="vms">
-    <!-- TODO: update with item selection button and TopBottomTable component when available -->
-    <p class="typo-body-regular-small count">{{ t('n-vms', { n: vms.length }) }}</p>
+    <div class="metaTable">
+      <!-- TODO: update with item selection button when available -->
+      <p class="typo-body-regular-small count">{{ t('n-vms', { n: vms.length }) }}</p>
+      <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+    </div>
     <VtsTable vertical-border>
       <thead>
         <tr>
@@ -11,7 +14,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr v-for="vm in vms" :key="vm.id">
+        <tr v-for="vm in vmsRecords" :key="vm.id">
           <VtsCellObject :id="vm.data.id">
             <UiObjectLink :route="`/vm/${vm.data.id}/`">
               <template #icon>
@@ -24,6 +27,11 @@
         </tr>
       </tbody>
     </VtsTable>
+    <div class="metaTable">
+      <!-- TODO: update with item selection button when available -->
+      <p class="typo-body-regular-small count">{{ t('n-vms', { n: vms.length }) }}</p>
+      <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+    </div>
   </UiCard>
 </template>
 
@@ -39,6 +47,8 @@ import VtsTable from '@core/components/table/VtsTable.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiObjectIcon from '@core/components/ui/object-icon/UiObjectIcon.vue'
 import UiObjectLink from '@core/components/ui/object-link/UiObjectLink.vue'
+import UiTablePagination from '@core/components/ui/table-pagination/UiTablePagination.vue'
+import { usePagination } from '@core/composables/pagination.composable'
 import { defineTree } from '@core/composables/tree/define-tree'
 import { useTree } from '@core/composables/tree.composable'
 import { faAlignLeft, faDesktop } from '@fortawesome/free-solid-svg-icons'
@@ -60,6 +70,7 @@ const definitions = computed(() =>
 )
 
 const { nodes: vms } = useTree(definitions)
+const { pageRecords: vmsRecords, paginationBindings } = usePagination('vms', vms)
 </script>
 
 <style lang="postcss" scoped>
@@ -68,7 +79,12 @@ const { nodes: vms } = useTree(definitions)
   gap: 0.8rem;
 }
 
-.count {
-  color: var(--color-neutral-txt-secondary);
+.metaTable {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  .count {
+    color: var(--color-neutral-txt-secondary);
+  }
 }
 </style>

--- a/@xen-orchestra/web/src/pages/host/[id]/vms.vue
+++ b/@xen-orchestra/web/src/pages/host/[id]/vms.vue
@@ -1,7 +1,7 @@
 <template>
   <VtsLoadingHero v-if="!isReady" type="page" />
   <UiCard v-else class="vms">
-    <div class="topBottomTable">
+    <div class="pagination-container">
       <!-- TODO: update with item selection button when available -->
       <p class="typo-body-regular-small count">{{ t('n-vms', { n: vms.length }) }}</p>
       <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
@@ -27,7 +27,7 @@
         </tr>
       </tbody>
     </VtsTable>
-    <div class="topBottomTable">
+    <div class="pagination-container">
       <!-- TODO: update with item selection button when available -->
       <p class="typo-body-regular-small count">{{ t('n-vms', { n: vms.length }) }}</p>
       <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
@@ -79,10 +79,11 @@ const { pageRecords: vmsRecords, paginationBindings } = usePagination('vms', vms
   gap: 0.8rem;
 }
 
-.topBottomTable {
+.pagination-container {
   display: flex;
   justify-content: space-between;
   align-items: center;
+
   .count {
     color: var(--color-neutral-txt-secondary);
   }

--- a/@xen-orchestra/web/src/pages/host/[id]/vms.vue
+++ b/@xen-orchestra/web/src/pages/host/[id]/vms.vue
@@ -1,7 +1,7 @@
 <template>
   <VtsLoadingHero v-if="!isReady" type="page" />
   <UiCard v-else class="vms">
-    <div class="metaTable">
+    <div class="topBottomTable">
       <!-- TODO: update with item selection button when available -->
       <p class="typo-body-regular-small count">{{ t('n-vms', { n: vms.length }) }}</p>
       <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
@@ -27,7 +27,7 @@
         </tr>
       </tbody>
     </VtsTable>
-    <div class="metaTable">
+    <div class="topBottomTable">
       <!-- TODO: update with item selection button when available -->
       <p class="typo-body-regular-small count">{{ t('n-vms', { n: vms.length }) }}</p>
       <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
@@ -79,7 +79,7 @@ const { pageRecords: vmsRecords, paginationBindings } = usePagination('vms', vms
   gap: 0.8rem;
 }
 
-.metaTable {
+.topBottomTable {
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/@xen-orchestra/web/src/pages/pool/[id]/hosts.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/hosts.vue
@@ -1,9 +1,9 @@
 <template>
   <VtsLoadingHero v-if="!isReady" type="page" />
   <UiCard v-else class="hosts">
-    <div class="topBottomTable">
+    <div class="pagination-container">
       <!-- TODO: update with item selection button when available -->
-      <p class="typo-body-regular-small count">{{ t('n-vms', { n: hosts.length }) }}</p>
+      <p class="typo-body-regular-small count">{{ t('n-hosts', { n: hosts.length }) }}</p>
       <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
     </div>
     <VtsTable vertical-border>
@@ -31,9 +31,9 @@
         </tr>
       </tbody>
     </VtsTable>
-    <div class="topBottomTable">
+    <div class="pagination-container">
       <!-- TODO: update with item selection button when available -->
-      <p class="typo-body-regular-small count">{{ t('n-vms', { n: hosts.length }) }}</p>
+      <p class="typo-body-regular-small count">{{ t('n-hosts', { n: hosts.length }) }}</p>
       <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
     </div>
   </UiCard>
@@ -88,10 +88,11 @@ const { pageRecords: hostsRecords, paginationBindings } = usePagination('hosts',
   text-transform: lowercase;
 }
 
-.topBottomTable {
+.pagination-container {
   display: flex;
   justify-content: space-between;
   align-items: center;
+
   .count {
     color: var(--color-neutral-txt-secondary);
   }

--- a/@xen-orchestra/web/src/pages/pool/[id]/hosts.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/hosts.vue
@@ -1,7 +1,7 @@
 <template>
   <VtsLoadingHero v-if="!isReady" type="page" />
   <UiCard v-else class="hosts">
-    <div class="metaTable">
+    <div class="topBottomTable">
       <!-- TODO: update with item selection button when available -->
       <p class="typo-body-regular-small count">{{ t('n-vms', { n: hosts.length }) }}</p>
       <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
@@ -31,7 +31,7 @@
         </tr>
       </tbody>
     </VtsTable>
-    <div class="metaTable">
+    <div class="topBottomTable">
       <!-- TODO: update with item selection button when available -->
       <p class="typo-body-regular-small count">{{ t('n-vms', { n: hosts.length }) }}</p>
       <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
@@ -86,5 +86,14 @@ const { pageRecords: hostsRecords, paginationBindings } = usePagination('hosts',
 .count {
   color: var(--color-neutral-txt-secondary);
   text-transform: lowercase;
+}
+
+.topBottomTable {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  .count {
+    color: var(--color-neutral-txt-secondary);
+  }
 }
 </style>

--- a/@xen-orchestra/web/src/pages/pool/[id]/hosts.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/hosts.vue
@@ -1,8 +1,11 @@
 <template>
   <VtsLoadingHero v-if="!isReady" type="page" />
   <UiCard v-else class="hosts">
-    <!-- TODO: update with item selection button and TopBottomTable component when available -->
-    <p class="typo-body-regular-small count">{{ t('n-hosts', { n: hosts.length }) }}</p>
+    <div class="metaTable">
+      <!-- TODO: update with item selection button when available -->
+      <p class="typo-body-regular-small count">{{ t('n-vms', { n: hosts.length }) }}</p>
+      <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+    </div>
     <VtsTable vertical-border>
       <thead>
         <tr>
@@ -11,7 +14,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr v-for="host in hosts" :key="host.id">
+        <tr v-for="host in hostsRecords" :key="host.id">
           <VtsCellObject :id="host.data.id">
             <UiObjectLink :route="`/host/${host.data.id}`">
               <template #icon>
@@ -28,6 +31,11 @@
         </tr>
       </tbody>
     </VtsTable>
+    <div class="metaTable">
+      <!-- TODO: update with item selection button when available -->
+      <p class="typo-body-regular-small count">{{ t('n-vms', { n: hosts.length }) }}</p>
+      <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+    </div>
   </UiCard>
 </template>
 
@@ -43,6 +51,8 @@ import VtsTable from '@core/components/table/VtsTable.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiObjectIcon from '@core/components/ui/object-icon/UiObjectIcon.vue'
 import UiObjectLink from '@core/components/ui/object-link/UiObjectLink.vue'
+import UiTablePagination from '@core/components/ui/table-pagination/UiTablePagination.vue'
+import { usePagination } from '@core/composables/pagination.composable'
 import { defineTree } from '@core/composables/tree/define-tree'
 import { useTree } from '@core/composables/tree.composable'
 import { faAlignLeft, faServer } from '@fortawesome/free-solid-svg-icons'
@@ -64,6 +74,7 @@ const definitions = computed(() =>
 )
 
 const { nodes: hosts } = useTree(definitions)
+const { pageRecords: hostsRecords, paginationBindings } = usePagination('hosts', hosts)
 </script>
 
 <style lang="postcss" scoped>

--- a/@xen-orchestra/web/src/pages/pool/[id]/vms.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/vms.vue
@@ -1,7 +1,7 @@
 <template>
   <VtsLoadingHero v-if="!isReady" type="page" />
   <UiCard v-else class="vms">
-    <div class="metaTable">
+    <div class="pagination-container">
       <!-- TODO: update with item selection button when available -->
       <p class="typo-body-regular-small count">{{ t('n-vms', { n: vms.length }) }}</p>
       <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
@@ -29,7 +29,7 @@
         </tr>
       </tbody>
     </VtsTable>
-    <div class="metaTable">
+    <div class="pagination-container">
       <!-- TODO: update with item selection button when available -->
       <p class="typo-body-regular-small count">{{ t('n-vms', { n: vms.length }) }}</p>
       <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
@@ -83,10 +83,11 @@ const { pageRecords: vmsRecords, paginationBindings } = usePagination('vms', vms
   gap: 0.8rem;
 }
 
-.metaTable {
+.pagination-container {
   display: flex;
   justify-content: space-between;
   align-items: center;
+
   .count {
     color: var(--color-neutral-txt-secondary);
   }

--- a/@xen-orchestra/web/src/pages/pool/[id]/vms.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/vms.vue
@@ -2,6 +2,7 @@
   <VtsLoadingHero v-if="!isReady" type="page" />
   <UiCard v-else class="vms">
     <div class="metaTable">
+      <!-- TODO: update with item selection button when available -->
       <p class="typo-body-regular-small count">{{ t('n-vms', { n: vms.length }) }}</p>
       <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
     </div>
@@ -13,7 +14,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr v-for="vm in pageRecords" :key="vm.id">
+        <tr v-for="vm in vmsRecords" :key="vm.id">
           <VtsCellObject :id="vm.data.id">
             <UiObjectLink :route="`/vm/${vm.data.id}/`">
               <template #icon>
@@ -29,6 +30,7 @@
       </tbody>
     </VtsTable>
     <div class="metaTable">
+      <!-- TODO: update with item selection button when available -->
       <p class="typo-body-regular-small count">{{ t('n-vms', { n: vms.length }) }}</p>
       <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
     </div>
@@ -72,7 +74,7 @@ const definitions = computed(() =>
 )
 
 const { nodes: vms } = useTree(definitions)
-const { pageRecords, paginationBindings } = usePagination('vms', vms)
+const { pageRecords: vmsRecords, paginationBindings } = usePagination('vms', vms)
 </script>
 
 <style lang="postcss" scoped>

--- a/@xen-orchestra/web/src/pages/pool/[id]/vms.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/vms.vue
@@ -1,8 +1,10 @@
 <template>
   <VtsLoadingHero v-if="!isReady" type="page" />
   <UiCard v-else class="vms">
-    <!-- TODO: update with item selection button and TopBottomTable component when available -->
-    <p class="typo-body-regular-small count">{{ t('n-vms', { n: vms.length }) }}</p>
+    <div class="metaTable">
+      <p class="typo-body-regular-small count">{{ t('n-vms', { n: vms.length }) }}</p>
+      <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+    </div>
     <VtsTable vertical-border>
       <thead>
         <tr>
@@ -11,7 +13,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr v-for="vm in vms" :key="vm.id">
+        <tr v-for="vm in pageRecords" :key="vm.id">
           <VtsCellObject :id="vm.data.id">
             <UiObjectLink :route="`/vm/${vm.data.id}/`">
               <template #icon>
@@ -20,10 +22,16 @@
               {{ vm.data.name_label }}
             </UiObjectLink>
           </VtsCellObject>
-          <VtsCellText>{{ vm.data.name_description }}</VtsCellText>
+          <VtsCellText>
+            {{ vm.data.name_description }}
+          </VtsCellText>
         </tr>
       </tbody>
     </VtsTable>
+    <div class="metaTable">
+      <p class="typo-body-regular-small count">{{ t('n-vms', { n: vms.length }) }}</p>
+      <UiTablePagination v-if="isReady" v-bind="paginationBindings" />
+    </div>
   </UiCard>
 </template>
 
@@ -39,6 +47,8 @@ import VtsTable from '@core/components/table/VtsTable.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiObjectIcon from '@core/components/ui/object-icon/UiObjectIcon.vue'
 import UiObjectLink from '@core/components/ui/object-link/UiObjectLink.vue'
+import UiTablePagination from '@core/components/ui/table-pagination/UiTablePagination.vue'
+import { usePagination } from '@core/composables/pagination.composable'
 import { defineTree } from '@core/composables/tree/define-tree'
 import { useTree } from '@core/composables/tree.composable'
 import { faAlignLeft, faDesktop } from '@fortawesome/free-solid-svg-icons'
@@ -62,6 +72,7 @@ const definitions = computed(() =>
 )
 
 const { nodes: vms } = useTree(definitions)
+const { pageRecords, paginationBindings } = usePagination('vms', vms)
 </script>
 
 <style lang="postcss" scoped>
@@ -70,7 +81,12 @@ const { nodes: vms } = useTree(definitions)
   gap: 0.8rem;
 }
 
-.count {
-  color: var(--color-neutral-txt-secondary);
+.metaTable {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  .count {
+    color: var(--color-neutral-txt-secondary);
+  }
 }
 </style>

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@
 - **XO 6:**
   - [i18n] Update Czech, German, Spanish, Dutch, Russian translations (PR [#8643](https://github.com/vatesfr/xen-orchestra/pull/8643))
   - [Host/system] Display pGpu name in hardware specifications card in host/system tab (PR [#8740](https://github.com/vatesfr/xen-orchestra/pull/8740))
+  - [Table] add pagination on table (PR [#8573](https://github.com/vatesfr/xen-orchestra/pull/8573))
 
 ### Bug fixes
 
@@ -39,6 +40,6 @@
 <!--packages-start-->
 
 - @xen-orchestra/web minor
-- @xen-orchestra/web-core patch
+- @xen-orchestra/web-core minor
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

Add pagination provider for table, use [this component](https://github.com/vatesfr/xen-orchestra/pull/8267).

_plain card_: [XO-963](https://project.vates.tech/vates-global/browse/XO-963/)
### Screenshots

![image](https://github.com/user-attachments/assets/4a27b8c4-cbf2-47f6-b597-0b150a50c3c0)
![image](https://github.com/user-attachments/assets/57adb5a0-28a0-4ad8-8d0c-64885ee8c5c2)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
