### PR TITLE
feat(@xen-orchestra/rest-api): ability to use ndjson for collections

### DIFF
--- a/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
@@ -1,12 +1,15 @@
 import { Controller, HttpStatusCodeLiteral } from 'tsoa'
+import { Readable } from 'node:stream'
 import { Request } from 'express'
 import type { Task } from '@vates/types/lib/vates/task'
 import { XoRecord } from '@vates/types/xo'
 
 import { BASE_URL } from '../index.mjs'
+import { makeNdJsonStream } from '../helpers/stream.helper.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { makeObjectMapper } from '../helpers/object-wrapper.helper.mjs'
-import type { MaybePromise, WithHref } from '../helpers/helper.type.mjs'
+import type { MaybePromise, SendObjects, WithHref } from '../helpers/helper.type.mjs'
+import type { Response as ExResponse } from 'express'
 
 const noop = () => {}
 
@@ -21,11 +24,21 @@ export abstract class BaseController<T extends XoRecord, IsSync extends boolean>
     this.restApi = restApi
   }
 
-  sendObjects(objects: T[], req: Request): string[] | WithHref<T>[] | WithHref<Partial<T>>[] {
+  sendObjects(objects: T[], req: Request): SendObjects<T> {
     const mapper = makeObjectMapper(req)
-    const mappedObjects = objects.map(mapper) as string[] | WithHref<T>[] | WithHref<Partial<T>>[]
+    const mappedObjects = objects.map(mapper) as string[] | WithHref<T>[]
 
-    return mappedObjects
+    if (req.query.ndjson === 'true') {
+      const res = req.res as ExResponse
+      res.setHeader('Content-Type', 'application/x-ndjson')
+
+      const stream = Readable.from(makeNdJsonStream(mappedObjects))
+      stream.pipe(res)
+
+      return stream
+    } else {
+      return mappedObjects
+    }
   }
 
   /**

--- a/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
@@ -12,6 +12,7 @@ import type { MaybePromise, SendObjects, WithHref } from '../helpers/helper.type
 import type { Response as ExResponse } from 'express'
 
 const noop = () => {}
+const NDJSON_CONTENT_TYPE = 'application/x-ndjson'
 
 export abstract class BaseController<T extends XoRecord, IsSync extends boolean> extends Controller {
   abstract getObjects(): IsSync extends false ? Promise<Record<T['id'], T>> : Record<T['id'], T>
@@ -30,7 +31,7 @@ export abstract class BaseController<T extends XoRecord, IsSync extends boolean>
 
     if (req.query.ndjson === 'true') {
       const res = req.res as ExResponse
-      res.setHeader('Content-Type', 'application/x-ndjson')
+      res.setHeader('Content-Type', NDJSON_CONTENT_TYPE)
 
       const stream = Readable.from(makeNdJsonStream(mappedObjects))
       stream.pipe(res)

--- a/@xen-orchestra/rest-api/src/alarms/alarm.controller.mts
+++ b/@xen-orchestra/rest-api/src/alarms/alarm.controller.mts
@@ -10,7 +10,7 @@ import { alarm, alarmIds, partialAlarms } from '../open-api/oa-examples/alarm.oa
 import { BASE_URL } from '../index.mjs'
 import { notFoundResp, unauthorizedResp, Unbrand } from '../open-api/common/response.common.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
-import { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 
 // E.g: 'value: 0.6\nconfig:\n<variable>\n<name value="cpu_usage"/>\n<alarm_trigger_level value="0.4"/>\n<alarm_trigger_period value ="60"/>\n</variable>';
@@ -112,9 +112,10 @@ export class AlarmController extends XapiXoController<XoAlarm> {
   getAlarms(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Partial<UnbrandedXoAlarm>>[] {
+  ): SendObjects<Partial<UnbrandedXoAlarm>> {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/groups/group.controller.mts
+++ b/@xen-orchestra/rest-api/src/groups/group.controller.mts
@@ -5,7 +5,7 @@ import type { XoGroup } from '@vates/types'
 
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { group, groupIds, partialGroups } from '../open-api/oa-examples/group.oa-example.mjs'
-import type { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
 
 @Route('groups')
@@ -33,9 +33,10 @@ export class GroupController extends XoController<XoGroup> {
   async getGroups(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): Promise<string[] | WithHref<Partial<Unbrand<XoGroup>>>[]> {
+  ): Promise<SendObjects<Partial<Unbrand<XoGroup>>>> {
     return this.sendObjects(Object.values(await this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/helpers/helper.type.mts
+++ b/@xen-orchestra/rest-api/src/helpers/helper.type.mts
@@ -1,3 +1,5 @@
+import type { Readable } from 'node:stream'
+
 export type MaybePromise<T> = T | Promise<T>
 
 export type WithHref<T> = T & { href: string }
@@ -10,3 +12,7 @@ export interface XoError extends Error {
   code: number
   data?: Record<string, unknown>
 }
+
+export type NdjsonStream = Readable
+
+export type SendObjects<T> = string[] | WithHref<T>[] | NdjsonStream

--- a/@xen-orchestra/rest-api/src/helpers/stream.helper.mts
+++ b/@xen-orchestra/rest-api/src/helpers/stream.helper.mts
@@ -1,0 +1,5 @@
+export function* makeNdJsonStream(array: unknown[]) {
+  for (const object of array) {
+    yield JSON.stringify(object) + '\n'
+  }
+}

--- a/@xen-orchestra/rest-api/src/hosts/host.controller.mts
+++ b/@xen-orchestra/rest-api/src/hosts/host.controller.mts
@@ -6,7 +6,7 @@ import type { XapiHostStats, XapiStatsGranularity, XoHost } from '@vates/types'
 
 import { host, hostIds, hostStats, partialHosts } from '../open-api/oa-examples/host.oa-example.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
-import type { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 import {
   internalServerErrorResp,
@@ -36,9 +36,10 @@ export class HostController extends XapiXoController<XoHost> {
   getHosts(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Partial<Unbrand<XoHost>>>[] {
+  ): SendObjects<Partial<Unbrand<XoHost>>> {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/messages/message.controller.mts
+++ b/@xen-orchestra/rest-api/src/messages/message.controller.mts
@@ -10,7 +10,7 @@ import { alarmPredicate } from '../alarms/alarm.controller.mjs'
 import { message, messageIds, partialMessages } from '../open-api/oa-examples/message.oa-example.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
-import type { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 
 type UnbrandedXoMessage = Unbrand<XoMessage>
@@ -65,9 +65,10 @@ export class MessageController extends XapiXoController<XoMessage> {
   getMessages(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Partial<UnbrandedXoMessage>>[] {
+  ): SendObjects<Partial<UnbrandedXoMessage>> {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/networks/network.controller.mts
+++ b/@xen-orchestra/rest-api/src/networks/network.controller.mts
@@ -7,7 +7,7 @@ import type { XoNetwork } from '@vates/types'
 import { network, networkIds, partialNetworks } from '../open-api/oa-examples/network.oa-example.mjs'
 import { noContentResp, notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
-import type { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 
 @Route('networks')
@@ -31,9 +31,10 @@ export class NetworkController extends XapiXoController<XoNetwork> {
   getNetworks(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Partial<Unbrand<XoNetwork>>>[] {
+  ): SendObjects<Partial<Unbrand<XoNetwork>>> {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/pifs/pif.controller.mts
+++ b/@xen-orchestra/rest-api/src/pifs/pif.controller.mts
@@ -7,7 +7,7 @@ import type { XoPif } from '@vates/types'
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { partialPifs, pif, pifIds } from '../open-api/oa-examples/pif.oa-example.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
-import type { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 
 type UnbrandedXoPif = Unbrand<XoPif>
@@ -33,9 +33,10 @@ export class PifController extends XapiXoController<XoPif> {
   getPifs(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Partial<UnbrandedXoPif>>[] {
+  ): SendObjects<Partial<UnbrandedXoPif>> {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/pools/pool.controller.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.controller.mts
@@ -29,7 +29,7 @@ import {
   unauthorizedResp,
   type Unbrand,
 } from '../open-api/common/response.common.mjs'
-import type { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 import type { XoNetwork, XoPif, XoPool } from '@vates/types'
 import { partialPools, pool, poolIds } from '../open-api/oa-examples/pool.oa-example.mjs'
@@ -59,9 +59,10 @@ export class PoolController extends XapiXoController<XoPool> {
   getPools(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Partial<Unbrand<XoPool>>>[] {
+  ): SendObjects<Partial<Unbrand<XoPool>>> {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/schedules/schedule.controller.mts
+++ b/@xen-orchestra/rest-api/src/schedules/schedule.controller.mts
@@ -14,7 +14,7 @@ import {
 } from '../open-api/common/response.common.mjs'
 import { partialSchedules, schedule, scheduleIds } from '../open-api/oa-examples/schedule.oa-example.mjs'
 import { taskLocation } from '../open-api/oa-examples/task.oa-example.mjs'
-import type { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
 
 @Route('schedules')
@@ -42,9 +42,10 @@ export class ScheduleController extends XoController<XoSchedule> {
   async getSchedules(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): Promise<string[] | WithHref<Partial<Unbrand<XoSchedule>>>[]> {
+  ): Promise<SendObjects<Partial<Unbrand<XoSchedule>>>> {
     return this.sendObjects(Object.values(await this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/servers/server.controller.mts
+++ b/@xen-orchestra/rest-api/src/servers/server.controller.mts
@@ -31,7 +31,7 @@ import {
 } from '../open-api/common/response.common.mjs'
 import { partialServers, server, serverId, serverIds } from '../open-api/oa-examples/server.oa-example.mjs'
 import { taskLocation } from '../open-api/oa-examples/task.oa-example.mjs'
-import type { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
 
 @Route('servers')
@@ -59,9 +59,10 @@ export class ServerController extends XoController<XoServer> {
   async getServers(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): Promise<string[] | WithHref<Partial<Unbrand<XoServer>>>[]> {
+  ): Promise<SendObjects<Partial<Unbrand<XoServer>>>> {
     return this.sendObjects(Object.values(await this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/srs/sr.controller.mts
+++ b/@xen-orchestra/rest-api/src/srs/sr.controller.mts
@@ -7,7 +7,7 @@ import type { XoSr } from '@vates/types'
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { partialSrs, sr, srIds } from '../open-api/oa-examples/sr.oa-example.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
-import type { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 
 @Route('srs')
@@ -31,9 +31,10 @@ export class SrController extends XapiXoController<XoSr> {
   getSrs(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Partial<Unbrand<XoSr>>>[] {
+  ): SendObjects<Partial<Unbrand<XoSr>>> {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/users/user.controller.mts
+++ b/@xen-orchestra/rest-api/src/users/user.controller.mts
@@ -5,7 +5,7 @@ import type { XoUser } from '@vates/types'
 
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { partialUsers, user, userIds } from '../open-api/oa-examples/user.oa-example.mjs'
-import type { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
 
 @Route('users')
@@ -46,9 +46,10 @@ export class UserController extends XoController<XoUser> {
   async getUsers(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): Promise<string[] | WithHref<Partial<Unbrand<XoUser>>>[]> {
+  ): Promise<SendObjects<Partial<Unbrand<XoUser>>>> {
     const users = Object.values(await this.getObjects({ filter, limit }))
     return this.sendObjects(users, req)
   }

--- a/@xen-orchestra/rest-api/src/vbds/vbd.controller.mts
+++ b/@xen-orchestra/rest-api/src/vbds/vbd.controller.mts
@@ -7,7 +7,7 @@ import type { XoVbd } from '@vates/types'
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { partialVbds, vbd, vbdIds } from '../open-api/oa-examples/vbd.oa-example.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
-import type { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 
 @Route('vbds')
@@ -32,9 +32,10 @@ export class VbdController extends XapiXoController<XoVbd> {
   getVbds(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Partial<Unbrand<XoVbd>>>[] {
+  ): SendObjects<Partial<Unbrand<XoVbd>>> {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/vdi-snapshots/vdi-snapshot.controller.mts
+++ b/@xen-orchestra/rest-api/src/vdi-snapshots/vdi-snapshot.controller.mts
@@ -6,7 +6,7 @@ import type { XoVdiSnapshot } from '@vates/types'
 
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
-import type { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 import { partialVdiSnapshots, vdiSnapshot, vdiSnapshotIds } from '../open-api/oa-examples/vdi-snapshot.oa-example.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 
@@ -31,9 +31,10 @@ export class VdiSnapshotController extends XapiXoController<XoVdiSnapshot> {
   getVdiSnapshots(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Partial<Unbrand<XoVdiSnapshot>>>[] {
+  ): SendObjects<Partial<Unbrand<XoVdiSnapshot>>> {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/vdis/vdi.controller.mts
+++ b/@xen-orchestra/rest-api/src/vdis/vdi.controller.mts
@@ -6,7 +6,7 @@ import type { XoVdi } from '@vates/types'
 
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
-import type { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 import { partialVdis, vdi, vdiIds } from '../open-api/oa-examples/vdi.oa-example.mjs'
 
@@ -31,9 +31,10 @@ export class VdiController extends XapiXoController<XoVdi> {
   getVdis(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Partial<Unbrand<XoVdi>>>[] {
+  ): SendObjects<Partial<Unbrand<XoVdi>>> {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/vifs/vif.controller.mts
+++ b/@xen-orchestra/rest-api/src/vifs/vif.controller.mts
@@ -6,7 +6,7 @@ import type { XoVif } from '@vates/types'
 import { provide } from 'inversify-binding-decorators'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
-import type { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 import { partialVifs, vif, vifIds } from '../open-api/oa-examples/vif.oa-example.mjs'
 
@@ -33,9 +33,10 @@ export class VifController extends XapiXoController<XoVif> {
   getVifs(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Partial<UnbrandedXoVif>>[] {
+  ): SendObjects<Partial<UnbrandedXoVif>> {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/vm-controller/vm-controller.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-controller/vm-controller.controller.mts
@@ -7,7 +7,7 @@ import { Request as ExRequest } from 'express'
 
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { provide } from 'inversify-binding-decorators'
-import type { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 import {
   partialVmControllers,
   vmController,
@@ -36,9 +36,10 @@ export class VmControllerController extends XapiXoController<XoVmController> {
   getVmControllers(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Partial<Unbrand<XoVmController>>>[] {
+  ): SendObjects<Partial<Unbrand<XoVmController>>> {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/vm-snapshots/vm-snapshot.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-snapshots/vm-snapshot.controller.mts
@@ -6,7 +6,7 @@ import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 import { XoVmSnapshot } from '@vates/types'
-import { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 import { provide } from 'inversify-binding-decorators'
 import { partialVmSnapshots, vmSnapshot, vmSnapshotIds } from '../open-api/oa-examples/vm-snapshot.oa-example.mjs'
 
@@ -32,9 +32,10 @@ export class VmSnapshotController extends XapiXoController<XoVmSnapshot> {
   getVmSnapshots(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Partial<Unbrand<XoVmSnapshot>>>[] {
+  ): SendObjects<Partial<Unbrand<XoVmSnapshot>>> {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
@@ -6,7 +6,7 @@ import type { XoVmTemplate } from '@vates/types'
 
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
-import type { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 import { partialVmTemplates, vmTemplate, vmTemplateIds } from '../open-api/oa-examples/vm-template.oa-example.mjs'
@@ -32,9 +32,10 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
   getVmTemplates(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Partial<Unbrand<XoVmTemplate>>>[] {
+  ): SendObjects<Partial<Unbrand<XoVmTemplate>>> {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -18,7 +18,7 @@ import { BASE_URL } from '../index.mjs'
 import { partialVms, vm, vmIds, vmStatsExample } from '../open-api/oa-examples/vm.oa-example.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { taskLocation } from '../open-api/oa-examples/task.oa-example.mjs'
-import type { WithHref } from '../helpers/helper.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 
 const IGNORED_VDIS_TAG = '[NOSNAP]'
@@ -47,9 +47,10 @@ export class VmController extends XapiXoController<XoVm> {
   getVms(
     @Request() req: ExRequest,
     @Query() fields?: string,
+    @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ): string[] | WithHref<Partial<Unbrand<XoVm>>>[] {
+  ): SendObjects<Partial<Unbrand<XoVm>>> {
     return this.sendObjects(Object.values(this.getObjects({ filter, limit })), req)
   }
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,8 @@
 
 ### Bug fixes
 
+[REST API] Ability to use `ndjson` query parameter also on migrated collections (PR [#8628](https://github.com/vatesfr/xen-orchestra/pull/8628))
+
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [VM/Advanced] Fix CPU mask list in VM (PR [#8661](https://github.com/vatesfr/xen-orchestra/pull/8661))

--- a/packages/xo-server/docs/rest-api.md
+++ b/packages/xo-server/docs/rest-api.md
@@ -114,7 +114,7 @@ Content-Type: application/json
 As NDJSON:
 
 ```http
-GET /rest/v0/vms?fields=name_label,power_state&ndjson HTTP/1.1
+GET /rest/v0/vms?fields=name_label,power_state&ndjson=true HTTP/1.1
 Cookie: authenticationToken=TN2YBOMYtXB_hHtf4wTzm9p5tTuqq2i15yeuhcz2xXM
 
 HTTP/1.1 200 OK
@@ -147,7 +147,7 @@ The `fields` and `filter` parameters are supported.
 Example:
 
 ```http
-GET /rest/v0/vms?fields=start,status&ndjson&watch HTTP/1.1
+GET /rest/v0/vms?fields=start,status&ndjson=true&watch HTTP/1.1
 Cookie: authenticationToken=TN2YBOMYtXB_hHtf4wTzm9p5tTuqq2i15yeuhcz2xXM
 
 HTTP/1.1 200 OK


### PR DESCRIPTION
### Description

The legacy REST API allows passing an `ndjson` query parameter to all collections. This feature is backported to the REST API.

[XO-1076](https://project.vates.tech/vates-global/browse/XO-1076/)
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
