### PR TITLE
feat(@xen-orchestra/rest-api): expose pool dashboard

### DIFF
--- a/@vates/types/src/lib/xen-orchestra-xapi.mts
+++ b/@vates/types/src/lib/xen-orchestra-xapi.mts
@@ -23,7 +23,7 @@ import type {
   XoVmTemplate,
 } from '../xo.mjs'
 
-type XcpPatches = {
+export type XcpPatches = {
   changelog?: {
     author: string
     date: number
@@ -37,7 +37,7 @@ type XcpPatches = {
   url: string
   version: string
 }
-type XsPatches = {
+export type XsPatches = {
   conflicts?: string[]
   date: string
   description: string

--- a/@xen-orchestra/rest-api/src/alarms/alarm.controller.mts
+++ b/@xen-orchestra/rest-api/src/alarms/alarm.controller.mts
@@ -1,22 +1,16 @@
-import * as CM from 'complex-matcher'
 import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
 import type { Request as ExRequest } from 'express'
 import { inject } from 'inversify'
 import { noSuchObject } from 'xo-common/api-errors.js'
 import { provide } from 'inversify-binding-decorators'
-import type { XapiXoRecord, XoAlarm, XoMessage } from '@vates/types'
+import type { XoAlarm, XoMessage } from '@vates/types'
 
 import { alarm, alarmIds, partialAlarms } from '../open-api/oa-examples/alarm.oa-example.mjs'
-import { BASE_URL } from '../index.mjs'
 import { notFoundResp, unauthorizedResp, Unbrand } from '../open-api/common/response.common.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
-
-// E.g: 'value: 0.6\nconfig:\n<variable>\n<name value="cpu_usage"/>\n<alarm_trigger_level value="0.4"/>\n<alarm_trigger_period value ="60"/>\n</variable>';
-const ALARM_BODY_REGEX = /^value:\s*(Infinity|NaN|-Infinity|\d+(?:\.\d+)?)\s*config:\s*<variable>\s*<name value="(.*?)"/
-const ALARM_NAMES = ['ALARM', 'BOND_STATUS_CHANGED', 'MULTIPATH_PERIODIC_ALERT']
-export const alarmPredicate = CM.parse(`name:|(${ALARM_NAMES.join(' ')})`).createPredicate()
+import { AlarmService } from './alarm.service.mjs'
 
 type UnbrandedXoAlarm = Unbrand<XoAlarm>
 
@@ -26,66 +20,18 @@ type UnbrandedXoAlarm = Unbrand<XoAlarm>
 @Tags('alarms')
 @provide(AlarmController)
 export class AlarmController extends XapiXoController<XoAlarm> {
-  constructor(@inject(RestApi) restApi: RestApi) {
+  #alarmService: AlarmService
+
+  constructor(@inject(RestApi) restApi: RestApi, @inject(AlarmService) alarmService) {
     super('message', restApi)
-  }
-
-  #parseAlarm({ $object, body, ...alarm }: XoMessage): XoAlarm {
-    let object: XapiXoRecord | { type: 'unknown'; uuid: XapiXoRecord['uuid'] }
-    try {
-      object = this.restApi.getObject<XapiXoRecord>($object)
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (err) {
-      object = {
-        type: 'unknown',
-        uuid: $object,
-      }
-    }
-
-    let href: string | undefined
-    if (object.type !== 'unknown') {
-      href = `${BASE_URL}/${object.type.toLowerCase() + 's'}/${object.uuid}`
-    }
-
-    const [, value, name] = body.match(ALARM_BODY_REGEX) ?? []
-    return {
-      ...alarm,
-      body: {
-        value, // Keep the value as a string because NaN, Infinity, -Infinity is not valid JSON
-        name: name ?? body, // for 'BOND_STATUS_CHANGED' and 'MULTIPATH_PERIODIC_ALERT', body is a non-xml string. ("body": "The status of the eth0+eth1 bond is: 1/2 up")
-      },
-      object: {
-        type: object.type,
-        uuid: object.uuid,
-        href,
-      },
-    }
+    this.#alarmService = alarmService
   }
 
   /**
    * Override parent getObjects in order to only get `ALARM` messages
    */
-  getObjects({ filter, limit = Infinity }: { filter?: string; limit?: number } = {}): Record<XoAlarm['id'], XoAlarm> {
-    const rawAlarms = this.restApi.getObjectsByType<XoMessage>('message', {
-      filter: alarmPredicate,
-    })
-
-    let userFilter: (obj: XoAlarm) => boolean = () => true
-    if (filter !== undefined) {
-      userFilter = CM.parse(filter).createPredicate()
-    }
-    const alarms: Record<XoAlarm['id'], XoAlarm> = {}
-    for (const id in rawAlarms) {
-      if (limit === 0) {
-        break
-      }
-      const alarm = this.#parseAlarm(rawAlarms[id])
-      if (userFilter(alarm)) {
-        alarms[id] = alarm
-        limit--
-      }
-    }
-    return alarms
+  getObjects(opts?: { filter?: string; limit?: number }): Record<XoAlarm['id'], XoAlarm> {
+    return this.#alarmService.getAlarms(opts)
   }
 
   /**
@@ -94,11 +40,11 @@ export class AlarmController extends XapiXoController<XoAlarm> {
   getObject(id: XoAlarm['id']): XoAlarm {
     const maybeAlarm = this.restApi.getObject<XoMessage>(id, 'message')
 
-    if (!alarmPredicate(maybeAlarm)) {
+    if (!this.#alarmService.isAlarm(maybeAlarm)) {
       throw noSuchObject(id, 'alarm')
     }
 
-    return this.#parseAlarm(maybeAlarm)
+    return this.#alarmService.parseAlarm(maybeAlarm)
   }
 
   /**

--- a/@xen-orchestra/rest-api/src/alarms/alarm.service.mts
+++ b/@xen-orchestra/rest-api/src/alarms/alarm.service.mts
@@ -16,11 +16,7 @@ export class AlarmService {
   }
 
   isAlarm(maybeAlarm: XoMessage) {
-    if (!alarmPredicate(maybeAlarm)) {
-      return false
-    }
-
-    return true
+    return alarmPredicate(maybeAlarm)
   }
 
   parseAlarm({ $object, body, ...alarm }: XoMessage): XoAlarm {

--- a/@xen-orchestra/rest-api/src/alarms/alarm.service.mts
+++ b/@xen-orchestra/rest-api/src/alarms/alarm.service.mts
@@ -1,0 +1,80 @@
+import { XapiXoRecord, XoAlarm, XoMessage } from '@vates/types'
+import { RestApi } from '../rest-api/rest-api.mjs'
+import * as CM from 'complex-matcher'
+import { BASE_URL } from '../index.mjs'
+
+// E.g: 'value: 0.6\nconfig:\n<variable>\n<name value="cpu_usage"/>\n<alarm_trigger_level value="0.4"/>\n<alarm_trigger_period value ="60"/>\n</variable>';
+const ALARM_BODY_REGEX = /^value:\s*(Infinity|NaN|-Infinity|\d+(?:\.\d+)?)\s*config:\s*<variable>\s*<name value="(.*?)"/
+const ALARM_NAMES = ['ALARM', 'BOND_STATUS_CHANGED', 'MULTIPATH_PERIODIC_ALERT']
+export const alarmPredicate = CM.parse(`name:|(${ALARM_NAMES.join(' ')})`).createPredicate()
+
+export class AlarmService {
+  #restApi: RestApi
+
+  constructor(restApi: RestApi) {
+    this.#restApi = restApi
+  }
+
+  isAlarm(maybeAlarm: XoMessage) {
+    if (!alarmPredicate(maybeAlarm)) {
+      return false
+    }
+
+    return true
+  }
+
+  parseAlarm({ $object, body, ...alarm }: XoMessage): XoAlarm {
+    let object: XapiXoRecord | { type: 'unknown'; uuid: XapiXoRecord['uuid'] }
+    try {
+      object = this.#restApi.getObject<XapiXoRecord>($object)
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (err) {
+      object = {
+        type: 'unknown',
+        uuid: $object,
+      }
+    }
+
+    let href: string | undefined
+    if (object.type !== 'unknown') {
+      href = `${BASE_URL}/${object.type.toLowerCase() + 's'}/${object.uuid}`
+    }
+
+    const [, value, name] = body.match(ALARM_BODY_REGEX) ?? []
+    return {
+      ...alarm,
+      body: {
+        value, // Keep the value as a string because NaN, Infinity, -Infinity is not valid JSON
+        name: name ?? body, // for 'BOND_STATUS_CHANGED' and 'MULTIPATH_PERIODIC_ALERT', body is a non-xml string. ("body": "The status of the eth0+eth1 bond is: 1/2 up")
+      },
+      object: {
+        type: object.type,
+        uuid: object.uuid,
+        href,
+      },
+    }
+  }
+
+  getAlarms({ filter, limit = Infinity }: { filter?: string | ((obj: XoAlarm) => boolean); limit?: number } = {}) {
+    const rawAlarms = this.#restApi.getObjectsByType<XoMessage>('message', {
+      filter: alarmPredicate,
+    })
+
+    let userFilter: (obj: XoAlarm) => boolean = () => true
+    if (filter !== undefined) {
+      userFilter = typeof filter === 'string' ? CM.parse(filter).createPredicate() : filter
+    }
+    const alarms: Record<XoAlarm['id'], XoAlarm> = {}
+    for (const id in rawAlarms) {
+      if (limit === 0) {
+        break
+      }
+      const alarm = this.parseAlarm(rawAlarms[id])
+      if (userFilter(alarm)) {
+        alarms[id] = alarm
+        limit--
+      }
+    }
+    return alarms
+  }
+}

--- a/@xen-orchestra/rest-api/src/helpers/utils.helper.mts
+++ b/@xen-orchestra/rest-api/src/helpers/utils.helper.mts
@@ -1,5 +1,8 @@
 import { AnyXoVm, XoSr } from '@vates/types'
+import { isPromise } from 'node:util/types'
 
+import { MaybePromise } from './helper.type.mjs'
+import { Writable } from 'node:stream'
 export const NDJSON_CONTENT_TYPE = 'application/x-ndjson'
 
 export const isSrWritable = (sr: XoSr) => sr.content_type !== 'iso' && sr.size > 0
@@ -39,4 +42,43 @@ export const getTopPerProperty = <T,>(
   }
 
   return arr
+}
+export const promiseWriteInStream = async <T,>({
+  maybePromise,
+  path,
+  stream,
+}: {
+  maybePromise: MaybePromise<T>
+  path: string
+  stream?: Writable
+}): Promise<T> => {
+  let data: T
+  if (isPromise(maybePromise)) {
+    data = await maybePromise
+  } else {
+    data = maybePromise
+  }
+
+  if (stream !== undefined) {
+    if (stream.writableNeedDrain) {
+      await new Promise(resolve => stream.once('drain', resolve))
+    }
+
+    // handle path like `foo.bar` -> `{foo: {bar: data}}`
+    const obj = {}
+    let current = obj
+    const keys = path.split('.')
+    keys.forEach((key, index) => {
+      if (index === keys.length - 1) {
+        current[key] = data
+      } else {
+        current[key] = {}
+        current = current[key]
+      }
+    })
+
+    stream.write(JSON.stringify(obj) + '\n')
+  }
+
+  return data
 }

--- a/@xen-orchestra/rest-api/src/helpers/utils.helper.mts
+++ b/@xen-orchestra/rest-api/src/helpers/utils.helper.mts
@@ -13,7 +13,7 @@ export const getTopPerProperty = <T,>(
   { length = Infinity, prop }: { length?: number; prop: keyof T & string }
 ): T[] => {
   // avoid mutate original array
-  const arr = [...array]
+  let arr = [...array]
 
   arr.sort((prev, next) => {
     const prevProp = +prev[prop]
@@ -38,7 +38,7 @@ export const getTopPerProperty = <T,>(
   })
 
   if (arr.length > length) {
-    arr.length = length
+    arr = arr.slice(0, length)
   }
 
   return arr

--- a/@xen-orchestra/rest-api/src/helpers/utils.helper.mts
+++ b/@xen-orchestra/rest-api/src/helpers/utils.helper.mts
@@ -5,3 +5,38 @@ export const NDJSON_CONTENT_TYPE = 'application/x-ndjson'
 export const isSrWritable = (sr: XoSr) => sr.content_type !== 'iso' && sr.size > 0
 export const isReplicaVm = (vm: AnyXoVm) => 'start' in vm.blockedOperations && vm.other['xo:backup:job'] !== undefined
 export const vmContainsNoBakTag = (vm: AnyXoVm) => vm.tags.some(t => t.split('=', 1)[0] === 'xo:no-bak')
+export const getTopPerProperty = <T,>(
+  array: T[],
+  { length = Infinity, prop }: { length?: number; prop: keyof T & string }
+): T[] => {
+  // avoid mutate original array
+  const arr = [...array]
+
+  arr.sort((prev, next) => {
+    const prevProp = +prev[prop]
+    const nextProp = +next[prop]
+    if (typeof prevProp !== 'number' || typeof nextProp !== 'number') {
+      throw new Error(`cannot parse: ${prop} as number. ${prev}, ${next}`)
+    }
+
+    if (isNaN(prevProp) && isNaN(nextProp)) {
+      return 0
+    }
+
+    if (isNaN(prevProp)) {
+      return 1
+    }
+
+    if (isNaN(nextProp)) {
+      return -1
+    }
+
+    return nextProp - prevProp
+  })
+
+  if (arr.length > length) {
+    arr.length = length
+  }
+
+  return arr
+}

--- a/@xen-orchestra/rest-api/src/hosts/host.service.mts
+++ b/@xen-orchestra/rest-api/src/hosts/host.service.mts
@@ -1,0 +1,48 @@
+import { HOST_POWER_STATE, type XoHost } from '@vates/types'
+import type { RestApi } from '../rest-api/rest-api.mjs'
+
+export class HostService {
+  #restApi: RestApi
+
+  constructor(restApi: RestApi) {
+    this.#restApi = restApi
+  }
+
+  getHostsStatus(opts?: { filter?: string | ((obj: XoHost) => boolean) }) {
+    const hosts = this.#restApi.getObjectsByType<XoHost>('host', opts)
+
+    let nRunning = 0
+    let nHalted = 0
+    let nDisabled = 0
+    let nUnknown = 0
+    let total = 0
+
+    for (const id in hosts) {
+      total++
+      const host = hosts[id as XoHost['id']]
+      if (!host.enabled) {
+        nDisabled++
+        continue
+      }
+      switch (host.power_state) {
+        case HOST_POWER_STATE.RUNNING:
+          nRunning++
+          break
+        case HOST_POWER_STATE.HALTED:
+          nHalted++
+          break
+        default:
+          nUnknown++
+          break
+      }
+    }
+
+    return {
+      disabled: nDisabled,
+      running: nRunning,
+      halted: nHalted,
+      unknown: nUnknown,
+      total,
+    }
+  }
+}

--- a/@xen-orchestra/rest-api/src/hosts/host.service.mts
+++ b/@xen-orchestra/rest-api/src/hosts/host.service.mts
@@ -1,5 +1,10 @@
-import { HOST_POWER_STATE, type XoHost } from '@vates/types'
+import { asyncEach } from '@vates/async-each'
+import { createLogger } from '@xen-orchestra/log'
+import { HOST_POWER_STATE, XcpPatches, XsPatches, type XoHost } from '@vates/types'
+
 import type { RestApi } from '../rest-api/rest-api.mjs'
+
+const log = createLogger('xo:rest-api:host-service')
 
 export class HostService {
   #restApi: RestApi
@@ -43,6 +48,54 @@ export class HostService {
       halted: nHalted,
       unknown: nUnknown,
       total,
+    }
+  }
+
+  async getMissingPatchesInfo(opts?: { filter?: string | ((obj: XoHost) => boolean) }): Promise<
+    | { hasAuthorization: false }
+    | {
+        hasAuthorization: true
+        nHostsWithMissingPatches: number
+        nPoolsWithMissingPatches: number
+        nHostsFailed: number
+        missingPatches: (XcpPatches | XsPatches)[]
+      }
+  > {
+    if (!(await this.#restApi.xoApp.hasFeatureAuthorization('LIST_MISSING_PATCHES'))) {
+      return {
+        hasAuthorization: false,
+      }
+    }
+
+    const hosts = Object.values(this.#restApi.getObjectsByType<XoHost>('host', opts))
+    const missingPatches = new Map<string, XcpPatches | XsPatches>()
+    const poolsWithMissingPatches = new Set()
+    let nHostsWithMissingPatches = 0
+    let nHostsFailed = 0
+
+    await asyncEach(hosts, async (host: XoHost) => {
+      const xapi = this.#restApi.xoApp.getXapi(host)
+
+      try {
+        const patches = await xapi.listMissingPatches(host.id)
+
+        if (patches.length > 0) {
+          nHostsWithMissingPatches++
+          poolsWithMissingPatches.add(host.$pool)
+          patches.forEach(patch => missingPatches.set(patch.id ?? patch.name, patch))
+        }
+      } catch (err) {
+        log.error('listMissingPatches failed', err)
+        nHostsFailed++
+      }
+    })
+
+    return {
+      hasAuthorization: true,
+      missingPatches: Array.from(missingPatches.values()),
+      nHostsFailed,
+      nHostsWithMissingPatches,
+      nPoolsWithMissingPatches: poolsWithMissingPatches.size,
     }
   }
 }

--- a/@xen-orchestra/rest-api/src/ioc/ioc.mts
+++ b/@xen-orchestra/rest-api/src/ioc/ioc.mts
@@ -8,6 +8,7 @@ import type { XoApp } from '../rest-api/rest-api.type.mjs'
 import { XoaService } from '../xoa/xoa.service.mjs'
 import { HostService } from '../hosts/host.service.mjs'
 import { PoolService } from '../pools/pool.service.mjs'
+import { AlarmService } from '../alarms/alarm.service.mjs'
 
 const iocContainer = new Container()
 
@@ -53,6 +54,14 @@ export function setupContainer(xoApp: XoApp) {
     .toDynamicValue(ctx => {
       const restApi = ctx.container.get(RestApi)
       return new HostService(restApi)
+    })
+    .inSingletonScope()
+
+  iocContainer
+    .bind(AlarmService)
+    .toDynamicValue(ctx => {
+      const restApi = ctx.container.get(RestApi)
+      return new AlarmService(restApi)
     })
     .inSingletonScope()
 }

--- a/@xen-orchestra/rest-api/src/ioc/ioc.mts
+++ b/@xen-orchestra/rest-api/src/ioc/ioc.mts
@@ -6,6 +6,8 @@ import { RestApi } from '../rest-api/rest-api.mjs'
 import { VmService } from '../vms/vm.service.mjs'
 import type { XoApp } from '../rest-api/rest-api.type.mjs'
 import { XoaService } from '../xoa/xoa.service.mjs'
+import { HostService } from '../hosts/host.service.mjs'
+import { PoolService } from '../pools/pool.service.mjs'
 
 const iocContainer = new Container()
 
@@ -19,7 +21,7 @@ export function setupContainer(xoApp: XoApp) {
 
   iocContainer
     .bind(RestApi)
-    .toDynamicValue(() => new RestApi(xoApp))
+    .toDynamicValue(() => new RestApi(xoApp, iocContainer))
     .inSingletonScope()
 
   iocContainer
@@ -35,6 +37,22 @@ export function setupContainer(xoApp: XoApp) {
     .toDynamicValue(ctx => {
       const restApi = ctx.container.get(RestApi)
       return new VmService(restApi)
+    })
+    .inSingletonScope()
+
+  iocContainer
+    .bind(PoolService)
+    .toDynamicValue(ctx => {
+      const restApi = ctx.container.get(RestApi)
+      return new PoolService(restApi)
+    })
+    .inSingletonScope()
+
+  iocContainer
+    .bind(HostService)
+    .toDynamicValue(ctx => {
+      const restApi = ctx.container.get(RestApi)
+      return new HostService(restApi)
     })
     .inSingletonScope()
 }

--- a/@xen-orchestra/rest-api/src/messages/message.controller.mts
+++ b/@xen-orchestra/rest-api/src/messages/message.controller.mts
@@ -6,7 +6,7 @@ import { noSuchObject } from 'xo-common/api-errors.js'
 import { provide } from 'inversify-binding-decorators'
 import type { XoMessage } from '@vates/types'
 
-import { alarmPredicate } from '../alarms/alarm.controller.mjs'
+import { alarmPredicate } from '../alarms/alarm.service.mjs'
 import { message, messageIds, partialMessages } from '../open-api/oa-examples/message.oa-example.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/pool.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/pool.oa-example.mts
@@ -291,3 +291,205 @@ export const poolStats = {
     },
   },
 }
+
+export const poolDashboard = {
+  hosts: {
+    status: {
+      running: 3,
+      disabled: 0,
+      halted: 0,
+      total: 3,
+    },
+    topFiveUsage: {
+      ram: [
+        {
+          name_label: 'XCP XO 8.3.0 master',
+          id: 'b61a5c92-700e-4966-a13b-00633f03eea8',
+          size: 34359738368,
+          usage: 6254059520,
+          percent: 18.201708793640137,
+        },
+        {
+          name_label: 'XCP XO 8.3.0 slave',
+          id: '84e555d8-267a-4720-aa5f-fd19035aadae',
+          size: 34359738368,
+          usage: 3544117248,
+          percent: 10.314738750457764,
+        },
+        {
+          name_label: 'XCP XO 8.3.0 slave 2',
+          id: '669df518-4e5d-4d84-b93a-9be2cdcdfca1',
+          size: 34359738368,
+          usage: 3544117248,
+          percent: 10.314738750457764,
+        },
+      ],
+      cpu: [
+        {
+          percent: 6.471593483001921,
+          id: 'b61a5c92-700e-4966-a13b-00633f03eea8',
+          name_label: 'XCP XO 8.3.0 master',
+        },
+        {
+          percent: 2.340522127838084,
+          id: '84e555d8-267a-4720-aa5f-fd19035aadae',
+          name_label: 'XCP XO 8.3.0 slave',
+        },
+        {
+          percent: 1.5935676943627188,
+          id: '669df518-4e5d-4d84-b93a-9be2cdcdfca1',
+          name_label: 'XCP XO 8.3.0 slave 2',
+        },
+      ],
+    },
+    missingPatches: {
+      hasAuthorization: true,
+      missingPatches: [
+        {
+          url: 'http://www.xen.org',
+          version: '25.6.0',
+          name: 'xenopsd-xc',
+          license: 'LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception',
+          changelog: {
+            date: 1750852800,
+            description: '- Fix remote syslog configuration being broken on updates',
+            author: 'Andrii Sultanov <andriy.sultanov@vates.tech> - 25.6.0-1.9',
+          },
+          release: '1.9.xcpng8.3',
+          size: 5421696,
+          description: 'Xenopsd using xc',
+        },
+        {
+          url: 'http://www.xen.org',
+          version: '25.6.0',
+          name: 'forkexecd',
+          license: 'LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception',
+          changelog: {
+            date: 1750852800,
+            description: '- Fix remote syslog configuration being broken on updates',
+            author: 'Andrii Sultanov <andriy.sultanov@vates.tech> - 25.6.0-1.9',
+          },
+          release: '1.9.xcpng8.3',
+          size: 2498124,
+          description: 'A subprocess management service',
+        },
+      ],
+    },
+  },
+  vms: {
+    status: {
+      running: 2,
+      halted: 38,
+      paused: 0,
+      total: 40,
+      suspended: 0,
+    },
+    topFiveUsage: {
+      ram: [
+        {
+          id: 'db822c15-6f7d-8920-10bd-68d40fb12ac6',
+          name_label: 'MRA alpine',
+          memory: 536858624,
+          memoryFree: 423256064,
+          percent: 21.160610060349892,
+        },
+        {
+          id: 'fe10b378-db7b-d2a4-eef6-0f1cde75d409',
+          name_label: 'pbt_test',
+          memory: 2147471360,
+          memoryFree: 1813676032,
+          percent: 15.54364515482991,
+        },
+      ],
+      cpu: [
+        {
+          id: 'db822c15-6f7d-8920-10bd-68d40fb12ac6',
+          name_label: 'MRA alpine',
+          percent: 1.04830558411777,
+        },
+        {
+          id: 'fe10b378-db7b-d2a4-eef6-0f1cde75d409',
+          name_label: 'pbt_test',
+          percent: 0.3743608540389682,
+        },
+      ],
+    },
+  },
+  srs: {
+    topFiveUsage: [
+      {
+        name_label: 'Local storage',
+        id: '4cb0d74e-a7c1-0b7d-46e3-09382c012abb',
+        percent: 45.51916716586373,
+        physical_usage: 33539653632,
+        size: 73682485248,
+      },
+      {
+        name_label: 'Local storage',
+        id: 'c4284e12-37c9-7967-b9e8-83ef229c3e03',
+        percent: 23.527768920458005,
+        physical_usage: 17335844864,
+        size: 73682485248,
+      },
+      {
+        name_label: 'XOSTOR NVME',
+        id: 'c787b75c-3e0d-70fa-d0c3-cbfd382d7e33',
+        percent: 18.56945625131877,
+        physical_usage: 95048891392,
+        size: 511856082944,
+      },
+      {
+        name_label: 'Local storage',
+        id: '8aa2fb4a-143e-c2bc-05d4-c68bbb101d41',
+        percent: 16.016159531372924,
+        physical_usage: 11801104384,
+        size: 73682485248,
+      },
+    ],
+  },
+  alarms: [
+    {
+      name: 'ALARM',
+      time: 1749572297,
+      id: '71ef8836-56e4-97ca-02d1-e118ee1aad98',
+      type: 'message',
+      uuid: '71ef8836-56e4-97ca-02d1-e118ee1aad98',
+      $pool: 'b7569d99-30f8-178a-7d94-801de3e29b5b',
+      $poolId: 'b7569d99-30f8-178a-7d94-801de3e29b5b',
+      _xapiRef: 'OpaqueRef:fed2a9e5-6c72-dada-6f27-7475583ff3e7',
+      body: {
+        value: '1.054742',
+        name: 'mem_usage',
+      },
+      object: {
+        type: 'VM-controller',
+        uuid: '9b4775bd-9493-490a-9afa-f786a44caa4f',
+        href: '/rest/v0/vm-controllers/9b4775bd-9493-490a-9afa-f786a44caa4f',
+      },
+    },
+    {
+      name: 'ALARM',
+      time: 1748688413,
+      id: 'ef9008da-e244-9875-4b83-12de733c8aa9',
+      type: 'message',
+      uuid: 'ef9008da-e244-9875-4b83-12de733c8aa9',
+      $pool: 'b7569d99-30f8-178a-7d94-801de3e29b5b',
+      $poolId: 'b7569d99-30f8-178a-7d94-801de3e29b5b',
+      _xapiRef: 'OpaqueRef:d03c24dc-037d-ac8b-80ea-c5a1106cd678',
+      body: {
+        value: '0.962104',
+        name: 'mem_usage',
+      },
+      object: {
+        type: 'VM-controller',
+        uuid: '9b4775bd-9493-490a-9afa-f786a44caa4f',
+        href: '/rest/v0/vm-controllers/9b4775bd-9493-490a-9afa-f786a44caa4f',
+      },
+    },
+  ],
+  cpuProvisioning: {
+    total: 48,
+    assigned: 4,
+    percent: 8.333333333333334,
+  },
+}

--- a/@xen-orchestra/rest-api/src/pools/pool.controller.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.controller.mts
@@ -44,7 +44,13 @@ import type {
   XoVm,
 } from '@vates/types'
 import { createVm, importVm, partialPools, pool, poolIds, poolStats } from '../open-api/oa-examples/pool.oa-example.mjs'
-import type { CreateNetworkBody, CreateVmAfterCreateParams, CreateVmBody, CreateVmParams } from './pool.type.mjs'
+import type {
+  CreateNetworkBody,
+  CreateVmAfterCreateParams,
+  CreateVmBody,
+  CreateVmParams,
+  PoolDashboard,
+} from './pool.type.mjs'
 import { taskLocation } from '../open-api/oa-examples/task.oa-example.mjs'
 import { createNetwork } from '../open-api/oa-examples/schedule.oa-example.mjs'
 import { BASE_URL } from '../index.mjs'
@@ -313,7 +319,11 @@ export class PoolController extends XapiXoController<XoPool> {
   }
 
   @Get('{id}/dashboard')
-  async getPoolDashboard(@Request() req: ExRequest, @Path() id: string, @Query() ndjson?: boolean) {
+  async getPoolDashboard(
+    @Request() req: ExRequest,
+    @Path() id: string,
+    @Query() ndjson?: boolean
+  ): Promise<PoolDashboard | void> {
     const poolId = id as XoPool['id']
     // throw if pool not found
     this.getObject(poolId)

--- a/@xen-orchestra/rest-api/src/pools/pool.controller.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.controller.mts
@@ -43,7 +43,15 @@ import type {
   XoSr,
   XoVm,
 } from '@vates/types'
-import { createVm, importVm, partialPools, pool, poolIds, poolStats } from '../open-api/oa-examples/pool.oa-example.mjs'
+import {
+  createVm,
+  importVm,
+  partialPools,
+  pool,
+  poolDashboard,
+  poolIds,
+  poolStats,
+} from '../open-api/oa-examples/pool.oa-example.mjs'
 import type {
   CreateNetworkBody,
   CreateVmAfterCreateParams,
@@ -318,7 +326,12 @@ export class PoolController extends XapiXoController<XoPool> {
     return this.restApi.xoApp.getXapiPoolStats(id as XoPool['id'], granularity)
   }
 
+  /**
+   * @example id "355ee47d-ff4c-4924-3db2-fd86ae629677"
+   */
+  @Example(poolDashboard)
   @Get('{id}/dashboard')
+  @Response(notFoundResp.status, notFoundResp.description)
   async getPoolDashboard(
     @Request() req: ExRequest,
     @Path() id: string,

--- a/@xen-orchestra/rest-api/src/pools/pool.service.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.service.mts
@@ -251,11 +251,12 @@ export class PoolService {
     }
 
     const total = pool.cpus.cores ?? 0
+    const percent = total === 0 ? 0 : (assignedVcpu * 100) / total
 
     return {
       total,
       assigned: assignedVcpu,
-      percent: (assignedVcpu * 100) / total,
+      percent,
     }
   }
 

--- a/@xen-orchestra/rest-api/src/pools/pool.service.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.service.mts
@@ -1,14 +1,17 @@
 import { type XoPool } from '@vates/types'
 import type { RestApi } from '../rest-api/rest-api.mjs'
 import { HostService } from '../hosts/host.service.mjs'
+import { VmService } from '../vms/vm.service.mjs'
 
 export class PoolService {
   #restApi: RestApi
   #hostService: HostService
+  #vmService: VmService
 
   constructor(restApi: RestApi) {
     this.#restApi = restApi
     this.#hostService = this.#restApi.ioc.get(HostService)
+    this.#vmService = this.#restApi.ioc.get(VmService)
   }
 
   #getHostsStatus(poolId: XoPool['id']) {
@@ -19,11 +22,27 @@ export class PoolService {
     return { running, disabled, halted, total }
   }
 
+  #getVmsStatus(poolId: XoPool['id']) {
+    const { running, halted, paused, total, suspended } = this.#vmService.getVmsStatus({
+      filter: vm => vm.$pool === poolId,
+    })
+
+    return {
+      running,
+      halted,
+      paused,
+      total,
+      suspended,
+    }
+  }
+
   async getDashboard(id: XoPool['id']) {
     const hostStatus = this.#getHostsStatus(id)
+    const vmsStatus = this.#getVmsStatus(id)
 
     return {
       hostStatus,
+      vmsStatus,
     }
   }
 }

--- a/@xen-orchestra/rest-api/src/pools/pool.service.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.service.mts
@@ -1,0 +1,29 @@
+import { type XoPool } from '@vates/types'
+import type { RestApi } from '../rest-api/rest-api.mjs'
+import { HostService } from '../hosts/host.service.mjs'
+
+export class PoolService {
+  #restApi: RestApi
+  #hostService: HostService
+
+  constructor(restApi: RestApi) {
+    this.#restApi = restApi
+    this.#hostService = this.#restApi.ioc.get(HostService)
+  }
+
+  #getHostsStatus(poolId: XoPool['id']) {
+    const { running, disabled, halted, total } = this.#hostService.getHostsStatus({
+      filter: host => host.$pool === poolId,
+    })
+
+    return { running, disabled, halted, total }
+  }
+
+  async getDashboard(id: XoPool['id']) {
+    const hostStatus = this.#getHostsStatus(id)
+
+    return {
+      hostStatus,
+    }
+  }
+}

--- a/@xen-orchestra/rest-api/src/pools/pool.service.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.service.mts
@@ -65,7 +65,7 @@ export class PoolService {
 
   #getAlarms(poolId: XoPool['id']): PoolDashboard['alarms'] {
     const alarms = this.#alarmService.getAlarms({ filter: alarm => alarm.$pool === poolId })
-    return Object.values(alarms)
+    return Object.keys(alarms)
   }
 
   async #getMissingPatches(poolId: XoPool['id']): Promise<PoolDashboard['hosts']['missingPatches']> {

--- a/@xen-orchestra/rest-api/src/pools/pool.service.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.service.mts
@@ -2,16 +2,19 @@ import { type XoPool } from '@vates/types'
 import type { RestApi } from '../rest-api/rest-api.mjs'
 import { HostService } from '../hosts/host.service.mjs'
 import { VmService } from '../vms/vm.service.mjs'
+import { AlarmService } from '../alarms/alarm.service.mjs'
 
 export class PoolService {
   #restApi: RestApi
   #hostService: HostService
   #vmService: VmService
+  #alarmService: AlarmService
 
   constructor(restApi: RestApi) {
     this.#restApi = restApi
     this.#hostService = this.#restApi.ioc.get(HostService)
     this.#vmService = this.#restApi.ioc.get(VmService)
+    this.#alarmService = this.#restApi.ioc.get(AlarmService)
   }
 
   #getHostsStatus(poolId: XoPool['id']) {
@@ -36,13 +39,20 @@ export class PoolService {
     }
   }
 
+  #getAlarms(poolId: XoPool['id']) {
+    const alarms = this.#alarmService.getAlarms({ filter: alarm => alarm.$pool === poolId })
+    return Object.values(alarms)
+  }
+
   async getDashboard(id: XoPool['id']) {
     const hostStatus = this.#getHostsStatus(id)
     const vmsStatus = this.#getVmsStatus(id)
+    const alarms = this.#getAlarms(id)
 
     return {
       hostStatus,
       vmsStatus,
+      alarms,
     }
   }
 }

