### PR TITLE
fix(xo-6/backup-jobs): correctly display "pending" jobs

### DIFF
--- a/@xen-orchestra/web-core/lib/locales/en.json
+++ b/@xen-orchestra/web-core/lib/locales/en.json
@@ -260,6 +260,7 @@
   "hyper-threading": "Hyper threading (SMT)",
   "id": "ID",
   "in-last-three-jobs": "In their last three jobs",
+  "in-progress": "In progress",
   "install-settings": "Install settings",
   "interfaces": "Interface | Interface | Interfaces",
   "interrupted": "Interrupted",

--- a/@xen-orchestra/web-core/lib/locales/fr.json
+++ b/@xen-orchestra/web-core/lib/locales/fr.json
@@ -260,6 +260,7 @@
   "hyper-threading": "Hyper-threading (SMT)",
   "id": "ID",
   "in-last-three-jobs": "Dans leurs trois derniers jobs",
+  "in-progress": "En cours",
   "install-settings": "Paramètres d'installation",
   "interfaces": "Interface | Interface | Interfaces",
   "interrupted": "Interrompu",

--- a/@xen-orchestra/web/src/components/site/backups/BackupJobsTable.vue
+++ b/@xen-orchestra/web/src/components/site/backups/BackupJobsTable.vue
@@ -160,6 +160,7 @@ const getRunStatus = createMapper<XoBackupLog['status'], { icon: IconName; toolt
     skipped: { icon: 'legacy:status:warning', tooltip: t('skipped') },
     interrupted: { icon: 'legacy:status:danger', tooltip: t('interrupted') },
     failure: { icon: 'legacy:status:danger', tooltip: t('failure') },
+    pending: { icon: 'legacy:status:info', tooltip: t('in-progress') },
   },
   'failure'
 )

--- a/@xen-orchestra/web/src/remote-resources/use-xo-backup-log-collection.ts
+++ b/@xen-orchestra/web/src/remote-resources/use-xo-backup-log-collection.ts
@@ -5,10 +5,10 @@ import { useSorted } from '@vueuse/core'
 import { computed } from 'vue'
 
 export const useXoBackupLogCollection = defineRemoteResource({
-  url: '/rest/v0/backup/logs/?fields=id,jobId,status,end',
+  url: '/rest/v0/backup/logs/?fields=id,jobId,status,start,end',
   initialData: () => [] as XoBackupLog[],
   state: (rawBackupLogs, context) => {
-    const backupLogs = useSorted(rawBackupLogs, (log1, log2) => log2.end - log1.end)
+    const backupLogs = useSorted(rawBackupLogs, (log1, log2) => log2.start - log1.start)
 
     const state = useXoCollectionState(backupLogs, {
       context,
@@ -16,16 +16,16 @@ export const useXoBackupLogCollection = defineRemoteResource({
     })
 
     const backupLogsByJobId = computed(() => {
-      const backupLogsByJobId = new Map<XoBackupLog['jobId'], XoBackupLog[]>()
+      const backupLogsByJobIdMap = new Map<XoBackupLog['jobId'], XoBackupLog[]>()
 
       backupLogs.value.forEach(backupLog => {
-        if (!backupLogsByJobId.has(backupLog.jobId)) {
-          backupLogsByJobId.set(backupLog.jobId, [])
+        if (!backupLogsByJobIdMap.has(backupLog.jobId)) {
+          backupLogsByJobIdMap.set(backupLog.jobId, [])
         }
-        backupLogsByJobId.get(backupLog.jobId)!.push(backupLog)
+        backupLogsByJobIdMap.get(backupLog.jobId)!.push(backupLog)
       })
 
-      return backupLogsByJobId
+      return backupLogsByJobIdMap
     })
 
     const getLastNBackupLogsByJobId = (jobId: XoBackupLog['jobId'], limit: number = 3): XoBackupLog[] => {

--- a/@xen-orchestra/web/src/types/xo/backup-log.type.ts
+++ b/@xen-orchestra/web/src/types/xo/backup-log.type.ts
@@ -5,6 +5,7 @@ export type XoBackupLog = {
   id: Branded<'backup-log'>
   type: 'backup-log'
   jobId: XoBackupJob['id']
-  status: 'success' | 'failure' | 'skipped' | 'interrupted'
-  end: number
+  status: 'success' | 'failure' | 'skipped' | 'interrupted' | 'pending'
+  start: number
+  end?: number
 }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,4 +31,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/web patch
+- @xen-orchestra/web-core patch
+
 <!--packages-end-->


### PR DESCRIPTION
Introduced by #8889 

### Description

"Pending" backup jobs weren’t being displayed correctly in the Backup Jobs table.
The PR fixes this issue by using the `start` property of Backup Logs, instead of `end`.

### Screenshots

<img width="659" height="79" alt="image" src="https://github.com/user-attachments/assets/54dc20fb-f7e8-4f98-a0be-bfb0ac6d94d8" />

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
