### PR TITLE
feat(xo-web): add copiable id link on templates

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - [REST API] Expose `/rest/v0/proxies` and `/rest/v0/proxies/<proxy-id>` (PR [#8920](https://github.com/vatesfr/xen-orchestra/pull/8920))
-- [XO5/Templates] Show template id when expanded the templates list
+- [XO5/Templates] Show template id when expanded the templates list (PR [#8949](https://github.com/vatesfr/xen-orchestra/pull/8949))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - [REST API] Expose `/rest/v0/proxies` and `/rest/v0/proxies/<proxy-id>` (PR [#8920](https://github.com/vatesfr/xen-orchestra/pull/8920))
+- [XO5/Templates] Show template id when expanded the templates list
 
 ### Bug fixes
 
@@ -35,5 +36,6 @@
 
 - @vates/types minor
 - @xen-orchestra/rest-api minor
+- xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-web/src/xo-app/home/template-item.js
+++ b/packages/xo-web/src/xo-app/home/template-item.js
@@ -1,6 +1,7 @@
 import _ from 'intl'
 import Component from 'base-component'
 import defined from '@xen-orchestra/defined'
+import Copiable from 'copiable'
 import Ellipsis, { EllipsisContainer } from 'ellipsis'
 import Icon from 'icon'
 import Link from 'link'
@@ -72,26 +73,31 @@ export default class TemplateItem extends Component {
           </Col>
         </SingleLineRow>
         {(this.state.expanded || expandAll) && (
-          <Row>
-            <Col mediumSize={4} className={styles.itemExpanded}>
-              <span>
-                <Number value={vm.CPUs.number} onChange={this._setCpus} />x <Icon icon='cpu' className='mr-1' />
-                <Size value={defined(vm.memory.size, null)} onChange={this._setMemory} /> <Icon icon='memory' />
-              </span>
-            </Col>
-            <Col largeSize={4} className={styles.itemExpanded}>
-              {map(vm.addresses, address => (
-                <span key={address} className='tag tag-info tag-ip'>
-                  {address}
+          <div className={styles.itemExpanded}>
+            <Row>
+              <Col mediumSize={4}>
+                <span>
+                  <Number value={vm.CPUs.number} onChange={this._setCpus} />x <Icon icon='cpu' className='mr-1' />
+                  <Size value={defined(vm.memory.size, null)} onChange={this._setMemory} /> <Icon icon='memory' />
                 </span>
-              ))}
-            </Col>
-            <Col mediumSize={4}>
-              <div style={{ fontSize: '1.4em' }}>
-                <HomeTags type='VM-template' labels={vm.tags} onDelete={this._removeTag} onAdd={this._addTag} />
-              </div>
-            </Col>
-          </Row>
+              </Col>
+              <Col largeSize={4} className={styles.itemExpanded}>
+                {map(vm.addresses, address => (
+                  <span key={address} className='tag tag-info tag-ip'>
+                    {address}
+                  </span>
+                ))}
+              </Col>
+              <Col mediumSize={4}>
+                <div style={{ fontSize: '1.4em' }}>
+                  <HomeTags type='VM-template' labels={vm.tags} onDelete={this._removeTag} onAdd={this._addTag} />
+                </div>
+              </Col>
+            </Row>
+            <Copiable tagName='pre' className='text-muted mb-0'>
+              {vm.id}
+            </Copiable>
+          </div>
         )}
       </div>
     )


### PR DESCRIPTION
templates ids are mandatory to import VM from esxi from command line

<img width="1694" height="448" alt="image" src="https://github.com/user-attachments/assets/b7887878-148b-4dea-bc21-278040d3cc01" />


### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
