### PR TITLE
fix(@xen-orchestra/rest-api): move networks into good folder

### DIFF
--- a/@xen-orchestra/rest-api/src/networks/network.controller.mts
+++ b/@xen-orchestra/rest-api/src/networks/network.controller.mts
@@ -4,11 +4,11 @@ import { provide } from 'inversify-binding-decorators'
 import { Request as ExRequest } from 'express'
 import type { XoNetwork } from '@vates/types'
 
-import { network, networkIds, partialNetworks } from '../oa-examples/network.oa-example.mjs'
-import { notFoundResp, unauthorizedResp, type Unbrand } from '../common/response.common.mjs'
-import { RestApi } from '../../rest-api/rest-api.mjs'
-import type { WithHref } from '../../helpers/helper.type.mjs'
-import { XapiXoController } from '../../abstract-classes/xapi-xo-controller.mjs'
+import { network, networkIds, partialNetworks } from '../open-api/oa-examples/network.oa-example.mjs'
+import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
+import { RestApi } from '../rest-api/rest-api.mjs'
+import type { WithHref } from '../helpers/helper.type.mjs'
+import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 
 @Route('networks')
 @Security('*')


### PR DESCRIPTION
### Description

introduced by #8497 
move from `open-api/networks/network.controller.mts` to `src/networks/network.controller.mts`

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
