### PR TITLE
feat(xo6): add alarms component on site dashboard

### DIFF
--- a/@xen-orchestra/web-core/lib/types/utility.type.ts
+++ b/@xen-orchestra/web-core/lib/types/utility.type.ts
@@ -11,7 +11,7 @@ export type EmptyObject = Record<string, never>
 export type StringKeyOf<T> = Extract<keyof T, string>
 
 export type KeyOfByValue<T, TValue> =
-  T extends Record<PropertyKey, unknown>
+  T extends Record<PropertyKey, any>
     ? keyof {
         [K in keyof T as T[K] extends TValue ? K : never]: T[K]
       }

--- a/@xen-orchestra/web-core/lib/utils/date-sorter.utils.ts
+++ b/@xen-orchestra/web-core/lib/utils/date-sorter.utils.ts
@@ -1,0 +1,7 @@
+export function createDateSorter<T>(key: keyof T) {
+  return (a: T, b: T) => {
+    const dateA = new Date(a[key] as Date | string | number)
+    const dateB = new Date(b[key] as Date | string | number)
+    return dateB.getTime() - dateA.getTime()
+  }
+}

--- a/@xen-orchestra/web-core/lib/utils/date-sorter.utils.ts
+++ b/@xen-orchestra/web-core/lib/utils/date-sorter.utils.ts
@@ -1,7 +1,12 @@
-export function createDateSorter<T>(key: keyof T) {
+import type { KeyOfByValue } from '@core/types/utility.type.ts'
+
+type DateLike = Date | string | number
+
+export function createDateSorter<T extends object>(key: KeyOfByValue<T, DateLike>) {
   return (a: T, b: T) => {
-    const dateA = new Date(a[key] as Date | string | number)
-    const dateB = new Date(b[key] as Date | string | number)
+    const dateA = new Date(a[key] as DateLike)
+    const dateB = new Date(b[key] as DateLike)
+
     return dateB.getTime() - dateA.getTime()
   }
 }

--- a/@xen-orchestra/web/src/components/pool/dashboard/alarms/PoolDashboardAlarms.vue
+++ b/@xen-orchestra/web/src/components/pool/dashboard/alarms/PoolDashboardAlarms.vue
@@ -12,7 +12,7 @@
     </UiCardTitle>
     <VtsLoadingHero v-if="!areAlarmsReady" type="card" />
     <VtsAllGoodHero v-else-if="alarms.length === 0" type="card" />
-    <div v-else class="alarm-items">
+    <div v-else class="alarm-list-container">
       <UiAlarmList>
         <template v-for="alarm in alarms" :key="alarm.id">
           <UiAlarmItem
@@ -97,7 +97,7 @@ const alarms = computed(() => {
 .pool-dashboard-alarms {
   max-height: 46.2rem;
 
-  .alarm-items {
+  .alarm-list-container {
     overflow: auto;
     margin-inline: -2.4rem;
     margin-block-end: -1.2rem;

--- a/@xen-orchestra/web/src/components/site/dashboard/AlarmLink.vue
+++ b/@xen-orchestra/web/src/components/site/dashboard/AlarmLink.vue
@@ -1,11 +1,8 @@
 <template>
   <div class="alarm-link">
-    <UiObjectLink :route>
-      <template #icon>
-        <UiObjectIcon :type="iconType" size="medium" :state="powerState" />
-      </template>
+    <UiLink size="small" :to="route" :icon>
       {{ nameLabel }}
-    </UiObjectLink>
+    </UiLink>
   </div>
 </template>
 
@@ -15,9 +12,8 @@ import { useSrStore } from '@/stores/xo-rest-api/sr.store.ts'
 import { useVmControllerStore } from '@/stores/xo-rest-api/vm-controller.store.ts'
 import { useVmStore } from '@/stores/xo-rest-api/vm.store.ts'
 import type { XoVmController } from '@/types/xo/vm-controller.type.ts'
-import type { SupportedState } from '@core/types/object-icon.type.ts'
-import UiObjectIcon from '@core/components/ui/object-icon/UiObjectIcon.vue'
-import UiObjectLink from '@core/components/ui/object-link/UiObjectLink.vue'
+import UiLink from '@core/components/ui/link/UiLink.vue'
+import { faDatabase, faDesktop, faServer } from '@fortawesome/free-solid-svg-icons'
 import type { XapiXoRecord } from '@vates/types'
 import { computed } from 'vue'
 
@@ -50,28 +46,20 @@ const record = computed(() => {
 
 const nameLabel = computed(() => record.value?.name_label ?? uuid)
 
-const iconType = computed(() => {
+const icon = computed(() => {
   if (type === 'VM' || type === 'VM-controller') {
-    return 'vm'
+    return faDesktop
   }
 
   if (type === 'host') {
-    return 'host'
+    return faServer
   }
 
   if (type === 'SR') {
-    return 'sr'
+    return faDatabase
   }
 
-  return 'vm'
-})
-
-const powerState = computed<SupportedState<'vm' | 'host'> | 'disabled'>(() => {
-  if (!record.value || !('power_state' in record.value)) {
-    return 'disabled'
-  }
-
-  return record.value.power_state.toLowerCase() as SupportedState<'vm' | 'host'>
+  return undefined
 })
 
 const route = computed(() => {
@@ -86,3 +74,10 @@ const route = computed(() => {
   return `/${type}/${uuid}`
 })
 </script>
+
+<style lang="postcss" scoped>
+.alarm-link {
+  align-items: center;
+  line-height: 1;
+}
+</style>

--- a/@xen-orchestra/web/src/components/site/dashboard/AlarmLink.vue
+++ b/@xen-orchestra/web/src/components/site/dashboard/AlarmLink.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="alarm-link">
+    <UiObjectLink :route>
+      <template #icon>
+        <UiObjectIcon :type="iconType" size="medium" :state="powerState" />
+      </template>
+      {{ nameLabel }}
+    </UiObjectLink>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useHostStore } from '@/stores/xo-rest-api/host.store.ts'
+import { useSrStore } from '@/stores/xo-rest-api/sr.store.ts'
+import { useVmControllerStore } from '@/stores/xo-rest-api/vm-controller.store.ts'
+import { useVmStore } from '@/stores/xo-rest-api/vm.store.ts'
+import type { XoVmController } from '@/types/xo/vm-controller.type.ts'
+import type { SupportedState } from '@core/types/object-icon.type.ts'
+import UiObjectIcon from '@core/components/ui/object-icon/UiObjectIcon.vue'
+import UiObjectLink from '@core/components/ui/object-link/UiObjectLink.vue'
+import type { XapiXoRecord } from '@vates/types'
+import { computed } from 'vue'
+
+const { type, uuid } = defineProps<{
+  type: XapiXoRecord['type'] | 'unknown'
+  uuid: XapiXoRecord['uuid']
+}>()
+
+const { records: hostRecords } = useHostStore().subscribe()
+const { records: vmRecords } = useVmStore().subscribe()
+const { records: vmControllerRecords } = useVmControllerStore().subscribe()
+const { records: srRecords } = useSrStore().subscribe()
+
+const record = computed(() => {
+  if (type === 'VM') {
+    return vmRecords.value.find(vm => vm.id === uuid)
+  }
+  if (type === 'host') {
+    return hostRecords.value.find(host => host.id === uuid)
+  }
+  if (type === 'VM-controller') {
+    return vmControllerRecords.value.find(vmController => vmController.id === uuid)
+  }
+  if (type === 'SR') {
+    return srRecords.value.find(sr => sr.id === uuid)
+  }
+
+  return undefined
+})
+
+const nameLabel = computed(() => record.value?.name_label ?? uuid)
+
+const iconType = computed(() => {
+  if (type === 'VM' || type === 'VM-controller') {
+    return 'vm'
+  }
+
+  if (type === 'host') {
+    return 'host'
+  }
+
+  if (type === 'SR') {
+    return 'sr'
+  }
+
+  return 'vm'
+})
+
+const powerState = computed<SupportedState<'vm' | 'host'> | 'disabled'>(() => {
+  if (!record.value || !('power_state' in record.value)) {
+    return 'disabled'
+  }
+
+  return record.value.power_state.toLowerCase() as SupportedState<'vm' | 'host'>
+})
+
+const route = computed(() => {
+  if (!record.value) {
+    return undefined
+  }
+
+  if (type === 'VM-controller') {
+    return `/host/${(record.value as XoVmController).$container}`
+  }
+
+  return `/${type}/${uuid}`
+})
+</script>

--- a/@xen-orchestra/web/src/components/site/dashboard/Alarms.vue
+++ b/@xen-orchestra/web/src/components/site/dashboard/Alarms.vue
@@ -3,30 +3,29 @@
     <UiCardTitle>
       {{ t('alarms') }}
       <UiCounter
-        v-if="alarms?.length !== 0 && areAlarmsReady"
+        v-if="alarms.length !== 0 && areAlarmsReady"
         accent="danger"
         size="small"
         variant="primary"
-        :value="alarms?.length"
+        :value="alarms.length"
       />
     </UiCardTitle>
     <VtsLoadingHero v-if="!areAlarmsReady" type="card" />
     <VtsAllGoodHero v-else-if="alarms.length === 0" type="card" />
     <div v-else class="alarm-items">
       <UiAlarmList>
-        <template v-for="alarm in alarms" :key="alarm.id">
-          <UiAlarmItem
-            v-if="alarm"
-            :label="alarm.body.name"
-            :percent="Number(alarm.body.value)"
-            :size="uiStore.isDesktopLarge ? 'large' : 'small'"
-            :date="alarm.time"
-          >
-            <template #link>
-              <AlarmLink :type="alarm.object.type" :uuid="alarm.object.uuid" />
-            </template>
-          </UiAlarmItem>
-        </template>
+        <UiAlarmItem
+          v-for="alarm in alarms"
+          :key="alarm.id"
+          :label="alarm.body.name"
+          :percent="Number(alarm.body.value)"
+          :size="uiStore.isDesktopLarge ? 'large' : 'small'"
+          :date="alarm.time"
+        >
+          <template #link>
+            <AlarmLink :type="alarm.object.type" :uuid="alarm.object.uuid" />
+          </template>
+        </UiAlarmItem>
       </UiAlarmList>
     </div>
   </UiCard>
@@ -61,18 +60,16 @@ const { isReady: areVmsReady } = useVmStore().subscribe()
 const { isReady: areVmControllersReady } = useVmControllerStore().subscribe()
 const { isReady: areSrsReady } = useSrStore().subscribe()
 
-const areAlarmsReady = computed(() => {
-  return (
-    alarms !== undefined && areHostsReady.value && areVmsReady.value && areVmControllersReady.value && areSrsReady.value
-  )
-})
+const areAlarmsReady = computed(
+  () => areHostsReady.value && areVmsReady.value && areVmControllersReady.value && areSrsReady.value
+)
 
 const uiStore = useUiStore()
 </script>
 
 <style lang="postcss" scoped>
 .site-dashboard-alarms {
-  max-height: 36.4rem;
+  max-height: 40.6rem;
 
   .alarm-items {
     overflow: auto;

--- a/@xen-orchestra/web/src/components/site/dashboard/Alarms.vue
+++ b/@xen-orchestra/web/src/components/site/dashboard/Alarms.vue
@@ -3,18 +3,18 @@
     <UiCardTitle>
       {{ t('alarms') }}
       <UiCounter
-        v-if="alarms.length !== 0 && areAlarmsReady"
+        v-if="alarms?.length !== 0 && areAlarmsReady"
         accent="danger"
         size="small"
         variant="primary"
-        :value="alarms.length"
+        :value="alarms?.length"
       />
     </UiCardTitle>
     <VtsLoadingHero v-if="!areAlarmsReady" type="card" />
     <VtsAllGoodHero v-else-if="alarms.length === 0" type="card" />
     <div v-else class="alarm-items">
       <UiAlarmList>
-        <template v-for="alarm in alarms" :key="alarm?.id">
+        <template v-for="alarm in alarms" :key="alarm.id">
           <UiAlarmItem
             v-if="alarm"
             :label="alarm.body.name"
@@ -34,11 +34,11 @@
 
 <script setup lang="ts">
 import AlarmLink from '@/components/site/dashboard/AlarmLink.vue'
-import { useAlarmStore } from '@/stores/xo-rest-api/alarm.store.ts'
 import { useHostStore } from '@/stores/xo-rest-api/host.store.ts'
 import { useSrStore } from '@/stores/xo-rest-api/sr.store.ts'
 import { useVmControllerStore } from '@/stores/xo-rest-api/vm-controller.store.ts'
 import { useVmStore } from '@/stores/xo-rest-api/vm.store.ts'
+import type { XoAlarm } from '@/types/xo/alarm.type.ts'
 import VtsAllGoodHero from '@core/components/state-hero/VtsAllGoodHero.vue'
 import VtsLoadingHero from '@core/components/state-hero/VtsLoadingHero.vue'
 import UiAlarmItem from '@core/components/ui/alarm-item/UiAlarmItem.vue'
@@ -50,9 +50,12 @@ import { useUiStore } from '@core/stores/ui.store.ts'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+const { alarms } = defineProps<{
+  alarms: XoAlarm[]
+}>()
+
 const { t } = useI18n()
 
-const { records: alarms } = useAlarmStore().subscribe()
 const { isReady: areHostsReady } = useHostStore().subscribe()
 const { isReady: areVmsReady } = useVmStore().subscribe()
 const { isReady: areVmControllersReady } = useVmControllerStore().subscribe()
@@ -60,19 +63,17 @@ const { isReady: areSrsReady } = useSrStore().subscribe()
 
 const areAlarmsReady = computed(() => {
   return (
-    alarms?.value !== undefined &&
-    areHostsReady.value &&
-    areVmsReady.value &&
-    areVmControllersReady.value &&
-    areSrsReady.value
+    alarms !== undefined && areHostsReady.value && areVmsReady.value && areVmControllersReady.value && areSrsReady.value
   )
 })
+
 const uiStore = useUiStore()
 </script>
 
 <style lang="postcss" scoped>
 .site-dashboard-alarms {
   max-height: 36.4rem;
+
   .alarm-items {
     overflow: auto;
     margin-inline: -2.4rem;

--- a/@xen-orchestra/web/src/components/site/dashboard/Alarms.vue
+++ b/@xen-orchestra/web/src/components/site/dashboard/Alarms.vue
@@ -12,7 +12,7 @@
     </UiCardTitle>
     <VtsLoadingHero v-if="!areAlarmsReady" type="card" />
     <VtsAllGoodHero v-else-if="alarms.length === 0" type="card" />
-    <div v-else class="alarm-items">
+    <div v-else class="alarm-list-container">
       <UiAlarmList>
         <UiAlarmItem
           v-for="alarm in alarms"
@@ -71,7 +71,7 @@ const uiStore = useUiStore()
 .site-dashboard-alarms {
   max-height: 40.6rem;
 
-  .alarm-items {
+  .alarm-list-container {
     overflow: auto;
     margin-inline: -2.4rem;
     margin-block-end: -1.2rem;

--- a/@xen-orchestra/web/src/components/site/dashboard/Alarms.vue
+++ b/@xen-orchestra/web/src/components/site/dashboard/Alarms.vue
@@ -1,0 +1,82 @@
+<template>
+  <UiCard class="site-dashboard-alarms">
+    <UiCardTitle>
+      {{ t('alarms') }}
+      <UiCounter
+        v-if="alarms.length !== 0 && areAlarmsReady"
+        accent="danger"
+        size="small"
+        variant="primary"
+        :value="alarms.length"
+      />
+    </UiCardTitle>
+    <VtsLoadingHero v-if="!areAlarmsReady" type="card" />
+    <VtsAllGoodHero v-else-if="alarms.length === 0" type="card" />
+    <div v-else class="alarm-items">
+      <UiAlarmList>
+        <template v-for="alarm in alarms" :key="alarm?.id">
+          <UiAlarmItem
+            v-if="alarm"
+            :label="alarm.body.name"
+            :percent="Number(alarm.body.value)"
+            :size="uiStore.isDesktopLarge ? 'large' : 'small'"
+            :date="alarm.time"
+          >
+            <template #link>
+              <AlarmLink :type="alarm.object.type" :uuid="alarm.object.uuid" />
+            </template>
+          </UiAlarmItem>
+        </template>
+      </UiAlarmList>
+    </div>
+  </UiCard>
+</template>
+
+<script setup lang="ts">
+import AlarmLink from '@/components/site/dashboard/AlarmLink.vue'
+import { useAlarmStore } from '@/stores/xo-rest-api/alarm.store.ts'
+import { useHostStore } from '@/stores/xo-rest-api/host.store.ts'
+import { useSrStore } from '@/stores/xo-rest-api/sr.store.ts'
+import { useVmControllerStore } from '@/stores/xo-rest-api/vm-controller.store.ts'
+import { useVmStore } from '@/stores/xo-rest-api/vm.store.ts'
+import VtsAllGoodHero from '@core/components/state-hero/VtsAllGoodHero.vue'
+import VtsLoadingHero from '@core/components/state-hero/VtsLoadingHero.vue'
+import UiAlarmItem from '@core/components/ui/alarm-item/UiAlarmItem.vue'
+import UiAlarmList from '@core/components/ui/alarm-list/UiAlarmList.vue'
+import UiCard from '@core/components/ui/card/UiCard.vue'
+import UiCardTitle from '@core/components/ui/card-title/UiCardTitle.vue'
+import UiCounter from '@core/components/ui/counter/UiCounter.vue'
+import { useUiStore } from '@core/stores/ui.store.ts'
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+const { records: alarms } = useAlarmStore().subscribe()
+const { isReady: areHostsReady } = useHostStore().subscribe()
+const { isReady: areVmsReady } = useVmStore().subscribe()
+const { isReady: areVmControllersReady } = useVmControllerStore().subscribe()
+const { isReady: areSrsReady } = useSrStore().subscribe()
+
+const areAlarmsReady = computed(() => {
+  return (
+    alarms?.value !== undefined &&
+    areHostsReady.value &&
+    areVmsReady.value &&
+    areVmControllersReady.value &&
+    areSrsReady.value
+  )
+})
+const uiStore = useUiStore()
+</script>
+
+<style lang="postcss" scoped>
+.site-dashboard-alarms {
+  max-height: 36.4rem;
+  .alarm-items {
+    overflow: auto;
+    margin-inline: -2.4rem;
+    margin-block-end: -1.2rem;
+  }
+}
+</style>

--- a/@xen-orchestra/web/src/pages/(site)/(dashboard).vue
+++ b/@xen-orchestra/web/src/pages/(site)/(dashboard).vue
@@ -3,6 +3,14 @@
     <PoolsStatus class="pools-status" :status="dashboard.poolsStatus" />
     <HostsStatus class="hosts-status" :status="dashboard.hostsStatus" />
     <VmsStatus class="vms-status" :status="dashboard.vmsStatus" />
+    <Alarms class="alarms" :alarms />
+    <Patches
+      class="patches"
+      :missing-patches="dashboard.missingPatches"
+      :n-hosts="dashboard.nHosts"
+      :n-hosts-eol="dashboard.nHostsEol"
+      :n-pools="dashboard.nPools"
+    />
     <ResourcesOverview class="resources-overview" :resources="dashboard.resourcesOverview" />
     <Backups class="backups" :backups="dashboard.backups" />
     <BackupIssues class="backup-issues" :issues="dashboard.backups?.issues" />
@@ -11,14 +19,6 @@
       :backup-repositories
       :storage-repositories
       :s3-size="dashboard.backupRepositories?.s3?.size"
-    />
-    <Alarms class="alarms" />
-    <Patches
-      class="patches"
-      :missing-patches="dashboard.missingPatches"
-      :n-hosts="dashboard.nHosts"
-      :n-hosts-eol="dashboard.nHostsEol"
-      :n-pools="dashboard.nPools"
     />
   </div>
 </template>
@@ -34,11 +34,13 @@ import Repositories from '@/components/site/dashboard/Repositories.vue'
 import ResourcesOverview from '@/components/site/dashboard/ResourcesOverview.vue'
 import VmsStatus from '@/components/site/dashboard/VmsStatus.vue'
 import { useSiteDashboard } from '@/requests/use-site-dashboard.request.ts'
+import { useAlarmStore } from '@/stores/xo-rest-api/alarm.store.ts'
 import { useUiStore } from '@core/stores/ui.store.ts'
 
 const uiStore = useUiStore()
 
 const { dashboard, backupRepositories, storageRepositories } = useSiteDashboard()
+const { records: alarms } = useAlarmStore().subscribe()
 </script>
 
 <style lang="postcss" scoped>

--- a/@xen-orchestra/web/src/pages/(site)/(dashboard).vue
+++ b/@xen-orchestra/web/src/pages/(site)/(dashboard).vue
@@ -12,6 +12,7 @@
       :storage-repositories
       :s3-size="dashboard.backupRepositories?.s3?.size"
     />
+    <Alarms class="alarms" />
     <Patches
       class="patches"
       :missing-patches="dashboard.missingPatches"
@@ -23,6 +24,7 @@
 </template>
 
 <script lang="ts" setup>
+import Alarms from '@/components/site/dashboard/Alarms.vue'
 import BackupIssues from '@/components/site/dashboard/BackupIssues.vue'
 import Backups from '@/components/site/dashboard/Backups.vue'
 import HostsStatus from '@/components/site/dashboard/HostsStatus.vue'
@@ -47,9 +49,9 @@ const { dashboard, backupRepositories, storageRepositories } = useSiteDashboard(
   grid-template-columns: repeat(8, 1fr);
   grid-template-areas:
     'pools-status pools-status hosts-status hosts-status vms-status vms-status resources-overview resources-overview'
+    'alarms alarms alarms alarms alarms alarms patches patches'
     'backups backups backups backup-issues backup-issues backup-issues backup-issues backup-issues'
-    'repositories repositories repositories repositories repositories repositories repositories repositories'
-    'alarms alarms alarms alarms alarms alarms patches patches';
+    'repositories repositories repositories repositories repositories repositories repositories repositories';
 
   &.mobile {
     grid-template-columns: 1fr;
@@ -57,11 +59,12 @@ const { dashboard, backupRepositories, storageRepositories } = useSiteDashboard(
       'pools-status'
       'hosts-status'
       'vms-status'
+      'alarms'
+      'patches'
       'resources-overview'
       'backups'
       'backup-issues'
-      'repositories'
-      'patches';
+      'repositories';
   }
 
   .pools-status {
@@ -74,6 +77,14 @@ const { dashboard, backupRepositories, storageRepositories } = useSiteDashboard(
 
   .vms-status {
     grid-area: vms-status;
+  }
+
+  .alarms {
+    grid-area: alarms;
+  }
+
+  .patches {
+    grid-area: patches;
   }
 
   .resources-overview {
@@ -90,10 +101,6 @@ const { dashboard, backupRepositories, storageRepositories } = useSiteDashboard(
 
   .repositories {
     grid-area: repositories;
-  }
-
-  .patches {
-    grid-area: patches;
   }
 }
 </style>

--- a/@xen-orchestra/web/src/pages/(site)/(dashboard).vue
+++ b/@xen-orchestra/web/src/pages/(site)/(dashboard).vue
@@ -56,7 +56,7 @@ const { records: alarms } = useAlarmStore().subscribe()
     'repositories repositories repositories repositories repositories repositories repositories repositories';
 
   &.mobile {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(20rem, 1fr);
     grid-template-areas:
       'pools-status'
       'hosts-status'

--- a/@xen-orchestra/web/src/stores/xo-rest-api/alarm.store.ts
+++ b/@xen-orchestra/web/src/stores/xo-rest-api/alarm.store.ts
@@ -1,16 +1,13 @@
 import type { XoAlarm } from '@/types/xo/alarm.type.ts'
 import { createXoStoreConfig } from '@/utils/create-xo-store-config.util'
 import { createSubscribableStoreContext } from '@core/utils/create-subscribable-store-context.util'
+import { createDateSorter } from '@core/utils/date-sorter.utils.ts'
 import { defineStore } from 'pinia'
 
 export const useAlarmStore = defineStore('alarm', () => {
   const config = createXoStoreConfig('alarm', {
-    sortBy: sortByDate,
+    sortBy: createDateSorter<XoAlarm>('time'),
   })
 
   return createSubscribableStoreContext(config, {})
 })
-
-function sortByDate(alarm1: XoAlarm, alarm2: XoAlarm) {
-  return new Date(alarm2.time).getTime() - new Date(alarm1.time).getTime()
-}

--- a/@xen-orchestra/web/src/stores/xo-rest-api/alarm.store.ts
+++ b/@xen-orchestra/web/src/stores/xo-rest-api/alarm.store.ts
@@ -1,9 +1,16 @@
+import type { XoAlarm } from '@/types/xo/alarm.type.ts'
 import { createXoStoreConfig } from '@/utils/create-xo-store-config.util'
 import { createSubscribableStoreContext } from '@core/utils/create-subscribable-store-context.util'
 import { defineStore } from 'pinia'
 
 export const useAlarmStore = defineStore('alarm', () => {
-  const config = createXoStoreConfig('alarm')
+  const config = createXoStoreConfig('alarm', {
+    sortBy: sortByDate,
+  })
 
   return createSubscribableStoreContext(config, {})
 })
+
+function sortByDate(alarm1: XoAlarm, alarm2: XoAlarm) {
+  return new Date(alarm2.time).getTime() - new Date(alarm1.time).getTime()
+}

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,10 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- **XO 6:**
+
+  - [Site/dashboard] add alarms component in dashboard (PR [#8838](https://github.com/vatesfr/xen-orchestra/pull/8838))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -30,5 +34,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- @xen-orchestra/web minor
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

Add alarms component on site dashboard

### Screenshots

<img width="1907" height="990" alt="image" src="https://github.com/user-attachments/assets/236359fd-3752-4f57-aa6e-fc3956561197" />

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
