### PR TITLE
fix(@xen-orchestra/rest-api): async actions return json

### DIFF
--- a/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
@@ -18,6 +18,8 @@ import { NDJSON_CONTENT_TYPE } from '../helpers/utils.helper.mjs'
 
 const noop = () => {}
 
+export type CreateActionReturnType<CbType> = Promise<{ taskId: string } | CbType>
+
 export abstract class BaseController<T extends XoRecord, IsSync extends boolean> extends Controller {
   abstract getObjects(): IsSync extends false ? Promise<Record<T['id'], T>> : Record<T['id'], T>
   abstract getObject(id: T['id']): IsSync extends false ? Promise<T> : T
@@ -92,7 +94,7 @@ export abstract class BaseController<T extends XoRecord, IsSync extends boolean>
       sync?: boolean
       taskProperties: { name: string; objectId: T['id']; params?: unknown; [key: string]: unknown }
     }
-  ): Promise<string | CbType> {
+  ): CreateActionReturnType<CbType> {
     taskProperties.name = 'REST API: ' + taskProperties.name
     taskProperties.type = 'xo:rest-api:action'
 
@@ -107,9 +109,9 @@ export abstract class BaseController<T extends XoRecord, IsSync extends boolean>
       const location = `${BASE_URL}/tasks/${task.id}`
       this.setStatus(202)
       this.setHeader('Location', location)
-      this.setHeader('Content-Type', 'text/plain')
+      this.setHeader('Content-Type', 'application/json')
 
-      return location
+      return { taskId: task.id }
     }
   }
 

