### PR TITLE
feat(@xen-orchestra/rest-api): migrate vm-templates tasks

### DIFF
--- a/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
@@ -28,6 +28,7 @@ import {
 } from '../open-api/oa-examples/vm-template.oa-example.mjs'
 import { VmService } from '../vms/vm.service.mjs'
 import { messageIds, partialMessages } from '../open-api/oa-examples/message.oa-example.mjs'
+import { partialTasks, taskIds } from '../open-api/oa-examples/task.oa-example.mjs'
 
 @Route('vm-templates')
 @Security('*')
@@ -189,7 +190,6 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
     return this.sendObjects(Object.values(messages), req, 'messages')
   }
 
-
   /**
    * @example id "613f541c-4bed-fc77-7ca8-2db6b68f079c"
    * @example fields "id,status,properties"
@@ -209,7 +209,7 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
     @Query() filter?: string,
     @Query() limit?: number
   ): Promise<SendObjects<Partial<Unbrand<XoTask>>>> {
-        const tasks = await this.getTasksForObject(id as XoVmTemplate['id'], { filter, limit })
+    const tasks = await this.getTasksForObject(id as XoVmTemplate['id'], { filter, limit })
 
     return this.sendObjects(Object.values(tasks), req, 'tasks')
   }

--- a/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
@@ -2,7 +2,7 @@ import { Example, Get, Security, Query, Request, Response, Route, Tags, Path, De
 import { Request as ExRequest } from 'express'
 import { inject } from 'inversify'
 import { provide } from 'inversify-binding-decorators'
-import type { XoAlarm, XoMessage, XoVdi, XoVmTemplate } from '@vates/types'
+import type { XoAlarm, XoMessage, XoVdi, XoTask, XoVmTemplate } from '@vates/types'
 import { Readable } from 'node:stream'
 
 import { AlarmService } from '../alarms/alarm.service.mjs'
@@ -26,6 +26,7 @@ import {
   vmTemplateIds,
   vmTemplateVdis,
 } from '../open-api/oa-examples/vm-template.oa-example.mjs'
+import { partialTasks, taskIds } from '../open-api/oa-examples/task.oa-example.mjs'
 import { VmService } from '../vms/vm.service.mjs'
 import { messageIds, partialMessages } from '../open-api/oa-examples/message.oa-example.mjs'
 
@@ -41,7 +42,7 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
   constructor(
     @inject(RestApi) restApi: RestApi,
     @inject(AlarmService) alarmService: AlarmService,
-    @inject(VmService) vmService: VmService
+    @inject(VmService) vmService: VmService,
   ) {
     super('VM-template', restApi)
     this.#alarmService = alarmService
@@ -187,5 +188,29 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
     const messages = this.getMessagesForObject(id as XoVmTemplate['id'], { filter, limit })
 
     return this.sendObjects(Object.values(messages), req, 'messages')
+  }
+
+  /**
+   * @example id "613f541c-4bed-fc77-7ca8-2db6b68f079c"
+   * @example fields "id,status,properties"
+   * @example filter "status:failure"
+   * @example limit 42
+   */
+  @Example(taskIds)
+  @Example(partialTasks)
+  @Get('{id}/tasks')
+  @Tags('tasks')
+  @Response(notFoundResp.status, notFoundResp.description)
+  async getVmTemplateTasks(
+    @Request() req: ExRequest,
+    @Path() id: string,
+    @Query() fields?: string,
+    @Query() ndjson?: boolean,
+    @Query() filter?: string,
+    @Query() limit?: number
+  ): Promise<SendObjects<Partial<Unbrand<XoTask>>>> {
+    const tasks = await this.getTasksForObject(id as XoVmTemplate['id'], { filter, limit })
+
+    return this.sendObjects(Object.values(tasks), req, 'tasks')
   }
 }

--- a/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
@@ -26,7 +26,6 @@ import {
   vmTemplateIds,
   vmTemplateVdis,
 } from '../open-api/oa-examples/vm-template.oa-example.mjs'
-import { partialTasks, taskIds } from '../open-api/oa-examples/task.oa-example.mjs'
 import { VmService } from '../vms/vm.service.mjs'
 import { messageIds, partialMessages } from '../open-api/oa-examples/message.oa-example.mjs'
 
@@ -42,7 +41,7 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
   constructor(
     @inject(RestApi) restApi: RestApi,
     @inject(AlarmService) alarmService: AlarmService,
-    @inject(VmService) vmService: VmService,
+    @inject(VmService) vmService: VmService
   ) {
     super('VM-template', restApi)
     this.#alarmService = alarmService
@@ -190,6 +189,7 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
     return this.sendObjects(Object.values(messages), req, 'messages')
   }
 
+
   /**
    * @example id "613f541c-4bed-fc77-7ca8-2db6b68f079c"
    * @example fields "id,status,properties"
@@ -209,7 +209,7 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
     @Query() filter?: string,
     @Query() limit?: number
   ): Promise<SendObjects<Partial<Unbrand<XoTask>>>> {
-    const tasks = await this.getTasksForObject(id as XoVmTemplate['id'], { filter, limit })
+        const tasks = await this.getTasksForObject(id as XoVmTemplate['id'], { filter, limit })
 
     return this.sendObjects(Object.values(tasks), req, 'tasks')
   }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
   - `GET /rest/v0/vdi-snapshots/<vdi-snapshot-id>/messages` (PR [#9043](https://github.com/vatesfr/xen-orchestra/pull/9043))
   - `GET /rest/v0/vdis/<vdi-id>/messages` (PR [#9044](https://github.com/vatesfr/xen-orchestra/pull/9044))
   - `GET /rest/v0/vifs/<vif-id>/messages` (PR [#9049](https://github.com/vatesfr/xen-orchestra/pull/9049))
+  - `GET /rest/v0/vm-templates/<vm-template-id>/tasks` (PR[#9004](https://github.com/vatesfr/xen-orchestra/pull/9004))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@
   - `GET /rest/v0/vdi-snapshots/<vdi-snapshot-id>/messages` (PR [#9043](https://github.com/vatesfr/xen-orchestra/pull/9043))
   - `GET /rest/v0/vdis/<vdi-id>/messages` (PR [#9044](https://github.com/vatesfr/xen-orchestra/pull/9044))
   - `GET /rest/v0/vifs/<vif-id>/messages` (PR [#9049](https://github.com/vatesfr/xen-orchestra/pull/9049))
-  - `GET /rest/v0/vm-templates/<vm-template-id>/tasks` (PR[#9004](https://github.com/vatesfr/xen-orchestra/pull/9004))
+  - `GET /rest/v0/vm-templates/<vm-template-id>/tasks` (PR [#9004](https://github.com/vatesfr/xen-orchestra/pull/9004))
 
 ### Bug fixes
 


### PR DESCRIPTION
### Description

<img width="1248" height="895" alt="Capture d’écran du 2025-09-24 09-54-10" src="https://github.com/user-attachments/assets/3565bb4e-556c-4360-babd-6357ef94a77b" />

[XO-1175](https://project.vates.tech/vates-global/browse/XO-1175/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
