### PR TITLE
docs(usage-reports): fix link to the server-usage-report plugin doc

### DIFF
--- a/packages/xo-server-usage-report/.USAGE.md
+++ b/packages/xo-server-usage-report/.USAGE.md
@@ -1,2 +1,2 @@
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/manage_infrastructure#usage-reports).

--- a/packages/xo-server-usage-report/README.md
+++ b/packages/xo-server-usage-report/README.md
@@ -7,7 +7,7 @@
 ## Usage
 
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/manage_infrastructure#usage-reports).
 
 ## Contributions
 


### PR DESCRIPTION
Previously, the Readme and Usage files related to the `server-usage-report` plugin contained links pointing to a [general page](https://docs.xen-orchestra.com/architecture#plugins) on plugins.

The plugin has since been [documented](https://docs.xen-orchestra.com/manage_infrastructure#usage-reports) in the **Management → Infrastructure management** page of the Xen Orchestra documentation. As a result, these links have become obsolete.

This commit make the obsolete links point to the actual, new documentation on the `server-usage-report` plugin.