### PR TITLE
feat(web-core): enhance collection library

### DIFF
--- a/@xen-orchestra/web-core/lib/packages/collection/README.md
+++ b/@xen-orchestra/web-core/lib/packages/collection/README.md
@@ -6,9 +6,9 @@ The `useCollection` composable helps you manage a collection of items with flags
 
 ```typescript
 const { items, useSubset, useFlag } = useCollection(sources, {
+  itemId: source => source.theId, // Required only if TSource doesn't have an `id` property
   flags: ['selected', 'active', { highlighted: { multiple: false } }],
   properties: source => ({
-    id: source.theId, // Required if TSource doesn't have an `id` property
     isAvailable: source.status === 'available',
     fullName: `${source.firstName} ${source.lastName}`,
   }),
@@ -18,8 +18,8 @@ const { items, useSubset, useFlag } = useCollection(sources, {
 ## Core Concepts
 
 - **Collection Item**: An object with a unique identifier, a reference to its source object, flags, computed properties, and methods to manipulate flags
-- **Flags**: Boolean states attached to items (like 'selected', 'active', 'highlighted')
-- **Properties**: Additional custom values
+- **Flags**: Arbitrary `boolean` states attached to items (like `selected`, `active`, `highlighted`, etc.)
+- **Properties**: Additional custom values attached to items, computed from the source object (like `fullName`, `isAvailable`, etc.)
 
 ## `useCollection` parameters
 
@@ -30,21 +30,22 @@ const { items, useSubset, useFlag } = useCollection(sources, {
 
 ### `options` object
 
-| Name         | Type                                           | Required | Description                                                           |
-| ------------ | ---------------------------------------------- | :------: | --------------------------------------------------------------------- |
-| `flags`      | `FlagsConfig<TFlag>`                           |          | Flags that can be applied to items in the collection                  |
-| `properties` | `(source: TSource) => Record<string, unknown>` |    ~     | Function that returns additional properties for each item (see below) |
+| Name         | Type                                           | Required | Description                                                              |
+| ------------ | ---------------------------------------------- | :------: | ------------------------------------------------------------------------ |
+| `itemId`     | `(source: TSource) => TId`                     |    ~     | Function to retrieve the item ID (if not provided, `TSource.id` is used) |
+| `flags`      | `FlagsConfig<TFlag>`                           |          | Flags that can be applied to items in the collection                     |
+| `properties` | `(source: TSource) => Record<string, unknown>` |          | Function that returns additional properties for each item (see below)    |
 
 ### Item ID
 
 The item ID will be retrieved automatically from `TSource.id`
 
-If `TSource` doesn't provide an `id`, then `options.properties` will be required and must return at least an `id`
+If `TSource` doesn't provide an `id`, then `options.itemId` will be required.
 
 ### `FlagsConfig` type
 
 ```typescript
-type FlagsConfig<TFlag extends string> = TFlag[] | { [K in TFlag]: { multiple?: boolean } }
+type FlagsConfig = string[] | Record<string, { multiple?: MaybeRef<boolean> }>
 ```
 
 Values for `multiple`:
@@ -169,4 +170,8 @@ const { items: users, useSubset } = useCollection(rawUsers, {
 const { items: admins, useSubset: useAdminSubset } = useSubset(item => item.source.group === 'admin')
 
 const { items: activeAdmins } = useAdminSubset(item => item.source.status === 'active')
+
+// This would be equivalent to:
+
+const { items: activeAdmins } = useSubset(item => item.source.group === 'admin' && item.source.status === 'active')
 ```