--- a/@xen-orchestra/rest-api/src/pools/pool.service.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.service.mts
@@ -140,16 +140,16 @@ export class PoolService {
   }
 
   #getVmWithLastCpuInfo(vm: XoVm, stats: XapiVmStats): XoVm & { usage: number } {
-    const cpus = Object.values(stats.stats.cpus ?? {})
+    const cpusStats = Object.values(stats.stats.cpus ?? {})
     const usage =
-      cpus.reduce((total, cpus, index) => {
-        const cpu = cpus.pop()
-        if (cpu == null) {
+      cpusStats.reduce((total, cpuStats, index) => {
+        const lastCpuStat = cpuStats.pop()
+        if (lastCpuStat == null) {
           log.warn(`cpu#${index} is null. vm:`, vm.id)
         }
-        total += cpu ?? 0
+        total += lastCpuStat ?? 0
         return total
-      }, 0) / cpus.length
+      }, 0) / cpusStats.length
 
     return { ...vm, usage }
   }
@@ -218,16 +218,16 @@ export class PoolService {
     for (const id in hosts) {
       const host = hosts[id as XoHost['id']]
       const stats = await this.#restApi.xoApp.getXapiHostStats(host.id, 'seconds')
-      const cpus = Object.values(stats.stats.cpus ?? {})
+      const cpusStats = Object.values(stats.stats.cpus ?? {})
       const percent =
-        cpus.reduce((total, cpus, index) => {
-          const cpu = cpus.pop()
-          if (cpu == null) {
+        cpusStats.reduce((total, cpuStats, index) => {
+          const lastCpuStat = cpuStats.pop()
+          if (lastCpuStat == null) {
             log.warn(`cpu#${index} is null. host:`, host.id)
           }
-          total += cpu ?? 0
+          total += lastCpuStat ?? 0
           return total
-        }, 0) / cpus.length
+        }, 0) / cpusStats.length
 
       hostsWithPercent.push({ percent, id: host.id, name_label: host.name_label })
     }

--- a/@xen-orchestra/rest-api/src/pools/pool.service.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.service.mts
@@ -44,15 +44,32 @@ export class PoolService {
     return Object.values(alarms)
   }
 
+  async #getMissingPatches(poolId: XoPool['id']) {
+    const missingPatchesInfo = await this.#hostService.getMissingPatchesInfo({ filter: host => host.$pool === poolId })
+    if (!missingPatchesInfo.hasAuthorization) {
+      return {
+        hasAuthorization: false,
+      }
+    }
+
+    const { hasAuthorization, missingPatches } = missingPatchesInfo
+    return {
+      hasAuthorization,
+      missingPatches,
+    }
+  }
+
   async getDashboard(id: XoPool['id']) {
     const hostStatus = this.#getHostsStatus(id)
     const vmsStatus = this.#getVmsStatus(id)
     const alarms = this.#getAlarms(id)
+    const missingPatches = await this.#getMissingPatches(id)
 
     return {
       hostStatus,
       vmsStatus,
       alarms,
+      missingPatches,
     }
   }
 }

