### PR TITLE
feat(web-core): added data ruler component

### DIFF
--- a/@xen-orchestra/lite/src/stories/web-core/ui/data-ruler/ui-data-ruler.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/data-ruler/ui-data-ruler.story.vue
@@ -1,0 +1,10 @@
+<template>
+  <ComponentStory :params="[]">
+    <UiDataRuler />
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import UiDataRuler from '@core/components/ui/data-ruler/UiDataRuler.vue'
+</script>

--- a/@xen-orchestra/web-core/lib/components/ui/data-ruler/UiDataRuler.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/data-ruler/UiDataRuler.vue
@@ -1,0 +1,23 @@
+<!-- v1 -->
+<template>
+  <div class="ui-data-ruler typo-body-regular-small">
+    <span>{{ t('n-percent', 0) }}</span>
+    <span>{{ t('n-percent', 50) }}</span>
+    <span>{{ t('n-percent', 100) }}</span>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+</script>
+
+<style lang="postcss" scoped>
+.ui-data-ruler {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+</style>

--- a/@xen-orchestra/web-core/lib/components/ui/data-ruler/UiDataRuler.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/data-ruler/UiDataRuler.vue
@@ -19,5 +19,6 @@ const { t } = useI18n()
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+  color: var(--color-neutral-txt-secondary);
 }
 </style>


### PR DESCRIPTION
### Description

Added data ruler component

### Screenshots

<img width="751" height="49" alt="image" src="https://github.com/user-attachments/assets/d2eb8712-e37b-480c-a738-4db2577c402a" />

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
