### PR TITLE
feat(@xen-orchestra/rest-api): expose proxies

### DIFF
--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -371,7 +371,14 @@ export type XoPool = BaseXapiXo & {
 
 export type XoProxy = {
   id: Branded<'proxy'>
-}
+  url: string
+  version?: string
+  name: string
+} & (
+  | { address?: undefined; vmUuid: XoVm['id'] }
+  | { address: string; vmUuid?: undefined }
+  | { address: string; vmUuid: XoVm['id'] }
+)
 
 type BaseXoJob = {
   id: Branded<'job'>

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/proxy.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/proxy.oa-example.mts
@@ -1,0 +1,27 @@
+export const proxyIds = [
+  '/rest/v0/proxies/e625ea0c-a876-405a-b838-109d762efe88',
+  '/rest/v0/proxies/17210f70-24f7-4309-bbf7-e6381fdc0b13',
+]
+
+export const partialProxies = [
+  {
+    vmUuid: '7330139d-288f-2248-5986-d508ea71f12c',
+    id: 'e625ea0c-a876-405a-b838-109d762efe88',
+    name: 'Proxy 2025-08-29T08:23:33.394Z',
+    href: '/rest/v0/proxies/e625ea0c-a876-405a-b838-109d762efe88',
+  },
+  {
+    vmUuid: '17210f70-24f7-4309-bbf7-e6381fdc0b13',
+    id: '88e3ab4d-d74a-495c-8ea2-27307f0c18ad',
+    name: 'Proxy 2022-02-13T10:45:32.644Z',
+    href: '/rest/v0/proxies/17210f70-24f7-4309-bbf7-e6381fdc0b13',
+  },
+]
+
+export const proxy = {
+  name: 'Proxy 2025-08-29T08:23:33.394Z',
+  vmUuid: '7330139d-288f-2248-5986-d508ea71f12c',
+  id: 'e625ea0c-a876-405a-b838-109d762efe88',
+  url: 'https://uxxa-NIAY9W29VlGMrRcKuxx2dsYMTldJo-7l2YnMNQ@10.1.7.238/',
+  version: '0.29.29',
+}

--- a/@xen-orchestra/rest-api/src/proxies/proxy.controller.mts
+++ b/@xen-orchestra/rest-api/src/proxies/proxy.controller.mts
@@ -1,0 +1,52 @@
+import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import { provide } from 'inversify-binding-decorators'
+import type { Request as ExRequest } from 'express'
+import type { XoProxy } from '@vates/types'
+
+import { notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
+import { partialProxies, proxy, proxyIds } from '../open-api/oa-examples/proxy.oa-example.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
+import { XoController } from '../abstract-classes/xo-controller.mjs'
+
+@Route('proxies')
+@Security('*')
+@Response(unauthorizedResp.status, unauthorizedResp.description)
+@Tags('proxies')
+@provide(ProxyController)
+export class ProxyController extends XoController<XoProxy> {
+  getAllCollectionObjects(): Promise<XoProxy[]> {
+    return this.restApi.xoApp.getAllProxies()
+  }
+  getCollectionObject(id: XoProxy['id']): Promise<XoProxy> {
+    return this.restApi.xoApp.getProxy(id)
+  }
+
+  /**
+   * @example fields "vmUuid,id,name"
+   * @example filter "vmUuid?"
+   * @example limit 42
+   */
+  @Example(proxyIds)
+  @Example(partialProxies)
+  @Get('')
+  async getProxies(
+    @Request() req: ExRequest,
+    @Query() fields?: string,
+    @Query() ndjson?: boolean,
+    @Query() filter?: string,
+    @Query() limit?: number
+  ): Promise<SendObjects<Partial<Unbrand<XoProxy>>>> {
+    const proxies = Object.values(await this.getObjects({ filter, limit }))
+    return this.sendObjects(proxies, req)
+  }
+
+  /**
+   * @example id "e625ea0c-a876-405a-b838-109d762efe88"
+   */
+  @Example(proxy)
+  @Get('{id}')
+  @Response(notFoundResp.status, notFoundResp.description)
+  getProxy(@Path() id: string): Promise<Unbrand<XoProxy>> {
+    return this.getObject(id as XoProxy['id'])
+  }
+}

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -34,6 +34,7 @@ import type {
   XoGroup,
   XoPool,
   XoTask,
+  XoProxy,
 } from '@vates/types/xo'
 
 import type { InsertableXoServer } from '../servers/server.type.mjs'
@@ -96,7 +97,9 @@ export type XoApp = {
   createGroup(params: { name: string; provider?: string; providerGroup?: string }): Promise<XoGroup>
   disconnectXenServer(id: XoServer['id']): Promise<void>
   getAllGroups(): Promise<XoGroup[]>
+  getAllProxies(): Promise<XoProxy[]>
   getAllJobs(type?: BACKUP_TYPE): Promise<AnyXoJob[]>
+  getProxy(id: XoProxy['id']): Promise<XoProxy>
   getRemote(id: XoBackupRepository['id']): Promise<XoBackupRepository>
   getAllRemotes(): Promise<XoBackupRepository[]>
   getAllRemotesInfo(): Promise<

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [REST API] Expose `/rest/v0/proxies` and `/rest/v0/proxies/<proxy-id>` (PR [#8920](https://github.com/vatesfr/xen-orchestra/pull/8920))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -30,5 +32,8 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- @vates/types minor
+- @xen-orchestra/rest-api minor
 
 <!--packages-end-->


### PR DESCRIPTION
### Screenshot

<img width="439" height="403" alt="Capture d’écran de 2025-08-29 10-57-47" src="https://github.com/user-attachments/assets/d44e5d99-4c7b-4857-bb68-a2af05e2f341" />

### Description

Endpoint needed for XO6 backups view

[XO-1418](https://project.vates.tech/vates-global/browse/XO-1418/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
