### PR TITLE
fix(fs): update timeout for b2 listing

### DIFF
--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -23,7 +23,7 @@ const computeRate = (hrtime, size) => {
   return size / seconds
 }
 
-const DEFAULT_TIMEOUT = 6e5 // 10 min
+const DEFAULT_TIMEOUT = 12e5 // 20 min
 const DEFAULT_MAX_PARALLEL_OPERATIONS = 10
 
 const ENCRYPTION_DESC_FILENAME = 'encryption.json'

--- a/@xen-orchestra/fs/src/abstract.test.js
+++ b/@xen-orchestra/fs/src/abstract.test.js
@@ -10,7 +10,7 @@ import AbstractHandler from './abstract'
 import fs from 'fs-extra'
 import tmp from 'tmp'
 
-const TIMEOUT = 6e5
+const TIMEOUT = 12e5
 
 class TestHandler extends AbstractHandler {
   constructor() {

--- a/@xen-orchestra/fs/src/abstract.test.js
+++ b/@xen-orchestra/fs/src/abstract.test.js
@@ -54,7 +54,7 @@ describe('closeFile()', () => {
 
     const promise = testHandler.closeFile({ fd: undefined, path: '' })
     clock.tick(TIMEOUT)
-    await assert.rejects(promise, TimeoutError)
+    await assert.rejects(promise, new TimeoutError())
   })
 })
 
@@ -64,7 +64,7 @@ describe('getInfo()', () => {
 
     const promise = testHandler.getInfo()
     clock.tick(TIMEOUT)
-    await assert.rejects(promise, TimeoutError)
+    await assert.rejects(promise, new TimeoutError())
   })
 })
 
@@ -74,7 +74,7 @@ describe('getSize()', () => {
 
     const promise = testHandler.getSize('')
     clock.tick(TIMEOUT)
-    await assert.rejects(promise, TimeoutError)
+    await assert.rejects(promise, new TimeoutError())
   })
 })
 
@@ -84,7 +84,7 @@ describe('list()', () => {
 
     const promise = testHandler.list('.')
     clock.tick(TIMEOUT)
-    await assert.rejects(promise, TimeoutError)
+    await assert.rejects(promise, new TimeoutError())
   })
 })
 
@@ -94,7 +94,7 @@ describe('openFile()', () => {
 
     const promise = testHandler.openFile('path')
     clock.tick(TIMEOUT)
-    await assert.rejects(promise, TimeoutError)
+    await assert.rejects(promise, new TimeoutError())
   })
 })
 
@@ -104,7 +104,7 @@ describe('rename()', () => {
 
     const promise = testHandler.rename('oldPath', 'newPath')
     clock.tick(TIMEOUT)
-    await assert.rejects(promise, TimeoutError)
+    await assert.rejects(promise, new TimeoutError())
   })
 })
 
@@ -114,7 +114,7 @@ describe('rmdir()', () => {
 
     const promise = testHandler.rmdir('dir')
     clock.tick(TIMEOUT)
-    await assert.rejects(promise, TimeoutError)
+    await assert.rejects(promise, new TimeoutError())
   })
 })
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,6 +37,7 @@
 - [Backup/Sequences] Prevent sequences from ending prematurely when a backup job is skipped (PR [#8859](https://github.com/vatesfr/xen-orchestra/pull/8859))
 - [Backups] Fix healthCheck triggered even when no data is transfered in delta backups (PR [#8879](https://github.com/vatesfr/xen-orchestra/pull/8879))
 - [Plugins/audit] Prevent audit plugin disabling from failing (PR [#8898](https://github.com/vatesfr/xen-orchestra/pull/8898))
+- [Backup] Update timeout in filesystem for expensive listing requests
 
 ### Packages to release
 
@@ -55,6 +56,7 @@
 <!--packages-start-->
 
 - @vates/types minor
+- @xen-orchestra/fs minor
 - @xen-orchestra/mixins patch
 - @xen-orchestra/backups minor
 - @xen-orchestra/rest-api minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@
 - [Host/General] Display additional hardware data for Dell server (PR [#8861](https://github.com/vatesfr/xen-orchestra/pull/8861))
 
 - **XO 6**:
+
   - [Pool,Host,VM/Dashboard] Remember the last visited tab per object type (Pool/Host/VM) when navigating (PR [#8873](https://github.com/vatesfr/xen-orchestra/pull/8873))
   - Replace native `select` with a new custom component (PR [#8681](https://github.com/vatesfr/xen-orchestra/pull/8681))
   - [i18n] Add Portuguese (Brazil) and update Czech, German, Spanish, Italian, Dutch and Swedish translations (PR [#8837](https://github.com/vatesfr/xen-orchestra/pull/8837))
@@ -57,9 +58,9 @@
 <!--packages-start-->
 
 - @vates/types minor
+- @xen-orchestra/backups minor
 - @xen-orchestra/fs patch
 - @xen-orchestra/mixins patch
-- @xen-orchestra/backups minor
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -38,6 +38,7 @@
 - [Backups] Fix healthCheck triggered even when no data is transfered in delta backups (PR [#8879](https://github.com/vatesfr/xen-orchestra/pull/8879))
 - [Plugins/audit] Prevent audit plugin disabling from failing (PR [#8898](https://github.com/vatesfr/xen-orchestra/pull/8898))
 - [Backup] Update timeout in filesystem for expensive listing requests
+- [Backup] Update timeout in filesystem for expensive listing requests (PR [#8903](https://github.com/vatesfr/xen-orchestra/pull/8903))
 
 ### Packages to release
 
@@ -56,7 +57,7 @@
 <!--packages-start-->
 
 - @vates/types minor
-- @xen-orchestra/fs minor
+- @xen-orchestra/fs patch
 - @xen-orchestra/mixins patch
 - @xen-orchestra/backups minor
 - @xen-orchestra/rest-api minor


### PR DESCRIPTION
### Description

Update timeout to handle backblaze expensive listing

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
