### PR TITLE
docs(airgap): fix broken link to xoa check

### DIFF
--- a/docs/docs/airgap.md
+++ b/docs/docs/airgap.md
@@ -19,7 +19,7 @@ In this scenario, you will need a QA/pre-production XCP-ng pool with Internet ac
 
 Make sure that your appliance is [properly registered](installation#registration) and [up-to-date](updater).
 
-It's also good to take a quick look at [the XOA check](xoa.html#xoa-check) to detect issues early.
+It's also good to take a quick look at [the XOA check](xoa#xoa-check) to detect issues early.
 
 When everything is good, you can shutdown your XOA and export it:
 


### PR DESCRIPTION
In the Airgap page of the XO documentation, a malformed link to the **Support → XOA Support → [XOA check](http://localhost:3000/xoa#xoa-check)** section was preventing Docusaurus from building the documentation correctly.

This PR corrects the link, ensuring the documentation can be built and updated when new content is added.