--- a/@xen-orchestra/web-core/lib/packages/collection/README.md
+++ b/@xen-orchestra/web-core/lib/packages/collection/README.md
@@ -30,11 +30,11 @@ const { items, useSubset, useFlag } = useCollection(sources, {
 
 ### `options` object
 
-| Name         | Type                                           | Required | Description                                                              |
-| ------------ | ---------------------------------------------- | :------: | ------------------------------------------------------------------------ |
-| `itemId`     | `(source: TSource) => TId`                     |    ~     | Function to retrieve the item ID (if not provided, `TSource.id` is used) |
-| `flags`      | `FlagsConfig<TFlag>`                           |          | Flags that can be applied to items in the collection                     |
-| `properties` | `(source: TSource) => Record<string, unknown>` |          | Function that returns additional properties for each item (see below)    |
+| Name         | Type                                           | Required | Description                                                                                     |
+| ------------ | ---------------------------------------------- | :------: | ----------------------------------------------------------------------------------------------- |
+| `itemId`     | `keyof TSource \| ((source: TSource) => TId)`  |    ~     | Function to retrieve the item ID or property of TSource (if not provided, `TSource.id` is used) |
+| `flags`      | `FlagsConfig<TFlag>`                           |          | Flags that can be applied to items in the collection                                            |
+| `properties` | `(source: TSource) => Record<string, unknown>` |          | Function that returns additional properties for each item (see below)                           |
 
 ### Item ID
 
@@ -64,13 +64,13 @@ Values for `multiple`:
 
 ### `CollectionItem` object
 
-| Name         | Type                           | Description                                               |
-| ------------ | ------------------------------ | --------------------------------------------------------- |
-| `id`         | `TId`                          | Unique identifier for the item (string, number or symbol) |
-| `source`     | `TSource`                      | The original source object                                |
-| `flags`      | `Record<TFlag, boolean>`       | Object containing the state of all flags for this item    |
-| `properties` | `TProperties`                  | Object containing all computed properties for this item   |
-| `toggleFlag` | `(flag, forcedValue?) => void` | Method to toggle a flag on this item                      |
+| Name         | Type                               | Description                                               |
+| ------------ | ---------------------------------- | --------------------------------------------------------- |
+| `id`         | `TId`                              | Unique identifier for the item (string, number or symbol) |
+| `source`     | `TSource`                          | The original source object                                |
+| `flags`      | `Record<TFlag, boolean>`           | Object containing the state of all flags for this item    |
+| `properties` | `TProperties`                      | Object containing all computed properties for this item   |
+| `toggleFlag` | `(flag, shouldBeFlagged?) => void` | Method to toggle a flag on this item                      |
 
 ### UseFlagReturn object
 
@@ -82,8 +82,8 @@ Values for `multiple`:
 | `areAllOn`  | `ComputedRef<boolean>`                      | Whether all items in the collection have this flag set |
 | `areSomeOn` | `ComputedRef<boolean>`                      | Whether at least one item has this flag set            |
 | `areNoneOn` | `ComputedRef<boolean>`                      | Whether no items have this flag set                    |
-| `toggle`    | `(id, forcedValue?) => void`                | Toggle this flag on a specific item                    |
-| `toggleAll` | `(forcedValue?) => void`                    | Toggle this flag on all items in the collection        |
+| `toggle`    | `(id, shouldBeFlagged?) => void`            | Toggle this flag on a specific item                    |
+| `toggleAll` | `(shouldBeFlagged?) => void`                | Toggle this flag on all items in the collection        |
 | `useSubset` | `(filter: (item) => boolean) => Collection` | Creates a sub collection matching the filter           |
 
 ## Flag Operations

--- a/@xen-orchestra/web-core/lib/packages/collection/create-collection.ts
+++ b/@xen-orchestra/web-core/lib/packages/collection/create-collection.ts
@@ -32,13 +32,13 @@ export function createCollection<
 
     const areNoneOn = computed(() => count.value === 0)
 
-    function toggle(id: TId, forcedValue?: boolean) {
-      flagRegistry.toggleFlag(id, flag, forcedValue)
+    function toggle(id: TId, shouldBeFlagged?: boolean) {
+      flagRegistry.toggleFlag(id, flag, shouldBeFlagged)
     }
 
-    function toggleAll(forcedValue = !areAllOn.value) {
+    function toggleAll(shouldBeFlagged = !areAllOn.value) {
       for (const item of items.value) {
-        flagRegistry.toggleFlag(item.id, flag, forcedValue)
+        flagRegistry.toggleFlag(item.id, flag, shouldBeFlagged)
       }
     }
 
@@ -57,8 +57,8 @@ export function createCollection<
     }
   }
 
-  function toggleFlag(id: TId, flag: TFlag, forcedValue?: boolean) {
-    flagRegistry.toggleFlag(id, flag, forcedValue)
+  function toggleFlag(id: TId, flag: TFlag, shouldBeFlagged?: boolean) {
+    flagRegistry.toggleFlag(id, flag, shouldBeFlagged)
   }
 
   const useSubset = createUseSubset<TSource, TFlag, TProperties, TId>(items, flagRegistry)

--- a/@xen-orchestra/web-core/lib/packages/collection/create-item.ts
+++ b/@xen-orchestra/web-core/lib/packages/collection/create-item.ts
@@ -1,16 +1,17 @@
-import { guessItemId } from '@core/packages/collection/guess-item-id.ts'
-import type { CollectionConfigProperties, CollectionItem, FlagRegistry } from '@core/packages/collection/types.ts'
+import type { CollectionItem, CollectionItemId, CollectionItemProperties, FlagRegistry } from './types.ts'
 import { reactive } from 'vue'
 
-export function createItem<TSource, TFlag extends string, TProperties extends CollectionConfigProperties>(
+export function createItem<
+  TSource,
+  TFlag extends string,
+  TProperties extends CollectionItemProperties,
+  TId extends CollectionItemId,
+>(
+  id: TId,
   source: TSource,
-  getProperties: undefined | ((source: TSource) => TProperties),
-  flagRegistry: FlagRegistry<TFlag>
-): CollectionItem<TSource, TFlag, TProperties> {
-  const properties = reactive(getProperties?.(source) ?? ({} as TProperties))
-
-  const id = guessItemId(source, properties)
-
+  properties: TProperties,
+  flagRegistry: FlagRegistry<TId, TFlag>
+): CollectionItem<TSource, TFlag, TProperties, TId> {
   return {
     id,
     source,
@@ -18,22 +19,22 @@ export function createItem<TSource, TFlag extends string, TProperties extends Co
       flagRegistry.toggleFlag(id, flag, forcedValue)
     },
     flags: new Proxy({} as Record<TFlag, boolean>, {
-      has(_, flag: TFlag) {
-        return flagRegistry.isFlagDefined(flag)
+      has(_, flag) {
+        return flagRegistry.isFlagDefined(flag as TFlag)
       },
-      get(_, flag: TFlag) {
-        if (!flagRegistry.isFlagDefined(flag)) {
+      get(_, flag) {
+        if (typeof flag === 'symbol' || flag.startsWith('__v_')) {
           return undefined
         }
 
-        return flagRegistry.isFlagged(id, flag)
+        return flagRegistry.isFlagged(id, flag as TFlag)
       },
-      set(_, flag: TFlag, value: boolean) {
-        flagRegistry.toggleFlag(id, flag, value)
+      set(_, flag, value: boolean) {
+        flagRegistry.toggleFlag(id, flag as TFlag, value)
 
         return true
       },
     }),
-    properties,
+    properties: reactive(properties),
   }
 }

--- a/@xen-orchestra/web-core/lib/packages/collection/create-item.ts
+++ b/@xen-orchestra/web-core/lib/packages/collection/create-item.ts
@@ -15,8 +15,8 @@ export function createItem<
   return {
     id,
     source,
-    toggleFlag(flag: TFlag, forcedValue?: boolean) {
-      flagRegistry.toggleFlag(id, flag, forcedValue)
+    toggleFlag(flag: TFlag, shouldBeFlagged?: boolean) {
+      flagRegistry.toggleFlag(id, flag, shouldBeFlagged)
     },
     flags: new Proxy({} as Record<TFlag, boolean>, {
       has(_, flag) {

--- a/@xen-orchestra/web-core/lib/packages/collection/create-use-subset.ts
+++ b/@xen-orchestra/web-core/lib/packages/collection/create-use-subset.ts
@@ -1,0 +1,23 @@
+import { createCollection } from '@core/packages/collection/create-collection.ts'
+import type {
+  Collection,
+  CollectionItem,
+  CollectionItemId,
+  CollectionItemProperties,
+  FlagRegistry,
+} from '@core/packages/collection/types.ts'
+import type { ArrayFilterPredicate } from '@core/types/utility.type.ts'
+import { useArrayFilter } from '@vueuse/core'
+import type { ComputedRef } from 'vue'
+
+export function createUseSubset<
+  TSource,
+  TFlag extends string,
+  TProperties extends CollectionItemProperties,
+  TId extends CollectionItemId,
+  $TItem extends CollectionItem<TSource, TFlag, TProperties, TId> = CollectionItem<TSource, TFlag, TProperties, TId>,
+>(items: ComputedRef<$TItem[]>, flagRegistry: FlagRegistry<TId, TFlag>) {
+  return function useSubset(filter: ArrayFilterPredicate<$TItem>): Collection<TSource, TFlag, TProperties, TId> {
+    return createCollection(useArrayFilter(items, filter), flagRegistry)
+  }
+}

--- a/@xen-orchestra/web-core/lib/packages/collection/index.ts
+++ b/@xen-orchestra/web-core/lib/packages/collection/index.ts
@@ -1,2 +1,6 @@
+export * from './create-collection.ts'
+export * from './create-item.ts'
+export * from './guess-item-id.ts'
 export * from './types.ts'
 export * from './use-collection.ts'
+export * from './use-flag-registry.ts'

--- a/@xen-orchestra/web-core/lib/packages/collection/types.ts
+++ b/@xen-orchestra/web-core/lib/packages/collection/types.ts
@@ -1,57 +1,85 @@
-import type { ComputedRef, Reactive } from 'vue'
-
-export type CollectionConfigProperties = Record<string, unknown> & { id?: unknown }
-
-export type CollectionConfigFlags<TFlag extends string> = TFlag[] | Record<TFlag, { multiple?: boolean }>
+import type { ArrayFilterPredicate, KeyOfByValue } from '@core/types/utility.type.ts'
+import type { ComputedRef, MaybeRefOrGetter, Reactive } from 'vue'
 
 export type CollectionItem<
-  TSource,
-  TFlag extends string = never,
-  TProperties extends CollectionConfigProperties = Record<string, never>,
+  TSource = unknown,
+  TFlag extends string = string,
+  TProperties extends CollectionItemProperties = CollectionItemProperties,
+  TId extends CollectionItemId = PickSourceId<TSource, 'id'>,
 > = {
-  id: GuessItemId<TSource, Reactive<TProperties>>
+  id: TId
   source: TSource
   flags: Record<TFlag, boolean>
   properties: Reactive<TProperties>
   toggleFlag: (flag: TFlag, forcedValue?: boolean) => void
 }
 
-export type FlagRegistry<TFlag extends string> = {
-  isFlagged: (id: PropertyKey, flag: TFlag) => boolean
+export type Collection<
+  TSource = unknown,
+  TFlag extends string = string,
+  TProperties extends CollectionItemProperties = CollectionItemProperties,
+  TId extends CollectionItemId = PickSourceId<TSource, 'id'>,
+  $TItem extends CollectionItem<TSource, TFlag, TProperties, TId> = CollectionItem<TSource, TFlag, TProperties, TId>,
+> = {
+  items: ComputedRef<$TItem[]>
+  count: ComputedRef<number>
+  useFlag: (flag: TFlag) => UseFlagReturn<TSource, TFlag, TProperties, TId>
+  toggleFlag: (id: TId, flag: TFlag, forcedValue?: boolean) => void
+  useSubset: (filter: ArrayFilterPredicate<$TItem>) => Collection<TSource, TFlag, TProperties, TId>
+}
+
+export type CollectionItemProperties = Record<PropertyKey, unknown>
+
+export type CollectionItemId = string | number
+
+export type PickSourceId<TSource, TKey> = TKey extends keyof TSource
+  ? TSource[TKey] extends CollectionItemId
+    ? TSource[TKey]
+    : never
+  : never
+
+export type ExtractSourceId<TSource, TGetId extends GetItemId<TSource>> = TGetId extends keyof TSource
+  ? PickSourceId<TSource, TGetId>
+  : TGetId extends (source: TSource) => infer R
+    ? R
+    : TSource extends CollectionItemId
+      ? TSource
+      : PickSourceId<TSource, 'id'>
+
+export type FlagConfig = {
+  multiple?: MaybeRefOrGetter<boolean>
+}
+
+export type CollectionConfigFlags<TFlag extends string> = TFlag[] | Record<TFlag, FlagConfig>
+
+export type FlagRegistry<TId extends CollectionItemId, TFlag extends string> = {
+  isFlagged: (id: TId, flag: TFlag) => boolean
   isFlagDefined: (flag: TFlag) => boolean
-  toggleFlag: (id: PropertyKey, flag: TFlag, forcedValue?: boolean) => void
+  toggleFlag: (id: TId, flag: TFlag, forcedValue?: boolean) => void
   clearFlag: (flag: TFlag) => void
   isMultipleAllowed: (flag: TFlag) => boolean
   assertFlag: (flag: TFlag) => void
 }
 
-export type UseFlagReturn<TSource, TFlag extends string, TProperties extends CollectionConfigProperties> = {
-  items: ComputedRef<CollectionItem<TSource, TFlag, TProperties>[]>
-  ids: ComputedRef<GuessItemId<TSource, TProperties>[]>
+export type UseFlagReturn<
+  TSource,
+  TFlag extends string,
+  TProperties extends CollectionItemProperties,
+  TId extends CollectionItemId,
+  $TItem extends CollectionItem<TSource, TFlag, TProperties, TId> = CollectionItem<TSource, TFlag, TProperties, TId>,
+> = {
+  items: ComputedRef<$TItem[]>
+  ids: ComputedRef<TId[]>
   count: ComputedRef<number>
   areAllOn: ComputedRef<boolean>
   areSomeOn: ComputedRef<boolean>
   areNoneOn: ComputedRef<boolean>
-  toggle: (id: GuessItemId<TSource, TProperties>, forcedValue?: boolean) => void
+  toggle: (id: TId, forcedValue?: boolean) => void
   toggleAll: (forcedValue?: boolean) => void
-  useSubset: (
-    filter: (item: CollectionItem<TSource, TFlag, TProperties>) => boolean
-  ) => Collection<TSource, TFlag, TProperties>
+  useSubset: (filter: ArrayFilterPredicate<$TItem>) => Collection<TSource, TFlag, TProperties, TId>
 }
 
-export type Collection<TSource, TFlag extends string, TProperties extends CollectionConfigProperties> = {
-  items: ComputedRef<CollectionItem<TSource, TFlag, TProperties>[]>
-  count: ComputedRef<number>
-  useFlag: (flag: TFlag) => UseFlagReturn<TSource, TFlag, TProperties>
-  useSubset: (
-    filter: (item: CollectionItem<TSource, TFlag, TProperties>) => boolean
-  ) => Collection<TSource, TFlag, TProperties>
-}
-
-type AssertId<TId> = TId extends PropertyKey ? TId : never
-
-export type GuessItemId<TSource, TProperties> = TProperties extends { id: infer TId }
-  ? AssertId<TId>
-  : TSource extends { id: infer TId }
-    ? AssertId<TId>
-    : never
+export type GetItemId<TSource> =
+  | undefined
+  | KeyOfByValue<TSource, CollectionItemId>
+  | ((source: TSource) => CollectionItemId)

--- a/@xen-orchestra/web-core/lib/packages/collection/types.ts
+++ b/@xen-orchestra/web-core/lib/packages/collection/types.ts
@@ -11,7 +11,7 @@ export type CollectionItem<
   source: TSource
   flags: Record<TFlag, boolean>
   properties: Reactive<TProperties>
-  toggleFlag: (flag: TFlag, forcedValue?: boolean) => void
+  toggleFlag: (flag: TFlag, shouldBeFlagged?: boolean) => void
 }
 
 export type Collection<
@@ -24,7 +24,7 @@ export type Collection<
   items: ComputedRef<$TItem[]>
   count: ComputedRef<number>
   useFlag: (flag: TFlag) => UseFlagReturn<TSource, TFlag, TProperties, TId>
-  toggleFlag: (id: TId, flag: TFlag, forcedValue?: boolean) => void
+  toggleFlag: (id: TId, flag: TFlag, shouldBeFlagged?: boolean) => void
   useSubset: (filter: ArrayFilterPredicate<$TItem>) => Collection<TSource, TFlag, TProperties, TId>
 }
 
@@ -55,7 +55,7 @@ export type CollectionConfigFlags<TFlag extends string> = TFlag[] | Record<TFlag
 export type FlagRegistry<TId extends CollectionItemId, TFlag extends string> = {
   isFlagged: (id: TId, flag: TFlag) => boolean
   isFlagDefined: (flag: TFlag) => boolean
-  toggleFlag: (id: TId, flag: TFlag, forcedValue?: boolean) => void
+  toggleFlag: (id: TId, flag: TFlag, shouldBeFlagged?: boolean) => void
   clearFlag: (flag: TFlag) => void
   isMultipleAllowed: (flag: TFlag) => boolean
   assertFlag: (flag: TFlag) => void
@@ -74,8 +74,8 @@ export type UseFlagReturn<
   areAllOn: ComputedRef<boolean>
   areSomeOn: ComputedRef<boolean>
   areNoneOn: ComputedRef<boolean>
-  toggle: (id: TId, forcedValue?: boolean) => void
-  toggleAll: (forcedValue?: boolean) => void
+  toggle: (id: TId, shouldBeFlagged?: boolean) => void
+  toggleAll: (shouldBeFlagged?: boolean) => void
   useSubset: (filter: ArrayFilterPredicate<$TItem>) => Collection<TSource, TFlag, TProperties, TId>
 }
 

--- a/@xen-orchestra/web-core/lib/packages/collection/use-collection.ts
+++ b/@xen-orchestra/web-core/lib/packages/collection/use-collection.ts
@@ -1,47 +1,97 @@
-import { createCollection } from '@core/packages/collection/create-collection.ts'
-import { createItem } from '@core/packages/collection/create-item.ts'
-import type { Collection, CollectionConfigFlags, CollectionConfigProperties } from '@core/packages/collection/types.ts'
-import { useFlagRegistry } from '@core/packages/collection/use-flag-registry.ts'
+import { guessItemId } from '@core/packages/collection/guess-item-id.ts'
+import type { EmptyObject } from '@core/types/utility.type.ts'
+import type {
+  Collection,
+  CollectionConfigFlags,
+  CollectionItemId,
+  CollectionItemProperties,
+  ExtractSourceId,
+  GetItemId,
+} from './types.ts'
 import { computed, type MaybeRefOrGetter, toValue } from 'vue'
+import { createCollection } from './create-collection.ts'
+import { createItem } from './create-item.ts'
+import { useFlagRegistry } from './use-flag-registry.ts'
+
+// Overload #1: Source is CollectionItemId
 
 export function useCollection<
-  TSource extends { id: unknown },
+  TSource extends CollectionItemId,
   TFlag extends string = never,
-  TProperties extends CollectionConfigProperties = { id?: unknown },
+  TProperties extends CollectionItemProperties = EmptyObject,
+  TGetId extends ((source: TSource) => CollectionItemId) | undefined = undefined,
+  $TId extends CollectionItemId = ExtractSourceId<TSource, TGetId>,
 >(
-  sources: MaybeRefOrGetter<TSource[]>,
+  source: MaybeRefOrGetter<TSource[]>,
   config?: {
+    itemId?: TGetId | ((source: TSource) => CollectionItemId)
     flags?: CollectionConfigFlags<TFlag>
     properties?: (source: TSource) => TProperties
   }
-): Collection<TSource, TFlag, TProperties>
+): Collection<TSource, TFlag, TProperties, $TId>
+
+// Overload #2: Source is an object with id
+
+export function useCollection<
+  TSource extends { id: CollectionItemId },
+  TFlag extends string = never,
+  TProperties extends CollectionItemProperties = EmptyObject,
+  TGetId extends GetItemId<TSource> = undefined,
+  $TId extends CollectionItemId = ExtractSourceId<TSource, TGetId>,
+>(
+  source: MaybeRefOrGetter<TSource[]>,
+  config?: {
+    itemId?: TGetId | ((source: TSource) => CollectionItemId)
+    flags?: CollectionConfigFlags<TFlag>
+    properties?: (source: TSource) => TProperties
+  }
+): Collection<TSource, TFlag, TProperties, $TId>
+
+// Overload #3: Any other case
 
 export function useCollection<
   TSource,
   TFlag extends string = never,
-  TProperties extends CollectionConfigProperties & { id: unknown } = never,
+  TProperties extends CollectionItemProperties = EmptyObject,
+  TGetId extends GetItemId<TSource> = never,
+  $TId extends CollectionItemId = ExtractSourceId<TSource, TGetId>,
 >(
-  sources: MaybeRefOrGetter<TSource[]>,
+  source: MaybeRefOrGetter<TSource[]>,
   config: {
-    flags?: CollectionConfigFlags<TFlag>
-    properties: (source: TSource) => TProperties
-  }
-): Collection<TSource, TFlag, TProperties>
-
-export function useCollection<
-  TSource,
-  TFlag extends string = never,
-  TProperties extends CollectionConfigProperties = { id?: unknown },
->(
-  sources: MaybeRefOrGetter<TSource[]>,
-  config?: {
+    itemId: TGetId | ((source: TSource) => CollectionItemId)
     flags?: CollectionConfigFlags<TFlag>
     properties?: (source: TSource) => TProperties
   }
-): Collection<TSource, TFlag, TProperties> {
-  const flagRegistry = useFlagRegistry(config?.flags)
+): Collection<TSource, TFlag, TProperties, $TId>
 
-  const items = computed(() => toValue(sources).map(source => createItem(source, config?.properties, flagRegistry)))
+// Implementation
+
+export function useCollection<
+  TSource,
+  TFlag extends string,
+  TProperties extends CollectionItemProperties,
+  TGetId extends GetItemId<TSource>,
+  $TId extends CollectionItemId,
+>(
+  _sources: MaybeRefOrGetter<TSource[]>,
+  config?: {
+    itemId?: TGetId
+    flags?: CollectionConfigFlags<TFlag>
+    properties?: (source: TSource) => TProperties
+  }
+): Collection<TSource, TFlag, TProperties, $TId> {
+  const flagRegistry = useFlagRegistry<TFlag, $TId>(config?.flags)
+
+  const sources = computed(() => toValue(_sources))
+
+  const items = computed(() =>
+    sources.value.map(source => {
+      const id = guessItemId(source, config?.itemId) as $TId
+      const properties = config?.properties?.(source) ?? ({} as TProperties)
+
+      return createItem<TSource, TFlag, TProperties, $TId>(id, source, properties, flagRegistry)
+    })
+  )
 
   return createCollection(items, flagRegistry)
 }

--- a/@xen-orchestra/web-core/lib/packages/form-select/types.ts
+++ b/@xen-orchestra/web-core/lib/packages/form-select/types.ts
@@ -1,4 +1,4 @@
-import type { CollectionConfigProperties, CollectionItem } from '@core/packages/collection'
+import type { CollectionItem, CollectionItemProperties } from '@core/packages/collection'
 import type { MaybeArray } from '@core/types/utility.type.ts'
 import type { ComputedRef, InjectionKey, Reactive, WritableComputedRef } from 'vue'
 
@@ -25,13 +25,13 @@ export type FormOptionProperties<TValue extends FormOptionValue> = {
 export type FormOption<
   TSource = unknown,
   TValue extends FormOptionValue = FormOptionValue,
-  TProperties extends CollectionConfigProperties = CollectionConfigProperties,
+  TProperties extends CollectionItemProperties = CollectionItemProperties,
 > = CollectionItem<TSource, 'active' | 'selected', TProperties & FormOptionProperties<TValue>>
 
 export type UseFormSelectReturn<
   TSource,
   TValue extends FormOptionValue,
-  TProperties extends CollectionConfigProperties,
+  TProperties extends CollectionItemProperties,
 > = {
   searchTerm: WritableComputedRef<string>
   allOptions: ComputedRef<FormOption<TSource, TValue, TProperties>[]>

--- a/@xen-orchestra/web-core/lib/packages/form-select/use-form-select.ts
+++ b/@xen-orchestra/web-core/lib/packages/form-select/use-form-select.ts
@@ -138,6 +138,7 @@ export function useFormSelect<
     useFlag,
     useSubset,
   } = useCollection(sources, {
+    itemId: source => (source as { value: FormOptionValue }).value ?? (source as { id: FormOptionValue }).id,
     flags: {
       active: { multiple: false },
       selected: { multiple: config?.multiple ?? false },

--- a/@xen-orchestra/web-core/lib/types/utility.type.ts
+++ b/@xen-orchestra/web-core/lib/types/utility.type.ts
@@ -9,3 +9,12 @@ export type Branded<TBrand extends string, TType = string> = TType & { [__brand]
 export type EmptyObject = Record<string, never>
 
 export type StringKeyOf<T> = Extract<keyof T, string>
+
+export type KeyOfByValue<T, TValue> =
+  T extends Record<PropertyKey, unknown>
+    ? keyof {
+        [K in keyof T as T[K] extends TValue ? K : never]: T[K]
+      }
+    : never
+
+export type ArrayFilterPredicate<T> = (value: T, index: number, array: T[]) => boolean

--- a/@xen-orchestra/web-core/lib/utils/object.util.ts
+++ b/@xen-orchestra/web-core/lib/utils/object.util.ts
@@ -1,0 +1,16 @@
+export function objectEntries<T, K extends string = string>(obj: { [Key in K]: T } | ArrayLike<T>): [K, T][] {
+  return Object.entries(obj) as [K, T][]
+}
+
+export function objectFromEntries<T = any, K extends PropertyKey = PropertyKey>(
+  entries: Iterable<readonly [K, T]>
+): { [Key in K]: T } {
+  return Object.fromEntries(entries) as { [Key in K]: T }
+}
+
+export function hasObjectProperty<TSource, TProperty extends PropertyKey>(
+  source: TSource,
+  property: TProperty
+): source is TSource & Record<TProperty, unknown> {
+  return typeof source === 'object' && source !== null && Object.prototype.hasOwnProperty.call(source, property)
+}

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,4 +31,6 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/web-core minor
+
 <!--packages-end-->


### PR DESCRIPTION
### Description

- Move item identifier outside of properties (`itemId`), which are now optional and dedicated to custom props
- Better ID guessing
- `itemId` can be a function returning an ID or just an existing property of `source`
- Makes TS typing clearer and simpler
- Allow reactive `multiple` option for flags
- Optimize flags when new value is same as old one

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
