### PR TITLE
feat(xo6): added loader in treeview when search is triggered

### DIFF
--- a/@xen-orchestra/web-core/lib/components/ui/input/UiInput.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/input/UiInput.vue
@@ -1,8 +1,7 @@
 <!-- v5 -->
 <template>
   <div :class="toVariants({ accent, disabled })" class="ui-input" @click.self="focus()">
-    <UiLoader v-if="isSearching" />
-    <VtsIcon v-else :name="icon" size="medium" class="left-icon" />
+    <VtsIcon :name="icon" size="medium" class="left-icon" />
     <input
       :id="wrapperController?.id ?? id"
       ref="inputRef"
@@ -31,7 +30,6 @@
 import VtsIcon from '@core/components/icon/VtsIcon.vue'
 import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import type { LabelAccent } from '@core/components/ui/label/UiLabel.vue'
-import UiLoader from '@core/components/ui/loader/UiLoader.vue'
 import type { IconName } from '@core/icons'
 import { useMapper } from '@core/packages/mapper/use-mapper.ts'
 import { IK_INPUT_WRAPPER_CONTROLLER } from '@core/utils/injection-keys.util'
@@ -59,7 +57,6 @@ const {
   icon?: IconName
   rightIcon?: IconName
   clearable?: boolean
-  isSearching?: boolean
 }>()
 
 const modelValue = defineModel<string | number>({ required: true })

--- a/@xen-orchestra/web/src/components/SidebarSearch.vue
+++ b/@xen-orchestra/web/src/components/SidebarSearch.vue
@@ -7,7 +7,6 @@
       :placeholder="t('sidebar.search-tree-view')"
       accent="brand"
       clearable
-      :is-searching
     />
   </div>
 </template>
@@ -15,8 +14,6 @@
 <script lang="ts" setup>
 import UiInput from '@core/components/ui/input/UiInput.vue'
 import { useI18n } from 'vue-i18n'
-
-defineProps<{ isSearching?: boolean }>()
 
 const search = defineModel<string>({ default: '' })
 

--- a/@xen-orchestra/web/src/layouts/AppLayout.vue
+++ b/@xen-orchestra/web/src/layouts/AppLayout.vue
@@ -25,8 +25,10 @@
       <VtsTreeList v-if="!isReady">
         <VtsTreeLoadingItem v-for="i in 5" :key="i" icon="fa:city" />
       </VtsTreeList>
-      <NoResults v-else-if="sites.length === 0" />
       <VtsStateHero v-else-if="isSearching" format="card" busy size="medium" class="loader" />
+      <VtsStateHero v-else-if="sites.length === 0" format="card" size="medium" type="no-result">
+        {{ t('no-results') }}
+      </VtsStateHero>
       <SiteTreeList v-else :branches="sites" />
     </template>
     <template #content>
@@ -38,7 +40,6 @@
 <script lang="ts" setup>
 import AccountMenu from '@/components/account-menu/AccountMenu.vue'
 import LogoTextOnly from '@/components/LogoTextOnly.vue'
-import NoResults from '@/components/NoResults.vue'
 import SidebarSearch from '@/components/SidebarSearch.vue'
 import QuickTaskButton from '@/components/task/QuickTaskButton.vue'
 import SiteTreeList from '@/components/tree/SiteTreeList.vue'
@@ -50,10 +51,12 @@ import UiButton from '@core/components/ui/button/UiButton.vue'
 import CoreLayout from '@core/layouts/CoreLayout.vue'
 import { useUiStore } from '@core/stores/ui.store'
 import { openUrl } from '@core/utils/open-url.utils'
+import { useI18n } from 'vue-i18n'
 
 defineSlots<{
   default(): any
 }>()
+const { t } = useI18n()
 
 const uiStore = useUiStore()
 

