### PR TITLE
fix(backups): getOldEntries must accept entries without id or timestamp

### DIFF
--- a/@xen-orchestra/backups/_getOldEntries.mjs
+++ b/@xen-orchestra/backups/_getOldEntries.mjs
@@ -130,7 +130,7 @@ export function getOldEntries(minRetentionCount, entries, { longTermRetention = 
       assert.deepStrictEqual(
         longTermRetention,
         {},
-        "Can't compute long term retentionif entries don't have a timestamp"
+        "Can't compute long term retention if entries don't have a timestamp"
       )
     }
 

--- a/@xen-orchestra/backups/_getOldEntries.test.mjs
+++ b/@xen-orchestra/backups/_getOldEntries.test.mjs
@@ -10,8 +10,8 @@ describe('_getOldEntries() should succeed', () => {
         1,
         [
           { timestamp: 1, id: 1 },
-          { timestamp: 3, id: 2 },
-          { timestamp: 2, id: 3 },
+          { timestamp: 2, id: 2 },
+          { timestamp: 3, id: 3 },
         ],
       ],
       expectedIds: [1, 2],
@@ -22,8 +22,8 @@ describe('_getOldEntries() should succeed', () => {
       args: [
         0,
         [
-          { timestamp: +new Date('2024-09-01 00:01:00'), id: 1 }, // too old
-          { timestamp: +new Date('2024-09-01 00:00:00'), id: 2 }, // too old
+          { timestamp: +new Date('2024-09-01 00:00:00'), id: 1 }, // too old
+          { timestamp: +new Date('2024-09-01 00:01:00'), id: 2 }, // too old
           { timestamp: +new Date('2024-09-02 00:09:00'), id: 3 }, // oldest in same day
           { timestamp: +new Date('2024-09-02 00:10:00'), id: 4 },
           { timestamp: +new Date('2024-09-03 00:09:00'), id: 5 },

--- a/@xen-orchestra/backups/_getOldEntries.test.mjs
+++ b/@xen-orchestra/backups/_getOldEntries.test.mjs
@@ -17,6 +17,11 @@ describe('_getOldEntries() should succeed', () => {
       expectedIds: [1, 2],
       testLabel: 'should  handle number based retention ',
     },
+    {
+      args: [3, [{ id: 1 }, 4, new Date(), 'watever']],
+      expectedIds: [1],
+      testLabel: 'should  handle number based retention without timestamp  ',
+    },
 
     {
       args: [
@@ -278,6 +283,19 @@ describe('_getOldEntries() should fail when called incorrectly', () => {
         },
       ],
       testLabel: 'broken date ',
+    },
+    {
+      args: [
+        1,
+        [{ obj: 1 }, 'toto', Date.now()],
+        {
+          longTermRetention: {
+            daily: { retention: 5 },
+          },
+          timezone: 'Europe/Paris',
+        },
+      ],
+      testLabel: 'should fails if LTR without timestamp   ',
     },
   ]
 

--- a/@xen-orchestra/backups/_getOldEntries.test.mjs
+++ b/@xen-orchestra/backups/_getOldEntries.test.mjs
@@ -18,7 +18,7 @@ describe('_getOldEntries() should succeed', () => {
       testLabel: 'should  handle number based retention ',
     },
     {
-      args: [3, [{ id: 1 }, 4, new Date(), 'watever']],
+      args: [3, [{ id: 1 }, 4, new Date(), 'whatever']],
       expectedIds: [1],
       testLabel: 'should  handle number based retention without timestamp  ',
     },
@@ -295,7 +295,7 @@ describe('_getOldEntries() should fail when called incorrectly', () => {
           timezone: 'Europe/Paris',
         },
       ],
-      testLabel: 'should fails if LTR without timestamp   ',
+      testLabel: 'should fail if LTR without timestamp',
     },
   ]
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,7 +24,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Backups] use the oldest record for Long Term Retention instead of newest (PR [#9180](https://github.com/vatesfr/xen-orchestra/pull/9180))
-- [Backups] fix infinite chain of snapshot and replication (PR [#9202](https://github.com/vatesfr/xen-orchestra/pull/0202))
+- [Backups] fix infinite chain of snapshot and replication [Forum#11540](https://xcp-ng.org/forum/topic/11540) [Forum#11539](https://xcp-ng.org/forum/topic/11539) (PR [#9202](https://github.com/vatesfr/xen-orchestra/pull/9202))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Backups] use the oldest record for Long Term Retention instead of newest (PR [#9180](https://github.com/vatesfr/xen-orchestra/pull/9180))
+- [Backups] fix infinite chain of snapshot and replication (PR [#9202](https://github.com/vatesfr/xen-orchestra/pull/0202))
 
 ### Packages to release
 


### PR DESCRIPTION
* entries should be any value
* it they have a timestamp , ensure they are sorted accordingly (and not
only the buckets)
* if they don't have a timestamp, ensure they don't have LTR
* 
introduced by #9180 

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
