### PR TITLE
feat(xo6): add loader on input search treeview when is triggered

### DIFF
--- a/@xen-orchestra/lite/src/stories/web-core/ui/input/ui-input.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/input/ui-input.story.vue
@@ -12,6 +12,7 @@
         choice({ label: 'Search', value: 'fa:magnifying-glass' }, { label: 'AngleDown', value: 'fa:angle-down' })
       ),
       prop('clearable').bool().widget(),
+      prop('isSearching').bool().widget(),
       prop('disabled').bool().widget().help('Not defined as component prop'),
       slot('rightIcon').help('Can be used in place of rightIcon prop'),
     ]"

--- a/@xen-orchestra/web-core/lib/components/ui/input/UiInput.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/input/UiInput.vue
@@ -1,7 +1,8 @@
 <!-- v5 -->
 <template>
   <div :class="toVariants({ accent, disabled })" class="ui-input" @click.self="focus()">
-    <VtsIcon :name="icon" size="medium" class="left-icon" />
+    <UiLoader v-if="isSearching" />
+    <VtsIcon v-else :name="icon" size="medium" class="left-icon" />
     <input
       :id="wrapperController?.id ?? id"
       ref="inputRef"
@@ -30,6 +31,7 @@
 import VtsIcon from '@core/components/icon/VtsIcon.vue'
 import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import type { LabelAccent } from '@core/components/ui/label/UiLabel.vue'
+import UiLoader from '@core/components/ui/loader/UiLoader.vue'
 import type { IconName } from '@core/icons'
 import { useMapper } from '@core/packages/mapper/use-mapper.ts'
 import { IK_INPUT_WRAPPER_CONTROLLER } from '@core/utils/injection-keys.util'
@@ -57,6 +59,7 @@ const {
   icon?: IconName
   rightIcon?: IconName
   clearable?: boolean
+  isSearching?: boolean
 }>()
 
 const modelValue = defineModel<string | number>({ required: true })

--- a/@xen-orchestra/web-core/lib/composables/tree-filter.composable.ts
+++ b/@xen-orchestra/web-core/lib/composables/tree-filter.composable.ts
@@ -6,9 +6,10 @@ export function useTreeFilter() {
   const filter = ref('')
   const debouncedFilter = refDebounced(filter, 500)
   const hasFilter = computed(() => debouncedFilter.value.trim().length > 0)
+  const isSearching = computed(() => filter.value !== debouncedFilter.value)
 
   const predicate = (node: TreeNodeBase) =>
     hasFilter.value ? node.label.toLocaleLowerCase().includes(debouncedFilter.value.toLocaleLowerCase()) : undefined
 
-  return { filter, predicate }
+  return { filter, predicate, isSearching }
 }

