### PR TITLE
feat(@xen-orchestra/web): implement reactivity for sub-stores

### DIFF
--- a/@xen-orchestra/web-core/lib/packages/remote-resource/define-remote-resource.ts
+++ b/@xen-orchestra/web-core/lib/packages/remote-resource/define-remote-resource.ts
@@ -70,7 +70,7 @@ export function defineRemoteResource<
     handleDelete: THandleDelete
     handlePost: THandlePost
     handleWatching: THandleWatching
-    predicate?: (receivedData: TData, args: ResourceContext<TArgs> | undefined) => boolean
+    predicate?: (receivedData: TData, context: ResourceContext<TArgs> | undefined) => boolean
   }
 }): UseRemoteResource<TState, TArgs>
 
@@ -94,7 +94,7 @@ export function defineRemoteResource<
     handleDelete: THandleDelete
     handlePost: THandlePost
     handleWatching: THandleWatching
-    predicate?: (receivedData: TData, args: ResourceContext<TArgs> | undefined) => boolean
+    predicate?: (receivedData: TData, context: ResourceContext<TArgs> | undefined) => boolean
   }
 }) {
   const cache = new Map<

--- a/@xen-orchestra/web-core/lib/packages/remote-resource/define-remote-resource.ts
+++ b/@xen-orchestra/web-core/lib/packages/remote-resource/define-remote-resource.ts
@@ -64,11 +64,13 @@ export function defineRemoteResource<
   onDataRemoved?: (data: Ref<NoInfer<TData>>, receivedData: any) => void
   stream?: boolean
   watchCollection: {
+    collectionId: string
     resource: string // reactivity only on XAPI XO record for now
     getIdentifier: (obj: unknown) => string
     handleDelete: THandleDelete
     handlePost: THandlePost
     handleWatching: THandleWatching
+    predicate?: (receivedData: TData, args: ResourceContext<TArgs> | undefined) => boolean
   }
 }): UseRemoteResource<TState, TArgs>
 
