### PR TITLE
fix(V2V): don't block the startup of stopped VM

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
   - `GET /rest/v0/vm-templates/<vm-template-id>/messages` (PR [#8995](https://github.com/vatesfr/xen-orchestra/pull/8995))
 
 - **XO 6:**
+
   - [i18n] Update some wordings in French translation (contribution by [@Luxinenglish](https://github.com/Luxinenglish)) (PR [#8983](https://github.com/vatesfr/xen-orchestra/pull/8983))
   - [i18n] Update Czech, Spanish, Italian, Dutch, Portuguese (Brazil), Russian and Ukrainian translations (PR [#8901](https://github.com/vatesfr/xen-orchestra/pull/8901))
   - [Site/Backups] Add side panel to backup jobs view (PR [#8966](https://github.com/vatesfr/xen-orchestra/pull/8966))
@@ -30,6 +31,7 @@
 - **XO 6:**
   - [VM/New] Fix `auto_poweron is an excess property and therefore is not allowed` during VM creation (PR [#8998](https://github.com/vatesfr/xen-orchestra/pull/8998))
   - [sdn-controller] Remove port for ICMP filtering (PR [#8488](https://github.com/vatesfr/xen-orchestra/pull/8488))
+  - [V2V] Don't block startup of stopped VM (PR [#9017](https://github.com/vatesfr/xen-orchestra/pull/9017))
 
 ### Packages to release
 

--- a/packages/xo-server/src/xo-mixins/vmware/index.mjs
+++ b/packages/xo-server/src/xo-mixins/vmware/index.mjs
@@ -201,7 +201,11 @@ export default class MigrateVm {
       await vm.set_name_label(metadata.name_label)
 
       // remove lock on start if the VM has been completly imported
-      stopSource && (await asyncMapSettled(['start', 'start_on'], op => vm.update_blocked_operations(op, null)))
+      // a running VM without stopsource will still have the data since the last snapshot
+      const isRunning = metadata.powerState !== 'poweredOff'
+      if (!isRunning || stopSource) {
+        await asyncMapSettled(['start', 'start_on'], op => vm.update_blocked_operations(op, null))
+      }
     })
 
     return vm.uuid


### PR DESCRIPTION
If the VM is stopped on vmware side before starting the migration
and the migration is successfull, then we are sure all the data
have been transfered, thus it's unnecessary to lock the VM start
and there won't be any next step (resume) of the transfer

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
