### PR TITLE
fix(xo-web): resource without volumes should be shown (diskless/tiebreaker)

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -47,7 +47,7 @@
 - [New VM] Add a new variable in custom cloud config to easily add SSH keys (PR [#8968](https://github.com/vatesfr/xen-orchestra/pull/8968))
 - [REST API] Expose `/rest/v0/backup-jobs` and `/rest/v0/backup-jobs/<backup-job-id>` (PR [#8970](https://github.com/vatesfr/xen-orchestra/pull/8970))
 - [Host/PIFs] Use a natural sort when sorting by device (eth9 < eth10) (PR [#8967](https://github.com/vatesfr/xen-orchestra/pull/8967))
-- [Xostor] Show resource without volumes in xostor View (PR [#8944](https://github.com/vatesfr/xen-orchestra/pull/8944))
+- [XOSTOR] Show resource without volumes in XOSTOR view (PR [#8944](https://github.com/vatesfr/xen-orchestra/pull/8944))
 
 - **XO 6:**
   - [VM/dashboard] Update QuickInfo card in dashboard to show more information (PR [#8952](https://github.com/vatesfr/xen-orchestra/pull/8952))

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -47,6 +47,7 @@
 - [New VM] Add a new variable in custom cloud config to easily add SSH keys (PR [#8968](https://github.com/vatesfr/xen-orchestra/pull/8968))
 - [REST API] Expose `/rest/v0/backup-jobs` and `/rest/v0/backup-jobs/<backup-job-id>` (PR [#8970](https://github.com/vatesfr/xen-orchestra/pull/8970))
 - [Host/PIFs] Use a natural sort when sorting by device (eth9 < eth10) (PR [#8967](https://github.com/vatesfr/xen-orchestra/pull/8967))
+- [Xostor] Show resource without volumes in xostor View (PR [#8944](https://github.com/vatesfr/xen-orchestra/pull/8944))
 
 - **XO 6:**
   - [VM/dashboard] Update QuickInfo card in dashboard to show more information (PR [#8952](https://github.com/vatesfr/xen-orchestra/pull/8952))

--- a/packages/xo-web/src/xo-app/sr/tab-xostor.js
+++ b/packages/xo-web/src/xo-app/sr/tab-xostor.js
@@ -55,8 +55,8 @@ const RESOURCE_COLUMNS = [
   },
   {
     name: _('diskState'),
-    itemRenderer: ({ volume }) => volume['disk-state'],
-    sortCriteria: ({ volume }) => volume['disk-state'],
+    itemRenderer: ({ volume }) => volume?.['disk-state'],
+    sortCriteria: ({ volume }) => volume?.['disk-state'],
   },
 ]
 
@@ -172,23 +172,21 @@ export default class TabXostor extends Component {
       return resourceNames.flatMap(resourceName =>
         Object.entries(healthCheck.resources[resourceName].nodes).reduce((acc, [hostname, nodeInfo]) => {
           const volume = nodeInfo.volumes[0] // Max only one volume
-          if (volume !== undefined) {
-            const nodeStatus = healthCheck.nodes[hostname]
-            const host = this.props.hostByHostname[hostname][0]
+          const nodeStatus = healthCheck.nodes[hostname]
+          const host = this.props.hostByHostname[hostname][0]
 
-            const resourceState = _(
-              `${nodeInfo['tie-breaker'] ? 'tieBreaker' : nodeInfo.diskful ? 'diskful' : 'diskless'}`
-            )
-            acc.push({
-              inUse: nodeInfo['in-use'],
-              vdiId: healthCheck.resources[resourceName].uuid,
-              volume,
-              nodeStatus,
-              host,
-              resourceName,
-              resourceState,
-            })
-          }
+          const resourceState = _(
+            `${nodeInfo['tie-breaker'] ? 'tieBreaker' : nodeInfo.diskful ? 'diskful' : 'diskless'}`
+          )
+          acc.push({
+            inUse: nodeInfo['in-use'],
+            vdiId: healthCheck.resources[resourceName].uuid,
+            volume,
+            nodeStatus,
+            host,
+            resourceName,
+            resourceState,
+          })
           return acc
         }, [])
       )

--- a/packages/xo-web/src/xo-app/sr/tab-xostor.js
+++ b/packages/xo-web/src/xo-app/sr/tab-xostor.js
@@ -31,8 +31,8 @@ const RESOURCE_COLUMNS = [
   },
   {
     name: _('node'),
-    itemRenderer: ({ host }) => <Host id={host.id} link />,
-    sortCriteria: ({ host }) => host.name_label,
+    itemRenderer: ({ host }) => host && <Host id={host.id} link />,
+    sortCriteria: ({ host }) => (host ? host.name_label : ''),
   },
   {
     name: _('nodeStatus'),

--- a/packages/xo-web/src/xo-app/sr/tab-xostor.js
+++ b/packages/xo-web/src/xo-app/sr/tab-xostor.js
@@ -173,7 +173,7 @@ export default class TabXostor extends Component {
         Object.entries(healthCheck.resources[resourceName].nodes).reduce((acc, [hostname, nodeInfo]) => {
           const volume = nodeInfo.volumes[0] // Max only one volume
           const nodeStatus = healthCheck.nodes[hostname]
-          const host = this.props.hostByHostname[hostname][0]
+          const host = this.props.hostByHostname[hostname]?.[0]
 
           const resourceState = _(
             `${nodeInfo['tie-breaker'] ? 'tieBreaker' : nodeInfo.diskful ? 'diskful' : 'diskless'}`


### PR DESCRIPTION
### Description

some tie breaker and diskless volume can be useful for support and advanced usages 
<img width="1581" height="980" alt="image" src="https://github.com/user-attachments/assets/0ec3a13f-df11-46f8-a05d-ac94d8fd2d67" />


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
