### PR TITLE
fix(backups): better handling of retrying an upload

### DIFF
--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -723,6 +723,7 @@ export class RemoteAdapter {
     await this._handler.outputStream(path, input, {
       checksum,
       dirMode: this._dirMode,
+      flags: 'w', // the file may already exists when retrying a failed upload
       maxStreamLength,
       streamLength,
       async validator() {

--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -723,7 +723,6 @@ export class RemoteAdapter {
     await this._handler.outputStream(path, input, {
       checksum,
       dirMode: this._dirMode,
-      flags: 'w', // the file may already exists when retrying a failed upload
       maxStreamLength,
       streamLength,
       async validator() {

--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -271,9 +271,10 @@ export default class RemoteHandlerAbstract {
    * @param {object} [options]
    * @param {boolean} [options.checksum]
    * @param {number} [options.dirMode]
+   * @param {string} [options.flags] file system fags used to create the output stream
    * @param {(this: RemoteHandlerAbstract, path: string) => Promise<undefined>} [options.validator] Function that will be called before the data is commited to the remote, if it fails, file should not exist
    */
-  async outputStream(path, input, { checksum = true, dirMode, maxStreamLength, streamLength, validator } = {}) {
+  async outputStream(path, input, { checksum = true, dirMode, flags, maxStreamLength, streamLength, validator } = {}) {
     path = normalizePath(path)
     let checksumStream
 
@@ -285,6 +286,7 @@ export default class RemoteHandlerAbstract {
     }
     await this._outputStream(path, input, {
       dirMode,
+      flags,
       maxStreamLength,
       streamLength,
       validator,
@@ -666,11 +668,11 @@ export default class RemoteHandlerAbstract {
     return this._outputFile(file, data, { flags })
   }
 
-  async _outputStream(path, input, { dirMode, validator }) {
+  async _outputStream(path, input, { dirMode, flags = 'wx', validator }) {
     const tmpPath = `${dirname(path)}/.${basename(path)}`
     const output = await this._createOutputStream(tmpPath, {
       dirMode,
-      flags: 'wx',
+      flags,
     })
     try {
       await fromCallback(pipeline, input, output)

--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -271,10 +271,9 @@ export default class RemoteHandlerAbstract {
    * @param {object} [options]
    * @param {boolean} [options.checksum]
    * @param {number} [options.dirMode]
-   * @param {string} [options.flags] file system fags used to create the output stream
    * @param {(this: RemoteHandlerAbstract, path: string) => Promise<undefined>} [options.validator] Function that will be called before the data is commited to the remote, if it fails, file should not exist
    */
-  async outputStream(path, input, { checksum = true, dirMode, flags, maxStreamLength, streamLength, validator } = {}) {
+  async outputStream(path, input, { checksum = true, dirMode, maxStreamLength, streamLength, validator } = {}) {
     path = normalizePath(path)
     let checksumStream
 
@@ -286,7 +285,6 @@ export default class RemoteHandlerAbstract {
     }
     await this._outputStream(path, input, {
       dirMode,
-      flags,
       maxStreamLength,
       streamLength,
       validator,
@@ -668,11 +666,11 @@ export default class RemoteHandlerAbstract {
     return this._outputFile(file, data, { flags })
   }
 
-  async _outputStream(path, input, { dirMode, flags = 'wx', validator }) {
-    const tmpPath = `${dirname(path)}/.${basename(path)}`
+  async _outputStream(path, input, { dirMode, validator }) {
+    const tmpPath = `${dirname(path)}/.${Date.now()}.${basename(path)}`
     const output = await this._createOutputStream(tmpPath, {
       dirMode,
-      flags,
+      flags: 'wx',
     })
     try {
       await fromCallback(pipeline, input, output)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,6 +32,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Backup] Fix full backup retry failing with EEXIST error (PR [#8776](https://github.com/vatesfr/xen-orchestra/pull/8776))
+
 - **XO 6:**
 
   - [Host/VM/Dashboard] Fix display error due to inversion of upload and download (PR [#8793](https://github.com/vatesfr/xen-orchestra/pull/8793))
@@ -58,6 +60,7 @@
 
 - @vates/generator-toolbox patch
 - @vates/types minor
+- @xen-orchestra/fs patch
 - @xen-orchestra/mixins patch
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor


### PR DESCRIPTION
### Description

when retrying an full backup, it try to recreate a temporary file with the same name, and thus fail since it already exists

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