--- a/@xen-orchestra/rest-api/src/pools/pool.type.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.type.mts
@@ -1,4 +1,5 @@
-import type { Xapi, XoHost, XoVmTemplate } from '@vates/types'
+import type { Xapi, XcpPatches, XoAlarm, XoHost, XoSr, XoVm, XoVmTemplate, XsPatches } from '@vates/types'
+import { Unbrand } from '../open-api/common/response.common.mjs'
 
 export interface CreateNetworkBody {
   name: string
@@ -58,3 +59,52 @@ export type CreateVmBody = Omit<
     repository: string | ''
   }
 } & CreateVmAfterCreateParams
+
+export type PoolDashboard = {
+  hosts: {
+    status: {
+      running: number
+      disabled: number
+      halted: number
+      total: number
+    }
+    topFiveUsage: {
+      ram: { name_label: string; size: number; usage: number; percent: number; id: Unbrand<XoHost>['id'] }[]
+      cpu: { name_label: string; percent: number; id: Unbrand<XoHost>['id'] }[]
+    }
+    missingPatches:
+      | {
+          hasAuthorization: false
+        }
+      | { hasAuthorization: true; missingPatches: (XcpPatches | XsPatches)[] }
+  }
+  vms: {
+    status: {
+      running: number
+      halted: number
+      paused: number
+      total: number
+      suspended: number
+    }
+    topFiveUsage?: {
+      cpu: { id: Unbrand<XoVm>['id']; name_label: string; percent: number }[]
+      ram: { id: Unbrand<XoVm>['id']; name_label: string; percent: number; memory: number; memoryFree: number }[]
+      isExpired?: boolean
+    }
+  }
+  srs: {
+    topFiveUsage: {
+      name_label: string
+      id: Unbrand<XoSr>['id']
+      percent: number
+      physical_usage: number
+      size: number
+    }[]
+  }
+  alarms: Unbrand<XoAlarm>[]
+  cpuProvisioning: {
+    total: number
+    assigned: number
+    percent: number
+  }
+}

