### PR TITLE
docs(footer): correct wrong GitHub link

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -135,7 +135,7 @@ const config: Config = {
             },
             {
               label: 'GitHub',
-              href: 'https://github.com/facebook/docusaurus',
+              href: 'https://github.com/vatesfr/xen-orchestra',
             },
           ],
         },


### PR DESCRIPTION
In the Xen Orchestra documentation, the GitHub link in the footer was the default one used by the Docusaurus template. 

This PR changes the link so that it points to the Xen Orchestra GitHub repository instead.