### PR TITLE
feat(@xen-orchestra/rest-api): expose VDI alarms

### DIFF
--- a/@xen-orchestra/rest-api/src/vdis/vdi.controller.mts
+++ b/@xen-orchestra/rest-api/src/vdis/vdi.controller.mts
@@ -62,7 +62,7 @@ export class VdiController extends XapiXoController<XoVdi> {
   @Get('{id}/alarms')
   @Tags('alarms')
   @Response(notFoundResp.status, notFoundResp.description)
-  getHostAlarms(
+  getVdiAlarms(
     @Request() req: ExRequest,
     @Path() id: string,
     @Query() fields?: string,

--- a/@xen-orchestra/rest-api/src/vdis/vdi.controller.mts
+++ b/@xen-orchestra/rest-api/src/vdis/vdi.controller.mts
@@ -2,8 +2,10 @@ import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } f
 import { inject } from 'inversify'
 import { provide } from 'inversify-binding-decorators'
 import { Request as ExRequest } from 'express'
-import type { XoVdi } from '@vates/types'
+import type { XoAlarm, XoVdi } from '@vates/types'
 
+import { AlarmService } from '../alarms/alarm.service.mjs'
+import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
@@ -16,8 +18,10 @@ import { partialVdis, vdi, vdiIds } from '../open-api/oa-examples/vdi.oa-example
 @Tags('vdis')
 @provide(VdiController)
 export class VdiController extends XapiXoController<XoVdi> {
-  constructor(@inject(RestApi) restApi: RestApi) {
+  #alarmService: AlarmService
+  constructor(@inject(RestApi) restApi: RestApi, @inject(AlarmService) alarmService: AlarmService) {
     super('VDI', restApi)
+    this.#alarmService = alarmService
   }
 
   /**
@@ -46,5 +50,32 @@ export class VdiController extends XapiXoController<XoVdi> {
   @Response(notFoundResp.status, notFoundResp.description)
   getVdi(@Path() id: string): Unbrand<XoVdi> {
     return this.getObject(id as XoVdi['id'])
+  }
+
+  /**
+   * @example id "c77f9955-c1d2-4b39-aa1c-73cdb2dacb7e"
+   * @example fields "id,time"
+   * @example filter "time:>1747053793"
+   * @example limit 42
+   */
+  @Example(genericAlarmsExample)
+  @Get('{id}/alarms')
+  @Tags('alarms')
+  @Response(notFoundResp.status, notFoundResp.description)
+  getHostAlarms(
+    @Request() req: ExRequest,
+    @Path() id: string,
+    @Query() fields?: string,
+    @Query() ndjson?: boolean,
+    @Query() filter?: string,
+    @Query() limit?: number
+  ): SendObjects<Partial<Unbrand<XoAlarm>>> {
+    const vdi = this.getObject(id as XoVdi['id'])
+    const alarms = this.#alarmService.getAlarms({
+      filter: `${filter ?? ''} object:uuid:${vdi.uuid}`,
+      limit,
+    })
+
+    return this.sendObjects(Object.values(alarms), req, 'alarms')
   }
 }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
   - `GET /rest/v0/hosts/<host-id>/alarms` (PR [#8800](http://github.com/vatesfr/xen-orchestra/pull/8800))
   - `GET /rest/v0/networks/<network-id>/alarms` (PR [#8801](https://github.com/vatesfr/xen-orchestra/pull/8801))
   - `GET /rest/v0/pifs/<pif-id>/alarms` (PR [#8802](http://github.com/vatesfr/xen-orchestra/pull/8802))
+  - `GET /rest/v0/vdis/<vdi-id>/alarms` (PR [#8823](http://github.com/vatesfr/xen-orchestra/pull/8823))
 
 - **XO 6:**
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,7 +19,7 @@
   - `GET /rest/v0/hosts/<host-id>/alarms` (PR [#8800](http://github.com/vatesfr/xen-orchestra/pull/8800))
   - `GET /rest/v0/networks/<network-id>/alarms` (PR [#8801](https://github.com/vatesfr/xen-orchestra/pull/8801))
   - `GET /rest/v0/pifs/<pif-id>/alarms` (PR [#8802](http://github.com/vatesfr/xen-orchestra/pull/8802))
-  - `GET /rest/v0/vdis/<vdi-id>/alarms` (PR [#8823](http://github.com/vatesfr/xen-orchestra/pull/8823))
+  - `GET /rest/v0/vdis/<vdi-id>/alarms` (PR [#8824](http://github.com/vatesfr/xen-orchestra/pull/8824))
 
 - **XO 6:**
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -265,7 +265,11 @@ export default class RestApi {
       },
       srs: {},
       vbds: {},
-      vdis: {},
+      vdis: {
+        routes: {
+          alarms: true,
+        },
+      },
       'vdi-snapshots': {},
       servers: {},
     }


### PR DESCRIPTION
### Screenshot

<img width="535" height="567" alt="Capture d’écran de 2025-07-23 16-02-16" src="https://github.com/user-attachments/assets/fedcaa8a-a0fa-40ca-a1aa-6b0676dd44fe" />


### Description

[XO-1121](https://project.vates.tech/vates-global/browse/XO-1121/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
