### PR TITLE
fix(backups): prevent checking for tags if no transfer during backups

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/IncrementalRemote.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/IncrementalRemote.mjs
@@ -114,9 +114,10 @@ class IncrementalRemoteVmBackupRunner extends AbstractRemote {
       await this._callWriters(writer => writer.cleanup(), 'writer.cleanup()')
       // for healthcheck
       this._tags = metadata.vm.tags
+      this._hasTransferredData = true
     }
     if (transferList.length === 0) {
-      this.noTransfer = true
+      this._hasTransferredData = false
     }
   }
 }

--- a/@xen-orchestra/backups/_runners/_vmRunners/IncrementalRemote.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/IncrementalRemote.mjs
@@ -115,6 +115,9 @@ class IncrementalRemoteVmBackupRunner extends AbstractRemote {
       // for healthcheck
       this._tags = metadata.vm.tags
     }
+    if (transferList.length === 0) {
+      this.noHealthcheck = true
+    }
   }
 }
 

--- a/@xen-orchestra/backups/_runners/_vmRunners/IncrementalRemote.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/IncrementalRemote.mjs
@@ -114,11 +114,8 @@ class IncrementalRemoteVmBackupRunner extends AbstractRemote {
       await this._callWriters(writer => writer.cleanup(), 'writer.cleanup()')
       // for healthcheck
       this._tags = metadata.vm.tags
-      this._hasTransferredData = true
     }
-    if (transferList.length === 0) {
-      this._hasTransferredData = false
-    }
+    this._hasTransferredData = transferList.length > 0
   }
 }
 

--- a/@xen-orchestra/backups/_runners/_vmRunners/IncrementalRemote.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/IncrementalRemote.mjs
@@ -116,7 +116,7 @@ class IncrementalRemoteVmBackupRunner extends AbstractRemote {
       this._tags = metadata.vm.tags
     }
     if (transferList.length === 0) {
-      this.noHealthcheck = true
+      this.noTransfer = true
     }
   }
 }

--- a/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.mjs
@@ -18,7 +18,7 @@ const asyncEach = async (iterable, fn, thisArg = iterable) => {
 }
 
 export const Abstract = class AbstractVmBackupRunner {
-  noTransfer = false
+  _hasTransferredData = true
   // calls fn for each function, warns of any errors, and throws only if there are no writers left
   async _callWriters(fn, step, parallel = true) {
     const writers = this._writers
@@ -73,8 +73,8 @@ export const Abstract = class AbstractVmBackupRunner {
       return
     }
 
-    if (this.noTransfer) {
-      Task.info(`No healthCheck needed because no data was transfered.`)
+    if (!this._hasTransferredData) {
+      Task.info(`No healthCheck needed because no data was transferred.`)
       return
     }
 

--- a/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.mjs
@@ -72,6 +72,9 @@ export const Abstract = class AbstractVmBackupRunner {
     if (this._healthCheckSr === undefined) {
       return
     }
+    if (this._hasTransferredData === undefined) {
+      throw new Error('Missing tag to check there are some transferred data ')
+    }
 
     if (!this._hasTransferredData) {
       Task.info(`No healthCheck needed because no data was transferred.`)

--- a/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.mjs
@@ -74,7 +74,7 @@ export const Abstract = class AbstractVmBackupRunner {
     }
 
     if (this.noTransfer) {
-      Task.info(`No healcheck needed because no data was transfered.`)
+      Task.info(`No healthcheck needed because no data was transfered.`)
       return
     }
 

--- a/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.mjs
@@ -18,6 +18,7 @@ const asyncEach = async (iterable, fn, thisArg = iterable) => {
 }
 
 export const Abstract = class AbstractVmBackupRunner {
+  _hasTransferredData
   // calls fn for each function, warns of any errors, and throws only if there are no writers left
   async _callWriters(fn, step, parallel = true) {
     const writers = this._writers

--- a/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.mjs
@@ -18,7 +18,6 @@ const asyncEach = async (iterable, fn, thisArg = iterable) => {
 }
 
 export const Abstract = class AbstractVmBackupRunner {
-  _hasTransferredData = true
   // calls fn for each function, warns of any errors, and throws only if there are no writers left
   async _callWriters(fn, step, parallel = true) {
     const writers = this._writers

--- a/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.mjs
@@ -74,7 +74,7 @@ export const Abstract = class AbstractVmBackupRunner {
     }
 
     if (this.noTransfer) {
-      Task.info(`No healthcheck needed because no data was transfered.`)
+      Task.info(`No healthCheck needed because no data was transfered.`)
       return
     }
 

--- a/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.mjs
@@ -18,7 +18,7 @@ const asyncEach = async (iterable, fn, thisArg = iterable) => {
 }
 
 export const Abstract = class AbstractVmBackupRunner {
-  noHealthcheck = false
+  noTransfer = false
   // calls fn for each function, warns of any errors, and throws only if there are no writers left
   async _callWriters(fn, step, parallel = true) {
     const writers = this._writers
@@ -73,7 +73,7 @@ export const Abstract = class AbstractVmBackupRunner {
       return
     }
 
-    if (this.noHealthcheck) {
+    if (this.noTransfer) {
       Task.info(`No healcheck needed because no data was transfered.`)
       return
     }

--- a/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.mjs
@@ -18,6 +18,7 @@ const asyncEach = async (iterable, fn, thisArg = iterable) => {
 }
 
 export const Abstract = class AbstractVmBackupRunner {
+  noHealthcheck = false
   // calls fn for each function, warns of any errors, and throws only if there are no writers left
   async _callWriters(fn, step, parallel = true) {
     const writers = this._writers
@@ -69,6 +70,11 @@ export const Abstract = class AbstractVmBackupRunner {
     const settings = this._settings
 
     if (this._healthCheckSr === undefined) {
+      return
+    }
+
+    if (this.noHealthcheck) {
+      Task.info(`No healcheck needed because no data was transfered.`)
       return
     }
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,6 +34,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Backup/Sequences] Prevent sequences from ending prematurely when a backup job is skipped (PR [#8859](https://github.com/vatesfr/xen-orchestra/pull/8859))
+- [Backups] Fix healthCheck triggered even when no data is transfered in delta backups (PR [#8879](https://github.com/vatesfr/xen-orchestra/pull/8879))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -54,6 +54,7 @@
 
 - @vates/types minor
 - @xen-orchestra/mixins patch
+- @xen-orchestra/backups minor
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor


### PR DESCRIPTION


### Description

Check if transferList is empty to avoid uncesserary healthcheck 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
