### PR TITLE
fix(xo6/lite): fixed display error due to inversion of upload and download

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -1,10 +1,13 @@
 # ChangeLog
 
+## **next**
+
+- [Host/VM/Dashboard] Fix display error due to inversion of upload and download (PR [#8793](https://github.com/vatesfr/xen-orchestra/pull/8793))
+
 ## **0.12.1**
 
 - [Charts] Fix tooltip overflow when too close to the edge [Forum#11012](https://xcp-ng.org/forum/topic/11012/graph-in-v0.12.0-48bf9/2) (PR [#8779](https://github.com/vatesfr/xen-orchestra/pull/8779))
 - [Host/VM/Dashboard] Fix timestamp on some charts [Forum#11012](https://xcp-ng.org/forum/topic/11012/graph-in-v0.12.0-48bf9) (PR [#8778](https://github.com/vatesfr/xen-orchestra/pull/8778))
-- [Host/VM/Dashboard] Fix display error due to inversion of upload and download (PR [#8793](https://github.com/vatesfr/xen-orchestra/pull/8793))
 
 ## **0.12.0** (2025-06-30)
 

--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [Charts] Fix tooltip overflow when too close to the edge [Forum#11012](https://xcp-ng.org/forum/topic/11012/graph-in-v0.12.0-48bf9/2) (PR [#8779](https://github.com/vatesfr/xen-orchestra/pull/8779))
 - [Host/VM/Dashboard] Fix timestamp on some charts [Forum#11012](https://xcp-ng.org/forum/topic/11012/graph-in-v0.12.0-48bf9) (PR [#8778](https://github.com/vatesfr/xen-orchestra/pull/8778))
+- [Host/VM/Dashboard] Fix display error due to inversion of upload and download (PR [#8793](https://github.com/vatesfr/xen-orchestra/pull/8793))
 
 ## **0.12.0** (2025-06-30)
 

--- a/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardNetworkUsageChart.vue
+++ b/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardNetworkUsageChart.vue
@@ -44,14 +44,14 @@ const networkUsage = computed<LinearChartData>(() => {
   }
 
   const addNetworkData = (type: 'rx' | 'tx') => ({
-    label: type === 'rx' ? t('network-upload') : t('network-download'),
+    label: type === 'rx' ? t('network-download') : t('network-upload'),
     data: Object.values(pifs[type])[0].map((_, hourIndex) => ({
       timestamp: (timestampStart + hourIndex * RRD_STEP_FROM_STRING.hours) * 1000,
       value: Object.values(pifs[type]).reduce((sum, values) => sum + (values[hourIndex] ?? NaN), 0),
     })),
   })
 
-  return [addNetworkData('rx'), addNetworkData('tx')]
+  return [addNetworkData('tx'), addNetworkData('rx')]
 })
 
 const maxValue = computed(() => {

--- a/@xen-orchestra/lite/src/components/vm/dashboard/VmDashboardNetworkUsageChart.vue
+++ b/@xen-orchestra/lite/src/components/vm/dashboard/VmDashboardNetworkUsageChart.vue
@@ -65,12 +65,12 @@ const networkUsage = computed<LinearChartData>(() => {
     })
 
     return {
-      label: type === 'rx' ? t('network-upload') : t('network-download'),
+      label: type === 'rx' ? t('network-download') : t('network-upload'),
       data,
     }
   }
 
-  return [addNetworkData('rx'), addNetworkData('tx')]
+  return [addNetworkData('tx'), addNetworkData('rx')]
 })
 
 const maxValue = computed(() => {

--- a/@xen-orchestra/web/src/components/host/dashboard/HostDashboardNetworkUsageChart.vue
+++ b/@xen-orchestra/web/src/components/host/dashboard/HostDashboardNetworkUsageChart.vue
@@ -41,19 +41,9 @@ const networkUsage = computed<LinearChartData>(() => {
     (_, i) => data.endTimestamp * 1000 - ((data.stats.pifs?.rx?.['0'].length ?? 0) - 1 - i) * data.interval * 1000
   )
 
-  const rxSeries = [
-    {
-      label: t('network-upload'),
-      data: timestamps.map((timestamp, index) => ({
-        timestamp,
-        value: Object.values(data.stats.pifs?.rx ?? {}).reduce((sum, values) => sum + (values[index] ?? NaN), 0),
-      })),
-    },
-  ]
-
   const txSeries = [
     {
-      label: t('network-download'),
+      label: t('network-upload'),
       data: timestamps.map((timestamp, index) => ({
         timestamp,
         value: Object.values(data.stats.pifs?.tx ?? {}).reduce((sum, values) => sum + (values[index] ?? NaN), 0),
@@ -61,7 +51,17 @@ const networkUsage = computed<LinearChartData>(() => {
     },
   ]
 
-  return [...rxSeries, ...txSeries]
+  const rxSeries = [
+    {
+      label: t('network-download'),
+      data: timestamps.map((timestamp, index) => ({
+        timestamp,
+        value: Object.values(data.stats.pifs?.rx ?? {}).reduce((sum, values) => sum + (values[index] ?? NaN), 0),
+      })),
+    },
+  ]
+
+  return [...txSeries, ...rxSeries]
 })
 
 const maxValue = computed(() => {

--- a/@xen-orchestra/web/src/components/host/dashboard/HostDashboardNetworkUsageChart.vue
+++ b/@xen-orchestra/web/src/components/host/dashboard/HostDashboardNetworkUsageChart.vue
@@ -41,22 +41,22 @@ const networkUsage = computed<LinearChartData>(() => {
     (_, i) => data.endTimestamp * 1000 - ((data.stats.pifs?.rx?.['0'].length ?? 0) - 1 - i) * data.interval * 1000
   )
 
+  const rxSeries = [
+    {
+      label: t('network-upload'),
+      data: timestamps.map((timestamp, index) => ({
+        timestamp,
+        value: Object.values(data.stats.pifs?.rx ?? {}).reduce((sum, values) => sum + (values[index] ?? NaN), 0),
+      })),
+    },
+  ]
+
   const txSeries = [
     {
       label: t('network-upload'),
       data: timestamps.map((timestamp, index) => ({
         timestamp,
         value: Object.values(data.stats.pifs?.tx ?? {}).reduce((sum, values) => sum + (values[index] ?? NaN), 0),
-      })),
-    },
-  ]
-
-  const rxSeries = [
-    {
-      label: t('network-download'),
-      data: timestamps.map((timestamp, index) => ({
-        timestamp,
-        value: Object.values(data.stats.pifs?.rx ?? {}).reduce((sum, values) => sum + (values[index] ?? NaN), 0),
       })),
     },
   ]

--- a/@xen-orchestra/web/src/components/vm/dashboard/VmDashboardNetworkUsageChart.vue
+++ b/@xen-orchestra/web/src/components/vm/dashboard/VmDashboardNetworkUsageChart.vue
@@ -45,22 +45,22 @@ const networkUsage = computed<LinearChartData>(() => {
     (_, i) => data.endTimestamp * 1000 - (rxArrays[0].length - 1 - i) * data.interval * 1000
   )
 
-  const txSeries = [
-    {
-      label: t('network-upload'),
-      data: timestamps.map((timestamp, index) => ({
-        timestamp,
-        value: Object.values(data.stats.vifs?.tx ?? {}).reduce((sum, values) => sum + (values[index] ?? NaN), 0),
-      })),
-    },
-  ]
-
   const rxSeries = [
     {
       label: t('network-download'),
       data: timestamps.map((timestamp, index) => ({
         timestamp,
         value: Object.values(data.stats.vifs?.rx ?? {}).reduce((sum, values) => sum + (values[index] ?? NaN), 0),
+      })),
+    },
+  ]
+
+  const txSeries = [
+    {
+      label: t('network-upload'),
+      data: timestamps.map((timestamp, index) => ({
+        timestamp,
+        value: Object.values(data.stats.vifs?.tx ?? {}).reduce((sum, values) => sum + (values[index] ?? NaN), 0),
       })),
     },
   ]

--- a/@xen-orchestra/web/src/components/vm/dashboard/VmDashboardNetworkUsageChart.vue
+++ b/@xen-orchestra/web/src/components/vm/dashboard/VmDashboardNetworkUsageChart.vue
@@ -45,19 +45,9 @@ const networkUsage = computed<LinearChartData>(() => {
     (_, i) => data.endTimestamp * 1000 - (rxArrays[0].length - 1 - i) * data.interval * 1000
   )
 
-  const rxSeries = [
-    {
-      label: t('network-upload'),
-      data: timestamps.map((timestamp, index) => ({
-        timestamp,
-        value: Object.values(data.stats.vifs?.rx ?? {}).reduce((sum, values) => sum + (values[index] ?? NaN), 0),
-      })),
-    },
-  ]
-
   const txSeries = [
     {
-      label: t('network-download'),
+      label: t('network-upload'),
       data: timestamps.map((timestamp, index) => ({
         timestamp,
         value: Object.values(data.stats.vifs?.tx ?? {}).reduce((sum, values) => sum + (values[index] ?? NaN), 0),
@@ -65,7 +55,17 @@ const networkUsage = computed<LinearChartData>(() => {
     },
   ]
 
-  return [...rxSeries, ...txSeries]
+  const rxSeries = [
+    {
+      label: t('network-download'),
+      data: timestamps.map((timestamp, index) => ({
+        timestamp,
+        value: Object.values(data.stats.vifs?.rx ?? {}).reduce((sum, values) => sum + (values[index] ?? NaN), 0),
+      })),
+    },
+  ]
+
+  return [...txSeries, ...rxSeries]
 })
 
 const maxValue = computed(() => {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,7 +24,6 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - **XO 6:**
-
   - [Host/VM/Dashboard] Fix display error due to inversion of upload and download (PR [#8793](https://github.com/vatesfr/xen-orchestra/pull/8793))
 
 - [Health] Fix labels and modals mentioning VMs instead of snapshots when deleting snapshots (PR [#8775](https://github.com/vatesfr/xen-orchestra/pull/8775))

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,18 +13,18 @@
 
 - **Migrated REST API endpoints**:
 
-    - `POST /rest/v0/users` (PR [#8697](https://github.com/vatesfr/xen-orchestra/pull/8697))
-    - `DELETE /rest/v0/users/<user-id>` (PR [#8698](https://github.com/vatesfr/xen-orchestra/pull/8698))
-    - `DELETE /rest/v0/groups/<group-id>` (PR [#8704](https://github.com/vatesfr/xen-orchestra/pull/8704))
+  - `POST /rest/v0/users` (PR [#8697](https://github.com/vatesfr/xen-orchestra/pull/8697))
+  - `DELETE /rest/v0/users/<user-id>` (PR [#8698](https://github.com/vatesfr/xen-orchestra/pull/8698))
+  - `DELETE /rest/v0/groups/<group-id>` (PR [#8704](https://github.com/vatesfr/xen-orchestra/pull/8704))
 
 - [REST API] Expose `/rest/v0/pools/<pool-id>/dashboard` (PR [#8768](https://github.com/vatesfr/xen-orchestra/pull/8768))
-
 
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - **XO 6:**
+
   - [Host/VM/Dashboard] Fix display error due to inversion of upload and download (PR [#8793](https://github.com/vatesfr/xen-orchestra/pull/8793))
 
 - [Health] Fix labels and modals mentioning VMs instead of snapshots when deleting snapshots (PR [#8775](https://github.com/vatesfr/xen-orchestra/pull/8775))
@@ -47,7 +47,6 @@
 
 - @vates/types minor
 - @xen-orchestra/rest-api minor
-- @xen-orchestra/web patch
 - @xen-orchestra/web minor
 - xo-server patch
 - xo-web patch

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,9 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- **XO 6:**
+  - [Host/VM/Dashboard] Fix display error due to inversion of upload and download (PR [#8793](https://github.com/vatesfr/xen-orchestra/pull/8793))
+
 - [Health] Fix labels and modals mentioning VMs instead of snapshots when deleting snapshots (PR [#8775](https://github.com/vatesfr/xen-orchestra/pull/8775))
 
 ### Packages to release
@@ -45,6 +48,7 @@
 - @vates/types minor
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web patch
+- @xen-orchestra/web minor
 - xo-server patch
 - xo-web patch
 


### PR DESCRIPTION
### Description

Fixed display error due to inversion of upload and download on host and vm dashboards

### Screenshots

Before: 
![image](https://github.com/user-attachments/assets/e5d45af4-0821-45b3-8e3b-469db612db5b)

After:
![image](https://github.com/user-attachments/assets/4febaeb3-9677-4887-917e-5e7d597f2869)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
