### PR TITLE
feat(xo6): fetch xo gui routes

### DIFF
--- a/@xen-orchestra/web-core/lib/packages/remote-resource/define-remote-resource.ts
+++ b/@xen-orchestra/web-core/lib/packages/remote-resource/define-remote-resource.ts
@@ -32,8 +32,8 @@ export function defineRemoteResource<
   initialData: () => TData
   state?: (data: Ref<NoInfer<TData>>, context: ResourceContext<TArgs>) => TState
   onDataReceived?: (data: Ref<NoInfer<TData>>, receivedData: any) => void
-  cacheDurationMs?: number
-  pollingIntervalMs?: number
+  cacheDurationMs?: number | false
+  pollingIntervalMs?: number | false
   stream?: boolean
 }): UseRemoteResource<TState, TArgs>
 
@@ -41,8 +41,8 @@ export function defineRemoteResource<TData, TState extends object, TArgs extends
   url: string | ((...args: TArgs) => string)
   state?: (data: Ref<TData | undefined>, context: ResourceContext<TArgs>) => TState
   onDataReceived?: (data: Ref<TData | undefined>, receivedData: any) => void
-  cacheDurationMs?: number
-  pollingIntervalMs?: number
+  cacheDurationMs?: number | false
+  pollingIntervalMs?: number | false
   stream?: boolean
 }): UseRemoteResource<TState, TArgs>
 
@@ -55,8 +55,8 @@ export function defineRemoteResource<
   initialData?: () => TData
   state?: (data: Ref<TData>, context: ResourceContext<TArgs>) => TState
   onDataReceived?: (data: Ref<NoInfer<TData>>, receivedData: any) => void
