### PR TITLE
feat(web-core): update progress bar component to add possibility to display GB instead of percent depending on the case 

### DIFF
--- a/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardCpuProvisioning.vue
+++ b/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardCpuProvisioning.vue
@@ -3,7 +3,7 @@
     <UiCardTitle>{{ t('cpu-provisioning') }}</UiCardTitle>
     <VtsLoadingHero v-if="!isReady" type="card" />
     <template v-else>
-      <UiProgressBar :value="vCpusCount" :max="cpusCount" :legend="t('vcpus')" />
+      <UiProgressBar display-mode="percent" :value="vCpusCount" :max="cpusCount" :legend="t('vcpus')" />
       <div class="total">
         <UiCardNumbers :label="t('vcpus-assigned')" :value="vCpusCount" size="medium" />
         <UiCardNumbers :label="t('total-cpus')" :value="cpusCount" size="medium" />

--- a/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardRamProvisioning.vue
+++ b/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardRamProvisioning.vue
@@ -3,7 +3,7 @@
     <UiCardTitle>{{ t('ram-provisioning') }}</UiCardTitle>
     <VtsLoadingHero v-if="!isReady" type="card" />
     <template v-else>
-      <UiProgressBar :value="memory?.usage ?? 0" :max="memory?.size" :legend="host.name_label" />
+      <UiProgressBar display-mode="percent" :value="memory?.usage ?? 0" :max="memory?.size" :legend="host.name_label" />
       <div class="total">
         <UiCardNumbers
           :label="t('total-assigned')"

--- a/@xen-orchestra/lite/src/stories/web-core/ui/progress-bar/ui-progress-bar.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/progress-bar/ui-progress-bar.story.vue
@@ -5,6 +5,7 @@
       prop('legend').preset('Legend').required().widget(),
       prop('value').preset(25).required().widget(),
       prop('max').num().widget(),
+      prop('displayMode').preset('value').widget().default('percent'),
       prop('showSteps').bool().help('Meant to display steps values under the progress bar. See Presets.').widget(),
     ]"
     :presets

--- a/@xen-orchestra/lite/src/stories/web-core/ui/progress-bar/ui-progress-bar.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/progress-bar/ui-progress-bar.story.vue
@@ -4,8 +4,8 @@
     :params="[
       prop('legend').preset('Legend').required().widget(),
       prop('value').preset(25).required().widget(),
-      prop('max').num().widget(),
-      prop('displayMode').preset('value').widget().default('percent'),
+      prop('max').num().widget().help(`Max will be required when displayMode is set to 'value'.`),
+      prop('displayMode').enum('value', 'percent').required().preset('percent').widget(),
       prop('showSteps').bool().help('Meant to display steps values under the progress bar. See Presets.').widget(),
     ]"
     :presets
@@ -24,12 +24,14 @@ const presets = {
     props: {
       legend: 'Ram usage',
       value: 80,
+      displayMode: 'percent',
     },
   },
   'Danger >= 90%': {
     props: {
       legend: 'Ram usage',
       value: 95,
+      displayMode: 'percent',
     },
   },
   'With steps': {
@@ -37,6 +39,7 @@ const presets = {
       legend: 'Ram usage',
       value: 250,
       max: 200,
+      displayMode: 'value',
     },
   },
 }

--- a/@xen-orchestra/web-core/lib/components/ui/legend/UiLegend.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/legend/UiLegend.vue
@@ -19,20 +19,20 @@ export type LegendItemAccent = 'neutral' | 'info' | 'success' | 'warning' | 'dan
 
 export type LegendItemProps = {
   accent: LegendItemAccent
-  value?: number
+  value?: number | string
   unit?: string
   tooltip?: string
 }
 
-const props = defineProps<LegendItemProps>()
+const { value, unit, accent } = defineProps<LegendItemProps>()
 
 defineSlots<{
-  default(): void
+  default(): any
 }>()
 
-const valueLabel = computed(() => [props.value, props.unit].join(' ').trim())
+const valueLabel = computed(() => [value, unit].join(' ').trim())
 
-const classNames = computed(() => toVariants({ accent: props.accent }))
+const classNames = computed(() => toVariants({ accent }))
 </script>
 
 <style lang="postcss" scoped>

--- a/@xen-orchestra/web-core/lib/components/ui/progress-bar/UiProgressBar.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/progress-bar/UiProgressBar.vue
@@ -9,7 +9,7 @@
       <span v-for="step in steps" :key="step">{{ n(step, 'percent') }}</span>
     </div>
     <VtsLegendList class="legend">
-      <UiLegend v-if="displayMode === 'percent'" :accent :value="Math.round(percent ? percent : percentage)" unit="%">
+      <UiLegend v-if="displayMode === 'percent'" :accent :value="Math.round(percentage)" unit="%">
         {{ legend }}
       </UiLegend>
       <UiLegend v-else :accent :value="legendValue">
@@ -28,25 +28,29 @@ import { useClamp, useMax } from '@vueuse/math'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-const {
-  value: _value,
-  max = 100,
-  showSteps,
-  displayMode = 'percent',
-} = defineProps<{
+interface Props {
   legend: string
   value: number
-  max?: number
-  percent?: number
   showSteps?: boolean
-  displayMode?: 'percent' | 'value'
-}>()
+}
+interface PercentageProps {
+  max?: number
+  displayMode: 'percent'
+}
+interface ValueProps {
+  max: number
+  displayMode: 'value'
+}
+
+const { value: _value, max: _max, showSteps, displayMode } = defineProps<Props & (PercentageProps | ValueProps)>()
 
 const { n } = useI18n()
 
 const value = useMax(0, () => _value)
 
