### PR TITLE
docs(xo): add Gmail App Password and Microsoft 365 auth guidance

### DIFF
--- a/docs/docs/backup_reports.md
+++ b/docs/docs/backup_reports.md
@@ -6,7 +6,7 @@ At the end of a backup job, you can configure Xen Orchestra to send backup repor
 
 ### Step-by-step
 
-1. In the **Settings → Plugins** enable and configure the **Backup-reports** plugin.
+1. In the **Settings → Plugins** view, enable and configure the **Backup-reports** plugin.
    ![](./assets/backup-reports-plugin.png)
 
 2. Configure also the `transport-email` plugin (see detailed configuration below).

--- a/docs/docs/backup_reports.md
+++ b/docs/docs/backup_reports.md
@@ -9,7 +9,7 @@ At the end of a backup job, you can configure Xen Orchestra to send backup repor
 1. On the "settings/plugins" view you have to activate and configure the "Backup-reports" plugin.
    ![](./assets/backup-reports-plugin.png)
 
-2. Still in the plugins view, you also have to configure the "transport-email" plugin.
+2. Still in the plugins view, you also have to configure the "transport-email" plugin (see detailed configuration below).
    ![](./assets/transport-email-plugin.png)
 
 3. Once it's done, you can now create your backup job. In the "report" selection you can choose the situation in wish you want to receive an email (always, never or failure).
@@ -18,6 +18,85 @@ At the end of a backup job, you can configure Xen Orchestra to send backup repor
 :::tip
 You can also modify existing backup jobs and change the behaviour of the report system.
 :::