--- a/@xen-orchestra/rest-api/src/open-api/common/response.common.mts
+++ b/@xen-orchestra/rest-api/src/open-api/common/response.common.mts
@@ -21,7 +21,6 @@ export const createdResp = {
 export const asynchronousActionResp = {
   status: 202,
   description: 'Action executed asynchronously',
-  produce: 'text/plain',
 } as const
 
 export const unauthorizedResp = {

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/task.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/task.oa-example.mts
@@ -1,4 +1,4 @@
-export const taskLocation = '/rest/v0/tasks/0m7kl0j9l'
+export const taskLocation = { taskId: '0m7kl0j9l' }
 
 export const taskIds = ['/rest/v0/tasks/0mdd1basu', '/rest/v0/tasks/0mdd1t24g']
 

--- a/@xen-orchestra/rest-api/src/pools/pool.controller.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.controller.mts
@@ -77,7 +77,7 @@ import { VmService } from '../vms/vm.service.mjs'
 import { PoolService } from './pool.service.mjs'
 import { escapeUnsafeComplexMatcher, NDJSON_CONTENT_TYPE } from '../helpers/utils.helper.mjs'
 import { messageIds, partialMessages } from '../open-api/oa-examples/message.oa-example.mjs'
-import { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
+import type { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
 
 @Route('pools')
 @Security('*')

--- a/@xen-orchestra/rest-api/src/pools/pool.controller.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.controller.mts
@@ -77,6 +77,7 @@ import { VmService } from '../vms/vm.service.mjs'
 import { PoolService } from './pool.service.mjs'
 import { escapeUnsafeComplexMatcher, NDJSON_CONTENT_TYPE } from '../helpers/utils.helper.mjs'
 import { messageIds, partialMessages } from '../open-api/oa-examples/message.oa-example.mjs'
+import { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
 
 @Route('pools')
 @Security('*')
@@ -152,7 +153,7 @@ export class PoolController extends XapiXoController<XoPool> {
     @Path() id: string,
     @Body() body: CreateNetworkBody,
     @Query() sync?: boolean
-  ): Promise<string | { id: Unbrand<XoNetwork>['id'] }> {
+  ): CreateActionReturnType<{ id: Unbrand<XoNetwork>['id'] }> {
     const poolId = id as XoPool['id']
     const action = async () => {
       const { pif, ...rest } = body
@@ -183,7 +184,7 @@ export class PoolController extends XapiXoController<XoPool> {
   @Response(noContentResp.status, noContentResp.description)
   @Response(featureUnauthorized.status, featureUnauthorized.description)
   @Response(notFoundResp.status, notFoundResp.description)
-  emergencyShutdown(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
+  emergencyShutdown(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const poolId = id as XoPool['id']
     const action = async () => {
       await this.restApi.xoApp.checkFeatureAuthorization('POOL_EMERGENCY_SHUTDOWN')
@@ -209,7 +210,7 @@ export class PoolController extends XapiXoController<XoPool> {
   @Response(noContentResp.status, noContentResp.description)
   @Response(featureUnauthorized.status, featureUnauthorized.description)
   @Response(notFoundResp.status, notFoundResp.description)
-  rollingReboot(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
+  rollingReboot(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const poolId = id as XoPool['id']
     const action = async (task: VatesTask) => {
       const pool = this.getObject(poolId)
@@ -236,7 +237,7 @@ export class PoolController extends XapiXoController<XoPool> {
   @Response(noContentResp.status, noContentResp.description)
   @Response(featureUnauthorized.status, featureUnauthorized.description)
   @Response(notFoundResp.status, notFoundResp.description)
-  rollingUpdate(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
+  rollingUpdate(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const poolId = id as XoPool['id']
     const action = async (task: VatesTask) => {
       const pool = this.getObject(poolId)
@@ -310,7 +311,7 @@ export class PoolController extends XapiXoController<XoPool> {
     @Path() id: string,
     @Body() body: Unbrand<CreateVmBody>,
     @Query() sync?: boolean
-  ): Promise<string | { id: Unbrand<XoVm>['id'] }> {
+  ): CreateActionReturnType<{ id: Unbrand<XoVm>['id'] }> {
     const poolId = id as XoPool['id']
     const action = async () => {
       const { affinity, template, ...rest } = body
@@ -320,7 +321,7 @@ export class PoolController extends XapiXoController<XoPool> {
       return { id: vmId }
     }
 
-    return this.createAction<string | { id: XoVm['id'] }>(action, {
+    return this.createAction<{ id: XoVm['id'] }>(action, {
       sync,
       statusCode: createdResp.status,
       taskProperties: {

--- a/@xen-orchestra/rest-api/src/pools/pool.controller.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.controller.mts
@@ -146,7 +146,7 @@ export class PoolController extends XapiXoController<XoPool> {
   @Middlewares(json())
   @Tags('networks')
   @SuccessResponse(createdResp.status, createdResp.description)
-  @Response(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @Response(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
   createNetwork(
@@ -180,7 +180,7 @@ export class PoolController extends XapiXoController<XoPool> {
    */
   @Example(taskLocation)
   @Post('{id}/actions/emergency_shutdown')
-  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(featureUnauthorized.status, featureUnauthorized.description)
   @Response(notFoundResp.status, notFoundResp.description)
@@ -206,7 +206,7 @@ export class PoolController extends XapiXoController<XoPool> {
    */
   @Example(taskLocation)
   @Post('{id}/actions/rolling_reboot')
-  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(featureUnauthorized.status, featureUnauthorized.description)
   @Response(notFoundResp.status, notFoundResp.description)
@@ -233,7 +233,7 @@ export class PoolController extends XapiXoController<XoPool> {
    */
   @Example(taskLocation)
   @Post('{id}/actions/rolling_update')
-  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(featureUnauthorized.status, featureUnauthorized.description)
   @Response(notFoundResp.status, notFoundResp.description)
@@ -304,7 +304,7 @@ export class PoolController extends XapiXoController<XoPool> {
   @Middlewares(json())
   @Tags('vms')
   @SuccessResponse(createdResp.status, createdResp.description)
-  @Response(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @Response(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
   async createVm(

--- a/@xen-orchestra/rest-api/src/schedules/schedule.controller.mts
+++ b/@xen-orchestra/rest-api/src/schedules/schedule.controller.mts
@@ -17,6 +17,7 @@ import { partialSchedules, schedule, scheduleIds } from '../open-api/oa-examples
 import { taskLocation } from '../open-api/oa-examples/task.oa-example.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
+import { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
 
 @Route('schedules')
 @Security('*')
@@ -71,7 +72,7 @@ export class ScheduleController extends XoController<XoSchedule> {
   @Response(featureUnauthorized.status, featureUnauthorized.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
-  async runSchedule(@Path() id: string, @Query() sync?: boolean) {
+  async runSchedule(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const scheduleId = id as XoSchedule['id']
     const action = async () => {
       const xoApp = this.restApi.xoApp
@@ -80,7 +81,7 @@ export class ScheduleController extends XoController<XoSchedule> {
       await xoApp.runJob(job, schedule)
     }
 
-    return this.createAction(action, {
+    return this.createAction<void>(action, {
       sync,
       statusCode: noContentResp.status,
       taskProperties: { name: 'run schedule', objectId: scheduleId },

--- a/@xen-orchestra/rest-api/src/schedules/schedule.controller.mts
+++ b/@xen-orchestra/rest-api/src/schedules/schedule.controller.mts
@@ -17,7 +17,7 @@ import { partialSchedules, schedule, scheduleIds } from '../open-api/oa-examples
 import { taskLocation } from '../open-api/oa-examples/task.oa-example.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
-import { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
+import type { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
 
 @Route('schedules')
 @Security('*')

--- a/@xen-orchestra/rest-api/src/schedules/schedule.controller.mts
+++ b/@xen-orchestra/rest-api/src/schedules/schedule.controller.mts
@@ -67,7 +67,7 @@ export class ScheduleController extends XoController<XoSchedule> {
    */
   @Example(taskLocation)
   @Post('{id}/actions/run')
-  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(featureUnauthorized.status, featureUnauthorized.description)
   @Response(notFoundResp.status, notFoundResp.description)

--- a/@xen-orchestra/rest-api/src/servers/server.controller.mts
+++ b/@xen-orchestra/rest-api/src/servers/server.controller.mts
@@ -35,7 +35,7 @@ import { partialServers, server, serverId, serverIds } from '../open-api/oa-exam
 import { partialTasks, taskIds, taskLocation } from '../open-api/oa-examples/task.oa-example.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
-import { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
+import type { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
 
 @Route('servers')
 @Security('*')

--- a/@xen-orchestra/rest-api/src/servers/server.controller.mts
+++ b/@xen-orchestra/rest-api/src/servers/server.controller.mts
@@ -35,6 +35,7 @@ import { partialServers, server, serverId, serverIds } from '../open-api/oa-exam
 import { partialTasks, taskIds, taskLocation } from '../open-api/oa-examples/task.oa-example.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
+import { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
 
 @Route('servers')
 @Security('*')
@@ -118,7 +119,7 @@ export class ServerController extends XoController<XoServer> {
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(409, 'The server is already connected')
-  connectServer(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
+  connectServer(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const serverId = id as XoServer['id']
     const action = async () => {
       await this.restApi.xoApp.connectXenServer(serverId)
@@ -140,7 +141,7 @@ export class ServerController extends XoController<XoServer> {
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(409, 'The server is already disconnected')
-  disconnectServer(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
+  disconnectServer(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const serverId = id as XoServer['id']
     const action = async () => {
       await this.restApi.xoApp.disconnectXenServer(serverId)

--- a/@xen-orchestra/rest-api/src/servers/server.controller.mts
+++ b/@xen-orchestra/rest-api/src/servers/server.controller.mts
@@ -115,7 +115,7 @@ export class ServerController extends XoController<XoServer> {
    */
   @Example(taskLocation)
   @Post('{id}/actions/connect')
-  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(409, 'The server is already connected')
@@ -137,7 +137,7 @@ export class ServerController extends XoController<XoServer> {
    */
   @Example(taskLocation)
   @Post('{id}/actions/disconnect')
-  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(409, 'The server is already disconnected')

--- a/@xen-orchestra/rest-api/src/tasks/task.controller.mts
+++ b/@xen-orchestra/rest-api/src/tasks/task.controller.mts
@@ -159,7 +159,7 @@ export class TaskController extends XoController<XoTask> {
    */
   @Example(taskLocation)
   @Post('{id}/actions/abort')
-  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async abortTask(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {

--- a/@xen-orchestra/rest-api/src/tasks/task.controller.mts
+++ b/@xen-orchestra/rest-api/src/tasks/task.controller.mts
@@ -31,7 +31,7 @@ import pDefer from 'promise-toolbox/defer'
 import { ApiError } from '../helpers/error.helper.mjs'
 import { Transform } from 'node:stream'
 import { makeObjectMapper } from '../helpers/object-wrapper.helper.mjs'
-import { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
+import type { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
 
 @Route('tasks')
 @Security('*')

--- a/@xen-orchestra/rest-api/src/tasks/task.controller.mts
+++ b/@xen-orchestra/rest-api/src/tasks/task.controller.mts
@@ -31,6 +31,7 @@ import pDefer from 'promise-toolbox/defer'
 import { ApiError } from '../helpers/error.helper.mjs'
 import { Transform } from 'node:stream'
 import { makeObjectMapper } from '../helpers/object-wrapper.helper.mjs'
+import { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
 
 @Route('tasks')
 @Security('*')
@@ -161,14 +162,14 @@ export class TaskController extends XoController<XoTask> {
   @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
-  async abortTask(@Path() id: string, @Query() sync?: boolean): Promise<string | void> {
+  async abortTask(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const taskId = id as XoTask['id']
 
     const action = async () => {
       await this.restApi.tasks.abort(taskId)
     }
 
-    return this.createAction(action, {
+    return this.createAction<void>(action, {
       sync,
       statusCode: noContentResp.status,
       taskProperties: {

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -240,7 +240,7 @@ export class VmController extends XapiXoController<XoVm> {
    */
   @Example(taskLocation)
   @Post('{id}/actions/start')
-  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
@@ -271,7 +271,7 @@ export class VmController extends XapiXoController<XoVm> {
    */
   @Example(taskLocation)
   @Post('{id}/actions/clean_shutdown')
-  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
@@ -318,7 +318,7 @@ export class VmController extends XapiXoController<XoVm> {
    */
   @Example(taskLocation)
   @Post('{id}/actions/hard_shutdown')
-  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
@@ -343,7 +343,7 @@ export class VmController extends XapiXoController<XoVm> {
    */
   @Example(taskLocation)
   @Post('{id}/actions/hard_reboot')
-  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
@@ -370,7 +370,7 @@ export class VmController extends XapiXoController<XoVm> {
    */
   @Example(taskLocation)
   @Post('{id}/actions/pause')
-  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
@@ -397,7 +397,7 @@ export class VmController extends XapiXoController<XoVm> {
    */
   @Example(taskLocation)
   @Post('{id}/actions/suspend')
-  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
@@ -424,7 +424,7 @@ export class VmController extends XapiXoController<XoVm> {
    */
   @Example(taskLocation)
   @Post('{id}/actions/resume')
-  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
@@ -451,7 +451,7 @@ export class VmController extends XapiXoController<XoVm> {
    */
   @Example(taskLocation)
   @Post('{id}/actions/unpause')
-  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
@@ -477,7 +477,7 @@ export class VmController extends XapiXoController<XoVm> {
    */
   @Example(taskLocation)
   @Post('{id}/actions/snapshot')
-  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description, asynchronousActionResp.produce)
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(createdResp.status, 'Snapshot created')
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -59,7 +59,7 @@ import type { UnbrandXoVmBackupJob } from '../backup-jobs/backup-job.type.mjs'
 import { partialVmBackupJobs, vmBackupJobIds } from '../open-api/oa-examples/backup-job.oa-example.mjs'
 import { messageIds, partialMessages } from '../open-api/oa-examples/message.oa-example.mjs'
 import type { UnbrandedVmDashboard } from './vm.type.mjs'
-import { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
+import type { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
 
 const IGNORED_VDIS_TAG = '[NOSNAP]'
 

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -59,6 +59,7 @@ import type { UnbrandXoVmBackupJob } from '../backup-jobs/backup-job.type.mjs'
 import { partialVmBackupJobs, vmBackupJobIds } from '../open-api/oa-examples/backup-job.oa-example.mjs'
 import { messageIds, partialMessages } from '../open-api/oa-examples/message.oa-example.mjs'
 import type { UnbrandedVmDashboard } from './vm.type.mjs'
+import { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
 
 const IGNORED_VDIS_TAG = '[NOSNAP]'
 
@@ -243,13 +244,17 @@ export class VmController extends XapiXoController<XoVm> {
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
-  async startVm(@Path() id: string, @Body() body?: { hostId?: string }, @Query() sync?: boolean) {
+  async startVm(
+    @Path() id: string,
+    @Body() body?: { hostId?: string },
+    @Query() sync?: boolean
+  ): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
       await this.getXapi(vmId).startVm(vmId, { startOnly: true, hostId: body?.hostId as XoHost['id'] })
     }
 
-    return this.createAction(action, {
+    return this.createAction<void>(action, {
       sync,
       statusCode: noContentResp.status,
       taskProperties: {
@@ -270,13 +275,13 @@ export class VmController extends XapiXoController<XoVm> {
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
-  async cleanShutdownVm(@Path() id: string, @Query() sync?: boolean): Promise<string | void> {
+  async cleanShutdownVm(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
       await this.getXapiObject(vmId).$callAsync('clean_shutdown')
     }
 
-    return this.createAction(action, {
+    return this.createAction<void>(action, {
       sync,
       statusCode: noContentResp.status,
       taskProperties: {
@@ -292,7 +297,7 @@ export class VmController extends XapiXoController<XoVm> {
    */
   @Example(taskLocation)
   @Post('{id}/actions/clean_reboot')
-  async cleanRebootVm(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
+  async cleanRebootVm(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
       await this.getXapiObject(vmId).$callAsync('clean_reboot')
@@ -317,13 +322,13 @@ export class VmController extends XapiXoController<XoVm> {
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
-  async hardShutdownVm(@Path() id: string, @Query() sync?: boolean): Promise<string | void> {
+  async hardShutdownVm(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
       await this.getXapiObject(vmId).$callAsync('hard_shutdown')
     }
 
-    return this.createAction(action, {
+    return this.createAction<void>(action, {
       sync,
       statusCode: noContentResp.status,
       taskProperties: {
@@ -342,7 +347,7 @@ export class VmController extends XapiXoController<XoVm> {
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
-  async hardRebootVm(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
+  async hardRebootVm(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
       await this.getXapiObject(vmId).$callAsync('hard_reboot')
@@ -369,7 +374,7 @@ export class VmController extends XapiXoController<XoVm> {
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
-  async pauseVm(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
+  async pauseVm(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
       await this.getXapiObject(vmId).$callAsync('pause')
@@ -396,7 +401,7 @@ export class VmController extends XapiXoController<XoVm> {
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
-  async suspendVm(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
+  async suspendVm(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
       await this.getXapiObject(vmId).$callAsync('suspend')
@@ -423,7 +428,7 @@ export class VmController extends XapiXoController<XoVm> {
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
-  async resumeVm(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
+  async resumeVm(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
       await this.getXapi(vmId).resumeVm(vmId)
@@ -450,7 +455,7 @@ export class VmController extends XapiXoController<XoVm> {
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
-  async unpauseVm(@Path() id: string, @Query() sync?: boolean): Promise<void | string> {
+  async unpauseVm(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
       await this.getXapi(vmId).unpauseVm(vmId)
@@ -480,7 +485,7 @@ export class VmController extends XapiXoController<XoVm> {
     @Path() id: string,
     @Body() body?: { name_label?: XoVmSnapshot['name_label'] },
     @Query() sync?: boolean
-  ): Promise<string | { id: XenApiVm['uuid'] }> {
+  ): CreateActionReturnType<{ id: XenApiVm['uuid'] }> {
     const vmId = id as XoVm['id']
     const action = async () => {
       const xapiVm = this.getXapiObject(vmId)
@@ -494,7 +499,7 @@ export class VmController extends XapiXoController<XoVm> {
       return { id: snapshotId }
     }
 
-    return this.createAction<Promise<{ id: XenApiVm['uuid'] }>>(action, {
+    return this.createAction<{ id: XenApiVm['uuid'] }>(action, {
       sync,
       statusCode: createdResp.status,
       taskProperties: {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,7 +19,7 @@
 - [Backup archives] Add `vm.tags` to `backups archives` (PR [#9190](https://github.com/vatesfr/xen-orchestra/pull/9190))
 - [Menu] Add link from XO 5 to XO 6 (PR [#9187](https://github.com/vatesfr/xen-orchestra/pull/9187))
 - [REST API] Expose VM dashboard endpoint `GET /rest/v0/vms/:vm-id/dashboard` (PR [#9143](https://github.com/vatesfr/xen-orchestra/pull/9143))
-- [REST API] Async actions now return `application/json` (PR [TODO]TODO))
+- [REST API] Async actions now return `application/json` (PR [9209](https://github.com/vatesfr/xen-orchestra/pull/9209))
 
 - **XO 6:**
   - [Input search] update design of input search (PR [#9156](https://github.com/vatesfr/xen-orchestra/pull/9156))

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,7 +19,7 @@
 - [Backup archives] Add `vm.tags` to `backups archives` (PR [#9190](https://github.com/vatesfr/xen-orchestra/pull/9190))
 - [Menu] Add link from XO 5 to XO 6 (PR [#9187](https://github.com/vatesfr/xen-orchestra/pull/9187))
 - [REST API] Expose VM dashboard endpoint `GET /rest/v0/vms/:vm-id/dashboard` (PR [#9143](https://github.com/vatesfr/xen-orchestra/pull/9143))
-- [REST API] Async actions now return `application/json` (PR [9209](https://github.com/vatesfr/xen-orchestra/pull/9209))
+- [REST API] **Breaking changes** Async actions now return `application/json` (PR [9209](https://github.com/vatesfr/xen-orchestra/pull/9209))
 
 - **XO 6:**
   - [Input search] update design of input search (PR [#9156](https://github.com/vatesfr/xen-orchestra/pull/9156))

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,7 +19,7 @@
 - [Backup archives] Add `vm.tags` to `backups archives` (PR [#9190](https://github.com/vatesfr/xen-orchestra/pull/9190))
 - [Menu] Add link from XO 5 to XO 6 (PR [#9187](https://github.com/vatesfr/xen-orchestra/pull/9187))
 - [REST API] Expose VM dashboard endpoint `GET /rest/v0/vms/:vm-id/dashboard` (PR [#9143](https://github.com/vatesfr/xen-orchestra/pull/9143))
-- [REST API] **Breaking changes** Async actions now return `application/json` (PR [9209](https://github.com/vatesfr/xen-orchestra/pull/9209))
+- [REST API] **Breaking changes** Async actions now return `application/json` (PR [#9209](https://github.com/vatesfr/xen-orchestra/pull/9209))
 
 - **XO 6:**
   - [Input search] update design of input search (PR [#9156](https://github.com/vatesfr/xen-orchestra/pull/9156))

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
 - [Backup archives] Add `vm.tags` to `backups archives` (PR [#9190](https://github.com/vatesfr/xen-orchestra/pull/9190))
 - [Menu] Add link from XO 5 to XO 6 (PR [#9187](https://github.com/vatesfr/xen-orchestra/pull/9187))
 - [REST API] Expose VM dashboard endpoint `GET /rest/v0/vms/:vm-id/dashboard` (PR [#9143](https://github.com/vatesfr/xen-orchestra/pull/9143))
+- [REST API] Async actions now return `application/json` (PR [TODO]TODO))
 
 - **XO 6:**
   - [Input search] update design of input search (PR [#9156](https://github.com/vatesfr/xen-orchestra/pull/9156))


### PR DESCRIPTION
### Description

See XO-1038

Async API REST actions now return the taskId as "application/json" instead of "plain/text".
The location is still available in the headers.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
