### PR TITLE
feat(@xen-orchestra/rest-api): expose xo tasks

### DIFF
--- a/@vates/types/src/lib/vates-task.mts
+++ b/@vates/types/src/lib/vates-task.mts
@@ -4,7 +4,7 @@ export interface VatesTask {
   _abortController: AbortController
   _onProgress(data?: unknown): void
 
-  id: Branded<'task'>
+  id: Branded<'vates-task'>
   status: 'failure' | 'pending' | 'success'
 
   abort(reason?: unknown): void

--- a/@vates/types/src/lib/vates-task.mts
+++ b/@vates/types/src/lib/vates-task.mts
@@ -1,7 +1,21 @@
 import { Branded } from '../common.mjs'
 
-export type Task = {
-  id: Branded<'task'>
+export interface VatesTask {
+  _abortController: AbortController
+  _onProgress(data?: unknown): void
 
-  run: <T>(fn: () => T) => Promise<T>
+  id: Branded<'task'>
+  status: 'failure' | 'pending' | 'success'
+
+  abort(reason?: unknown): void
+  failure(error?: unknown): void
+  info(message: string, data: unknown): void
+  run<T>(fn: () => T | (() => Promise<T>)): Promise<T>
+  runInside<T>(fn: () => T | (() => Promise<T>)): Promise<T>
+  set(name: string, value: unknown): void
+  start(): void
+  success(result?: unknown): void
+  warning(message: string, data: unknown): void
+  wrap<T>(fn: () => T | (() => Promise<T>)): Promise<T>
+  wrapInside<T>(fn: () => T | (() => Promise<T>)): Promise<T>
 }

--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -491,7 +491,7 @@ export type XoSm = BaseXapiXo & {
 
 export type XoTask = {
   abortionRequestedAt?: number
-  end: number
+  end?: number
   id: Branded<'task'>
   infos?: { data: unknown; message: string }[]
   properties: {

--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -624,6 +624,8 @@ export type XoVtpm = BaseXapiXo & {
   type: 'VTPM'
 }
 
+export type XoTask = {}
+
 export type XapiXoRecord =
   | XoAlarm
   | XoGpuGroup

--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -489,6 +489,28 @@ export type XoSm = BaseXapiXo & {
   type: 'SM'
 }
 
+export type XoTask = {
+  abortionRequestedAt?: number
+  end: number
+  id: Branded<'task'>
+  infos?: { data: unknown; message: string }[]
+  properties: {
+    method?: string
+    name?: string
+    objectId?: string
+    params?: Record<string, unknown>
+    type?: string
+    userId?: string
+    [key: string]: unknown | undefined
+  }
+  result: Record<string, unknown>
+  start: number
+  status: 'failure' | 'interrupted' | 'pending' | 'success'
+  tasks?: XoTask[]
+  updatedAt?: number
+  warning?: { data: unknown; message: string }[]
+}
+
 export type XoUser = {
   authProviders?: Record<string, string>
   email: string
@@ -624,8 +646,6 @@ export type XoVtpm = BaseXapiXo & {
   type: 'VTPM'
 }
 
-export type XoTask = {}
-
 export type XapiXoRecord =
   | XoAlarm
   | XoGpuGroup
@@ -651,7 +671,7 @@ export type XapiXoRecord =
   | XoVtpm
   | XoSm
 
-export type NonXapiXoRecord = XoGroup | XoProxy | XoJob | XoBackupRepository | XoSchedule | XoServer | XoUser
+export type NonXapiXoRecord = XoGroup | XoProxy | XoJob | XoBackupRepository | XoSchedule | XoServer | XoTask | XoUser
 
 export type XoRecord = XapiXoRecord | NonXapiXoRecord
 

--- a/@xen-orchestra/mixins/Tasks.mjs
+++ b/@xen-orchestra/mixins/Tasks.mjs
@@ -225,7 +225,7 @@ export default class Tasks extends EventEmitter {
     }
   }
 
-  async *list({ filter, limit = Infinity }) {
+  async *list({ filter, limit = Infinity } = {}) {
     const predicate = filter === undefined ? stubTrue : typeof filter === 'function' ? filter : iteratee(filter)
 
     for await (const [, taskLog] of this.#store.iterator()) {

--- a/@xen-orchestra/rest-api/package.json
+++ b/@xen-orchestra/rest-api/package.json
@@ -43,6 +43,7 @@
     "inversify": "^6.2.2",
     "inversify-binding-decorators": "^4.0.0",
     "lodash": "^4.17.21",
+    "promise-toolbox": "^0.21.0",
     "semver": "^7.7.2",
     "swagger-ui-express": "^5.0.1",
     "tsoa": "^6.6.0",

--- a/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
@@ -3,7 +3,7 @@ import { createGzip } from 'node:zlib'
 import { pipeline } from 'node:stream/promises'
 import { Readable, type Transform } from 'node:stream'
 import { Request } from 'express'
-import type { Task } from '@vates/types/lib/vates/task'
+import type { VatesTask } from '@vates/types/lib/vates/task'
 import type { XapiXoRecord, XoRecord } from '@vates/types/xo'
 import type { Xapi } from '@vates/types/lib/xen-orchestra/xapi'
 
@@ -49,7 +49,7 @@ export abstract class BaseController<T extends XoRecord, IsSync extends boolean>
    * statusCode must represent the status code in case of a synchronous request. Default 200
    */
   async createAction<CbType>(
-    cb: (task: Task) => MaybePromise<CbType>,
+    cb: (task: VatesTask) => MaybePromise<CbType>,
     {
       statusCode = 200,
       sync = false,

--- a/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
@@ -57,7 +57,7 @@ export abstract class BaseController<T extends XoRecord, IsSync extends boolean>
     }: {
       statusCode?: HttpStatusCodeLiteral
       sync?: boolean
-      taskProperties: { name: string; objectId: T['id']; args?: unknown; [key: string]: unknown }
+      taskProperties: { name: string; objectId: T['id']; params?: unknown; [key: string]: unknown }
     }
   ): Promise<string | CbType> {
     taskProperties.name = 'REST API: ' + taskProperties.name

--- a/@xen-orchestra/rest-api/src/helpers/error.helper.mts
+++ b/@xen-orchestra/rest-api/src/helpers/error.helper.mts
@@ -1,0 +1,14 @@
+import { HttpStatusCodeLiteral } from 'tsoa'
+
+export class ApiError extends Error {
+  #status: HttpStatusCodeLiteral
+
+  constructor(message: string, status: HttpStatusCodeLiteral) {
+    super(message)
+    this.#status = status
+  }
+
+  get status() {
+    return this.#status
+  }
+}

--- a/@xen-orchestra/rest-api/src/middlewares/generic-error-handler.middleware.mts
+++ b/@xen-orchestra/rest-api/src/middlewares/generic-error-handler.middleware.mts
@@ -13,6 +13,7 @@ import {
 import type { HttpStatusCodeLiteral } from 'tsoa'
 import { NextFunction, Request, Response } from 'express'
 
+import { ApiError } from '../helpers/error.helper.mjs'
 import type { XoError } from '../helpers/helper.type.mjs'
 
 const log = createLogger('xo:rest-api:error-handler')
@@ -32,7 +33,9 @@ export default function genericErrorHandler(error: unknown, req: Request, res: R
   }
   let statusCode: HttpStatusCodeLiteral
 
-  if (noSuchObject.is(error)) {
+  if (error instanceof ApiError) {
+    statusCode = error.status
+  } else if (noSuchObject.is(error)) {
     statusCode = 404
   } else if (unauthorized.is(error) || forbiddenOperation.is(error)) {
     statusCode = 403

--- a/@xen-orchestra/rest-api/src/open-api/common/response.common.mts
+++ b/@xen-orchestra/rest-api/src/open-api/common/response.common.mts
@@ -63,3 +63,8 @@ export const forbiddenOperationResp = {
   status: 403,
   description: 'Forbidden',
 } as const
+
+export const badRequestResp = {
+  status: 400,
+  description: 'Bad request',
+} as const

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/task.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/task.oa-example.mts
@@ -1,1 +1,51 @@
 export const taskLocation = '/rest/v0/tasks/0m7kl0j9l'
+
+export const taskIds = ['/rest/v0/tasks/0mdd1basu', '/rest/v0/tasks/0mdd1t24g']
+
+export const partialTasks = [
+  {
+    status: 'failure',
+    id: '0mdd1basu',
+    properties: {
+      method: 'xoa.licenses.getSelf',
+      params: {},
+      name: 'API call: xoa.licenses.getSelf',
+      userId: 'e531b8c9-3876-4ed9-8fd2-0476d5f825c9',
+      type: 'api.call',
+    },
+    href: '/rest/v0/tasks/0mdd1basu',
+  },
+  {
+    status: 'failure',
+    id: '0mdd1t24g',
+    properties: {
+      method: 'xoa.licenses.getSelf',
+      params: {},
+      name: 'API call: xoa.licenses.getSelf',
+      userId: 'e531b8c9-3876-4ed9-8fd2-0476d5f825c9',
+      type: 'api.call',
+    },
+    href: '/rest/v0/tasks/0mdd1t24g',
+  },
+]
+
+export const task = {
+  id: '0mdd1basu',
+  properties: {
+    method: 'xoa.licenses.getSelf',
+    params: {},
+    name: 'API call: xoa.licenses.getSelf',
+    userId: 'e531b8c9-3876-4ed9-8fd2-0476d5f825c9',
+    type: 'api.call',
+  },
+  start: 1753098047598,
+  status: 'failure',
+  updatedAt: 1753098047696,
+  end: 1753098047600,
+  result: {
+    message: 'invalid status closed, expected open',
+    name: 'ConnectionError',
+    stack:
+      'ConnectionError: invalid status closed, expected open\n    at JsonRpcWebSocketClient._assertStatus (/home/debian/xoa/node_modules/jsonrpc-websocket-client/src/websocket-client.js:141:13)\n    at JsonRpcWebSocketClient.send (/home/debian/xoa/node_modules/jsonrpc-websocket-client/src/websocket-client.js:128:10)\n    at Peer.<anonymous> (/home/debian/xoa/node_modules/jsonrpc-websocket-client/src/index.js:47:12)\n    at Peer.emit (node:events:518:28)\n    at Peer.emit (/home/debian/xen-orchestra/@xen-orchestra/log/configure.js:52:17)\n    at Peer.push (/home/debian/xoa/node_modules/json-rpc-peer/src/index.js:196:52)\n    at /home/debian/xoa/node_modules/json-rpc-peer/src/index.js:142:12\n    at Promise._execute (/home/debian/xen-orchestra/node_modules/bluebird/js/release/debuggability.js:384:9)\n    at Promise._resolveFromExecutor (/home/debian/xen-orchestra/node_modules/bluebird/js/release/promise.js:518:18)\n    at new Promise (/home/debian/xen-orchestra/node_modules/bluebird/js/release/promise.js:103:10)\n    at Peer.request (/home/debian/xoa/node_modules/json-rpc-peer/src/index.js:139:12)\n    at JsonRpcWebSocketClient.call (/home/debian/xoa/node_modules/jsonrpc-websocket-client/src/index.js:63:23)\n    at Xoa.apply [as _getSelfLicenses] (/home/debian/xoa/packages/xo-server-xoa/src/index.js:929:26)\n    at Xo.call (file:///home/debian/xen-orchestra/packages/xo-server/src/xo-mixins/api.mjs:269:25)\n    at file:///home/debian/xen-orchestra/packages/xo-server/src/xo-mixins/api.mjs:421:33\n    at AsyncLocalStorage.run (node:internal/async_local_storage/async_hooks:91:14)\n    at Task.runInside (/home/debian/xen-orchestra/@vates/task/index.js:175:41)\n    at Task.run (/home/debian/xen-orchestra/@vates/task/index.js:159:31)\n    at run (file:///home/debian/xen-orchestra/packages/xo-server/src/xo-mixins/api.mjs:421:16)\n    at Api.#callApiMethod (file:///home/debian/xen-orchestra/packages/xo-server/src/xo-mixins/api.mjs:469:24)',
+  },
+}

--- a/@xen-orchestra/rest-api/src/pools/pool.controller.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.controller.mts
@@ -17,7 +17,7 @@ import { inject } from 'inversify'
 import { PassThrough } from 'node:stream'
 import { provide } from 'inversify-binding-decorators'
 import { json, type Request as ExRequest, type Response as ExResponse } from 'express'
-import type { Task } from '@vates/types/lib/vates/task'
+import type { VatesTask } from '@vates/types/lib/vates/task'
 
 import { RestApi } from '../rest-api/rest-api.mjs'
 import {
@@ -201,7 +201,7 @@ export class PoolController extends XapiXoController<XoPool> {
   @Response(notFoundResp.status, notFoundResp.description)
   rollingReboot(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
     const poolId = id as XoPool['id']
-    const action = async (task: Task) => {
+    const action = async (task: VatesTask) => {
       const pool = this.getObject(poolId)
       await this.restApi.xoApp.rollingPoolReboot(pool, { parentTask: task })
     }
@@ -228,7 +228,7 @@ export class PoolController extends XapiXoController<XoPool> {
   @Response(notFoundResp.status, notFoundResp.description)
   rollingUpdate(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
     const poolId = id as XoPool['id']
-    const action = async (task: Task) => {
+    const action = async (task: VatesTask) => {
       const pool = this.getObject(poolId)
       await this.restApi.xoApp.rollingPoolUpdate(pool, { parentTask: task })
     }

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -33,6 +33,7 @@ import type {
   XoJob,
   XoGroup,
   XoPool,
+  XoTask,
 } from '@vates/types/xo'
 
 import type { InsertableXoServer } from '../servers/server.type.mjs'
@@ -68,6 +69,8 @@ export type XoApp = {
   }
   tasks: EventEmitter & {
     create: (params: { name: string; objectId?: string; type?: string }) => VatesTask
+    get(id: XoTask['id']): XoTask
+    list(): AsyncGenerator<XoTask>
   }
   apiContext: {
     user?: XoUser

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -69,8 +69,8 @@ export type XoApp = {
   }
   tasks: EventEmitter & {
     create: (params: { name: string; objectId?: string; type?: string }) => VatesTask
-    get(id: XoTask['id']): XoTask
-    list(): AsyncGenerator<XoTask>
+    get(id: XoTask['id']): Promise<XoTask>
+    list(opts?: { filter?: string | ((obj: XoTask) => boolean); limit?: number }): AsyncGenerator<XoTask>
   }
   apiContext: {
     user?: XoUser

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -71,6 +71,7 @@ export type XoApp = {
     create: (params: { name: string; objectId?: string; type?: string }) => VatesTask
     get(id: XoTask['id']): Promise<XoTask>
     list(opts?: { filter?: string | ((obj: XoTask) => boolean); limit?: number }): AsyncGenerator<XoTask>
+    watch(id: XoTask['id'], cb: (task: XoTask) => void): Promise<() => void>
   }
   apiContext: {
     user?: XoUser

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -1,5 +1,5 @@
 import type { EventEmitter } from 'node:events'
-import type { Task } from '@vates/types/lib/vates/task'
+import type { VatesTask } from '@vates/types/lib/vates/task'
 import type { Xapi } from '@vates/types/lib/xen-orchestra/xapi'
 import type { XapiHostStats, XapiVmStats, XapiStatsGranularity, BACKUP_TYPE, XapiPoolStats } from '@vates/types/common'
 import type {
@@ -67,7 +67,7 @@ export type XoApp = {
     getOptionalDuration(path: string): number | undefined
   }
   tasks: EventEmitter & {
-    create: (params: { name: string; objectId?: string; type?: string }) => Task
+    create: (params: { name: string; objectId?: string; type?: string }) => VatesTask
   }
   apiContext: {
     user?: XoUser
@@ -136,8 +136,8 @@ export type XoApp = {
   hasObject<T extends XapiXoRecord>(id: T['id'], type: T['type']): boolean
   /** Allow to add a new server in the DB (XCP-ng/XenServer) */
   registerXenServer(body: InsertableXoServer): Promise<XoServer>
-  rollingPoolReboot(pool: XoPool, opts?: { parentTask?: Task }): Promise<void>
-  rollingPoolUpdate(pool: XoPool, opts?: { rebootVm?: boolean; parentTask?: Task }): Promise<void>
+  rollingPoolReboot(pool: XoPool, opts?: { parentTask?: VatesTask }): Promise<void>
+  rollingPoolUpdate(pool: XoPool, opts?: { rebootVm?: boolean; parentTask?: VatesTask }): Promise<void>
   removeUserFromGroup(userId: XoUser['id'], id: XoGroup['id']): Promise<void>
   runJob(job: XoJob, schedule: XoSchedule): void
   runWithApiContext: (user: XoUser, fn: () => void) => Promise<unknown>

--- a/@xen-orchestra/rest-api/src/tasks/task.controller.mts
+++ b/@xen-orchestra/rest-api/src/tasks/task.controller.mts
@@ -1,0 +1,52 @@
+import type { Request as ExRequest } from 'express'
+import type { XoTask } from '@vates/types'
+import { XoController } from '../abstract-classes/xo-controller.mjs'
+import { Get, Path, Query, Request, Route, Security, Tags, Response, Example } from 'tsoa'
+import { SendObjects } from '../helpers/helper.type.mjs'
+import { notFoundResp, unauthorizedResp, Unbrand } from '../open-api/common/response.common.mjs'
+import { provide } from 'inversify-binding-decorators'
+import { partialTasks, task, taskIds } from '../open-api/oa-examples/task.oa-example.mjs'
+
+@Route('tasks')
+@Security('*')
+@Response(unauthorizedResp.status, unauthorizedResp.description)
+@Tags('tasks')
+@provide(TaskController)
+export class TaskController extends XoController<XoTask> {
+  getAllCollectionObjects(): Promise<XoTask[]> {
+    return Array.fromAsync(this.restApi.tasks.list())
+  }
+
+  getCollectionObject(id: XoTask['id']): Promise<XoTask> {
+    return this.restApi.tasks.get(id)
+  }
+
+  /**
+   * @example fields "status,id,properties"
+   * @example filter "status:failure"
+   * @example limit 42
+   */
+  @Example(taskIds)
+  @Example(partialTasks)
+  @Get('')
+  async getTasks(
+    @Request() req: ExRequest,
+    @Query() fields?: string,
+    @Query() ndjson?: boolean,
+    @Query() filter?: string,
+    @Query() limit?: number
+  ): Promise<SendObjects<Partial<Unbrand<XoTask>>>> {
+    const tasks = Object.values(await this.getObjects({ filter, limit }))
+    return this.sendObjects(tasks, req)
+  }
+
+  /**
+   * @example id "0mdd1basu"
+   */
+  @Example(task)
+  @Get('{id}')
+  @Response(notFoundResp.status, notFoundResp.description)
+  async getTask(@Path() id: string): Promise<Unbrand<XoTask>> {
+    return this.getObject(id as XoTask['id'])
+  }
+}

--- a/@xen-orchestra/rest-api/tsconfig.json
+++ b/@xen-orchestra/rest-api/tsconfig.json
@@ -5,6 +5,7 @@
 
     "strict": true,
     "module": "ESNext",
+    "lib": ["ESNext"],
     "moduleResolution": "bundler",
     "target": "ES2023",
     "skipLibCheck": true,

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,11 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- **Migrated REST API endpoints**:
+
+  - `GET /rest/v0/tasks` (PR [#8801](https://github.com/vatesfr/xen-orchestra/pull/8843))
+  - `GET /rest/v0/tasks/<task-id>` (PR [#8801](https://github.com/vatesfr/xen-orchestra/pull/8843))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -30,5 +35,11 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- @vates/types minor
+- @xen-orchestra/mixins patch
+- @xen-orchestra/rest-api minor
+- xo-server minor
+- xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -10,7 +10,6 @@ import { json, Router } from 'express'
 import { Readable } from 'node:stream'
 import cloneDeep from 'lodash/cloneDeep.js'
 import path from 'node:path'
-import pDefer from 'promise-toolbox/defer'
 import pick from 'lodash/pick.js'
 import * as CM from 'complex-matcher'
 import { VDI_FORMAT_RAW, VDI_FORMAT_VHD } from '@xen-orchestra/xapi'
@@ -650,20 +649,7 @@ export default class RestApi {
     collections.restore = {}
     collections.tasks = {
       async getObject(id, req) {
-        const { wait } = req.query
-        if (wait !== undefined) {
-          const { promise, resolve } = pDefer()
-          const stopWatch = await app.tasks.watch(id, task => {
-            if (wait !== 'result' || task.status !== 'pending') {
-              stopWatch()
-              resolve(task)
-            }
-          })
-          req.on('close', stopWatch)
-          return promise
-        } else {
-          return app.tasks.get(id)
-        }
+        return app.tasks.get(id)
       },
       getObjects(filter, limit) {
         return app.tasks.list({ filter, limit })

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -312,6 +312,7 @@ export default class RestApi {
         },
       },
       servers: {},
+      tasks: {},
     }
 
     const withParams = (fn, paramsSchema) => {

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -629,7 +629,7 @@ export const subscribeXoTasks = (() => {
     while (true) {
       try {
         // starts watching collection
-        const resWatch = await fetch(basePath + '&ndjson&watch', { signal: abortController.signal })
+        const resWatch = await fetch(basePath + '&ndjson=true&watch=true', { signal: abortController.signal })
 
         // fetches existing objects
         const response = await fetch(basePath, { signal: abortController.signal })


### PR DESCRIPTION
### Screenshot

<img width="344" height="155" alt="Capture d’écran de 2025-08-04 15-09-38" src="https://github.com/user-attachments/assets/c46329af-07b9-4eef-bdce-6a2acf6a0bf2" />

### Description

Squash the PR, but can be reviewed by **commits**
[XO-646](https://project.vates.tech/vates-global/browse/XO-646/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
