### PR TITLE
fix(@xen-orchestra/rest-api): fix eventListener not reattached

### DIFF
--- a/@xen-orchestra/rest-api/src/abstract-classes/listener.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/listener.mts
@@ -41,11 +41,11 @@ export abstract class Listener {
     this.#eventCallbacks.forEach((cb, event) => {
       this.#eventEmitter.off(event, cb)
     })
+    this.#eventCallbacks.clear()
   }
 
   clear() {
     this.removeAllEventListeners()
-    this.#eventCallbacks.clear()
     this.#subscribers.clear()
     this.#watchedEvent = []
   }


### PR DESCRIPTION
### Description

introduced by 7112c331420d4263510f9ad4836fd2200eb5d5c4

When no subscriber is listening for changes to the collection, the listener removes the associated event listeners to free up memory, but I forgot to clean up `eventCallbacks`. Therefore, the event listeners were not reattached to the event emitter, because `#addEventListener` assumed the event listeners were already attached.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
