### PR TITLE
feat(web-core): new `useProgress` and `useProgressGroup` composables

### DIFF
--- a/@xen-orchestra/web-core/lib/packages/progress/README.md
+++ b/@xen-orchestra/web-core/lib/packages/progress/README.md
@@ -1,0 +1,62 @@
+# `useProgress` / `useProgressGroup`
+
+## `useProgress`
+
+### Arguments
+
+| Argument  | Type                       | Required | Description        |
+| --------- | -------------------------- | :------: | ------------------ |
+| `current` | `MaybeRefOrGetter<number>` |    ✓     | The current value. |
+| `total`   | `MaybeRefOrGetter<number>` |    ✓     | The total value.   |
+
+### Returns
+
+| Property        | Type                      | Description                                                |
+| --------------- | ------------------------- | ---------------------------------------------------------- |
+| `current`       | `ComputedRef<number>`     | The normalized `current` input                             |
+| `total`         | `ComputedRef<number>`     | The normalized `total` input                               |
+| `fillWidth`     | `ComputedRef<${number}%>` | The width of the progress bar to be filled (e.g. `"35%"`). |
+| `percentage`    | `ComputedRef<number>`     | The percentage between `current` and `total`.              |
+| `percentageCap` | `number`                  | The percentage cap of the progress bar. (see below)        |
+
+`percentageCap` is the `percentage` rounded up to the nearest hundred.
+
+For example, if `current` is `15` and `total` is `10`, then `percentage` will be `150` and `percentageCap` will be `200`.
+
+`fillWidth` is the percentage of the progress bar to be filled.
+
+In the example above, `fillWidth` will be `"75%"` (`150` / `200` = `0.75`).
+
+```ts
+const { fillWidth, percentage, percentageCap } = useProgress(current, total)
+
+// current = 15; total = 60
+// → percentage = 25
+// → percentageCap = 100
+// → fillWidth = '25%'
+
+// current = 90; total = 60
+// → percentage = 150
+// → percentageCap = 200
+// → fillWidth = '75%'
+```
+
+## `useProgressGroup`
+
+This composable will allow handling multiple progress bars and normalize their fill width across all of them.
+
+### Arguments
+
+| Argument  | Type                                                | Required | Description                                                                                                              |
+| --------- | --------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `sources` | `MaybeRefOrGetter<T[]>`                             | ✓        | The sources array                                                                                                        |
+| `fn`      | `(source: T) => { current: number; total: number }` | ~        | Returns `current` and `total` for each `source`. If `source` already has these properties, this argument can be omitted. |
+| `options` | `{ sort?: 'asc' \| 'desc' }                         |          | Whether to sort the progress items                                                                                       |
+
+### Returns
+
+| Property               | Type                                                      | Description                                           |
+| ---------------------- | --------------------------------------------------------- | ----------------------------------------------------- |
+| `progressItems`        | `ComputedRef<Reactive<Progress & { source: TSource }>[]>` | The normalized progress items.                        |
+| `highestPercentage`    | `ComputedRef<number>`                                     | The highest `percentage` among all progress items.    |
+| `highestPercentageCap` | `ComputedRef<number>`                                     | The highest `percentageCap` among all progress items. |

--- a/@xen-orchestra/web-core/lib/packages/progress/README.md
+++ b/@xen-orchestra/web-core/lib/packages/progress/README.md
@@ -48,9 +48,9 @@ This composable will allow handling multiple progress bars and normalize their f
 ### Arguments
 
 | Argument  | Type                                                | Required | Description                                                                                                              |
-| --------- | --------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `sources` | `MaybeRefOrGetter<T[]>`                             | ✓        | The sources array                                                                                                        |
-| `fn`      | `(source: T) => { current: number; total: number }` | ~        | Returns `current` and `total` for each `source`. If `source` already has these properties, this argument can be omitted. |
+| --------- | --------------------------------------------------- | :------: | ------------------------------------------------------------------------------------------------------------------------ |
+| `sources` | `MaybeRefOrGetter<T[]>`                             |    ✓     | The sources array                                                                                                        |
+| `fn`      | `(source: T) => { current: number; total: number }` |    ~     | Returns `current` and `total` for each `source`. If `source` already has these properties, this argument can be omitted. |
 | `options` | `{ sort?: 'asc' \| 'desc' }                         |          | Whether to sort the progress items                                                                                       |
 
 ### Returns

--- a/@xen-orchestra/web-core/lib/packages/progress/types.ts
+++ b/@xen-orchestra/web-core/lib/packages/progress/types.ts
@@ -1,0 +1,19 @@
+import type { ComputedRef, MaybeRefOrGetter, Reactive } from 'vue'
+
+export type Progress = {
+  current: ComputedRef<number>
+  total: ComputedRef<number>
+  percentage: ComputedRef<number>
+  fillWidth: ComputedRef<string>
+  percentageCap: ComputedRef<number>
+}
+
+export type ProgressGroup<TSource> = {
+  progressItems: ComputedRef<Reactive<Progress & { source: TSource }>[]>
+  highestPercentage: ComputedRef<number>
+  highestPercentageCap: ComputedRef<number>
+}
+
+export type UseProgressGroupOptions = {
+  sort?: MaybeRefOrGetter<'asc' | 'desc' | undefined>
+}

