### PR TITLE
docs(tab-advanced-js): fix wrong link to guest uefi secure boot guide

### DIFF
--- a/packages/xo-web/src/xo-app/vm/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/vm/tab-advanced.js
@@ -1234,7 +1234,7 @@ export default class TabAdvanced extends Component {
                     </Tooltip>
                     <a
                       className='text-muted'
-                      href='https://xcp-ng.org/docs/guides.html#guest-uefi-secure-boot'
+                      href='https://docs.xcp-ng.org/guides/guest-UEFI-Secure-Boot/'
                       rel='noreferrer'
                       style={{ display: 'block' }}
                       target='_blank'


### PR DESCRIPTION
A link to the [Guest UEFI Secure Boot guide](https://docs.xcp-ng.org/guides/guest-UEFI-Secure-Boot/) pointed to an obsolete URL. This PR replaces it with the current URL.