### PR TITLE
fix(web-core): remove secondary cancel button on search input

### DIFF
--- a/@xen-orchestra/web-core/lib/components/ui/input/UiInput.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/input/UiInput.vue
@@ -127,6 +127,10 @@ defineExpose({ focus })
     &::placeholder {
       color: var(--color-neutral-txt-secondary);
     }
+
+    &::-webkit-search-cancel-button {
+      -webkit-appearance: none;
+    }
   }
 
   /* VARIANT */


### PR DESCRIPTION
### Description

On Safari and Chromium-based browsers, there’s a pseudo-element called `cancel` added to the right of the input field with the type `search`. I’ve disabled this.

### Screenshots
#### Before:
safari:
<img width="396" height="87" alt="image" src="https://github.com/user-attachments/assets/2e3d0149-5d33-4e40-a304-990b22ada94b" />
<img width="430" height="88" alt="image" src="https://github.com/user-attachments/assets/48e0bf9a-e17d-4f5e-9de2-c490cf949c91" />
<img width="398" height="85" alt="image" src="https://github.com/user-attachments/assets/6c2636b1-c309-48e8-9efa-09332a67b0cc" />
<img width="428" height="87" alt="image" src="https://github.com/user-attachments/assets/930f2e64-7767-4c4e-a1de-950e43ad3ad6" />

Chromium:
<img width="331" height="82" alt="image" src="https://github.com/user-attachments/assets/bc0946cd-bc80-4b0b-8c89-40cc2822e8dd" />
<img width="330" height="84" alt="image" src="https://github.com/user-attachments/assets/ae2d79a9-d1a3-4801-a0af-d8b5b71573fa" />
<img width="332" height="92" alt="image" src="https://github.com/user-attachments/assets/6aafadef-8850-4c26-936b-f05ec6e473b5" />
<img width="328" height="92" alt="image" src="https://github.com/user-attachments/assets/0892b3b5-c188-4b6f-9aa6-19ae3b62750a" />

#### After:
<img width="431" height="98" alt="image" src="https://github.com/user-attachments/assets/91315b7b-4961-4361-9def-a73e5fecd46c" />
<img width="399" height="84" alt="image" src="https://github.com/user-attachments/assets/d634d2ac-927b-4bc1-8580-8c05df51eee8" />
<img width="422" height="85" alt="image" src="https://github.com/user-attachments/assets/af957731-9b0c-4ea9-90b7-f13c8c22a361" />
<img width="401" height="96" alt="image" src="https://github.com/user-attachments/assets/4e6cc74e-d97c-435d-9612-9e4a7d455e97" />

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