--- a/@xen-orchestra/web-core/lib/composables/tree-filter.composable.ts
+++ b/@xen-orchestra/web-core/lib/composables/tree-filter.composable.ts
@@ -5,9 +5,10 @@ import { computed, ref } from 'vue'
 export function useTreeFilter() {
   const filter = ref('')
   const debouncedFilter = refDebounced(filter, 500)
-  const hasFilter = computed(() => debouncedFilter.value.trim().length > 0)
-  const isSearching = computed(() => filter.value !== debouncedFilter.value)
-
+  const hasFilter = computed(() => filter.value.trim().length > 0)
+  const isSearching = computed(() =>
+    filter.value.trim().length === 0 ? false : filter.value !== debouncedFilter.value
+  )
   const predicate = (node: TreeNodeBase) =>
     hasFilter.value ? node.label.toLocaleLowerCase().includes(debouncedFilter.value.toLocaleLowerCase()) : undefined
 

--- a/@xen-orchestra/web/src/components/SidebarSearch.vue
+++ b/@xen-orchestra/web/src/components/SidebarSearch.vue
@@ -3,7 +3,7 @@
     <UiInput
       v-model="search"
       :aria-label="t('sidebar.search-tree-view')"
-      :icon="!isSearching ? 'fa:magnifying-glass' : undefined"
+      icon="fa:magnifying-glass"
       :placeholder="t('sidebar.search-tree-view')"
       accent="brand"
       clearable

--- a/@xen-orchestra/web/src/components/SidebarSearch.vue
+++ b/@xen-orchestra/web/src/components/SidebarSearch.vue
@@ -3,9 +3,11 @@
     <UiInput
       v-model="search"
       :aria-label="t('sidebar.search-tree-view')"
-      icon="fa:magnifying-glass"
+      :icon="!isSearching ? 'fa:magnifying-glass' : undefined"
       :placeholder="t('sidebar.search-tree-view')"
       accent="brand"
+      clearable
+      :is-searching
     />
   </div>
 </template>
@@ -13,6 +15,8 @@
 <script lang="ts" setup>
 import UiInput from '@core/components/ui/input/UiInput.vue'
 import { useI18n } from 'vue-i18n'
+
+defineProps<{ isSearching?: boolean }>()
 
 const search = defineModel<string>({ default: '' })
 

--- a/@xen-orchestra/web/src/composables/pool-tree.composable.ts
+++ b/@xen-orchestra/web/src/composables/pool-tree.composable.ts
@@ -12,7 +12,7 @@ export function useSiteTree() {
   const { pools, arePoolsReady } = useXoPoolCollection()
   const { hostsByPool, areHostsReady } = useXoHostCollection()
   const { vmsByHost, hostLessVmsByPool, areVmsReady } = useXoVmCollection()
-  const { filter, predicate } = useTreeFilter()
+  const { filter, predicate, isSearching } = useTreeFilter()
 
   const site: XoSite = {
     id: useId(),
@@ -68,5 +68,6 @@ export function useSiteTree() {
     isReady,
     sites: nodes,
     filter,
+    isSearching,
   }
 }

--- a/@xen-orchestra/web/src/layouts/AppLayout.vue
+++ b/@xen-orchestra/web/src/layouts/AppLayout.vue
@@ -19,7 +19,7 @@
       <AccountMenu />
     </template>
     <template #sidebar-header>
-      <SidebarSearch v-model="filter" />
+      <SidebarSearch v-model="filter" :is-searching />
     </template>
     <template #sidebar-content>
       <VtsTreeList v-if="!isReady">
@@ -55,7 +55,7 @@ defineSlots<{
 
 const uiStore = useUiStore()
 
-const { sites, isReady, filter } = useSiteTree()
+const { sites, isReady, filter, isSearching } = useSiteTree()
 </script>
 
 <style lang="postcss" scoped>

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -71,6 +71,7 @@
 
 - **XO 6:**
   - [Collections] Implement virtual lists for tasks and alarms to improve performance (PR [#9077](https://github.com/vatesfr/xen-orchestra/pull/9077))
+  - [Treeview search] Add loader when search is triggered and ability to clear search (PR [#9122](https://github.com/vatesfr/xen-orchestra/pull/9122))
 
 ### Bug fixes
 


### PR DESCRIPTION
### Description

Created new props "isSearching"  to the UiInput component to display the loader when searching.
Updated the UiInput story component.

Added clearable props in UiInput component to make search clearing available

**Before**
<img width="534" height="467" alt="image" src="https://github.com/user-attachments/assets/011a03f6-1a94-4d86-9ac2-cb10ab0726df" />

<img width="534" height="467" alt="image" src="https://github.com/user-attachments/assets/6026efda-3500-40ee-b7a8-a0cc7141c61c" />


**After**
<img width="534" height="467" alt="image" src="https://github.com/user-attachments/assets/53af80b0-3e89-4485-8be6-9a2608fafd2e" />

<img width="534" height="467" alt="image" src="https://github.com/user-attachments/assets/0bf45ba9-cda1-4ff7-97cf-cba5b428e857" />



### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
