### PR TITLE
feat(xo-web/tasks):  show only failed tasks by default in xo-task view

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@
 - [Backup] Support qcow2 disks > 2TB for backup and replication (PR [#8668](https://github.com/vatesfr/xen-orchestra/pull/8668))
 - [Export] Support qcow2 disks exports (PR [#8668](https://github.com/vatesfr/xen-orchestra/pull/8668))
 - [REST API] Expose `GET /rest/v0/sms` and `GET /rest/v0/sms/<sm-id>` (PR [#8696](https://github.com/vatesfr/xen-orchestra/pull/8696))
+- [XO5/Tasks] hide pending/successful xo tasks (PR [#8676](https://github.com/vatesfr/xen-orchestra/pull/8676))
 
 ### Bug fixes
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -167,6 +167,7 @@ const messages = {
   // ----- Filters -----
   onError: 'On error',
   successful: 'Successful',
+  filterKeepFailed: 'Keep only failed',
   filterOutShortTasks: 'Hide short tasks',
   filterOnlyManaged: 'Managed disks',
   filterOnlyOrphaned: 'Orphaned disks',

--- a/packages/xo-web/src/xo-app/tasks/index.js
+++ b/packages/xo-web/src/xo-app/tasks/index.js
@@ -63,7 +63,7 @@ const TASK_ITEM_STYLE = {
 
 const FILTERS = {
   filterOutShortTasks: '!name_label: |(SR.scan host.call_plugin "/rrd_updates")',
-  filterKeepFailed: 'status:fail',
+  filterKeepFailed: 'status:failure',
 }
 
 @connectStore(() => ({

--- a/packages/xo-web/src/xo-app/tasks/index.js
+++ b/packages/xo-web/src/xo-app/tasks/index.js
@@ -63,6 +63,7 @@ const TASK_ITEM_STYLE = {
 
 const FILTERS = {
   filterOutShortTasks: '!name_label: |(SR.scan host.call_plugin "/rrd_updates")',
+  filterKeepFailed: 'status:fail',
 }
 
 @connectStore(() => ({
@@ -372,6 +373,7 @@ export default class Tasks extends Component {
                 <SortedTable
                   className='mt-1'
                   collection={this._getFinishedTasks()}
+                  defaultFilter='filterKeepFailed'
                   columns={FINISHED_TASKS_COLUMNS}
                   filters={FILTERS}
                   stateUrlParam='s_previous'

--- a/packages/xo-web/src/xo-app/tasks/index.js
+++ b/packages/xo-web/src/xo-app/tasks/index.js
@@ -373,7 +373,6 @@ export default class Tasks extends Component {
                 <SortedTable
                   className='mt-1'
                   collection={this._getFinishedTasks()}
-                  defaultFilter='filterKeepFailed'
                   columns={FINISHED_TASKS_COLUMNS}
                   filters={FILTERS}
                   stateUrlParam='s_previous'
@@ -392,6 +391,8 @@ export default class Tasks extends Component {
                 columns={XO_TASKS_COLUMNS}
                 individualActions={XO_TASKS_INDIVIDUAL_ACTIONS}
                 stateUrlParam='s_xo'
+                filters={FILTERS}
+                defaultFilter='filterKeepFailed'
               />
             </Col>
           </Row>


### PR DESCRIPTION
from : asked by support to stop  task flickering 

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
