### PR TITLE
fix(backups): mustDoSnapshot now checks if a vdi has a tag NOBAK

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/FullXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/FullXapi.mjs
@@ -15,8 +15,6 @@ export const FullXapi = class FullXapiVmBackupRunner extends AbstractXapi {
 
   async _mustDoSnapshot() {
     const vm = this._vm
-    const vdis = await this._xapi.getRecords('VDI', await vm.$getDisks())
-    const hasNOBAKtag = vdis.some(idx => idx.name_label.includes('[NOBAK]'))
     const settings = this._settings
 
     // General setting forcing snapshot at all times
@@ -35,6 +33,9 @@ export const FullXapi = class FullXapiVmBackupRunner extends AbstractXapi {
     if (settings.snapshotRetention !== 0) {
       return true
     }
+
+    const vdis = await this._xapi.getRecords('VDI', await vm.$getDisks())
+    const hasNOBAKtag = vdis.some(idx => idx.name_label.includes('[NOBAK]'))
 
     // if there is a disk with NOBAK tag
     // we need to make a snapshot

--- a/@xen-orchestra/backups/_runners/_vmRunners/FullXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/FullXapi.mjs
@@ -13,14 +13,16 @@ export const FullXapi = class FullXapiVmBackupRunner extends AbstractXapi {
     return [FullRemoteWriter, FullXapiWriter]
   }
 
-  _mustDoSnapshot() {
+  async _mustDoSnapshot() {
     const vm = this._vm
-
+    const vdis = await this._xapi.getRecords('VDI', await vm.$getDisks())
+    const hasNOBAKtag = vdis.some(idx => idx.name_label.includes('[NOBAK]'))
     const settings = this._settings
     return (
       settings.unconditionalSnapshot ||
       (!settings.offlineBackup && vm.power_state === 'Running') ||
-      settings.snapshotRetention !== 0
+      settings.snapshotRetention !== 0 ||
+      !hasNOBAKtag
     )
   }
   _selectBaseVm() {}

--- a/@xen-orchestra/backups/_runners/_vmRunners/FullXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/FullXapi.mjs
@@ -18,12 +18,29 @@ export const FullXapi = class FullXapiVmBackupRunner extends AbstractXapi {
     const vdis = await this._xapi.getRecords('VDI', await vm.$getDisks())
     const hasNOBAKtag = vdis.some(idx => idx.name_label.includes('[NOBAK]'))
     const settings = this._settings
-    return (
-      settings.unconditionalSnapshot ||
-      (!settings.offlineBackup && vm.power_state === 'Running') ||
-      settings.snapshotRetention !== 0 ||
-      !hasNOBAKtag
-    )
+
+    // General setting forcing snapshot at all times
+    if (settings.unconditionalSnapshot) {
+      return true
+    }
+
+    // If offline backup option is not checked
+    // and vm is running, we make a snapshot
+    if (!settings.offlineBackup && vm.power_state === 'Running') {
+      return true
+    }
+
+    // General setting used for snapshot retention
+    // see schedule in backupJob edition
+    if (settings.snapshotRetention !== 0) {
+      return true
+    }
+
+    // if there is a disk with NOBAK tag
+    // we need to make a snapshot
+    if (hasNOBAKtag) {
+      return true
+    }
   }
   _selectBaseVm() {}
 

--- a/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
@@ -23,7 +23,7 @@ export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends Abstr
     return [IncrementalRemoteWriter, IncrementalXapiWriter]
   }
 
-  _mustDoSnapshot() {
+  async _mustDoSnapshot() {
     return true
   }
 

--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
@@ -141,7 +141,7 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
 
     const settings = this._settings
 
-    if (this._mustDoSnapshot()) {
+    if (await this._mustDoSnapshot()) {
       await Task.run({ name: 'snapshot' }, async () => {
         if (!settings.bypassVdiChainsCheck) {
           await vm.$assertHealthyVdiChains()
@@ -324,7 +324,7 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
     throw new Error('Not implemented')
   }
 
-  _mustDoSnapshot() {
+  async _mustDoSnapshot() {
     throw new Error('Not implemented')
   }
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,6 +36,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Backup] Fix full backup retry failing with EEXIST error (PR [#8776](https://github.com/vatesfr/xen-orchestra/pull/8776))
+- [Backup] Force snapshot if one of its VDIs has a NOBAK tag (PR [#8820](https://github.com/vatesfr/xen-orchestra/pull/8820))
 
 - **XO 6:**
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -64,6 +64,7 @@
 
 - @vates/generator-toolbox patch
 - @vates/types minor
+- @xen-orchestra/backups minor
 - @xen-orchestra/fs patch
 - @xen-orchestra/mixins patch
 - @xen-orchestra/openflow patch


### PR DESCRIPTION
### Description

Backup created a full backup with all VDI included when a VM had a VDI with the tag NOBAK. It should not be the case, here is a proposal to fix this. It will create a snapshot if a VDI has a tag NOBAK.

Ticket number: 41359

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
