### PR TITLE
feat(@xen-orchestra/rest-api): expose vms/:id/tags/:tag

### DIFF
--- a/@vates/types/src/xen-api.mts
+++ b/@vates/types/src/xen-api.mts
@@ -263,7 +263,7 @@ export interface XenApiPoolUpdate {
   version?: string
 }
 
-type XenApiVmCallMethods = {
+type XenApiVmCallMethods = TagCallMethods & {
   (method: 'start', start_paused: boolean, force: boolean): Promise<void>
   (method: 'clean_shutdown'): Promise<void>
   (method: 'hard_shutdown'): Promise<void>

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -641,8 +641,8 @@ export class VmController extends XapiXoController<XoVm> {
   @SuccessResponse(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async putVmTag(@Path() id: string, @Path() tag: string): Promise<void> {
-    const pool = this.getXapiObject(id as XoVm['id'])
-    await pool.$call('add_tags', tag)
+    const vm = this.getXapiObject(id as XoVm['id'])
+    await vm.$call('add_tags', tag)
   }
 
   /**
@@ -653,7 +653,7 @@ export class VmController extends XapiXoController<XoVm> {
   @SuccessResponse(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async deleteVmTag(@Path() id: string, @Path() tag: string): Promise<void> {
-    const pool = this.getXapiObject(id as XoVm['id'])
-    await pool.$call('remove_tags', tag)
+    const vm = this.getXapiObject(id as XoVm['id'])
+    await vm.$call('remove_tags', tag)
   }
 }

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -632,4 +632,28 @@ export class VmController extends XapiXoController<XoVm> {
 
     return this.sendObjects(Object.values(tasks), req, 'tasks')
   }
+
+  /**
+   * @example id "613f541c-4bed-fc77-7ca8-2db6b68f079c"
+   * @example tag "from-rest-api"
+   */
+  @Put('{id}/tags/{tag}')
+  @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  async putVmTag(@Path() id: string, @Path() tag: string): Promise<void> {
+    const pool = this.getXapiObject(id as XoVm['id'])
+    await pool.$call('add_tags', tag)
+  }
+
+  /**
+   * @example id "613f541c-4bed-fc77-7ca8-2db6b68f079c"
+   * @example tag "from-rest-api"
+   */
+  @Delete('{id}/tags/{tag}')
+  @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  async deleteVmTag(@Path() id: string, @Path() tag: string): Promise<void> {
+    const pool = this.getXapiObject(id as XoVm['id'])
+    await pool.$call('remove_tags', tag)
+  }
 }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,6 +37,8 @@
   - `DELETE /rest/v0/networks/<network-id>/tags/:tag` (PR [#9087](https://github.com/vatesfr/xen-orchestra/pull/9087))
   - `PUT /rest/v0/pools/<pool-id>/tags/:tag` (PR [#9088](https://github.com/vatesfr/xen-orchestra/pull/9088))
   - `DELETE /rest/v0/pools/<pool-id>/tags/:tag` (PR [#9088](https://github.com/vatesfr/xen-orchestra/pull/9088))
+  - `PUT /rest/v0/vms/<vm-id>/tags/:tag` (PR [#9088](https://github.com/vatesfr/xen-orchestra/pull/9088))
+  - `DELETE /rest/v0/vms/<vm-id>/tags/:tag` (PR [#9088](https://github.com/vatesfr/xen-orchestra/pull/9088))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,8 +37,8 @@
   - `DELETE /rest/v0/networks/<network-id>/tags/:tag` (PR [#9087](https://github.com/vatesfr/xen-orchestra/pull/9087))
   - `PUT /rest/v0/pools/<pool-id>/tags/:tag` (PR [#9088](https://github.com/vatesfr/xen-orchestra/pull/9088))
   - `DELETE /rest/v0/pools/<pool-id>/tags/:tag` (PR [#9088](https://github.com/vatesfr/xen-orchestra/pull/9088))
-  - `PUT /rest/v0/vms/<vm-id>/tags/:tag` (PR [#9088](https://github.com/vatesfr/xen-orchestra/pull/9088))
-  - `DELETE /rest/v0/vms/<vm-id>/tags/:tag` (PR [#9088](https://github.com/vatesfr/xen-orchestra/pull/9088))
+  - `PUT /rest/v0/vms/<vm-id>/tags/:tag` (PR [#9092](https://github.com/vatesfr/xen-orchestra/pull/9092))
+  - `DELETE /rest/v0/vms/<vm-id>/tags/:tag` (PR [#9092](https://github.com/vatesfr/xen-orchestra/pull/9092))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xo-mixins/rest-api.mjs
+++ b/packages/xo-server/src/xo-mixins/rest-api.mjs
@@ -289,6 +289,7 @@ export default class RestApi {
           vdis: true,
           messages: true,
           tasks: true,
+          tags: true,
         },
       },
       'vm-controllers': {


### PR DESCRIPTION
### Screnshot


<img width="326" height="109" alt="Capture d’écran de 2025-10-09 14-46-50" src="https://github.com/user-attachments/assets/d7bed0fa-358e-4923-ba23-c0ed9e469ecc" />

### Description

[XO-1162](https://project.vates.tech/vates-global/browse/XO-1162/)
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
