### PR TITLE
fix(xo-server-load-balancer): correctly avoid migrating tagged VMs

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -83,6 +83,7 @@
 - [Backup/immutabiltiy] Fix double delete file that can block immutability lifting (PR [#9104](https://github.com/vatesfr/xen-orchestra/pull/9104))
 - [Backups] Fix VDI_NO_MANAGED error during replication (PR [#9117](https://github.com/vatesfr/xen-orchestra/pull/9117))
 - [VM/advanced] Fix error while changing running VM memory limit (PR [#9121](https://github.com/vatesfr/xen-orchestra/pull/9121))
+- [Plugins/load balancer] Avoid migrating VMs tagged with anti-affinity when balancing performance (PR [#9139](https://github.com/vatesfr/xen-orchestra/pull/9139))
 
 - **XO 6**:
   - [Site/Backups] Fix an issue properties of undefined in backups tab (PR [#9064](https://github.com/vatesfr/xen-orchestra/pull/9064))
@@ -119,6 +120,7 @@
 - vhd-lib patch
 - xo-server minor
 - xo-server-auth-saml minor
+- xo-server-load-balancer patch
 - xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-server-load-balancer/src/performance-plan.js
+++ b/packages/xo-server-load-balancer/src/performance-plan.js
@@ -1,4 +1,4 @@
-import filter from 'lodash/filter.js'
+import { filter, intersection } from 'lodash'
 
 import Plan from './plan'
 import { debug as debugP } from './utils'
@@ -196,18 +196,17 @@ export default class PerformancePlan extends Plan {
         continue
       }
 
-      for (const tag of vm.tags) {
-        // TODO: Improve this piece of code. We could compute variance to check if the VM
-        // is migratable. But the code must be rewritten:
-        // - All VMs, hosts and stats must be fetched at one place.
-        // - It's necessary to maintain a dictionary of tags for each host.
-        // - ...
-        if (this._antiAffinityTags.includes(tag)) {
-          debug(
-            `VM (${vm.id}) of Host (${exceededHost.id}) cannot be migrated. It contains anti-affinity tag '${tag}'.`
-          )
-          continue
-        }
+      // TODO: Improve this piece of code. We could compute variance to check if the VM
+      // is migratable. But the code must be rewritten:
+      // - All VMs, hosts and stats must be fetched at one place.
+      // - It's necessary to maintain a dictionary of tags for each host.
+      // - ...
+      const blockingTags = intersection(vm.tags, this._antiAffinityTags)
+      if (blockingTags.length > 0) {
+        debug(
+          `VM (${vm.id}) of Host (${exceededHost.id}) cannot be migrated. It contains anti-affinity tag(s): ${blockingTags}.`
+        )
+        continue
       }
 
       hosts.sort((a, b) => {


### PR DESCRIPTION
### Description

The piece of code preventing the load balancer from migrating VMs with anti-affinity tags was failing.

The `continue` was probably thought to refer to the VM loop, but it referred to the tag loop.

Introduced by 9ef05b8afede7eba85ed5cae32d1017d6d24f905

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
