### PR TITLE
feat(xo-6/treeview): add debounce to search input

### DIFF
--- a/@xen-orchestra/web-core/lib/composables/tree-filter.composable.ts
+++ b/@xen-orchestra/web-core/lib/composables/tree-filter.composable.ts
@@ -1,12 +1,14 @@
 import type { TreeNodeBase } from '@core/composables/tree/tree-node-base'
+import { refDebounced } from '@vueuse/shared'
 import { computed, ref } from 'vue'
 
 export function useTreeFilter() {
   const filter = ref('')
-  const hasFilter = computed(() => filter.value.trim().length > 0)
+  const debouncedFilter = refDebounced(filter, 500)
+  const hasFilter = computed(() => debouncedFilter.value.trim().length > 0)
 
   const predicate = (node: TreeNodeBase) =>
-    hasFilter.value ? node.label.toLocaleLowerCase().includes(filter.value.toLocaleLowerCase()) : undefined
+    hasFilter.value ? node.label.toLocaleLowerCase().includes(debouncedFilter.value.toLocaleLowerCase()) : undefined
 
   return { filter, predicate }
 }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -60,6 +60,7 @@
   - [VM/dashboard] Update QuickInfo card in dashboard to show more information (PR [#8952](https://github.com/vatesfr/xen-orchestra/pull/8952))
   - [StateHero] Update VtsStateHero component and modify usages in every component (PR [#8910](https://github.com/vatesfr/pull/8910))
   - [VM] Add Backup Jobs page (PR [#8976](https://github.com/vatesfr/xen-orchestra/pull/8976))
+  - [Treeview] Add a debounce function to the search input to improve user experience (PR [#8892](https://github.com/vatesfr/xen-orchestra/pull/8892))
 
 ### Bug fixes
 


### PR DESCRIPTION
### Description

Add 500ms debounce when using treeview search input.

### Screenshots

[debounce](https://github.com/user-attachments/assets/4dcee695-85d0-48d4-bb9b-e6af4815fe76)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
