### PR TITLE
feat(xo-cli): add system status download functionality for hosts and pools

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -42,6 +42,7 @@
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
 - @xen-orchestra/xapi minor
+- xo-server minor
 - xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-server/src/api/host.mjs
+++ b/packages/xo-server/src/api/host.mjs
@@ -723,16 +723,6 @@ async function handleGetSystemStatus(req, res, { xapi, host }) {
   return fromCallback(pipeline, response, res)
 }
 
-export async function getSystemStatus({ host }) {
-  return {
-    $getFrom: await this.registerHttpRequest(
-      handleGetSystemStatus,
-      { xapi: this.getXapi(host), host },
-      { suffix: `/${encodeURIComponent(host.name_label)}-system-status.tar.bz2` }
-    ),
-  }
-}
-
 /**
  * Download system status (bug report) from a host
  *
@@ -743,6 +733,16 @@ export async function getSystemStatus({ host }) {
  * @param {string} id - Host UUID
  * @returns {object} File download via $getFrom
  */
+export async function getSystemStatus({ host }) {
+  return {
+    $getFrom: await this.registerHttpRequest(
+      handleGetSystemStatus,
+      { xapi: this.getXapi(host), host },
+      { suffix: `/${encodeURIComponent(host.name_label)}-system-status.tar.bz2` }
+    ),
+  }
+}
+
 getSystemStatus.description = 'Download system status (bug report) from a host'
 
 getSystemStatus.params = {

--- a/packages/xo-server/src/api/host.mjs
+++ b/packages/xo-server/src/api/host.mjs
@@ -1,13 +1,15 @@
 import TTLCache from '@isaacs/ttlcache'
-import semver from 'semver'
 import { createLogger } from '@xen-orchestra/log'
 import assert from 'assert'
 import { format } from 'json-rpc-peer'
-import { incorrectState } from 'xo-common/api-errors.js'
 import { X509Certificate } from 'node:crypto'
+import { pipeline } from 'node:stream'
+import semver from 'semver'
+import { incorrectState } from 'xo-common/api-errors.js'
 
-import backupGuard from './_backupGuard.mjs'
 import { asyncEach } from '@vates/async-each'
+import { fromCallback } from 'promise-toolbox'
+import backupGuard from './_backupGuard.mjs'
 
 import { debounceWithKey } from '../_pDebounceWithKey.mjs'
 
@@ -679,5 +681,74 @@ getBiosInfo.params = {
   id: { type: 'string' },
 }
 getBiosInfo.resolve = {
+  host: ['id', 'host', 'administrate'],
+}
+
+// ===================================================================
+
+/**
+ * Download system status (bug report) from a host via HTTPS
+ * @param {object} req HTTP request object
+ * @param {object} res HTTP response object
+ * @param {object} data Handler data { xapi, host, format }
+ */
+async function handleGetSystemStatus(req, res, { xapi, host }) {
+  // Get server credentials using the host object which has $pool property
+  const serverId = this.getXenServerIdByObject(host)
+  const server = await this.getXenServerWithCredentials(serverId)
+
+  // Build URL
+  // Use host.address (the target host IP), not server.host (the XAPI server)
+  const url = new URL(`http://${host.address}/system-status`)
+  url.protocol = xapi._url.protocol // Use same protocol as XAPI connection
+  url.searchParams.set('output', 'tar.bz2') // XCP-ng requires output format parameter
+
+  // Setup HTTP Basic Auth headers
+  const opts = {
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${server.username}:${server.password}`).toString('base64')}`,
+    },
+    rejectUnauthorized: !server.allowUnauthorized,
+    timeout: 0, // No timeout for large downloads
+  }
+
+  // Set response headers
+  res.set({
+    'content-type': 'application/x-bzip2',
+    'content-disposition': `attachment; filename="${host.name_label}-system-status.tar-bz2"`,
+  })
+
+  // Download and stream to client
+  const response = await this.httpRequest(url, opts)
+  return fromCallback(pipeline, response, res)
+}
+
+export async function getSystemStatus({ host }) {
+  return {
+    $getFrom: await this.registerHttpRequest(
+      handleGetSystemStatus,
+      { xapi: this.getXapi(host), host },
+      { suffix: `/${encodeURIComponent(host.name_label)}-system-status.tar.bz2` }
+    ),
+  }
+}
+
+/**
+ * Download system status (bug report) from a host
+ *
+ * @description Connects to the host via HTTPS and downloads the system status
+ *              (detailed diagnostic information) in tar.bz2 format.
+ *              Authentication uses the same credentials as the XAPI connection.
+ *
+ * @param {string} id - Host UUID
+ * @returns {object} File download via $getFrom
+ */
+getSystemStatus.description = 'Download system status (bug report) from a host'
+
+getSystemStatus.params = {
+  id: { type: 'string' },
+}
+
+getSystemStatus.resolve = {
   host: ['id', 'host', 'administrate'],
 }

