### PR TITLE
fix(backups): wrong error on close before init

### DIFF
--- a/@xen-orchestra/xapi/disks/Xapi.mjs
+++ b/@xen-orchestra/xapi/disks/Xapi.mjs
@@ -107,7 +107,8 @@ export class XapiDiskSource extends DiskPassthrough {
         }
         return streamSource
       }
-      await source?.close() // this will close source and stream source
+      // init probaby failed, so nothing to close , but better safe than sorry
+      await source?.close().catch(warn)
       throw err
     }
     this.#useNbd = true
@@ -140,7 +141,8 @@ export class XapiDiskSource extends DiskPassthrough {
       await source.init()
       source = new TimeoutDisk(source, this.#timeout)
     } catch (error) {
-      await source?.close()
+      // init probaby failed, so nothing to close , but better safe than sorry
+      await source?.close().catch(warn)
       if (baseRef !== undefined) {
         warn(`can't compute delta ${vdiRef} from ${baseRef}, fallBack to a full`, { error })
         this.#baseRef = undefined
@@ -180,7 +182,9 @@ export class XapiDiskSource extends DiskPassthrough {
       return readAhead
     } catch (error) {
       info('Error in openNbdCBT', error)
-      await source.close()
+      // init probaby failed, so nothing to close , but better safe than sorry
+      await source?.close().catch(warn)
+
       // A lot of things can go wrong with CBT:
       // Not enabled on the baseRef,
       // Not enabled on the VDI,


### PR DESCRIPTION
this happens if the disk init fails, for example when trying
to read qcow2 disk from a non qcow2 SR

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
