### PR TITLE
feat(@xen-orchestra/backups): add vm.tags to backups-archives

### DIFF
--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -165,6 +165,7 @@ export type XoVmBackupArchive = {
     uuid: XoVm['uuid']
     name_description: string
     name_label: string
+    tags: XoVm['tags']
   }
   differencingVhds?: number
   dynamicVhds?: number

--- a/@xen-orchestra/backups/formatVmBackups.mjs
+++ b/@xen-orchestra/backups/formatVmBackups.mjs
@@ -43,6 +43,7 @@ function formatVmBackup(backup) {
       uuid: backup.vm.uuid,
       name_description: backup.vm.name_description,
       name_label: backup.vm.name_label,
+      tags: backup.vm.tags,
     },
 
     differencingVhds,

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/backup-archive.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/backup-archive.oa-example.mts
@@ -55,6 +55,7 @@ export const backupArchive = {
     uuid: '7cf6150f-a978-09e6-6b41-0d1d41967bdc',
     name_description: 'root:vateslab',
     name_label: 'mra_vtp_test',
+    tags: ['tag_1'],
   },
   differencingVhds: 1,
   dynamicVhds: 0,

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/backup-archive.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/backup-archive.oa-example.mts
@@ -53,7 +53,7 @@ export const backupArchive = {
   timestamp: 1758202182963,
   vm: {
     uuid: '7cf6150f-a978-09e6-6b41-0d1d41967bdc',
-    name_description: 'root:vateslab',
+    name_description: 'test vm used for demo',
     name_label: 'mra_vtp_test',
     tags: ['tag_1'],
   },

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,8 @@
 - [REST API] Expose `DELETE /rest/v0/events/:id/subscriptions` to remove a subscription in the SSE connection (PR [#9130](https://github.com/vatesfr/xen-orchestra/pull/9130))
 - [Backup] Add warning message: enabling/disabling backup job from VM > Backup affects all VMs in the job (PR [#9155](https://github.com/vatesfr/xen-orchestra/pull/9155))
 - [Plugins/Usage Report] Add operating system information to reports - displays OS distribution statistics and includes OS details (name, distribution, version) in both HTML reports and CSV exports (PR [#9179](https://github.com/vatesfr/xen-orchestra/pull/9179))
+- [REST API] Add `vm.tags` to `backups-archives` routes (PR [TODO](TODO))
+
 - **XO 6:**
   - [Input search] update design of input search (PR [#9156](https://github.com/vatesfr/xen-orchestra/pull/9156))
 
@@ -42,7 +44,7 @@
 <!--packages-start-->
 
 - @vates/types minor
-- @xen-orchestra/backups patch
+- @xen-orchestra/backups minor
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,7 @@
 - [REST API] Expose `DELETE /rest/v0/events/:id/subscriptions` to remove a subscription in the SSE connection (PR [#9130](https://github.com/vatesfr/xen-orchestra/pull/9130))
 - [Backup] Add warning message: enabling/disabling backup job from VM > Backup affects all VMs in the job (PR [#9155](https://github.com/vatesfr/xen-orchestra/pull/9155))
 - [Plugins/Usage Report] Add operating system information to reports - displays OS distribution statistics and includes OS details (name, distribution, version) in both HTML reports and CSV exports (PR [#9179](https://github.com/vatesfr/xen-orchestra/pull/9179))
-- [REST API] Add `vm.tags` to `backups-archives` routes (PR [#9190](https://github.com/vatesfr/xen-orchestra/pull/9190))
+- [Backup archives] Add `vm.tags` to `backups archives` (PR [#9190](https://github.com/vatesfr/xen-orchestra/pull/9190))
 
 - **XO 6:**
   - [Input search] update design of input search (PR [#9156](https://github.com/vatesfr/xen-orchestra/pull/9156))

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,7 @@
 - [REST API] Expose `DELETE /rest/v0/events/:id/subscriptions` to remove a subscription in the SSE connection (PR [#9130](https://github.com/vatesfr/xen-orchestra/pull/9130))
 - [Backup] Add warning message: enabling/disabling backup job from VM > Backup affects all VMs in the job (PR [#9155](https://github.com/vatesfr/xen-orchestra/pull/9155))
 - [Plugins/Usage Report] Add operating system information to reports - displays OS distribution statistics and includes OS details (name, distribution, version) in both HTML reports and CSV exports (PR [#9179](https://github.com/vatesfr/xen-orchestra/pull/9179))
-- [REST API] Add `vm.tags` to `backups-archives` routes (PR [TODO](TODO))
+- [REST API] Add `vm.tags` to `backups-archives` routes (PR [#9190](https://github.com/vatesfr/xen-orchestra/pull/9190))
 
 - **XO 6:**
   - [Input search] update design of input search (PR [#9156](https://github.com/vatesfr/xen-orchestra/pull/9156))


### PR DESCRIPTION
### Description

See XO-1508

Adds vm.tags to backups-archives, updates XoVmBackupArchive type and api example.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
