### PR TITLE
REST API: add missing VM change states

### DIFF
--- a/@vates/types/src/lib/xen-orchestra-xapi.mts
+++ b/@vates/types/src/lib/xen-orchestra-xapi.mts
@@ -1,6 +1,6 @@
 import { WrappedXenApiRecord, XenApiNetworkWrapped, XenApiRecord, XenApiSr, XenApiVm } from '../xen-api.mjs'
-import type { XoHost, XoNetwork, XoPif } from '../xo.mjs'
 import type { Readable } from 'node:stream'
+import type { XoHost, XoNetwork, XoPif, XoVm } from '../xo.mjs'
 
 type XcpPatches = {
   changelog?: {
@@ -59,6 +59,21 @@ export interface Xapi {
   deleteNetwork(id: XoNetwork['id']): Promise<void>
   listMissingPatches(host: XoHost['id']): Promise<XcpPatches[] | XsPatches[]>
   pool_emergencyShutdown(): Promise<void>
+  startVm(
+    id: XoVm['id'],
+    opts?: {
+      bypassMacAddressesCheck?: boolean
+      force?: boolean
+      hostId?: XoHost['id']
+      /**
+       * if startOnly is true and the VM is not halted, throw VM_BAD_POWER_STATE
+       * otherwise, unpause/resume the VM
+      *
+      * @default false
+      */
+     startOnly?: boolean
+    }
+  ): Promise<void>
   VM_import(
     stream: Readable,
     srRef?: XenApiSr['$ref'],

--- a/@vates/types/src/lib/xen-orchestra-xapi.mts
+++ b/@vates/types/src/lib/xen-orchestra-xapi.mts
@@ -59,6 +59,7 @@ export interface Xapi {
   deleteNetwork(id: XoNetwork['id']): Promise<void>
   listMissingPatches(host: XoHost['id']): Promise<XcpPatches[] | XsPatches[]>
   pool_emergencyShutdown(): Promise<void>
+  resumeVm(id: XoVm['id']): Promise<void>
   startVm(
     id: XoVm['id'],
     opts?: {

--- a/@vates/types/src/lib/xen-orchestra-xapi.mts
+++ b/@vates/types/src/lib/xen-orchestra-xapi.mts
@@ -60,6 +60,7 @@ export interface Xapi {
   listMissingPatches(host: XoHost['id']): Promise<XcpPatches[] | XsPatches[]>
   pool_emergencyShutdown(): Promise<void>
   resumeVm(id: XoVm['id']): Promise<void>
+  unpauseVm(id: XoVm['id']): Promise<void>
   startVm(
     id: XoVm['id'],
     opts?: {

--- a/@vates/types/src/xen-api.mts
+++ b/@vates/types/src/xen-api.mts
@@ -262,6 +262,7 @@ type XenApiVmCallMethods = {
   (method: 'hard_shutdown'): Promise<void>
   (method: 'clean_reboot'): Promise<void>
   (method: 'hard_reboot'): Promise<void>
+  (method: 'pause'): Promise<void>
   (method: 'record_data_source', dataSource: string): Promise<void>
   (method: 'forget_data_source_archives', dataSource: string): Promise<void>
 }

--- a/@vates/types/src/xen-api.mts
+++ b/@vates/types/src/xen-api.mts
@@ -263,6 +263,7 @@ type XenApiVmCallMethods = {
   (method: 'clean_reboot'): Promise<void>
   (method: 'hard_reboot'): Promise<void>
   (method: 'pause'): Promise<void>
+  (method: 'suspend'): Promise<void>
   (method: 'record_data_source', dataSource: string): Promise<void>
   (method: 'forget_data_source_archives', dataSource: string): Promise<void>
 }

--- a/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
@@ -2,7 +2,8 @@ import { Controller, HttpStatusCodeLiteral } from 'tsoa'
 import { Readable } from 'node:stream'
 import { Request } from 'express'
 import type { Task } from '@vates/types/lib/vates/task'
-import { XoRecord } from '@vates/types/xo'
+import type { XapiXoRecord, XoRecord } from '@vates/types/xo'
+import type { Xapi } from '@vates/types/lib/xen-orchestra/xapi'
 
 import { BASE_URL } from '../index.mjs'
 import { makeNdJsonStream } from '../helpers/stream.helper.mjs'
@@ -75,5 +76,9 @@ export abstract class BaseController<T extends XoRecord, IsSync extends boolean>
 
       return location
     }
+  }
+
+  getXapi(maybeId: XapiXoRecord | XapiXoRecord['id']): Xapi {
+    return this.restApi.xoApp.getXapi(maybeId)
   }
 }

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -310,6 +310,33 @@ export class VmController extends XapiXoController<XoVm> {
   }
 
   /**
+   * The VM must be running
+   *
+   * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
+   */
+  @Example(taskLocation)
+  @Post('{id}/actions/suspend')
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @Response(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  @Response(internalServerErrorResp.status, internalServerErrorResp.description)
+  async suspendVm(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
+    const vmId = id as XoVm['id']
+    const action = async () => {
+      await this.getXapiObject(vmId).$callAsync('suspend')
+    }
+
+    return this.createAction<void>(action, {
+      sync,
+      statusCode: noContentResp.status,
+      taskProperties: {
+        name: 'suspend VM',
+        objectId: vmId,
+      },
+    })
+  }
+
+  /**
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    * @example body { "name_label": "my_awesome_snapshot" }
    */

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -343,6 +343,33 @@ export class VmController extends XapiXoController<XoVm> {
   }
 
   /**
+   * The VM must be suspended
+   *
+   * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
+   */
+  @Example(taskLocation)
+  @Post('{id}/actions/resume')
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @Response(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  @Response(internalServerErrorResp.status, internalServerErrorResp.description)
+  async resumeVm(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
+    const vmId = id as XoVm['id']
+    const action = async () => {
+      await this.getXapi(vmId).resumeVm(vmId)
+    }
+
+    return this.createAction<void>(action, {
+      sync,
+      statusCode: noContentResp.status,
+      taskProperties: {
+        name: 'resume VM',
+        objectId: vmId,
+      },
+    })
+  }
+
+  /**
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    * @example body { "name_label": "my_awesome_snapshot" }
    */

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -283,6 +283,33 @@ export class VmController extends XapiXoController<XoVm> {
   }
 
   /**
+   * The VM must be running
+   *
+   * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
+   */
+  @Example(taskLocation)
+  @Post('{id}/actions/pause')
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @Response(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  @Response(internalServerErrorResp.status, internalServerErrorResp.description)
+  async pauseVm(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
+    const vmId = id as XoVm['id']
+    const action = async () => {
+      await this.getXapiObject(vmId).$callAsync('pause')
+    }
+
+    return this.createAction<void>(action, {
+      sync,
+      statusCode: noContentResp.status,
+      taskProperties: {
+        name: 'pause VM',
+        objectId: vmId,
+      },
+    })
+  }
+
+  /**
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    * @example body { "name_label": "my_awesome_snapshot" }
    */

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -370,6 +370,33 @@ export class VmController extends XapiXoController<XoVm> {
   }
 
   /**
+   * The VM must be paused
+   *
+   * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
+   */
+  @Example(taskLocation)
+  @Post('{id}/actions/unpause')
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @Response(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  @Response(internalServerErrorResp.status, internalServerErrorResp.description)
+  async unpauseVm(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
+    const vmId = id as XoVm['id']
+    const action = async () => {
+      await this.getXapi(vmId).unpauseVm(vmId)
+    }
+
+    return this.createAction<void>(action, {
+      sync,
+      statusCode: noContentResp.status,
+      taskProperties: {
+        name: 'unpause VM',
+        objectId: vmId,
+      },
+    })
+  }
+
+  /**
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    * @example body { "name_label": "my_awesome_snapshot" }
    */

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@
 - [Export] Support qcow2 disks exports (PR [#8668](https://github.com/vatesfr/xen-orchestra/pull/8668))
 - [REST API] Expose `GET /rest/v0/sms` and `GET /rest/v0/sms/<sm-id>` (PR [#8696](https://github.com/vatesfr/xen-orchestra/pull/8696))
 - [XO5/Tasks] hide pending/successful xo tasks (PR [#8676](https://github.com/vatesfr/xen-orchestra/pull/8676))
+- [REST API] Expose `POST /rest/v0/vms/<vm-id>/actions/pause` (PR [#8744](https://github.com/vatesfr/xen-orchestra/pull/8744))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@
 - [REST API] Expose `GET /rest/v0/sms` and `GET /rest/v0/sms/<sm-id>` (PR [#8696](https://github.com/vatesfr/xen-orchestra/pull/8696))
 - [XO5/Tasks] hide pending/successful xo tasks (PR [#8676](https://github.com/vatesfr/xen-orchestra/pull/8676))
 - [REST API] Expose `POST /rest/v0/vms/<vm-id>/actions/pause` (PR [#8744](https://github.com/vatesfr/xen-orchestra/pull/8744))
+- [REST API] Expose `POST /rest/v0/vms/<vm-id>/actions/suspend` (PR [#8744](https://github.com/vatesfr/xen-orchestra/pull/8744))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@
 - [XO5/Tasks] hide pending/successful xo tasks (PR [#8676](https://github.com/vatesfr/xen-orchestra/pull/8676))
 - [REST API] Expose `POST /rest/v0/vms/<vm-id>/actions/pause` (PR [#8744](https://github.com/vatesfr/xen-orchestra/pull/8744))
 - [REST API] Expose `POST /rest/v0/vms/<vm-id>/actions/suspend` (PR [#8744](https://github.com/vatesfr/xen-orchestra/pull/8744))
+- [REST API] Expose `POST /rest/v0/vms/<vm-id>/actions/resume` (PR [#8744](https://github.com/vatesfr/xen-orchestra/pull/8744))
 - [REST API] Add `hostId` in body of `POST /rest/v0/vms/<vm-id>/actions/start` to start a VM on a specific host (PR [#8744](https://github.com/vatesfr/xen-orchestra/pull/8744))
 
 ### Bug fixes

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@
 - [REST API] Expose `POST /rest/v0/vms/<vm-id>/actions/pause` (PR [#8744](https://github.com/vatesfr/xen-orchestra/pull/8744))
 - [REST API] Expose `POST /rest/v0/vms/<vm-id>/actions/suspend` (PR [#8744](https://github.com/vatesfr/xen-orchestra/pull/8744))
 - [REST API] Expose `POST /rest/v0/vms/<vm-id>/actions/resume` (PR [#8744](https://github.com/vatesfr/xen-orchestra/pull/8744))
+- [REST API] Expose `POST /rest/v0/vms/<vm-id>/actions/unpause` (PR [#8744](https://github.com/vatesfr/xen-orchestra/pull/8744))
 - [REST API] Add `hostId` in body of `POST /rest/v0/vms/<vm-id>/actions/start` to start a VM on a specific host (PR [#8744](https://github.com/vatesfr/xen-orchestra/pull/8744))
 
 ### Bug fixes

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@
 - [XO5/Tasks] hide pending/successful xo tasks (PR [#8676](https://github.com/vatesfr/xen-orchestra/pull/8676))
 - [REST API] Expose `POST /rest/v0/vms/<vm-id>/actions/pause` (PR [#8744](https://github.com/vatesfr/xen-orchestra/pull/8744))
 - [REST API] Expose `POST /rest/v0/vms/<vm-id>/actions/suspend` (PR [#8744](https://github.com/vatesfr/xen-orchestra/pull/8744))
+- [REST API] Add `hostId` in body of `POST /rest/v0/vms/<vm-id>/actions/start` to start a VM on a specific host (PR [#8744](https://github.com/vatesfr/xen-orchestra/pull/8744))
 
 ### Bug fixes
 


### PR DESCRIPTION
### Screenshot

![Capture d’écran de 2025-06-23 16-34-55](https://github.com/user-attachments/assets/d870b5a3-6f70-4ea0-a364-6c50a12bb889)

### Description

[XO-998](https://project.vates.tech/vates-global/browse/XO-998/)

**do not squash**

add `startOnly` in `startVm` to not handle `VM.resume` and `VM.unpause` in order to make the `start` endpoint more `RESTful` and less confusing for users

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