--- a/packages/xo-server/src/api/pool.mjs
+++ b/packages/xo-server/src/api/pool.mjs
@@ -2,11 +2,14 @@ import TTLCache from '@isaacs/ttlcache'
 import { asyncMap } from '@xen-orchestra/async-map'
 import { createLogger } from '@xen-orchestra/log'
 import { format } from 'json-rpc-peer'
+import { pipeline } from 'node:stream'
+import tarStream from 'tar-stream'
 import { Ref } from 'xen-api'
 import { incorrectState } from 'xo-common/api-errors.js'
 
 import backupGuard from './_backupGuard.mjs'
 
+import { fromCallback } from 'promise-toolbox'
 import { moveFirst } from '../_moveFirst.mjs'
 
 const log = createLogger('xo:api:pool')
@@ -413,4 +416,123 @@ listPoolsMatchingCriteria.params = {
   minHostVersion: { type: 'string', optional: true },
   poolNameRegExp: { type: 'string', optional: true },
   srNameRegExp: { type: 'string', optional: true },
+}
+
+// ===================================================================
+
+/**
+ * Download system status (bug report) from all hosts in a pool via HTTPS
+ * @param {object} req HTTP request object
+ * @param {object} res HTTP response object
+ * @param {object} data Handler data { xapi, pool, format }
+ */
+async function handleGetSystemStatuses(_req, res, { xapi, pool }) {
+  // Get all hosts in pool
+  const hosts = Object.values(xapi.objects.indexes.type.host)
+
+  // Get server credentials using the pool object which has $pool property
+  const serverId = this.getXenServerIdByObject(pool)
+  const server = await this.getXenServerWithCredentials(serverId)
+
+  // Create tar pack stream for archive
+  const pack = tarStream.pack()
+
+  // Set response headers
+  res.set({
+    'content-type': 'application/x-tar',
+    'content-disposition': `attachment; filename="${pool.name_label}-system-statuses.tar"`,
+  })
+
+  // Stream tar to response and handle downloads
+  // Create promise to track pipeline completion and catch errors
+  const pipelinePromise = fromCallback(pipeline, pack, res)
+
+  try {
+    // Download from each host in parallel (with concurrency limit to avoid resource exhaustion)
+    await asyncMap(
+      hosts,
+      async host => {
+        // Build system-status URL
+        // Use host.address (the target host IP), not server.host (the XAPI server)
+        const url = new URL(`http://${host.address}/system-status`)
+        url.protocol = xapi._url.protocol // Use same protocol as XAPI connection
+        url.searchParams.set('output', 'tar.bz2') // XCP-ng requires output format parameter
+
+        // Setup HTTP Basic Auth
+        const opts = {
+          headers: {
+            Authorization: `Basic ${Buffer.from(`${server.username}:${server.password}`).toString('base64')}`,
+          },
+          rejectUnauthorized: !server.allowUnauthorized,
+          timeout: 0, // No timeout for large downloads
+        }
+
+        // Download and add to tar archive
+        const response = await this.httpRequest(url, opts)
+        const filename = `${host.name_label}-system-status.tar.bz2`
+
+        // Get the size from Content-Length header if available
+        const size = response.headers['content-length']
+          ? Number.parseInt(response.headers['content-length'], 10)
+          : undefined
+
+        const entry = pack.entry({ name: filename, size }, err => {
+          if (err) {
+            log.error('Failed to create tar entry', {
+              hostName: host.name_label,
+              filename,
+              error: err,
+            })
+            // Destroy pack with error to propagate to pipelinePromise
+            pack.destroy(err)
+          }
+        })
+
+        await fromCallback(pipeline, response, entry)
+      },
+      { concurrency: 5 } // Limit concurrent downloads to avoid overwhelming the network/hosts
+    )
+
+    // Finalize archive after all downloads complete
+    pack.finalize()
+
+    // Wait for pipeline to complete - ensures errors are properly caught
+    await pipelinePromise
+  } catch (err) {
+    log.warn('Failed to download system-statuses', { error: err })
+    pack.destroy()
+    throw err
+  }
+}
+
+export async function getSystemStatuses({ pool }) {
+  return {
+    $getFrom: await this.registerHttpRequest(
+      handleGetSystemStatuses,
+      { xapi: this.getXapi(pool), pool },
+      { suffix: `/${encodeURIComponent(pool.name_label)}-system-statuses.tar` }
+    ),
+  }
+}
+
+/**
+ * Download system status (bug report) from all hosts in a pool
+ *
+ * @description Connects to all hosts in the pool via HTTPS and downloads their
+ *              system status (detailed diagnostic information) in tar.bz2 format.
+ *              All host status files are packaged in a single TAR archive.
+ *              Downloads happen in parallel (max 5 concurrent) for performance.
+ *              If any host fails, the entire operation fails (fail-fast).
+ *
+ * @param {string} id - Pool UUID
+ * @returns {object} TAR archive download via $getFrom
+ */
+getSystemStatuses.description = 'Download system status (bug report) from all hosts in a pool'
+
+getSystemStatuses.params = {
+  id: { type: 'string' },
+}
+
+getSystemStatuses.resolve = {
+  pool: ['id', 'pool', 'administrate'],
 }

