### PR TITLE
fix(backups): long term retention taking the most recent values

### DIFF
--- a/@xen-orchestra/backups/_getOldEntries.test.mjs
+++ b/@xen-orchestra/backups/_getOldEntries.test.mjs
@@ -24,10 +24,10 @@ describe('_getOldEntries() should succeed', () => {
         [
           { timestamp: +new Date('2024-09-01 00:01:00'), id: 1 }, // too old
           { timestamp: +new Date('2024-09-01 00:00:00'), id: 2 }, // too old
-          { timestamp: +new Date('2024-09-02 00:09:00'), id: 3 }, // too old in same day
+          { timestamp: +new Date('2024-09-02 00:09:00'), id: 3 }, // oldest in same day
           { timestamp: +new Date('2024-09-02 00:10:00'), id: 4 },
           { timestamp: +new Date('2024-09-03 00:09:00'), id: 5 },
-          { timestamp: +new Date('2024-09-04 00:09:00'), id: 6 }, // too old in same day
+          { timestamp: +new Date('2024-09-04 00:09:00'), id: 6 }, // oldest in same day
           { timestamp: +new Date('2024-09-04 00:10:00'), id: 7 },
         ],
         {
@@ -37,22 +37,22 @@ describe('_getOldEntries() should succeed', () => {
           timezone: 'Europe/Paris',
         },
       ],
-      expectedIds: [1, 2, 3, 6],
+      expectedIds: [1, 2, 4, 7],
       testLabel: 'should  handle day based retention  ',
     },
     {
       args: [
         0,
         [
-          { timestamp: +new Date('2024-09-01 00:01:00'), id: 1 }, // week n-3 too old
-          { timestamp: +new Date('2024-09-02 00:00:00'), id: 2 }, // week n-3 too old
+          { timestamp: +new Date('2024-08-30 00:01:00'), id: 1 }, // week n-3 too old
+          { timestamp: +new Date('2024-08-31 00:00:00'), id: 2 }, // week n-3 too old
           { timestamp: +new Date('2024-09-03 00:09:00'), id: 3 }, // week n-2
           { timestamp: +new Date('2024-09-04 00:09:00'), id: 4 }, // week n-2
           { timestamp: +new Date('2024-09-05 00:09:00'), id: 5 }, // week n-2
           { timestamp: +new Date('2024-09-06 00:09:00'), id: 6 }, // week n-2
-          { timestamp: +new Date('2024-09-07 00:09:00'), id: 7 }, // week n-2, most recent kept
-          { timestamp: +new Date('2024-09-09 00:09:00'), id: 8 }, // week n-1, too old
-          { timestamp: +new Date('2024-09-15 00:09:00'), id: 9 }, // week n-1  kept
+          { timestamp: +new Date('2024-09-07 00:09:00'), id: 7 }, // week n-2
+          { timestamp: +new Date('2024-09-15 00:09:00'), id: 8 }, // week n-1, oldest
+          { timestamp: +new Date('2024-09-21 00:09:00'), id: 9 }, // week n-1  most recent
           { timestamp: +new Date('2024-09-22 00:09:00'), id: 10 }, // week n  kept
         ],
         {
@@ -62,7 +62,7 @@ describe('_getOldEntries() should succeed', () => {
           timezone: 'Europe/Paris',
         },
       ],
-      expectedIds: [1, 2, 3, 4, 5, 6, 8],
+      expectedIds: [1, 2, 4, 5, 6, 7, 9],
       testLabel: 'should  handle week based retention  ',
     },
     {
@@ -85,26 +85,26 @@ describe('_getOldEntries() should succeed', () => {
           timezone: 'Europe/Paris',
         },
       ],
-      expectedIds: [1, 3, 4, 6, 7],
+      expectedIds: [1, 4, 5, 7, 8],
       testLabel: 'should  handle month based retention',
     },
     {
       args: [
-        0,
+        2,
         [
-          { timestamp: +new Date('2023-05-18 00:09:00'), id: 1 }, // too old
-          { timestamp: +new Date('2024-06-15 00:09:00'), id: 2 }, // too old in same year
-          { timestamp: +new Date('2024-07-04 00:09:00'), id: 3 }, // too old
-          { timestamp: +new Date('2024-08-12 00:09:00'), id: 4 }, // too old
-          { timestamp: +new Date('2024-09-05 00:09:00'), id: 5 }, // too old
-          { timestamp: +new Date('2024-10-02 00:09:00'), id: 6 }, // new month,
-          { timestamp: +new Date('2024-11-01 00:09:00'), id: 7 }, // new month , week reached retention
-          { timestamp: +new Date('2024-12-17 00:09:00'), id: 8 }, // new week
-          { timestamp: +new Date('2024-12-24 00:09:00'), id: 9 }, // new week/month / year  daily reach retention
-          { timestamp: +new Date('2025-01-01 00:09:00'), id: 10 }, // same day/week/month/year
-          { timestamp: +new Date('2025-01-01 00:10:00'), id: 11 }, //  new  day / week / month
-          { timestamp: +new Date('2025-12-31 00:09:00'), id: 12 }, // same day/week/month/year
-          { timestamp: +new Date('2025-12-31 00:09:00'), id: 13 }, // new month /year
+          { timestamp: +new Date('2023-05-18 00:09:00'), id: 1 }, //
+          { timestamp: +new Date('2024-06-15 00:09:00'), id: 2 }, //  year n -1
+          { timestamp: +new Date('2024-07-04 00:09:00'), id: 3 }, //
+          { timestamp: +new Date('2024-08-12 00:09:00'), id: 4 }, //
+          { timestamp: +new Date('2024-09-05 00:09:00'), id: 5 }, //
+          { timestamp: +new Date('2024-10-02 00:09:00'), id: 6 }, //  month n-4
+          { timestamp: +new Date('2024-11-01 00:09:00'), id: 7 }, //  month n-3
+          { timestamp: +new Date('2024-12-17 00:09:00'), id: 8 }, //  week n-3
+          { timestamp: +new Date('2024-12-24 00:09:00'), id: 9 }, //  week n-2, month n-2,
+          { timestamp: +new Date('2025-01-01 00:09:00'), id: 10 }, //  week n-1, year n
+          { timestamp: +new Date('2025-01-02 00:10:00'), id: 11 }, //  day n-1, month n-1,
+          { timestamp: +new Date('2025-12-31 00:09:00'), id: 12 }, //  day n , week n , month n
+          { timestamp: +new Date('2025-12-31 10:09:00'), id: 13 }, // min retention
         ],
         {
           longTermRetention: {
@@ -116,18 +116,18 @@ describe('_getOldEntries() should succeed', () => {
           timezone: 'Europe/Paris', // use a time zone here because week definition is timezone bound
         },
       ],
-      expectedIds: [1, 2, 3, 4, 5, 10, 12],
+      expectedIds: [1, 3, 4, 5],
       testLabel: 'complete test  ',
     },
     {
       args: [
         0,
         [
-          { timestamp: +new Date('2024-09-01 00:01:00'), id: 1 }, // thrid day too old
-          { timestamp: +new Date('2024-09-01 00:10:00'), id: 2 }, // thrid day
-          { timestamp: +new Date('2024-09-01 00:20:00'), id: 3 }, // second day, too old
-          { timestamp: +new Date('2024-09-02 00:22:00'), id: 4 }, // second day too old
-          { timestamp: +new Date('2024-09-03 00:20:00'), id: 5 }, // second day in NZ
+          { timestamp: +new Date('2024-08-31 09:01:00'), id: 1 }, // 4th day too old
+          { timestamp: +new Date('2024-09-01 00:10:00'), id: 2 }, // thisd day
+          { timestamp: +new Date('2024-09-01 14:20:00'), id: 3 }, // second day, oldest
+          { timestamp: +new Date('2024-09-02 00:22:00'), id: 4 }, // second day
+          { timestamp: +new Date('2024-09-03 14:00:00'), id: 5 }, // same day oldest
           { timestamp: +new Date('2024-09-04 00:09:00'), id: 6 }, // same day in NZ
           { timestamp: +new Date('2024-09-04 00:10:00'), id: 7 }, // most recent
         ],
@@ -135,10 +135,10 @@ describe('_getOldEntries() should succeed', () => {
           longTermRetention: {
             daily: { retention: 3 },
           },
-          timezone: 'Pacific/Auckland', // GMT +6
+          timezone: 'Pacific/Auckland', // GMT +13
         },
       ],
-      expectedIds: [1, 2, 3, 6],
+      expectedIds: [1, 4, 6, 7],
       testLabel: 'should  handle timezone ',
     },
   ]
@@ -149,13 +149,20 @@ describe('_getOldEntries() should succeed', () => {
       assert.strictEqual(
         oldEntries.length,
         expectedIds.length,
-        `different length , ${JSON.stringify({ oldEntries, expectedIds })}`
+        `different length , ${JSON.stringify({ expectedIds, oldEntries: oldEntries.map(({ id }) => id) })}`
       )
       for (let i = 0; i < expectedIds.length; i++) {
+        if (i > 0) {
+          assert.strictEqual(
+            expectedIds[i - 1] < expectedIds[i],
+            true,
+            `expect ids in ascending order ${expectedIds[i - 1]} ${expectedIds[i]}`
+          )
+        }
         assert.strictEqual(
           oldEntries[i].id,
           expectedIds[i],
-          `different id , ${JSON.stringify({ i, expectedIds, oldEntries })}`
+          `different id , ${JSON.stringify({ i, expectedIds, oldEntries: oldEntries.map(({ id }) => id) })}`
         )
       }
     })

--- a/@xen-orchestra/backups/_getOldEntries.test.mjs
+++ b/@xen-orchestra/backups/_getOldEntries.test.mjs
@@ -124,7 +124,7 @@ describe('_getOldEntries() should succeed', () => {
         0,
         [
           { timestamp: +new Date('2024-08-31 09:01:00'), id: 1 }, // 4th day too old
-          { timestamp: +new Date('2024-09-01 00:10:00'), id: 2 }, // thisd day
+          { timestamp: +new Date('2024-09-01 00:10:00'), id: 2 }, // third day
           { timestamp: +new Date('2024-09-01 14:20:00'), id: 3 }, // second day, oldest
           { timestamp: +new Date('2024-09-02 00:22:00'), id: 4 }, // second day
           { timestamp: +new Date('2024-09-03 14:00:00'), id: 5 }, // same day oldest

--- a/@xen-orchestra/backups/_getOldEntries.test.mjs
+++ b/@xen-orchestra/backups/_getOldEntries.test.mjs
@@ -46,7 +46,7 @@ describe('_getOldEntries() should succeed', () => {
         [
           { timestamp: +new Date('2024-08-30 00:01:00'), id: 1 }, // week n-3 too old
           { timestamp: +new Date('2024-08-31 00:00:00'), id: 2 }, // week n-3 too old
-          { timestamp: +new Date('2024-09-03 00:09:00'), id: 3 }, // week n-2
+          { timestamp: +new Date('2024-09-03 00:09:00'), id: 3 }, // week n-2, oldest
           { timestamp: +new Date('2024-09-04 00:09:00'), id: 4 }, // week n-2
           { timestamp: +new Date('2024-09-05 00:09:00'), id: 5 }, // week n-2
           { timestamp: +new Date('2024-09-06 00:09:00'), id: 6 }, // week n-2

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [Backups] use older record for Long Term Retention nstead of newer
+- [Backups] use the oldest record for Long Term Retention instead of newest (PR [#9180](https://github.com/vatesfr/xen-orchestra/pull/9180))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Backups] use older record for Long Term Retention nstead of newer
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -33,4 +35,5 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
 <!--packages-end-->


### PR DESCRIPTION
as stated in the doc, the LTR should keep the oldest record of
the most recent "time bucket"

the previous implementation was using the most recent records,
and the tests seems to be in between

This PR ensure the right records are kept

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
