### PR TITLE
feat(@xen-orchestra/rest-api): expose networks/:id/tags/:tag

### DIFF
--- a/@vates/types/src/xen-api.mts
+++ b/@vates/types/src/xen-api.mts
@@ -620,6 +620,8 @@ export interface XenApiHostCpu {
   vendor: string
 }
 
+type XenApiNetworkCallMethods = TagCallMethods & {}
+
 export interface XenApiNetwork {
   $ref: Branded<'network'>
   allowed_operations: NETWORK_OPERATIONS[]
@@ -639,8 +641,7 @@ export interface XenApiNetwork {
   uuid: string
   VIFs: XenApiVif['$ref'][]
 }
-export interface XenApiNetworkWrapped extends WrapperXenApi<XenApiNetwork, 'network'> {}
-
+export interface XenApiNetworkWrapped extends WrapperXenApi<XenApiNetwork, 'network', XenApiNetworkCallMethods> {}
 export interface XenApiVif {
   $ref: Branded<'VIF'>
   allowed_operations: VIF_OPERATIONS[]

--- a/@xen-orchestra/rest-api/src/networks/network.controller.mts
+++ b/@xen-orchestra/rest-api/src/networks/network.controller.mts
@@ -1,4 +1,4 @@
-import { Example, Get, Path, Query, Response, Request, Route, Security, Tags, Delete, SuccessResponse } from 'tsoa'
+import { Example, Get, Path, Query, Response, Request, Route, Security, Tags, Delete, SuccessResponse, Put } from 'tsoa'
 import { inject } from 'inversify'
 import { provide } from 'inversify-binding-decorators'
 import { Request as ExRequest } from 'express'
@@ -139,5 +139,29 @@ export class NetworkController extends XapiXoController<XoNetwork> {
     const tasks = await this.getTasksForObject(id as XoNetwork['id'], { filter, limit })
 
     return this.sendObjects(Object.values(tasks), req, 'tasks')
+  }
+
+  /**
+   * @example id "9fe12ca3-d75d-cfb0-492e-cfd2bc6c568f"
+   * @example tag "from-rest-api"
+   */
+  @Put('{id}/tags/{tag}')
+  @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  async putNetworkTag(@Path() id: string, @Path() tag: string): Promise<void> {
+    const network = this.getXapiObject(id as XoNetwork['id'])
+    await network.$call('add_tags', tag)
+  }
+
+  /**
+   * @example id "9fe12ca3-d75d-cfb0-492e-cfd2bc6c568f"
+   * @example tag "from-rest-api"
+   */
+  @Delete('{id}/tags/{tag}')
+  @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  async deleteNetworkTag(@Path() id: string, @Path() tag: string): Promise<void> {
+    const network = this.getXapiObject(id as XoNetwork['id'])
+    await network.$call('add_tags', tag)
   }
 }

--- a/@xen-orchestra/rest-api/src/networks/network.controller.mts
+++ b/@xen-orchestra/rest-api/src/networks/network.controller.mts
@@ -162,6 +162,6 @@ export class NetworkController extends XapiXoController<XoNetwork> {
   @Response(notFoundResp.status, notFoundResp.description)
   async deleteNetworkTag(@Path() id: string, @Path() tag: string): Promise<void> {
     const network = this.getXapiObject(id as XoNetwork['id'])
-    await network.$call('add_tags', tag)
+    await network.$call('remove_tags', tag)
   }
 }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,6 +33,8 @@
   - `GET /rest/v0/vdi-snapshots/<vdi-snaphot-id>/tasks` (PR [#9082](https://github.com/vatesfr/xen-orchestra/pull/9082))
   - `PUT /rest/v0/hosts/<host-id>/tags/:tag` (PR [#9037](https://github.com/vatesfr/xen-orchestra/pull/9037))
   - `DELETE /rest/v0/hosts/<host-id>/tags/:tag` (PR [#9037](https://github.com/vatesfr/xen-orchestra/pull/9037))
+  - `PUT /rest/v0/networks/<network-id>/tags/:tag` (PR [#9087](https://github.com/vatesfr/xen-orchestra/pull/9087))
+  - `DELETE /rest/v0/networks/<network-id>/tags/:tag` (PR [#9087](https://github.com/vatesfr/xen-orchestra/pull/9087))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -231,6 +231,7 @@ export default class RestApi {
           alarms: true,
           messages: true,
           tasks: true,
+          tags: true,
         },
       },
       pifs: {


### PR DESCRIPTION
### Description

<img width="385" height="113" alt="image" src="https://github.com/user-attachments/assets/d69825bf-54d9-4c80-92a0-ccbb82257e2a" />

[1172](https://project.vates.tech/vates-global/browse/XO-1172/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
