### PR TITLE
fix(xo-6/backup-settings): reactivity issue when using useXoBackupJobSettingsUtils

### DIFF
--- a/@xen-orchestra/web/src/components/backups/configuration/BackupJobSettings.vue
+++ b/@xen-orchestra/web/src/components/backups/configuration/BackupJobSettings.vue
@@ -91,5 +91,5 @@ const {
   settings,
   reportWhenValueTranslation,
   snapshotModeTranslation,
-} = useXoBackupJobSettingsUtils(backupJob)
+} = useXoBackupJobSettingsUtils(() => backupJob)
 </script>

--- a/@xen-orchestra/web/src/components/backups/jobs/panel/cards/BackupJobSettingsCard.vue
+++ b/@xen-orchestra/web/src/components/backups/jobs/panel/cards/BackupJobSettingsCard.vue
@@ -130,7 +130,7 @@ const {
   proxy,
   reportWhenValueTranslation,
   settings,
-} = useXoBackupJobSettingsUtils(backupJob)
+} = useXoBackupJobSettingsUtils(() => backupJob)
 </script>
 
 <style scoped lang="postcss">

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,8 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Hub/EasyVirt] Fix the EasyVirt deployment form to allow static network configuration and password for DC Netscope web interface (PR [#9107](https://github.com/vatesfr/xen-orchestra/pull/9107))
+- **XO 6:**
+  - [Site/Backups/Settings] Fix a reactivity issue in displayed settings when the backup job object changes (PR [#9169](https://github.com/vatesfr/xen-orchestra/pull/9169))
 
 ### Packages to release
 
@@ -35,6 +37,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/web patch
 - xo-web minor
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

Introduced by e547447

Computed returned values of the composable weren’t updated when `backupJob` prop changed.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
