### PR TITLE
feat(@xen-orchestra/rest-api): expose groups/:id/tasks

### DIFF
--- a/@xen-orchestra/rest-api/src/groups/group.controller.mts
+++ b/@xen-orchestra/rest-api/src/groups/group.controller.mts
@@ -19,7 +19,7 @@ import {
 import { inject } from 'inversify'
 import { json, type Request as ExRequest } from 'express'
 import { provide } from 'inversify-binding-decorators'
-import type { XoGroup, XoUser } from '@vates/types'
+import type { XoGroup, XoTask, XoUser } from '@vates/types'
 
 import { forbiddenOperation } from 'xo-common/api-errors.js'
 import {
@@ -40,6 +40,7 @@ import { UserService } from '../users/user.service.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { limitAndFilterArray } from '../helpers/utils.helper.mjs'
 import { partialUsers, userIds } from '../open-api/oa-examples/user.oa-example.mjs'
+import { partialTasks, taskIds } from '../open-api/oa-examples/task.oa-example.mjs'
 
 @Route('groups')
 @Security('*')
@@ -195,5 +196,29 @@ export class GroupController extends XoController<XoGroup> {
     const group = await this.getObject(id as XoGroup['id'])
     const users = await Promise.all(group.users.map(id => this.#userService.getUser(id)))
     return this.sendObjects(limitAndFilterArray(users, { filter, limit }), req, 'users')
+  }
+
+  /**
+   * @example id "6c81b5e1-afc1-43ea-8f8d-939ceb5f3f90"
+   * @example fields "id,status,properties"
+   * @example filter "status:failure"
+   * @example limit 42
+   */
+  @Example(taskIds)
+  @Example(partialTasks)
+  @Get('{id}/tasks')
+  @Tags('tasks')
+  @Response(notFoundResp.status, notFoundResp.description)
+  async getGroupTasks(
+    @Request() req: ExRequest,
+    @Path() id: string,
+    @Query() fields?: string,
+    @Query() ndjson?: boolean,
+    @Query() filter?: string,
+    @Query() limit?: number
+  ): Promise<SendObjects<Partial<Unbrand<XoTask>>>> {
+    const tasks = await this.getTasksForObject(id as XoGroup['id'], { filter, limit })
+
+    return this.sendObjects(Object.values(tasks), req, 'tasks')
   }
 }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@
   - `GET /rest/v0/vm-snapshots/<vm-snapshot-id>/tasks` (PR [#9005](https://github.com/vatesfr/xen-orchestra/pull/9005))
   - `GET /rest/v0/servers/<server-id>/tasks` (PR [#9065](https://github.com/vatesfr/xen-orchestra/pull/9065))
   - `GET /rest/v0/vm-templates/<vm-template-id>/tasks` (PR [#9004](https://github.com/vatesfr/xen-orchestra/pull/9004))
+  - `GET /rest/v0/groups/<group-id>/tasks` (PR [#9072](https://github.com/vatesfr/xen-orchestra/pull/9072))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -342,7 +342,7 @@ export default class RestApi {
       servers: {
         routes: {
           tasks: true,
-        },
+        }
       },
       tasks: {},
     }
@@ -816,18 +816,20 @@ export default class RestApi {
         )
       )
 
-    api.get(
-      '/restore',
-      wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
-    )
-    api.get(
-      '/tasks/:id/actions',
-      wrap(async (req, res) => {
-        const task = await app.tasks.get(req.params.id)
+    api
+      .get(
+        '/restore',
+        wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
+      )
+    api
+      .get(
+        '/tasks/:id/actions',
+        wrap(async (req, res) => {
+          const task = await app.tasks.get(req.params.id)
 
-        await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
-      })
-    )
+          await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
+        })
+      )
 
     api.get(
       '/:collection',

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -254,6 +254,7 @@ export default class RestApi {
       groups: {
         routes: {
           users: true,
+          tasks: true,
         },
       },
       users: {
@@ -341,7 +342,7 @@ export default class RestApi {
       servers: {
         routes: {
           tasks: true,
-        }
+        },
       },
       tasks: {},
     }
@@ -815,20 +816,18 @@ export default class RestApi {
         )
       )
 
-    api
-      .get(
-        '/restore',
-        wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
-      )
-    api
-      .get(
-        '/tasks/:id/actions',
-        wrap(async (req, res) => {
-          const task = await app.tasks.get(req.params.id)
+    api.get(
+      '/restore',
+      wrap((req, res) => sendObjects([{ id: 'logs' }], req, res))
+    )
+    api.get(
+      '/tasks/:id/actions',
+      wrap(async (req, res) => {
+        const task = await app.tasks.get(req.params.id)
 
-          await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
-        })
-      )
+        await sendObjects(task.status === 'pending' ? [{ id: 'abort' }] : [], req, res)
+      })
+    )
 
     api.get(
       '/:collection',


### PR DESCRIPTION
### Screenshot

<img width="304" height="45" alt="Capture d’écran de 2025-10-08 09-44-09" src="https://github.com/user-attachments/assets/5ec831a1-88a2-4711-bddd-e88cdfead60c" />


### Description

[XO-1187](https://project.vates.tech/vates-global/browse/XO-1187/)
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
