### PR TITLE
fix(api-error): api-error return an error instead of throwing

### DIFF
--- a/@xen-orchestra/rest-api/src/alarms/alarm.controller.mts
+++ b/@xen-orchestra/rest-api/src/alarms/alarm.controller.mts
@@ -95,7 +95,7 @@ export class AlarmController extends XapiXoController<XoAlarm> {
     const maybeAlarm = this.restApi.getObject<XoMessage>(id, 'message')
 
     if (!alarmPredicate(maybeAlarm)) {
-      /* throw */ noSuchObject(id, 'alarm')
+      throw noSuchObject(id, 'alarm')
     }
 
     return this.#parseAlarm(maybeAlarm)

--- a/@xen-orchestra/rest-api/src/messages/message.controller.mts
+++ b/@xen-orchestra/rest-api/src/messages/message.controller.mts
@@ -48,7 +48,7 @@ export class MessageController extends XapiXoController<XoMessage> {
     const message = super.getObject(id)
 
     if (alarmPredicate(message)) {
-      /* throw */ noSuchObject(id, 'message')
+      throw noSuchObject(id, 'message')
     }
 
     return message

--- a/@xen-orchestra/rest-api/src/middlewares/tsoa-to-xo-error.middleware.mts
+++ b/@xen-orchestra/rest-api/src/middlewares/tsoa-to-xo-error.middleware.mts
@@ -4,7 +4,7 @@ import { ValidateError } from 'tsoa'
 
 export default function tsoaToXoErrorHandler(error: unknown, _req: Request, _res: Response, next: NextFunction) {
   if (error instanceof ValidateError) {
-    /* throw */ invalidParameters(error.fields)
+    throw invalidParameters(error.fields)
   }
 
   return next(error)

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -99,7 +99,7 @@ export class VmController extends XapiXoController<XoVm> {
           property: 'resident_on',
         })
       ) {
-        /* throw */ invalidParameters(`VM ${id} is halted or host could not be found.`, error)
+        throw invalidParameters(`VM ${id} is halted or host could not be found.`, error)
       }
       throw error
     }

