### PR TITLE
fix(nbd-client): nbddisk must emit full size block

### DIFF
--- a/@vates/nbd-client/NbdDisk.mjs
+++ b/@vates/nbd-client/NbdDisk.mjs
@@ -42,7 +42,9 @@ export class NbdDisk extends RandomAccessDisk {
     }
     let data = await this.#nbdClient.readBlock(index, this.getBlockSize())
     if (data.length !== this.getBlockSize()) {
-      if (index === Math.floor(this.getVirtualSize() / this.getBlockSize()) - 1) {
+      // this condition only work on non aligned disks
+      // we won't accept truncated block from unaligned disks
+      if (index === Math.ceil(this.getVirtualSize() / this.getBlockSize()) - 1) {
         // last block add zeros at the end
         data = Buffer.concat([data], this.getBlockSize())
       } else {

--- a/@vates/nbd-client/NbdDisk.mjs
+++ b/@vates/nbd-client/NbdDisk.mjs
@@ -49,13 +49,6 @@ export class NbdDisk extends RandomAccessDisk {
         throw new Error(`Block ${index} is not at the right size, expecting ${this.getBlockSize()}, got ${data.length}`)
       }
     }
-    if (
-      index === Math.floor(this.getVirtualSize() / this.getBlockSize() - 1) && // last block
-      data.length < this.getBlockSize() // truncated
-    ) {
-      // add zeros at the end
-      data = Buffer.concat([data], this.getBlockSize())
-    }
     return {
       index,
       data,

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@
   - [i18n] Update Czech, German, French, Italian, Dutch, Portuguese (Brazil), and Ukrainian translations, and add Danish translation (PR [#9165](https://github.com/vatesfr/xen-orchestra/pull/9165))
 
 ### Bug fixes
+- [V2V] fix transfer failing at 99% for unaligned disk (PR [#9233](https://github.com/vatesfr/xen-orchestra/pull/9233))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -35,8 +35,7 @@
 
 <!--packages-start-->
 
-- @xen-orchestra/web minor
-- @xen-orchestra/web-core minor
-- xo-web minor
+- @vates/nbd-client patch
+- vhd-lib patch
 
 <!--packages-end-->

--- a/packages/vhd-lib/disk-consumer/DiskConsumerVhdStream.mjs
+++ b/packages/vhd-lib/disk-consumer/DiskConsumerVhdStream.mjs
@@ -1,5 +1,6 @@
 import { Readable } from 'stream'
 import { BaseVhd, FULL_BLOCK_BITMAP } from './BaseVhd.mjs'
+import assert from 'node:assert'
 
 /**
  * @typedef {Readable & { length: number }} VhdStream
@@ -23,6 +24,7 @@ export class DiskConsumerVhdStream extends BaseVhd {
       yield header
       yield bat
       for await (const { data } of blockGenerator) {
+        assert.strictEqual(data.length, 2 * 1024 * 1024)
         yield Buffer.concat([FULL_BLOCK_BITMAP, data])
       }
       yield footer


### PR DESCRIPTION
### Description

nbd client will emit an truncated block on the last block if the disk is not aligned to 2097152 bytes in size 
vhd import expect all the block to be of 2097152 bytes size 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
