### PR TITLE
feat(xo-server-usage-report): add OS information to usage reports

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 - [REST API] Expose `POST /rest/v0/events/:id/subscriptions` to add a subscription in the SSE connection (PR [#9130](https://github.com/vatesfr/xen-orchestra/pull/9130))
 - [REST API] Expose `DELETE /rest/v0/events/:id/subscriptions` to remove a subscription in the SSE connection (PR [#9130](https://github.com/vatesfr/xen-orchestra/pull/9130))
 - [Backup] Add warning message: enabling/disabling backup job from VM > Backup affects all VMs in the job (PR [#9155](https://github.com/vatesfr/xen-orchestra/pull/9155))
+- [Plugins/Usage Report] Add operating system information to reports - displays OS distribution statistics and includes OS details (name, distribution, version) in both HTML reports and CSV exports (PR [#9179](https://github.com/vatesfr/xen-orchestra/pull/9179))
 
 - **XO 6:**
 
@@ -44,6 +45,7 @@
 - @xen-orchestra/backups patch
 - @xen-orchestra/rest-api minor
 - xo-collection minor
+- xo-server-usage-report minor
 - xo-web minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,12 +11,12 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+
 - [REST API] Expose `GET /rest/v0/events` to open an SSE connection (PR [#9130](https://github.com/vatesfr/xen-orchestra/pull/9130))
 - [REST API] Expose `POST /rest/v0/events/:id/subscriptions` to add a subscription in the SSE connection (PR [#9130](https://github.com/vatesfr/xen-orchestra/pull/9130))
 - [REST API] Expose `DELETE /rest/v0/events/:id/subscriptions` to remove a subscription in the SSE connection (PR [#9130](https://github.com/vatesfr/xen-orchestra/pull/9130))
 - [Backup] Add warning message: enabling/disabling backup job from VM > Backup affects all VMs in the job (PR [#9155](https://github.com/vatesfr/xen-orchestra/pull/9155))
 - [Plugins/Usage Report] Add operating system information to reports - displays OS distribution statistics and includes OS details (name, distribution, version) in both HTML reports and CSV exports (PR [#9179](https://github.com/vatesfr/xen-orchestra/pull/9179))
-
 - **XO 6:**
 
 ### Bug fixes

--- a/packages/xo-server-usage-report/report.html.tpl
+++ b/packages/xo-server-usage-report/report.html.tpl
@@ -397,6 +397,25 @@
               {{/if}}
           </table>
           <table>
+            <caption>Operating Systems Distribution</caption>
+            <tr>
+              <th>Operating System</th>
+              <th>Count</th>
+            </tr>
+            {{#if global.vms.osDistribution}}
+              {{#each global.vms.osDistribution}}
+                <tr>
+                  <td>{{@key}}</td>
+                  <td>{{this}}</td>
+                </tr>
+              {{/each}}
+            {{else}}
+              <tr>
+                <td colspan="2">No OS information available</td>
+              </tr>
+            {{/if}}
+          </table>
+          <table>
             <caption>Added Users</caption>
             <tr>
               <th>Email</th>
@@ -520,6 +539,7 @@
             <tr>
               <th>UUID</th>
               <th>Name</th>
+              <th>Operating System</th>
               <th>IP addresses</th>
               <th>CPU</th>
               <th>RAM (GiB)</th>
@@ -535,6 +555,7 @@
               <tr>
                 <td>{{shortUUID this.uuid}}</td>
                 <td>{{this.name}}</td>
+                <td>{{#if this.osVersion}}{{#if this.osVersion.name}}{{this.osVersion.name}}{{else}}{{this.osVersion.distro}} {{this.osVersion.major}}.{{this.osVersion.minor}}{{/if}}{{else}}Unknown{{/if}}</td>
                 <td>{{formatAddresses this.addresses}}</td>
                 <td>{{normaliseValue this.cpu}} % {{normaliseEvolution this.evolution.cpu}}</td>
                 <td>{{normaliseValue this.ram}} {{normaliseEvolution this.evolution.ram}}</td>

--- a/packages/xo-server-usage-report/src/index.js
+++ b/packages/xo-server-usage-report/src/index.js
@@ -450,10 +450,10 @@ function computeGlobalVmsStats({ haltedVms, vmsStats, xo }) {
   // Calculate OS statistics
   const osStats = {}
   vmsStats.forEach(vm => {
-    if (vm.osVersion && vm.osVersion.name) {
+    if (vm.osVersion?.name) {
       const osName = vm.osVersion.name
       osStats[osName] = (osStats[osName] || 0) + 1
-    } else if (vm.osVersion && vm.osVersion.distro) {
+    } else if (vm.osVersion?.distro) {
       let osName = vm.osVersion.distro
       const major = vm.osVersion.major
       const minor = vm.osVersion.minor


### PR DESCRIPTION
### Description

Add Operating System information to the usage-report plugin. The plugin now collects and displays OS information (name, distribution, version) from VMs in both HTML reports and CSV exports. This enhancement provides better visibility into the OS landscape across the infrastructure.

**Ticket:** [XO-1205](https://project.vates.tech/vates-global/browse/XO-1205/)

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue (`Fixes XO-1205`)
  - [ ] If bug fix, add `Introduced by` - _N/A - This is a feature_
- Changelog
  - [x] If visible by XOA users, add changelog entry
  - [x] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [ ] If UI changes, add screenshots - _Will add email report screenshots_
  - [ ] If not finished or not tested, open as _Draft_

### Changes Made

#### 1. **VM Statistics Collection** (`src/index.js`)
- Modified `getVmsStats()` to include `osVersion` field from `vm.os_version`
- Added OS distribution statistics calculation in `computeGlobalVmsStats()`

#### 2. **CSV Export Enhancement** (`src/index.js`)
- Added 4 new CSV columns:
  - `Operating System` - Full OS name
  - `OS Distribution` - OS type (ubuntu, windows, centos, etc.)
  - `OS Major Version` - Major version number
  - `OS Minor Version` - Minor version number

#### 3. **HTML Report Enhancement** (`report.html.tpl`)
- Added "Operating Systems Distribution" table showing OS counts
- Added "Operating System" column in the "All resources" VMs table
- Smart formatting: displays full name if available, otherwise `distro major.minor`

### Testing

- [x] Code compiles successfully (`npm run build`)
- [x] HTML report displays OS information correctly
- [x] CSV export includes new OS columns (requires `all: true` in config)
- [ ] Tested with real VMs having different OS types
- [ ] Tested with VMs without guest tools (shows "Unknown")

### Screenshots


<img width="621" height="197" alt="FireShot Capture 008 - Xen Orchestra − Usage Report − 2025-11-04 - " src="https://github.com/user-attachments/assets/37f35161-e7a3-42ca-85be-13481509b539" />

<img width="585" height="342" alt="Captures d&#39;écran de 2025-11-04 09 25 05" src="https://github.com/user-attachments/assets/fa18e37f-837f-4565-9aab-9e6c10414447" />


### How to Test

1. **Enable the feature:**
   - Go to Settings → Plugins → usage-report
   - Enable the `all` option for CSV exports
   - Configure email recipients

2. **Generate report:**
   - Click "Test" button or wait for scheduled run
   - Check email for HTML report with OS information
   - Download CSV attachments to verify new columns

3. **Expected results:**
   - HTML: OS distribution statistics table
   - CSV: 4 new OS-related columns in VMs export