### PR TITLE
fix(xo-server/resource-sets): only edit limits if `limits` is passed

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -49,7 +49,7 @@
 - [Home/Pool] Fix "an error has occurred" for non-admin users (PR [#8946](https://github.com/vatesfr/xen-orchestra/pull/8946))
 - [Backup] Fix VDI_NOT_MANAGED error during incremental replication (PR [#8935](https://github.com/vatesfr/xen-orchestra/pull/8935))
 - [Backup] Fix replication delta always falling back to full [Forum#11261](https://xcp-ng.org/forum/topic/11261/continuous-replication-jobs-creates-full-backups-every-time-since-2025-09-06-xo-from-source) (PR [#8971](https://github.com/vatesfr/xen-orchestra/pull/8971))
-- [API] Fix resource set limits being deleted when calling `resourceSet.set` on the API
+- [API] Fix resource set limits being deleted when calling `resourceSet.set` on the API (PR [#8979](https://github.com/vatesfr/xen-orchestra/pull/8979))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -49,6 +49,7 @@
 - [Home/Pool] Fix "an error has occurred" for non-admin users (PR [#8946](https://github.com/vatesfr/xen-orchestra/pull/8946))
 - [Backup] Fix VDI_NOT_MANAGED error during incremental replication (PR [#8935](https://github.com/vatesfr/xen-orchestra/pull/8935))
 - [Backup] Fix replication delta always falling back to full [Forum#11261](https://xcp-ng.org/forum/topic/11261/continuous-replication-jobs-creates-full-backups-every-time-since-2025-09-06-xo-from-source) (PR [#8971](https://github.com/vatesfr/xen-orchestra/pull/8971))
+- [API] Fix resource set limits being deleted when calling `resourceSet.set` on the API
 
 ### Packages to release
 

--- a/packages/xo-server/src/xo-mixins/resource-sets.mjs
+++ b/packages/xo-server/src/xo-mixins/resource-sets.mjs
@@ -217,32 +217,32 @@ export default class {
     if (objects) {
       set.objects = objects
     }
-
-    const previousLimits = set.limits
-    const newLimits = {}
-    forEach(limits, (quantity, id) => {
-      const previous = previousLimits[id]
-      if (previous !== undefined) {
-        newLimits[id] = {
-          total: quantity,
-          usage: previous.usage,
+    if (limits !== undefined) {
+      const previousLimits = set.limits
+      const newLimits = {}
+      forEach(limits, (quantity, id) => {
+        const previous = previousLimits[id]
+        if (previous !== undefined) {
+          newLimits[id] = {
+            total: quantity,
+            usage: previous.usage,
+          }
+        } else {
+          newLimits[id] = {
+            total: quantity,
+            usage: 0,
+          }
         }
-      } else {
+      })
+
+      const removedLimits = Object.keys(previousLimits).filter(key => !(key in newLimits))
+      removedLimits.forEach(id => {
         newLimits[id] = {
-          total: quantity,
-          usage: 0,
+          usage: previousLimits[id].usage ?? 0,
         }
-      }
-    })
-
-    const removedLimits = Object.keys(previousLimits).filter(key => !(key in newLimits))
-    removedLimits.forEach(id => {
-      newLimits[id] = {
-        usage: previousLimits[id].usage ?? 0,
-      }
-    })
-    set.limits = newLimits
-
+      })
+      set.limits = newLimits
+    }
     if (ipPools) {
       set.ipPools = ipPools
     }


### PR DESCRIPTION
See https://xcp-ng.org/forum/topic/11241/why-changing-objects-in-resource-set-wipe-limits
Introduced by #7353

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
