### PR TITLE
feat(@xen-orchestra/rest-api): expose hosts/:id/tags/:tag

### DIFF
--- a/@vates/types/src/xen-api.mts
+++ b/@vates/types/src/xen-api.mts
@@ -489,7 +489,6 @@ export interface XenApiDrTask {
 }
 
 type XenApiHostCallMethods = TagCallMethods & {}
-
 export interface XenApiHost {
   $ref: Branded<'host'>
   address: string

--- a/@vates/types/src/xen-api.mts
+++ b/@vates/types/src/xen-api.mts
@@ -70,6 +70,11 @@ import type { Xapi } from './lib/xen-orchestra-xapi.mjs'
 // https://github.com/vatesfr/xen-orchestra/tree/wip-xapi-types-generator/%40xen-orchestra/xapi-generator
 // All properties added after XenServer 7.0 (dundee) release have been marked as optional
 
+type TagCallMethods = {
+  (method: 'add_tags', tag: string): Promise<void>
+  (method: 'remove_tags', tag: string): Promise<void>
+}
+
 /**
  * Add properties injected by `xen-api`.
  * $ref property is also injected by XOLite, so she is not present here.
@@ -483,6 +488,8 @@ export interface XenApiDrTask {
   uuid: string
 }
 
+type XenApiHostCallMethods = TagCallMethods & {}
+
 export interface XenApiHost {
   $ref: Branded<'host'>
   address: string
@@ -559,7 +566,7 @@ export interface XenApiHost {
   uuid: string
   virtual_hardware_platform_versions: number[]
 }
-export type XenApiHostWrapped = WrapperXenApi<XenApiHost, 'host'>
+export type XenApiHostWrapped = WrapperXenApi<XenApiHost, 'host', XenApiHostCallMethods>
 
 export interface XenApiHostCrashdump {
   $ref: Branded<'host_crashdump'>

--- a/@xen-orchestra/rest-api/src/hosts/host.controller.mts
+++ b/@xen-orchestra/rest-api/src/hosts/host.controller.mts
@@ -1,4 +1,4 @@
-import { Example, Get, Path, Query, Request, Response, Route, Security, SuccessResponse, Tags } from 'tsoa'
+import { Delete, Example, Get, Path, Put, Query, Request, Response, Route, Security, SuccessResponse, Tags } from 'tsoa'
 import type { Request as ExRequest, Response as ExResponse } from 'express'
 import { inject } from 'inversify'
 import { pipeline } from 'node:stream/promises'
@@ -31,6 +31,7 @@ import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 import {
   featureUnauthorized,
   internalServerErrorResp,
+  noContentResp,
   notFoundResp,
   unauthorizedResp,
   type Unbrand,
@@ -255,5 +256,29 @@ export class HostController extends XapiXoController<XoHost> {
     const tasks = await this.getTasksForObject(id as XoHost['id'], { filter, limit })
 
     return this.sendObjects(Object.values(tasks), req, 'tasks')
+  }
+
+  /**
+   * @example id "b61a5c92-700e-4966-a13b-00633f03eea8"
+   * @example tag "from-rest-api"
+   */
+  @Put('{id}/tags/{tag}')
+  @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  async putHostTag(@Path() id: string, @Path() tag: string): Promise<void> {
+    const host = this.getXapiObject(id as XoHost['id'])
+    await host.$call('add_tags', tag)
+  }
+
+  /**
+   * @example id "b61a5c92-700e-4966-a13b-00633f03eea8"
+   * @example tag "from-rest-api"
+   */
+  @Delete('{id}/tags/{tag}')
+  @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  async deleteHostTag(@Path() id: string, @Path() tag: string): Promise<void> {
+    const host = this.getXapiObject(id as XoHost['id'])
+    await host.$call('remove_tags', tag)
   }
 }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,6 +31,8 @@
   - `GET /rest/v0/vbds/<vbd-id>/messages` (PR [#9029](https://github.com/vatesfr/xen-orchestra/pull/9029))
   - `GET /rest/v0/vdis/<vdi-id>/tasks` (PR [#9079](https://github.com/vatesfr/xen-orchestra/pull/9079))
   - `GET /rest/v0/vdi-snapshots/<vdi-snaphot-id>/tasks` (PR [#9082](https://github.com/vatesfr/xen-orchestra/pull/9082))
+  - `PUT /rest/v0/hosts/<host-id>/tags/:tag` (PR [#9027](https://github.com/vatesfr/xen-orchestra/pull/9027))
+  - `DELETE /rest/v0/hosts/<host-id>/tags/:tag` (PR [#9027](https://github.com/vatesfr/xen-orchestra/pull/9027))
 
 ### Bug fixes
 
@@ -57,6 +59,7 @@
 
 <!--packages-start-->
 
+- @vates/types minor
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,8 +31,8 @@
   - `GET /rest/v0/vbds/<vbd-id>/messages` (PR [#9029](https://github.com/vatesfr/xen-orchestra/pull/9029))
   - `GET /rest/v0/vdis/<vdi-id>/tasks` (PR [#9079](https://github.com/vatesfr/xen-orchestra/pull/9079))
   - `GET /rest/v0/vdi-snapshots/<vdi-snaphot-id>/tasks` (PR [#9082](https://github.com/vatesfr/xen-orchestra/pull/9082))
-  - `PUT /rest/v0/hosts/<host-id>/tags/:tag` (PR [#9027](https://github.com/vatesfr/xen-orchestra/pull/9027))
-  - `DELETE /rest/v0/hosts/<host-id>/tags/:tag` (PR [#9027](https://github.com/vatesfr/xen-orchestra/pull/9027))
+  - `PUT /rest/v0/hosts/<host-id>/tags/:tag` (PR [#9037](https://github.com/vatesfr/xen-orchestra/pull/9037))
+  - `DELETE /rest/v0/hosts/<host-id>/tags/:tag` (PR [#9037](https://github.com/vatesfr/xen-orchestra/pull/9037))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -826,18 +826,20 @@ export default class RestApi {
         )
       )
 
-    api.get(
-      '/restore',
-      wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
-    )
-    api.get(
-      '/tasks/:id/actions',
-      wrap(async (req, res) => {
-        const task = await app.tasks.get(req.params.id)
+    api
+      .get(
+        '/restore',
+        wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
+      )
+    api
+      .get(
+        '/tasks/:id/actions',
+        wrap(async (req, res) => {
+          const task = await app.tasks.get(req.params.id)
 
-        await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
-      })
-    )
+          await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
+        })
+      )
 
     api.get(
       '/:collection',

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -320,6 +320,7 @@ export default class RestApi {
           missing_patches: true,
           messages: true,
           tasks: true,
+          tags: true,
         },
       },
       srs: {
@@ -919,7 +920,11 @@ export default class RestApi {
       )
       .delete(
         '/:collection/:object/tags/:tag',
-        wrap(async (req, res) => {
+        wrap(async (req, res, next) => {
+          const { collection } = req
+          if (swaggerEndpoints[collection.id].routes.tags) {
+            return next('route')
+          }
           await req.xapiObject.$call('remove_tags', req.params.tag)
 
           res.sendStatus(204)
@@ -927,7 +932,11 @@ export default class RestApi {
       )
       .put(
         '/:collection/:object/tags/:tag',
-        wrap(async (req, res) => {
+        wrap(async (req, res, next) => {
+          const { collection } = req
+          if (swaggerEndpoints[collection.id].routes.tags) {
+            return next('route')
+          }
           await req.xapiObject.$call('add_tags', req.params.tag)
 
           res.sendStatus(204)

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -826,20 +826,18 @@ export default class RestApi {
         )
       )
 
-    api
-      .get(
-        '/restore',
-        wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
-      )
-    api
-      .get(
-        '/tasks/:id/actions',
-        wrap(async (req, res) => {
-          const task = await app.tasks.get(req.params.id)
+    api.get(
+      '/restore',
+      wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
+    )
+    api.get(
+      '/tasks/:id/actions',
+      wrap(async (req, res) => {
+        const task = await app.tasks.get(req.params.id)
 
-          await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
-        })
-      )
+        await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
+      })
+    )
 
     api.get(
       '/:collection',


### PR DESCRIPTION
### Screenshot

<img width="326" height="116" alt="Capture d’écran de 2025-10-01 15-15-08" src="https://github.com/user-attachments/assets/74e6e56f-6751-49dd-ac26-6574c570f643" />


### Description

[XO-1173](https://project.vates.tech/vates-global/browse/XO-1173/)
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
