### PR TITLE
feat(xo-core): add VtsEnabledState component

### DIFF
--- a/@xen-orchestra/lite/src/stories/web-core/enabled-state/vts-enabled-state.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/enabled-state/vts-enabled-state.story.vue
@@ -1,0 +1,11 @@
+<template>
+  <ComponentStory v-slot="{ properties }" :params="[prop('enabled').required().preset(true).widget()]">
+    <VtsEnabledState v-bind="properties" />
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import { prop } from '@/libs/story/story-param'
+import VtsEnabledState from '@core/enabled-state/VtsEnabledState.vue'
+</script>

--- a/@xen-orchestra/web-core/lib/enabled-state/VtsEnabledState.vue
+++ b/@xen-orchestra/web-core/lib/enabled-state/VtsEnabledState.vue
@@ -1,0 +1,26 @@
+<template>
+  <UiInfo :accent="state.accent">
+    {{ state.label }}
+  </UiInfo>
+</template>
+
+<script setup lang="ts">
+import UiInfo, { type InfoAccent } from '@core/components/ui/info/UiInfo.vue'
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+type StatesMap = Record<'enabled' | 'disabled', { label: string; accent: InfoAccent }>
+
+const { enabled } = defineProps<{
+  enabled: boolean
+}>()
+
+const { t } = useI18n()
+
+const statesMap: StatesMap = {
+  enabled: { label: t('enabled'), accent: 'success' },
+  disabled: { label: t('disabled'), accent: 'muted' },
+}
+
+const state = computed(() => (enabled ? statesMap.enabled : statesMap.disabled))
+</script>

--- a/@xen-orchestra/web-core/lib/enabled-state/VtsEnabledState.vue
+++ b/@xen-orchestra/web-core/lib/enabled-state/VtsEnabledState.vue
@@ -9,7 +9,7 @@ import UiInfo, { type InfoAccent } from '@core/components/ui/info/UiInfo.vue'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-type StatesMap = Record<'enabled' | 'disabled', { label: string; accent: InfoAccent }>
+type StatesMap = { label: string; accent: InfoAccent }
 
 const { enabled } = defineProps<{
   enabled: boolean
@@ -17,10 +17,7 @@ const { enabled } = defineProps<{
 
 const { t } = useI18n()
 
-const statesMap: StatesMap = {
-  enabled: { label: t('enabled'), accent: 'success' },
-  disabled: { label: t('disabled'), accent: 'muted' },
-}
-
-const state = computed(() => (enabled ? statesMap.enabled : statesMap.disabled))
+const state = computed<StatesMap>(() =>
+  enabled ? { label: t('enabled'), accent: 'success' } : { label: t('disabled'), accent: 'muted' }
+)
 </script>


### PR DESCRIPTION
### Description

Add new `VtsEnabledState` component

### Screenshots

![vts-enabled-state](https://github.com/user-attachments/assets/8cd7bc54-5e6c-45d5-aabf-a14acc790fa9)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
