### PR TITLE
fix(xo-server/plugins): disable strictRequired in JSON compilation

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -40,6 +40,7 @@
 
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+- xo-server patch
 - xo-server-perf-alert patch
 - xo-web minor
 

--- a/packages/xo-server/src/xo-mixins/plugins.mjs
+++ b/packages/xo-server/src/xo-mixins/plugins.mjs
@@ -17,6 +17,11 @@ export default class {
   constructor(app) {
     this._ajv = new Ajv({
       strict: 'log',
+      // `strictRequired` option seems to require that the object's properties are defined in the same sub-schema (even
+      // though the documentation says that it can also be defined in a parent schema) which is inconvenient with
+      // features such as `anyOf` (see xo-server-auth-oidc)
+      // https://ajv.js.org/strict-mode.html#defined-required-properties
+      strictRequired: false,
       useDefaults: true,
     }).addVocabulary(['$multiline', '$type', 'enumNames'])
     this._plugins = { __proto__: null }


### PR DESCRIPTION
See https://ajv.js.org/strict-mode.html#defined-required-properties

### Description

`strictRequired` option seems to require that the object's properties are defined in the same sub-schema (even though the documentation says that it can also be defined in a parent schema) which is inconvenient with features such as `anyOf` (see xo-server-auth-oidc)

Tested with this schema which requires either `foo` or `bar` to be present:
```js
const schema = {
  type: 'object',
  properties: {
    foo: { type: 'string' },
    bar: { type: 'string' },
  },
  anyOf: [
    { required: ['foo'] },
    { required: ['bar'] },
  ],
}

const validate = new Ajv({
  strictRequired: 'log',
}).compile(schema)
```

Ajv complains about `required`s being declared in sub-schemas:
```
strict mode: required property "foo" is not defined at "#/anyOf/0" (strictRequired)
strict mode: required property "bar" is not defined at "#/anyOf/1" (strictRequired)
```

Then:
```js
console.log('Should be valid:', validate({ foo: 'hello' }))
console.log('Should be invalid:', validate({}))
```

which still correctly detects when sub-schema `required` conditions are not respected, despite the above warnings:
```
Should be valid: true
Should be invalid: false
```

This PR disables the warnings.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
