### PR TITLE
fix(xo-web): avoid unrelevant errors on isPubKeyTooShort

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Hosts] Avoid getting XO tasks logs flooded with errors on `host.isPubKeyTooShort` (PR [#8605](https://github.com/vatesfr/xen-orchestra/pull/8605))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -38,5 +40,6 @@
 - @vates/types minor
 - @xen-orchestra/rest-api minor
 - xo-server patch
+- xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -1418,7 +1418,13 @@ export const installCertificateOnHost = (id, props) => _call('host.installCertif
 
 export const setControlDomainMemory = (id, memory) => _call('host.setControlDomainMemory', { id, memory })
 
-export const isPubKeyTooShort = id => _call('host.isPubKeyTooShort', { id })
+export const isPubKeyTooShort = host => {
+  // this check is only relevant for old hosts, and cannot be done on offline hosts
+  if (host.productBrand !== 'XCP-ng' || semver.satisfies(host.version, '>=8.3.0') || host.power_state === 'Halted') {
+    return Promise.resolve(false)
+  }
+  return _call('host.isPubKeyTooShort', { id: host.id })
+}
 
 // for XCP-ng now
 export const installAllPatchesOnHost = ({ host }) =>

--- a/packages/xo-web/src/xo-app/home/host-item.js
+++ b/packages/xo-web/src/xo-app/home/host-item.js
@@ -64,7 +64,7 @@ export default class HostItem extends Component {
   }
 
   componentWillMount() {
-    isPubKeyTooShort(this.props.item.id).then(value =>
+    isPubKeyTooShort(this.props.item).then(value =>
       this.setState({
         isPubKeyTooShort: value,
       })

--- a/packages/xo-web/src/xo-app/home/host-item.js
+++ b/packages/xo-web/src/xo-app/home/host-item.js
@@ -47,10 +47,6 @@ import { getXoaPlan, SOURCES } from '../../common/xoa-plans'
 }))
 @connectStore(() => ({
   container: createGetObject((_, props) => props.item.$pool),
-  isPubKeyTooShort: createSelector(
-    (_, props) => props.item.id,
-    hostId => isPubKeyTooShort(hostId)
-  ),
   needsRestart: createDoesHostNeedRestart((_, props) => props.item),
   nVms: createGetObjectsOfType('VM').count(
     createSelector(
@@ -68,7 +64,11 @@ export default class HostItem extends Component {
   }
 
   componentWillMount() {
-    this.props.isPubKeyTooShort.then(isPubKeyTooShort => this.setState({ isPubKeyTooShort }))
+    isPubKeyTooShort(this.props.item.id).then(value =>
+      this.setState({
+        isPubKeyTooShort: value,
+      })
+    )
     Promise.resolve(isHostTimeConsistentWithXoaTime(this.props.item)).then(value =>
       this.setState({
         isHostTimeConsistentWithXoaTime: value,


### PR DESCRIPTION
### Description

**review by commit, do not squash**

[XO-844](https://project.vates.tech/vates-global/browse/XO-844/)

Avoid getting XO Task logs flooded with irrelevant errors on `host.isPubKeyTooShort`

- First commit: Avoid this method to be called every second for every host
- Second commit: avoid calling this method for offline hosts (can't get key length) and for >= 8.3 hosts (key length is relevant to update to XCP-ng 8.3)

Introduced by cc3d5f2efcb96286751d0a4525268c794e69d5b6

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
