### PR TITLE
fix(xo-web/VM/ActionBar): do not hide actions if user is admin

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [VM] Fix some action buttons being hidden from admin users when VM had been created with Self Service (PR [#9061](https://github.com/vatesfr/xen-orchestra/pull/9061))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -40,5 +42,6 @@
 
 - @xen-orchestra/rest-api minor
 - xo-server patch
+- xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-web/src/xo-app/vm/action-bar.js
+++ b/packages/xo-web/src/xo-app/vm/action-bar.js
@@ -3,7 +3,7 @@ import ActionBar, { Action } from 'action-bar'
 import React from 'react'
 import { addSubscriptions, connectStore } from 'utils'
 import { find, includes } from 'lodash'
-import { createSelector, getCheckPermissions, getUser } from 'selectors'
+import { createSelector, getCheckPermissions, getUser, isAdmin } from 'selectors'
 import { cloneVm, copyVm, exportVm, migrateVm, restartVm, snapshotVm, startVm, stopVm, subscribeResourceSets } from 'xo'
 
 const vmActionBarByState = {
@@ -163,11 +163,17 @@ const VmActionBar = addSubscriptions(() => ({
   connectStore(() => ({
     checkPermissions: getCheckPermissions,
     user: getUser,
-  }))(({ checkPermissions, vm, user, resourceSets }) => {
+    isAdmin,
+  }))(({ checkPermissions, vm, user, resourceSets, isAdmin }) => {
     // Is the user in the same resource set as the VM
     const _getIsSelfUser = createSelector(
+      () => isAdmin,
       () => resourceSets,
-      resourceSets => {
+      (isAdmin, resourceSets) => {
+        if (isAdmin) {
+          return false
+        }
+
         const vmResourceSet = vm.resourceSet && find(resourceSets, { id: vm.resourceSet })
 
         return (


### PR DESCRIPTION
See Zammad#44366

### Description

Admin users should always be able to perform actions on VMs even if the VM was created with Self Service.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
