### PR TITLE
feat(xo-server/rest-api): migrate delete user

### DIFF
--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -85,7 +85,7 @@ export type XoApp = {
   /* connect a server (XCP-ng/XenServer) */
   connectXenServer(id: XoServer['id']): Promise<void>
   createUser(params: { name?: string; password?: string; [key: string]: unknown }): Promise<XoUser>
-  deleteUser: (id: XoUser['id']) => Promise<void>
+  deleteUser(id: XoUser['id']): Promise<void>
   /* disconnect a server (XCP-ng/XenServer) */
   disconnectXenServer(id: XoServer['id']): Promise<void>
   getAllGroups(): Promise<XoGroup[]>

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -85,6 +85,7 @@ export type XoApp = {
   /* connect a server (XCP-ng/XenServer) */
   connectXenServer(id: XoServer['id']): Promise<void>
   createUser(params: { name?: string; password?: string; [key: string]: unknown }): Promise<XoUser>
+  deleteUser: (id: XoUser['id']) => Promise<void>
   /* disconnect a server (XCP-ng/XenServer) */
   disconnectXenServer(id: XoServer['id']): Promise<void>
   getAllGroups(): Promise<XoGroup[]>

--- a/@xen-orchestra/rest-api/src/users/user.controller.mts
+++ b/@xen-orchestra/rest-api/src/users/user.controller.mts
@@ -1,6 +1,7 @@
 import {
   Body,
-  Delete, Example,
+  Delete,
+  Example,
   Get,
   Middlewares,
   Path,
@@ -10,13 +11,21 @@ import {
   Response,
   Route,
   Security,
-  SuccessResponse, Tags,
+  SuccessResponse,
+  Tags,
 } from 'tsoa'
 import { json, type Request as ExRequest } from 'express'
 import { provide } from 'inversify-binding-decorators'
 import type { XoUser } from '@vates/types'
 
-import { createdResp, invalidParameters, noContentResp, notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
+import {
+  createdResp,
+  invalidParameters,
+  noContentResp,
+  notFoundResp,
+  unauthorizedResp,
+  type Unbrand,
+} from '../open-api/common/response.common.mjs'
 import { partialUsers, user, userId, userIds } from '../open-api/oa-examples/user.oa-example.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'

--- a/@xen-orchestra/rest-api/src/users/user.controller.mts
+++ b/@xen-orchestra/rest-api/src/users/user.controller.mts
@@ -1,6 +1,6 @@
 import {
   Body,
-  Example,
+  Delete, Example,
   Get,
   Middlewares,
   Path,
@@ -10,20 +10,13 @@ import {
   Response,
   Route,
   Security,
-  SuccessResponse,
-  Tags,
+  SuccessResponse, Tags,
 } from 'tsoa'
 import { json, type Request as ExRequest } from 'express'
 import { provide } from 'inversify-binding-decorators'
 import type { XoUser } from '@vates/types'
 
-import {
-  createdResp,
-  invalidParameters,
-  notFoundResp,
-  unauthorizedResp,
-  type Unbrand,
-} from '../open-api/common/response.common.mjs'
+import { createdResp, invalidParameters, noContentResp, notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { partialUsers, user, userId, userIds } from '../open-api/oa-examples/user.oa-example.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
@@ -99,5 +92,15 @@ export class UserController extends XoController<XoUser> {
     const user = await this.restApi.xoApp.createUser(body)
 
     return { id: user.id }
+  }
+
+  /**
+   * @example id "722d17b9-699b-49d2-8193-be1ac573d3de"
+   */
+  @Delete('{id}')
+  @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  async deleteUser(@Path() id: string): Promise<void> {
+    await this.restApi.xoApp.deleteUser(id as XoUser['id'])
   }
 }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@
 - **Migrated REST API endpoints**:
 
     - `POST /rest/v0/users` (PR [#8697](https://github.com/vatesfr/xen-orchestra/pull/8697))
-    - `DELETE /rest/v0/users` (PR [#8698](https://github.com/vatesfr/xen-orchestra/pull/8698))
+    - `DELETE /rest/v0/users/<user-id>` (PR [#8698](https://github.com/vatesfr/xen-orchestra/pull/8698))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@
 - **Migrated REST API endpoints**:
 
     - `POST /rest/v0/users` (PR [#8697](https://github.com/vatesfr/xen-orchestra/pull/8697))
+    - `DELETE /rest/v0/users` (PR [#8698](https://github.com/vatesfr/xen-orchestra/pull/8698))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -1149,15 +1149,6 @@ export default class RestApi {
       })
     )
 
-    api.delete(
-      '/:collection(users)/:id',
-      wrap(async (req, res) => {
-        const { id } = req.params
-        await app.deleteUser(id)
-        res.sendStatus(204)
-      }, true)
-    )
-
     api.put(
       '/:collection(groups)/:id/users/:userId',
       wrap(async (req, res) => {


### PR DESCRIPTION
### Description

![image](https://github.com/user-attachments/assets/b00241c6-bba8-439c-89da-5343c1352055)

[XO-1154](https://project.vates.tech/vates-global/browse/XO-1154/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
