### PR TITLE
fix(@vates/types,@xen-orchestra/rest-api): fix eslint config

### DIFF
--- a/@vates/types/eslint.config.mjs
+++ b/@vates/types/eslint.config.mjs
@@ -2,8 +2,17 @@
 
 import eslint from '@eslint/js'
 import tseslint from 'typescript-eslint'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default tseslint.config(eslint.configs.recommended, tseslint.configs.recommended, {
+  languageOptions: {
+    parserOptions: {
+      tsconfigRootDir: __dirname,
+    },
+  },
   ignores: ['dist'],
   rules: {
     // Allow empty interface for recursive generic typing (E.g. interface XenApiNetworkWrapped)

--- a/@xen-orchestra/rest-api/eslint.config.mjs
+++ b/@xen-orchestra/rest-api/eslint.config.mjs
@@ -2,8 +2,17 @@
 
 import eslint from '@eslint/js'
 import tseslint from 'typescript-eslint'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default tseslint.config(eslint.configs.recommended, tseslint.configs.recommended, {
+  languageOptions: {
+    parserOptions: {
+      tsconfigRootDir: __dirname,
+    },
+  },
   rules: {
     'no-unused-vars': ['off'], // In order to define the OpenAPI specification, we sometimes need to declare variables that will not be used.
   },


### PR DESCRIPTION
### Description

Fix eslint error 
```
Parsing error: No tsconfigRootDir was set, and multiple candidate TSConfigRootDirs are present:
 - /home/debian/xen-orchestra/@vates/types
 - /home/debian/xen-orchestra/@xen-orchestra/rest-api
You'll need to explicitly set tsconfigRootDir in your parser options.
See: https://typescript-eslint.io/packages/parser/#tsconfigrootdireslint
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