--- a/@xen-orchestra/web/src/layouts/AppLayout.vue
+++ b/@xen-orchestra/web/src/layouts/AppLayout.vue
@@ -19,13 +19,14 @@
       <AccountMenu />
     </template>
     <template #sidebar-header>
-      <SidebarSearch v-model="filter" :is-searching />
+      <SidebarSearch v-model="filter" />
     </template>
     <template #sidebar-content>
       <VtsTreeList v-if="!isReady">
         <VtsTreeLoadingItem v-for="i in 5" :key="i" icon="fa:city" />
       </VtsTreeList>
       <NoResults v-else-if="sites.length === 0" />
+      <VtsStateHero v-else-if="isSearching" format="card" busy size="medium" class="loader" />
       <SiteTreeList v-else :branches="sites" />
     </template>
     <template #content>
@@ -42,6 +43,7 @@ import SidebarSearch from '@/components/SidebarSearch.vue'
 import QuickTaskButton from '@/components/task/QuickTaskButton.vue'
 import SiteTreeList from '@/components/tree/SiteTreeList.vue'
 import { useSiteTree } from '@/composables/pool-tree.composable'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import VtsTreeList from '@core/components/tree/VtsTreeList.vue'
 import VtsTreeLoadingItem from '@core/components/tree/VtsTreeLoadingItem.vue'
 import UiButton from '@core/components/ui/button/UiButton.vue'
@@ -67,5 +69,9 @@ const { sites, isReady, filter, isSearching } = useSiteTree()
 
 .logo {
   height: 1.6rem;
+}
+
+.loader {
+  padding-top: 4rem;
 }
 </style>

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,7 +20,7 @@
   - [Site/Backups] Add backed-up VMs view (PR [#9018](https://github.com/vatesfr/xen-orchestra/pull/9018))
 
 - **XO 6:**
-  - [Treeview] Change location loader of search input to treeview when search is triggered (PR [#9142](https://github.com/vatesfr/xen-orchestra/pull/9142))
+  - [Treeview] Move search loader from input to Treeview (PR [#9142](https://github.com/vatesfr/xen-orchestra/pull/9142))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,10 +17,8 @@
 
 - **XO 6:**
   - [User Menu] Added new links in the user menu and customized it (PR [#9126](https://github.com/vatesfr/xen-orchestra/pull/9126))
-  - [Site/Backups] Add backed-up VMs view (PR [#9018](https://github.com/vatesfr/xen-orchestra/pull/9018))
-
-- **XO 6:**
   - [Treeview] Move search loader from input to Treeview (PR [#9142](https://github.com/vatesfr/xen-orchestra/pull/9142))
+  - [Site/Backups] Add backed-up VMs view (PR [#9018](https://github.com/vatesfr/xen-orchestra/pull/9018))
 
 ### Bug fixes
 
@@ -42,7 +40,6 @@
 
 <!--packages-start-->
 
-- @xen-orchestra/web minor
 - @xen-orchestra/qcow2 minor
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,9 @@
   - [User Menu] Added new links in the user menu and customized it (PR [#9126](https://github.com/vatesfr/xen-orchestra/pull/9126))
   - [Site/Backups] Add backed-up VMs view (PR [#9018](https://github.com/vatesfr/xen-orchestra/pull/9018))
 
+- **XO 6:**
+  - [Treeview] Change location loader of search input to treeview when search is triggered (PR [#9142](https://github.com/vatesfr/xen-orchestra/pull/9142))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -39,6 +42,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/web minor
 - @xen-orchestra/qcow2 minor
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor


### PR DESCRIPTION
### Description

Change location loader of  input search to treeview when search is triggered


**Screenshots** 

<img width="430" height="856" alt="image" src="https://github.com/user-attachments/assets/48df0536-15c2-4dce-b607-340c5b07c015" />

<img width="420" height="859" alt="image" src="https://github.com/user-attachments/assets/4b5574af-d00b-4b3f-95f1-91bb30f3742c" />


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
