### PR TITLE
chore(types): complete exiting xo type definitions

### DIFF
--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -140,7 +140,12 @@ type BaseXoLog = {
   [key: string]: unknown
 }
 export type XoBackupLog = BaseXoLog & {
+  status: 'success' | 'skipped' | 'interrupted' | 'failure' | 'pending'
   message: 'backup' | 'metadata'
+  start: number
+  end?: number
+  tasks?: XoTask[]
+  jobId?: AnyXoBackupJob['id']
 }
 export type XoRestoreLog = BaseXoLog & {
   message: 'restore'
@@ -228,7 +233,7 @@ export type XoHost = BaseXapiXo & {
 
   address: string
   agentStartTime: null | number
-  bios_string: Record<string, string>
+  bios_strings: Record<string, string>
   build: string
   certificates?: {
     fingerprint: string
@@ -237,7 +242,7 @@ export type XoHost = BaseXapiXo & {
   chipset_info: {
     iommu?: boolean
   }
-  controlDomain?: XoVm['id']
+  controlDomain?: XoVmController['id']
   cpus: {
     cores?: number
     sockets?: number
@@ -385,7 +390,7 @@ export type XoPif = BaseXapiXo & {
 
   attached: boolean
   bondMaster?: XoPif['id']
-  bondSalves?: XoPif['id'][]
+  bondSlaves?: XoPif['id'][]
   carrier: boolean
   device: string
   deviceName?: string
@@ -418,7 +423,7 @@ export type XoPool = BaseXapiXo & {
   }
   crashDumpSr?: XoSr['id']
   current_operations: Record<string, POOL_ALLOWED_OPERATIONS>
-  defaultSr?: XoSr['id']
+  default_SR?: XoSr['id']
   HA_enabled: boolean
   haSrs: XoSr['id'][]
   id: Branded<'pool'>
@@ -455,8 +460,8 @@ type BaseXoJob = {
 type XoBackupJobGeneralSettings = {
   backupReportTpl?: 'compactMjml' | 'mjml'
   reportWhen?: 'always' | 'error' | 'failure' | 'never'
+  reportRecipients?: string[]
   hideSuccessfulItems?: boolean
-  [key: string]: unknown
 }
 
 export type XoVmBackupJobGeneralSettings = XoBackupJobGeneralSettings & {
@@ -468,6 +473,8 @@ export type XoVmBackupJobGeneralSettings = XoBackupJobGeneralSettings & {
     monthly?: { retention: number; settings: Record<string, unknown> }
     yearly?: { retention: number; settings: Record<string, unknown> }
   }
+  checkpointSnapshot?: boolean
+  offlineSnapshot?: boolean
   maxExportRate?: number
   nbdConcurrency?: number
   nRetriesVmBackupFailures?: number
@@ -476,7 +483,6 @@ export type XoVmBackupJobGeneralSettings = XoBackupJobGeneralSettings & {
   mergeBackupsSynchronously?: boolean
   offlineBackup?: boolean
   timeout?: number
-  [key: string]: unknown
 }
 export type XoVmBackupJobScheduleSettings = {
   exportRetention?: number
@@ -486,7 +492,6 @@ export type XoVmBackupJobScheduleSettings = {
   snapshotRetention?: number
   cbtDestroySnapshotData?: boolean
   healthCheckSr?: XoSr['id']
-  [key: string]: unknown
 }
 export type XoVmBackupJob = BaseXoJob & {
   compression?: 'native' | 'zstd' | ''
@@ -524,6 +529,7 @@ export type XoMetadataBackupJob = BaseXoJob & {
 export type XoMirrorBackupGeneralSettings = XoBackupJobGeneralSettings & {
   concurrency?: number
   nRetriesVmBackupFailures?: number
+  mergeBackupsSynchronously?: boolean
   timeout?: number
   maxExportRate?: number
   backupReportTpl?: 'compactMjml'
@@ -541,6 +547,7 @@ export type XoMirrorBackupJob = BaseXoJob & {
   mode: 'full' | 'delta'
   sourceRemote: XoBackupRepository['id']
   remotes: CMType.IdOr<XoBackupRepository['id']>
+  proxy?: XoProxy['id']
   settings: {
     '': XoMirrorBackupGeneralSettings
     [scheduleId: XoSchedule['id']]: XoMirrorBackupScheduleSettings | undefined

--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -462,6 +462,7 @@ type XoBackupJobGeneralSettings = {
   reportWhen?: 'always' | 'error' | 'failure' | 'never'
   reportRecipients?: string[]
   hideSuccessfulItems?: boolean
+  [key: string]: unknown
 }
 
 export type XoVmBackupJobGeneralSettings = XoBackupJobGeneralSettings & {
@@ -492,6 +493,7 @@ export type XoVmBackupJobScheduleSettings = {
   snapshotRetention?: number
   cbtDestroySnapshotData?: boolean
   healthCheckSr?: XoSr['id']
+  [key: string]: unknown
 }
 export type XoVmBackupJob = BaseXoJob & {
   compression?: 'native' | 'zstd' | ''
@@ -534,7 +536,6 @@ export type XoMirrorBackupGeneralSettings = XoBackupJobGeneralSettings & {
   maxExportRate?: number
   backupReportTpl?: 'compactMjml'
   reportWhen: 'failure'
-  [key: string]: unknown
 }
 export type XoMirrorBackupScheduleSettings = {
   exportRetention?: number


### PR DESCRIPTION
### Description

This PR adds and/or fixes properties in existing XO types

It also remove overly permissive `[key: string]: unknown` from some type definitions. Future missing properties should be added when needed.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
