### PR TITLE
feat(@xen-orchestra/rest-api): expose vdis/:id.(vhd|raw)

### DIFF
--- a/@vates/types/src/lib/xen-orchestra-xapi.mts
+++ b/@vates/types/src/lib/xen-orchestra-xapi.mts
@@ -182,6 +182,11 @@ export interface Xapi {
     vdiRef: XenApiVdi['$ref'],
     opts: { baseRef?: string; cancelToken?: unknown; format: SUPPORTED_VDI_FORMAT }
   ): Promise<Readable & { length?: number }>
+  VDI_importContent(
+    vdiRef: XenApiVdi['$ref'],
+    stream: Readable,
+    opts: { cancelToken?: unknown; format: SUPPORTED_VDI_FORMAT }
+  ): Promise<void>
   VM_createCloudInitConfig(
     vmRef: XenApiVm['$ref'],
     cloudConfig: string,

--- a/@xen-orchestra/rest-api/src/vdi-snapshots/vdi-snapshot.controller.mts
+++ b/@xen-orchestra/rest-api/src/vdi-snapshots/vdi-snapshot.controller.mts
@@ -112,7 +112,7 @@ export class VdiSnapshotController extends XapiXoController<XoVdiSnapshot> {
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(422, 'Invalid format')
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
-  async importVdiContent(
+  async importVdiSnapshotContent(
     @Request() req: ExRequest & { length?: number },
     @Path() id: string,
     @Path() format: Exclude<SUPPORTED_VDI_FORMAT, 'qcow2'>

--- a/@xen-orchestra/rest-api/src/vdi-snapshots/vdi-snapshot.controller.mts
+++ b/@xen-orchestra/rest-api/src/vdi-snapshots/vdi-snapshot.controller.mts
@@ -1,18 +1,4 @@
-import {
-  Delete,
-  Deprecated,
-  Example,
-  Get,
-  Path,
-  Put,
-  Query,
-  Request,
-  Response,
-  Route,
-  Security,
-  SuccessResponse,
-  Tags,
-} from 'tsoa'
+import { Delete, Example, Get, Path, Put, Query, Request, Response, Route, Security, SuccessResponse, Tags } from 'tsoa'
 import { inject } from 'inversify'
 import { provide } from 'inversify-binding-decorators'
 import type { Readable } from 'node:stream'
@@ -20,13 +6,7 @@ import type { Request as ExRequest, Response as ExResponse } from 'express'
 import type { SUPPORTED_VDI_FORMAT, XoAlarm, XoMessage, XoTask, XoVdiSnapshot } from '@vates/types'
 
 import { escapeUnsafeComplexMatcher } from '../helpers/utils.helper.mjs'
-import {
-  internalServerErrorResp,
-  noContentResp,
-  notFoundResp,
-  unauthorizedResp,
-  type Unbrand,
-} from '../open-api/common/response.common.mjs'
+import { noContentResp, notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { partialVdiSnapshots, vdiSnapshot, vdiSnapshotIds } from '../open-api/oa-examples/vdi-snapshot.oa-example.mjs'
@@ -97,35 +77,6 @@ export class VdiSnapshotController extends XapiXoController<XoVdiSnapshot> {
     req.on('close', () => stream.destroy())
     return stream
   }
-
-  // ----------- DEPRECATED TO BE REMOVED IN ONE YEAR  (10-01-2026)--------------------
-  // Do not forget to also remove the spec in tsoa.json
-  /**
-   *
-   * Import VDI-snapshot content
-   *
-   * @example id "d2727772-735b-478f-b6f9-11e7db56dfd0"
-   */
-  @Deprecated()
-  @Put('{id}.{format}')
-  @SuccessResponse(noContentResp.status, noContentResp.description)
-  @Response(notFoundResp.status, notFoundResp.description)
-  @Response(422, 'Invalid format')
-  @Response(internalServerErrorResp.status, internalServerErrorResp.description)
-  async importVdiSnapshotContent(
-    @Request() req: ExRequest & { length?: number },
-    @Path() id: string,
-    @Path() format: Exclude<SUPPORTED_VDI_FORMAT, 'qcow2'>
-  ): Promise<void> {
-    const xapiVdiSnapshot = this.getXapiObject(id as XoVdiSnapshot['id'])
-
-    if (req.headers['content-length'] !== undefined) {
-      req.length = +req.headers['content-length']
-    }
-    process.on('SIGTERM', () => req.destroy())
-    await xapiVdiSnapshot.$xapi.VDI_importContent(xapiVdiSnapshot.$ref, req, { format })
-  }
-  // ----------- DEPRECATED TO BE REMOVED IN ONE YEAR  (10-01-2026)--------------------
 
   /**
    * @example id "d2727772-735b-478f-b6f9-11e7db56dfd0"

--- a/@xen-orchestra/rest-api/src/vdi-snapshots/vdi-snapshot.controller.mts
+++ b/@xen-orchestra/rest-api/src/vdi-snapshots/vdi-snapshot.controller.mts
@@ -116,7 +116,7 @@ export class VdiSnapshotController extends XapiXoController<XoVdiSnapshot> {
     @Request() req: ExRequest & { length?: number },
     @Path() id: string,
     @Path() format: Exclude<SUPPORTED_VDI_FORMAT, 'qcow2'>
-  ) {
+  ): Promise<void> {
     const xapiVdiSnapshot = this.getXapiObject(id as XoVdiSnapshot['id'])
 
     if (req.headers['content-length'] !== undefined) {

--- a/@xen-orchestra/rest-api/src/vdis/vdi.controller.mts
+++ b/@xen-orchestra/rest-api/src/vdis/vdi.controller.mts
@@ -95,7 +95,7 @@ export class VdiController extends XapiXoController<XoVdi> {
     @Request() req: ExRequest & { length?: number },
     @Path() id: string,
     @Path() format: Exclude<SUPPORTED_VDI_FORMAT, 'qcow2'>
-  ) {
+  ): Promise<void> {
     const xapiVdi = this.getXapiObject(id as XoVdi['id'])
 
     if (req.headers['content-length'] !== undefined) {

--- a/@xen-orchestra/rest-api/src/vdis/vdi.controller.mts
+++ b/@xen-orchestra/rest-api/src/vdis/vdi.controller.mts
@@ -3,12 +3,18 @@ import { inject } from 'inversify'
 import { provide } from 'inversify-binding-decorators'
 import type { Readable } from 'node:stream'
 import type { Request as ExRequest, Response as ExResponse } from 'express'
-import type { XoAlarm, XoMessage, XoTask, XoVdi } from '@vates/types'
+import type { SUPPORTED_VDI_FORMAT, XoAlarm, XoMessage, XoTask, XoVdi } from '@vates/types'
 
 import { AlarmService } from '../alarms/alarm.service.mjs'
 import { escapeUnsafeComplexMatcher } from '../helpers/utils.helper.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
-import { noContentResp, notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
+import {
+  internalServerErrorResp,
+  noContentResp,
+  notFoundResp,
+  unauthorizedResp,
+  type Unbrand,
+} from '../open-api/common/response.common.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
@@ -65,13 +71,38 @@ export class VdiController extends XapiXoController<XoVdi> {
   async exportVdiContent(
     @Request() req: ExRequest,
     @Path() id: string,
-    @Path() format: 'vhd' | 'raw'
+    @Path() format: Exclude<SUPPORTED_VDI_FORMAT, 'qcow2'>
   ): Promise<Readable> {
     const res = req.res as ExResponse
     const stream = await this.#vdiService.exportContent(id as XoVdi['id'], 'VDI', { format, response: res })
     process.on('SIGTERM', () => req.destroy())
     req.on('close', () => stream.destroy())
     return stream
+  }
+
+  /**
+   *
+   * Import VDI content
+   *
+   * @example id "c77f9955-c1d2-4b39-aa1c-73cdb2dacb7e"
+   */
+  @Put('{id}.{format}')
+  @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  @Response(422, 'Invalid format')
+  @Response(internalServerErrorResp.status, internalServerErrorResp.description)
+  async importVdiContent(
+    @Request() req: ExRequest & { length?: number },
+    @Path() id: string,
+    @Path() format: Exclude<SUPPORTED_VDI_FORMAT, 'qcow2'>
+  ) {
+    const xapiVdi = this.getXapiObject(id as XoVdi['id'])
+
+    if (req.headers['content-length'] !== undefined) {
+      req.length = +req.headers['content-length']
+    }
+    process.on('SIGTERM', () => req.destroy())
+    await xapiVdi.$xapi.VDI_importContent(xapiVdi.$ref, req, { format })
   }
 
   /**

--- a/@xen-orchestra/rest-api/tsoa.json
+++ b/@xen-orchestra/rest-api/tsoa.json
@@ -61,21 +61,6 @@
             }
           }
         },
-        "/vdi-snapshots/{id}.{format}": {
-          "put": {
-            "requestBody": {
-              "required": true,
-              "content": {
-                "application/octet-stream": {
-                  "schema": {
-                    "type": "string",
-                    "format": "binary"
-                  }
-                }
-              }
-            }
-          }
-        },
         "/docs/swagger.json": {
           "get": {
             "operationId": "swaggerSpec",

--- a/@xen-orchestra/rest-api/tsoa.json
+++ b/@xen-orchestra/rest-api/tsoa.json
@@ -46,6 +46,36 @@
             }
           }
         },
+        "/vdis/{id}.{format}": {
+          "put": {
+            "requestBody": {
+              "required": true,
+              "content": {
+                "application/octet-stream": {
+                  "schema": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/vdi-snapshots/{id}.{format}": {
+          "put": {
+            "requestBody": {
+              "required": true,
+              "content": {
+                "application/octet-stream": {
+                  "schema": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
         "/docs/swagger.json": {
           "get": {
             "operationId": "swaggerSpec",

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -58,6 +58,8 @@
   - `GET /rest/v0/vm-templates/<vm-template-id>/tasks` (PR [#9099](https://github.com/vatesfr/xen-orchestra/pull/9099))
   - `PUT /rest/v0/vm-controllers/<vm-controller-id>/tags/:tag` (PR [#9097](https://github.com/vatesfr/xen-orchestra/pull/9097))
   - `DELETE /rest/v0/vm-controllers/<vm-controller-id>/tags/:tag` (PR [#9097](https://github.com/vatesfr/xen-orchestra/pull/9097))
+  - `PUT /rest/v0/vdis/<vdi-id>.(vhd|raw)` (PR [#9027](https://github.com/vatesfr/xen-orchestra/pull/9027))
+  - **deprecated** `PUT /rest/v0/vdi-snapshots/<vdi-snapshot-id>.(vhd|raw)` (PR [#9027](https://github.com/vatesfr/xen-orchestra/pull/9027))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -59,7 +59,7 @@
   - `PUT /rest/v0/vm-controllers/<vm-controller-id>/tags/:tag` (PR [#9097](https://github.com/vatesfr/xen-orchestra/pull/9097))
   - `DELETE /rest/v0/vm-controllers/<vm-controller-id>/tags/:tag` (PR [#9097](https://github.com/vatesfr/xen-orchestra/pull/9097))
   - `PUT /rest/v0/vdis/<vdi-id>.(vhd|raw)` (PR [#9038](https://github.com/vatesfr/xen-orchestra/pull/9038))
-  - **deprecated** `PUT /rest/v0/vdi-snapshots/<vdi-snapshot-id>.(vhd|raw)` (PR [#9038](https://github.com/vatesfr/xen-orchestra/pull/9038))
+  - **removed** `PUT /rest/v0/vdi-snapshots/<vdi-snapshot-id>.(vhd|raw)` (PR [#9038](https://github.com/vatesfr/xen-orchestra/pull/9038))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -58,8 +58,8 @@
   - `GET /rest/v0/vm-templates/<vm-template-id>/tasks` (PR [#9099](https://github.com/vatesfr/xen-orchestra/pull/9099))
   - `PUT /rest/v0/vm-controllers/<vm-controller-id>/tags/:tag` (PR [#9097](https://github.com/vatesfr/xen-orchestra/pull/9097))
   - `DELETE /rest/v0/vm-controllers/<vm-controller-id>/tags/:tag` (PR [#9097](https://github.com/vatesfr/xen-orchestra/pull/9097))
-  - `PUT /rest/v0/vdis/<vdi-id>.(vhd|raw)` (PR [#9027](https://github.com/vatesfr/xen-orchestra/pull/9027))
-  - **deprecated** `PUT /rest/v0/vdi-snapshots/<vdi-snapshot-id>.(vhd|raw)` (PR [#9027](https://github.com/vatesfr/xen-orchestra/pull/9027))
+  - `PUT /rest/v0/vdis/<vdi-id>.(vhd|raw)` (PR [#9038](https://github.com/vatesfr/xen-orchestra/pull/9038))
+  - **deprecated** `PUT /rest/v0/vdi-snapshots/<vdi-snapshot-id>.(vhd|raw)` (PR [#9038](https://github.com/vatesfr/xen-orchestra/pull/9038))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -840,18 +840,20 @@ export default class RestApi {
         )
       )
 
-    api.get(
-      '/restore',
-      wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
-    )
-    api.get(
-      '/tasks/:id/actions',
-      wrap(async (req, res) => {
-        const task = await app.tasks.get(req.params.id)
+    api
+      .get(
+        '/restore',
+        wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
+      )
+    api
+      .get(
+        '/tasks/:id/actions',
+        wrap(async (req, res) => {
+          const task = await app.tasks.get(req.params.id)
 
-        await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
-      })
-    )
+          await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
+        })
+      )
 
     api.get(
       '/:collection',

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -882,16 +882,6 @@ export default class RestApi {
       })
     )
 
-    api.put(
-      '/:collection(vdis|vdi-snapshots)/:object.:format(vhd|raw)',
-      wrap(async (req, res) => {
-        req.length = +req.headers['content-length']
-        await req.xapiObject.$importContent(req, { format: req.params.format })
-
-        res.sendStatus(204)
-      })
-    )
-
     api.get('/:collection/:object', (req, res, next) => {
       const { collection } = req
       if (swaggerEndpoints[collection.id] !== undefined) {

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -840,20 +840,18 @@ export default class RestApi {
         )
       )
 
-    api
-      .get(
-        '/restore',
-        wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
-      )
-    api
-      .get(
-        '/tasks/:id/actions',
-        wrap(async (req, res) => {
-          const task = await app.tasks.get(req.params.id)
+    api.get(
+      '/restore',
+      wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
+    )
+    api.get(
+      '/tasks/:id/actions',
+      wrap(async (req, res) => {
+        const task = await app.tasks.get(req.params.id)
 
-          await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
-        })
-      )
+        await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
+      })
+    )
 
     api.get(
       '/:collection',


### PR DESCRIPTION
### Screenshots

<img width="282" height="58" alt="Capture d’écran de 2025-10-01 17-43-59" src="https://github.com/user-attachments/assets/54dab891-ad4f-47af-82f7-a89d80d8502c" />

### Description

[XO-1143](https://project.vates.tech/vates-global/browse/XO-1143/)
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
