### PR TITLE
feat(web-core): new `useThreshold` composable

### DIFF
--- a/@xen-orchestra/web-core/lib/packages/threshold/README.md
+++ b/@xen-orchestra/web-core/lib/packages/threshold/README.md
@@ -6,10 +6,10 @@ It returns the payload of the highest matching threshold for that value.
 
 ## Arguments
 
-| Argument       | Type                                               | Required | Description                           |
-| -------------- | -------------------------------------------------- | :------: | ------------------------------------- |
-| `currentValue` | `MaybeRefOrGetter<number>`                         |    ✓     | The value to check against thresholds |
-| `config`       | `Record<number, TPayload> & { default: TPayload }` |    ✓     | The thresholds configuration          |
+| Argument       | Type                                                                 | Required | Description                           |
+| -------------- | -------------------------------------------------------------------- | :------: | ------------------------------------- |
+| `currentValue` | `MaybeRefOrGetter<number>`                                           |    ✓     | The value to check against thresholds |
+| `config`       | `MaybeRefOrGetter<Record<number, TPayload> & { default: TPayload }>` |    ✓     | The thresholds configuration          |
 
 ## Returns
 

--- a/@xen-orchestra/web-core/lib/packages/threshold/README.md
+++ b/@xen-orchestra/web-core/lib/packages/threshold/README.md
@@ -7,9 +7,9 @@ It returns the payload of the highest matching threshold for that value.
 ## Arguments
 
 | Argument       | Type                                               | Required | Description                           |
-| -------------- | -------------------------------------------------- | -------- | ------------------------------------- |
-| `currentValue` | `ComputedRef<number>`                              | ✓        | The value to check against thresholds |
-| `config`       | `Record<number, TPayload> & { default: TPayload }` | ✓        | The thresholds configuration          |
+| -------------- | -------------------------------------------------- | :------: | ------------------------------------- |
+| `currentValue` | `MaybeRefOrGetter<number>`                         |    ✓     | The value to check against thresholds |
+| `config`       | `Record<number, TPayload> & { default: TPayload }` |    ✓     | The thresholds configuration          |
 
 ## Returns
 

--- a/@xen-orchestra/web-core/lib/packages/threshold/README.md
+++ b/@xen-orchestra/web-core/lib/packages/threshold/README.md
@@ -1,0 +1,30 @@
+# `useThreshold`
+
+`useThreshold` composable allows defining payloads for different thresholds.
+
+It returns the payload of the highest matching threshold for that value.
+
+## Arguments
+
+| Argument       | Type                                               | Required | Description                           |
+| -------------- | -------------------------------------------------- | -------- | ------------------------------------- |
+| `currentValue` | `ComputedRef<number>`                              | ✓        | The value to check against thresholds |
+| `config`       | `Record<number, TPayload> & { default: TPayload }` | ✓        | The thresholds configuration          |
+
+## Returns
+
+`ComputedRef<{ value: number | undefined; payload: TPayload }>`
+
+## Example
+
+```ts
+const threshold = useThreshold(value, {
+  50: 'orange',
+  100: 'red',
+  default: 'green',
+})
+
+// value = 20 → threshold = { value: undefined, payload: 'green' }
+// value = 70 → threshold = { value: 50, payload: 'orange' }
+// value = 130 → threshold = { value: 100, payload: 'red' }
+```

--- a/@xen-orchestra/web-core/lib/packages/threshold/type.ts
+++ b/@xen-orchestra/web-core/lib/packages/threshold/type.ts
@@ -1,0 +1,3 @@
+export type ThresholdConfig<TPayload> = Record<number, TPayload> & { default: TPayload }
+
+export type ThresholdResult<TPayload> = { value: number | undefined; payload: TPayload }

--- a/@xen-orchestra/web-core/lib/packages/threshold/use-threshold.ts
+++ b/@xen-orchestra/web-core/lib/packages/threshold/use-threshold.ts
@@ -1,0 +1,19 @@
+import type { ThresholdConfig, ThresholdResult } from '@core/packages/threshold/type.ts'
+import { computed, type ComputedRef, type MaybeRefOrGetter, toValue } from 'vue'
+
+export function useThreshold<TPayload>(
+  rawCurrentValue: MaybeRefOrGetter<number>,
+  rawConfig: MaybeRefOrGetter<ThresholdConfig<TPayload>>
+): ComputedRef<ThresholdResult<TPayload>> {
+  const currentValue = computed(() => toValue(rawCurrentValue))
+
+  const config = computed(() => toValue(rawConfig))
+
+  return computed(
+    () =>
+      Object.entries(config.value)
+        .map(([value, payload]) => ({ value: value === 'default' ? -Infinity : Number(value), payload }))
+        .sort((a, b) => b.value - a.value)
+        .find(threshold => currentValue.value >= threshold.value)!
+  )
+}


### PR DESCRIPTION
### Description

This PR introduces `useThreshold` composable, mainly intended to be used in the upcoming `VtsProgressBar` component

```ts
const threshold = useThreshold(value, {
  50: 'orange',
  100: 'red',
  default: 'green',
})

// value = 20 → threshold = { value: undefined, payload: 'green' }
// value = 70 → threshold = { value: 50, payload: 'orange' }
// value = 130 → threshold = { value: 100, payload: 'red' }
```


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
