### PR TITLE
fix(xo-6/xo-lite): issue with load average chart when value is null

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [Pool/system] Display pool information in pool/system tab (PR [#8660](https://github.com/vatesfr/xen-orchestra/pull/8660))
 - [VM/Dashboard] Display VM information in dashboard tab (PR [#8529](https://github.com/vatesfr/xen-orchestra/pull/8529))
+- [Host/Dashboard] Fix load average chart when a value is null (PR [#8720](https://github.com/vatesfr/xen-orchestra/pull/8720))
 
 ## **0.11.0** (2025-05-27)
 

--- a/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardCpuUsageChart.vue
+++ b/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardCpuUsageChart.vue
@@ -59,7 +59,7 @@ const cpuUsage = computed<LinearChartData>(() => {
 })
 
 const maxValue = computed(() => {
-  const values = cpuUsage.value[0]?.data.map(item => item.value ?? 0) ?? []
+  const values = cpuUsage.value[0]?.data.map(item => Number(item.value) ?? 0) ?? []
   if (values.length === 0) {
     return 100
   }

--- a/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardLoadAverageChart.vue
+++ b/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardLoadAverageChart.vue
@@ -43,7 +43,7 @@ const loadAverage = computed<LinearChartData>(() => {
 
   const result = load.map((value, index) => ({
     timestamp: (timestampStart + index * RRD_STEP_FROM_STRING.hours) * 1000,
-    value: Number(value.toFixed(2)),
+    value: value ? Number(value.toFixed(2)) : '',
   }))
 
   return [
@@ -55,7 +55,7 @@ const loadAverage = computed<LinearChartData>(() => {
 })
 
 const maxValue = computed(() => {
-  const values = loadAverage.value[0]?.data.map(item => item.value ?? 0) ?? []
+  const values = loadAverage.value[0]?.data.map(item => Number(item.value) ?? 0) ?? []
 
   if (values.length === 0) {
     return 10

--- a/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardNetworkUsageChart.vue
+++ b/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardNetworkUsageChart.vue
@@ -59,7 +59,7 @@ const networkUsage = computed<LinearChartData>(() => {
 
 const maxValue = computed(() => {
   const values = networkUsage.value.reduce(
-    (acc, series) => [...acc, ...series.data.map(item => item.value ?? 0)],
+    (acc, series) => [...acc, ...series.data.map(item => Number(item.value) ?? 0)],
     [] as number[]
   )
 

--- a/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardNetworkChart.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardNetworkChart.vue
@@ -101,7 +101,7 @@ const isLoading = computed(() => isFetching.value || !isStatFetched.value)
 
 const customMaxValue = computed(() => {
   const values = data.value.reduce(
-    (acc, series) => [...acc, ...series.data.map(item => item.value ?? 0)],
+    (acc, series) => [...acc, ...series.data.map(item => Number(item.value) ?? 0)],
 
     [] as number[]
   )

--- a/@xen-orchestra/lite/src/components/vm/dashboard/VmDashboardCpuUsageChart.vue
+++ b/@xen-orchestra/lite/src/components/vm/dashboard/VmDashboardCpuUsageChart.vue
@@ -61,7 +61,7 @@ const cpuUsage = computed<LinearChartData>(() => {
 })
 
 const maxValue = computed(() => {
-  const values = cpuUsage.value[0]?.data.map(item => item.value ?? 0) ?? []
+  const values = cpuUsage.value[0]?.data.map(item => Number(item.value) ?? 0) ?? []
 
   if (values.length === 0) {
     return 100

--- a/@xen-orchestra/lite/src/components/vm/dashboard/VmDashboardNetworkUsageChart.vue
+++ b/@xen-orchestra/lite/src/components/vm/dashboard/VmDashboardNetworkUsageChart.vue
@@ -77,7 +77,7 @@ const networkUsage = computed<LinearChartData>(() => {
 
 const maxValue = computed(() => {
   const values = networkUsage.value.reduce(
-    (acc, series) => [...acc, ...series.data.map(item => item.value ?? 0)],
+    (acc, series) => [...acc, ...series.data.map(item => Number(item.value) ?? 0)],
     [] as number[]
   )
 

--- a/@xen-orchestra/lite/src/components/vm/dashboard/VmDashboardVdiUsageChart.vue
+++ b/@xen-orchestra/lite/src/components/vm/dashboard/VmDashboardVdiUsageChart.vue
@@ -80,7 +80,7 @@ const vdiUsage = computed((): LinearChartData => {
 
 const maxValue = computed(() => {
   const values = vdiUsage.value.reduce(
-    (acc, series) => [...acc, ...series.data.map(item => item.value ?? 0)],
+    (acc, series) => [...acc, ...series.data.map(item => Number(item.value) ?? 0)],
     [] as number[]
   )
 

--- a/@xen-orchestra/web-core/lib/types/chart.ts
+++ b/@xen-orchestra/web-core/lib/types/chart.ts
@@ -2,7 +2,7 @@ export type LinearChartData = {
   label: string
   data: {
     timestamp: number
-    value: number | null
+    value: number | string | null
   }[]
 }[]
 

--- a/@xen-orchestra/web/src/components/host/dashboard/HostDashboardCpuUsageChart.vue
+++ b/@xen-orchestra/web/src/components/host/dashboard/HostDashboardCpuUsageChart.vue
@@ -58,7 +58,7 @@ const cpuUsage = computed<LinearChartData>(() => {
 })
 
 const maxValue = computed(() => {
-  const values = cpuUsage.value[0]?.data.map(item => item.value ?? 0) ?? []
+  const values = cpuUsage.value[0]?.data.map(item => Number(item.value) ?? 0) ?? []
 
   if (values.length === 0) {
     return 100

--- a/@xen-orchestra/web/src/components/host/dashboard/HostDashboardLoadAverageChart.vue
+++ b/@xen-orchestra/web/src/components/host/dashboard/HostDashboardLoadAverageChart.vue
@@ -36,7 +36,7 @@ const loadAverage = computed<LinearChartData>(() => {
   }
 
   const loadValues = data.stats.load
-  const result = new Map<number, { timestamp: number; value: number }>()
+  const result = new Map<number, { timestamp: number; value: number | string }>()
   const timestampStart = data.endTimestamp - data.interval * (loadValues.length - 1)
 
   for (let hourIndex = 0; hourIndex < loadValues.length; hourIndex++) {
@@ -45,7 +45,7 @@ const loadAverage = computed<LinearChartData>(() => {
 
     result.set(timestamp, {
       timestamp,
-      value: Number(load.toFixed(2)),
+      value: load ? Number(load.toFixed(2)) : '',
     })
   }
 
@@ -58,7 +58,7 @@ const loadAverage = computed<LinearChartData>(() => {
 })
 
 const maxValue = computed(() => {
-  const values = loadAverage.value[0]?.data.map(item => item.value ?? 0) ?? []
+  const values = loadAverage.value[0]?.data.map(item => Number(item.value) || 0) ?? []
   if (values.length === 0) {
     return 10
   }

--- a/@xen-orchestra/web/src/components/host/dashboard/HostDashboardNetworkUsageChart.vue
+++ b/@xen-orchestra/web/src/components/host/dashboard/HostDashboardNetworkUsageChart.vue
@@ -65,7 +65,7 @@ const networkUsage = computed<LinearChartData>(() => {
 })
 
 const maxValue = computed(() => {
-  const values = networkUsage.value.flatMap(series => series.data.map(item => item.value ?? 0))
+  const values = networkUsage.value.flatMap(series => series.data.map(item => Number(item.value) ?? 0))
 
   if (values.length === 0) {
     return 100

--- a/@xen-orchestra/web/src/components/vm/dashboard/VmDashboardCpuUsageChart.vue
+++ b/@xen-orchestra/web/src/components/vm/dashboard/VmDashboardCpuUsageChart.vue
@@ -62,7 +62,7 @@ const cpuUsage = computed<LinearChartData>(() => {
 })
 
 const maxValue = computed(() => {
-  const values = cpuUsage.value[0]?.data.map(item => item.value ?? 0) ?? []
+  const values = cpuUsage.value[0]?.data.map(item => Number(item.value) ?? 0) ?? []
 
   if (values.length === 0) {
     return 100

--- a/@xen-orchestra/web/src/components/vm/dashboard/VmDashboardNetworkUsageChart.vue
+++ b/@xen-orchestra/web/src/components/vm/dashboard/VmDashboardNetworkUsageChart.vue
@@ -70,7 +70,7 @@ const networkUsage = computed<LinearChartData>(() => {
 
 const maxValue = computed(() => {
   const values = networkUsage.value.reduce(
-    (acc, series) => [...acc, ...series.data.map(item => item.value ?? 0)],
+    (acc, series) => [...acc, ...series.data.map(item => Number(item.value) ?? 0)],
     [] as number[]
   )
 

--- a/@xen-orchestra/web/src/components/vm/dashboard/VmDashboardVdiUsageChart.vue
+++ b/@xen-orchestra/web/src/components/vm/dashboard/VmDashboardVdiUsageChart.vue
@@ -70,7 +70,7 @@ const vdiUsage = computed<LinearChartData>(() => {
 
 const maxValue = computed(() => {
   const values = vdiUsage.value.reduce(
-    (acc, series) => [...acc, ...series.data.map(item => item.value ?? 0)],
+    (acc, series) => [...acc, ...series.data.map(item => Number(item.value) ?? 0)],
     [] as number[]
   )
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - **XO 6:**
+
   - [Pool/system] Display pool information in pool/system tab (PR [#8581](https://github.com/vatesfr/xen-orchestra/pull/8581))
   - [Host/Dashboard] Update RAM usage components wordings and update CPU provisioning logic (PR [#8648](https://github.com/vatesfr/xen-orchestra/pull/8648))
   - [Site/Dashboard] Update BackupIssues and VtsBackupState components to display data in table (PR [#8674](https://github.com/vatesfr/xen-orchestra/pull/8674)
@@ -19,6 +20,7 @@
   - [Site] Add "Site" level in treeview and add "Site" header and tabs (PR [#8694](https://github.com/vatesfr/xen-orchestra/pull/8694))
 
 - **Migrated REST API endpoints**
+
   - `/rest/v0/pools/<pool-id>/actions/emergency_shutdown` (PR [#8653](https://github.com/vatesfr/xen-orchestra/pull/8653))
   - `/rest/v0/pools/<pool-id>/actions/rolling_reboot` (PR [#8653](https://github.com/vatesfr/xen-orchestra/pull/8653))
   - `/rest/v0/pools/<pool-id>/actions/rolling_update` (PR [#8653](https://github.com/vatesfr/xen-orchestra/pull/8653))
@@ -46,6 +48,7 @@
 
 - [VM/Advanced] Fix CPU mask list in VM (PR [#8661](https://github.com/vatesfr/xen-orchestra/pull/8661))
 - [Server] Fix server deletion now fully disconnects and deletes (PR [#8710](https://github.com/vatesfr/xen-orchestra/pull/8710))
+- [Host/Dashboard] Fix load average chart when a value is null (PR [#8720](https://github.com/vatesfr/xen-orchestra/pull/8720))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

We got an issue when a value is null with load average chart

### Screenshots

![image](https://github.com/user-attachments/assets/78edaedf-e289-44cb-8409-9c97bca2b792)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
