### PR TITLE
fix(fs): better handling of incomplete read

### DIFF
--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -158,7 +158,7 @@ export default class RemoteHandlerAbstract {
   }
 
   #conditionRetry(error) {
-    return !['EEXIST', 'EISDIR', 'ENOTEMPTY', 'ENOENT', 'ENOTDIR', 'SystemInUse'].includes(error?.code)
+    return !['EEXIST', 'EISDIR', 'ENOTEMPTY', 'ENOENT', 'ENOTDIR', 'SystemInUse', 'ERR_ASSERTION'].includes(error?.code)
   }
 
   #applySafeGuards(options) {

--- a/@xen-orchestra/fs/src/fs.test.js
+++ b/@xen-orchestra/fs/src/fs.test.js
@@ -195,8 +195,8 @@ handlers.forEach(url => {
     describe('#read()', () => {
       beforeEach(() => handler.outputFile('file', TEST_DATA))
 
-      const start = random(TEST_DATA_LEN)
-      const size = random(TEST_DATA_LEN)
+      const start = random(TEST_DATA_LEN - 1)
+      const size = random(TEST_DATA_LEN - start)
 
       testWithFileDescriptor('file', 'r', async ({ file }) => {
         const buffer = Buffer.alloc(size)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Backup] Better handling of filesystem error while reading file (PR [#8818](https://github.com/vatesfr/xen-orchestra/pull/8818))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -31,6 +33,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/fs patch
 - xo-web patch
 
 <!--packages-end-->

--- a/packages/vhd-lib/Vhd/VhdDirectory.js
+++ b/packages/vhd-lib/Vhd/VhdDirectory.js
@@ -209,6 +209,11 @@ exports.VhdDirectory = class VhdDirectory extends VhdAbstract {
       throw new Error(`reading 'bitmap of block' ${blockId} in a VhdDirectory is not implemented`)
     }
     const { buffer } = await this._readChunk(this.#getBlockPath(blockId))
+    assert.strictEqual(
+      buffer.length,
+      this.fullBlockSize,
+      `partial read of a block , expecting ${this.fullBlockSize}, got ${buffer.length}`
+    )
     return {
       id: blockId,
       bitmap: buffer.slice(0, this.bitmapSize),


### PR DESCRIPTION
do not squash 

from ticket 42001

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