-const percentage = computed(() => (max <= 0 ? 0 : (value.value / max) * 100))
+const max = computed(() => _max ?? 100)
+
+const percentage = computed(() => (max.value <= 0 ? 0 : (value.value / max.value) * 100))
 const maxPercentage = computed(() => Math.ceil(percentage.value / 100) * 100)
 const fillWidth = useClamp(() => (percentage.value / maxPercentage.value) * 100 || 0, 0, 100)
 const shouldShowSteps = computed(() => showSteps || percentage.value > 100)
@@ -68,7 +72,7 @@ const className = computed(() => toVariants({ accent: accent.value }))
 
 const formattedValue = computed(() => formatSizeRaw(value.value, 1))
 
-const formattedMax = computed(() => formatSizeRaw(max, 0))
+const formattedMax = computed(() => formatSizeRaw(max.value, 0))
 
 const legendValue = computed(() => {
   return `${formattedValue.value.value} ${formattedValue.value.prefix} / ${formattedMax.value.value} ${formattedMax.value.prefix}`

--- a/@xen-orchestra/web-core/lib/components/ui/progress-bar/UiProgressBar.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/progress-bar/UiProgressBar.vue
@@ -9,7 +9,12 @@
       <span v-for="step in steps" :key="step">{{ n(step, 'percent') }}</span>
     </div>
     <VtsLegendList class="legend">
-      <UiLegend :accent :value="Math.round(percentage)" unit="%">{{ legend }}</UiLegend>
+      <UiLegend v-if="displayMode === 'percent'" :accent :value="Math.round(percent ? percent : percentage)" unit="%">
+        {{ legend }}
+      </UiLegend>
+      <UiLegend v-else :accent :value="legendValue">
+        {{ legend }}
+      </UiLegend>
     </VtsLegendList>
   </div>
 </template>
@@ -17,6 +22,7 @@
 <script lang="ts" setup>
 import VtsLegendList from '@core/components/legend-list/VtsLegendList.vue'
 import UiLegend from '@core/components/ui/legend/UiLegend.vue'
+import { formatSizeRaw } from '@core/utils/size.util.ts'
 import { toVariants } from '@core/utils/to-variants.util'
 import { useClamp, useMax } from '@vueuse/math'
 import { computed } from 'vue'
@@ -26,11 +32,14 @@ const {
   value: _value,
   max = 100,
   showSteps,
+  displayMode = 'percent',
 } = defineProps<{
   legend: string
   value: number
   max?: number
+  percent?: number
   showSteps?: boolean
+  displayMode?: 'percent' | 'value'
 }>()
 
 const { n } = useI18n()
@@ -56,6 +65,14 @@ const accent = computed(() => {
 })
 
 const className = computed(() => toVariants({ accent: accent.value }))
+
+const formattedValue = computed(() => formatSizeRaw(value.value, 1))
+
+const formattedMax = computed(() => formatSizeRaw(max, 0))
+
+const legendValue = computed(() => {
+  return `${formattedValue.value.value} ${formattedValue.value.prefix} / ${formattedMax.value.value} ${formattedMax.value.prefix}`
+})
 </script>
 
 <style lang="postcss" scoped>

--- a/@xen-orchestra/web/src/components/host/dashboard/HostDashboardCpuProvisioning.vue
+++ b/@xen-orchestra/web/src/components/host/dashboard/HostDashboardCpuProvisioning.vue
@@ -3,7 +3,7 @@
     <UiCardTitle>{{ t('cpu-provisioning') }}</UiCardTitle>
     <VtsLoadingHero v-if="!isReady" type="card" />
     <template v-else>
-      <UiProgressBar :value="vCpusCount" :max="cpusCount" :legend="t('vcpus')" />
+      <UiProgressBar display-mode="percent" :value="vCpusCount" :max="cpusCount" :legend="t('vcpus')" />
       <div class="total">
         <UiCardNumbers :label="t('vcpus-assigned')" :value="vCpusCount" size="medium" />
         <UiCardNumbers :label="t('total-cpus')" :value="cpusCount" size="medium" />

--- a/@xen-orchestra/web/src/components/host/dashboard/HostDashboardRamProvisioning.vue
+++ b/@xen-orchestra/web/src/components/host/dashboard/HostDashboardRamProvisioning.vue
@@ -3,7 +3,12 @@
     <UiCardTitle>{{ t('ram-provisioning') }}</UiCardTitle>
     <VtsLoadingHero v-if="!isReady" type="card" />
     <template v-else>
-      <UiProgressBar :value="host.memory.usage" :max="host.memory.size" :legend="host.name_label" />
+      <UiProgressBar
+        display-mode="percent"
+        :value="host.memory.usage"
+        :max="host.memory.size"
+        :legend="host.name_label"
+      />
       <div class="total">
         <UiCardNumbers
           :label="t('total-assigned')"


### PR DESCRIPTION
### Description

Update progress bar component to add possibility to display GB etc instead of percent depending on the case 

### Screenshots

<img width="751" height="138" alt="image" src="https://github.com/user-attachments/assets/b2616a80-1762-4677-b414-7b4e28d3cb3e" />


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
