### PR TITLE
fix(backup): set transfer tag only on AbstractRemote

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/FullRemote.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/FullRemote.mjs
@@ -37,5 +37,6 @@ export const FullRemote = class FullRemoteVmBackupRunner extends AbstractRemote 
       // for healthcheck
       this._tags = metadata.vm.tags
     }
+    this._hasTransferredData = transferList.length > 0
   }
 }

--- a/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_Abstract.mjs
@@ -18,7 +18,6 @@ const asyncEach = async (iterable, fn, thisArg = iterable) => {
 }
 
 export const Abstract = class AbstractVmBackupRunner {
-  _hasTransferredData
   // calls fn for each function, warns of any errors, and throws only if there are no writers left
   async _callWriters(fn, step, parallel = true) {
     const writers = this._writers
@@ -70,14 +69,6 @@ export const Abstract = class AbstractVmBackupRunner {
     const settings = this._settings
 
     if (this._healthCheckSr === undefined) {
-      return
-    }
-    if (this._hasTransferredData === undefined) {
-      throw new Error('Missing tag to check there are some transferred data ')
-    }
-
-    if (!this._hasTransferredData) {
-      Task.info(`No healthCheck needed because no data was transferred.`)
       return
     }
 

--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractRemote.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractRemote.mjs
@@ -13,6 +13,8 @@ import { Task } from '../../Task.mjs'
 
 export const AbstractRemote = class AbstractRemoteVmBackupRunner extends Abstract {
   _filterPredicate
+  _hasTransferredData
+
   constructor({
     config,
     job,
@@ -141,7 +143,16 @@ export const AbstractRemote = class AbstractRemoteVmBackupRunner extends Abstrac
         })
       }, 'writer.beforeBackup()')
       await this._run()
-      await this._healthCheck()
+
+      if (this._hasTransferredData === undefined) {
+        throw new Error('Missing tag to check there are some transferred data ')
+      }
+
+      if (this._hasTransferredData) {
+        await this._healthCheck()
+      } else {
+        Task.info(`No healthCheck needed because no data was transferred.`)
+      }
     })
   }
 }

--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractRemote.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractRemote.mjs
@@ -145,7 +145,7 @@ export const AbstractRemote = class AbstractRemoteVmBackupRunner extends Abstrac
       await this._run()
 
       if (this._hasTransferredData === undefined) {
-        throw new Error('Missing tag to check there are some transferred data ')
+        throw new Error('Missing tag to check there are some transferred data')
       }
 
       if (this._hasTransferredData) {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 [Backup]: fix error footer1 !== footer2 (PR [#8882](https://github.com/vatesfr/pull/8882))
+- [Backup] Fix false positive in FullRemote transfer where tag is undefined (PR [#8907](https://github.com/vatesfr/xen-orchestra/pull/8907))
 
 ### Packages to release
 
@@ -36,6 +37,7 @@
 <!--packages-start-->
 
 - @vates/nbd-client patch
+- @xen-orchestra/backups patch
 - @xen-orchestra/vmware-explorer patch
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,7 +18,6 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 [Backup]: fix error footer1 !== footer2 (PR [#8882](https://github.com/vatesfr/pull/8882))
-- [Backup] Fix false positive in FullRemote transfer where tag is undefined (PR [#8907](https://github.com/vatesfr/xen-orchestra/pull/8907))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

Fix issue reported here: https://xcp-ng.org/forum/topic/11218/delta-backups-failing-again-xoce.-error-missing-tag-to-check-there-are-some-transferred-data/3

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
