### PR TITLE
feat(web-core): add `useDefaultTab` to handle redirection to last visited tab

### DIFF
--- a/@xen-orchestra/web-core/lib/composables/default-tab.composable.md
+++ b/@xen-orchestra/web-core/lib/composables/default-tab.composable.md
@@ -1,0 +1,42 @@
+# `useDefaultTab` Composable
+
+This composable manages automatic navigation to default tabs and remembers the last visited tab for a given router dispatcher.
+
+## How it works
+
+The composable watches route changes and:
+
+- Automatically redirects to the remembered or default tab when navigating to the base dispatcher route
+- Stores the current tab in localStorage for future visits
+- Uses the naming convention `{dispatcherRouteName}/{tabName}` for tab route names
+
+## Parameters
+
+| Name                  | Type     | Required | Description                                     |
+| --------------------- | -------- | :------: | ----------------------------------------------- |
+| `dispatcherRouteName` | `string` |    ✓     | Dispatcher page route name (e.g., '/pool/<id>') |
+| `defaultTab`          | `string` |    ✓     | Default tab name (e.g., 'dashboard')            |
+
+## Usage
+
+```typescript
+// In the dispatcher page component (e.g., `pages/pool/[id].vue`)
+useDefaultTab('pool/[id]', 'dashboard')
+
+// User first navigates to /pool/123
+// → Automatic redirect to /pool/123/dashboard (default tab)
+
+// User then navigates to /pool/123/stats
+// → 'stats' is stored as the last visited tab for this route
+
+// Finally, user navigates to /pool/456
+// → Automatic redirect to /pool/456/stats
+```
+
+## Storage
+
+Tab preferences are stored in localStorage under the key `default-tabs` with the structure:
+
+```typescript
+Map<string, string> // dispatcherRouteName -> lastVisitedTab
+```

--- a/@xen-orchestra/web-core/lib/composables/default-tab.composable.ts
+++ b/@xen-orchestra/web-core/lib/composables/default-tab.composable.ts
@@ -1,0 +1,26 @@
+import { useLocalStorage } from '@vueuse/core'
+import { watch } from 'vue'
+import { type RouteLocationRaw, type RouteRecordName, useRoute, useRouter } from 'vue-router'
+
+export function useDefaultTab(dispatcherRouteName: RouteRecordName & string, defaultTab: string) {
+  const storage = useLocalStorage('default-tabs', new Map<string, string>())
+  const router = useRouter()
+  const route = useRoute()
+
+  watch(
+    () => route.name as string,
+    name => {
+      if (name === dispatcherRouteName) {
+        const tabName = storage.value.get(dispatcherRouteName) ?? defaultTab
+        void router.replace({ name: `${dispatcherRouteName}/${tabName}` } as RouteLocationRaw)
+      } else if (!name.startsWith(dispatcherRouteName)) {
+        return
+      }
+
+      const tab = name.slice(dispatcherRouteName.length).split('/')[1] ?? defaultTab
+
+      storage.value.set(dispatcherRouteName, tab)
+    },
+    { immediate: true }
+  )
+}

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -38,6 +38,7 @@
 
 - @vates/types minor
 - @xen-orchestra/rest-api minor
+- @xen-orchestra/web-core minor
 - xo-server minor
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

This PR introduces `useDefaultTab` composable to manage automatic tab navigation and persistence.

This composable redirects users to their last visited tab when navigating to a dispatcher route and remembers last visited tab in `localStorage`.

#### Example

```ts
// File: pages/pool/[id].vue 
// Registering `pool/[id]` route name as dispatcher
// Setting `dashboard` as default tab
useDefaultTab('pool/[id]', 'dashboard') 

// Navigation flow:
// /pool/123 → redirects to /pool/123/dashboard (first visit)
// /pool/123/stats → remembers 'stats' tab
// /pool/456 → redirects to /pool/456/stats (uses remembered tab)
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
