### PR TITLE
fix(web): unable to change tab in tasks quick panel

### DIFF
--- a/@xen-orchestra/web-core/lib/components/backdrop/VtsBackdrop.vue
+++ b/@xen-orchestra/web-core/lib/components/backdrop/VtsBackdrop.vue
@@ -1,6 +1,14 @@
 <template>
-  <div class="vts-backdrop" />
+  <div class="vts-backdrop">
+    <slot />
+  </div>
 </template>
+
+<script lang="ts" setup>
+defineSlots<{
+  default?(): any
+}>()
+</script>
 
 <style lang="postcss" scoped>
 .vts-backdrop {

--- a/@xen-orchestra/web-core/lib/components/task/VtsQuickTaskButton.vue
+++ b/@xen-orchestra/web-core/lib/components/task/VtsQuickTaskButton.vue
@@ -9,8 +9,9 @@
     @click="isPanelOpen = true"
   />
   <Teleport v-if="isPanelOpen" to="body">
-    <VtsBackdrop @click="isPanelOpen = false" />
-    <UiQuickTaskPanel ref="panelRef" :loading :tasks />
+    <VtsBackdrop @click.self="isPanelOpen = false">
+      <UiQuickTaskPanel ref="panelRef" :loading :tasks />
+    </VtsBackdrop>
   </Teleport>
 </template>
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,9 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- **XO 6**:
+  - Fix the impossibility to change tab in the tasks quick panel (PR [#8930](https://github.com/vatesfr/xen-orchestra/pull/8930))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -30,5 +33,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- @xen-orchestra/web patch
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

This PR fixes the issue that prevented navigation between tabs in the tasks quick panel.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
