### PR TITLE
fix(xo-web/getLicenseNearExpiration): properly check if trial is running

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
 - **Migrated REST API endpoints**:
+
   - `DELETE /rest/v0/tasks` (PR [#8905](https://github.com/vatesfr/xen-orchestra/pull/8905))
   - `DELETE /rest/v0/tasks/<task-id>` (PR [#8905](https://github.com/vatesfr/xen-orchestra/pull/8905))
   - `DELETE /rest/v0/vms/<vm-id>` (PR [#8938](https://github.com/vatesfr/xen-orchestra/pull/8938))
@@ -60,7 +61,7 @@
 - [Backup] Fix VDI_NOT_MANAGED error during incremental replication (PR [#8935](https://github.com/vatesfr/xen-orchestra/pull/8935))
 - [Backup] Fix replication delta always falling back to full [Forum#11261](https://xcp-ng.org/forum/topic/11261/continuous-replication-jobs-creates-full-backups-every-time-since-2025-09-06-xo-from-source) (PR [#8971](https://github.com/vatesfr/xen-orchestra/pull/8971))
 - [API] Fix resource set limits being deleted when calling `resourceSet.set` on the API (PR [#8979](https://github.com/vatesfr/xen-orchestra/pull/8979))
-- [XOA] Fix XOA UI showing expired license error during trial
+- [XOA] Fix XOA UI showing expired license error during trial (PR [#8991](https://github.com/vatesfr/xen-orchestra/pull/8991))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -60,6 +60,7 @@
 - [Backup] Fix VDI_NOT_MANAGED error during incremental replication (PR [#8935](https://github.com/vatesfr/xen-orchestra/pull/8935))
 - [Backup] Fix replication delta always falling back to full [Forum#11261](https://xcp-ng.org/forum/topic/11261/continuous-replication-jobs-creates-full-backups-every-time-since-2025-09-06-xo-from-source) (PR [#8971](https://github.com/vatesfr/xen-orchestra/pull/8971))
 - [API] Fix resource set limits being deleted when calling `resourceSet.set` on the API (PR [#8979](https://github.com/vatesfr/xen-orchestra/pull/8979))
+- [XOA] Fix XOA UI showing expired license error during trial
 
 ### Packages to release
 

--- a/packages/xo-web/src/common/xoa-updater.js
+++ b/packages/xo-web/src/common/xoa-updater.js
@@ -36,7 +36,7 @@ export function blockXoaAccess(xoaState) {
   return block
 }
 
-export function getLicenseNearExpiration(licenses, trial) {
+export function getLicenseNearExpiration(licenses, trialState) {
   const plan = getXoaPlan()
   // user does not have a licence for free or source version
   // also don't crash the app if the licence is in unexpected state
@@ -44,7 +44,7 @@ export function getLicenseNearExpiration(licenses, trial) {
     return
   }
   // user under trial are not expected to have licences
-  if (isTrialRunning(trial)) {
+  if (isTrialRunning(trialState.trial)) {
     return
   }
   // got a unlimited license bound to this XO nothing can expires

--- a/packages/xo-web/src/xo-app/index.js
+++ b/packages/xo-web/src/xo-app/index.js
@@ -155,7 +155,7 @@ export const ICON_POOL_LICENSE = {
     vm => vm.vulnerabilities?.xsa468?.reason === 'pv-driver-version-vulnerable' && !vm.tags.includes('HIDE_XSA468'),
   ])
   return {
-    trial: state.xoaTrialState,
+    trialState: state.xoaTrialState,
     registerNeeded: state.xoaUpdaterState === 'registerNeeded',
     signedUp: !!state.user,
     hosts: getHosts(state),
@@ -449,13 +449,13 @@ export default class XoApp extends Component {
   }
 
   render() {
-    const { signedUp, trial, registerNeeded, xsa468VulnerableVms } = this.props
+    const { signedUp, trialState, registerNeeded, xsa468VulnerableVms } = this.props
     const { pathname } = this.context.router.location
-    const licenseNearExpiration = this.props.selfLicences && getLicenseNearExpiration(this.props.selfLicences, trial)
+    const licenseNearExpiration = this.props.selfLicences && getLicenseNearExpiration(this.props.selfLicences, trialState)
     // If we are under expired or unstable trial (signed up only)
     const blocked =
       signedUp &&
-      (blockXoaAccess(trial) || licenseNearExpiration?.blocked === true) &&
+      (blockXoaAccess(trialState) || licenseNearExpiration?.blocked === true) &&
       !(pathname.startsWith('/xoa/') || pathname === '/backup/restore')
     const plan = getXoaPlan()
 
@@ -494,11 +494,11 @@ export default class XoApp extends Component {
                   </button>
                 </div>
               )}
-              {isTrialRunning(trial.trial) && !this.state.dismissedTrialBanner && (
+              {isTrialRunning(trialState.trial) && !this.state.dismissedTrialBanner && (
                 <div className='alert alert-info mb-0'>
                   {_('trialLicenseInfo', {
-                    edition: getXoaPlan(productId2Plan[trial.trial.productId]),
-                    date: new Date(trial.trial.end),
+                    edition: getXoaPlan(productId2Plan[trialState.trial.productId]),
+                    date: new Date(trialState.trial.end),
                   })}
                   <button className='close' onClick={this.dismissTrialBanner}>
                     &times;


### PR DESCRIPTION
Introduced by #8557
See Zammad#44878 Zammad#44755 Zammad#44431 Zammad#43526 Zammad#44556 ...
See #8523 → #8551 → #8557

### Description

Pass the license object to isTrialRunning instead of passing the parent object.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
