### PR TITLE
feat(xo-server):  Make timeout for import xva from url configurable

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,7 @@
 
 - [REST API] Expose `/rest/v0/proxies` and `/rest/v0/proxies/<proxy-id>` (PR [#8920](https://github.com/vatesfr/xen-orchestra/pull/8920))
 - [V2V] Add task to track library installation progress and error (PR [#8927](https://github.com/vatesfr/xen-orchestra/pull/8927))
+- [Import] Make timeout for import xva from url configurable (PR [#8931](https://github.com/vatesfr/xen-orchestra/pull/8931))
 
 ### Bug fixes
 

--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -233,3 +233,7 @@ xoaUpgradeTimeout = '5 min'
 [rest-api]
 dashboardCacheTimeout = '1 min'
 dashboardCacheExpiresIn = '1 min'
+
+
+[jsonrpc-api]
+xvaImportFromUrlTimeout = '6s'

--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -1358,8 +1358,8 @@ async function import_({ data, sr, type = 'xva', url }) {
     if (type !== 'xva') {
       throw invalidParameters('URL import is only compatible with XVA')
     }
-
-    const ref = await xapi.VM_import(await hrp(url), sr._xapiRef)
+    const timeout = this.config.get('jsonrpc-api').xvaImportFromUrlTimeout ?? 6e3
+    const ref = await xapi.VM_import(await hrp(url, { timeout }), sr._xapiRef)
     return xapi.call('VM.get_uuid', ref)
   }
 

--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -1353,12 +1353,11 @@ async function import_({ data, sr, type = 'xva', url }) {
 
   const xapi = this.getXapi(sr)
   const srId = sr._xapiId
-
   if (url !== undefined) {
     if (type !== 'xva') {
       throw invalidParameters('URL import is only compatible with XVA')
     }
-    const timeout = this.config.get('jsonrpc-api').xvaImportFromUrlTimeout ?? 6e3
+    const timeout = this.config.getOptionalDuration('jsonrpc-api.xvaImportFromUrlTimeout') ?? 6e3
     const ref = await xapi.VM_import(await hrp(url, { timeout }), sr._xapiRef)
     return xapi.call('VM.get_uuid', ref)
   }

--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -1353,10 +1353,12 @@ async function import_({ data, sr, type = 'xva', url }) {
 
   const xapi = this.getXapi(sr)
   const srId = sr._xapiId
+
   if (url !== undefined) {
     if (type !== 'xva') {
       throw invalidParameters('URL import is only compatible with XVA')
     }
+
     const timeout = this.config.getOptionalDuration('jsonrpc-api.xvaImportFromUrlTimeout') ?? 6e3
     const ref = await xapi.VM_import(await hrp(url, { timeout }), sr._xapiRef)
     return xapi.call('VM.get_uuid', ref)

--- a/packages/xo-server/src/xo-mixins/vmware/index.mjs
+++ b/packages/xo-server/src/xo-mixins/vmware/index.mjs
@@ -31,6 +31,7 @@ export default class MigrateVm {
     const { vmId, snapshots } = metadata
     const candidates = Object.values(xapi.objects.indexes.type.VM).filter(
       object =>
+        object.$type === 'VM' &&
         object.is_a_snapshot === false &&
         object.other_config.sourceVmId === vmId &&
         object.other_config.sourceSnapshotId === snapshots?.current &&
@@ -43,11 +44,11 @@ export default class MigrateVm {
     }
     if (candidates.length > 1) {
       Task.warning(`More than one candidate found, fall back to full import to ensure data security`)
-      return
     }
-    // exactly one VM found
-    Task.info(`Found VM, resuming transfer.`)
-    return candidates[0]
+    if (candidates.length === 1) {
+      Task.info(`Found VM, resuming transfer.`)
+      return candidates[0]
+    }
   }
 
   async #updateVmMetadata(xapiVm, metadata) {

--- a/packages/xo-server/src/xo-mixins/vmware/index.mjs
+++ b/packages/xo-server/src/xo-mixins/vmware/index.mjs
@@ -31,7 +31,6 @@ export default class MigrateVm {
     const { vmId, snapshots } = metadata
     const candidates = Object.values(xapi.objects.indexes.type.VM).filter(
       object =>
-        object.$type === 'VM' &&
         object.is_a_snapshot === false &&
         object.other_config.sourceVmId === vmId &&
         object.other_config.sourceSnapshotId === snapshots?.current &&
@@ -44,11 +43,11 @@ export default class MigrateVm {
     }
     if (candidates.length > 1) {
       Task.warning(`More than one candidate found, fall back to full import to ensure data security`)
+      return
     }
-    if (candidates.length === 1) {
-      Task.info(`Found VM, resuming transfer.`)
-      return candidates[0]
-    }
+    // exactly one VM found
+    Task.info(`Found VM, resuming transfer.`)
+    return candidates[0]
   }
 
   async #updateVmMetadata(xapiVm, metadata) {


### PR DESCRIPTION
the entry in the config file is

[jsonrpc-api]
xvaImportFromUrlTimeout = '6s'

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
