### PR TITLE
fix(@xen-orchestra/rest-api): escape unsafe complex matcher input

### DIFF
--- a/@xen-orchestra/rest-api/src/helpers/utils.helper.mts
+++ b/@xen-orchestra/rest-api/src/helpers/utils.helper.mts
@@ -111,10 +111,10 @@ export async function promiseWriteInStream<T>({
   return data
 }
 
-export function escapeComplexMatcher(string: undefined): undefined
-export function escapeComplexMatcher(string: string): string
-export function escapeComplexMatcher(string: string | undefined): string | undefined
-export function escapeComplexMatcher(maybeString: string | undefined): string | undefined {
+export function escapeUnsafeComplexMatcher(string: undefined): undefined
+export function escapeUnsafeComplexMatcher(string: string): string
+export function escapeUnsafeComplexMatcher(string: string | undefined): string | undefined
+export function escapeUnsafeComplexMatcher(maybeString: string | undefined): string | undefined {
   if (maybeString === undefined) {
     return maybeString
   }

--- a/@xen-orchestra/rest-api/src/helpers/utils.helper.mts
+++ b/@xen-orchestra/rest-api/src/helpers/utils.helper.mts
@@ -110,3 +110,18 @@ export async function promiseWriteInStream<T>({
 
   return data
 }
+
+export function escapeComplexMatcher(string: undefined): undefined
+export function escapeComplexMatcher(string: string): string
+export function escapeComplexMatcher(string: string | undefined): string | undefined
+export function escapeComplexMatcher(maybeString: string | undefined): string | undefined {
+  if (maybeString === undefined) {
+    return maybeString
+  }
+
+  if (maybeString === undefined || maybeString === '') {
+    return maybeString
+  }
+
+  return `(${maybeString})`
+}

--- a/@xen-orchestra/rest-api/src/helpers/utils.helper.mts
+++ b/@xen-orchestra/rest-api/src/helpers/utils.helper.mts
@@ -115,10 +115,6 @@ export function escapeUnsafeComplexMatcher(string: undefined): undefined
 export function escapeUnsafeComplexMatcher(string: string): string
 export function escapeUnsafeComplexMatcher(string: string | undefined): string | undefined
 export function escapeUnsafeComplexMatcher(maybeString: string | undefined): string | undefined {
-  if (maybeString === undefined) {
-    return maybeString
-  }
-
   if (maybeString === undefined || maybeString === '') {
     return maybeString
   }

--- a/@xen-orchestra/rest-api/src/hosts/host.controller.mts
+++ b/@xen-orchestra/rest-api/src/hosts/host.controller.mts
@@ -6,6 +6,7 @@ import { provide } from 'inversify-binding-decorators'
 import type { XapiHostStats, XapiStatsGranularity, XoAlarm, XoHost } from '@vates/types'
 
 import { AlarmService } from '../alarms/alarm.service.mjs'
+import { escapeComplexMatcher } from '../helpers/utils.helper.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
 import { host, hostIds, hostStats, partialHosts } from '../open-api/oa-examples/host.oa-example.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
@@ -119,7 +120,7 @@ export class HostController extends XapiXoController<XoHost> {
   ): SendObjects<Partial<Unbrand<XoAlarm>>> {
     const host = this.getObject(id as XoHost['id'])
     const alarms = this.#alarmService.getAlarms({
-      filter: `${filter ?? ''} object:uuid:${host.uuid}`,
+      filter: `${escapeComplexMatcher(filter) ?? ''} object:uuid:${host.uuid}`,
       limit,
     })
 

--- a/@xen-orchestra/rest-api/src/hosts/host.controller.mts
+++ b/@xen-orchestra/rest-api/src/hosts/host.controller.mts
@@ -6,7 +6,7 @@ import { provide } from 'inversify-binding-decorators'
 import type { XapiHostStats, XapiStatsGranularity, XoAlarm, XoHost } from '@vates/types'
 
 import { AlarmService } from '../alarms/alarm.service.mjs'
-import { escapeComplexMatcher } from '../helpers/utils.helper.mjs'
+import { escapeUnsafeComplexMatcher } from '../helpers/utils.helper.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
 import { host, hostIds, hostStats, partialHosts } from '../open-api/oa-examples/host.oa-example.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
@@ -120,7 +120,7 @@ export class HostController extends XapiXoController<XoHost> {
   ): SendObjects<Partial<Unbrand<XoAlarm>>> {
     const host = this.getObject(id as XoHost['id'])
     const alarms = this.#alarmService.getAlarms({
-      filter: `${escapeComplexMatcher(filter) ?? ''} object:uuid:${host.uuid}`,
+      filter: `${escapeUnsafeComplexMatcher(filter) ?? ''} object:uuid:${host.uuid}`,
       limit,
     })
 

--- a/@xen-orchestra/rest-api/src/networks/network.controller.mts
+++ b/@xen-orchestra/rest-api/src/networks/network.controller.mts
@@ -5,7 +5,7 @@ import { Request as ExRequest } from 'express'
 import type { XoAlarm, XoNetwork } from '@vates/types'
 
 import { AlarmService } from '../alarms/alarm.service.mjs'
-import { escapeComplexMatcher } from '../helpers/utils.helper.mjs'
+import { escapeUnsafeComplexMatcher } from '../helpers/utils.helper.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
 import { network, networkIds, partialNetworks } from '../open-api/oa-examples/network.oa-example.mjs'
 import { noContentResp, notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
@@ -84,7 +84,7 @@ export class NetworkController extends XapiXoController<XoNetwork> {
   ): SendObjects<Partial<Unbrand<XoAlarm>>> {
     const network = this.getObject(id as XoNetwork['id'])
     const alarms = this.#alarmService.getAlarms({
-      filter: `${escapeComplexMatcher(filter) ?? ''} object:uuid:${network.uuid}`,
+      filter: `${escapeUnsafeComplexMatcher(filter) ?? ''} object:uuid:${network.uuid}`,
       limit,
     })
 

--- a/@xen-orchestra/rest-api/src/networks/network.controller.mts
+++ b/@xen-orchestra/rest-api/src/networks/network.controller.mts
@@ -5,6 +5,7 @@ import { Request as ExRequest } from 'express'
 import type { XoAlarm, XoNetwork } from '@vates/types'
 
 import { AlarmService } from '../alarms/alarm.service.mjs'
+import { escapeComplexMatcher } from '../helpers/utils.helper.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
 import { network, networkIds, partialNetworks } from '../open-api/oa-examples/network.oa-example.mjs'
 import { noContentResp, notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
@@ -83,7 +84,7 @@ export class NetworkController extends XapiXoController<XoNetwork> {
   ): SendObjects<Partial<Unbrand<XoAlarm>>> {
     const network = this.getObject(id as XoNetwork['id'])
     const alarms = this.#alarmService.getAlarms({
-      filter: `${filter ?? ''} object:uuid:${network.uuid}`,
+      filter: `${escapeComplexMatcher(filter) ?? ''} object:uuid:${network.uuid}`,
       limit,
     })
 

--- a/@xen-orchestra/rest-api/src/pifs/pif.controller.mts
+++ b/@xen-orchestra/rest-api/src/pifs/pif.controller.mts
@@ -5,6 +5,7 @@ import type { Request as ExRequest } from 'express'
 import type { XoAlarm, XoPif } from '@vates/types'
 
 import { AlarmService } from '../alarms/alarm.service.mjs'
+import { escapeComplexMatcher } from '../helpers/utils.helper.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { partialPifs, pif, pifIds } from '../open-api/oa-examples/pif.oa-example.mjs'
@@ -74,7 +75,7 @@ export class PifController extends XapiXoController<XoPif> {
   ): SendObjects<Partial<Unbrand<XoAlarm>>> {
     const pif = this.getObject(id as XoPif['id'])
     const alarms = this.#alarmService.getAlarms({
-      filter: `${filter ?? ''} object:uuid:${pif.uuid}`,
+      filter: `${escapeComplexMatcher(filter) ?? ''} object:uuid:${pif.uuid}`,
       limit,
     })
 

--- a/@xen-orchestra/rest-api/src/pifs/pif.controller.mts
+++ b/@xen-orchestra/rest-api/src/pifs/pif.controller.mts
@@ -5,7 +5,7 @@ import type { Request as ExRequest } from 'express'
 import type { XoAlarm, XoPif } from '@vates/types'
 
 import { AlarmService } from '../alarms/alarm.service.mjs'
-import { escapeComplexMatcher } from '../helpers/utils.helper.mjs'
+import { escapeUnsafeComplexMatcher } from '../helpers/utils.helper.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { partialPifs, pif, pifIds } from '../open-api/oa-examples/pif.oa-example.mjs'
@@ -75,7 +75,7 @@ export class PifController extends XapiXoController<XoPif> {
   ): SendObjects<Partial<Unbrand<XoAlarm>>> {
     const pif = this.getObject(id as XoPif['id'])
     const alarms = this.#alarmService.getAlarms({
-      filter: `${escapeComplexMatcher(filter) ?? ''} object:uuid:${pif.uuid}`,
+      filter: `${escapeUnsafeComplexMatcher(filter) ?? ''} object:uuid:${pif.uuid}`,
       limit,
     })
 

--- a/@xen-orchestra/rest-api/src/vdi-snapshots/vdi-snapshot.controller.mts
+++ b/@xen-orchestra/rest-api/src/vdi-snapshots/vdi-snapshot.controller.mts
@@ -4,6 +4,7 @@ import { provide } from 'inversify-binding-decorators'
 import { Request as ExRequest } from 'express'
 import type { XoAlarm, XoVdiSnapshot } from '@vates/types'
 
+import { escapeComplexMatcher } from '../helpers/utils.helper.mjs'
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
@@ -72,7 +73,7 @@ export class VdiSnapshotController extends XapiXoController<XoVdiSnapshot> {
   ): SendObjects<Partial<Unbrand<XoAlarm>>> {
     const vdiSnapshot = this.getObject(id as XoVdiSnapshot['id'])
     const alarms = this.#alarmService.getAlarms({
-      filter: `${filter ?? ''} object:uuid:${vdiSnapshot.uuid}`,
+      filter: `${escapeComplexMatcher(filter) ?? ''} object:uuid:${vdiSnapshot.uuid}`,
       limit,
     })
 

