### PR TITLE
fix(xo-server): set default cores-per-socket value

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## **next**
 
+- [VM/New] Fix the default topology by setting the platform:cores-per-socket value correctly (PR [#9136](https://github.com/vatesfr/xen-orchestra/pull/9136))
+
 ## **0.15.0** (2025-09-30)
 
 - [settigns] fix key-value alignement and refactor page (PR [#8981](https://github.com/vatesfr/xen-orchestra/pull/8981))

--- a/@xen-orchestra/lite/src/pages/vm/new.vue
+++ b/@xen-orchestra/lite/src/pages/vm/new.vue
@@ -702,7 +702,7 @@ const vmCreationParams = computed(() => ({
   bootAfterCreate: vmState.boot_vm,
   copyHostBiosStrings: vmState.boot_firmware !== 'uefi' && !templateHasBiosStrings.value && vmState.copyHostBiosStrings,
   hvmBootFirmware: vmState.boot_firmware ?? 'bios',
-  coresPerSocket: vmState.topology,
+  coresPerSocket: vmState.topology ?? vmState.vCPU,
   tags: vmState.tags,
   cloudConfig: '',
 }))
@@ -980,6 +980,8 @@ watch(
       affinity,
     } = template
 
+    const topology = Number(platform['cores-per-socket'])
+
     Object.assign(vmState, {
       name: name_label,
       description: other_config.default_template === 'true' ? '' : name_description,
@@ -988,7 +990,7 @@ watch(
       ram: memory_dynamic_max,
       vdis: getVdis(template),
       tags,
-      topology: platform['cores-per-socket'] ?? null,
+      topology: isNaN(topology) ? null : topology,
       affinity_host: affinity,
       existingVdis: getExistingVdis(template),
       networkInterfaces: getExistingInterface(template),

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -88,6 +88,8 @@
 - [Backups] Fix VDI_NO_MANAGED error during replication (PR [#9117](https://github.com/vatesfr/xen-orchestra/pull/9117))
 - [VM/advanced] Fix error while changing running VM memory limit (PR [#9121](https://github.com/vatesfr/xen-orchestra/pull/9121))
 - [Plugins/load balancer] Avoid migrating VMs tagged with anti-affinity when balancing performance (PR [#9139](https://github.com/vatesfr/xen-orchestra/pull/9139))
+- [VM] Set a default `cores-per-socket` value for all new VM [#9111](https://github.com/vatesfr/xen-orchestra/issues/9111) (PR [#9136](https://github.com/vatesfr/xen-orchestra/pull/9136))
+- [VM] Update invalid `platform.cores-per-socket` for all existing VM with invalid value [#9111](https://github.com/vatesfr/xen-orchestra/issues/9111) (PR [#9136](https://github.com/vatesfr/xen-orchestra/pull/9136))
 
 - **XO 6**:
   - [Site/Backups] Fix an issue properties of undefined in backups tab (PR [#9064](https://github.com/vatesfr/xen-orchestra/pull/9064))

--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -574,6 +574,17 @@ const TRANSFORMS = {
     const coresPerSocket = obj.platform['cores-per-socket']
     if (coresPerSocket !== undefined) {
       vm.coresPerSocket = +coresPerSocket
+    } else {
+      // https://github.com/vatesfr/xen-orchestra/issues/9111
+      // TODO: Remove when correctly handled by XCP-ng
+      obj
+        .update_platform('cores-per-socket', String(vm.CPUs.number))
+        .catch(err => {
+          warn(`unable to set default cores per socket property for VM: ${obj.$id}`, err)
+        })
+        .finally(() => {
+          debug(`cores-per-socket was called for: ${obj.$id}`)
+        })
     }
 
     if (obj.is_control_domain) {


### PR DESCRIPTION
### Description

**do not squash**

fix #9111 
add default  `platform:cores-per-socket` value for **ALL** VMs with `coresPerSocket === undefined`

[XO-1561](https://project.vates.tech/vates-global/browse/XO-1561/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
