### PR TITLE
fix(@xen-orchestra/xapi): await VBD.plug

### DIFF
--- a/@xen-orchestra/xapi/vbd.mjs
+++ b/@xen-orchestra/xapi/vbd.mjs
@@ -25,6 +25,7 @@ export default class Vbd {
 
     empty = !Ref.isNotEmpty(VDI),
     mode = type === 'Disk' ? 'RW' : 'RO',
+    throwVbdPlug = false,
   }) {
     if (userdevice == null) {
       const allowed = await this.call('VM.get_allowed_VBD_devices', VM)
@@ -67,7 +68,14 @@ export default class Vbd {
     })
 
     if (isVmRunning(powerState)) {
-      this.callAsync('VBD.plug', vbdRef).catch(warn)
+      try {
+        await this.callAsync('VBD.plug', vbdRef)
+      } catch (error) {
+        if (throwVbdPlug) {
+          throw error
+        }
+        warn(error)
+      }
     }
 
     return vbdRef

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -43,6 +43,7 @@
 - @vates/types minor
 - @xen-orchestra/backups patch
 - @xen-orchestra/rest-api minor
+- @xen-orchestra/xapi patch
 - xo-collection minor
 - xo-server minor
 - xo-server-usage-report minor

--- a/packages/xo-server/src/api/vm.mjs
+++ b/packages/xo-server/src/api/vm.mjs
@@ -1576,6 +1576,7 @@ export const attachDisk = defer(async function ($defer, { vm, vdi, position, mod
     userdevice: position,
     VDI: vdi._xapiRef,
     VM: vm._xapiRef,
+    throwVbdPlug: true,
   })
 })
 


### PR DESCRIPTION
### Description

introduced by d353dc6
See [mm](https://team.vates.fr/vates/pl/h7s8kjjic38w9g5h3fztref49r)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