--- a/@xen-orchestra/rest-api/src/vdi-snapshots/vdi-snapshot.controller.mts
+++ b/@xen-orchestra/rest-api/src/vdi-snapshots/vdi-snapshot.controller.mts
@@ -4,7 +4,7 @@ import { provide } from 'inversify-binding-decorators'
 import { Request as ExRequest } from 'express'
 import type { XoAlarm, XoVdiSnapshot } from '@vates/types'
 
-import { escapeComplexMatcher } from '../helpers/utils.helper.mjs'
+import { escapeUnsafeComplexMatcher } from '../helpers/utils.helper.mjs'
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
@@ -73,7 +73,7 @@ export class VdiSnapshotController extends XapiXoController<XoVdiSnapshot> {
   ): SendObjects<Partial<Unbrand<XoAlarm>>> {
     const vdiSnapshot = this.getObject(id as XoVdiSnapshot['id'])
     const alarms = this.#alarmService.getAlarms({
-      filter: `${escapeComplexMatcher(filter) ?? ''} object:uuid:${vdiSnapshot.uuid}`,
+      filter: `${escapeUnsafeComplexMatcher(filter) ?? ''} object:uuid:${vdiSnapshot.uuid}`,
       limit,
     })
 

--- a/@xen-orchestra/rest-api/src/vdis/vdi.controller.mts
+++ b/@xen-orchestra/rest-api/src/vdis/vdi.controller.mts
@@ -5,7 +5,7 @@ import { Request as ExRequest } from 'express'
 import type { XoAlarm, XoVdi } from '@vates/types'
 
 import { AlarmService } from '../alarms/alarm.service.mjs'
