### PR TITLE
fix(@xen-orchestra/rest-api): identify errors case for some computed objects

### DIFF
--- a/@xen-orchestra/rest-api/src/helpers/helper.type.mts
+++ b/@xen-orchestra/rest-api/src/helpers/helper.type.mts
@@ -16,3 +16,5 @@ export interface XoError extends Error {
 export type NdjsonStream = Readable
 
 export type SendObjects<T> = string[] | WithHref<T>[] | NdjsonStream
+
+export type PromiseWriteInStreamError = { error: true }

--- a/@xen-orchestra/rest-api/src/helpers/utils.helper.mts
+++ b/@xen-orchestra/rest-api/src/helpers/utils.helper.mts
@@ -71,7 +71,7 @@ export async function promiseWriteInStream<T>({
   stream?: Writable
   handleError?: boolean
 }): Promise<T | PromiseWriteInStreamError> {
-  let data: T | { error: true }
+  let data: T | PromiseWriteInStreamError
   if (isPromise(maybePromise)) {
     try {
       data = await maybePromise

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -97,9 +97,9 @@ export type XoApp = {
       XoBackupRepository['id'],
       {
         size?: number
-        used: number
+        used?: number
         available?: number
-        encryption: {
+        encryption?: {
           algorithm: string
           isLegacy: boolean
           recommanded: string

--- a/@xen-orchestra/rest-api/src/xoa/xoa.service.mts
+++ b/@xen-orchestra/rest-api/src/xoa/xoa.service.mts
@@ -30,7 +30,7 @@ import { HostService } from '../hosts/host.service.mjs'
 const log = createLogger('xo:rest-api:xoa-service')
 
 type DashboardAsyncCache = {
-  backupRepositories: MaybePromise<DashboardBackupRepositoriesSizeInfo>
+  backupRepositories: MaybePromise<DashboardBackupRepositoriesSizeInfo | undefined>
   backups: MaybePromise<DashboardBackupsInfo>
 }
 
@@ -64,16 +64,18 @@ export class XoaService {
       async () => {
         const xoApp = this.#restApi.xoApp
 
-        const s3Brsize: DashboardBackupRepositoriesSizeInfo['s3']['size'] = { backups: 0 }
-        const otherBrSize: DashboardBackupRepositoriesSizeInfo['other']['size'] = {
-          available: 0,
-          backups: 0,
-          other: 0,
-          total: 0,
-          used: 0,
-        }
+        let s3Brsize: { size: { backups: number } } | undefined
+        let otherBrSize:
+          | {
+              size: { available?: number; backups: number; other?: number; total?: number; used?: number }
+            }
+          | undefined
 
         const backupRepositories = await xoApp.getAllRemotes()
+        if (backupRepositories.length === 0) {
+          return undefined
+        }
+
         const backupRepositoriesInfo = await xoApp.getAllRemotesInfo()
         for (const backupRepository of backupRepositories) {
           const { type } = parse(backupRepository.url)
@@ -88,21 +90,53 @@ export class XoaService {
           const { available, size, used } = backupRepositoryInfo
 
           const isS3 = type === 's3'
-          const target = isS3 ? s3Brsize : otherBrSize
 
-          target.backups += totalBackupSize.onDisk
-          if (!isS3) {
-            const _target = target as DashboardBackupRepositoriesSizeInfo['other']['size']
-            _target.available += available ?? 0
-            _target.other += used - totalBackupSize.onDisk
-            _target.total += size ?? 0
-            _target.used += used
+          if (isS3) {
+            if (s3Brsize === undefined) {
+              s3Brsize = { size: { backups: 0 } }
+            }
+            s3Brsize.size.backups += totalBackupSize.onDisk
+          } else {
+            if (otherBrSize === undefined) {
+              otherBrSize = {
+                size: {
+                  backups: 0,
+                  available: undefined,
+                  other: undefined,
+                  total: undefined,
+                  used: undefined,
+                },
+              }
+            }
+            if (available === undefined || size === undefined || used === undefined) {
+              log.info('#getBackupRepositoriesSizeInfo missing info for BR:', backupRepository.id)
+            }
+
+            otherBrSize.size.backups += totalBackupSize.onDisk
+            if (available !== undefined) {
+              otherBrSize.size.available = (otherBrSize.size.available ?? 0) + available
+            }
+            if (used !== undefined) {
+              otherBrSize.size.used = (otherBrSize.size.used ?? 0) + used
+              otherBrSize.size.other = (otherBrSize.size.other ?? 0) + (used - totalBackupSize.onDisk)
+            }
+            if (size !== undefined) {
+              otherBrSize.size.total = (otherBrSize.size.total ?? 0) + size
+            }
           }
         }
 
-        return { s3: { size: s3Brsize }, other: { size: otherBrSize } }
+        const result: DashboardBackupRepositoriesSizeInfo = {}
+        if (s3Brsize !== undefined) {
+          result.s3 = s3Brsize
+        }
+        if (otherBrSize !== undefined) {
+          result.other = otherBrSize
+        }
+
+        return result
       },
-      this.#dashboardCacheOpts
+      { ...this.#dashboardCacheOpts, expiresIn: 1 }
     )
 
     if (brResult?.value !== undefined) {
@@ -514,39 +548,41 @@ export class XoaService {
       promiseWriteInStream({ maybePromise: this.#getNumberOfPools(), path: 'nPools', stream }),
       promiseWriteInStream({ maybePromise: this.#getNumberOfHosts(), path: 'nHosts', stream }),
       promiseWriteInStream({ maybePromise: this.#getHostsStatus(), path: 'hostsStatus', stream }),
-      promiseWriteInStream({ maybePromise: this.#getResourcesOverview(), path: 'resourcesOverview', stream }),
+      promiseWriteInStream({
+        maybePromise: this.#getResourcesOverview(),
+        path: 'resourcesOverview',
+        stream,
+      }),
       promiseWriteInStream({ maybePromise: this.#getVmsStatus(), path: 'vmsStatus', stream }),
       promiseWriteInStream({
         maybePromise: this.#getStorageRepositoriesSizeInfo(),
         path: 'storageRepositories',
         stream,
+        handleError: true,
       }),
       promiseWriteInStream({ maybePromise: this.#getPoolsStatus(), path: 'poolsStatus', stream }),
-      promiseWriteInStream({ maybePromise: this.#getMissingPatchesInfo(), path: 'missingPatches', stream }),
       promiseWriteInStream({
-        maybePromise: this.#getBackupRepositoriesSizeInfo().catch(err => {
-          log.error('#getBackupRepositoriesSizeInfo failed', err)
-          // explicitly return undefined because typescript understand it as void instead of undefined
-          return undefined
-        }),
+        maybePromise: this.#getMissingPatchesInfo(),
+        path: 'missingPatches',
+        stream,
+      }),
+      promiseWriteInStream({
+        maybePromise: this.#getBackupRepositoriesSizeInfo(),
         path: 'backupRepositories',
         stream,
+        handleError: true,
       }),
       promiseWriteInStream({
-        maybePromise: this.#getNumberOfEolHosts().catch(err => {
-          log.error('#getNumberOfEolHosts failed', err)
-          return undefined
-        }),
+        maybePromise: this.#getNumberOfEolHosts(),
         path: 'nHostsEol',
         stream,
+        handleError: true,
       }),
       promiseWriteInStream({
-        maybePromise: this.#getbackupsInfo().catch(err => {
-          log.error('#getbackupsInfo failed', err)
-          return undefined
-        }),
+        maybePromise: this.#getbackupsInfo(),
         path: 'backups',
         stream,
+        handleError: true,
       }),
     ])
 

--- a/@xen-orchestra/rest-api/src/xoa/xoa.service.mts
+++ b/@xen-orchestra/rest-api/src/xoa/xoa.service.mts
@@ -136,7 +136,7 @@ export class XoaService {
 
         return result
       },
-      { ...this.#dashboardCacheOpts, expiresIn: 1 }
+      this.#dashboardCacheOpts
     )
 
     if (brResult?.value !== undefined) {
@@ -548,11 +548,7 @@ export class XoaService {
       promiseWriteInStream({ maybePromise: this.#getNumberOfPools(), path: 'nPools', stream }),
       promiseWriteInStream({ maybePromise: this.#getNumberOfHosts(), path: 'nHosts', stream }),
       promiseWriteInStream({ maybePromise: this.#getHostsStatus(), path: 'hostsStatus', stream }),
-      promiseWriteInStream({
-        maybePromise: this.#getResourcesOverview(),
-        path: 'resourcesOverview',
-        stream,
-      }),
+      promiseWriteInStream({ maybePromise: this.#getResourcesOverview(), path: 'resourcesOverview', stream }),
       promiseWriteInStream({ maybePromise: this.#getVmsStatus(), path: 'vmsStatus', stream }),
       promiseWriteInStream({
         maybePromise: this.#getStorageRepositoriesSizeInfo(),
@@ -561,11 +557,7 @@ export class XoaService {
         handleError: true,
       }),
       promiseWriteInStream({ maybePromise: this.#getPoolsStatus(), path: 'poolsStatus', stream }),
-      promiseWriteInStream({
-        maybePromise: this.#getMissingPatchesInfo(),
-        path: 'missingPatches',
-        stream,
-      }),
+      promiseWriteInStream({ maybePromise: this.#getMissingPatchesInfo(), path: 'missingPatches', stream }),
       promiseWriteInStream({
         maybePromise: this.#getBackupRepositoriesSizeInfo(),
         path: 'backupRepositories',

--- a/@xen-orchestra/rest-api/src/xoa/xoa.type.mts
+++ b/@xen-orchestra/rest-api/src/xoa/xoa.type.mts
@@ -1,12 +1,13 @@
 import { BACKUP_TYPE } from '@vates/types'
+import type { PromiseWriteInStreamError } from '../helpers/helper.type.mjs'
 
 export type DashboardBackupRepositoriesSizeInfo = {
-  s3: {
+  s3?: {
     size: {
       backups: number
     }
   }
-  other: { size: { available: number; backups: number; other: number; total: number; used: number } }
+  other?: { size: { available?: number; backups: number; other?: number; total?: number; used?: number } }
 }
 
 export type DashboardBackupsInfo = {
@@ -33,7 +34,7 @@ export type DashboardBackupsInfo = {
 export type XoaDashboard = {
   nPools: number
   nHosts: number
-  nHostsEol?: number
+  nHostsEol?: number | PromiseWriteInStreamError
   hostsStatus: {
     running: number
     halted: number
@@ -54,17 +55,20 @@ export type XoaDashboard = {
         nPoolsWithMissingPatches: number
         nHostsFailed: number
       }
-  backupRepositories?: DashboardBackupRepositoriesSizeInfo
-  storageRepositories: {
-    size: {
-      available: number
-      other: number
-      replicated: number
-      total: number
-      used: number
-    }
-  }
-  backups?: DashboardBackupsInfo
+  backupRepositories?: DashboardBackupRepositoriesSizeInfo | PromiseWriteInStreamError
+  storageRepositories:
+    | {
+        size: {
+          available: number
+          other: number
+          replicated: number
+          total: number
+          used: number
+        }
+      }
+    | PromiseWriteInStreamError
+  backups?: DashboardBackupsInfo | PromiseWriteInStreamError
+
   resourcesOverview: {
     nCpus: number
     memorySize: number

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -35,6 +35,7 @@
 
 - [Health] Fix labels and modals mentioning VMs instead of snapshots when deleting snapshots (PR [#8775](https://github.com/vatesfr/xen-orchestra/pull/8775))
 - [REST API] Alarm time is now in milliseconds and body value is now in percentage (PR [#8802](https://github.com/vatesfr/xen-orchestra/pull/8802))
+- [REST API/XOA/Dashboard] Fix some type issues. Some object may return `{error: true}` instead of `undefined` on error.`s3` and `other` object may be undefined (if no S3 or other backup repositories detected) (PR [#8806](https://github.com/vatesfr/xen-orchestra/pull/8806))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

For `dashboards` endpoints, It may be hard to know if a value is undefined because of no value, or if because of an error. Explicit this in `PromiseWriteInStream`.

In case an error is thrown, return `{error: true}` instead of `undefined` and keep `undefined` if no value is present.

E.g:
`backupRepositories === undefined` if no remote on the infra
`backupRepositories.error` if an error occurred

`backupRepositories.s3` and `backupRepositories.other` can now be undefined. (if no S3 / Other remote)

Discussed with @ByScripts 
[XO-1333](https://project.vates.tech/vates-global/browse/XO-1333/)
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
