### PR TITLE
doc(xo): update links to new xo doc domain name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,8 +40,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        - Don't forget to [read this first](https://xen-orchestra.com/docs/community.html)
-        - As well as follow [this guide](https://xen-orchestra.com/docs/community.html#report-a-bug)
+        - Don't forget to [read this first](https://docs.xen-orchestra.com/community)
+        - As well as follow [this guide](https://docs.xen-orchestra.com/community#report-a-bug)
   - type: input
     id: xo-sources-commit-number
     attributes:

--- a/@xen-orchestra/lite/src/views/xoa-deploy/XoaDeployView.vue
+++ b/@xen-orchestra/lite/src/views/xoa-deploy/XoaDeployView.vue
@@ -116,7 +116,7 @@
             </VtsInputWrapper>
             <VtsInputWrapper
               :label="t('netmask')"
-              learn-more-url="https://xen-orchestra.com/docs/xoa.html#network-configuration"
+              learn-more-url="https://docs.xen-orchestra.com/xoa#network-configuration"
             >
               <FormInput v-model="netmask" :disabled="!requireIpConf" placeholder="255.255.255.0" />
             </VtsInputWrapper>
@@ -124,13 +124,13 @@
           <div class="row">
             <VtsInputWrapper
               :label="t('dns')"
-              learn-more-url="https://xen-orchestra.com/docs/xoa.html#network-configuration"
+              learn-more-url="https://docs.xen-orchestra.com/xoa#network-configuration"
             >
               <FormInput v-model="dns" :disabled="!requireIpConf" placeholder="8.8.8.8" />
             </VtsInputWrapper>
             <VtsInputWrapper
               :label="t('gateway')"
-              learn-more-url="https://xen-orchestra.com/docs/xoa.html#network-configuration"
+              learn-more-url="https://docs.xen-orchestra.com/xoa#network-configuration"
             >
               <FormInput v-model="gateway" :disabled="!requireIpConf" placeholder="xxx.xxx.xxx.xxx" />
             </VtsInputWrapper>
@@ -141,7 +141,7 @@
           <div class="row">
             <VtsInputWrapper
               :label="t('admin-login')"
-              learn-more-url="https://xen-orchestra.com/docs/xoa.html#default-xo-account"
+              learn-more-url="https://docs.xen-orchestra.com/xoa#default-xo-account"
             >
               <FormInput v-model="xoaUser" required placeholder="email@example.com" />
             </VtsInputWrapper>
@@ -149,13 +149,13 @@
           <div class="row">
             <VtsInputWrapper
               :label="t('admin-password')"
-              learn-more-url="https://xen-orchestra.com/docs/xoa.html#default-xo-account"
+              learn-more-url="https://docs.xen-orchestra.com/xoa#default-xo-account"
             >
               <FormInput v-model="xoaPwd" type="password" required :placeholder="t('password')" />
             </VtsInputWrapper>
             <VtsInputWrapper
               :label="t('admin-password-confirm')"
-              learn-more-url="https://xen-orchestra.com/docs/xoa.html#default-xo-account"
+              learn-more-url="https://docs.xen-orchestra.com/xoa#default-xo-account"
             >
               <FormInput v-model="xoaPwdConfirm" type="password" required :placeholder="t('password')" />
             </VtsInputWrapper>

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -206,7 +206,7 @@ Usage:
     filter=<filter>
       List only objects that match the filter
 
-      Syntax: https://xen-orchestra.com/docs/manage_infrastructure.html#filter-syntax
+      Syntax: https://docs.xen-orchestra.com/manage_infrastructure#filter-syntax
 
     limit=<limit>
       Maximum number of objects to list, e.g. `limit=10`

--- a/packages/xo-server-audit/.USAGE.md
+++ b/packages/xo-server-audit/.USAGE.md
@@ -1,2 +1,2 @@
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://xen-orchestra.com/docs/plugins.html).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).

--- a/packages/xo-server-sdn-controller/.USAGE.md
+++ b/packages/xo-server-sdn-controller/.USAGE.md
@@ -1,6 +1,6 @@
 XO Server plugin that allows the creation of pool-wide and cross-pool private networks, a bit similar to [XenServer's DVCS](https://www.knowcitrix.com/posts/distributed-virtual-switch-controller-dvsc/).
 
-Please see the plugin's [official documentation](https://xen-orchestra.com/docs/sdn_controller.html).
+Please see the plugin's [official documentation](https://docs.xen-orchestra.com/sdn_controller).
 
 # Features
 

--- a/packages/xo-server-sdn-controller/README.md
+++ b/packages/xo-server-sdn-controller/README.md
@@ -8,7 +8,7 @@
 
 XO Server plugin that allows the creation of pool-wide and cross-pool private networks, a bit similar to [XenServer's DVCS](https://www.knowcitrix.com/posts/distributed-virtual-switch-controller-dvsc/).
 
-Please see the plugin's [official documentation](https://xen-orchestra.com/docs/sdn_controller.html).
+Please see the plugin's [official documentation](https://docs.xen-orchestra.com/sdn_controller).
 
 # Features
 

--- a/packages/xo-server-test/_xoConnection.mjs
+++ b/packages/xo-server-test/_xoConnection.mjs
@@ -138,7 +138,7 @@ export class XoConnection extends Xo.default {
           // it must be enabled because the XAPI might be not able to coalesce VDIs
           // as fast as the tests run
           //
-          // see https://xen-orchestra.com/docs/backup_troubleshooting.html#vdi-chain-protection
+          // see https://docs.xen-orchestra.com/backup_troubleshooting#vdi-chain-protection
           bypassVdiChainsCheck: true,
 
           // it must be 'never' to avoid race conditions with the plugin `backup-reports`

--- a/packages/xo-server-transport-xmpp/README.md
+++ b/packages/xo-server-transport-xmpp/README.md
@@ -7,7 +7,7 @@
 ## Usage
 
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://xen-orchestra.com/docs/plugins.html).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
 
 ## Contributions
 

--- a/packages/xo-web/src/xo-app/about/index.js
+++ b/packages/xo-web/src/xo-app/about/index.js
@@ -190,7 +190,7 @@ export default class About extends Component {
                   <p className='text-muted'>{_('issuesText')}</p>
                 </Col>
                 <Col mediumSize={6}>
-                  <a href='https://xen-orchestra.com/docs' target='_blank' rel='noreferrer'>
+                  <a href='https://docs.xen-orchestra.com/' target='_blank' rel='noreferrer'>
                     <Icon icon='user' size={4} />
                     <h4>{_('documentation')}</h4>
                   </a>
@@ -217,7 +217,7 @@ export default class About extends Component {
                   <p className='text-muted'>{_('openTicketText')}</p>
                 </Col>
                 <Col mediumSize={6}>
-                  <a href='https://xen-orchestra.com/docs' target='_blank' rel='noreferrer'>
+                  <a href='https://docs.xen-orchestra.com/' target='_blank' rel='noreferrer'>
                     <Icon icon='user' size={4} />
                     <h4>{_('documentation')}</h4>
                   </a>

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -1117,7 +1117,7 @@ const New = decorate([
                           <Tooltip content={_('clickForMoreInformation')}>
                             <a
                               className='text-info'
-                              href='https://xen-orchestra.com/docs/incremental_backups.html#key-backup-interval'
+                              href='https://docs.xen-orchestra.com/incremental_backups#key-backup-interval'
                               rel='noopener noreferrer'
                               target='_blank'
                             >

--- a/packages/xo-web/src/xo-app/home/index.js
+++ b/packages/xo-web/src/xo-app/home/index.js
@@ -1017,7 +1017,7 @@ export default class Home extends Component {
               <Tooltip content={_('filterSyntaxLinkTooltip')}>
                 <a
                   className='input-group-addon'
-                  href='https://xen-orchestra.com/docs/manage_infrastructure.html#live-filter-search'
+                  href='https://docs.xen-orchestra.com/manage_infrastructure#live-filter-search'
                   rel='noopener noreferrer'
                   target='_blank'
                 >


### PR DESCRIPTION
The Xen Orchestra documentation moved to a new domain name a while ago (from `xen-orchestra.com/docs` to `docs.xen-orchestra.com`). 

This PR updates the last remaining links in the XO doc and app that pointed to the old domain name