+
+### Email Provider Configuration
+
+:::warning
+**Important Authentication Changes**
+
+- **Gmail**: Requires App Passwords with 2FA
+- **Microsoft 365**: Basic auth will be disabled soon
+  :::
+
+#### Gmail Configuration
+
+Gmail users must use App Passwords for SMTP authentication.
+
+**Prerequisites:**
+
+- 2-Factor Authentication enabled on your Google account
+
+**Steps:**
+
+1. **Enable 2FA**: Go to [Google Account Security](https://myaccount.google.com/security) → 2-Step Verification
+2. **Generate App Password**: Visit [App Passwords](https://myaccount.google.com/apppasswords) → Select "Mail" → Generate
+3. **Configure transport-email plugin:**
+   - Host: `smtp.gmail.com`
+   - Port: `587`
+   - Secure: `Auto` or `STARTTLS`
+   - Username: Your Gmail address
+   - Password: The 16-character App Password (no spaces)
+
+:::tip
+App Passwords are more secure than regular passwords as they require 2FA and can be revoked individually.
+:::
+
+#### Microsoft 365 Configuration
+
+**Current Configuration :**
+
+- Host: `smtp.office365.com`
+- Port: `587`
+- Secure: `STARTTLS`
+- Username: Your Office 365 email
+- Password: Your Office 365 password
+
+:::danger
+Microsoft will permanently disable basic authentication soon.
+:::
+
+#### Other SMTP Providers
+
+For providers supporting basic authentication:
+
+- Host: Your SMTP server
+- Port: `587` (STARTTLS) or `465` (TLS)
+- Username/Password: As provided by your service
+
+### Network Requirements
+
+The transport-email plugin requires outbound access to:
+
+- Port 587 (SMTP with STARTTLS)
+- Port 465 (SMTP over TLS)
+- SMTP server addresses (e.g., smtp.gmail.com)
+
+### Troubleshooting
+
+**Gmail "Authentication failed":**
+
+- Ensure you're using an App Password, not your regular password
+- Verify 2FA is enabled
+
+**Microsoft 365 "Authentication unsuccessful":**
+
+- Check if your organization has disabled SMTP AUTH
+- Contact your IT administrator
+
+**Connection timeouts:**
+
+- Verify firewall allows outbound SMTP
+- Test connectivity: `telnet [smtp-server] 587`
 
 ## XMPP
 

--- a/docs/docs/backup_reports.md
+++ b/docs/docs/backup_reports.md
@@ -6,10 +6,10 @@ At the end of a backup job, you can configure Xen Orchestra to send backup repor
 
 ### Step-by-step
 
-1. On the "settings/plugins" view you have to activate and configure the "Backup-reports" plugin.
+1. In the **Settings → Plugins** enable and configure the **Backup-reports** plugin.
    ![](./assets/backup-reports-plugin.png)
 
-2. Still in the plugins view, you also have to configure the "transport-email" plugin (see detailed configuration below).
+2. Configure also the `transport-email` plugin (see detailed configuration below).
    ![](./assets/transport-email-plugin.png)
 
 3. Once it's done, you can now create your backup job. In the "report" selection you can choose the situation in wish you want to receive an email (always, never or failure).
@@ -21,12 +21,13 @@ You can also modify existing backup jobs and change the behaviour of the report 
 
 ### Email Provider Configuration
 
-:::warning
-**Important Authentication Changes**
+:::info
+**Authentication Requirements**
 
-- **Gmail**: Requires App Passwords with 2FA
-- **Microsoft 365**: Basic auth will be disabled soon
-  :::
+- **Gmail**: Standard passwords no longer work - App Passwords with 2FA are required
+- **Microsoft 365**: Basic authentication still works but will be disabled in March 2026
+
+:::
 
 #### Gmail Configuration
 
@@ -34,7 +35,7 @@ Gmail users must use App Passwords for SMTP authentication.
 
 **Prerequisites:**
 
-- 2-Factor Authentication enabled on your Google account
+- Enable 2-Factor Authentication on your Google account.
 
 **Steps:**
 
@@ -48,7 +49,7 @@ Gmail users must use App Passwords for SMTP authentication.
    - Password: The 16-character App Password (no spaces)
 
 :::tip
-App Passwords are more secure than regular passwords as they require 2FA and can be revoked individually.
+App Passwords are more secure than regular passwords, as they require 2FA and can be revoked individually.
 :::
 
 #### Microsoft 365 Configuration
@@ -61,8 +62,8 @@ App Passwords are more secure than regular passwords as they require 2FA and can
 - Username: Your Office 365 email
 - Password: Your Office 365 password
 
-:::danger
-Microsoft will permanently disable basic authentication soon.
+:::warning
+Microsoft will permanently disable basic authentication between March 1 and April 30, 2026. After this date, your email notifications will stop working
 :::
 
 #### Other SMTP Providers
@@ -85,7 +86,7 @@ The transport-email plugin requires outbound access to:
 
 **Gmail "Authentication failed":**
 
-- Ensure you're using an App Password, not your regular password
+- Ensure you're using an App Password, not your regular password.
 - Verify 2FA is enabled
 
 **Microsoft 365 "Authentication unsuccessful":**


### PR DESCRIPTION
### Description

This PR updates the email configuration documentation to address authentication changes for Gmail and Microsoft 365. It provides immediate solutions for Gmail users through App Passwords and warns about the upcoming Microsoft 365 OAuth 2.0 requirement in March 2026.

[#XO-1612](https://project.vates.tech/vates-global/browse/XO-1612/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions) ✅
  - Reference the relevant issue (See [XCP-ng Forum Discussion](https://xcp-ng.org/forum/topic/10793/transport-email-plugin-oauth-for-gmail/6))
  - If bug fix, add `Introduced by` - N/A (documentation only)
- Changelog
  - If visible by XOA users, add changelog entry - No (documentation only)
  - Update "Packages to release" in `CHANGELOG.unreleased.md` - No (documentation only)
- PR
  - If UI changes, add screenshots - N/A (documentation only)
  - If not finished or not tested, open as _Draft_ - Ready for review

### Context

This documentation update addresses urgent user concerns raised in the XCP-ng forums where users reported email notifications no longer working with Gmail. The root cause is Google's deprecation of basic authentication in favor of App Passwords (with 2FA) or OAuth 2.0.

Microsoft 365 will follow suit soon, making this documentation critical for users to plan their migration strategy.

### References

- [Google: App Passwords Documentation](https://support.google.com/mail/answer/185833)
- [Microsoft: SMTP AUTH Deprecation Announcement](https://techcommunity.microsoft.com/blog/exchange/exchange-online-to-retire-basic-auth-for-client-submission-smtp-auth/4114750)
- [XCP-ng Forum: Email OAuth Discussion](https://xcp-ng.org/forum/topic/10793/transport-email-plugin-oauth-for-gmail/6)
