### PR TITLE
feat(@xen-orchestra/rest-api): migrate vm-controllers tasks

### DIFF
--- a/@xen-orchestra/rest-api/src/vm-controller/vm-controller.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-controller/vm-controller.controller.mts
@@ -118,7 +118,7 @@ export class VmControllerController extends XapiXoController<XoVmController> {
   }
 
   /**
-   * @example id "e3fc847c-159a-48dc-bee4-cf2da216a795"
+   * @example id "9b4775bd-9493-490a-9afa-f786a44caa4f"
    * @example fields "id,status,properties"
    * @example filter "status:failure"
    * @example limit 42
@@ -128,7 +128,7 @@ export class VmControllerController extends XapiXoController<XoVmController> {
   @Get('{id}/tasks')
   @Tags('tasks')
   @Response(notFoundResp.status, notFoundResp.description)
-  async getVmSnapshotTasks(
+  async getVmControllerTasks(
     @Request() req: ExRequest,
     @Path() id: string,
     @Query() fields?: string,

--- a/@xen-orchestra/rest-api/src/vm-controller/vm-controller.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-controller/vm-controller.controller.mts
@@ -1,7 +1,7 @@
 import { inject } from 'inversify'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
-import type { XoAlarm, XoMessage, XOTask, XoVdi, XoVdiSnapshot, XoVmController } from '@vates/types'
+import type { XoAlarm, XoMessage, XoTask, XoVdi, XoVdiSnapshot, XoVmController } from '@vates/types'
 import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
 import { Request as ExRequest } from 'express'
 

--- a/@xen-orchestra/rest-api/src/vm-controller/vm-controller.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-controller/vm-controller.controller.mts
@@ -1,7 +1,7 @@
 import { inject } from 'inversify'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
-import type { XoAlarm, XoTask, XoVdi, XoVdiSnapshot, XoVmController, XoVmSnapshot } from '@vates/types'
+import type { XoAlarm, XoTask, XoVdi, XoVdiSnapshot, XoVmController } from '@vates/types'
 import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
 import { Request as ExRequest } from 'express'
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
   - `GET /rest/v0/vdi-snapshots/<vdi-snapshot-id>/messages` (PR [#9043](https://github.com/vatesfr/xen-orchestra/pull/9043))
   - `GET /rest/v0/vdis/<vdi-id>/messages` (PR [#9044](https://github.com/vatesfr/xen-orchestra/pull/9044))
   - `GET /rest/v0/vifs/<vif-id>/messages` (PR [#9049](https://github.com/vatesfr/xen-orchestra/pull/9049))
+  - `GET /rest/v0/vm-controllers/<vm-controller-id>/tasks` (PR [#9069](https://github.com/vatesfr/xen-orchestra/pull/9069))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -288,6 +288,7 @@ export default class RestApi {
         routes: {
           alarms: true,
           vdis: true,
+          tasks: true,
         },
       },
       'vm-snapshots': {
@@ -810,20 +811,18 @@ export default class RestApi {
         )
       )
 
-    api
-      .get(
-        '/restore',
-        wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
-      )
-    api
-      .get(
-        '/tasks/:id/actions',
-        wrap(async (req, res) => {
-          const task = await app.tasks.get(req.params.id)
+    api.get(
+      '/restore',
+      wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
+    )
+    api.get(
+      '/tasks/:id/actions',
+      wrap(async (req, res) => {
+        const task = await app.tasks.get(req.params.id)
 
-          await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
-        })
-      )
+        await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
+      })
+    )
 
     api.get(
       '/:collection',

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -811,18 +811,20 @@ export default class RestApi {
         )
       )
 
-    api.get(
-      '/restore',
-      wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
-    )
-    api.get(
-      '/tasks/:id/actions',
-      wrap(async (req, res) => {
-        const task = await app.tasks.get(req.params.id)
+    api
+      .get(
+        '/restore',
+        wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
+      )
+    api
+      .get(
+        '/tasks/:id/actions',
+        wrap(async (req, res) => {
+          const task = await app.tasks.get(req.params.id)
 
-        await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
-      })
-    )
+          await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
+        })
+      )
 
     api.get(
       '/:collection',


### PR DESCRIPTION
### Description

<img width="438" height="52" alt="image" src="https://github.com/user-attachments/assets/e3de5651-85cc-4de4-8843-ac4237086107" />

[XO-1177](https://project.vates.tech/vates-global/browse/XO-1177/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