--- a/@xen-orchestra/xapi/vm.mjs
+++ b/@xen-orchestra/xapi/vm.mjs
@@ -584,7 +584,7 @@ class Vm {
       query.sr_id = srRef
     } else if (this.pool.default_SR === Ref.EMPTY) {
       error('Unable to import VM if no SR is specified and no default_SR is set on the pool')
-      /* throw */ incorrectState({
+      throw incorrectState({
         actual: this.pool.default_SR,
         expected: 'Not empty',
         object: this.pool.uuid,

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -44,8 +44,8 @@
 
 - @vates/types minor
 - @xen-orchestra/rest-api minor
-- @xen-orchestra/xapi patch
 - @xen-orchestra/web-core minor
+- @xen-orchestra/xapi patch
 - xen-api patch
 - xo-server minor
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -45,7 +45,6 @@
 - @vates/types minor
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/xapi patch
-- xen-api patch
 - @xen-orchestra/web-core minor
 - xen-api patch
 - xo-server minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [VM/New] Fix `Cannot read properties of undefined (reading '$ref')` when creating VM configured to PXE boot (PR [#8782](https://github.com/vatesfr/xen-orchestra/pull/8782))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -39,6 +41,8 @@
 
 - @vates/types minor
 - @xen-orchestra/rest-api minor
+- @xen-orchestra/xapi patch
+- xen-api patch
 - xo-server minor
 
 <!--packages-end-->

--- a/packages/xen-api/index.mjs
+++ b/packages/xen-api/index.mjs
@@ -723,7 +723,7 @@ export class Xapi extends EventEmitter {
 
     if (arguments.length > 1) return defaultValue
 
-    /* throw */ noSuchObject(idOrUuidOrRef)
+    throw noSuchObject(idOrUuidOrRef)
   }
 
   // Returns the object for a given opaque reference (internal to
@@ -735,7 +735,7 @@ export class Xapi extends EventEmitter {
 
     if (arguments.length > 1) return defaultValue
 
-    /* throw */ noSuchObject(ref)
+    throw noSuchObject(ref)
   }
 
   // Returns the object for a given UUID (unique identifier that some
@@ -748,7 +748,7 @@ export class Xapi extends EventEmitter {
 
     if (arguments.length > 1) return defaultValue
 
-    /* throw */ noSuchObject(uuid)
+    throw noSuchObject(uuid)
   }
 
   // manually run events watching if set to `false` in constructor

--- a/packages/xo-server/src/models/server.mjs
+++ b/packages/xo-server/src/models/server.mjs
@@ -36,7 +36,7 @@ export class Servers extends Collection {
 
     if (await this.exists({ host })) {
       const _host = await this.get({ host })
-      /* throw */ objectAlreadyExists({
+      throw objectAlreadyExists({
         objectId: _host.id,
         objectType: 'server',
       })

--- a/packages/xo-server/src/xapi-stats.mjs
+++ b/packages/xo-server/src/xapi-stats.mjs
@@ -477,7 +477,7 @@ export default class XapiStats {
     const vm = xapi.getObject(vmId)
     const host = vm.$resident_on
     if (!host) {
-      /* throw */ incorrectState({
+      throw incorrectState({
         actual: host,
         expected: '<host-uuid>',
         object: vm,

--- a/packages/xo-server/src/xapi/mixins/patching.mjs
+++ b/packages/xo-server/src/xapi/mixins/patching.mjs
@@ -508,9 +508,7 @@ const methods = {
   async _poolWideInstall($defer, patches, xsCredentials) {
     // New XS patching system: https://support.citrix.com/article/CTX473972/upcoming-changes-in-xencenter
     if (xsCredentials?.username === undefined || xsCredentials?.apikey === undefined) {
-      throw new Error(
-        'XenServer credentials not found. See https://docs.xen-orchestra.com/updater#xenserver-updates'
-      )
+      throw new Error('XenServer credentials not found. See https://docs.xen-orchestra.com/updater#xenserver-updates')
     }
 
     // Legacy XS patches
@@ -646,7 +644,7 @@ const methods = {
     const pendingGuidances = await this._getPendingGuidances(object, level)
 
     if (pendingGuidances.length > 0) {
-      /* throw */ incorrectState({
+      throw incorrectState({
         actual: pendingGuidances,
         expected: [],
         object: object.uuid,
@@ -675,7 +673,7 @@ const methods = {
     }
 
     log.error(`Pending guidances not implemented: ${pendingGuidances.join(',')}`)
-    /* throw */ notImplemented()
+    throw notImplemented()
   },
 
   async _updateLinstorPackages() {
@@ -724,7 +722,7 @@ const methods = {
           const { full, mandatory, recommended } = host.guidance
           const guidances = [...full, ...mandatory, ...recommended]
           if (['RestartVM', 'RestartDeviceModel'].some(guidance => guidances.includes(guidance))) {
-            /* throw */ incorrectState({
+            throw incorrectState({
               actual: guidances,
               expected: [],
               object: host.uuid,

--- a/packages/xo-server/src/xo-mixins/backups-ng-logs.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng-logs.mjs
@@ -181,7 +181,7 @@ export default {
 
       if (runId !== undefined) {
         if (consolidated[runId] === undefined) {
-          /* throw */ noSuchObject(runId, 'backup-ng-log')
+          throw noSuchObject(runId, 'backup-ng-log')
         }
         return consolidated[runId]
       }

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -318,7 +318,7 @@ export default class XenServers {
     const server = await this.getXenServerWithCredentials(id)
     const serverStatus = this._getXenServerStatus(id)
     if (serverStatus !== 'disconnected') {
-      /* throw */ incorrectState({
+      throw incorrectState({
         actual: serverStatus,
         expected: 'disconnected',
         object: server.id,
@@ -538,7 +538,7 @@ export default class XenServers {
     const server = await this.getXenServer(id)
     const status = this._getXenServerStatus(id)
     if (status === 'disconnected' && !server.enabled) {
-      /* throw */ incorrectState({
+      throw incorrectState({
         actual: status,
         expected: ['connected', 'connecting'],
         object: id,


### PR DESCRIPTION
### Description

For some reason that I ignore, `api-errors` returns an error instead of throwing on XOA which leads to various errors

code of `api-errors` in XOA QA.
```js
const create = (code, getProps) => {
  const factory = function factory() {
    return new XoError(_objectSpread(_objectSpread({}, getProps(...arguments)), {}, {
      code
    }));
  };

  factory.is = (error, predicate) => error.code === code && (predicate === undefined || (0, _iteratee2.default)(predicate)(error.data));

  return factory;
};
```

Source code
```js
const create = (code, getProps) => {
  const factory = (...args) => {
    const props = getProps(...args)
    props.code = code
    throw new XoError(props)
  }
  factory.is = (error, predicate) => error.code === code && (predicate === undefined || iteratee(predicate)(error.data))

  return factory
}
```



See [zammad#41220](https://help.vates.tech/#ticket/zoom/41220)
Introduced by d47fa03ec8e7eeb01bef725be10fc2681476a2f2
Can be tested on XOA-QA

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