@@ -86,11 +88,13 @@ export function defineRemoteResource<
   pollingIntervalMs?: number | false
   stream?: boolean
   watchCollection?: {
+    collectionId: string
     resource: string // reactivity only on XAPI XO record for now
     getIdentifier: (obj: unknown) => string
     handleDelete: THandleDelete
     handlePost: THandlePost
     handleWatching: THandleWatching
+    predicate?: (receivedData: TData, args: ResourceContext<TArgs> | undefined) => boolean
   }
 }) {
   const cache = new Map<
@@ -131,7 +135,11 @@ export function defineRemoteResource<
 
   const onDataReceived =
     config.onDataReceived ??
-    ((data: Ref<TData>, receivedData: any) => {
+    ((data: Ref<TData>, receivedData: any, args?: ResourceContext<TArgs>) => {
+      // allow to ignore some update (like for sub collection. E.g. vms/:id/vdis)
+      if (config.watchCollection?.predicate?.(receivedData, args) === false) {
+        return
+      }
       if (data.value === undefined || (Array.isArray(data.value) && Array.isArray(receivedData))) {
         data.value = receivedData
         return
@@ -148,7 +156,12 @@ export function defineRemoteResource<
 
   const onDataRemoved =
     config.onDataRemoved ??
-    ((data: Ref<TData>, receivedData: any) => {
+    ((data: Ref<TData>, receivedData: any, args?: ResourceContext<TArgs>) => {
+      // allow to ignore some update (like for sub collection. E.g. vms/:id/vdis)
+      if (!config.watchCollection?.predicate?.(receivedData, args)) {
+        return
+      }
+
       // for now only support `onDataRemoved` when watching XapiXoRecord collection
       if (Array.isArray(data.value) && !Array.isArray(receivedData)) {
         removeData(data.value, receivedData)
@@ -244,18 +257,19 @@ export function defineRemoteResource<
     let resume: VoidFunction = execute
 
     if (config.watchCollection !== undefined) {
-      const { resource, handleDelete, handlePost, handleWatching } = config.watchCollection
+      const { collectionId, resource, handleDelete, handlePost, handleWatching } = config.watchCollection
       const { watch, unwatch } = useSseStore()
 
-      pause = () => unwatch({ resource, handleDelete })
+      pause = () => unwatch({ collectionId, resource, handleDelete })
       resume = async function () {
         await execute()
         await watch({
+          collectionId,
           handleWatching,
           handlePost,
           resource,
-          onDataReceived: receivedData => onDataReceived(data, receivedData),
-          onDataRemoved: receivedData => onDataRemoved(data, receivedData),
+          onDataReceived: receivedData => onDataReceived(data, receivedData, context),
+          onDataRemoved: receivedData => onDataRemoved(data, receivedData, context),
         })
       }
     } else if (pollingInterval !== false) {

--- a/@xen-orchestra/web/src/remote-resources/use-xo-alarm-collection.ts
+++ b/@xen-orchestra/web/src/remote-resources/use-xo-alarm-collection.ts
@@ -4,7 +4,7 @@ import { defineRemoteResource } from '@core/packages/remote-resource/define-remo
 import type { XoAlarm } from '@vates/types'
 import { useSorted } from '@vueuse/core'
 
-const alarmFields: (keyof XoAlarm)[] = ['id', 'time', 'body', 'object', 'type'] as const
+export const alarmFields: (keyof XoAlarm)[] = ['id', 'time', 'body', 'object', 'type'] as const
 
 export const useXoAlarmCollection = defineRemoteResource({
   url: `/rest/v0/alarms?fields=${alarmFields.join(',')}`,

--- a/@xen-orchestra/web/src/remote-resources/use-xo-host-alarms-collection.ts
+++ b/@xen-orchestra/web/src/remote-resources/use-xo-host-alarms-collection.ts
@@ -1,12 +1,30 @@
 import { useXoCollectionState } from '@/composables/xo-collection-state/use-xo-collection-state.ts'
+import { watchCollectionWrapper } from '@/utils/sse.util'
 import { defineRemoteResource } from '@core/packages/remote-resource/define-remote-resource.ts'
 import { createDateSorter } from '@core/utils/date-sorter.utils.ts'
 import type { XoAlarm } from '@vates/types'
 import { useSorted } from '@vueuse/core'
+import { toValue } from 'vue'
+import { alarmFields } from './use-xo-alarm-collection'
 
 export const useXoHostAlarmsCollection = defineRemoteResource({
-  url: (hostId: string) => `/rest/v0/hosts/${hostId}/alarms?fields=id,time,body,object`,
+  url: (hostId: string) => `/rest/v0/hosts/${hostId}/alarms?fields=${alarmFields.join(',')}`,
   initialData: () => [] as XoAlarm[],
+  watchCollection: watchCollectionWrapper<XoAlarm>({
+    collectionId: 'hostAlarm',
+    resource: 'alarm',
+    fields: alarmFields,
+    predicate(alarm, context) {
+      if (context === undefined || context.args === undefined || Array.isArray(alarm)) {
+        return true
+      }
+
+      const [id] = context.args
+      const hostId = toValue(id)
+
+      return alarm.object.uuid === hostId
+    },
+  }),
   state: (rawHostAlarms, context) => {
     const hostAlarms = useSorted(rawHostAlarms, createDateSorter('time'))
 

--- a/@xen-orchestra/web/src/remote-resources/use-xo-vbd-collection.ts
+++ b/@xen-orchestra/web/src/remote-resources/use-xo-vbd-collection.ts
@@ -3,7 +3,7 @@ import { watchCollectionWrapper } from '@/utils/sse.util'
 import { defineRemoteResource } from '@core/packages/remote-resource/define-remote-resource.ts'
 import type { XoVbd } from '@vates/types'
 
-const vbdFields: (keyof XoVbd)[] = ['id', 'VDI', 'is_cd_drive', 'position', 'type', 'attached', 'device'] as const
+const vbdFields: (keyof XoVbd)[] = ['id', 'VDI', 'VM', 'is_cd_drive', 'position', 'type', 'attached', 'device'] as const
 
 export const useXoVbdCollection = defineRemoteResource({
   url: `/rest/v0/vbds?fields=${vbdFields.join(',')}`,

--- a/@xen-orchestra/web/src/remote-resources/use-xo-vdi-collection.ts
+++ b/@xen-orchestra/web/src/remote-resources/use-xo-vdi-collection.ts
@@ -3,7 +3,7 @@ import { watchCollectionWrapper } from '@/utils/sse.util'
 import { defineRemoteResource } from '@core/packages/remote-resource/define-remote-resource.ts'
 import type { XoVdi } from '@vates/types'
 
-const vdiFields: (keyof XoVdi)[] = [
+export const vdiFields: (keyof XoVdi)[] = [
   'id',
   'name_label',
   'name_description',
@@ -12,6 +12,11 @@ const vdiFields: (keyof XoVdi)[] = [
   'size',
   '$pool',
   'type',
+  'usage',
+  'tags',
+  'uuid',
+  'cbt_enabled',
+  'image_format',
 ] as const
 
 export const useXoVdiCollection = defineRemoteResource({

--- a/@xen-orchestra/web/src/remote-resources/use-xo-vm-alarms-collection.ts
+++ b/@xen-orchestra/web/src/remote-resources/use-xo-vm-alarms-collection.ts
@@ -1,12 +1,30 @@
 import { useXoCollectionState } from '@/composables/xo-collection-state/use-xo-collection-state.ts'
+import { watchCollectionWrapper } from '@/utils/sse.util'
 import { defineRemoteResource } from '@core/packages/remote-resource/define-remote-resource.ts'
 import { createDateSorter } from '@core/utils/date-sorter.utils.ts'
 import type { XoAlarm } from '@vates/types'
 import { useSorted } from '@vueuse/core'
+import { toValue } from 'vue'
+import { alarmFields } from './use-xo-alarm-collection'
 
 export const useXoVmAlarmsCollection = defineRemoteResource({
-  url: (vmId: string) => `/rest/v0/vms/${vmId}/alarms?fields=id,time,body,object`,
+  url: (vmId: string) => `/rest/v0/vms/${vmId}/alarms?fields=${alarmFields.join(',')}`,
   initialData: () => [] as XoAlarm[],
+  watchCollection: watchCollectionWrapper<XoAlarm>({
+    collectionId: 'vmAlarm',
+    resource: 'alarm',
+    fields: alarmFields,
+    predicate(alarm, context) {
+      if (context === undefined || context.args === undefined || Array.isArray(alarm)) {
+        return true
+      }
+
+      const [id] = context.args
+      const vmId = toValue(id)
+
+      return alarm.object.uuid === vmId
+    },
+  }),
   state: (rawVmAlarms, context) => {
     const vmAlarms = useSorted(rawVmAlarms, createDateSorter('time'))
 

--- a/@xen-orchestra/web/src/remote-resources/use-xo-vm-vdis-collection.ts
+++ b/@xen-orchestra/web/src/remote-resources/use-xo-vm-vdis-collection.ts
@@ -1,11 +1,32 @@
 import { useXoCollectionState } from '@/composables/xo-collection-state/use-xo-collection-state.ts'
+import { watchCollectionWrapper } from '@/utils/sse.util'
 import { defineRemoteResource } from '@core/packages/remote-resource/define-remote-resource.ts'
 import type { XoVdi } from '@vates/types'
+import { toValue } from 'vue'
+import { useXoVbdCollection } from './use-xo-vbd-collection'
+import { vdiFields } from './use-xo-vdi-collection'
 
 export const useXoVmVdisCollection = defineRemoteResource({
-  url: (vmId: string) =>
-    `/rest/v0/vms/${vmId}/vdis?fields=id,name_label,name_description,usage,size,uuid,tags,cbt_enabled,$VBDs,$SR,image_format`,
+  url: (vmId: string) => `/rest/v0/vms/${vmId}/vdis?fields=${vdiFields.join(',')}`,
   initialData: () => [] as XoVdi[],
+  watchCollection: watchCollectionWrapper<XoVdi>({
+    collectionId: 'vmVdi',
+    resource: 'VDI',
+    fields: vdiFields,
+    predicate(obj, context) {
+      if (context === undefined || context.args === undefined || Array.isArray(obj)) {
+        return true
+      }
+
+      const [id] = context.args
+      const vmId = toValue(id)
+
+      const { getVbdsByIds } = useXoVbdCollection(context)
+      const vbds = getVbdsByIds(obj.$VBDs)
+
+      return vbds.some(vbd => vbd.VM === vmId)
+    },
+  }),
   state: (vmVdis, context) => {
     return useXoCollectionState(vmVdis, {
       context,


### PR DESCRIPTION
### Description

Allow sub store (like vmVdis, hostAlarms, ...) to watch collection

IMO, "sub-store" must be rewritten due to potential scaling issue.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
