### PR TITLE
fix(@xen-orchestra/xapi): better fallback messages for backups

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
@@ -45,6 +45,9 @@ export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends Abstr
     for (const key in deltaExport.disks) {
       const disk = deltaExport.disks[key]
       isVhdDifferencing[key] = disk.isDifferencing()
+      if (!isFull && !isVhdDifferencing[key] && key !== exportedVm.$suspend_VDI?.$ref) {
+        Task.warning('Backup fell back to a full')
+      }
       deltaExport.disks[key] = new SynchronizedDisk(disk)
       useNbd = useNbd || disk.useNbd()
     }

--- a/@xen-orchestra/xapi/disks/Xapi.mjs
+++ b/@xen-orchestra/xapi/disks/Xapi.mjs
@@ -6,15 +6,15 @@
  */
 
 import { DiskLargerBlock, DiskPassthrough, ReadAhead } from '@xen-orchestra/disk-transform'
+import { createLogger } from '@xen-orchestra/log'
 import { XapiVhdCbtSource } from './XapiVhdCbt.mjs'
 import { XapiStreamNbdSource } from './XapiStreamNbd.mjs'
 import { XapiVhdStreamSource } from './XapiVhdStreamSource.mjs'
-import { createLogger } from '@xen-orchestra/log'
 import { XapiProgressHandler } from './XapiProgress.mjs'
 import { XapiQcow2StreamSource } from './XapiQcow2StreamSource.mjs'
 
 // @todo how to type this ?
-const { info, warn } = createLogger('@xen-orchestra/xapi/disks/Xapi')
+const { info, warn } = createLogger('xo:xapi:xapi-disks')
 
 export const VHD_MAX_SIZE = 2 * 1024 * 1024 * 1024 * 1024 /* 2TB */ - 8 * 1024 /* metadata */
 
@@ -166,7 +166,7 @@ export class XapiDiskSource extends DiskPassthrough {
       readAhead.progressHandler = new XapiProgressHandler(xapi, `Exporting content of VDI ${label} through NBD+CBT`)
       return readAhead
     } catch (error) {
-      info('openNbdCBT', error)
+      info('Error in openNbdCBT', error)
       await source.close()
       // A lot of things can go wrong with CBT:
       // Not enabled on the baseRef,

--- a/@xen-orchestra/xapi/disks/XapiStreamNbd.mjs
+++ b/@xen-orchestra/xapi/disks/XapiStreamNbd.mjs
@@ -7,10 +7,11 @@
  */
 
 import { DiskPassthrough } from '@xen-orchestra/disk-transform'
-import { connectNbdClientIfPossible } from './utils.mjs'
 import { createLogger } from '@xen-orchestra/log'
+import { connectNbdClientIfPossible } from './utils.mjs'
 
-const { warn } = createLogger('@xen-orchestra/xapi/disks/XapiStreamNbd')
+const { warn } = createLogger('xo:xapi:XapiStreamNbd')
+
 export class XapiStreamNbdSource extends DiskPassthrough {
   /** @type {MultiNbdClient|undefined} */
   #nbdClient

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [XO6/New VM] Display only ISO VDIs for the ISO input (PR [#8922](https://github.com/vatesfr/xen-orchestra/pull/8922))
+- [Backups] Display a warning in backup logs when delta replication falls back to a full replication (PR [#8926](https://github.com/vatesfr/xen-orchestra/pull/8926))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,8 +36,10 @@
 <!--packages-start-->
 
 - @vates/types minor
+- @xen-orchestra/backups patch
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web patch
+- @xen-orchestra/xapi patch
 - xo-web patch
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

Backup replication jobs falling back to a full backup were not notified in the backup log, only with a `logger.warn()`. This should now appear in the backup logs:

<img width="588" height="578" alt="image" src="https://github.com/user-attachments/assets/28f9a29b-3272-4876-96b0-990d1e298ecd" />

This PR also sets a better namespace for some loggers

[XO-1340](https://project.vates.tech/vates-global/browse/XO-1430/)

Fixes https://help.vates.tech/#ticket/zoom/43464

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
