### PR TITLE
fix(xo-server/VM.setAndRestart): explicitly pass `forceShutdownDelay: 0` to VM.stop

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,6 +28,7 @@
 - [Plugins/Perf-alert] Fixing plugin configuration error happening while editing config [Forum#9658](https://xcp-ng.org/forum/post/90573) (PR [#8561](https://github.com/vatesfr/xen-orchestra/pull/8561))
 - [Plugins/Perf-alert] Prevent non-running VMs and hosts to be monitored in specific cases [Forum#10802](https://xcp-ng.org/forum/topic/10802/performance-alerts-fail-when-turning-on-all-running-hosts-all-running-vm-s-etc) (PR [#8561](https://github.com/vatesfr/xen-orchestra/pull/8561))
 - [Signin] Fix size of the icon on login pages for Safari browser [#8301](https://github.com/vatesfr/xen-orchestra/issues/8301) (PR [#8572](https://github.com/vatesfr/xen-orchestra/pull/8572)).
+- [VM/Edit RAM] Fix hard-reboot being triggered instead of soft-reboot when RAM is edited and VM restarted (PR [#8592](https://github.com/vatesfr/xen-orchestra/pull/8592))
 
 ### Packages to release
 

--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -828,7 +828,7 @@ export const setAndRestart = defer(async function ($defer, params) {
   const vm = params.VM
   const force = extract(params, 'force')
 
-  await stop.bind(this)({ vm, force })
+  await stop.bind(this)({ vm, force, forceShutdownDelay: 0 })
 
   $defer(start.bind(this), { vm, force })
 
@@ -1140,7 +1140,7 @@ export const stop = defer(async function ($defer, { vm, force, forceShutdownDela
 stop.params = {
   id: { type: 'string' },
   force: { type: 'boolean', optional: true },
-  forceShutdownDelay: { type: 'number', default: 5 * 60 * 1e3 },
+  forceShutdownDelay: { type: 'number', default: 0 },
   bypassBlockedOperation: { type: 'boolean', optional: true },
 }
 

--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -1140,7 +1140,7 @@ export const stop = defer(async function ($defer, { vm, force, forceShutdownDela
 stop.params = {
   id: { type: 'string' },
   force: { type: 'boolean', optional: true },
-  forceShutdownDelay: { type: 'number', default: 0 },
+  forceShutdownDelay: { type: 'number', default: 5 * 60 * 1e3 },
   bypassBlockedOperation: { type: 'boolean', optional: true },
 }
 


### PR DESCRIPTION
Fixes Zammad#38602
Introduced by #7247

### Description

API methods' default values are only resolved when they are called from the API. Here, `forceShutdownDelay: 0` needs to be passed explicitly otherwise `promise-toolbox`'s `timeout` will receive `undefined`, which does not disable the timeout.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
