### PR TITLE
fix(xo-core/vts-quick-info-row): handle long values in slot, add tooltip for key, add missing mobile styles

### DIFF
--- a/@xen-orchestra/web-core/lib/components/quick-info-row/VtsQuickInfoRow.vue
+++ b/@xen-orchestra/web-core/lib/components/quick-info-row/VtsQuickInfoRow.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="vts-quick-info-row">
-    <span class="typo-body-regular label">
+  <div class="vts-quick-info-row" :class="{ mobile: uiStore.isMobile }">
+    <span v-tooltip class="typo-body-regular label text-ellipsis">
       <slot name="label">
         {{ label }}
       </slot>
     </span>
-    <span v-tooltip class="typo-body-regular value text-ellipsis">
+    <span class="typo-body-regular value">
       <slot name="value">
         {{ value }}
       </slot>
@@ -15,6 +15,7 @@
 
 <script lang="ts" setup>
 import { vTooltip } from '@core/directives/tooltip.directive'
+import { useUiStore } from '@core/stores/ui.store.ts'
 
 defineProps<{
   label?: string
@@ -25,13 +26,19 @@ defineSlots<{
   label?(): any
   value?(): any
 }>()
+
+const uiStore = useUiStore()
 </script>
 
 <style lang="postcss" scoped>
 .vts-quick-info-row {
   display: flex;
-  align-items: center;
   gap: 2.4rem;
+
+  &.mobile {
+    flex-direction: column;
+    gap: 0.8rem;
+  }
 
   .label {
     flex-shrink: 0;


### PR DESCRIPTION
### Description

- Handle long values in slot: when displaying long text for the value slot, show the full length, wrapped on multiple lines if needed
- Add tooltip for key: when using long key text, show ellipsis + tooltip
- Add missing mobile styles: use correct `flex-direction` and `gap` properties

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
