### PR TITLE
docs(xo): mention automatic daily deployment of documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Log in to your account and use the deploy form available from the [Vates website
 
 The official documentation is available at https://docs.xen-orchestra.com/
 
+Documentation updates are deployed automatically once per day.
+
 ## 🚀 Features
 
 - **Centralized interface**: one Xen Orchestra to rule your entire infrastructure, even across datacenters at various locations


### PR DESCRIPTION
The README now specifies that Xen Orchestra documentation updates are deployed automatically once per day. This makes it clearer for users that the online docs are always up to date without requiring manual intervention.