### PR TITLE
fix(xo6): fix to display only ISO VDIs for the ISO input list in the VM creation form

### DIFF
--- a/@xen-orchestra/web/src/remote-resources/use-xo-sr-collection.ts
+++ b/@xen-orchestra/web/src/remote-resources/use-xo-sr-collection.ts
@@ -16,8 +16,10 @@ export const useXoSrCollection = defineRemoteResource({
       baseName: 'sr',
     })
 
+    const isoSrs = computed(() => srs.value.filter(sr => sr.SR_type === 'iso'))
+
     const isoVdiIds = computed(() =>
-      srs.value.reduce((acc, sr) => {
+      isoSrs.value.reduce((acc, sr) => {
         if (sr.VDIs) {
           sr.VDIs.forEach(vdiId => acc.add(vdiId))
         }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+[VM]: fix wrong display in the sr iso list (PR [#8922](https://github.com/vatesfr/pull/8922))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -30,5 +32,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- @xen-orchestra/web minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,6 +33,6 @@
 
 <!--packages-start-->
 
-- @xen-orchestra/web minor
+- @xen-orchestra/web patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-[VM]: fix wrong display in the sr iso list (PR [#8922](https://github.com/vatesfr/pull/8922))
+[XO6/New VM] Display only ISO VDIs for the ISO input (PR [#8922](https://github.com/vatesfr/pull/8922))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

Fix to display only ISO VDIs for the ISO input list in the VM creation form

### Screenshots

Before:
<img width="827" height="610" alt="image" src="https://github.com/user-attachments/assets/9b5d73f8-d752-41c8-9664-fd4495e92672" />
After: 
<img width="827" height="572" alt="image" src="https://github.com/user-attachments/assets/d02a9ed2-4337-49cd-b74e-78ac4d1f6d92" />

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
