### PR TITLE
Feat fs safeguards

### DIFF
--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -3,13 +3,14 @@ import getStream from 'get-stream'
 import { asyncEach } from '@vates/async-each'
 import { coalesceCalls } from '@vates/coalesce-calls'
 import { createLogger } from '@xen-orchestra/log'
-import { fromCallback, fromEvent, ignoreErrors, timeout } from 'promise-toolbox'
+import { fromCallback, fromEvent, ignoreErrors, pRetry } from 'promise-toolbox'
 import { limitConcurrency } from 'limit-concurrency-decorator'
 import { parse } from 'xo-remote-parser'
 import { pipeline } from 'stream'
 import { randomBytes, randomUUID } from 'crypto'
 import { synchronized } from 'decorator-synchronized'
 
+import { withTimeout } from './utils'
 import { basename, dirname, normalize as normalizePath } from './path'
 import { createChecksumStream, validChecksumOfReadStream } from './checksum'
 import { DEFAULT_ENCRYPTION_ALGORITHM, UNENCRYPTED_ALGORITHM, _getEncryptor } from './_encryptor'
@@ -27,6 +28,58 @@ const DEFAULT_MAX_PARALLEL_OPERATIONS = 10
 
 const ENCRYPTION_DESC_FILENAME = 'encryption.json'
 const ENCRYPTION_METADATA_FILENAME = 'metadata.json'
