### PR TITLE
feat(xo-web/update): disable registration email input when XOA is in trial

### DIFF
--- a/packages/xo-web/src/xo-app/xoa/update/index.js
+++ b/packages/xo-web/src/xo-app/xoa/update/index.js
@@ -9,7 +9,7 @@ import Icon from 'icon'
 import Link from 'link'
 import React from 'react'
 import Tooltip from 'tooltip'
-import xoaUpdater, { exposeTrial, isTrialRunning } from 'xoa-updater'
+import xoaUpdater, { blockXoaAccess, exposeTrial, isTrialRunning } from 'xoa-updater'
 import { addSubscriptions, adminOnly, connectStore } from 'utils'
 import { Card, CardBlock, CardHeader } from 'card'
 import { confirm } from 'modal'
@@ -325,11 +325,7 @@ const Updates = decorate([
                   )}
                   {state.isDisconnected && (
                     <p>
-                      <a
-                        href='https://docs.xen-orchestra.com/updater#troubleshooting'
-                        target='_blank'
-                        rel='noreferrer'
-                      >
+                      <a href='https://docs.xen-orchestra.com/updater#troubleshooting' target='_blank' rel='noreferrer'>
                         {_('updaterTroubleshootingLink')}
                       </a>
                     </p>
@@ -485,6 +481,7 @@ const Updates = decorate([
                       <div className='form-group'>
                         <input
                           className='form-control'
+                          disabled={state.askRegisterAgain && (state.isTrialAvailable || blockXoaAccess(xoaTrialState))}
                           name='email'
                           onChange={effects.linkState}
                           placeholder={formatMessage(messages.updateRegistrationEmailPlaceHolder)}


### PR DESCRIPTION
### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
