### PR TITLE
feat(xo-server): use xva to write disks

### DIFF
--- a/@xen-orchestra/xva/_writeDisk.mjs
+++ b/@xen-orchestra/xva/_writeDisk.mjs
@@ -30,7 +30,7 @@ export async function writeDisk(pack, disk, basePath) {
     }
     previousIndex = index
     if (data.length > XVA_DISK_CHUNK_LENGTH) {
-      throw new Error(`Block must be at most {XVA_DISK_CHUNK_LENGTH} bytes, got ${data.length}`)
+      throw new Error(`Block must be at most ${XVA_DISK_CHUNK_LENGTH} bytes, got ${data.length}`)
     }
     if (
       // write first block

--- a/@xen-orchestra/xva/_writeOvaXml.mjs
+++ b/@xen-orchestra/xva/_writeOvaXml.mjs
@@ -13,7 +13,7 @@ import { XVA_DISK_CHUNK_LENGTH } from './_writeDisk.mjs'
 
 export default async function writeOvaXml(
   pack,
-  { memory, networks, nCpus, firmware, vdis, vhds, ...vmSnapshot },
+  { memory, networks, nCpus, firmware, vdis, disks, ...vmSnapshot },
   { sr, network }
 ) {
   let refId = 0
@@ -76,10 +76,10 @@ export default async function writeOvaXml(
   )
 
   data.objects.push(srObj)
-  assert.strictEqual(vhds.length, vdis.length)
-  for (let index = 0; index < vhds.length; index++) {
+  assert.strictEqual(disks.length, vdis.length)
+  for (let index = 0; index < vdis.length; index++) {
     const userdevice = index + 1
-    const vhd = vhds[index]
+    const disk = disks[index]
     const alignedSize = Math.ceil(vdis[index].virtual_size / XVA_DISK_CHUNK_LENGTH) * XVA_DISK_CHUNK_LENGTH
     const vdi = defaultsDeep(
       {
@@ -97,7 +97,7 @@ export default async function writeOvaXml(
 
     data.objects.push(vdi)
     srObj.snapshot.VDIs.push(vdi.id)
-    vhd.ref = vdi.id
+    disk.ref = vdi.id
 
     const vbd = defaultsDeep(
       {

--- a/@xen-orchestra/xva/importVdi.mjs
+++ b/@xen-orchestra/xva/importVdi.mjs
@@ -5,7 +5,7 @@ export async function importVdi(vdi, disk, xapi, sr) {
   // create a fake VM
   const vmRef = await importVm(
     {
-      name_label: `[xva-disp-import]${vdi.name_label}`,
+      name_label: `[V2V-temp-import]${vdi.name_label}`,
       memory: 1024 * 1024 * 32,
       nCpus: 1,
       firmware: 'bios',

--- a/@xen-orchestra/xva/importVm.mjs
+++ b/@xen-orchestra/xva/importVm.mjs
@@ -1,7 +1,7 @@
 import tar from 'tar-stream'
 
 import writeOvaXml from './_writeOvaXml.mjs'
-import writeDisk from './_writeDisk.mjs'
+import { writeDisk } from './_writeDisk.mjs'
 
 export async function importVm(vm, xapi, sr, network) {
   const pack = tar.pack()
@@ -18,8 +18,8 @@ export async function importVm(vm, xapi, sr, network) {
     .catch(err => console.error(err))
 
   await writeOvaXml(pack, vm, { sr, network })
-  for (const vhd of vm.vhds) {
-    await writeDisk(pack, vhd, vhd.ref)
+  for (const disk of vm.disks) {
+    await writeDisk(pack, disk, disk.ref)
   }
   pack.finalize()
   const str = await promise


### PR DESCRIPTION
xva import benefits:
* can filter out bloc allocated but full of 0
* smaller block granualrity (1MB instead of 2MB)
* faster import ( a few percent)
* support disk up to 99 999 999 1Mb blocks if storage supports it

xva negative:
* create a temp VM , no progress bar, no ETA

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