--- a/@xen-orchestra/web-core/lib/packages/progress/use-progress-group.ts
+++ b/@xen-orchestra/web-core/lib/packages/progress/use-progress-group.ts
@@ -1,0 +1,68 @@
+import type { ProgressGroup, UseProgressGroupOptions } from './types.ts'
+import { useArrayMap } from '@vueuse/shared'
+import { computed, markRaw, type MaybeRefOrGetter, reactive, toValue } from 'vue'
+import { useProgress } from './use-progress.ts'
+
+export function useProgressGroup<TSource extends { current: number; total: number }>(
+  rawSources: MaybeRefOrGetter<TSource[]>,
+  options?: UseProgressGroupOptions
+): ProgressGroup<TSource>
+
+export function useProgressGroup<TSource>(
+  rawSources: MaybeRefOrGetter<TSource[]>,
+  fn: (item: TSource) => { current: number; total: number },
+  options?: UseProgressGroupOptions
+): ProgressGroup<TSource>
+
+export function useProgressGroup<TSource>(
+  rawSources: MaybeRefOrGetter<TSource[]>,
+  fnOrOptions?: UseProgressGroupOptions | ((item: TSource) => { current: number; total: number }),
+  optionsOrNone?: UseProgressGroupOptions
+): ProgressGroup<TSource> {
+  const fn =
+    typeof fnOrOptions === 'function' ? fnOrOptions : (item: TSource) => item as { current: number; total: number }
+  const options = typeof fnOrOptions === 'function' ? optionsOrNone : fnOrOptions
+
+  const progressItems = useArrayMap(rawSources, source => {
+    const { current, total } = fn(source)
+
+    return {
+      source: typeof source === 'object' && source !== null ? markRaw(source) : source,
+      ...useProgress(current, total),
+    }
+  })
+
+  const highestPercentage = computed(() =>
+    progressItems.value.reduce((highestPercentage, item) => Math.max(highestPercentage, item.percentage.value), 0)
+  )
+
+  const highestPercentageCap = computed(() =>
+    progressItems.value.reduce((highestCap, item) => Math.max(highestCap, item.percentageCap.value), 0)
+  )
+
+  const normalizedProgressItems = useArrayMap(progressItems, item => {
+    const fillWidth = computed(() => `${(item.percentage.value / highestPercentageCap.value) * 100}%`)
+
+    return reactive({
+      ...item,
+      fillWidth,
+    })
+  })
+
+  const sortedProgressItems = computed(() => {
+    switch (toValue(options?.sort)) {
+      case 'asc':
+        return [...normalizedProgressItems.value].sort((a, b) => a.percentage - b.percentage)
+      case 'desc':
+        return [...normalizedProgressItems.value].sort((a, b) => b.percentage - a.percentage)
+      default:
+        return normalizedProgressItems.value
+    }
+  })
+
+  return {
+    progressItems: sortedProgressItems,
+    highestPercentage,
+    highestPercentageCap,
+  }
+}

--- a/@xen-orchestra/web-core/lib/packages/progress/use-progress.ts
+++ b/@xen-orchestra/web-core/lib/packages/progress/use-progress.ts
@@ -1,0 +1,22 @@
+import type { Progress } from './types.ts'
+import { computed, type MaybeRefOrGetter, toValue } from 'vue'
+
+export function useProgress(rawCurrent: MaybeRefOrGetter<number>, rawTotal: MaybeRefOrGetter<number>): Progress {
+  const current = computed(() => toValue(rawCurrent))
+
+  const total = computed(() => toValue(rawTotal))
+
+  const percentage = computed(() => (total.value === 0 ? 0 : (current.value / total.value) * 100))
+
+  const percentageCap = computed(() => Math.max(100, Math.ceil(percentage.value / 100) * 100))
+
+  const fillWidth = computed(() => `${(percentage.value / percentageCap.value) * 100}%`)
+
+  return {
+    current,
+    total,
+    percentage,
+    fillWidth,
+    percentageCap,
+  }
+}


### PR DESCRIPTION
### Description

This PR introduces `useProgress` and `useProgressGroup`, mainly intended to be used in incoming `VtsProgressBar` and `VtsProgressBarGroup` components.

#### `useProgress`

```ts
const { fillWidth, percentage, percentageCap } = useProgress(current, total)

useProgress(15, 60) // { fillWidth: '25%', percentage: 25, percentageCap: 100 }

useProgress(90, 60) // { fillWidth: '75%', percentage: 150, percentageCap: 200 }
```

#### `useProgressGroup`

```ts
const { progressItems, highestPercentage, highestPercentageCap } = useProgressGroup(sources)
```

Each `progressItems` item will contains an the same properties as `useProgress` + a `source` property


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
