### PR TITLE
feat(xo-server-auth-oidc): import user groups from OIDC

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,17 +13,14 @@
 
 - [HUB Recipe] Support custom cluster CIDR and Xo CCM (Cloud Controller Manager) in Pyrgos recipe
 - [Disk] Add warning before disconnecting a VBD (PR [#9211](https://github.com/vatesfr/xen-orchestra/pull/9211))
-- [REST API] Expose `GET /rest/v0/events` to open an SSE connection (PR [#9130](https://github.com/vatesfr/xen-orchestra/pull/9130))
-- [REST API] Expose `POST /rest/v0/events/:id/subscriptions` to add a subscription in the SSE connection (PR [#9130](https://github.com/vatesfr/xen-orchestra/pull/9130))
-- [REST API] Expose `DELETE /rest/v0/events/:id/subscriptions` to remove a subscription in the SSE connection (PR [#9130](https://github.com/vatesfr/xen-orchestra/pull/9130))
-- [Backup] Add warning message: enabling/disabling backup job from VM > Backup affects all VMs in the job (PR [#9155](https://github.com/vatesfr/xen-orchestra/pull/9155))
-- [Plugins/Usage Report] Add operating system information to reports - displays OS distribution statistics and includes OS details (name, distribution, version) in both HTML reports and CSV exports (PR [#9179](https://github.com/vatesfr/xen-orchestra/pull/9179))
 - [Plugins/OIDC] Import user groups from OIDC (PR [#9206](https://github.com/vatesfr/xen-orchestra/pull/9206))
+
 - **XO 6:**
   - [New/VM] Display unsupported features information message (PR [#9203](https://github.com/vatesfr/xen-orchestra/pull/9203))
   - [i18n] Update Czech, German, French, Italian, Dutch, Portuguese (Brazil), and Ukrainian translations, and add Danish translation (PR [#9165](https://github.com/vatesfr/xen-orchestra/pull/9165))
 
 ### Bug fixes
+
 - [V2V] fix transfer failing at 99% for unaligned disk (PR [#9233](https://github.com/vatesfr/xen-orchestra/pull/9233))
 
 ### Packages to release
@@ -43,17 +40,8 @@
 <!--packages-start-->
 
 - @vates/nbd-client patch
-- @vates/types minor
-- @xen-orchestra/backups patch
-- @xen-orchestra/rest-api minor
-- @xen-orchestra/web minor
-- @xen-orchestra/web-core minor
-- @xen-orchestra/xapi patch
 - vhd-lib patch
-- xo-collection minor
-- xo-server minor
 - xo-server-auth-oidc minor
-- xo-server-usage-report minor
 - xo-web minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,10 +11,14 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-
 - [HUB Recipe] Support custom cluster CIDR and Xo CCM (Cloud Controller Manager) in Pyrgos recipe
 - [Disk] Add warning before disconnecting a VBD (PR [#9211](https://github.com/vatesfr/xen-orchestra/pull/9211))
-
+- [REST API] Expose `GET /rest/v0/events` to open an SSE connection (PR [#9130](https://github.com/vatesfr/xen-orchestra/pull/9130))
+- [REST API] Expose `POST /rest/v0/events/:id/subscriptions` to add a subscription in the SSE connection (PR [#9130](https://github.com/vatesfr/xen-orchestra/pull/9130))
+- [REST API] Expose `DELETE /rest/v0/events/:id/subscriptions` to remove a subscription in the SSE connection (PR [#9130](https://github.com/vatesfr/xen-orchestra/pull/9130))
+- [Backup] Add warning message: enabling/disabling backup job from VM > Backup affects all VMs in the job (PR [#9155](https://github.com/vatesfr/xen-orchestra/pull/9155))
+- [Plugins/Usage Report] Add operating system information to reports - displays OS distribution statistics and includes OS details (name, distribution, version) in both HTML reports and CSV exports (PR [#9179](https://github.com/vatesfr/xen-orchestra/pull/9179))
+- [AUTH] Import user groups from OIDC (PR [TODO](TODO))
 - **XO 6:**
   - [New/VM] Display unsupported features information message (PR [#9203](https://github.com/vatesfr/xen-orchestra/pull/9203))
   - [i18n] Update Czech, German, French, Italian, Dutch, Portuguese (Brazil), and Ukrainian translations, and add Danish translation (PR [#9165](https://github.com/vatesfr/xen-orchestra/pull/9165))
@@ -39,7 +43,17 @@
 <!--packages-start-->
 
 - @vates/nbd-client patch
+- @vates/types minor
+- @xen-orchestra/backups patch
+- @xen-orchestra/rest-api minor
+- @xen-orchestra/web minor
+- @xen-orchestra/web-core minor
+- @xen-orchestra/xapi patch
 - vhd-lib patch
+- xo-collection minor
+- xo-server minor
+- xo-server-auth-oidc minor
+- xo-server-usage-report minor
 - xo-web minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,7 +18,7 @@
 - [REST API] Expose `DELETE /rest/v0/events/:id/subscriptions` to remove a subscription in the SSE connection (PR [#9130](https://github.com/vatesfr/xen-orchestra/pull/9130))
 - [Backup] Add warning message: enabling/disabling backup job from VM > Backup affects all VMs in the job (PR [#9155](https://github.com/vatesfr/xen-orchestra/pull/9155))
 - [Plugins/Usage Report] Add operating system information to reports - displays OS distribution statistics and includes OS details (name, distribution, version) in both HTML reports and CSV exports (PR [#9179](https://github.com/vatesfr/xen-orchestra/pull/9179))
-- [AUTH] Import user groups from OIDC (PR [#9206](https://github.com/vatesfr/xen-orchestra/pull/9206))
+- [Plugins/OIDC] Import user groups from OIDC (PR [#9206](https://github.com/vatesfr/xen-orchestra/pull/9206))
 - **XO 6:**
   - [New/VM] Display unsupported features information message (PR [#9203](https://github.com/vatesfr/xen-orchestra/pull/9203))
   - [i18n] Update Czech, German, French, Italian, Dutch, Portuguese (Brazil), and Ukrainian translations, and add Danish translation (PR [#9165](https://github.com/vatesfr/xen-orchestra/pull/9165))

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,7 +18,7 @@
 - [REST API] Expose `DELETE /rest/v0/events/:id/subscriptions` to remove a subscription in the SSE connection (PR [#9130](https://github.com/vatesfr/xen-orchestra/pull/9130))
 - [Backup] Add warning message: enabling/disabling backup job from VM > Backup affects all VMs in the job (PR [#9155](https://github.com/vatesfr/xen-orchestra/pull/9155))
 - [Plugins/Usage Report] Add operating system information to reports - displays OS distribution statistics and includes OS details (name, distribution, version) in both HTML reports and CSV exports (PR [#9179](https://github.com/vatesfr/xen-orchestra/pull/9179))
-- [AUTH] Import user groups from OIDC (PR [TODO](TODO))
+- [AUTH] Import user groups from OIDC (PR [#9206](https://github.com/vatesfr/xen-orchestra/pull/9206))
 - **XO 6:**
   - [New/VM] Display unsupported features information message (PR [#9203](https://github.com/vatesfr/xen-orchestra/pull/9203))
   - [i18n] Update Czech, German, French, Italian, Dutch, Portuguese (Brazil), and Ukrainian translations, and add Danish translation (PR [#9165](https://github.com/vatesfr/xen-orchestra/pull/9165))

--- a/packages/xo-server-auth-oidc/index.js
+++ b/packages/xo-server-auth-oidc/index.js
@@ -5,7 +5,7 @@ const { Strategy } = require('passport-openidconnect')
 
 // ===================================================================
 
-const DISCOVERABLE_SETTINGS = ['authorizationURL', 'issuer', 'tokenURL']
+const DISCOVERABLE_SETTINGS = ['authorizationURL', 'issuer', 'userInfoURL', 'tokenURL']
 
 exports.configurationSchema = {
   type: 'object',

--- a/packages/xo-server-auth-oidc/index.js
+++ b/packages/xo-server-auth-oidc/index.js
@@ -151,7 +151,7 @@ class AuthOidc {
    * @param {XoUser} user
    * @param {string[]} oidcGroups
    *
-   * @returns {void}
+   * @returns {Promise<void>}
    */
   async _synchronizeGroups(user, oidcGroups) {
     if (oidcGroups.length > 0) {

--- a/packages/xo-server-auth-oidc/index.js
+++ b/packages/xo-server-auth-oidc/index.js
@@ -157,6 +157,13 @@ class AuthOidc {
     if (oidcGroups.length > 0) {
       const xoGroups = await this.#xo.getAllGroups()
 
+      for (const xoGroup of xoGroups) {
+        // If the user is in a XO group that he is not a part of in OIDC, we remove him.
+        if (!oidcGroups.includes(xoGroup.name)) {
+          await this.#xo.removeUserFromGroup(user.id, xoGroup.id)
+        }
+      }
+
       for (const oidcGroupName of oidcGroups) {
         // Try to find the OIDC group in the XO groups by name.
         let xoGroup = xoGroups.find(group => group.name === oidcGroupName)

--- a/packages/xo-server-auth-oidc/index.js
+++ b/packages/xo-server-auth-oidc/index.js
@@ -158,7 +158,7 @@ class AuthOidc {
 
     for (const xoGroup of xoGroups) {
       // If the user is in a XO group that he is not a part of in OIDC, we remove him.
-      if (xoGroup.provider === 'oidc' && !oidcGroups.includes(xoGroup.name)) {
+      if (xoGroup.provider === 'oidc' && xoGroup.users.includes(user.id) && !oidcGroups.includes(xoGroup.name)) {
         await this.#xo.removeUserFromGroup(user.id, xoGroup.id)
       }
     }

--- a/packages/xo-server-auth-oidc/index.test.js
+++ b/packages/xo-server-auth-oidc/index.test.js
@@ -94,6 +94,8 @@ describe('AuthOidc._synchronizeGroups', () => {
     mockData.xoGroups = [
       { id: 1, users: ['id1'], name: 'group-1', provider: 'oidc' },
       { id: 2, users: [], name: 'group-2', provider: 'oidc' },
+      { id: 3, users: [], name: 'group-3', provider: 'oidc' },
+      { id: 4, users: ['id1'], name: 'group-4', provider: 'ldap' },
     ]
     const mockUser = { id: 'id1' }
     const mockOidcGroups = ['group-2']
@@ -108,6 +110,8 @@ describe('AuthOidc._synchronizeGroups', () => {
     assert.deepEqual(mockData.xoGroups, [
       { id: 1, users: [], name: 'group-1', provider: 'oidc' },
       { id: 2, users: ['id1'], name: 'group-2', provider: 'oidc' },
+      { id: 3, users: [], name: 'group-3', provider: 'oidc' },
+      { id: 4, users: ['id1'], name: 'group-4', provider: 'ldap' },
     ])
   })
 })

--- a/packages/xo-server-auth-oidc/index.test.js
+++ b/packages/xo-server-auth-oidc/index.test.js
@@ -18,9 +18,14 @@ beforeEach(() => {
       return newGroup
     }),
     addUserToGroup: mock.fn(async (userId, groupId) => {
-      const group = mockData.xoGroups.find(g => g.id === groupId)
+      const group = mockData.xoGroups.find(group => group.id === groupId)
       if (!group) throw new Error(`Group ${groupId} not found`)
       if (!group.users.includes(userId)) group.users.push(userId)
+    }),
+    removeUserFromGroup: mock.fn(async (userId, groupId) => {
+      const group = mockData.xoGroups.find(group => group.id === groupId)
+      if (!group) throw new Error(`Group ${groupId} not found`)
+      if (group.users.includes(userId)) group.users.splice(group.users.indexOf(userId), 1)
     }),
   }
 
@@ -38,6 +43,7 @@ describe('AuthOidc._synchronizeGroups', () => {
     // We created 2 groups and added 1 user to each.
     assert.equal(mockXo.createGroup.mock.calls.length, 2)
     assert.equal(mockXo.addUserToGroup.mock.calls.length, 2)
+    assert.equal(mockXo.removeUserFromGroup.mock.calls.length, 0)
 
     assert.deepEqual(mockData.xoGroups, [
       { id: 1, users: ['id1'], name: 'group-1', provider: 'oidc' },
@@ -58,9 +64,31 @@ describe('AuthOidc._synchronizeGroups', () => {
     // We added 1 user to each group.
     assert.equal(mockXo.createGroup.mock.calls.length, 0)
     assert.equal(mockXo.addUserToGroup.mock.calls.length, 2)
+    assert.equal(mockXo.removeUserFromGroup.mock.calls.length, 0)
 
     assert.deepEqual(mockData.xoGroups, [
       { id: 1, users: ['id1'], name: 'group-1', provider: 'oidc' },
+      { id: 2, users: ['id1'], name: 'group-2', provider: 'oidc' },
+    ])
+  })
+
+  it('synchronizeGroups should remove user from groups he is not a part of', async () => {
+    mockData.xoGroups = [
+      { id: 1, users: ['id1'], name: 'group-1', provider: 'oidc' },
+      { id: 2, users: [], name: 'group-2', provider: 'oidc' },
+    ]
+    const mockUser = { id: 'id1' }
+    const mockOidcGroups = ['group-2']
+
+    await authOidc._synchronizeGroups(mockUser, mockOidcGroups)
+
+    // We removed the user from 1 group and added him to 1 group.
+    assert.equal(mockXo.createGroup.mock.calls.length, 0)
+    assert.equal(mockXo.addUserToGroup.mock.calls.length, 1)
+    assert.equal(mockXo.removeUserFromGroup.mock.calls.length, 1)
+
+    assert.deepEqual(mockData.xoGroups, [
+      { id: 1, users: [], name: 'group-1', provider: 'oidc' },
       { id: 2, users: ['id1'], name: 'group-2', provider: 'oidc' },
     ])
   })

--- a/packages/xo-server-auth-oidc/index.test.js
+++ b/packages/xo-server-auth-oidc/index.test.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const { beforeEach, describe, it, mock } = require('node:test')
+const assert = require('node:assert/strict')
+
+let mockData
+let mockXo
+let authOidc
+
+beforeEach(() => {
+  mockData = { xoGroups: [] }
+
+  mockXo = {
+    getAllGroups: mock.fn(async () => mockData.xoGroups),
+    createGroup: mock.fn(async group => {
+      const newGroup = { id: mockData.xoGroups.length + 1, users: [], ...group }
+      mockData.xoGroups.push(newGroup)
+      return newGroup
+    }),
+    addUserToGroup: mock.fn(async (userId, groupId) => {
+      const group = mockData.xoGroups.find(g => g.id === groupId)
+      if (!group) throw new Error(`Group ${groupId} not found`)
+      if (!group.users.includes(userId)) group.users.push(userId)
+    }),
+  }
+
+  authOidc = require('./index.js').default({ xo: mockXo })
+})
+
+describe('AuthOidc._synchronizeGroups', () => {
+  it('_synchronizeGroups should create the user groups and add the user', async () => {
+    mockData.xoGroups = []
+    const mockUser = { id: 'id1' }
+    const mockOidcGroups = ['group-1', 'group-2']
+
+    await authOidc._synchronizeGroups(mockUser, mockOidcGroups)
+
+    // We created 2 groups and added 1 user to each.
+    assert.equal(mockXo.createGroup.mock.calls.length, 2)
+    assert.equal(mockXo.addUserToGroup.mock.calls.length, 2)
+
+    assert.deepEqual(mockData.xoGroups, [
+      { id: 1, users: ['id1'], name: 'group-1', provider: 'oidc' },
+      { id: 2, users: ['id1'], name: 'group-2', provider: 'oidc' },
+    ])
+  })
+
+  it('_synchronizeGroups should not recreate existing groups but still add the user', async () => {
+    mockData.xoGroups = [
+      { id: 1, users: [], name: 'group-1', provider: 'oidc' },
+      { id: 2, users: [], name: 'group-2', provider: 'oidc' },
+    ]
+    const mockUser = { id: 'id1' }
+    const mockOidcGroups = ['group-1', 'group-2']
+
+    await authOidc._synchronizeGroups(mockUser, mockOidcGroups)
+
+    // We added 1 user to each group.
+    assert.equal(mockXo.createGroup.mock.calls.length, 0)
+    assert.equal(mockXo.addUserToGroup.mock.calls.length, 2)
+
+    assert.deepEqual(mockData.xoGroups, [
+      { id: 1, users: ['id1'], name: 'group-1', provider: 'oidc' },
+      { id: 2, users: ['id1'], name: 'group-2', provider: 'oidc' },
+    ])
+  })
+})

--- a/packages/xo-server-auth-oidc/index.test.js
+++ b/packages/xo-server-auth-oidc/index.test.js
@@ -28,7 +28,7 @@ beforeEach(() => {
 })
 
 describe('AuthOidc._synchronizeGroups', () => {
-  it('_synchronizeGroups should create the user groups and add the user', async () => {
+  it('synchronizeGroups should create the user groups and add the user', async () => {
     mockData.xoGroups = []
     const mockUser = { id: 'id1' }
     const mockOidcGroups = ['group-1', 'group-2']
@@ -45,7 +45,7 @@ describe('AuthOidc._synchronizeGroups', () => {
     ])
   })
 
-  it('_synchronizeGroups should not recreate existing groups but still add the user', async () => {
+  it('synchronizeGroups should not recreate existing groups but still add the user', async () => {
     mockData.xoGroups = [
       { id: 1, users: [], name: 'group-1', provider: 'oidc' },
       { id: 2, users: [], name: 'group-2', provider: 'oidc' },

--- a/packages/xo-server-auth-oidc/index.test.js
+++ b/packages/xo-server-auth-oidc/index.test.js
@@ -72,6 +72,24 @@ describe('AuthOidc._synchronizeGroups', () => {
     ])
   })
 
+  it('synchronizeGroups should check the provider of the existing groups', async () => {
+    mockData.xoGroups = [{ id: 1, users: [], name: 'group-1', provider: 'ldap' }]
+    const mockUser = { id: 'id1' }
+    const mockOidcGroups = ['group-1']
+
+    await authOidc._synchronizeGroups(mockUser, mockOidcGroups)
+
+    // We created 1 group and added 1 user to it.
+    assert.equal(mockXo.createGroup.mock.calls.length, 1)
+    assert.equal(mockXo.addUserToGroup.mock.calls.length, 1)
+    assert.equal(mockXo.removeUserFromGroup.mock.calls.length, 0)
+
+    assert.deepEqual(mockData.xoGroups, [
+      { id: 1, users: [], name: 'group-1', provider: 'ldap' },
+      { id: 2, users: ['id1'], name: 'group-1', provider: 'oidc' },
+    ])
+  })
+
   it('synchronizeGroups should remove user from groups he is not a part of', async () => {
     mockData.xoGroups = [
       { id: 1, users: ['id1'], name: 'group-1', provider: 'oidc' },

--- a/packages/xo-server-auth-oidc/package.json
+++ b/packages/xo-server-auth-oidc/package.json
@@ -20,6 +20,9 @@
     "type": "git",
     "url": "https://github.com/vatesfr/xen-orchestra.git"
   },
+  "scripts": {
+    "test": "node --test"
+  },
   "author": {
     "name": "Vates SAS",
     "url": "https://vates.fr"


### PR DESCRIPTION
### Description

See XO-1618

Import user groups when logging in through OIDC.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
