### PR TITLE
feat(@xen-orchestra/rest-api): expose users/:id/tasks

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
   - `GET /rest/v0/vdi-snapshots/<vdi-snapshot-id>/messages` (PR [#9043](https://github.com/vatesfr/xen-orchestra/pull/9043))
   - `GET /rest/v0/vdis/<vdi-id>/messages` (PR [#9044](https://github.com/vatesfr/xen-orchestra/pull/9044))
   - `GET /rest/v0/vifs/<vif-id>/messages` (PR [#9049](https://github.com/vatesfr/xen-orchestra/pull/9049))
+  - `GET /rest/v0/users/<user-id>/tasks` (PR [#9049](https://github.com/vatesfr/xen-orchestra/pull/9049))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@
   - `GET /rest/v0/vdi-snapshots/<vdi-snapshot-id>/messages` (PR [#9043](https://github.com/vatesfr/xen-orchestra/pull/9043))
   - `GET /rest/v0/vdis/<vdi-id>/messages` (PR [#9044](https://github.com/vatesfr/xen-orchestra/pull/9044))
   - `GET /rest/v0/vifs/<vif-id>/messages` (PR [#9049](https://github.com/vatesfr/xen-orchestra/pull/9049))
-  - `GET /rest/v0/users/<user-id>/tasks` (PR [#9049](https://github.com/vatesfr/xen-orchestra/pull/9049))
+  - `GET /rest/v0/users/<user-id>/tasks` (PR [#9066](https://github.com/vatesfr/xen-orchestra/pull/9066))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -260,6 +260,7 @@ export default class RestApi {
         routes: {
           groups: true,
           authentication_tokens: true,
+          tasks: true,
         },
       },
       vifs: {
@@ -810,20 +811,18 @@ export default class RestApi {
         )
       )
 
-    api
-      .get(
-        '/restore',
-        wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
-      )
-    api
-      .get(
-        '/tasks/:id/actions',
-        wrap(async (req, res) => {
-          const task = await app.tasks.get(req.params.id)
+    api.get(
+      '/restore',
+      wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
+    )
+    api.get(
+      '/tasks/:id/actions',
+      wrap(async (req, res) => {
+        const task = await app.tasks.get(req.params.id)
 
-          await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
-        })
-      )
+        await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
+      })
+    )
 
     api.get(
       '/:collection',

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -811,18 +811,20 @@ export default class RestApi {
         )
       )
 
-    api.get(
-      '/restore',
-      wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
-    )
-    api.get(
-      '/tasks/:id/actions',
-      wrap(async (req, res) => {
-        const task = await app.tasks.get(req.params.id)
+    api
+      .get(
+        '/restore',
+        wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
+      )
+    api
+      .get(
+        '/tasks/:id/actions',
+        wrap(async (req, res) => {
+          const task = await app.tasks.get(req.params.id)
 
-        await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
-      })
-    )
+          await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
+        })
+      )
 
     api.get(
       '/:collection',


### PR DESCRIPTION
### Screenshot

<img width="287" height="50" alt="Capture d’écran de 2025-10-06 17-15-51" src="https://github.com/user-attachments/assets/a95645c5-a197-41e5-9a5d-62a66ae35353" />


### Description

[XO-1188](https://project.vates.tech/vates-global/browse/XO-1188/)
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
