### PR TITLE
feat(@xen-orchestra/rest-api): expose pools/:id/messages

### DIFF
--- a/@xen-orchestra/rest-api/src/abstract-classes/xapi-xo-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/xapi-xo-controller.mts
@@ -1,7 +1,9 @@
-import type { XapiXoRecord } from '@vates/types/xo'
+import type { XapiXoRecord, XoMessage } from '@vates/types/xo'
 
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { BaseController } from './base-controller.mjs'
+import { escapeUnsafeComplexMatcher } from '../helpers/utils.helper.mjs'
+import { RAW_ALARM_FILTER } from '../alarms/alarm.service.mjs'
 
 export abstract class XapiXoController<T extends XapiXoRecord> extends BaseController<T, true> {
   #type: T['type']
@@ -21,5 +23,18 @@ export abstract class XapiXoController<T extends XapiXoRecord> extends BaseContr
 
   getXapiObject(maybeId: T['id'] | T) {
     return this.restApi.getXapiObject<T>(maybeId, this.#type)
+  }
+
+  getMessagesForObject(
+    id: T['id'],
+    { filter, limit }: { filter?: string; limit?: number } = {}
+  ): Record<XoMessage['id'], XoMessage> {
+    const object = this.getObject(id)
+    const messages = this.restApi.getObjectsByType<XoMessage>('message', {
+      filter: `${escapeUnsafeComplexMatcher(filter) ?? ''} $object:${object.uuid} !${RAW_ALARM_FILTER}`,
+      limit,
+    })
+
+    return messages
   }
 }

--- a/@xen-orchestra/rest-api/src/hosts/host.controller.mts
+++ b/@xen-orchestra/rest-api/src/hosts/host.controller.mts
@@ -13,7 +13,7 @@ import type {
   XsPatches,
 } from '@vates/types'
 
-import { AlarmService, RAW_ALARM_FILTER } from '../alarms/alarm.service.mjs'
+import { AlarmService } from '../alarms/alarm.service.mjs'
 import { escapeUnsafeComplexMatcher } from '../helpers/utils.helper.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
 import {
@@ -226,11 +226,7 @@ export class HostController extends XapiXoController<XoHost> {
     @Query() filter?: string,
     @Query() limit?: number
   ): SendObjects<Partial<Unbrand<XoMessage>>> {
-    const host = this.getObject(id as XoHost['id'])
-    const messages = this.restApi.getObjectsByType<XoMessage>('message', {
-      filter: `${escapeUnsafeComplexMatcher(filter) ?? ''} $object:${host.uuid} !${RAW_ALARM_FILTER}`,
-      limit,
-    })
+    const messages = this.getMessagesForObject(id as XoHost['id'], { filter, limit })
 
     return this.sendObjects(Object.values(messages), req, 'messages')
   }

--- a/@xen-orchestra/rest-api/src/pools/pool.controller.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.controller.mts
@@ -47,7 +47,7 @@ import type {
   XoVm,
   XsPatches,
 } from '@vates/types'
-import { AlarmService, RAW_ALARM_FILTER } from '../alarms/alarm.service.mjs'
+import { AlarmService } from '../alarms/alarm.service.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
 import {
   createVm,
@@ -429,11 +429,7 @@ export class PoolController extends XapiXoController<XoPool> {
     @Query() filter?: string,
     @Query() limit?: number
   ): SendObjects<Partial<Unbrand<XoMessage>>> {
-    const pool = this.getObject(id as XoPool['id'])
-    const messages = this.restApi.getObjectsByType<XoMessage>('message', {
-      filter: `${escapeUnsafeComplexMatcher(filter) ?? ''} $object:${pool.uuid} !${RAW_ALARM_FILTER}`,
-      limit,
-    })
+    const messages = this.getMessagesForObject(id as XoPool['id'], { filter, limit })
 
     return this.sendObjects(Object.values(messages), req, 'messages')
   }

--- a/@xen-orchestra/rest-api/src/pools/pool.controller.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.controller.mts
@@ -413,7 +413,7 @@ export class PoolController extends XapiXoController<XoPool> {
   /**
    * @example id "355ee47d-ff4c-4924-3db2-fd86ae629676"
    * @example fields "name,id,$object"
-   * @example filter "name:VM_STARTED"
+   * @example filter "name:IP_CONFIGURED_PIF_CAN_UNPLUG"
    * @example limit 42
    */
   @Example(messageIds)

--- a/@xen-orchestra/rest-api/src/srs/sr.controller.mts
+++ b/@xen-orchestra/rest-api/src/srs/sr.controller.mts
@@ -4,7 +4,7 @@ import { provide } from 'inversify-binding-decorators'
 import { Request as ExRequest } from 'express'
 import { SUPPORTED_VDI_FORMAT, XenApiVdi, XoMessage, XoVdi, type XoAlarm, type XoSr } from '@vates/types'
 
-import { AlarmService, RAW_ALARM_FILTER } from '../alarms/alarm.service.mjs'
+import { AlarmService } from '../alarms/alarm.service.mjs'
 import { BASE_URL } from '../index.mjs'
 import { escapeUnsafeComplexMatcher } from '../helpers/utils.helper.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
@@ -140,11 +140,7 @@ export class SrController extends XapiXoController<XoSr> {
     @Query() filter?: string,
     @Query() limit?: number
   ): SendObjects<Partial<Unbrand<XoMessage>>> {
-    const sr = this.getObject(id as XoSr['id'])
-    const messages = this.restApi.getObjectsByType<XoMessage>('message', {
-      filter: `${escapeUnsafeComplexMatcher(filter) ?? ''} $object:${sr.uuid} !${RAW_ALARM_FILTER}`,
-      limit,
-    })
+    const messages = this.getMessagesForObject(id as XoSr['id'], { filter, limit })
 
     return this.sendObjects(Object.values(messages), req, 'messages')
   }

--- a/@xen-orchestra/rest-api/src/vm-snapshots/vm-snapshot.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-snapshots/vm-snapshot.controller.mts
@@ -3,7 +3,7 @@ import { Request as ExRequest } from 'express'
 import { inject } from 'inversify'
 import { Readable } from 'node:stream'
 
-import { AlarmService, RAW_ALARM_FILTER } from '../alarms/alarm.service.mjs'
+import { AlarmService } from '../alarms/alarm.service.mjs'
 import { escapeUnsafeComplexMatcher, limitAndFilterArray } from '../helpers/utils.helper.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
 import {
@@ -184,11 +184,7 @@ export class VmSnapshotController extends XapiXoController<XoVmSnapshot> {
     @Query() filter?: string,
     @Query() limit?: number
   ): SendObjects<Partial<Unbrand<XoMessage>>> {
-    const vm = this.getObject(id as XoVmSnapshot['id'])
-    const messages = this.restApi.getObjectsByType<XoMessage>('message', {
-      filter: `${escapeUnsafeComplexMatcher(filter) ?? ''} $object:${vm.uuid} !${RAW_ALARM_FILTER}`,
-      limit,
-    })
+    const messages = this.getMessagesForObject(id as XoVmSnapshot['id'], { filter, limit })
 
     return this.sendObjects(Object.values(messages), req, 'messages')
   }

--- a/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
@@ -5,7 +5,7 @@ import { provide } from 'inversify-binding-decorators'
 import type { XoAlarm, XoMessage, XoVdi, XoVmTemplate } from '@vates/types'
 import { Readable } from 'node:stream'
 
-import { AlarmService, RAW_ALARM_FILTER } from '../alarms/alarm.service.mjs'
+import { AlarmService } from '../alarms/alarm.service.mjs'
 import { escapeUnsafeComplexMatcher, limitAndFilterArray } from '../helpers/utils.helper.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
 import {
@@ -184,11 +184,7 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
     @Query() filter?: string,
     @Query() limit?: number
   ): SendObjects<Partial<Unbrand<XoMessage>>> {
-    const vmTemplate = this.getObject(id as XoVmTemplate['id'])
-    const messages = this.restApi.getObjectsByType<XoMessage>('message', {
-      filter: `${escapeUnsafeComplexMatcher(filter) ?? ''} $object:${vmTemplate.uuid} !${RAW_ALARM_FILTER}`,
-      limit,
-    })
+    const messages = this.getMessagesForObject(id as XoVmTemplate['id'], { filter, limit })
 
     return this.sendObjects(Object.values(messages), req, 'messages')
   }

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -33,7 +33,7 @@ import type {
 } from '@vates/types'
 import { Readable } from 'node:stream'
 
-import { AlarmService, RAW_ALARM_FILTER } from '../alarms/alarm.service.mjs'
+import { AlarmService } from '../alarms/alarm.service.mjs'
 import {
   asynchronousActionResp,
   createdResp,
@@ -608,15 +608,11 @@ export class VmController extends XapiXoController<XoVm> {
     @Query() filter?: string,
     @Query() limit?: number
   ): SendObjects<Partial<Unbrand<XoMessage>>> {
-    const vm = this.getObject(id as XoVm['id'])
-    const messages = this.restApi.getObjectsByType<XoMessage>('message', {
-      filter: `${escapeUnsafeComplexMatcher(filter) ?? ''} $object:${vm.uuid} !${RAW_ALARM_FILTER}`,
-      limit,
-    })
+    const messages = this.getMessagesForObject(id as XoVm['id'], { filter, limit })
 
     return this.sendObjects(Object.values(messages), req, 'messages')
   }
-  
+
   /**
    * @example id "613f541c-4bed-fc77-7ca8-2db6b68f079c"
    * @example fields "id,status,properties"

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@
 - **Migrated REST API endpoints**:
   - `GET /rest/v0/srs/<sr-id>/messages` (PR [#9028](https://github.com/vatesfr/xen-orchestra/pull/9028))
   - `GET /rest/v0/hosts/<host-id>/messages` (PR [#9027](https://github.com/vatesfr/xen-orchestra/pull/9027))
+  - `GET /rest/v0/pools/<pool-id>/messages` (PR [#9022](https://github.com/vatesfr/xen-orchestra/pull/9022))
 
 
 ### Bug fixes

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -805,18 +805,20 @@ export default class RestApi {
         )
       )
 
-    api.get(
-      '/restore',
-      wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
-    )
-    api.get(
-      '/tasks/:id/actions',
-      wrap(async (req, res) => {
-        const task = await app.tasks.get(req.params.id)
+    api
+      .get(
+        '/restore',
+        wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
+      )
+    api
+      .get(
+        '/tasks/:id/actions',
+        wrap(async (req, res) => {
+          const task = await app.tasks.get(req.params.id)
 
-        await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
-      })
-    )
+          await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
+        })
+      )
 
     api.get(
       '/:collection',

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -246,6 +246,7 @@ export default class RestApi {
         routes: {
           alarms: true,
           missing_patches: true,
+          messages: true,
         },
       },
       groups: {
@@ -804,20 +805,18 @@ export default class RestApi {
         )
       )
 
-    api
-      .get(
-        '/restore',
-        wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
-      )
-    api
-      .get(
-        '/tasks/:id/actions',
-        wrap(async (req, res) => {
-          const task = await app.tasks.get(req.params.id)
+    api.get(
+      '/restore',
+      wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
+    )
+    api.get(
+      '/tasks/:id/actions',
+      wrap(async (req, res) => {
+        const task = await app.tasks.get(req.params.id)
 
-          await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
-        })
-      )
+        await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
+      })
+    )
 
     api.get(
       '/:collection',


### PR DESCRIPTION
### Screenshot

<img width="298" height="61" alt="Capture d’écran de 2025-09-29 17-04-15" src="https://github.com/user-attachments/assets/e656cf43-1fd1-4979-afa8-d5a1138c7211" />


### Description

[XO-1105](https://project.vates.tech/vates-global/browse/XO-1105/)
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
