### PR TITLE
fix(xo-web): hub ensure template is a template

### DIFF
--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -3970,12 +3970,13 @@ const downloadAndInstallXosanPack = (pack, pool, { version }) =>
     pool: resolveId(pool),
   })
 
-export const downloadAndInstallResource = ({ namespace, id, version, sr }) =>
+export const downloadAndInstallResource = ({ namespace, id, version, sr, templateOnly }) =>
   _call('cloud.downloadAndInstallResource', {
     namespace,
     id,
     version,
     sr: resolveId(sr),
+    templateOnly,
   })
 
 import UpdateXosanPacksModal from './update-xosan-packs-modal' // eslint-disable-line import/first

--- a/packages/xo-web/src/xo-app/hub/templates/resource.js
+++ b/packages/xo-web/src/xo-app/hub/templates/resource.js
@@ -73,6 +73,7 @@ export default decorate([
                 id,
                 version,
                 sr: defined(resourceParams.mapPoolsSrs[pool.id], pool.default_SR),
+                templateOnly: true,
               })
               const oldTemplates = filter(
                 templates,


### PR DESCRIPTION
### Description

Following https://git.vates.tech/vates/xoa/pulls/234

Prevent importing hub templates that are actually not templates. Importing an incorrect template previously created a VM without any way to know it.

[XO-1021](https://project.vates.tech/vates-global/browse/XO-1021/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
