### PR TITLE
feat(@xen-orchestra/rest-api): expose VM template alarms

### DIFF
--- a/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
@@ -63,7 +63,7 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
   @Get('{id}/alarms')
   @Tags('alarms')
   @Response(notFoundResp.status, notFoundResp.description)
-  getvmTemplateAlarms(
+  getVmTemplateAlarms(
     @Request() req: ExRequest,
     @Path() id: string,
     @Query() fields?: string,

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@
   - `GET /rest/v0/networks/<network-id>/alarms` (PR [#8801](https://github.com/vatesfr/xen-orchestra/pull/8801))
   - `GET /rest/v0/pifs/<pif-id>/alarms` (PR [#8802](http://github.com/vatesfr/xen-orchestra/pull/8802))
   - `GET /rest/v0/vdi-snapshots/<vdi-snapshot-id>/alarms` (PR [#8823](http://github.com/vatesfr/xen-orchestra/pull/8823))
+  - `GET /rest/v0/vm-templates/<vm-template-id>/alarms` (PR [#8828](http://github.com/vatesfr/xen-orchestra/pull/8828))
 
 - **XO 6:**
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -262,7 +262,11 @@ export default class RestApi {
       },
       'vm-controllers': {},
       'vm-snapshots': {},
-      'vm-templates': {},
+      'vm-templates': {
+        routes: {
+          alarms: true,
+        },
+      },
       hosts: {
         routes: {
           'audit.txt': true,


### PR DESCRIPTION
### Screenshot

<img width="488" height="578" alt="Capture d’écran de 2025-07-24 10-26-01" src="https://github.com/user-attachments/assets/08f1739d-47f8-4b64-b079-fca3cb87ff1f" />

### Description

[XO-1117](https://project.vates.tech/vates-global/browse/XO-1117/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
