### PR TITLE
feat(@xen-orchestra/rest-api): expose pools/:id/tags/:tag

### DIFF
--- a/@vates/types/src/xen-api.mts
+++ b/@vates/types/src/xen-api.mts
@@ -167,6 +167,8 @@ export interface XenApiEvent {
   timestamp?: string
 }
 
+type XenApiPoolCallMethods = TagCallMethods & {}
+
 export interface XenApiPool {
   $ref: Branded<'pool'>
   allowed_operations: POOL_ALLOWED_OPERATIONS[]
@@ -229,7 +231,7 @@ export interface XenApiPool {
   /** @deprecated */
   wlb_verify_cert?: boolean
 }
-export type XenApiPoolWrapped = WrapperXenApi<XenApiPool, 'pool'>
+export type XenApiPoolWrapped = WrapperXenApi<XenApiPool, 'pool', XenApiPoolCallMethods>
 
 /** @deprecated */
 export interface XenApiPoolPatch {

--- a/@xen-orchestra/rest-api/src/pools/pool.controller.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.controller.mts
@@ -12,6 +12,8 @@ import {
   Middlewares,
   Body,
   SuccessResponse,
+  Put,
+  Delete,
 } from 'tsoa'
 import { inject } from 'inversify'
 import { PassThrough } from 'node:stream'
@@ -432,5 +434,29 @@ export class PoolController extends XapiXoController<XoPool> {
     const messages = this.getMessagesForObject(id as XoPool['id'], { filter, limit })
 
     return this.sendObjects(Object.values(messages), req, 'messages')
+  }
+
+  /**
+   * @example id "355ee47d-ff4c-4924-3db2-fd86ae629676"
+   * @example tag "from-rest-api"
+   */
+  @Put('{id}/tags/{tag}')
+  @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  async putPoolTag(@Path() id: string, @Path() tag: string): Promise<void> {
+    const pool = this.getXapiObject(id as XoPool['id'])
+    await pool.$call('add_tags', tag)
+  }
+
+  /**
+   * @example id "355ee47d-ff4c-4924-3db2-fd86ae629676"
+   * @example tag "from-rest-api"
+   */
+  @Delete('{id}/tags/{tag}')
+  @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  async deletePoolTag(@Path() id: string, @Path() tag: string): Promise<void> {
+    const pool = this.getXapiObject(id as XoPool['id'])
+    await pool.$call('remove_tags', tag)
   }
 }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -35,6 +35,8 @@
   - `DELETE /rest/v0/hosts/<host-id>/tags/:tag` (PR [#9037](https://github.com/vatesfr/xen-orchestra/pull/9037))
   - `PUT /rest/v0/networks/<network-id>/tags/:tag` (PR [#9087](https://github.com/vatesfr/xen-orchestra/pull/9087))
   - `DELETE /rest/v0/networks/<network-id>/tags/:tag` (PR [#9087](https://github.com/vatesfr/xen-orchestra/pull/9087))
+  - `PUT /rest/v0/pools/<pool-id>/tags/:tag` (PR [#9088](https://github.com/vatesfr/xen-orchestra/pull/9088))
+  - `DELETE /rest/v0/pools/<pool-id>/tags/:tag` (PR [#9088](https://github.com/vatesfr/xen-orchestra/pull/9088))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -252,6 +252,7 @@ export default class RestApi {
           alarms: true,
           missing_patches: true,
           messages: true,
+          tags: true,
         },
       },
       groups: {


### PR DESCRIPTION
### Description

<img width="385" height="113" alt="image" src="https://github.com/user-attachments/assets/e677f4ac-4c8c-4bc7-b3a7-1d50ff93f93b" />

[XO-1171](https://project.vates.tech/vates-global/browse/XO-1171/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
