### PR TITLE
fix(xo-server-perf-alert): better handling of VM not loaded in xapi and undefined

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,5 +36,6 @@
 <!--packages-start-->
 
 - @xen-orchestra/web-core patch
+- xo-server-perf-alert patch
 
 <!--packages-end-->

--- a/packages/xo-server-perf-alert/src/RrdHostVm.js
+++ b/packages/xo-server-perf-alert/src/RrdHostVm.js
@@ -247,8 +247,8 @@ export class RrdHostVm extends MonitorStrategy {
 
     let alarms = this.#computeHostAlarm(xoHost, hostStat, this.#rules.getObjectAlerts(xoHost))
     for (const [vmUid, vmStats] of Object.entries(hostStat.vms ?? {})) {
-      const xoVm = this.#xo.getObject(vmUid)
       try {
+        const xoVm = this.#xo.getObject(vmUid)
         alarms = alarms.concat(this.#computeVmAlarm(xoVm, vmStats, this.#rules.getObjectAlerts(xoVm)))
       } catch (err) {}
     }

--- a/packages/xo-server-perf-alert/src/RrdHostVm.js
+++ b/packages/xo-server-perf-alert/src/RrdHostVm.js
@@ -321,7 +321,7 @@ export class RrdHostVm extends MonitorStrategy {
         await new Promise((resolve, reject) => {
           const interval = setTimeout(() => {
             resolve()
-            this.#abortWaitController.signal.removeEventListener('abort', onAbort)
+            this.#abortWaitController?.signal.removeEventListener('abort', onAbort)
           }, nextRun)
           function onAbort() {
             clearInterval(interval)
@@ -329,13 +329,13 @@ export class RrdHostVm extends MonitorStrategy {
             error.code = 'ERR_ABORTED'
             reject(error)
           }
-          this.#abortWaitController.signal.addEventListener('abort', onAbort)
+          this.#abortWaitController?.signal.addEventListener('abort', onAbort)
         })
       }
 
       this.#lastChangeComputation = Date.now()
       const changes = await this.computeAlarmChanges()
-      if (this.#abortWaitController.signal.aborted) {
+      if (this.#abortWaitController?.signal.aborted) {
         return
       }
       await onChanges(changes)
@@ -344,7 +344,7 @@ export class RrdHostVm extends MonitorStrategy {
         throw error
       }
     } finally {
-      if (!this.#abortWaitController.signal.aborted) {
+      if (!this.#abortWaitController?.signal.aborted) {
         this.#poll(onChanges, delay)
       }
     }


### PR DESCRIPTION
### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