--- a/packages/xo-server/src/api/pool.mjs
+++ b/packages/xo-server/src/api/pool.mjs
@@ -505,16 +505,6 @@ async function handleGetSystemStatuses(_req, res, { xapi, pool }) {
   }
 }
 
-export async function getSystemStatuses({ pool }) {
-  return {
-    $getFrom: await this.registerHttpRequest(
-      handleGetSystemStatuses,
-      { xapi: this.getXapi(pool), pool },
-      { suffix: `/${encodeURIComponent(pool.name_label)}-system-statuses.tar` }
-    ),
-  }
-}
-
 /**
  * Download system status (bug report) from all hosts in a pool
  *
@@ -527,6 +517,16 @@ export async function getSystemStatuses({ pool }) {
  * @param {string} id - Pool UUID
  * @returns {object} TAR archive download via $getFrom
  */
+export async function getSystemStatuses({ pool }) {
+  return {
+    $getFrom: await this.registerHttpRequest(
+      handleGetSystemStatuses,
+      { xapi: this.getXapi(pool), pool },
+      { suffix: `/${encodeURIComponent(pool.name_label)}-system-statuses.tar` }
+    ),
+  }
+}
+
 getSystemStatuses.description = 'Download system status (bug report) from all hosts in a pool'
 
 getSystemStatuses.params = {


### PR DESCRIPTION
### Description

Add two new API methods to download XCP-ng/XenServer system status (bug reports) via xo-cli:

1. **`host.getSystemStatus`** - Download system status from a single host
2. **`pool.getSystemStatuses`** - Download system status from all hosts in a pool in parallel

### Checklist

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #XO-1571`)
  - Not a bug fix (new feature)

- Changelog
  - Added changelog entry for new xo-cli API methods
  - Updated "Packages to release" in `CHANGELOG.unreleased.md`

- PR
  - Not UI changes
  - Fully tested on XOA infrastructure
  - All tests passing (ESLint, syntax validation)

### Usage Examples

**Single Host Download:**
```bash
xo-cli host.getSystemStatus id=<host-uuid> @=host-status.tar.bz2
```

**Pool Download:**
```bash
xo-cli pool.getSystemStatuses id=<pool-uuid> @=pool-statuses.tar
tar -tf pool-statuses.tar | head -10  # List contents
```

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
