### PR TITLE
feat(xo6): updated ui of input search

### DIFF
--- a/@xen-orchestra/lite/src/stories/web-core/ui/input/ui-input.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/input/ui-input.story.vue
@@ -7,7 +7,6 @@
       prop('id').str().widget(),
       prop('required').bool().widget(),
       prop('type').enum('text', 'number', 'password', 'search').preset('text').widget(),
-      iconProp(),
       prop('rightIcon').widget(
         choice({ label: 'Search', value: 'fa:magnifying-glass' }, { label: 'AngleDown', value: 'fa:angle-down' })
       ),
@@ -23,7 +22,7 @@
 
 <script lang="ts" setup>
 import ComponentStory from '@/components/component-story/ComponentStory.vue'
-import { iconProp, model, prop, slot } from '@/libs/story/story-param'
+import { model, prop, slot } from '@/libs/story/story-param'
 import { choice } from '@/libs/story/story-widget.ts'
 import UiInput from '@core/components/ui/input/UiInput.vue'
 </script>

--- a/@xen-orchestra/lite/src/stories/web-core/ui/input/ui-input.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/input/ui-input.story.vue
@@ -11,7 +11,6 @@
         choice({ label: 'Search', value: 'fa:magnifying-glass' }, { label: 'AngleDown', value: 'fa:angle-down' })
       ),
       prop('clearable').bool().widget(),
-      prop('isSearching').bool().widget(),
       prop('disabled').bool().widget().help('Not defined as component prop'),
       slot('rightIcon').help('Can be used in place of rightIcon prop'),
     ]"

--- a/@xen-orchestra/web-core/lib/components/ui/input/UiInput.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/input/UiInput.vue
@@ -1,7 +1,6 @@
 <!-- v5 -->
 <template>
   <div :class="toVariants({ accent, disabled })" class="ui-input" @click.self="focus()">
-    <VtsIcon :name="icon" size="medium" class="left-icon" />
     <input
       :id="wrapperController?.id ?? id"
       ref="inputRef"
@@ -114,14 +113,9 @@ defineExpose({ focus })
   min-width: 15rem;
   padding-inline: 1.6rem;
 
-  .left-icon,
   .right-icon {
     pointer-events: none;
-    color: var(--color-neutral-txt-secondary);
-  }
-
-  &:not(.disabled) .right-icon {
-    color: var(--color-brand-item-base);
+    color: var(--color-brand-txt-base);
   }
 
   .input {

--- a/@xen-orchestra/web/src/components/SidebarSearch.vue
+++ b/@xen-orchestra/web/src/components/SidebarSearch.vue
@@ -3,7 +3,7 @@
     <UiInput
       v-model="search"
       :aria-label="t('sidebar.search-tree-view')"
-      icon="fa:magnifying-glass"
+      right-icon="fa:magnifying-glass"
       :placeholder="t('sidebar.search-tree-view')"
       accent="brand"
       clearable

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 - [Backup] Add warning message: enabling/disabling backup job from VM > Backup affects all VMs in the job (PR [#9155](https://github.com/vatesfr/xen-orchestra/pull/9155))
 - [Plugins/Usage Report] Add operating system information to reports - displays OS distribution statistics and includes OS details (name, distribution, version) in both HTML reports and CSV exports (PR [#9179](https://github.com/vatesfr/xen-orchestra/pull/9179))
 - **XO 6:**
+  - [Input search] update design of input search (PR [#9156](https://github.com/vatesfr/xen-orchestra/pull/9156))
 
 ### Bug fixes
 
@@ -43,6 +44,8 @@
 - @vates/types minor
 - @xen-orchestra/backups patch
 - @xen-orchestra/rest-api minor
+- @xen-orchestra/web minor
+- @xen-orchestra/web-core minor
 - @xen-orchestra/xapi patch
 - xo-collection minor
 - xo-server minor


### PR DESCRIPTION
### Description

Updated the design of the search input by removing the left icon and updated the CSS of the right icon. 

**Screenshots**

<img width="505" height="272" alt="image" src="https://github.com/user-attachments/assets/b1b748d7-d579-4d0e-9ed6-49a2018b804f" />

<img width="505" height="272" alt="image" src="https://github.com/user-attachments/assets/6430ff2b-a9c2-4edf-877c-6afe8b30f488" />



### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