+
+const WITH_LIMIT = [
+  'closeFile',
+  'copy',
+  'getInfo',
+  'getSizeOnDisk',
+  'list',
+  'mkdir',
+  'openFile',
+  'outputFile',
+  'read',
+  'readFile',
+  'rename',
+  'rmdir',
+  'truncate',
+  'unlink',
+  'write',
+  'writeFile',
+]
+
+const WITH_RETRY = [
+  '_closeFile',
+  '_copy',
+  '_getInfo',
+  '_getSize',
+  '_list',
+  '_mkdir',
+  '_openFile',
+  '_outputFile',
+  '_read',
+  '_readFile',
+  '_rename',
+  '_rmdir',
+  '_truncate',
+  '_unlink',
+  '_write',
+  '_writeFile',
+]
+
+const WITH_TIMEOUT = [
+  '_closeFile',
+  '_createReadStream',
+  '_getInfo',
+  '_getSize',
+  '_list',
+  '_rename',
+  '_copy',
+  '_rmdir',
+  '_closeFile',
+  '_openFile',
+  '_createOutputStream',
+]
 
 const ignoreEnoent = error => {
   if (error == null || error.code !== 'ENOENT') {
@@ -95,26 +148,46 @@ export default class RemoteHandlerAbstract {
     }
     ;({ highWaterMark: this._highWaterMark, timeout: this._timeout = DEFAULT_TIMEOUT } = options)
 
-    const sharedLimit = limitConcurrency(options.maxParallelOperations ?? DEFAULT_MAX_PARALLEL_OPERATIONS)
-    this.closeFile = sharedLimit(this.closeFile)
-    this.copy = sharedLimit(this.copy)
-    this.getInfo = sharedLimit(this.getInfo)
-    this.getSizeOnDisk = sharedLimit(this.getSizeOnDisk)
-    this.list = sharedLimit(this.list)
-    this.mkdir = sharedLimit(this.mkdir)
-    this.openFile = sharedLimit(this.openFile)
-    this.outputFile = sharedLimit(this.outputFile)
-    this.read = sharedLimit(this.read)
-    this.readFile = sharedLimit(this.readFile)
-    this.rename = sharedLimit(this.rename)
-    this.rmdir = sharedLimit(this.rmdir)
-    this.truncate = sharedLimit(this.truncate)
-    this.unlink = sharedLimit(this.unlink)
-    this.write = sharedLimit(this.write)
-    this.writeFile = sharedLimit(this.writeFile)
-
     this._forget = coalesceCalls(this._forget)
     this._sync = coalesceCalls(this._sync)
+
+    this._applySafeGuards(options)
+  }
+
+  _applySafeGuards(options, { toLimit = WITH_LIMIT, toTimeout = WITH_TIMEOUT, toRetry = WITH_RETRY } = {}) {
+    const sharedLimit = limitConcurrency(options.maxParallelOperations ?? DEFAULT_MAX_PARALLEL_OPERATIONS)
+    toLimit.forEach(functionName => {
+      if (this[functionName] !== undefined) {
+        this[functionName] = sharedLimit(this[functionName])
+      }
+    })
+
+    toTimeout.forEach(functionName => {
+      if (this[functionName] !== undefined) {
+        this[functionName] = withTimeout(this[functionName], DEFAULT_TIMEOUT)
+      }
+    })
+
+    toRetry.forEach(functionName => {
+      if (this[functionName] !== undefined) {
+        // adding the retry on the top level method won't
+        // cover when _functionName are called internally
+        this[functionName] = pRetry.wrap(this[functionName], {
+          delays: [100, 200, 500, 1000, 2000],
+          // these errors should not change on retry
+          when: err => !['EEXIST', 'EISDIR', 'ENOTEMPTY', 'ENOENT', 'ENOTDIR', 'SystemInUse'].includes(err?.code),
+          onRetry(error) {
+            warn('retrying method on fs ', {
+              method: functionName,
+              attemptNumber: this.attemptNumber,
+              delay: this.delay,
+              error,
+              file: this.arguments?.[0],
+            })
+          },
+        })
+      }
+    })
   }
 
   // Public members
@@ -140,11 +213,7 @@ export default class RemoteHandlerAbstract {
       file = normalizePath(file)
     }
 
-    let stream = await timeout.call(
-      this._createReadStream(file, { ...options, highWaterMark: this._highWaterMark }),
-      this._timeout
-    )
-
+    let stream = await this._createReadStream(file, { ...options, highWaterMark: this._highWaterMark })
     // detect early errors
     await fromEvent(stream, 'readable')
 
@@ -228,7 +297,7 @@ export default class RemoteHandlerAbstract {
   }
 
   async getInfo() {
-    return timeout.call(this._getInfo(), this._timeout)
+    return this._getInfo()
   }
 
   // returns the real size occupied by an unencrypted file
@@ -239,7 +308,7 @@ export default class RemoteHandlerAbstract {
   }
 
   async getSizeOnDisk(file) {
-    return timeout.call(this._getSize(typeof file === 'string' ? normalizePath(file) : file), this._timeout)
+    return this._getSize(typeof file === 'string' ? normalizePath(file) : file)
   }
 
   async __list(dir, { filter, ignoreMissing = false, prependDir = false } = {}) {
@@ -247,7 +316,7 @@ export default class RemoteHandlerAbstract {
       const virtualDir = normalizePath(dir)
       dir = normalizePath(dir)
 
-      let entries = await timeout.call(this._list(dir), this._timeout)
+      let entries = await this._list(dir)
       if (filter !== undefined) {
         entries = entries.filter(filter)
       }
@@ -293,7 +362,7 @@ export default class RemoteHandlerAbstract {
 
   async #rename(oldPath, newPath, { checksum }, createTree = true) {
     try {
-      let p = timeout.call(this._rename(oldPath, newPath), this._timeout)
+      let p = this._rename(oldPath, newPath)
       if (checksum) {
         p = Promise.all([p, this._rename(checksumFile(oldPath), checksumFile(newPath))])
       }
@@ -316,7 +385,7 @@ export default class RemoteHandlerAbstract {
     oldPath = normalizePath(oldPath)
     newPath = normalizePath(newPath)
 
-    let p = timeout.call(this._copy(oldPath, newPath), this._timeout)
+    let p = this._copy(oldPath, newPath)
     if (checksum) {
       p = Promise.all([p, this._copy(checksumFile(oldPath), checksumFile(newPath))])
     }
@@ -324,7 +393,7 @@ export default class RemoteHandlerAbstract {
   }
 
   async rmdir(dir) {
-    await timeout.call(this._rmdir(normalizePath(dir)).catch(ignoreEnoent), this._timeout)
+    await this._rmdir(normalizePath(dir)).catch(ignoreEnoent)
   }
 
   async rmtree(dir) {
@@ -473,7 +542,7 @@ export default class RemoteHandlerAbstract {
   // Methods that can be called by private methods to avoid parallel limit on public methods
 
   async __closeFile(fd) {
-    await timeout.call(this._closeFile(fd.fd), this._timeout)
+    await this._closeFile(fd.fd)
   }
 
   async __mkdir(dir, { mode } = {}) {
@@ -495,7 +564,7 @@ export default class RemoteHandlerAbstract {
     path = normalizePath(path)
 
     return {
-      fd: await timeout.call(this._openFile(path, flags), this._timeout),
+      fd: await this._openFile(path, flags),
       path,
     }
   }
@@ -588,13 +657,10 @@ export default class RemoteHandlerAbstract {
 
   async _outputStream(path, input, { dirMode, validator }) {
     const tmpPath = `${dirname(path)}/.${basename(path)}`
-    const output = await timeout.call(
-      this._createOutputStream(tmpPath, {
-        dirMode,
-        flags: 'wx',
-      }),
-      this._timeout
-    )
+    const output = this._createOutputStream(tmpPath, {
+      dirMode,
+      flags: 'wx',
+    })
     try {
       await fromCallback(pipeline, input, output)
       if (validator !== undefined) {

--- a/@xen-orchestra/fs/src/abstract.test.js
+++ b/@xen-orchestra/fs/src/abstract.test.js
@@ -13,16 +13,34 @@ import tmp from 'tmp'
 const TIMEOUT = 6e5
 
 class TestHandler extends AbstractHandler {
-  constructor(impl) {
-    const options = { timeout: TIMEOUT }
+  constructor() {
+    const options = { timeout: TIMEOUT, withRetry: [] }
     super({ url: 'test://' }, options)
     Object.defineProperty(this, 'isEncrypted', {
       get: () => false, // encryption is tested separately
     })
-    Object.keys(impl).forEach(method => {
-      this[`_${method}`] = impl[method]
-    })
-    this._applySafeGuards(options, { toRetry: [] }) // workaround to reapply safeGuards on mocks
+  }
+
+  async _closeFile() {
+    Promise(() => {})
+  }
+  async _getInfo() {
+    Promise(() => {})
+  }
+  async _getSize() {
+    Promise(() => {})
+  }
+  async _list() {
+    Promise(() => {})
+  }
+  async _openFile() {
+    Promise(() => {})
+  }
+  async _rename() {
+    Promise(() => {})
+  }
+  async _rmdir() {
+    Promise(() => {})
   }
 }
 
@@ -32,9 +50,7 @@ const clock = sinon.useFakeTimers()
 
 describe('closeFile()', () => {
   it(`throws in case of timeout`, async () => {
-    const testHandler = new TestHandler({
-      closeFile: () => new Promise(() => {}),
-    })
+    const testHandler = new TestHandler()
 
     const promise = testHandler.closeFile({ fd: undefined, path: '' })
     clock.tick(TIMEOUT)
@@ -44,9 +60,7 @@ describe('closeFile()', () => {
 
 describe('getInfo()', () => {
   it('throws in case of timeout', async () => {
-    const testHandler = new TestHandler({
-      getInfo: () => new Promise(() => {}),
-    })
+    const testHandler = new TestHandler()
 
     const promise = testHandler.getInfo()
     clock.tick(TIMEOUT)
@@ -56,9 +70,7 @@ describe('getInfo()', () => {
 
 describe('getSize()', () => {
   it(`throws in case of timeout`, async () => {
-    const testHandler = new TestHandler({
-      getSize: () => new Promise(() => {}),
-    })
+    const testHandler = new TestHandler()
 
     const promise = testHandler.getSize('')
     clock.tick(TIMEOUT)
@@ -68,9 +80,7 @@ describe('getSize()', () => {
 
 describe('list()', () => {
   it(`throws in case of timeout`, async () => {
-    const testHandler = new TestHandler({
-      list: () => new Promise(() => {}),
-    })
+    const testHandler = new TestHandler()
 
     const promise = testHandler.list('.')
     clock.tick(TIMEOUT)
@@ -80,9 +90,7 @@ describe('list()', () => {
 
 describe('openFile()', () => {
   it(`throws in case of timeout`, async () => {
-    const testHandler = new TestHandler({
-      openFile: () => new Promise(() => {}),
-    })
+    const testHandler = new TestHandler()
 
     const promise = testHandler.openFile('path')
     clock.tick(TIMEOUT)
@@ -92,9 +100,7 @@ describe('openFile()', () => {
 
 describe('rename()', () => {
   it(`throws in case of timeout`, async () => {
-    const testHandler = new TestHandler({
-      rename: () => new Promise(() => {}),
-    })
+    const testHandler = new TestHandler()
 
     const promise = testHandler.rename('oldPath', 'newPath')
     clock.tick(TIMEOUT)
@@ -104,9 +110,7 @@ describe('rename()', () => {
 
 describe('rmdir()', () => {
   it(`throws in case of timeout`, async () => {
-    const testHandler = new TestHandler({
-      rmdir: () => new Promise(() => {}),
-    })
+    const testHandler = new TestHandler()
 
     const promise = testHandler.rmdir('dir')
     clock.tick(TIMEOUT)

--- a/@xen-orchestra/fs/src/abstract.test.js
+++ b/@xen-orchestra/fs/src/abstract.test.js
@@ -10,17 +10,19 @@ import AbstractHandler from './abstract'
 import fs from 'fs-extra'
 import tmp from 'tmp'
 
-const TIMEOUT = 10e3
+const TIMEOUT = 6e5
 
 class TestHandler extends AbstractHandler {
   constructor(impl) {
-    super({ url: 'test://' }, { timeout: TIMEOUT })
+    const options = { timeout: TIMEOUT }
+    super({ url: 'test://' }, options)
     Object.defineProperty(this, 'isEncrypted', {
       get: () => false, // encryption is tested separately
     })
     Object.keys(impl).forEach(method => {
       this[`_${method}`] = impl[method]
     })
+    this._applySafeGuards(options, { toRetry: [] }) // workaround to reapply safeGuards on mocks
   }
 }
 

--- a/@xen-orchestra/fs/src/utils.js
+++ b/@xen-orchestra/fs/src/utils.js
@@ -1,0 +1,19 @@
+import { TimeoutError } from 'promise-toolbox'
+
+export function withTimeout(fn, timeout) {
+  return function (...args) {
+    let timeoutHandle
+    const timeoutPromise = new Promise((_resolve, reject) => {
+      timeoutHandle = setTimeout(() => reject(new TimeoutError()), timeout)
+    })
+    return Promise.race([Promise.resolve().then(() => fn.apply(this, args)), timeoutPromise])
+      .then(result => {
+        clearTimeout(timeoutHandle)
+        return result
+      })
+      .catch(err => {
+        clearTimeout(timeoutHandle)
+        throw err
+      })
+  }
+}

--- a/@xen-orchestra/fs/src/utils.js
+++ b/@xen-orchestra/fs/src/utils.js
@@ -3,7 +3,7 @@ import { TimeoutError } from 'promise-toolbox'
 
 const { info, warn } = createLogger('xo:fs:abstract')
 
-export function withTimeout(fn, timeout, { onTimeout, onSuccessAfterTimeout, onFailureAfterTimeout } = {}) {
+export function withTimeout(fn, timeout, { onSuccessAfterTimeout, onFailureAfterTimeout } = {}) {
   return function (...args) {
     let timeoutHandle
     let didTimeout = false
@@ -12,10 +12,7 @@ export function withTimeout(fn, timeout, { onTimeout, onSuccessAfterTimeout, onF
     return new Promise((resolve, reject) => {
       timeoutHandle = setTimeout(() => {
         didTimeout = true
-        onTimeout?.()
-        if (onSuccessAfterTimeout === undefined && onFailureAfterTimeout === undefined) {
-          reject(timeoutError)
-        }
+        reject(timeoutError)
       }, timeout)
       const promise = fn.apply(this, args)
       if (promise?.then === undefined) {

--- a/@xen-orchestra/fs/src/utils.js
+++ b/@xen-orchestra/fs/src/utils.js
@@ -1,19 +1,45 @@
+import { createLogger } from '@xen-orchestra/log'
 import { TimeoutError } from 'promise-toolbox'
+const { info, warn } = createLogger('xo:fs:abstract')
 
-export function withTimeout(fn, timeout) {
+export function withTimeout(fn, timeout, { onSuccess, onTimeout, onSuccessAfterTimeout, onFailureAfterTimeout } = {}) {
+  if (typeof fn.then !== 'undefined') {
+    throw new Error('Function needs to be asynchronous.')
+  }
+
   return function (...args) {
     let timeoutHandle
-    const timeoutPromise = new Promise((_resolve, reject) => {
-      timeoutHandle = setTimeout(() => reject(new TimeoutError()), timeout)
+    let didTimeout = false
+    const timeoutError = new TimeoutError('Async call timeout limit reached')
+
+    return new Promise((resolve, reject) => {
+      timeoutHandle = setTimeout(() => {
+        didTimeout = true
+        onTimeout?.()
+        if (onSuccessAfterTimeout === undefined && onFailureAfterTimeout === undefined) {
+          reject(timeoutError)
+        }
+      }, timeout)
+      fn.apply(this, args)
+        .then(result => {
+          clearTimeout(timeoutHandle)
+          if (didTimeout) {
+            info('Success after timeout:\n', result)
+            onSuccessAfterTimeout?.(result)
+            reject(timeoutError)
+          } else {
+            onSuccess?.(result)
+            resolve(result)
+          }
+        })
+        .catch(error => {
+          clearTimeout(timeoutHandle)
+          if (didTimeout) {
+            warn('Failure after timeout:\n', error)
+            onFailureAfterTimeout?.(error)
+          }
+          reject(error)
+        })
     })
-    return Promise.race([Promise.resolve().then(() => fn.apply(this, args)), timeoutPromise])
-      .then(result => {
-        clearTimeout(timeoutHandle)
-        return result
-      })
-      .catch(err => {
-        clearTimeout(timeoutHandle)
-        throw err
-      })
   }
 }

--- a/@xen-orchestra/fs/src/utils.js
+++ b/@xen-orchestra/fs/src/utils.js
@@ -24,7 +24,6 @@ export function withTimeout(fn, timeout, { onSuccessAfterTimeout, onFailureAfter
           if (didTimeout) {
             info('Success after timeout:\n', result)
             onSuccessAfterTimeout?.(result)
-            reject(timeoutError)
           } else {
             resolve(result)
           }
@@ -34,8 +33,9 @@ export function withTimeout(fn, timeout, { onSuccessAfterTimeout, onFailureAfter
           if (didTimeout) {
             warn('Failure after timeout:\n', error)
             onFailureAfterTimeout?.(error)
+          } else {
+            reject(error)
           }
-          reject(error)
         }
       )
     })

--- a/@xen-orchestra/fs/src/utils.js
+++ b/@xen-orchestra/fs/src/utils.js
@@ -18,7 +18,7 @@ export function withTimeout(fn, timeout, { onTimeout, onSuccessAfterTimeout, onF
         }
       }, timeout)
       const promise = fn.apply(this, args)
-      if (promise === undefined) {
+      if (promise?.then === undefined) {
         throw new Error('Function needs to be asynchronous.')
       }
       promise.then(

--- a/@xen-orchestra/fs/src/utils.js
+++ b/@xen-orchestra/fs/src/utils.js
@@ -47,7 +47,7 @@ export function withTimeout(fn, timeout, { onSuccessAfterTimeout, onFailureAfter
         reject(timeoutError)
       }, timeout)
 
-      // if fn is synchronous and throw an error, it will throws it here
+      // if fn is synchronous and throws an error, it will throw it here
       const promise = fn.apply(this, args)
       if (promise?.then === undefined) {
         throw new Error('Function needs to be asynchronous.')

--- a/@xen-orchestra/fs/src/utils.js
+++ b/@xen-orchestra/fs/src/utils.js
@@ -3,10 +3,42 @@ import { TimeoutError } from 'promise-toolbox'
 
 const { info, warn } = createLogger('xo:fs:abstract')
 
+/**
+ * Wraps an asynchronous function with timeout functionality.
+ *
+ * @template T
+ * @param {(...args: any[]) => Promise<T>} fn - The asynchronous function to wrap
+ * @param {Object} [options] - Configuration options
+ * @param {(result: T) => void} [options.onSuccessAfterTimeout] - Callback invoked if original promise resolves after timeout
+ * @param {(error: any) => void} [options.onFailureAfterTimeout] - Callback invoked if original promise rejects after timeout
+ * @returns {(...args: any[]) => Promise<T>} A new function that will enforce the timeout
+ * @throws {TypeError} If fn is not a function or timeout is not a positive number
+ *
+ * @example
+ * // Basic usage
+ * const fnWithTimeout = withTimeout(asyncFunc, 1000)
+ * try {
+ *   const result = await fnWithTimeout()
+ * } catch (error) {
+ *   if (error instanceof TimeoutError) {
+ *     // Handle timeout
+ *   }
+ * }
+ *
+ * @example
+ * // With callbacks
+ * const fnWithTimeout = withTimeout(asyncFunc, 1000, {
+ *   onSuccessAfterTimeout: (result) => console.log('Late success', result),
+ *   onFailureAfterTimeout: (error) => console.log('Late failure', error)
+ * })
+ */
 export function withTimeout(fn, timeout, { onSuccessAfterTimeout, onFailureAfterTimeout } = {}) {
   return function (...args) {
     let timeoutHandle
     let didTimeout = false
+    if (typeof fn !== 'function') {
+      throw new TypeError('First argument must be a function')
+    }
     const timeoutError = new TimeoutError('Async call timeout limit reached')
 
     return new Promise((resolve, reject) => {
@@ -14,6 +46,8 @@ export function withTimeout(fn, timeout, { onSuccessAfterTimeout, onFailureAfter
         didTimeout = true
         reject(timeoutError)
       }, timeout)
+
+      // if fn is synchronous and throw an error, it will throws it here
       const promise = fn.apply(this, args)
       if (promise?.then === undefined) {
         throw new Error('Function needs to be asynchronous.')

--- a/@xen-orchestra/fs/src/utils.test.js
+++ b/@xen-orchestra/fs/src/utils.test.js
@@ -1,19 +1,88 @@
-import { describe, it } from 'node:test'
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
 import { strict as assert } from 'assert'
 import sinon from 'sinon'
-import { withTimeout } from './utils'
 import { TimeoutError } from 'promise-toolbox'
+import { withTimeout } from './utils'
 
 const TIMEOUT = 6e6
 
-const clock = sinon.useFakeTimers()
-
 describe('withTimeout()', () => {
+  let clock
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers()
+  })
+
+  afterEach(() => {
+    clock.restore()
+    mock.reset()
+  })
+
   it(`throws in case of timeout`, async () => {
     let promiseFct = () => new Promise(() => {})
     promiseFct = withTimeout(promiseFct, TIMEOUT)
     const promise = promiseFct()
     clock.tick(TIMEOUT)
     await assert.rejects(promise, TimeoutError)
+  })
+
+  it(`can success after timeout()`, async () => {
+    let promiseFct = () =>
+      new Promise(resolve => {
+        setTimeout(() => resolve('done'), 5000)
+      })
+    const mockMethod = mock.fn(() => {})
+    promiseFct = withTimeout(promiseFct, 2000, { onSuccessAfterTimeout: mockMethod })
+
+    const promise = promiseFct()
+    clock.tick(6000)
+    await assert.rejects(promise, TimeoutError)
+    assert.strictEqual(mockMethod.mock.callCount(), 1)
+    assert.strictEqual(mockMethod.mock.calls[0].arguments[0], 'done')
+  })
+
+  it(`can fail after timeout()`, async () => {
+    const testError = new Error('test')
+    let promiseFct = () =>
+      new Promise((_resolve, reject) => {
+        setTimeout(() => {
+          reject(testError)
+        }, 5000)
+      })
+
+    const mockMethod = mock.fn(() => {})
+    promiseFct = withTimeout(promiseFct, 2000, { onFailureAfterTimeout: mockMethod })
+    const promise = promiseFct()
+    clock.tick(TIMEOUT)
+    await assert.rejects(promise, Error)
+
+    assert.strictEqual(mockMethod.mock.callCount(), 1)
+    assert.strictEqual(mockMethod.mock.calls[0].arguments[0], testError)
+  })
+
+  it(`can success before timeout()`, async () => {
+    let promiseFct = () =>
+      new Promise(resolve => {
+        setTimeout(() => resolve('done'), 1000)
+      })
+    promiseFct = withTimeout(promiseFct, 2000)
+
+    const promise = promiseFct()
+    clock.tick(1000)
+    const result = await promise
+    assert.strictEqual(result, 'done')
+  })
+
+  it(`can fail before timeout()`, async () => {
+    const testError = new Error('test')
+    let promiseFct = () =>
+      new Promise((_resolve, reject) => {
+        setTimeout(() => reject(testError), 1000)
+      })
+    promiseFct = withTimeout(promiseFct, 2000)
+
+    const promise = promiseFct()
+    clock.tick(1000)
+    assert.rejects(promise, testError)
   })
 })

--- a/@xen-orchestra/fs/src/utils.test.js
+++ b/@xen-orchestra/fs/src/utils.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon'
 import { TimeoutError } from 'promise-toolbox'
 import { withTimeout } from './utils'
 
-const TIMEOUT = 6e6
+const TIMEOUT = 5000
 
 describe('withTimeout()', () => {
   let clock
@@ -18,25 +18,32 @@ describe('withTimeout()', () => {
     mock.reset()
   })
 
+  it(`throws if function is synchronous`, async () => {
+    let promiseFct = () => {}
+    promiseFct = withTimeout(promiseFct, TIMEOUT)
+    const promise = promiseFct()
+    assert.rejects(promise, new Error('Function needs to be asynchronous.'))
+  })
+
   it(`throws in case of timeout`, async () => {
     let promiseFct = () => new Promise(() => {})
     promiseFct = withTimeout(promiseFct, TIMEOUT)
     const promise = promiseFct()
     clock.tick(TIMEOUT)
-    await assert.rejects(promise, TimeoutError)
+    await assert.rejects(promise, new TimeoutError())
   })
 
   it(`can success after timeout()`, async () => {
     let promiseFct = () =>
       new Promise(resolve => {
-        setTimeout(() => resolve('done'), 5000)
+        setTimeout(() => resolve('done'), TIMEOUT)
       })
     const mockMethod = mock.fn(() => {})
-    promiseFct = withTimeout(promiseFct, 2000, { onSuccessAfterTimeout: mockMethod })
+    promiseFct = withTimeout(promiseFct, TIMEOUT / 2, { onSuccessAfterTimeout: mockMethod })
 
     const promise = promiseFct()
-    clock.tick(6000)
-    await assert.rejects(promise, TimeoutError)
+    clock.tick(TIMEOUT)
+    await assert.rejects(promise, new TimeoutError())
     assert.strictEqual(mockMethod.mock.callCount(), 1)
     assert.strictEqual(mockMethod.mock.calls[0].arguments[0], 'done')
   })
@@ -47,14 +54,14 @@ describe('withTimeout()', () => {
       new Promise((_resolve, reject) => {
         setTimeout(() => {
           reject(testError)
-        }, 5000)
+        }, TIMEOUT)
       })
 
     const mockMethod = mock.fn(() => {})
-    promiseFct = withTimeout(promiseFct, 2000, { onFailureAfterTimeout: mockMethod })
+    promiseFct = withTimeout(promiseFct, TIMEOUT / 2, { onFailureAfterTimeout: mockMethod })
     const promise = promiseFct()
     clock.tick(TIMEOUT)
-    await assert.rejects(promise, Error)
+    await assert.rejects(promise, testError)
 
     assert.strictEqual(mockMethod.mock.callCount(), 1)
     assert.strictEqual(mockMethod.mock.calls[0].arguments[0], testError)
@@ -63,12 +70,12 @@ describe('withTimeout()', () => {
   it(`can success before timeout()`, async () => {
     let promiseFct = () =>
       new Promise(resolve => {
-        setTimeout(() => resolve('done'), 1000)
+        setTimeout(() => resolve('done'), TIMEOUT)
       })
-    promiseFct = withTimeout(promiseFct, 2000)
+    promiseFct = withTimeout(promiseFct, TIMEOUT * 2)
 
     const promise = promiseFct()
-    clock.tick(1000)
+    clock.tick(TIMEOUT)
     const result = await promise
     assert.strictEqual(result, 'done')
   })
@@ -77,12 +84,12 @@ describe('withTimeout()', () => {
     const testError = new Error('test')
     let promiseFct = () =>
       new Promise((_resolve, reject) => {
-        setTimeout(() => reject(testError), 1000)
+        setTimeout(() => reject(testError), TIMEOUT)
       })
-    promiseFct = withTimeout(promiseFct, 2000)
+    promiseFct = withTimeout(promiseFct, TIMEOUT * 2)
 
     const promise = promiseFct()
-    clock.tick(1000)
+    clock.tick(TIMEOUT)
     assert.rejects(promise, testError)
   })
 })

--- a/@xen-orchestra/fs/src/utils.test.js
+++ b/@xen-orchestra/fs/src/utils.test.js
@@ -1,0 +1,19 @@
+import { describe, it } from 'node:test'
+import { strict as assert } from 'assert'
+import sinon from 'sinon'
+import { withTimeout } from './utils'
+import { TimeoutError } from 'promise-toolbox'
+
+const TIMEOUT = 6e6
+
+const clock = sinon.useFakeTimers()
+
+describe('withTimeout()', () => {
+  it(`throws in case of timeout`, async () => {
+    let promiseFct = () => new Promise(() => {})
+    promiseFct = withTimeout(promiseFct, TIMEOUT)
+    const promise = promiseFct()
+    clock.tick(TIMEOUT)
+    await assert.rejects(promise, TimeoutError)
+  })
+})

--- a/@xen-orchestra/fs/src/utils.test.js
+++ b/@xen-orchestra/fs/src/utils.test.js
@@ -63,7 +63,7 @@ describe('withTimeout()', () => {
     promiseFct = withTimeout(promiseFct, TIMEOUT / 2, { onFailureAfterTimeout: mockMethod })
     const promise = promiseFct()
     clock.tick(TIMEOUT)
-    await assert.rejects(promise, testError)
+    await assert.rejects(promise, new TimeoutError())
 
     assert.strictEqual(mockMethod.mock.callCount(), 1)
     assert.strictEqual(mockMethod.mock.calls[0].arguments[0], testError)

--- a/@xen-orchestra/fs/src/utils.test.js
+++ b/@xen-orchestra/fs/src/utils.test.js
@@ -19,7 +19,9 @@ describe('withTimeout()', () => {
   })
 
   it(`throws if function is synchronous`, async () => {
-    let promiseFct = () => {}
+    let promiseFct = () => {
+      return 'return value'
+    }
     promiseFct = withTimeout(promiseFct, TIMEOUT)
     const promise = promiseFct()
     assert.rejects(promise, new Error('Function needs to be asynchronous.'))


### PR DESCRIPTION
### Description

Add safety functions in abstract instead of s3 and azure. A new function "withTimeout" allows to handle timeout and success/failure after timeout.
It should help for better debug and it can be used in several situations.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
