### PR TITLE
feat(lite): add i18n engage link on settings page

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [Pool,Host,VM/Dashboard] Remember the last visited tab per object type (Pool/Host/VM) when navigating (PR [#8872](https://github.com/vatesfr/xen-orchestra/pull/8872))
 - Replace native `select` with a new custom component (PR [#8681](https://github.com/vatesfr/xen-orchestra/pull/8681))
+- Add i18n engage link on the settings page [Issue#8603](https://github.com/vatesfr/xen-orchestra/issues/8603) (PR [#8884](https://github.com/vatesfr/xen-orchestra/pull/8884))
 
 ## **0.13.1** (2025-08-06)
 

--- a/@xen-orchestra/lite/src/pages/settings.vue
+++ b/@xen-orchestra/lite/src/pages/settings.vue
@@ -101,7 +101,16 @@
     </UiCard>
     <UiCard class="group">
       <UiCardTitle>{{ t('language') }}</UiCardTitle>
-      <VtsSelect :id="localeSelectId" :icon="faEarthAmericas" accent="brand" />
+      <VtsColumns class="i18n-columns">
+        <VtsColumn>
+          <VtsSelect :id="localeSelectId" :icon="faEarthAmericas" accent="brand" />
+        </VtsColumn>
+        <VtsColumn class="i18n-link-column" :size="2">
+          <UiLink size="small" href="https://translate.vates.tech/engage/xen-orchestra/">
+            {{ t('settings.missing-translations') }}
+          </UiLink>
+        </VtsColumn>
+      </VtsColumns>
     </UiCard>
   </div>
 </template>
@@ -116,7 +125,10 @@ import UiKeyValueRow from '@/components/ui/UiKeyValueRow.vue'
 import { usePageTitleStore } from '@/stores/page-title.store.ts'
 import { useHostStore } from '@/stores/xen-api/host.store.ts'
 import { usePoolStore } from '@/stores/xen-api/pool.store.ts'
+import VtsColumn from '@core/components/column/VtsColumn.vue'
+import VtsColumns from '@core/components/columns/VtsColumns.vue'
 import VtsSelect from '@core/components/select/VtsSelect.vue'
+import UiLink from '@core/components/ui/link/UiLink.vue'
 import { locales } from '@core/i18n.ts'
 import { useFormSelect } from '@core/packages/form-select'
 import { useUiStore } from '@core/stores/ui.store.ts'
@@ -201,6 +213,16 @@ h5 {
       box-shadow: var(--shadow-100);
       border-radius: 8px;
     }
+  }
+}
+
+.i18n-columns {
+  padding-inline: 0;
+  gap: 2rem;
+
+  .i18n-link-column {
+    flex: 2;
+    justify-content: center;
   }
 }
 </style>

--- a/@xen-orchestra/web-core/lib/locales/en.json
+++ b/@xen-orchestra/web-core/lib/locales/en.json
@@ -483,6 +483,7 @@
   "send-ctrl-alt-del": "Send Ctrl+Alt+Del",
   "send-us-feedback": "Send us feedback",
   "settings": "Settings",
+  "settings.missing-translations": "Missing or incorrect translations?",
   "shutdown": "Shutdown",
   "sidebar.search-tree-view": "Search in treeview",
   "sidebar.vms-treeview": "VMs treeview",

--- a/@xen-orchestra/web-core/lib/locales/fr.json
+++ b/@xen-orchestra/web-core/lib/locales/fr.json
@@ -483,6 +483,7 @@
   "send-ctrl-alt-del": "Envoyer Ctrl+Alt+Suppr",
   "send-us-feedback": "Envoyez-nous vos commentaires",
   "settings": "Paramètres",
+  "settings.missing-translations": "Traductions manquantes ou incorrectes ?",
   "shutdown": "Arrêter",
   "sidebar.search-tree-view": "Rechercher dans l'arborescence",
   "sidebar.vms-treeview": "Arborescence des VMs",


### PR DESCRIPTION
Closes #8603

### Description

Add a link on the settings page to engage users in i18n contributions when translations are missing or need improvement

<img width="814" height="139" alt="Capture 2025-08-18@08 06 36" src="https://github.com/user-attachments/assets/1dd3b823-1150-4a0e-85c0-670bbe4e2648" />


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
