### PR TITLE
fix(xo-6/dashboard): prevent double scrollbar in alarms lists

### DIFF
--- a/@xen-orchestra/web/src/components/alarms/DashboardAlarms.vue
+++ b/@xen-orchestra/web/src/components/alarms/DashboardAlarms.vue
@@ -64,7 +64,7 @@ const {
   wrapperProps,
 } = useVirtualList(
   computed(() => rawAlarms),
-  { itemHeight: () => (uiStore.isDesktopLarge ? 40 : 70) }
+  { itemHeight: () => (uiStore.isDesktopLarge ? 42 : 70) }
 )
 </script>
 

--- a/@xen-orchestra/web/src/components/alarms/DashboardAlarms.vue
+++ b/@xen-orchestra/web/src/components/alarms/DashboardAlarms.vue
@@ -64,7 +64,7 @@ const {
   wrapperProps,
 } = useVirtualList(
   computed(() => rawAlarms),
-  { itemHeight: () => (uiStore.isDesktopLarge ? 42 : 70) }
+  { itemHeight: () => (uiStore.isDesktopLarge ? 42 : 71) }
 )
 </script>
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,6 +32,7 @@
 
 - **XO 6:**
   - [Host/Vm] fix issues on dashboards, and translation on charts (PR [#9204](https://github.com/vatesfr/xen-orchestra/pull/9204))
+  - [Dashboards/Alarms] fix double scrollbar in Alarms lists due to incorrect height setting (PR [#9246](https://github.com/vatesfr/xen-orchestra/pull/9246))
 - [V2V] fix transfer failing at 99% for unaligned disk (PR [#9233](https://github.com/vatesfr/xen-orchestra/pull/9233))
 
 ### Packages to release
@@ -53,6 +54,7 @@
 - @vates/nbd-client patch
 - @xen-orchestra/rest-api patch
 - @xen-orchestra/vmware-explorer patch
+- @xen-orchestra/web patch
 - @xen-orchestra/web-core minor
 - vhd-cli major
 - vhd-lib patch


### PR DESCRIPTION
### Description

Prevent double scrollbar in Alarms lists by taking into account the border width of each list item.

### Screenshots

- Before:
<img width="723" height="461" alt="image" src="https://github.com/user-attachments/assets/c0e0d4b6-8480-4c29-bbcc-346d3adeaf28" />

- After:
<img width="723" height="461" alt="image" src="https://github.com/user-attachments/assets/872845c9-3cda-4fc0-b9b3-9965744bb7d5" />

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
