### PR TITLE
fix(xo-server-perf-alert): compute core average if cpu_usage is missing

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -35,4 +35,5 @@
 
 <!--packages-start-->
 
+- xo-server-perf-alert patch
 <!--packages-end-->

--- a/packages/xo-server-perf-alert/src/RrdHostVm.js
+++ b/packages/xo-server-perf-alert/src/RrdHostVm.js
@@ -246,7 +246,7 @@ export class RrdHostVm extends MonitorStrategy {
                   coresUsage.push(xapiAverage(vmMetricValue))
                 }
               }
-              value = xapiAverage(coresUsage)
+              value = Math.round(100 * xapiAverage(coresUsage))
             }
             break
           case 'memoryUsage': {

--- a/packages/xo-server-perf-alert/src/RrdHostVm.js
+++ b/packages/xo-server-perf-alert/src/RrdHostVm.js
@@ -243,7 +243,7 @@ export class RrdHostVm extends MonitorStrategy {
           vmAlarm.push(new Alarm({ rule, target: xoVm, value }))
         }
       } catch (err) {
-        // value computation can fail if the VM didn't accumaulate values yes
+        // value computation can fail if the VM didn't accumulate values yet
         logger.debug('VM alarm computation skipped', { vmId: xoVm?.id, rule: rule.variableName, error: err.message })
       }
     }

--- a/packages/xo-server-perf-alert/src/RrdHostVm.js
+++ b/packages/xo-server-perf-alert/src/RrdHostVm.js
@@ -244,7 +244,7 @@ export class RrdHostVm extends MonitorStrategy {
         }
       } catch (err) {
         // value computation can fail if the VM didn't accumaulate values yes
-        // of if it's missing its tool
+        logger.debug('VM alarm computation skipped', { vmId: xoVm?.id, rule: rule.variableName, error: err.message })
       }
     }
     return vmAlarm

--- a/packages/xo-server-perf-alert/src/RrdHostVm.js
+++ b/packages/xo-server-perf-alert/src/RrdHostVm.js
@@ -12,7 +12,18 @@ import { Alarm, MonitorStrategy } from './Strategy.js'
 
 const logger = createLogger('xo:xo-server-perf-alert:rrdStrategy')
 
