### PR TITLE
fix(xo-server/xen-server): fix disabling an enabled but disconnected server

### DIFF
--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -535,9 +535,9 @@ export default class XenServers {
 
   async disconnectXenServer(id) {
     // throw no such object if the server does not exist
-    await this.getXenServer(id)
+    const server = await this.getXenServer(id)
     const status = this._getXenServerStatus(id)
-    if (status === 'disconnected') {
+    if (status === 'disconnected' && !server.enabled) {
       /* throw */ incorrectState({
         actual: status,
         expected: ['connected', 'connecting'],
@@ -547,6 +547,10 @@ export default class XenServers {
     }
     await this.updateXenServer(id, { enabled: false })
 
+    /**
+     * if the server is enabled but disconnected, xapi is undefined
+     * @type {Xapi | undefined}
+     */
     const xapi = this._xapis[id]
     delete this._xapis[id]
 
@@ -556,7 +560,7 @@ export default class XenServers {
       delete serverIdsByPool[id]
     }
 
-    return xapi.disconnect()
+    return xapi?.disconnect()
   }
 
   getAllXapis() {


### PR DESCRIPTION
### Description

introduced by [#8565](https://github.com/vatesfr/xen-orchestra/pull/8565)
See [Forum#10863](https://xcp-ng.org/forum/topic/10863/can-t-disable-enabled-errored-server/3)
No changelog because the bug is not published

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
