### PR TITLE
fix(@xen-orchestra/rest-api): alarm time in ms and alarm value in percent

### DIFF
--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -123,7 +123,7 @@ type BaseXoVm = BaseXapiXo & {
 
 export type XoAlarm = Omit<XoMessage, '$object' | 'body'> & {
   body: {
-    value: string
+    value?: string
     name: string
   }
   object: {

--- a/@xen-orchestra/rest-api/src/alarms/alarm.service.mts
+++ b/@xen-orchestra/rest-api/src/alarms/alarm.service.mts
@@ -19,7 +19,7 @@ export class AlarmService {
     return alarmPredicate(maybeAlarm)
   }
 
-  parseAlarm({ $object, body, ...alarm }: XoMessage): XoAlarm {
+  parseAlarm({ $object, body, time, ...alarm }: XoMessage): XoAlarm {
     let object: XapiXoRecord | { type: 'unknown'; uuid: XapiXoRecord['uuid'] }
     try {
       object = this.#restApi.getObject<XapiXoRecord>($object)
@@ -40,7 +40,7 @@ export class AlarmService {
     return {
       ...alarm,
       body: {
-        value, // Keep the value as a string because NaN, Infinity, -Infinity is not valid JSON
+        value: Number.isFinite(+value) ? String(+value * 100) : value, // Keep the value as a string because NaN, Infinity, -Infinity is not valid JSON
         name: name ?? body, // for 'BOND_STATUS_CHANGED' and 'MULTIPATH_PERIODIC_ALERT', body is a non-xml string. ("body": "The status of the eth0+eth1 bond is: 1/2 up")
       },
       object: {
@@ -48,6 +48,7 @@ export class AlarmService {
         uuid: object.uuid,
         href,
       },
+      time: time * 1000,
     }
   }
 

--- a/@xen-orchestra/rest-api/src/alarms/alarm.service.mts
+++ b/@xen-orchestra/rest-api/src/alarms/alarm.service.mts
@@ -40,7 +40,7 @@ export class AlarmService {
     return {
       ...alarm,
       body: {
-        value: Number.isFinite(+value) ? String(+value * 100) : value, // Keep the value as a string because NaN, Infinity, -Infinity is not valid JSON
+        value: Number.isFinite(+value) ? (+value * 100).toFixed(1) : value, // Keep the value as a string because NaN, Infinity, -Infinity is not valid JSON
         name: name ?? body, // for 'BOND_STATUS_CHANGED' and 'MULTIPATH_PERIODIC_ALERT', body is a non-xml string. ("body": "The status of the eth0+eth1 bond is: 1/2 up")
       },
       object: {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,6 +34,7 @@
   - [Host/VM/Dashboard] Fix display error due to inversion of upload and download (PR [#8793](https://github.com/vatesfr/xen-orchestra/pull/8793))
 
 - [Health] Fix labels and modals mentioning VMs instead of snapshots when deleting snapshots (PR [#8775](https://github.com/vatesfr/xen-orchestra/pull/8775))
+- [REST API] Alarm time is now in milliseconds and body value is now in percentage
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,7 +34,7 @@
   - [Host/VM/Dashboard] Fix display error due to inversion of upload and download (PR [#8793](https://github.com/vatesfr/xen-orchestra/pull/8793))
 
 - [Health] Fix labels and modals mentioning VMs instead of snapshots when deleting snapshots (PR [#8775](https://github.com/vatesfr/xen-orchestra/pull/8775))
-- [REST API] Alarm time is now in milliseconds and body value is now in percentage
+- [REST API] Alarm time is now in milliseconds and body value is now in percentage (PR [#8802](https://github.com/vatesfr/xen-orchestra/pull/8802))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

Requested by XO6 team

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
