### PR TITLE
feat(web-core): add objectIcon helper

### DIFF
--- a/@xen-orchestra/web-core/lib/components/object-icon/VtsObjectIcon.vue
+++ b/@xen-orchestra/web-core/lib/components/object-icon/VtsObjectIcon.vue
@@ -2,19 +2,14 @@
   <VtsIcon :name="iconName" :size />
 </template>
 
-<script generic="TType extends ObjectIconType" lang="ts" setup>
+<script generic="TType extends ObjectType, TState extends ObjectState<TType>" lang="ts" setup>
 import VtsIcon, { type IconSize } from '@core/components/icon/VtsIcon.vue'
-import type { ObjectIconName } from '@core/icons'
+import type { ObjectIconName, ObjectState, ObjectType } from '@core/icons'
 import { computed } from 'vue'
-
-export type ObjectIconType = ObjectIconName extends `object:${infer TType}:${string}` ? TType : never
-
-export type ObjectIconState<TType extends ObjectIconType> =
-  Extract<ObjectIconName, `object:${TType}:${string}`> extends `object:${TType}:${infer TState}` ? TState : never
 
 const { type, state } = defineProps<{
   type: TType
-  state: ObjectIconState<TType>
+  state: TState
   size: IconSize
 }>()
 

--- a/@xen-orchestra/web-core/lib/icons/index.ts
+++ b/@xen-orchestra/web-core/lib/icons/index.ts
@@ -17,3 +17,20 @@ export type ObjectIconName = Extract<IconName, `object:${string}:${string}`>
 export function icon<TName extends IconName>(name: TName): TName {
   return name
 }
+
+export type ObjectStateByType = {
+  [TName in IconName as TName extends `object:${infer TType}:${string}`
+    ? TType
+    : never]: TName extends `object:${string}:${infer TType}` ? TType : never
+}
+
+export type ObjectType = keyof ObjectStateByType
+
+export type ObjectState<TType extends ObjectType> = ObjectStateByType[TType]
+
+export function objectIcon<TType extends ObjectType, TState extends ObjectState<TType>>(
+  type: TType,
+  state: TState
+): IconName {
+  return `object:${type}:${state}` as IconName
+}


### PR DESCRIPTION
### Description

This PR introduces a new fully-typed `objectIcon` meant to generate object icon names and extract typing utilities from `VtsObjectIcon`

```ts
const icon = objectIcon('host', 'disconnected') // `object:host:disconnected`

const icon = objectIcon('network', '|')
//                                  ^ will propose 'connected' and 'disconnected'

const icon = objectIcon('host', 'connectd')
//                                  ^ will raise an error
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
