### PR TITLE
feat(xo-server-backup-reports): avoid making report content depend on reportWhen

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,6 +31,7 @@
 - [REST API] Ability to delete a network `DELETE /rest/v0/networks/<network-id>` (PR [#8671](https://github.com/vatesfr/xen-orchestra/pull/8671))
 - [REST API] Expose `GET /rest/v0/pcis` and `GET /rest/v0/pcis/<pci-id>` (PR [#8686](https://github.com/vatesfr/xen-orchestra/pull/8686))
 - [REST API] expose `GET /rest/v0/pgpus` and `GET /rest/v0/pgpus/<pgpu-id>` (PR [#8684](https://github.com/vatesfr/xen-orchestra/pull/8684))
+- [Backup reports] Make content of backup reports independant of 'Report when' parameter (PR [#8670](https://github.com/vatesfr/xen-orchestra/pull/8670))
 
 - **Azure Blob Storage**:
   - [Backups]: Implemented Azure Blob Storage for backups, Integrating with both the Azurite emulator and Azure (PR [#8415](https://github.com/vatesfr/xen-orchestra/pull/8415))
@@ -68,6 +69,7 @@
 - xo-remote-parser minor
 - xo-server minor
 - xo-server-auth-oidc patch
+- xo-server-backup-reports minor
 - xo-server-perf-alert patch
 - xo-web patch
 

--- a/packages/xo-server-backup-reports/src/index.js
+++ b/packages/xo-server-backup-reports/src/index.js
@@ -168,7 +168,7 @@ class BackupReportsXoPlugin {
 
     const tasksByStatus = groupBy(log.tasks, 'status')
 
-    if (log.status === 'failure' && log.data?.hideSuccessfulVms) {
+    if (log.status === 'failure' && log.data?.hideSuccessfulItems) {
       delete tasksByStatus.success
     }
 
@@ -248,7 +248,7 @@ class BackupReportsXoPlugin {
         continue
       }
 
-      if (taskLog.status === 'success' && log.status === 'failure' && log.data?.hideSuccessfulVms) {
+      if (taskLog.status === 'success' && log.status === 'failure' && log.data?.hideSuccessfulItems) {
         ++nSuccesses
         continue
       }
@@ -366,7 +366,7 @@ class BackupReportsXoPlugin {
         skipped: { tasks: skippedVms, count: nSkipped },
         interrupted: { tasks: interruptedVms, count: nInterrupted },
         success: {
-          tasks: log.status === 'failure' && log.data?.hideSuccessfulVms ? [] : successfulVms,
+          tasks: log.status === 'failure' && log.data?.hideSuccessfulItems ? [] : successfulVms,
           count: nSuccesses,
         },
         vmTasks: { count: nVmTasks },

--- a/packages/xo-server-backup-reports/src/index.js
+++ b/packages/xo-server-backup-reports/src/index.js
@@ -136,8 +136,9 @@ class BackupReportsXoPlugin {
         // Handle improper value introduced by:
         // https://github.com/vatesfr/xen-orchestra/commit/753ee994f2948bbaca9d3161eaab82329a682773#diff-9c044ab8a42ed6576ea927a64c1ec3ebR105
         reportWhen === 'Never' ||
+        // 'failure' refers to 'Skipped and failure'
         (reportWhen === 'failure' && log.status === 'success') ||
-        // 'error' refers to 'Skipped and failure'
+        // 'error' refers to 'Failure'
         (reportWhen === 'error' && (log.status === 'success' || log.status === 'skipped')))
     ) {
       return

--- a/packages/xo-server/src/xo-mixins/jobs/index.mjs
+++ b/packages/xo-server/src/xo-mixins/jobs/index.mjs
@@ -276,7 +276,7 @@ export default class Jobs {
       runs[runJobId] = { cancel }
       $defer(() => delete runs[runJobId])
 
-      const status = await executor({
+      await executor({
         app,
         cancelToken: token,
         connection,
@@ -296,7 +296,7 @@ export default class Jobs {
         true
       )
 
-      app.emit('job:terminated', runJobId, { status, type })
+      app.emit('job:terminated', runJobId, { type })
     } catch (error) {
       await logger.error(
         `The execution of ${id} has failed.`,

--- a/packages/xo-server/src/xo-mixins/jobs/index.mjs
+++ b/packages/xo-server/src/xo-mixins/jobs/index.mjs
@@ -176,7 +176,7 @@ export default class Jobs {
               mode: job.mode,
               reportWhen: job.settings['']?.reportWhen ?? 'failure',
               backupReportTpl: job.settings['']?.backupReportTpl,
-              hideSuccessfulVms: job.settings['']?.hideSuccessfulVms,
+              hideSuccessfulItems: job.settings['']?.hideSuccessfulItems,
             }
           : undefined,
       event: 'job.start',

--- a/packages/xo-server/src/xo-mixins/jobs/index.mjs
+++ b/packages/xo-server/src/xo-mixins/jobs/index.mjs
@@ -176,6 +176,7 @@ export default class Jobs {
               mode: job.mode,
               reportWhen: job.settings['']?.reportWhen ?? 'failure',
               backupReportTpl: job.settings['']?.backupReportTpl,
+              hideSuccessfulVms: job.settings['']?.hideSuccessfulVms,
             }
           : undefined,
       event: 'job.start',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -633,6 +633,7 @@ const messages = {
   numberOfWeeklyBackupsKept: 'Number of weekly backups kept',
   numberOfMonthlyBackupsKept: 'Number of monthly backups kept',
   numberOfYearlyBackupsKept: 'Number of yearly backups kept',
+  hideSuccessfulVms: 'Hide successful VMs in failure reports',
 
   // ------ New Remote -----
   newRemote: 'New file system remote',

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -633,7 +633,7 @@ const messages = {
   numberOfWeeklyBackupsKept: 'Number of weekly backups kept',
   numberOfMonthlyBackupsKept: 'Number of monthly backups kept',
   numberOfYearlyBackupsKept: 'Number of yearly backups kept',
-  hideSuccessfulVms: 'Hide successful VMs in failure reports',
+  hideSuccessfulItems: 'Hide successful items in failure reports',
 
   // ------ New Remote -----
   newRemote: 'New file system remote',

--- a/packages/xo-web/src/xo-app/backup/_getSettingsWithNonDefaultValue.js
+++ b/packages/xo-web/src/xo-app/backup/_getSettingsWithNonDefaultValue.js
@@ -9,7 +9,7 @@ const DEFAULTS = {
   compression: '',
   concurrency: 0,
   fullInterval: 0,
-  hideSuccessfulVms: false,
+  hideSuccessfulItems: false,
   nbdConcurrency: 1,
   offlineBackup: false,
   offlineSnapshot: false,

--- a/packages/xo-web/src/xo-app/backup/_getSettingsWithNonDefaultValue.js
+++ b/packages/xo-web/src/xo-app/backup/_getSettingsWithNonDefaultValue.js
@@ -9,6 +9,7 @@ const DEFAULTS = {
   compression: '',
   concurrency: 0,
   fullInterval: 0,
+  hideSuccessfulVms: false,
   nbdConcurrency: 1,
   offlineBackup: false,
   offlineSnapshot: false,

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -699,9 +699,9 @@ const New = decorate([
           backupReportTpl: compactBackupTpl ? 'compactMjml' : 'mjml',
         })
       },
-      setHideSucessfulVms({ setGlobalSettings }, hideSuccessfulVms) {
+      setHideSuccessfulItems({ setGlobalSettings }, hideSuccessfulItems) {
         setGlobalSettings({
-          hideSuccessfulVms,
+          hideSuccessfulItems,
         })
       },
       setMergeBackupsSynchronously({ setGlobalSettings }, mergeBackupsSynchronously) {
@@ -721,7 +721,7 @@ const New = decorate([
       inputNbdConcurrency: generateId,
       inputNRetriesVmBackupFailures: generateId,
       inputBackupReportTplId: generateId,
-      inputHideSuccessfulVmsId: generateId,
+      inputHideSuccessfulItemsId: generateId,
       inputMergeBackupsSynchronously: generateId,
       inputTimeoutId: generateId,
       inputLongTermRetentionDaily: generateId,
@@ -848,7 +848,7 @@ const New = decorate([
       reportRecipients,
       reportWhen = 'failure',
       backupReportTpl = 'mjml',
-      hideSuccessfulVms,
+      hideSuccessfulItems,
       mergeBackupsSynchronously,
       timeout,
     } = settings.get('') || {}
@@ -1245,14 +1245,14 @@ const New = decorate([
                         />
                       </FormGroup>
                       <FormGroup>
-                        <label htmlFor={state.inputHideSuccessfulVmsId}>
-                          <strong>{_('hideSuccessfulVms')}</strong>
+                        <label htmlFor={state.inputHideSuccessfulItemsId}>
+                          <strong>{_('hideSuccessfulItems')}</strong>
                         </label>
                         <Toggle
                           className='pull-right'
-                          id={state.inputHideSuccessfulVmsId}
-                          value={hideSuccessfulVms}
-                          onChange={effects.setHideSucessfulVms}
+                          id={state.inputHideSuccessfulItemsId}
+                          value={hideSuccessfulItems}
+                          onChange={effects.setHideSuccessfulItems}
                         />
                       </FormGroup>
                       <FormGroup>

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -699,6 +699,11 @@ const New = decorate([
           backupReportTpl: compactBackupTpl ? 'compactMjml' : 'mjml',
         })
       },
+      setHideSucessfulVms({ setGlobalSettings }, hideSuccessfulVms) {
+        setGlobalSettings({
+          hideSuccessfulVms,
+        })
+      },
       setMergeBackupsSynchronously({ setGlobalSettings }, mergeBackupsSynchronously) {
         setGlobalSettings({
           mergeBackupsSynchronously,
@@ -716,6 +721,7 @@ const New = decorate([
       inputNbdConcurrency: generateId,
       inputNRetriesVmBackupFailures: generateId,
       inputBackupReportTplId: generateId,
+      inputHideSuccessfulVmsId: generateId,
       inputMergeBackupsSynchronously: generateId,
       inputTimeoutId: generateId,
       inputLongTermRetentionDaily: generateId,
@@ -842,6 +848,7 @@ const New = decorate([
       reportRecipients,
       reportWhen = 'failure',
       backupReportTpl = 'mjml',
+      hideSuccessfulVms,
       mergeBackupsSynchronously,
       timeout,
     } = settings.get('') || {}
@@ -1235,6 +1242,17 @@ const New = decorate([
                           id={state.inputBackupReportTplId}
                           value={backupReportTpl === 'compactMjml'}
                           onChange={effects.setBackupReportTpl}
+                        />
+                      </FormGroup>
+                      <FormGroup>
+                        <label htmlFor={state.inputHideSuccessfulVmsId}>
+                          <strong>{_('hideSuccessfulVms')}</strong>
+                        </label>
+                        <Toggle
+                          className='pull-right'
+                          id={state.inputHideSuccessfulVmsId}
+                          value={hideSuccessfulVms}
+                          onChange={effects.setHideSucessfulVms}
                         />
                       </FormGroup>
                       <FormGroup>

--- a/packages/xo-web/src/xo-app/backup/new/metadata/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/metadata/index.js
@@ -197,6 +197,9 @@ export default decorate([
       setBackupReportTpl({ setGlobalSettings }, compactBackupTpl) {
         setGlobalSettings('backupReportTpl', compactBackupTpl ? 'compactMjml' : 'mjml')
       },
+      setHideSucessfulVms({ setGlobalSettings }, hideSuccessfulVms) {
+        setGlobalSettings('hideSuccessfulVms', hideSuccessfulVms)
+      },
       toggleMode:
         (_, { mode }) =>
         state => ({
@@ -218,6 +221,7 @@ export default decorate([
     computed: {
       idForm: generateId,
       inputBackupReportTplId: generateId,
+      inputHideSuccessfulVmsId: generateId,
 
       modePoolMetadata: ({ _modePoolMetadata }, { job }) =>
         defined(_modePoolMetadata, () => !isEmpty(destructPattern(job.pools))),
@@ -296,6 +300,7 @@ export default decorate([
       reportWhen = 'failure',
       reportRecipients = [],
       backupReportTpl = 'mjml',
+      hideSuccessfulVms,
     } = defined(() => state.settings[GLOBAL_SETTING_KEY], {})
 
     return (
@@ -396,6 +401,17 @@ export default decorate([
                       id={state.inputBackupReportTplId}
                       value={backupReportTpl === 'compactMjml'}
                       onChange={effects.setBackupReportTpl}
+                    />
+                  </FormGroup>
+                  <FormGroup>
+                    <label htmlFor={state.inputHideSuccessfulVmsId}>
+                      <strong>{_('hideSuccessfulVms')}</strong>
+                    </label>
+                    <Toggle
+                      className='pull-right'
+                      id={state.inputHideSuccessfulVmsId}
+                      value={hideSuccessfulVms}
+                      onChange={effects.setHideSucessfulVms}
                     />
                   </FormGroup>
                 </CardBlock>

--- a/packages/xo-web/src/xo-app/backup/new/metadata/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/metadata/index.js
@@ -197,8 +197,8 @@ export default decorate([
       setBackupReportTpl({ setGlobalSettings }, compactBackupTpl) {
         setGlobalSettings('backupReportTpl', compactBackupTpl ? 'compactMjml' : 'mjml')
       },
-      setHideSucessfulVms({ setGlobalSettings }, hideSuccessfulVms) {
-        setGlobalSettings('hideSuccessfulVms', hideSuccessfulVms)
+      setHideSuccessfulItems({ setGlobalSettings }, hideSuccessfulItems) {
+        setGlobalSettings('hideSuccessfulItems', hideSuccessfulItems)
       },
       toggleMode:
         (_, { mode }) =>
@@ -221,7 +221,7 @@ export default decorate([
     computed: {
       idForm: generateId,
       inputBackupReportTplId: generateId,
-      inputHideSuccessfulVmsId: generateId,
+      inputHideSuccessfulItemsId: generateId,
 
       modePoolMetadata: ({ _modePoolMetadata }, { job }) =>
         defined(_modePoolMetadata, () => !isEmpty(destructPattern(job.pools))),
@@ -300,7 +300,7 @@ export default decorate([
       reportWhen = 'failure',
       reportRecipients = [],
       backupReportTpl = 'mjml',
-      hideSuccessfulVms,
+      hideSuccessfulItems,
     } = defined(() => state.settings[GLOBAL_SETTING_KEY], {})
 
     return (
@@ -404,14 +404,14 @@ export default decorate([
                     />
                   </FormGroup>
                   <FormGroup>
-                    <label htmlFor={state.inputHideSuccessfulVmsId}>
-                      <strong>{_('hideSuccessfulVms')}</strong>
+                    <label htmlFor={state.inputHideSuccessfulItemsId}>
+                      <strong>{_('hideSuccessfulItems')}</strong>
                     </label>
                     <Toggle
                       className='pull-right'
-                      id={state.inputHideSuccessfulVmsId}
-                      value={hideSuccessfulVms}
-                      onChange={effects.setHideSucessfulVms}
+                      id={state.inputHideSuccessfulItemsId}
+                      value={hideSuccessfulItems}
+                      onChange={effects.setHideSuccessfulItems}
                     />
                   </FormGroup>
                 </CardBlock>

--- a/packages/xo-web/src/xo-app/backup/new/mirror/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/mirror/index.js
@@ -154,6 +154,11 @@ const NewMirrorBackup = decorate([
         setAdvancedSettings({ nRetriesVmBackupFailures }),
       setBackupReportTpl: ({ setAdvancedSettings }, compactBackupTpl) =>
         setAdvancedSettings({ backupReportTpl: compactBackupTpl ? 'compactMjml' : 'mjml' }),
+      setHideSucessfulVms({ setAdvancedSettings }, hideSuccessfulVms) {
+        setAdvancedSettings({
+          hideSuccessfulVms,
+        })
+      },
       setSourceRemote: (_, obj) => () => ({
         sourceRemote: obj === null ? {} : obj.value,
         vmsToMirror: undefined,
@@ -270,6 +275,7 @@ const NewMirrorBackup = decorate([
       inputMaxExportRateId: generateId,
       inputNRetriesVmBackupFailures: generateId,
       inputBackupReportTplId: generateId,
+      inputHideSuccessfulVmsId: generateId,
       inputMirrorAllId: generateId,
       isBackupInvalid: state =>
         state.isMissingName ||
@@ -309,6 +315,7 @@ const NewMirrorBackup = decorate([
       timeout,
       maxExportRate,
       backupReportTpl = 'mjml',
+      hideSuccessfulVms,
       nRetriesVmBackupFailures = 0,
     } = state.advancedSettings
     return (
@@ -438,6 +445,17 @@ const NewMirrorBackup = decorate([
                           id={state.inputBackupReportTplId}
                           value={backupReportTpl === 'compactMjml'}
                           onChange={effects.setBackupReportTpl}
+                        />
+                      </FormGroup>
+                      <FormGroup>
+                        <label htmlFor={state.inputHideSuccessfulVmsId}>
+                          <strong>{_('hideSuccessfulVms')}</strong>
+                        </label>
+                        <Toggle
+                          className='pull-right'
+                          id={state.inputHideSuccessfulVmsId}
+                          value={hideSuccessfulVms}
+                          onChange={effects.setHideSucessfulVms}
                         />
                       </FormGroup>
                     </div>

--- a/packages/xo-web/src/xo-app/backup/new/mirror/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/mirror/index.js
@@ -154,9 +154,9 @@ const NewMirrorBackup = decorate([
         setAdvancedSettings({ nRetriesVmBackupFailures }),
       setBackupReportTpl: ({ setAdvancedSettings }, compactBackupTpl) =>
         setAdvancedSettings({ backupReportTpl: compactBackupTpl ? 'compactMjml' : 'mjml' }),
-      setHideSucessfulVms({ setAdvancedSettings }, hideSuccessfulVms) {
+      setHideSuccessfulItems({ setAdvancedSettings }, hideSuccessfulItems) {
         setAdvancedSettings({
-          hideSuccessfulVms,
+          hideSuccessfulItems,
         })
       },
       setSourceRemote: (_, obj) => () => ({
@@ -275,7 +275,7 @@ const NewMirrorBackup = decorate([
       inputMaxExportRateId: generateId,
       inputNRetriesVmBackupFailures: generateId,
       inputBackupReportTplId: generateId,
-      inputHideSuccessfulVmsId: generateId,
+      inputHideSuccessfulItemsId: generateId,
       inputMirrorAllId: generateId,
       isBackupInvalid: state =>
         state.isMissingName ||
@@ -315,7 +315,7 @@ const NewMirrorBackup = decorate([
       timeout,
       maxExportRate,
       backupReportTpl = 'mjml',
-      hideSuccessfulVms,
+      hideSuccessfulItems,
       nRetriesVmBackupFailures = 0,
     } = state.advancedSettings
     return (
@@ -448,14 +448,14 @@ const NewMirrorBackup = decorate([
                         />
                       </FormGroup>
                       <FormGroup>
-                        <label htmlFor={state.inputHideSuccessfulVmsId}>
-                          <strong>{_('hideSuccessfulVms')}</strong>
+                        <label htmlFor={state.inputHideSuccessfulItemsId}>
+                          <strong>{_('hideSuccessfulItems')}</strong>
                         </label>
                         <Toggle
                           className='pull-right'
-                          id={state.inputHideSuccessfulVmsId}
-                          value={hideSuccessfulVms}
-                          onChange={effects.setHideSucessfulVms}
+                          id={state.inputHideSuccessfulItemsId}
+                          value={hideSuccessfulItems}
+                          onChange={effects.setHideSuccessfulItems}
                         />
                       </FormGroup>
                     </div>

--- a/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
+++ b/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
@@ -322,6 +322,7 @@ class JobsTable extends React.Component {
             compression,
             concurrency,
             fullInterval,
+            hideSuccessfulVms,
             maxExportRate,
             nbdConcurrency,
             nRetriesVmBackupFailures,
@@ -350,6 +351,9 @@ class JobsTable extends React.Component {
                     _(backupReportTpl === 'compactMjml' ? 'stateEnabled' : 'stateDisabled')
                   )}
                 </Li>
+              )}
+              {hideSuccessfulVms !== undefined && (
+                <Li>{_.keyValue(_('hideSuccessfulVms'), _(hideSuccessfulVms ? 'stateEnabled' : 'stateDisabled'))}</Li>
               )}
               {concurrency !== undefined && <Li>{_.keyValue(_('concurrency'), concurrency)}</Li>}
               {preferNbd && <Li>{_.keyValue(_('nbdConnections'), nbdConcurrency ?? 1)}</Li>}

--- a/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
+++ b/packages/xo-web/src/xo-app/backup/overview/tab-jobs.js
@@ -322,7 +322,7 @@ class JobsTable extends React.Component {
             compression,
             concurrency,
             fullInterval,
-            hideSuccessfulVms,
+            hideSuccessfulItems,
             maxExportRate,
             nbdConcurrency,
             nRetriesVmBackupFailures,
@@ -352,8 +352,10 @@ class JobsTable extends React.Component {
                   )}
                 </Li>
               )}
-              {hideSuccessfulVms !== undefined && (
-                <Li>{_.keyValue(_('hideSuccessfulVms'), _(hideSuccessfulVms ? 'stateEnabled' : 'stateDisabled'))}</Li>
+              {hideSuccessfulItems !== undefined && (
+                <Li>
+                  {_.keyValue(_('hideSuccessfulItems'), _(hideSuccessfulItems ? 'stateEnabled' : 'stateDisabled'))}
+                </Li>
               )}
               {concurrency !== undefined && <Li>{_.keyValue(_('concurrency'), concurrency)}</Li>}
               {preferNbd && <Li>{_.keyValue(_('nbdConnections'), nbdConcurrency ?? 1)}</Li>}


### PR DESCRIPTION
### Description

New parameter in backup job configuration:
![image](https://github.com/user-attachments/assets/b0404096-700a-450d-9696-7a43d01c7772)


**review by commit**

- 1st commit: remove a value that was only used for backup reports, and was no longer used since we use the template system
- 2nd commit: avoid the backup report content to differ when the backup job has `reportWhen = false`, which also caused differences between regular backup reports and backup reports generated with the "test plugin" button. To make sure the users can still have the previous behavior, we add parameter in the backup job configuration that allows short failure reports by not displaying all successful VMs in error reports.
- 3rd commit: just rewording "successful VMs" to "successful items" so it also makes sense for metadata backups

[XO-1090](https://project.vates.tech/vates-global/browse/XO-1090/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
