### PR TITLE
feat(@xen-orchestra/rest-api): add reactivity on task store

### DIFF
--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -632,6 +632,7 @@ export type XoTask = {
   end?: number
   id: Branded<'task'>
   infos?: { data: unknown; message: string }[]
+  progress?: number
   properties: {
     method?: string
     name?: string

--- a/@xen-orchestra/web/src/remote-resources/use-xo-task-collection.ts
+++ b/@xen-orchestra/web/src/remote-resources/use-xo-task-collection.ts
@@ -1,13 +1,17 @@
 import { useXoCollectionState } from '@/composables/xo-collection-state/use-xo-collection-state.ts'
 import { convertTaskToCore } from '@/utils/convert-task-to-core.util.ts'
+import { watchCollectionWrapper } from '@/utils/sse.util'
 import { defineRemoteResource } from '@core/packages/remote-resource/define-remote-resource.ts'
 import type { XoTask } from '@vates/types'
 import { computed } from 'vue'
 
 const ONE_DAY = 24 * 60 * 60 * 1000
 
+const taskFields: (keyof XoTask)[] = ['id', 'start', 'end', 'properties', 'status', 'progress', 'tasks'] as const
+
 export const useXoTaskCollection = defineRemoteResource({
-  url: '/rest/v0/tasks?fields=id,start,end,properties,status,progress,tasks',
+  url: `/rest/v0/tasks?fields=${taskFields}`,
+  watchCollection: watchCollectionWrapper({ resource: 'task', fields: taskFields }),
   initialData: () => [] as XoTask[],
   state: (tasks, context) => {
     const lastDayTasks = computed(() => {

--- a/@xen-orchestra/web/src/utils/sse.util.ts
+++ b/@xen-orchestra/web/src/utils/sse.util.ts
@@ -28,7 +28,7 @@ export function watchCollectionWrapper<T>({
   handleWatching?: THandleWatching
   predicate?: (receivedObj: T | T[], context: ResourceContext<any[]> | undefined) => boolean
 }) {
-  const _getType: (obj: unknown) => string | undefined = getType ?? ((obj: any) => obj.type)
+  const _getType: (obj: unknown) => string | undefined = getType ?? ((obj: any) => obj.$subscription)
   const _getIdentifier: (obj: unknown) => string | undefined = getIdentifier ?? ((obj: any) => obj.id)
 
   if (handleDelete === undefined) {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 
 - **XO 6:**
   - [i18n] Update Czech, Danish, Spanish, French, Italian, Dutch, Portuguese (Brazil), and Russian translations (PR [#9243](https://github.com/vatesfr/xen-orchestra/pull/9243))
+  - [Reactivity] Tasks are now reactive (PR [#9271](https://github.com/vatesfr/xen-orchestra/pull/9271))
 
 ### Bug fixes
 
@@ -39,8 +40,10 @@
 
 <!--packages-start-->
 
+- @vates/types minor
 - @xen-orchestra/mixins minor
 - @xen-orchestra/rest-api minor
+- @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

Merge after for #9269 

`getType` use now `$subscription` by default instead of `obj.type` as all XO Object do not have a type property

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