-const USED_METRICS = ['cpu_usage', 'memory', 'memory_internal_free', 'cpu_avg', 'memory_total_kib', 'memory_free_kib']
+const VM_CORE_USAGE_METRIC = /^cpu[0-9+]$/
+
+/**
+ *
+ * @param {string} metricName
+ * @returns
+ */
+function isWatchedMetric(metricName) {
+  const USED_METRICS = ['cpu_usage', 'memory', 'memory_internal_free', 'cpu_avg', 'memory_total_kib', 'memory_free_kib']
+  return USED_METRICS.includes(metricName) || metricName.match(VM_CORE_USAGE_METRIC)
+}
+
 /**
  *
  * @param {*} xapi
@@ -103,22 +114,22 @@ export class RrdHostVm extends MonitorStrategy {
         logger.debug(`Can't parse legend ${legend}`)
         return
       }
-      const [, type, uuidInStat, metricType] = matches
-      if (!USED_METRICS.includes(metricType) || metricType.match(/cpu[0-9]+/)) {
+      const [, type, uuidInStat, metricName] = matches
+      if (!isWatchedMetric(metricName)) {
         return
       }
       switch (type) {
         case 'host':
-          hostStats.stats[metricType] = []
+          hostStats.stats[metricName] = []
           data.forEach(({ values }) => {
-            hostStats.stats[metricType].push(values[index])
+            hostStats.stats[metricName].push(values[index])
           })
           break
         case 'vm':
           hostStats.vms[uuidInStat] = hostStats.vms[uuidInStat] ?? {}
-          hostStats.vms[uuidInStat][metricType] = []
+          hostStats.vms[uuidInStat][metricName] = []
           data.forEach(({ values }) => {
-            hostStats.vms[uuidInStat][metricType].push(values[index])
+            hostStats.vms[uuidInStat][metricName].push(values[index])
           })
           break
       }
@@ -180,22 +191,31 @@ export class RrdHostVm extends MonitorStrategy {
     for (const rule of rules) {
       // compare value to data extracted from rrd
       let value
-      switch (rule.variableName) {
-        case 'cpuUsage':
-          value = Math.round(100 * xapiAverage(hostStat.stats.cpu_avg))
-          break
-        case 'memoryUsage': {
-          const total = xapiAverage(hostStat.stats.memory_total_kib)
-          const free = xapiAverage(hostStat.stats.memory_free_kib)
-          value = Math.round((100 * (total - free)) / total)
-          break
-        }
-        default:
-          throw new Error(`Can't compute alert of type ${rule.variableName} for host`)
-      }
 
-      if (rule.isTriggeredBy(value)) {
-        hostAlarms.push(new Alarm({ rule, target: xoHost, value }))
+      try {
+        switch (rule.variableName) {
+          case 'cpuUsage':
+            value = Math.round(100 * xapiAverage(hostStat.stats.cpu_avg))
+            break
+          case 'memoryUsage': {
+            const total = xapiAverage(hostStat.stats.memory_total_kib)
+            const free = xapiAverage(hostStat.stats.memory_free_kib)
+            value = Math.round((100 * (total - free)) / total)
+            break
+          }
+          default:
+            throw new Error(`Can't compute alert of type ${rule.variableName} for host`)
+        }
+
+        if (rule.isTriggeredBy(value)) {
+          hostAlarms.push(new Alarm({ rule, target: xoHost, value }))
+        }
+      } catch (err) {
+        logger.debug('host alarm computation skipped', {
+          hostId: xoHost?.id,
+          rule: rule.variableName,
+          error: err.message,
+        })
       }
     }
     return hostAlarms
@@ -221,9 +241,9 @@ export class RrdHostVm extends MonitorStrategy {
               value = Math.round(100 * xapiAverage(vmStats.cpu_usage))
             } else {
               const coresUsage = []
-              for (const [metric, value] of Object.entries(vmStats)) {
-                if (metric.match(/cpu[0-9]+/)) {
-                  coresUsage.push(xapiAverage(value))
+              for (const [vmMetricName, vmMetricValue] of Object.entries(vmStats)) {
+                if (vmMetricName.match(VM_CORE_USAGE_METRIC)) {
+                  coresUsage.push(xapiAverage(vmMetricValue))
                 }
               }
               value = xapiAverage(coresUsage)
@@ -244,6 +264,8 @@ export class RrdHostVm extends MonitorStrategy {
         }
       } catch (err) {
         // value computation can fail if the VM didn't accumulate values yet
+        // or if it's missing xen tools
+
         logger.debug('VM alarm computation skipped', { vmId: xoVm?.id, rule: rule.variableName, error: err.message })
       }
     }
@@ -296,7 +318,6 @@ export class RrdHostVm extends MonitorStrategy {
           watchedVmsByHosts.get(vm.$container).add(vm.id)
         }
       })
-
     const alarmsByObjects = []
 
     await asyncEach(
@@ -323,7 +344,6 @@ export class RrdHostVm extends MonitorStrategy {
       },
       { concurrency: 5 }
     )
-
     return [].concat(...alarmsByObjects)
   }
 

--- a/packages/xo-server-perf-alert/src/RrdHostVm.js
+++ b/packages/xo-server-perf-alert/src/RrdHostVm.js
@@ -104,7 +104,7 @@ export class RrdHostVm extends MonitorStrategy {
         return
       }
       const [, type, uuidInStat, metricType] = matches
-      if (!USED_METRICS.includes(metricType) || metricType.match('/cpu[0-9]+')) {
+      if (!USED_METRICS.includes(metricType) || metricType.match(/cpu[0-9]+/)) {
         return
       }
       switch (type) {

--- a/packages/xo-server-perf-alert/src/templates/mjml/newAlarms.hbs
+++ b/packages/xo-server-perf-alert/src/templates/mjml/newAlarms.hbs
@@ -42,7 +42,7 @@
                   {{target.name_label}}
                 </td>
                 <td   align="center">
-                  {{value}}
+                  {{value}} %
                 </td>
                 <td  align="center">
                   {{notificationType}}

--- a/packages/xo-server-perf-alert/src/templates/mjml/newAlarms.hbs
+++ b/packages/xo-server-perf-alert/src/templates/mjml/newAlarms.hbs
@@ -41,13 +41,13 @@
                 <td  >
                   {{target.name_label}}
                 </td>
-                <td   align="center">
+                <td   align="center" style="width:6em">
                   {{value}} %
                 </td>
-                <td  align="center">
+                <td  align="center" style="width:6em">
                   {{notificationType}}
                 </td>
-                <td  align="center"><a href="{{{url}}}">link</a> </td>
+                <td  align="center" style="width:6em"><a href="{{{url}}}">link</a> </td>
               </tr> 
               {{/each}}
             </mj-table> 


### PR DESCRIPTION
### Description

* a metric can be missing for an object, don't fail all its metrics check
* cpu_usage can be missing ( especially on xcp 8.2) , compute it by averaging the cores values 
* improve mail : unit alignment
* add debug for ignored values 
* 
<img width="875" height="938" alt="image" src="https://github.com/user-attachments/assets/4eeb48f7-ea20-4b80-a21a-a1b65e61d58a" />

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
