### PR TITLE
fix(xo-lite/vm/system): correctly display secure boot

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## **next**
 
-- [VM/System] Correctly display enable/disable for secure boot
+- [VM/System] Correctly display enable/disable for secure boot (PR [#8925](https://github.com/vatesfr/xen-orchestra/pull/8925))
 
 ## **0.14.0** (2025-08-28)
 

--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## **next**
+
+- [VM/System] Correctly display enable/disable for secure boot
+
 ## **0.14.0** (2025-08-28)
 
 - [Pool,Host,VM/Dashboard] Remember the last visited tab per object type (Pool/Host/VM) when navigating (PR [#8872](https://github.com/vatesfr/xen-orchestra/pull/8872))

--- a/@xen-orchestra/lite/src/components/vm/system/VmVirtualizationAndBoot.vue
+++ b/@xen-orchestra/lite/src/components/vm/system/VmVirtualizationAndBoot.vue
@@ -6,7 +6,7 @@
     <VtsQuickInfoRow :label="t('virtualization-mode')" :value="virtualizationMode" />
     <VtsQuickInfoRow :label="t('secure-boot')">
       <template #value>
-        <VtsEnabledState :enabled="Boolean(vm.platform.secureboot)" />
+        <VtsEnabledState :enabled="vm.platform.secureboot === 'true'" />
       </template>
     </VtsQuickInfoRow>
     <VtsQuickInfoRow :label="t('virtual-tpm')" :value="vm.VTPMs.length > 0 ? vm.VTPMs.join(', ') : t('none')" />

--- a/@xen-orchestra/lite/src/components/vm/system/VmVirtualizationAndBoot.vue
+++ b/@xen-orchestra/lite/src/components/vm/system/VmVirtualizationAndBoot.vue
@@ -6,7 +6,7 @@
     <VtsQuickInfoRow :label="t('virtualization-mode')" :value="virtualizationMode" />
     <VtsQuickInfoRow :label="t('secure-boot')">
       <template #value>
-        <VtsEnabledState :enabled="vm.platform.secureBoot !== undefined" />
+        <VtsEnabledState :enabled="Boolean(vm.platform.secureboot)" />
       </template>
     </VtsQuickInfoRow>
     <VtsQuickInfoRow :label="t('virtual-tpm')" :value="vm.VTPMs.length > 0 ? vm.VTPMs.join(', ') : t('none')" />


### PR DESCRIPTION
### Description

Related to [forum#11227](https://xcp-ng.org/forum/topic/11227/boot-new-vm-to-iso-in-xo-lite/26)
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
