### PR TITLE
feat(@xen-orchestra/rest-api): expose vm (clean/hard)_reboot

### DIFF
--- a/@vates/types/src/xen-api.mts
+++ b/@vates/types/src/xen-api.mts
@@ -256,6 +256,8 @@ type XenApiVmCallMethods = {
   (method: 'start', start_paused: boolean, force: boolean): Promise<void>
   (method: 'clean_shutdown'): Promise<void>
   (method: 'hard_shutdown'): Promise<void>
+  (method: 'clean_reboot'): Promise<void>
+  (method: 'hard_reboot'): Promise<void>
 }
 export interface XenApiVm {
   $ref: Branded<'VM'>

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -180,7 +180,7 @@ export class VmController extends XapiXoController<XoVm> {
       },
     })
   }
-  
+
   /**
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    */

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -135,6 +135,28 @@ export class VmController extends XapiXoController<XoVm> {
   }
 
   /**
+   * Requires guest tools to be installed
+   * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
+   */
+  @Example(taskLocation)
+  @Post('{id}/actions/clean_reboot')
+  async cleanRebootVm(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
+    const vmId = id as XoVm['id']
+    const action = async () => {
+      await this.getXapiObject(vmId).$callAsync('clean_reboot')
+    }
+
+    return this.createAction<void>(action, {
+      sync,
+      statusCode: noContentResp.status,
+      taskProperties: {
+        name: 'clean reboot VM',
+        objectId: vmId,
+      },
+    })
+  }
+
+  /**
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    */
   @Example(taskLocation)
@@ -154,6 +176,31 @@ export class VmController extends XapiXoController<XoVm> {
       statusCode: noContentResp.status,
       taskProperties: {
         name: 'hard shutdown VM',
+        objectId: vmId,
+      },
+    })
+  }
+  
+  /**
+   * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
+   */
+  @Example(taskLocation)
+  @Post('{id}/actions/hard_reboot')
+  @SuccessResponse(actionAsyncroneResp.status, actionAsyncroneResp.description, actionAsyncroneResp.produce)
+  @Response(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  @Response(internalServerErrorResp.status, internalServerErrorResp.description)
+  async hardRebootVm(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
+    const vmId = id as XoVm['id']
+    const action = async () => {
+      await this.getXapiObject(vmId).$callAsync('hard_reboot')
+    }
+
+    return this.createAction<void>(action, {
+      sync,
+      statusCode: noContentResp.status,
+      taskProperties: {
+        name: 'hard reboot VM',
         objectId: vmId,
       },
     })

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,8 @@
 - **Migrated REST API endpoints**
   - `/rest/v0/vms/<vm-id>/actions/clean_shutdown` (PR [#8612](https://github.com/vatesfr/xen-orchestra/pull/8612))
   - `/rest/v0/vms/<vm-id>/actions/hard_shutdown` (PR [#8612](https://github.com/vatesfr/xen-orchestra/pull/8612))
+  - `/rest/v0/vms/<vm-id>/actions/clean_reboot`
+  - `/rest/v0/vms/<vm-id>/actions/hard_reboot`
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,8 +21,8 @@
 - **Migrated REST API endpoints**
   - `/rest/v0/vms/<vm-id>/actions/clean_shutdown` (PR [#8612](https://github.com/vatesfr/xen-orchestra/pull/8612))
   - `/rest/v0/vms/<vm-id>/actions/hard_shutdown` (PR [#8612](https://github.com/vatesfr/xen-orchestra/pull/8612))
-  - `/rest/v0/vms/<vm-id>/actions/clean_reboot`
-  - `/rest/v0/vms/<vm-id>/actions/hard_reboot`
+  - `/rest/v0/vms/<vm-id>/actions/clean_reboot` (PR [#8611](https://github.com/vatesfr/xen-orchestra/pull/8611))
+  - `/rest/v0/vms/<vm-id>/actions/hard_reboot` (PR [#8611](https://github.com/vatesfr/xen-orchestra/pull/8611))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -617,6 +617,8 @@ export default class RestApi {
           start: true,
           clean_shutdown: true,
           hard_shutdown: true,
+          clean_reboot: true,
+          hard_reboot: true,
         },
       },
       'vm-controllers': {},


### PR DESCRIPTION
### Screenshot

![Capture d’écran de 2025-05-21 17-08-54](https://github.com/user-attachments/assets/0ed5a9e7-1453-491b-899f-67c1ffded9cc)

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
