### PR TITLE
fix(xapi): respect the config file setting for preferNbd

### DIFF
--- a/@vates/nbd-client/multi.mjs
+++ b/@vates/nbd-client/multi.mjs
@@ -70,7 +70,9 @@ export default class MultiNbdClient {
       await _connect()
     }
     if (this.#clients.length === 0) {
-      throw new Error(`Fail to connect to any Nbd client`)
+      const error = new Error(`Fail to connect to any Nbd client`, { nbdInfos: this.#settings })
+      error.code = 'NO_NBD_AVAILABLE'
+      throw error
     }
     if (this.#clients.length < this.#nbdConcurrency) {
       warn(

--- a/@xen-orchestra/xapi/disks/Xapi.mjs
+++ b/@xen-orchestra/xapi/disks/Xapi.mjs
@@ -126,15 +126,14 @@ export class XapiDiskSource extends DiskPassthrough {
         source = new XapiQcow2StreamSource({ vdiRef, baseRef, xapi })
       }
       await source.init()
-    } catch (err) {
+    } catch (error) {
       await source?.close()
-      if (err.code === 'VDI_CANT_DO_DELTA') {
-        warn(`can't compute delta of XapiVhdStreamSource ${vdiRef} from ${baseRef}, fallBack to a full`)
-        // @todo : should clear CBT status since it probably a little broken
-        source = new XapiVhdStreamSource({ vdiRef, baseRef: undefined, xapi })
-        await source.init()
+      if (baseRef !== undefined) {
+        warn(`can't compute delta ${vdiRef} from ${baseRef}, fallBack to a full`, { error })
+        this.#baseRef = undefined
+        return this.#openExportStream()
       } else {
-        throw err
+        throw error
       }
     }
     return source

--- a/@xen-orchestra/xapi/disks/Xapi.mjs
+++ b/@xen-orchestra/xapi/disks/Xapi.mjs
@@ -52,7 +52,7 @@ export class XapiDiskSource extends DiskPassthrough {
    * @param {number} [params.nbdConcurrency=2]
    * @param {number} [params.blockSize=2*1024*1024]
    */
-  constructor({ xapi, vdiRef, baseRef, preferNbd = true, nbdConcurrency = 2, blockSize = 2 * 1024 * 1024 }) {
+  constructor({ xapi, vdiRef, baseRef, preferNbd = xapi._preferNbd, nbdConcurrency = 2, blockSize = 2 * 1024 * 1024 }) {
     super(undefined)
     this.#baseRef = baseRef
     this.#blockSize = blockSize

--- a/@xen-orchestra/xapi/disks/Xapi.mjs
+++ b/@xen-orchestra/xapi/disks/Xapi.mjs
@@ -89,17 +89,15 @@ export class XapiDiskSource extends DiskPassthrough {
         source = new DiskLargerBlock(source, this.#blockSize)
       }
     } catch (err) {
-      await source?.close()
       if (err.code === 'NO_NBD_AVAILABLE') {
         warn(`can't connect through NBD, fallback to stream export`)
         if (streamSource === undefined) {
           throw new Error(`Can't open stream source`)
         }
         return streamSource
-      } else {
-        await streamSource?.close()
-        throw err
       }
+      await source?.close() // this will close source and stream source
+      throw err
     }
     this.#useNbd = true
     const readAhead = new ReadAhead(source)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -42,6 +42,7 @@
 
 <!--packages-start-->
 
+- @vates/nbd-client patch
 - @vates/types minor
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web-core minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@
   - [Charts] Fix tooltip overflow when too close to the edge [Forum#11012](https://xcp-ng.org/forum/topic/11012/graph-in-v0.12.0-48bf9/2) (PR [#8779](https://github.com/vatesfr/xen-orchestra/pull/8779))
 
 - [VM/New] Fix `Cannot read properties of undefined (reading '$ref')` when creating VM configured to PXE boot (PR [#8782](https://github.com/vatesfr/xen-orchestra/pull/8782))
+- [Backups] fix backup job getting stuck without NBD (PR [#8780](https://github.com/vatesfr/xen-orchestra/pull/8780))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

from https://xcp-ng.org/forum/topic/10970/xo-community-edition-backups-dont-work-as-of-build-6b263/62 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
