### PR TITLE
docs(xo): specify configuration file path

### DIFF
--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -283,7 +283,7 @@ $ xo-cli register http://xo.my-company.net admin@admin.net admin
 Successfully logged with admin@admin.net
 ```
 
-Note: only a token will be saved in the configuration file.
+Note: only a token will be saved in the configuration file (`/etc/xo-server/config.toml`).
 
 #### List available objects
 

--- a/docs/docs/backups.md
+++ b/docs/docs/backups.md
@@ -40,7 +40,7 @@ Here's an example:
 
 You can send all your XO logs to an external syslog server.
 
-To enable syslog, add this to your configuration file: 
+To enable syslog, add this to your configuration file (`/etc/xo-server/config.toml`): 
 
 ```
 [logs.transport.syslog]

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -201,7 +201,7 @@ And to download the patches, we need access to `https://fileservice.citrix.com/d
 
 To do that behind a corporate proxy, just add the `httpProxy` variable to match your current proxy configuration.
 
-You can add this at the end of your config file:
+You can add this at the end of your config file (`/etc/xo-server/config.toml`):
 
 ```toml
 # HTTP proxy configuration used by xo-server to fetch resources on the Internet.

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -389,14 +389,20 @@ rcctl start redis
 
 ### sudo
 
-If you are running `xo-server` as a non-root user, you need to use `sudo` to be able to mount NFS remotes. You can do this by editing `xo-server` configuration file and setting `useSudo = true`. It's near the end of the file:
+If you are running `xo-server` as a non-root user, you need to use `sudo` to be able to mount NFS remotes. You can do this by editing the `xo-server` configuration file and setting `useSudo = true`. It's near the end of the file:
 
 ```toml
 useSudo = true
 ```
 
-You need to configure `sudo` to allow the user of your choice to run mount/umount commands without asking for a password. Depending on your operating system / sudo version, the location of this configuration may change. Regardless, you can use:
+You need to configure `sudo` to allow the user of your choice to run mount/umount commands without asking for a password. 
+
+:::tip
+Depending on your operating system or `sudo` version, the location of this configuration may change. 
+
+Regardless, you can use:
 
 ```
 username ALL=(root)NOPASSWD: /bin/mount, /bin/umount, /bin/findmnt
 ```
+:::

--- a/docs/docs/migrate_to_new_xoa.md
+++ b/docs/docs/migrate_to_new_xoa.md
@@ -16,7 +16,7 @@ You can set a passphrase to encrypt the exported configuration.
 ### Import configuration
 
 Now it's time to import your configuration to the new appliance.
-Go to the **Settings** -> **Config** page of your new appliance. Here you have an **_import_** section where you can drag and drop your exported configuration file.
+Go to the **Settings** → **Config** page of your new appliance. Here, you have an **_import_** section where you can drag and drop your exported configuration file.
 
 ![](./assets/importModal.png)
 
@@ -24,4 +24,4 @@ When your configuration is loaded, click to import. A new modal will appear to a
 
 ### Advanced users
 
-If you made custom adjustments to the `/etc/xo-server` config file on your previous appliance, unfortunately you will have to recreate these modifications on the new appliance.
+If you made custom adjustments to the `/etc/xo-server/config.toml` config file on your previous appliance, unfortunately you will have to recreate these modifications on the new appliance.


### PR DESCRIPTION
Several sections of the Xen Orchestra documentation mention modifying the config file, without specifying the actual file path. This commit updates those references to explicitly include `/etc/xo-server/config.toml`, which helps users locate and edit the correct configuration file more easily.