--- a/@xen-orchestra/rest-api/src/pools/pool.type.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.type.mts
@@ -101,7 +101,7 @@ export type PoolDashboard = {
       size: number
     }[]
   }
-  alarms: Unbrand<XoAlarm>[]
+  alarms: Unbrand<XoAlarm>['id'][]
   cpuProvisioning: {
     total: number
     assigned: number

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
@@ -1,12 +1,15 @@
 import type { XapiXoRecord } from '@vates/types'
 
 import type { XoApp } from './rest-api.type.mjs'
+import type { Container } from 'inversify'
 
 export class RestApi {
+  #ioc: Container
   #xoApp: XoApp
 
-  constructor(xoApp: XoApp) {
+  constructor(xoApp: XoApp, iocContainer: Container) {
     this.#xoApp = xoApp
+    this.#ioc = iocContainer
   }
 
   get tasks() {
@@ -15,6 +18,10 @@ export class RestApi {
 
   get xoApp() {
     return this.#xoApp
+  }
+
+  get ioc() {
+    return this.#ioc
   }
 
   authenticateUser(...args: Parameters<XoApp['authenticateUser']>) {

--- a/@xen-orchestra/web/src/utils/create-xo-store-config.util.ts
+++ b/@xen-orchestra/web/src/utils/create-xo-store-config.util.ts
@@ -14,6 +14,7 @@ import type { SubscribableStoreConfig } from '@core/types/subscribable-store.typ
 import type { VoidFunction } from '@core/types/utility.type'
 import { toArray } from '@core/utils/to-array.utils'
 import { noop, useFetch, useIntervalFn, watchOnce } from '@vueuse/core'
+import merge from 'lodash/merge'
 import { computed, readonly, ref, shallowReactive } from 'vue'
 
 type SingleOptions = {
@@ -100,7 +101,8 @@ export function createXoStoreConfig(
             const recordToAdd = apiDefinition.handler(item)
 
             const previous = recordsById.get(singleRecordId)
-            recordsById.set(singleRecordId, { ...previous, ...recordToAdd })
+            const record = merge(previous, recordToAdd)
+            recordsById.set(singleRecordId, record)
           }
         }
         reader.releaseLock()

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [REST API] Expose `/rest/v0/pools/<pool-id>/dashboard` (PR [#8768](https://github.com/vatesfr/xen-orchestra/pull/8768))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -30,5 +32,9 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- @vates/types minor
+- @xen-orchestra/rest-api minor
+- @xen-orchestra/web patch
 
 <!--packages-end-->


### PR DESCRIPTION
### Screenshot

![Capture d’écran de 2025-07-04 16-25-49](https://github.com/user-attachments/assets/5cf7b8d0-280a-42f4-8930-4ac4feb404da)


### Description

[XO-1295](https://project.vates.tech/vates-global/browse/XO-1295/)
Block #8791 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