-import { escapeComplexMatcher } from '../helpers/utils.helper.mjs'
+import { escapeUnsafeComplexMatcher } from '../helpers/utils.helper.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
@@ -73,7 +73,7 @@ export class VdiController extends XapiXoController<XoVdi> {
   ): SendObjects<Partial<Unbrand<XoAlarm>>> {
     const vdi = this.getObject(id as XoVdi['id'])
     const alarms = this.#alarmService.getAlarms({
-      filter: `${escapeComplexMatcher(filter) ?? ''} object:uuid:${vdi.uuid}`,
+      filter: `${escapeUnsafeComplexMatcher(filter) ?? ''} object:uuid:${vdi.uuid}`,
       limit,
     })
 

--- a/@xen-orchestra/rest-api/src/vdis/vdi.controller.mts
+++ b/@xen-orchestra/rest-api/src/vdis/vdi.controller.mts
@@ -5,6 +5,7 @@ import { Request as ExRequest } from 'express'
 import type { XoAlarm, XoVdi } from '@vates/types'
 
 import { AlarmService } from '../alarms/alarm.service.mjs'
+import { escapeComplexMatcher } from '../helpers/utils.helper.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
@@ -72,7 +73,7 @@ export class VdiController extends XapiXoController<XoVdi> {
   ): SendObjects<Partial<Unbrand<XoAlarm>>> {
     const vdi = this.getObject(id as XoVdi['id'])
     const alarms = this.#alarmService.getAlarms({
-      filter: `${filter ?? ''} object:uuid:${vdi.uuid}`,
+      filter: `${escapeComplexMatcher(filter) ?? ''} object:uuid:${vdi.uuid}`,
       limit,
     })
 

