### PR TITLE
fix(xo-web): prevent `subscribeSelfLicenses` from returning an object

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [XOA] Fix "an error has occurred" when XOA is not registered
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -30,5 +32,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- xo-web patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [XOA] Fix "an error has occurred" when XOA is not registered
+- [XOA] Fix "an error has occurred" when XOA is not registered (PR [#8646](https://github.com/vatesfr/xen-orchestra/pull/8646))
 
 ### Packages to release
 

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -4060,7 +4060,19 @@ export const selfBindLicense = ({ id, plan, oldXoaId }) =>
     .then(() => _call('xoa.licenses.bindToSelf', { licenseId: id, oldXoaId }), noop)
     ::tap(subscribeSelfLicenses.forceRefresh)
 
-export const subscribeSelfLicenses = createSubscription(() => _call('xoa.licenses.getSelf'))
+export const subscribeSelfLicenses = createSubscription(() =>
+  _call('xoa.licenses.getSelf').then(licenses => {
+    if (!Array.isArray(licenses)) {
+      if (licenses?.state === 'register-needed') {
+        return []
+      }
+
+      throw new Error(licenses?.message || 'Could not fetch licenses')
+    }
+
+    return licenses
+  })
+)
 
 const createLicenseSubscription = productType =>
   createSubscription(() =>


### PR DESCRIPTION
Introduced by #8523

### Description

In `subscribeSelfLicenses`, the call to `xoa.licenses.getSelf` may return an object in case of error (for instance if the XOA is not registered), which breaks `getLicenseNearExpiration`. This fix ensures that either an array is returned or an error is thrown.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