-  cacheDurationMs?: number
-  pollingIntervalMs?: number
+  cacheDurationMs?: number | false
+  pollingIntervalMs?: number | false
   stream?: boolean
 }) {
   const cache = new Map<
@@ -79,7 +79,7 @@ export function defineRemoteResource<
 
   const buildState = config.state ?? ((data: Ref<TData>) => ({ data }))
 
-  const cacheDuration = config.cacheDurationMs ?? DEFAULT_CACHE_DURATION_MS
+  const cacheExpiration = config.cacheDurationMs ?? DEFAULT_CACHE_DURATION_MS
 
   const pollingInterval = config.pollingIntervalMs ?? DEFAULT_POLLING_INTERVAL_MS
 
@@ -128,9 +128,11 @@ export function defineRemoteResource<
 
     entry.pause()
 
-    setTimeout(() => {
-      cache.delete(url)
-    }, cacheDuration)
+    if (cacheExpiration !== false) {
+      setTimeout(() => {
+        cache.delete(url)
+      }, cacheExpiration)
+    }
   }
 
   function registerUrl(url: string, context: ResourceContext<TArgs>) {
@@ -182,7 +184,7 @@ export function defineRemoteResource<
     let pause: VoidFunction = noop
     let resume: VoidFunction = execute
 
-    if (pollingInterval > 0) {
+    if (pollingInterval !== false) {
       const timeoutPoll = useTimeoutPoll(execute, pollingInterval, {
         immediateCallback: true,
         immediate: false,

--- a/@xen-orchestra/web-core/lib/packages/remote-resource/define-remote-resource.ts
+++ b/@xen-orchestra/web-core/lib/packages/remote-resource/define-remote-resource.ts
@@ -19,7 +19,7 @@ import {
   watch,
 } from 'vue'
 
-const DEFAULT_CACHE_DURATION_MS = 10_000
+const DEFAULT_CACHE_EXPIRATION_MS = 10_000
 
 const DEFAULT_POLLING_INTERVAL_MS = 30_000
 
@@ -32,7 +32,7 @@ export function defineRemoteResource<
   initialData: () => TData
   state?: (data: Ref<NoInfer<TData>>, context: ResourceContext<TArgs>) => TState
   onDataReceived?: (data: Ref<NoInfer<TData>>, receivedData: any) => void
-  cacheDurationMs?: number | false
+  cacheExpirationMs?: number | false
   pollingIntervalMs?: number | false
   stream?: boolean
 }): UseRemoteResource<TState, TArgs>
@@ -41,7 +41,7 @@ export function defineRemoteResource<TData, TState extends object, TArgs extends
   url: string | ((...args: TArgs) => string)
   state?: (data: Ref<TData | undefined>, context: ResourceContext<TArgs>) => TState
   onDataReceived?: (data: Ref<TData | undefined>, receivedData: any) => void
-  cacheDurationMs?: number | false
+  cacheExpirationMs?: number | false
   pollingIntervalMs?: number | false
   stream?: boolean
 }): UseRemoteResource<TState, TArgs>
@@ -55,7 +55,7 @@ export function defineRemoteResource<
   initialData?: () => TData
   state?: (data: Ref<TData>, context: ResourceContext<TArgs>) => TState
   onDataReceived?: (data: Ref<NoInfer<TData>>, receivedData: any) => void
-  cacheDurationMs?: number | false
+  cacheExpirationMs?: number | false
   pollingIntervalMs?: number | false
   stream?: boolean
 }) {
@@ -79,7 +79,7 @@ export function defineRemoteResource<
 
   const buildState = config.state ?? ((data: Ref<TData>) => ({ data }))
 
-  const cacheExpiration = config.cacheDurationMs ?? DEFAULT_CACHE_DURATION_MS
+  const cacheExpiration = config.cacheExpirationMs ?? DEFAULT_CACHE_EXPIRATION_MS
 
   const pollingInterval = config.pollingIntervalMs ?? DEFAULT_POLLING_INTERVAL_MS
 

--- a/@xen-orchestra/web/src/layouts/AppLayout.vue
+++ b/@xen-orchestra/web/src/layouts/AppLayout.vue
@@ -11,7 +11,7 @@
         accent="brand"
         right-icon="fa:arrow-up-right-from-square"
         variant="tertiary"
-        @click="openUrl('/', true)"
+        @click="openUrl(rawRoutes.xo5, true)"
       >
         XO 5
       </UiButton>
@@ -44,6 +44,7 @@ import SidebarSearch from '@/components/SidebarSearch.vue'
 import QuickTaskButton from '@/components/task/QuickTaskButton.vue'
 import SiteTreeList from '@/components/tree/SiteTreeList.vue'
 import { useSiteTree } from '@/composables/pool-tree.composable'
+import { useXoRoutes } from '@/remote-resources/use-xo-routes.ts'
 import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import VtsTreeList from '@core/components/tree/VtsTreeList.vue'
 import VtsTreeLoadingItem from '@core/components/tree/VtsTreeLoadingItem.vue'
@@ -61,6 +62,7 @@ const { t } = useI18n()
 const uiStore = useUiStore()
 
 const { sites, isReady, filter, isSearching } = useSiteTree()
+const { rawRoutes } = useXoRoutes()
 </script>
 
 <style lang="postcss" scoped>

--- a/@xen-orchestra/web/src/layouts/AppLayout.vue
+++ b/@xen-orchestra/web/src/layouts/AppLayout.vue
@@ -11,7 +11,7 @@
         accent="brand"
         right-icon="fa:arrow-up-right-from-square"
         variant="tertiary"
-        @click="openUrl(rawRoutes.xo5, true)"
+        @click="openUrl(xo5Route, true)"
       >
         XO 5
       </UiButton>
@@ -52,6 +52,7 @@ import UiButton from '@core/components/ui/button/UiButton.vue'
 import CoreLayout from '@core/layouts/CoreLayout.vue'
 import { useUiStore } from '@core/stores/ui.store'
 import { openUrl } from '@core/utils/open-url.utils'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 defineSlots<{
@@ -62,7 +63,8 @@ const { t } = useI18n()
 const uiStore = useUiStore()
 
 const { sites, isReady, filter, isSearching } = useSiteTree()
-const { rawRoutes } = useXoRoutes()
+const { routes } = useXoRoutes()
+const xo5Route = computed(() => routes.value?.xo5 ?? '')
 </script>
 
 <style lang="postcss" scoped>

--- a/@xen-orchestra/web/src/remote-resources/use-xo-routes.ts
+++ b/@xen-orchestra/web/src/remote-resources/use-xo-routes.ts
@@ -1,0 +1,14 @@
+import type { XoRoutes } from '@/types/xo/xo-routes.type.ts'
+import { defineRemoteResource } from '@core/packages/remote-resource/define-remote-resource.ts'
+
+export const useXoRoutes = defineRemoteResource({
+  url: '/rest/v0/gui-routes',
+  pollingIntervalMs: 0,
+  initialData: () => ({}) as XoRoutes,
+  state: (rawRoutes, context) => {
+    return {
+      rawRoutes,
+      hasError: context.hasError,
+    }
+  },
+})

--- a/@xen-orchestra/web/src/remote-resources/use-xo-routes.ts
+++ b/@xen-orchestra/web/src/remote-resources/use-xo-routes.ts
@@ -3,11 +3,12 @@ import { defineRemoteResource } from '@core/packages/remote-resource/define-remo
 
 export const useXoRoutes = defineRemoteResource({
   url: '/rest/v0/gui-routes',
-  pollingIntervalMs: 0,
-  initialData: () => ({}) as XoRoutes,
-  state: (rawRoutes, context) => {
+  cacheDurationMs: false,
+  pollingIntervalMs: false,
+  initialData: () => undefined as XoRoutes | undefined,
+  state: (routes, context) => {
     return {
-      rawRoutes,
+      routes,
       hasError: context.hasError,
     }
   },

--- a/@xen-orchestra/web/src/remote-resources/use-xo-routes.ts
+++ b/@xen-orchestra/web/src/remote-resources/use-xo-routes.ts
@@ -3,7 +3,7 @@ import { defineRemoteResource } from '@core/packages/remote-resource/define-remo
 
 export const useXoRoutes = defineRemoteResource({
   url: '/rest/v0/gui-routes',
-  cacheDurationMs: false,
+  cacheExpirationMs: false,
   pollingIntervalMs: false,
   initialData: () => undefined as XoRoutes | undefined,
   state: (routes, context) => {

--- a/@xen-orchestra/web/src/types/xo/xo-routes.type.ts
+++ b/@xen-orchestra/web/src/types/xo/xo-routes.type.ts
@@ -1,0 +1,4 @@
+export type XoRoutes = {
+  xo5: string
+  xo6: string
+}

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,6 +27,7 @@
 - [REST API] **Breaking changes** Async actions now return `application/json` (PR [#9209](https://github.com/vatesfr/xen-orchestra/pull/9209))
 
 - **XO 6:**
+  - [XO routes] fetch xo gui routes (PR [#9138](https://github.com/vatesfr/xen-orchestra/pull/9138))
   - [Input search] update design of input search (PR [#9156](https://github.com/vatesfr/xen-orchestra/pull/9156))
   - [Site/Hosts] Implement hosts view and side panel information (PR [#9128](https://github.com/vatesfr/xen-orchestra/pull/9128))
   - [Backups] Update wordings for backup jobs' modes to match XO documentation (PR [#9199](https://github.com/vatesfr/xen-orchestra/pull/9199))


### PR DESCRIPTION
### Description

Retrieving xo gui routes  and updating the URL to make the route dynamic on the xo5 button. 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