--- a/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
@@ -5,7 +5,7 @@ import { provide } from 'inversify-binding-decorators'
 import type { XoAlarm, XoVmTemplate } from '@vates/types'
 
 import { AlarmService } from '../alarms/alarm.service.mjs'
-import { escapeComplexMatcher } from '../helpers/utils.helper.mjs'
+import { escapeUnsafeComplexMatcher } from '../helpers/utils.helper.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
@@ -74,7 +74,7 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
   ): SendObjects<Partial<Unbrand<XoAlarm>>> {
     const vmTemplate = this.getObject(id as XoVmTemplate['id'])
     const alarms = this.#alarmService.getAlarms({
-      filter: `${escapeComplexMatcher(filter) ?? ''} object:uuid:${vmTemplate.uuid}`,
+      filter: `${escapeUnsafeComplexMatcher(filter) ?? ''} object:uuid:${vmTemplate.uuid}`,
       limit,
     })
 

--- a/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
@@ -5,6 +5,7 @@ import { provide } from 'inversify-binding-decorators'
 import type { XoAlarm, XoVmTemplate } from '@vates/types'
 
 import { AlarmService } from '../alarms/alarm.service.mjs'
+import { escapeComplexMatcher } from '../helpers/utils.helper.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
 import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
@@ -73,7 +74,7 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
   ): SendObjects<Partial<Unbrand<XoAlarm>>> {
     const vmTemplate = this.getObject(id as XoVmTemplate['id'])
     const alarms = this.#alarmService.getAlarms({
-      filter: `${filter ?? ''} object:uuid:${vmTemplate.uuid}`,
+      filter: `${escapeComplexMatcher(filter) ?? ''} object:uuid:${vmTemplate.uuid}`,
       limit,
     })
 


### PR DESCRIPTION
### Description

e.g.
`!power_state:running ! uuid:e7a4f544-6bf3-52b4-843a-119fb2e1f165` // KO
`(!power_state:running !) uuid:e7a4f544-6bf3-52b4-843a-119fb2e1f165` // OK

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
