### PR TITLE
fix(xo-server,auth-ldap): do not pass undefined ID to registerUser2

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -54,6 +54,7 @@
 - @xen-orchestra/web patch
 - @xen-orchestra/web-core patch
 - xo-server minor
+- xo-server-auth-ldap patch
 - xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-server-auth-ldap/src/index.js
+++ b/packages/xo-server-auth-ldap/src/index.js
@@ -296,6 +296,10 @@ class AuthLdap {
           }
 
           const ldapId = entry[this._userIdAttribute]
+          if (ldapId === undefined) {
+            throw new Error(`could not find field ${this._userIdAttribute} on user ${username}`)
+          }
+
           const user = await this._xo.registerUser2('ldap', {
             user: { id: ldapId, name: username },
           })

--- a/packages/xo-server/src/xo-mixins/subjects.mjs
+++ b/packages/xo-server/src/xo-mixins/subjects.mjs
@@ -248,6 +248,8 @@ export default class {
   // - name: the name of the user according to the provider
   // - data: additional data about the user that the provider may want to store
   async registerUser2(providerId, { user: { id, name }, data }) {
+    assert.equal(typeof id, 'string')
+    assert.notEqual(id, '')
     assert.equal(typeof name, 'string')
     assert.notEqual(name, '')
 


### PR DESCRIPTION
### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
