### PR TITLE
docs(sdn-controller): document OpenFlow XAPI plugin usage

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -64,6 +64,19 @@ You shouldn't have to change this. It's the path where `xo-web` files are served
 '/' = '../xo-web/dist/'
 ```
 
+## SDN Controller mode
+
+The SDN Controller plugin has 2 modes for the OpenFlow rule management. The default mode uses a direct channel to talk through the OpenFlow protocol. The other mode uses a XAPI plugin on XCP-ng side.
+
+:::tip
+For this kind of setting, we recommend using something like `/etc/xo-server/config.sdncontroller.toml` and not to modify the main configuration file.
+:::
+
+```
+[plugins.sdn-controller]
+useDirectChannel = false
+```
+
 ## Custom certificate authority
 
 If you use certificates signed by an in-house CA for your XCP-ng or XenServer hosts, and want to have Xen Orchestra connect to them without rejection, you can use the [`NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#cli_node_extra_ca_certs_file) environment variable.
@@ -162,11 +175,11 @@ acmeEmail = 'admin@my.domain.net'
 To configure your XOA with Let's Encrypt:
 
 1. In the HTTPS section of your XO configuration file, add the following entry:
-    - `autoCert = true`
-    - `acmeDomain = example.org`
+   - `autoCert = true`
+   - `acmeDomain = example.org`
 2. Add an entry following this pattern: `acmeDomain = EXAMPLE`, where EXAMPLE is a [fully qualified domain name](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) (FQDN) that points to your XOA environment.
 3. Load the FQDN in your browser.\
-After a few seconds, the certificate will be automatically generated and installed
+   After a few seconds, the certificate will be automatically generated and installed.
 
 ## Redis server
 


### PR DESCRIPTION
- State to use a single XOA instance with SDN Controller plugin enabled
- Cleanup existing OpenFlow documentation
- Document XAPI plugin usage, including xo-cli commands
- Add configuration to toggle between direct channel and XAPI plugin

Tied to XCP-ng documentation PR: https://github.com/xcp-ng/xcp-ng-org/pull/401

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
