### PR TITLE
docs(xo): document recipes

### DIFF
--- a/docs/docs/advanced.md
+++ b/docs/docs/advanced.md
@@ -364,6 +364,14 @@ If you get a `403 Forbidden` error when testing the plugin, make sure you correc
 
 ## Recipes
 
+### What are recipes?
+
+In Xen Orchestra, recipes are ready-to-use automation templates that make it easy to deploy complex infrastructures. You don’t need to configure each virtual machine manually. 
+
+With just a few clicks, you can launch a complete multi-VM environment, where all nodes are automatically set up and connected.
+
 :::tip
-TODO: this section is still a work in progress!
+Currently, the only available recipe is for Kubernetes clusters. [This guide](https://docs.vates.tech/devops-tools/kubernetes/) will walk you through creating one.
+
+Coming soon: We’ll expand the Recipes feature to include EasyVirt DC Scope deployment.
 :::


### PR DESCRIPTION
The [Management → Advanced Features](https://docs.xen-orchestra.com/advanced#recipes) page in the Xen Orchestra documentation had an empty section on Recipes. Meanwhile, the only guide on automatically creating a Kubernetes cluster using recipes was buried in a [blog post](https://xen-orchestra.com/blog/virtops-6-create-a-kubernetes-cluster-in-minutes/).

This pull request:

- explains recipes in the official Xen Orchestra documentation
- adds a link in the XO doc to the [guide on how to to automatically create a Kubernetes cluster](https://docs.vates.tech/devops-tools/kubernetes/), in Vates VMS documentation. This guide was added at the same time this PR was created.

This way, users will have detailed, structured and illustrated steps to create and manage their clusters, all at the intended place. No need to dig through old blog posts anymore.