### PR TITLE
fix(xo-web): avoid throwing error from confirm

### DIFF
--- a/packages/xo-web/src/common/form/toggle.js
+++ b/packages/xo-web/src/common/form/toggle.js
@@ -24,17 +24,17 @@ export default class Toggle extends Component {
     iconSize: 2,
   }
 
-  _toggle = () => {
+  _toggle = async () => {
     const { props } = this
 
     if (!props.disabled) {
-     try {
-       await props.onChange(!props.value)
-     } catch (err) {
-       if (err !== undefined) {
-         throw err
-       }
-     }
+      try {
+        await props.onChange(!props.value)
+      } catch (err) {
+        if (err !== undefined) {
+          throw err
+        }
+      }
     }
   }
 

--- a/packages/xo-web/src/common/form/toggle.js
+++ b/packages/xo-web/src/common/form/toggle.js
@@ -28,13 +28,13 @@ export default class Toggle extends Component {
     const { props } = this
 
     if (!props.disabled) {
-      // turning props.onChange into a promise to cover both sync and async onChange functions
-      Promise.resolve(props.onChange(!props.value)).catch(error => {
-        // ignore when undefined because it usually means that the action has been canceled
-        if (error !== undefined) {
-          throw error
-        }
-      })
+     try {
+       await props.onChange(!props.value)
+     } catch (err) {
+       if (err !== undefined) {
+         throw err
+       }
+     }
     }
   }
 

--- a/packages/xo-web/src/common/form/toggle.js
+++ b/packages/xo-web/src/common/form/toggle.js
@@ -28,7 +28,13 @@ export default class Toggle extends Component {
     const { props } = this
 
     if (!props.disabled) {
-      props.onChange(!props.value)
+      // turning props.onChange into a promise to cover both sync and async onChange functions
+      Promise.resolve(props.onChange(!props.value)).catch(error => {
+        // ignore when undefined because it usually means that the action has been canceled
+        if (error !== undefined) {
+          throw error
+        }
+      })
     }
   }
 

--- a/packages/xo-web/src/xo-app/pool/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/pool/tab-advanced.js
@@ -245,20 +245,11 @@ class ToggleHa extends Component {
 
   _onChange = async value => {
     if (value) {
-      let haSrs
-      try {
-        haSrs = await confirm({
-          body: <EnableHaModal srs={this.props.pool.haSrs ?? []} pool={this.props.pool} />,
-          title: _('poolEnableHa'),
-          icon: 'pool',
-        })
-      } catch (err) {
-        // don't throw for confirm cancel
-        if (typeof err === 'undefined') {
-          return
-        }
-        throw err
-      }
+      const haSrs = await confirm({
+        body: <EnableHaModal srs={this.props.pool.haSrs ?? []} pool={this.props.pool} />,
+        title: _('poolEnableHa'),
+        icon: 'pool',
+      })
 
       try {
         this.setState({ busy: true })
@@ -271,15 +262,10 @@ class ToggleHa extends Component {
         this.setState({ busy: false })
       }
     } else {
-      try {
-        await confirm({
-          title: _('poolDisableHa'),
-          body: _('poolDisableHaConfirm'),
-        })
-      } catch (err) {
-        // don't throw for confirm cancel
-        return
-      }
+      await confirm({
+        title: _('poolDisableHa'),
+        body: _('poolDisableHaConfirm'),
+      })
       try {
         this.setState({ busy: true })
         await disableHa(this.props.pool)

--- a/packages/xo-web/src/xo-app/pool/tab-advanced.js
+++ b/packages/xo-web/src/xo-app/pool/tab-advanced.js
@@ -245,11 +245,20 @@ class ToggleHa extends Component {
 
   _onChange = async value => {
     if (value) {
-      const haSrs = await confirm({
-        body: <EnableHaModal srs={this.props.pool.haSrs ?? []} pool={this.props.pool} />,
-        title: _('poolEnableHa'),
-        icon: 'pool',
-      })
+      let haSrs
+      try {
+        haSrs = await confirm({
+          body: <EnableHaModal srs={this.props.pool.haSrs ?? []} pool={this.props.pool} />,
+          title: _('poolEnableHa'),
+          icon: 'pool',
+        })
+      } catch (err) {
+        // don't throw for confirm cancel
+        if (typeof err === 'undefined') {
+          return
+        }
+        throw err
+      }
 
       try {
         this.setState({ busy: true })
@@ -262,10 +271,15 @@ class ToggleHa extends Component {
         this.setState({ busy: false })
       }
     } else {
-      await confirm({
-        title: _('poolDisableHa'),
-        body: _('poolDisableHaConfirm'),
-      })
+      try {
+        await confirm({
+          title: _('poolDisableHa'),
+          body: _('poolDisableHaConfirm'),
+        })
+      } catch (err) {
+        // don't throw for confirm cancel
+        return
+      }
       try {
         this.setState({ busy: true })
         await disableHa(this.props.pool)


### PR DESCRIPTION
### Description

Updating the `Toggle` component to avoid throwing an error coming from a `confirm` modal, which ends up appearing in the console.

This also changes a bit the behaviour of the `Toggle` component, which now awaits its `onChange` function.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
