### PR TITLE
feat(backups): enable CBT only when using "purge snapshot data"

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
@@ -146,9 +146,9 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
         if (!settings.bypassVdiChainsCheck) {
           await vm.$assertHealthyVdiChains()
         }
-        if (settings.preferNbd) {
+        if (settings.cbtDestroySnapshotData) {
           try {
-            // enable CBT on all disks if possible
+            // enable CBT on all disks if we want to be able to purge snapshot data
             const diskRefs = await xapi.VM_getDisks(vm.$ref)
             await Promise.all(diskRefs.map(diskRef => xapi.callAsync('VDI.enable_cbt', diskRef)))
           } catch (error) {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,6 +37,8 @@
 - [REST API] expose `DELETE /rest/v0/servers/<server-id>` (PR [#8710](https://github.com/vatesfr/xen-orchestra/pull/8710))
 - [Backup reports] Make content of backup reports independant of 'Report when' parameter (PR [#8670](https://github.com/vatesfr/xen-orchestra/pull/8670))
 - [i18n] Ability to switch language to ones newly present in XO6, but not available for XO5 (Thanks [p-bo](https://github.com/p-bo)!) (PR [#8711](https://github.com/vatesfr/xen-orchestra/pull/8711))
+- [Backups]: Enable CBT only when the "purge snapshot data is enabled" (PR [#8735](https://github.com/vatesfr/xen-orchestra/pull/8735))
+
 - **Azure Blob Storage**:
   - [Backups]: Implemented Azure Blob Storage for backups, Integrating with both the Azurite emulator and Azure (PR [#8415](https://github.com/vatesfr/xen-orchestra/pull/8415))
 

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -619,10 +619,10 @@ const messages = {
   customTag: 'Custom tag',
   editJobNotFound: "The job you're trying to edit wasn't found",
   preferNbd: 'Use NBD + CBT to transfer disk if available',
-  preferNbdInformation:
-    'A network accessible by XO or the proxy must have NBD enabled. Storage must support Change Block Tracking (CBT) to use it in a backup',
+  preferNbdInformation: 'A network accessible by XO or the proxy must have NBD enabled.',
   nbdConcurrency: 'Number of NBD connection per disk',
-  cbtDestroySnapshotData: 'Purge snapshot data when using CBT',
+  cbtDestroySnapshotData:
+    'Purge snapshot data when using CBT. This will automatically enable Change Block Tracking (CBT) on the disks',
   cbtDestroySnapshotDataInformation:
     "The snapshot won't use any notable space on the SR, won't be shown in the UI and won't be usable to do a rollback nor differential restores",
   cbtDestroySnapshotDataDisabledInformation:


### PR DESCRIPTION
this should reduce the use and CBT, thus reduce some of the
unsolved edg cases ( like snapshot migraiton or LVM )

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
