### PR TITLE
docs(plugins): fix links to various plugin documentation

### DIFF
--- a/packages/xo-server-backup-reports/.USAGE.md
+++ b/packages/xo-server-backup-reports/.USAGE.md
@@ -1,4 +1,4 @@
 XO-Server plugin which sends email reports and Xmpp messages when backup jobs are done.
 
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/backup_reports).

--- a/packages/xo-server-backup-reports/README.md
+++ b/packages/xo-server-backup-reports/README.md
@@ -9,7 +9,7 @@
 XO-Server plugin which sends email reports and Xmpp messages when backup jobs are done.
 
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/backup_reports).
 
 ## Contributions
 

--- a/packages/xo-server-load-balancer/.USAGE.md
+++ b/packages/xo-server-load-balancer/.USAGE.md
@@ -1,2 +1,2 @@
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://xen-orchestra.com/docs/plugins.html).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/load_balancing).

--- a/packages/xo-server-load-balancer/README.md
+++ b/packages/xo-server-load-balancer/README.md
@@ -7,7 +7,7 @@
 ## Usage
 
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://xen-orchestra.com/docs/plugins.html).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/load_balancing).
 
 ## Contributions
 

--- a/packages/xo-server-netbox/.USAGE.md
+++ b/packages/xo-server-netbox/.USAGE.md
@@ -1,2 +1,2 @@
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/advanced#netbox).

--- a/packages/xo-server-netbox/README.md
+++ b/packages/xo-server-netbox/README.md
@@ -7,7 +7,7 @@
 ## Usage
 
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/advanced#netbox).
 
 ## Contributions
 

--- a/packages/xo-server-perf-alert/.USAGE.md
+++ b/packages/xo-server-perf-alert/.USAGE.md
@@ -1,5 +1,5 @@
 Like all xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/advanced#performance-alerts).
 
 You can define monitors in the plugin configuration. Monitors let you check storage usage for your SRs, CPU usage or memory usage of your hosts and VMs.
 

--- a/packages/xo-server-perf-alert/README.md
+++ b/packages/xo-server-perf-alert/README.md
@@ -7,7 +7,7 @@
 ## Usage
 
 Like all xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/advanced#performance-alerts).
 
 You can define monitors in the plugin configuration. Monitors let you check storage usage for your SRs, CPU usage or memory usage of your hosts and VMs.
 

--- a/packages/xo-server-web-hooks/.USAGE.md
+++ b/packages/xo-server-web-hooks/.USAGE.md
@@ -1,2 +1,2 @@
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/advanced#web-hooks).

--- a/packages/xo-server-web-hooks/README.md
+++ b/packages/xo-server-web-hooks/README.md
@@ -7,7 +7,7 @@
 ## Usage
 
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/advanced#web-hooks).
 
 ## Contributions
 


### PR DESCRIPTION
Over time, the documentation for multiple plugins has been updated or moved outside of the general [Plugins page](https://docs.xen-orchestra.com/architecture#plugins).

As a result, the links in various plugin README or Usage files have become obsolete, as they all point to the general Plugins page instead of the specific plugin documentations.

This commit updates those links to their relevant locations.