### PR TITLE
feat(xo-web): add merge synchronously option to mirror backups

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Backups] Add `Merge backups synchronously` to mirror backup (PR [#9118](https://github.com/vatesfr/xen-orchestra/pull/9118))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -30,5 +32,6 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
 - xo-web minor
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,5 +30,5 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
-
+- xo-web minor
 <!--packages-end-->

--- a/packages/xo-web/src/xo-app/backup/new/mirror/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/mirror/index.js
@@ -279,7 +279,7 @@ const NewMirrorBackup = decorate([
       inputBackupReportTplId: generateId,
       inputHideSuccessfulItemsId: generateId,
       inputMirrorAllId: generateId,
-      inputMergeBackupsSynchronousl: generateId,
+      inputMergeBackupsSynchronously: generateId,
       isBackupInvalid: state =>
         state.isMissingName ||
         state.isMissingBackupMode ||

--- a/packages/xo-web/src/xo-app/backup/new/mirror/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/mirror/index.js
@@ -279,6 +279,7 @@ const NewMirrorBackup = decorate([
       inputBackupReportTplId: generateId,
       inputHideSuccessfulItemsId: generateId,
       inputMirrorAllId: generateId,
+      inputMergeBackupsSynchronousl: generateId,
       isBackupInvalid: state =>
         state.isMissingName ||
         state.isMissingBackupMode ||

--- a/packages/xo-web/src/xo-app/backup/new/mirror/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/mirror/index.js
@@ -237,6 +237,8 @@ const NewMirrorBackup = decorate([
       onChangeVmBackups: (_, vmBackups) => () => ({
         vmsToMirror: vmBackups.map(({ value: vmUuid }) => vmUuid),
       }),
+      setMergeBackupsSynchronously: ({ setAdvancedSettings }, mergeBackupsSynchronously) =>
+        setAdvancedSettings({ mergeBackupsSynchronously }),
     },
     computed: {
       vmBackupOptions: async state => {
@@ -317,6 +319,7 @@ const NewMirrorBackup = decorate([
       backupReportTpl = 'mjml',
       hideSuccessfulItems,
       nRetriesVmBackupFailures = 0,
+      mergeBackupsSynchronously,
     } = state.advancedSettings
     return (
       <form id={state.formId}>
@@ -456,6 +459,21 @@ const NewMirrorBackup = decorate([
                           id={state.inputHideSuccessfulItemsId}
                           value={hideSuccessfulItems}
                           onChange={effects.setHideSuccessfulItems}
+                        />
+                      </FormGroup>
+                      <FormGroup>
+                        <label htmlFor={state.inputMergeBackupsSynchronously}>
+                          <strong>{_('mergeBackupsSynchronously')}</strong>
+                        </label>{' '}
+                        <Tooltip content={_('mergeBackupsSynchronouslyTooltip')}>
+                          <Icon icon='info' />
+                        </Tooltip>
+                        <Toggle
+                          className='pull-right'
+                          id={state.inputMergeBackupsSynchronously}
+                          name='mergeBackupsSynchronously'
+                          value={mergeBackupsSynchronously}
+                          onChange={effects.setMergeBackupsSynchronously}
                         />
                       </FormGroup>
                     </div>


### PR DESCRIPTION
useful when  restarting the job or when multiple mirrors are chained

<img width="851" height="283" alt="image" src="https://github.com/user-attachments/assets/e1f279c9-510f-4627-a051-45650af8d4ef" />

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
