### PR TITLE
feat(@xen-orchestra/rest-api): enhance getCurrentUser

### DIFF
--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
@@ -1,7 +1,11 @@
-import type { XapiXoRecord } from '@vates/types'
+import { createLogger } from '@xen-orchestra/log'
+import { invalidCredentials } from 'xo-common/api-errors.js'
+import type { XapiXoRecord, XoUser } from '@vates/types'
 
 import type { XoApp } from './rest-api.type.mjs'
 import type { Container } from 'inversify'
+
+const log = createLogger('xo:rest-api:error-handler')
 
 export class RestApi {
   #ioc: Container
@@ -28,8 +32,18 @@ export class RestApi {
     return this.#xoApp.authenticateUser(...args)
   }
 
-  getCurrentUser() {
-    return this.#xoApp.apiContext.user
+  getCurrentUser(opts?: { throwUnauthenticated?: true }): XoUser
+  getCurrentUser(opts: { throwUnauthenticated: false }): undefined | XoUser
+  getCurrentUser(opts?: { throwUnauthenticated?: boolean }): undefined | XoUser
+  getCurrentUser({ throwUnauthenticated = true }: { throwUnauthenticated?: boolean } = {}): undefined | XoUser {
+    const user = this.#xoApp.apiContext.user
+
+    if (user === undefined && throwUnauthenticated) {
+      log.error('getCurrentUser received an unauthenticated API call')
+      throw invalidCredentials()
+    }
+
+    return user
   }
 
   getObject<T extends XapiXoRecord>(id: T['id'], type?: T['type']) {

--- a/@xen-orchestra/rest-api/src/users/user.controller.mts
+++ b/@xen-orchestra/rest-api/src/users/user.controller.mts
@@ -109,10 +109,6 @@ export class UserController extends XoController<XoUser> {
   async updateUser(@Path() id: string, @Body() body: UpdateUserRequestBody): Promise<void> {
     const currentUser = this.restApi.getCurrentUser()
 
-    if (currentUser === undefined) {
-      throw new Error('current user is not defined')
-    }
-
     const isAdmin = currentUser.permission === 'admin'
 
     if (isAdmin) {

--- a/@xen-orchestra/rest-api/src/vms/vm.service.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.service.mts
@@ -34,7 +34,7 @@ export class VmService {
     const xapi = xoApp.getXapi(pool)
     const currentUser = this.#restApi.getCurrentUser()
 
-    const xapiVm = await xapi.createVm(template, rest, undefined, currentUser?.id)
+    const xapiVm = await xapi.createVm(template, rest, undefined, currentUser.id)
     $defer.onFailure(() => xapi.VM_destroy(xapiVm.$ref))
     const xoVm = this.#restApi.getObject<XoVm>(xapiVm.uuid as XoVm['id'], 'VM')
 


### PR DESCRIPTION
### Description

In the REST API, we generally work on `authenticated` requests. `getCurrentUser` can therefore be a bit tedious, as it can return `undefined | XoUser`. So, whenever we need the current user in an `authenticated` request, we need to add a check:
`if user === undefined throw` for typescript to be happy

So now: `getCurrentUser` returns `XoUser` (throw if no user) and `getCurrentUser({throwUnauthenticated: false})` returns `undefined | XoUser`
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
