### PR TITLE
feat(web-core): simplify logic of `VtsCopyButton`

### DIFF
--- a/@xen-orchestra/web-core/lib/components/copy-button/VtsCopyButton.vue
+++ b/@xen-orchestra/web-core/lib/components/copy-button/VtsCopyButton.vue
@@ -1,13 +1,13 @@
 <template>
-  <UiButtonIcon v-tooltip="copied && t('core.copied')" :icon size="medium" accent="brand" @click="copyToClipboard()" />
+  <UiButtonIcon v-tooltip="copied && t('core.copied')" :icon size="medium" accent="brand" @click="copy()" />
 </template>
 
 <script setup lang="ts">
 import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import { vTooltip } from '@core/directives/tooltip.directive'
 import { faCheckCircle, faCopy } from '@fortawesome/free-solid-svg-icons'
-import { useClipboard, useTimeoutFn } from '@vueuse/core'
-import { ref } from 'vue'
+import { useClipboard } from '@vueuse/core'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const { value } = defineProps<{
@@ -16,17 +16,7 @@ const { value } = defineProps<{
 
 const { t } = useI18n()
 
-const { copy, copied } = useClipboard()
+const { copy, copied } = useClipboard({ source: () => value })
 
-const icon = ref(faCopy)
-
-const { start: changeIcon } = useTimeoutFn(() => {
-  icon.value = faCopy
-}, 1_500) // 1.5s is time to Tooltip is visible
-
-function copyToClipboard() {
-  copy(value)
-  icon.value = faCheckCircle
-  changeIcon()
-}
+const icon = computed(() => (copied.value ? faCheckCircle : faCopy))
 </script>


### PR DESCRIPTION
### Description

- Remove usage of `useTimeoutFn`
- Base the button icon on the `copied` boolean state
- Pass the source directly to the `useClipboard` config

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
