### PR TITLE
Feat/use vif move for network change

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,6 +31,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [VIF] Fix VIFs with device > 7 being destroyed when changing network - now uses non-destructive VIF.move API (XenServer 7.1+) that preserves VIF UUID and avoids network downtime (PR [#9221](https://github.com/vatesfr/xen-orchestra/pull/9221))
 - [Backups] use the oldest record for Long Term Retention instead of newest (PR [#9180](https://github.com/vatesfr/xen-orchestra/pull/9180))
 - [Backups] fix infinite chain of snapshot and replication [Forum#11540](https://xcp-ng.org/forum/topic/11540) [Forum#11539](https://xcp-ng.org/forum/topic/11539) (PR [#9202](https://github.com/vatesfr/xen-orchestra/pull/9202))
 - [V2V] fix missing libssl.so.3 in path on debian 11 (PR [#9208](https://github.com/vatesfr/xen-orchestra/pull/9208))

--- a/packages/xo-server/src/api/vif.mjs
+++ b/packages/xo-server/src/api/vif.mjs
@@ -113,7 +113,7 @@ export async function set({
     if (isNetworkChanged && mac === undefined) {
       try {
         // Try VIF.move first (XenServer 7.1+)
-        await xapi.moveVif(vif._xapiId, networkId)
+        await xapi.callAsync('VIF.move', vif._xapiRef, network._xapiRef)
 
         log.info('VIF moved to new network using VIF.move', {
           vifId: vif.id,

--- a/packages/xo-server/src/api/vif.mjs
+++ b/packages/xo-server/src/api/vif.mjs
@@ -87,7 +87,8 @@ export async function set({
     await this.checkPermissions([[network?.id ?? vif.$network, 'operate']])
   }
 
-  if (isNetworkChanged || mac) {
+  // Handle network and/or MAC address changes
+  if (isNetworkChanged || mac !== undefined) {
     const networkId = network?.id
     if (mac !== undefined && this.apiContext.permission !== 'admin') {
       await this.checkPermissions([[networkId ?? vif.$network, 'administrate']])
@@ -102,6 +103,57 @@ export async function set({
 
     const xapi = this.getXapi(vif)
 
+    // If only the network is changing (not MAC), try to use VIF.move which is non-destructive
+    // VIF.move was introduced in XenServer 7.1 and keeps the VIF UUID, avoiding network downtime
+    if (isNetworkChanged && mac === undefined) {
+      const targetNetwork = xapi.getObject(networkId)
+
+      try {
+        // Try VIF.move first (XenServer 7.1+)
+        await xapi.moveVif(vif._xapiId, targetNetwork._xapiId)
+
+        this.log.info('VIF moved to new network using VIF.move', {
+          vifId: vif.id,
+          oldNetworkId: vif.$network,
+          newNetworkId: networkId,
+        })
+
+        // Update IP addresses allocation
+        const [addAddresses, removeAddresses] = diffItems(newIpAddresses, oldIpAddresses)
+        await this.allocIpAddresses(vif.id, addAddresses, removeAddresses)
+
+        // Update other VIF properties if needed
+        await xapi.editVif(vif._xapiId, {
+          ipv4Allowed: newIpv4Addresses.length > 0 ? newIpv4Addresses : undefined,
+          ipv6Allowed: newIpv6Addresses.length > 0 ? newIpv6Addresses : undefined,
+          lockingMode: lockingMode ?? 'network_default',
+          rateLimit,
+          txChecksumming,
+        })
+
+        return vif.id // VIF ID is preserved with VIF.move
+      } catch (error) {
+        // Fallback to delete+create for XenServer < 7.1 or if VIF.move fails
+        if (error.code === 'MESSAGE_METHOD_UNKNOWN') {
+          this.log.warn('VIF.move not available, falling back to delete+create', {
+            vifId: vif.id,
+            xenServerVersion: 'pre-7.1',
+          })
+        } else {
+          this.log.warn('VIF.move failed, falling back to delete+create', {
+            vifId: vif.id,
+            error: error.message,
+          })
+        }
+        // Continue to delete+create fallback below
+      }
+    }
+
+    // Fallback: delete and recreate VIF
+    // This path is used when:
+    // 1. MAC address is changing (VIF.move doesn't support MAC changes)
+    // 2. VIF.move is not available (XenServer < 7.1)
+    // 3. VIF.move failed for some reason
     const vm = xapi.getObject(vif.$VM)
     mac == null && (mac = vif.MAC)
     network = xapi.getObject(networkId ?? vif.$network)

--- a/packages/xo-server/src/api/vif.mjs
+++ b/packages/xo-server/src/api/vif.mjs
@@ -111,11 +111,9 @@ export async function set({
     // If only the network is changing (not MAC), try to use VIF.move which is non-destructive
     // VIF.move was introduced in XenServer 7.1 and keeps the VIF UUID, avoiding network downtime
     if (isNetworkChanged && mac === undefined) {
-      const targetNetwork = xapi.getObject(networkId)
-
       try {
         // Try VIF.move first (XenServer 7.1+)
-        await xapi.moveVif(vif._xapiId, targetNetwork._xapiId)
+        await xapi.moveVif(vif._xapiId, networkId)
 
         log.info('VIF moved to new network using VIF.move', {
           vifId: vif.id,

--- a/packages/xo-server/src/api/vif.mjs
+++ b/packages/xo-server/src/api/vif.mjs
@@ -1,6 +1,11 @@
+import { createLogger } from '@xen-orchestra/log'
 import { ignoreErrors } from 'promise-toolbox'
 
 import { diffItems } from '../utils.mjs'
+
+// ===================================================================
+
+const log = createLogger('xo:api:vif')
 
 // ===================================================================
 
@@ -112,7 +117,7 @@ export async function set({
         // Try VIF.move first (XenServer 7.1+)
         await xapi.moveVif(vif._xapiId, targetNetwork._xapiId)
 
-        this.log.info('VIF moved to new network using VIF.move', {
+        log.info('VIF moved to new network using VIF.move', {
           vifId: vif.id,
           oldNetworkId: vif.$network,
           newNetworkId: networkId,
@@ -135,12 +140,12 @@ export async function set({
       } catch (error) {
         // Fallback to delete+create for XenServer < 7.1 or if VIF.move fails
         if (error.code === 'MESSAGE_METHOD_UNKNOWN') {
-          this.log.warn('VIF.move not available, falling back to delete+create', {
+          log.warn('VIF.move not available, falling back to delete+create', {
             vifId: vif.id,
             xenServerVersion: 'pre-7.1',
           })
         } else {
-          this.log.warn('VIF.move failed, falling back to delete+create', {
+          log.warn('VIF.move failed, falling back to delete+create', {
             vifId: vif.id,
             error: error.message,
           })

--- a/packages/xo-server/src/xapi/mixins/networking.mjs
+++ b/packages/xo-server/src/xapi/mixins/networking.mjs
@@ -23,21 +23,6 @@ export default {
   async disconnectVif(vifId) {
     await this._disconnectVif(this.getObject(vifId))
   },
-  /**
-   * Move a VIF to a different network (non-destructive)
-   * Requires XenServer 7.1+ / XCP-ng 7.1+
-   * Preserves VIF UUID and avoids network downtime
-   *
-   * @param {string} vifId - VIF UUID or opaque reference
-   * @param {string} networkId - Network UUID or opaque reference
-   * @returns {Promise<void>}
-   * @throws {Error} MESSAGE_METHOD_UNKNOWN if XenServer < 7.1
-   */
-  async moveVif(vifId, networkId) {
-    const vif = this.getObject(vifId)
-    const network = this.getObject(networkId)
-    await this.callAsync('VIF.move', vif.$ref, network.$ref)
-  },
   editVif: makeEditObject({
     ipv4Allowed: {
       get: true,

--- a/packages/xo-server/src/xapi/mixins/networking.mjs
+++ b/packages/xo-server/src/xapi/mixins/networking.mjs
@@ -23,6 +23,21 @@ export default {
   async disconnectVif(vifId) {
     await this._disconnectVif(this.getObject(vifId))
   },
+  /**
+   * Move a VIF to a different network (non-destructive)
+   * Requires XenServer 7.1+ / XCP-ng 7.1+
+   * Preserves VIF UUID and avoids network downtime
+   *
+   * @param {string} vifId - VIF UUID or opaque reference
+   * @param {string} networkId - Network UUID or opaque reference
+   * @returns {Promise<void>}
+   * @throws {Error} MESSAGE_METHOD_UNKNOWN if XenServer < 7.1
+   */
+  async moveVif(vifId, networkId) {
+    const vif = this.getObject(vifId)
+    const network = this.getObject(networkId)
+    await this.callAsync('VIF.move', vif.$ref, network.$ref)
+  },
   editVif: makeEditObject({
     ipv4Allowed: {
       get: true,


### PR DESCRIPTION
# Use VIF.move for network changes instead of delete+create

### Description

This PR replaces the destructive delete+create workflow with the non-destructive `VIF.move` XAPI method when changing a VIF's network, introduced in XenServer 7.1.

**Problem**: When changing a VIF's network, XO would unplug, destroy, and recreate the VIF. This caused:
- Network downtime during the operation
- VIF UUID changes (breaking references)

**Solution**: Use `VIF.move(vif_ref, network_ref)` which:
- Preserves VIF UUID
- Avoids network downtime
- Works even with device > 7 (no recreation needed)
- Falls back to delete+create for XenServer < 7.1 or when MAC address changes

**Implementation**:
- Added `moveVif()` helper method in `xapi/mixins/networking.mjs`
- Modified `vif.set()` in `api/vif.mjs` to use VIF.move when only network changes
- Graceful fallback with `MESSAGE_METHOD_UNKNOWN` error handling
- Structured logging for monitoring (VIF.move success/fallback)

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue: Fixes XO-1497
  - [ ] If bug fix, add `Introduced by` - N/A (pre-existing behavior)
- Changelog
  - [ ] If visible by XOA users, add changelog entry
  - [x] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [ ] If UI changes, add screenshots - N/A (backend only)
  - [ ] If not finished or not tested, open as _Draft_ - ⚠️ Testing in progress

### Related Issues

- Fixes: [XO-1497](https://project.vates.tech/vates-global/browse/XO-1497/)

### Breaking Changes

None. The change is backward compatible:
- XenServer ≥ 7.1: Uses VIF.move (improved behavior)
- XenServer < 7.1: Falls back to delete+create (existing behavior)
- MAC changes: Always use delete+create (required)

### Migration Notes

No migration required. The change is transparent to users and automatically adapts based on XenServer version and operation type.

### Review Process

**Junior Reviewer**: _To be assigned_

**Senior Reviewer**: _To be assigned_