### PR TITLE
refactor(web-core): merge `busy` prop into `type` in `VtsStateHero`

### DIFF
--- a/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardCpuProvisioning.vue
+++ b/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardCpuProvisioning.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCard class="host-dashboard-cpu-provisioning">
     <UiCardTitle>{{ t('cpu-provisioning') }}</UiCardTitle>
-    <VtsStateHero v-if="!isReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!isReady" format="card" type="busy" size="medium" />
     <template v-else>
       <VtsProgressBar
         :current="vCpusCount"

--- a/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardCpuUsageChart.vue
+++ b/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardCpuUsageChart.vue
@@ -4,7 +4,7 @@
       {{ t('cpu-usage') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading || data.stats === undefined" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading || data.stats === undefined" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardLoadAverageChart.vue
+++ b/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardLoadAverageChart.vue
@@ -4,7 +4,7 @@
       {{ t('load-average') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading || data.stats === undefined" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading || data.stats === undefined" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardNetworkUsageChart.vue
+++ b/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardNetworkUsageChart.vue
@@ -4,7 +4,7 @@
       {{ t('network-throughput') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading || data.stats === undefined" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading || data.stats === undefined" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardRamProvisioning.vue
+++ b/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardRamProvisioning.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCard class="host-dashboard-ram-provisioning">
     <UiCardTitle>{{ t('ram-provisioning') }}</UiCardTitle>
-    <VtsStateHero v-if="!isReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!isReady" format="card" type="busy" size="medium" />
     <template v-else>
       <VtsProgressBar
         :current="memory?.usage ?? 0"

--- a/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardRamUsageChart.vue
+++ b/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardRamUsageChart.vue
@@ -4,7 +4,7 @@
       {{ t('ram-usage') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading || data.stats === undefined" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading || data.stats === undefined" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardVmsStatus.vue
+++ b/@xen-orchestra/lite/src/components/host/dashboard/HostDashboardVmsStatus.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCard class="host-dashboard-vms-status">
     <UiCardTitle>{{ t('vms-status') }}</UiCardTitle>
-    <VtsStateHero v-if="!isReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!isReady" format="card" type="busy" size="medium" />
     <template v-else>
       <VtsDonutChartWithLegend :segments />
       <UiCardNumbers class="total" :label="t('total')" :value="total" size="small" />

--- a/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardAlarms.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardAlarms.vue
@@ -18,7 +18,7 @@
       </div>
     </div>
     <NoDataError v-else-if="hasError" />
-    <VtsStateHero v-else-if="!isReady" format="card" busy size="medium" />
+    <VtsStateHero v-else-if="!isReady" format="card" type="busy" size="medium" />
     <div v-else-if="alarms.length === 0" class="no-alarm">
       <div>
         <img alt="" src="@/assets/server-status.svg" />

--- a/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardCpuProvisioning.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardCpuProvisioning.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCard :color="hasError ? 'error' : undefined">
     <UiCardTitle>{{ t('cpu-provisioning') }}</UiCardTitle>
-    <VtsStateHero v-if="!isReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!isReady" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="hasError" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardNetworkChart.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardNetworkChart.vue
@@ -4,7 +4,7 @@
     <UiCardTitle :level="UiCardTitleLevel.Subtitle">
       {{ t('last-week') }}
     </UiCardTitle>
-    <VtsStateHero v-if="isLoading" format="card" busy size="medium" />
+    <VtsStateHero v-if="isLoading" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="hasError" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardStatus.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardStatus.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCard class="pool-dashboard-status" :color="hasError ? 'error' : undefined">
     <UiCardTitle>{{ t('status') }}</UiCardTitle>
-    <VtsStateHero v-if="!isReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!isReady" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="hasError" format="card" type="error" size="medium">{{ t('error-no-data') }}</VtsStateHero>
     <template v-else>
       <PoolDashboardStatusItem

--- a/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardStorageUsage.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/PoolDashboardStorageUsage.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCard :color="hasError ? 'error' : undefined">
     <UiCardTitle :left="t('storage-usage')" :right="t('top-#', { n: N_ITEMS })" />
-    <VtsStateHero v-if="!isReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!isReady" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="hasError" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/lite/src/components/pool/dashboard/cpuUsage/HostsCpuUsage.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/cpuUsage/HostsCpuUsage.vue
@@ -1,6 +1,6 @@
 <template>
   <UiCardTitle :left="t('hosts')" :level="UiCardTitleLevel.SubtitleWithUnderline" :right="t('top-#', { n: N_ITEMS })" />
-  <VtsStateHero v-if="isLoading" format="card" busy size="medium" />
+  <VtsStateHero v-if="isLoading" format="card" type="busy" size="medium" />
   <VtsStateHero v-else-if="hasError" format="card" type="error" size="medium">{{ t('error-no-data') }}</VtsStateHero>
   <VtsStateHero v-else-if="isStatEmpty" format="card" type="no-data" size="medium">
     {{ t('no-data-to-calculate') }}

--- a/@xen-orchestra/lite/src/components/pool/dashboard/cpuUsage/PoolCpuUsageChart.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/cpuUsage/PoolCpuUsageChart.vue
@@ -4,7 +4,7 @@
     <UiCardTitle :level="UiCardTitleLevel.Subtitle">
       {{ t('last-week') }}
     </UiCardTitle>
-    <VtsStateHero v-if="isLoading" format="card" busy size="medium" />
+    <VtsStateHero v-if="isLoading" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="hasError" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/lite/src/components/pool/dashboard/cpuUsage/VmsCpuUsage.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/cpuUsage/VmsCpuUsage.vue
@@ -4,7 +4,7 @@
     :level="UiCardTitleLevel.SubtitleWithUnderline"
     :right="t('top-#', { n: N_ITEMS })"
   />
-  <VtsStateHero v-if="isLoading" format="card" busy size="medium" />
+  <VtsStateHero v-if="isLoading" format="card" type="busy" size="medium" />
   <VtsStateHero v-else-if="hasError" format="card" type="error" size="medium">{{ t('error-no-data') }}</VtsStateHero>
   <VtsStateHero v-else-if="isStatEmpty" format="card" type="no-data" size="medium">
     {{ t('no-data-to-calculate') }}

--- a/@xen-orchestra/lite/src/components/pool/dashboard/ramUsage/HostsRamUsage.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/ramUsage/HostsRamUsage.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCardTitle :left="t('hosts')" :level="UiCardTitleLevel.SubtitleWithUnderline" :right="t('top-#', { n: N_ITEMS })" />
   <VtsStateHero v-if="hasError" format="card" type="error" size="medium">{{ t('error-no-data') }}</VtsStateHero>
-  <VtsStateHero v-else-if="isLoading" format="card" busy size="medium" />
+  <VtsStateHero v-else-if="isLoading" format="card" type="busy" size="medium" />
   <VtsStateHero v-else-if="isStatEmpty" format="card" type="no-data" size="medium">
     {{ t('no-data-to-calculate') }}
   </VtsStateHero>

--- a/@xen-orchestra/lite/src/components/pool/dashboard/ramUsage/PoolRamUsageChart.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/ramUsage/PoolRamUsageChart.vue
@@ -4,7 +4,7 @@
     <UiCardTitle :level="UiCardTitleLevel.Subtitle">
       {{ t('last-week') }}
     </UiCardTitle>
-    <VtsStateHero v-if="isLoading" format="card" busy size="medium" />
+    <VtsStateHero v-if="isLoading" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="hasError" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/lite/src/components/pool/dashboard/ramUsage/VmsRamUsage.vue
+++ b/@xen-orchestra/lite/src/components/pool/dashboard/ramUsage/VmsRamUsage.vue
@@ -5,7 +5,7 @@
     :right="t('top-#', { n: N_ITEMS })"
   />
   <VtsStateHero v-if="hasError" format="card" type="error" size="medium">{{ t('error-no-data') }}</VtsStateHero>
-  <VtsStateHero v-else-if="isLoading" format="card" busy size="medium" />
+  <VtsStateHero v-else-if="isLoading" format="card" type="busy" size="medium" />
   <VtsStateHero v-else-if="isStatEmpty" format="card" type="no-data" size="medium">
     {{ t('no-data-to-calculate') }}
   </VtsStateHero>

--- a/@xen-orchestra/lite/src/components/pool/system/PoolManagement.vue
+++ b/@xen-orchestra/lite/src/components/pool/system/PoolManagement.vue
@@ -3,7 +3,7 @@
     <UiTitle>
       {{ t('pool-management') }}
     </UiTitle>
-    <VtsStateHero v-if="!isReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!isReady" format="card" type="busy" size="medium" />
     <template v-else>
       <VtsQuickInfoRow :label="t('master')">
         <template #value>

--- a/@xen-orchestra/lite/src/components/pool/system/PoolNetworking.vue
+++ b/@xen-orchestra/lite/src/components/pool/system/PoolNetworking.vue
@@ -3,7 +3,7 @@
     <UiTitle>
       {{ t('networking') }}
     </UiTitle>
-    <VtsStateHero v-if="!isReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!isReady" format="card" type="busy" size="medium" />
     <template v-else>
       <VtsQuickInfoRow :label="t('backup-network')">
         <template #value>

--- a/@xen-orchestra/lite/src/components/pool/system/PoolStorageConfiguration.vue
+++ b/@xen-orchestra/lite/src/components/pool/system/PoolStorageConfiguration.vue
@@ -3,7 +3,7 @@
     <UiTitle>
       {{ t('storage-configuration') }}
     </UiTitle>
-    <VtsStateHero v-if="!isReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!isReady" format="card" type="busy" size="medium" />
     <template v-else>
       <VtsQuickInfoRow :label="t('default-storage-repository')">
         <template #value>

--- a/@xen-orchestra/lite/src/components/vm/dashboard/VmDashboardCpuUsageChart.vue
+++ b/@xen-orchestra/lite/src/components/vm/dashboard/VmDashboardCpuUsageChart.vue
@@ -4,7 +4,7 @@
       {{ t('cpu-usage') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/lite/src/components/vm/dashboard/VmDashboardNetworkUsageChart.vue
+++ b/@xen-orchestra/lite/src/components/vm/dashboard/VmDashboardNetworkUsageChart.vue
@@ -4,7 +4,7 @@
       {{ t('network-throughput') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/lite/src/components/vm/dashboard/VmDashboardRamUsageChart.vue
+++ b/@xen-orchestra/lite/src/components/vm/dashboard/VmDashboardRamUsageChart.vue
@@ -4,7 +4,7 @@
       {{ t('ram-usage') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/lite/src/components/vm/dashboard/VmDashboardVdiUsageChart.vue
+++ b/@xen-orchestra/lite/src/components/vm/dashboard/VmDashboardVdiUsageChart.vue
@@ -4,7 +4,7 @@
       {{ t('vdi-throughput') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/lite/src/pages/pool/[uuid]/system.vue
+++ b/@xen-orchestra/lite/src/pages/pool/[uuid]/system.vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsStateHero v-if="!isReady" format="page" busy size="medium" />
+  <VtsStateHero v-if="!isReady" format="page" type="busy" size="medium" />
   <VtsStateHero v-else-if="pool === undefined" format="page" type="no-data" size="medium">
     {{ t('no-data') }}
   </VtsStateHero>

--- a/@xen-orchestra/lite/src/stories/web-core/ui/panel/ui-panel.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/panel/ui-panel.story.vue
@@ -29,7 +29,7 @@
           {{ settings.action2 }}
         </UiButton>
       </template>
-      <VtsStateHero v-if="!isReady" format="card" busy />
+      <VtsStateHero v-if="!isReady" format="card" type="busy" size="medium" />
       <UiCard v-else-if="!properties.error">
         <div>Content 1</div>
         <div>Content 1</div>

--- a/@xen-orchestra/web-core/lib/components/console/VtsRemoteConsole.vue
+++ b/@xen-orchestra/web-core/lib/components/console/VtsRemoteConsole.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="uiStore.isMobile ? 'mobile' : undefined" class="vts-remote-console">
-    <VtsStateHero v-if="!isReady" format="page" busy size="medium">{{ t('loading') }}</VtsStateHero>
+    <VtsStateHero v-if="!isReady" format="page" type="busy" size="medium">{{ t('loading') }}</VtsStateHero>
     <div ref="console-container" class="console" />
   </div>
 </template>

--- a/@xen-orchestra/web-core/lib/components/data-table/VtsDataTable.vue
+++ b/@xen-orchestra/web-core/lib/components/data-table/VtsDataTable.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="table-container">
-    <VtsStateHero v-if="!isReady" format="table" busy size="medium" />
+    <VtsStateHero v-if="!isReady" format="table" type="busy" size="medium" />
     <VtsStateHero v-else-if="hasError" format="table" type="error" size="small" no-background>
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/web-core/lib/components/quick-info-card/VtsQuickInfoCard.vue
+++ b/@xen-orchestra/web-core/lib/components/quick-info-card/VtsQuickInfoCard.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCard class="vts-quick-info-card">
     <UiCardTitle>{{ t('quick-info') }}</UiCardTitle>
-    <VtsStateHero v-if="loading" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading" format="card" type="busy" size="medium" />
     <div v-else class="info-container">
       <slot />
     </div>

--- a/@xen-orchestra/web-core/lib/components/state-hero/VtsStateHero.vue
+++ b/@xen-orchestra/web-core/lib/components/state-hero/VtsStateHero.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="[className, { horizontal, error, success, 'no-background': noBackground }]" class="vts-state-hero">
-    <UiLoader v-if="busy" class="loader" />
+    <UiLoader v-if="type === 'busy'" class="loader" />
     <img v-else-if="imageSrc" :src="imageSrc" :alt="type" class="image" />
     <div v-if="slots.default" :class="typoClass" class="content">
       <slot />
@@ -15,7 +15,8 @@ import { computed } from 'vue'
 
 export type StateHeroFormat = 'page' | 'card' | 'panel' | 'table'
 
-type StateHeroType =
+export type StateHeroType =
+  | 'busy'
   | 'no-result'
   | 'under-construction'
   | 'no-data'
@@ -26,12 +27,11 @@ type StateHeroType =
   | 'all-good'
   | 'all-done'
 
-const { format, type, size, busy } = defineProps<{
+const { format, type, size } = defineProps<{
   format: StateHeroFormat
-  type?: StateHeroType
+  type: StateHeroType
   size: 'extra-small' | 'small' | 'medium' | 'large'
   horizontal?: boolean
-  busy?: boolean
   noBackground?: boolean
 }>()
 
@@ -43,12 +43,12 @@ const typoClass = computed(() => (format === 'page' ? 'typo-h2' : 'typo-h4'))
 
 const className = computed(() => toVariants({ size, format }))
 
-const error = computed(() => !busy && type === 'error')
+const error = computed(() => type === 'error')
 
-const success = computed(() => !busy && (type === 'all-good' || type === 'all-done'))
+const success = computed(() => type === 'all-good' || type === 'all-done')
 
 const imageSrc = computed(() => {
-  if (!type) {
+  if (type === 'busy') {
     return undefined
   }
 

--- a/@xen-orchestra/web/src/components/alarms/DashboardAlarms.vue
+++ b/@xen-orchestra/web/src/components/alarms/DashboardAlarms.vue
@@ -10,7 +10,7 @@
         :value="rawAlarms.length"
       />
     </UiCardTitle>
-    <VtsStateHero v-if="!isReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!isReady" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="rawAlarms.length === 0" format="card" type="all-good" horizontal size="medium">
       <span>{{ t('all-good') }}</span>
       <span>{{ t('no-alarms-detected') }}</span>

--- a/@xen-orchestra/web/src/components/host/dashboard/HostDashboardCpuProvisioning.vue
+++ b/@xen-orchestra/web/src/components/host/dashboard/HostDashboardCpuProvisioning.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCard class="host-dashboard-cpu-provisioning">
     <UiCardTitle>{{ t('cpu-provisioning') }}</UiCardTitle>
-    <VtsStateHero v-if="!isReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!isReady" format="card" type="busy" size="medium" />
     <template v-else>
       <VtsProgressBar
         :label="t('vcpus')"

--- a/@xen-orchestra/web/src/components/host/dashboard/HostDashboardCpuUsageChart.vue
+++ b/@xen-orchestra/web/src/components/host/dashboard/HostDashboardCpuUsageChart.vue
@@ -4,7 +4,7 @@
       {{ t('cpu-usage') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading || data === null" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading || data === null" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">{{ t('error-no-data') }}</VtsStateHero>
     <VtsStateHero v-else-if="cpuUsage.length === 0" format="card" type="no-data" size="medium">
       {{ t('no-data-to-calculate') }}

--- a/@xen-orchestra/web/src/components/host/dashboard/HostDashboardLoadAverageChart.vue
+++ b/@xen-orchestra/web/src/components/host/dashboard/HostDashboardLoadAverageChart.vue
@@ -4,7 +4,7 @@
       {{ t('load-average') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading || data === null" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading || data === null" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">{{ t('error-no-data') }}</VtsStateHero>
     <VtsStateHero v-else-if="loadAverage.length === 0" format="card" type="no-data" size="medium">
       {{ t('no-data-to-calculate') }}

--- a/@xen-orchestra/web/src/components/host/dashboard/HostDashboardNetworkUsageChart.vue
+++ b/@xen-orchestra/web/src/components/host/dashboard/HostDashboardNetworkUsageChart.vue
@@ -4,7 +4,7 @@
       {{ t('network-throughput') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading || data === null" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading || data === null" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">{{ t('error-no-data') }}</VtsStateHero>
     <VtsStateHero v-else-if="networkUsage.length === 0" format="card" type="no-data" size="medium">
       {{ t('no-data-to-calculate') }}

--- a/@xen-orchestra/web/src/components/host/dashboard/HostDashboardPatches.vue
+++ b/@xen-orchestra/web/src/components/host/dashboard/HostDashboardPatches.vue
@@ -8,7 +8,7 @@
         </template>
       </UiCardTitle>
     </div>
-    <VtsStateHero v-if="!areHostMissingPatchesReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areHostMissingPatchesReady" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="noMissingPatches" format="card" type="all-done" size="extra-small" horizontal>
       <span> {{ t('all-good') }} </span>
       <span>{{ t('patches-up-to-date') }}</span>

--- a/@xen-orchestra/web/src/components/host/dashboard/HostDashboardRamProvisioning.vue
+++ b/@xen-orchestra/web/src/components/host/dashboard/HostDashboardRamProvisioning.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCard class="host-dashboard-ram-provisioning">
     <UiCardTitle>{{ t('ram-provisioning') }}</UiCardTitle>
-    <VtsStateHero v-if="!areHostsReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areHostsReady" format="card" type="busy" size="medium" />
     <template v-else>
       <VtsProgressBar
         :label="host.name_label"

--- a/@xen-orchestra/web/src/components/host/dashboard/HostDashboardRamUsageChart.vue
+++ b/@xen-orchestra/web/src/components/host/dashboard/HostDashboardRamUsageChart.vue
@@ -4,7 +4,7 @@
       {{ t('ram-usage') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading || data === null" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading || data === null" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">{{ t('error-no-data') }}</VtsStateHero>
     <VtsStateHero v-else-if="ramUsage.length === 0" format="card" type="no-data" size="medium">
       {{ t('no-data-to-calculate') }}

--- a/@xen-orchestra/web/src/components/host/dashboard/HostDashboardVmsStatus.vue
+++ b/@xen-orchestra/web/src/components/host/dashboard/HostDashboardVmsStatus.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCard class="host-dashboard-vms-status">
     <UiCardTitle>{{ t('vms-status') }}</UiCardTitle>
-    <VtsStateHero v-if="!isReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!isReady" format="card" type="busy" size="medium" />
     <template v-else>
       <VtsDonutChartWithLegend :segments />
       <UiCardNumbers class="total" :label="t('total')" :value="total" size="small" />

--- a/@xen-orchestra/web/src/components/pool/dashboard/PoolDashboardCpuProvisioning.vue
+++ b/@xen-orchestra/web/src/components/pool/dashboard/PoolDashboardCpuProvisioning.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCard :has-error class="pool-dashboard-cpu-provisioning">
     <UiCardTitle>{{ t('cpu-provisioning') }}</UiCardTitle>
-    <VtsStateHero v-if="!isCpuProvisioningReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!isCpuProvisioningReady" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="hasError" format="card" type="error" size="extra-small" horizontal>
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/web/src/components/pool/dashboard/PoolDashboardCpuUsage.vue
+++ b/@xen-orchestra/web/src/components/pool/dashboard/PoolDashboardCpuUsage.vue
@@ -9,7 +9,7 @@
         {{ t('top-#', 5) }}
       </template>
     </UiCardSubtitle>
-    <VtsStateHero v-if="!areHostsCpuUsageReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areHostsCpuUsageReady" format="card" type="busy" size="medium" />
     <template v-else>
       <HostsCpuUsage :top-five-cpu="poolDashboard?.hosts?.topFiveUsage?.cpu" :has-error />
     </template>
@@ -19,7 +19,7 @@
         {{ t('top-#', 5) }}
       </template>
     </UiCardSubtitle>
-    <VtsStateHero v-if="!areVmsCpuUsageReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areVmsCpuUsageReady" format="card" type="busy" size="medium" />
     <template v-else>
       <VmsCpuUsage :top-five-cpu="poolDashboard?.vms?.topFiveUsage?.cpu" :has-error />
     </template>

--- a/@xen-orchestra/web/src/components/pool/dashboard/PoolDashboardHostsPatches.vue
+++ b/@xen-orchestra/web/src/components/pool/dashboard/PoolDashboardHostsPatches.vue
@@ -8,7 +8,7 @@
         </template>
       </UiCardTitle>
     </div>
-    <VtsStateHero v-if="!areMissingPatchesReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areMissingPatchesReady" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="noMissingPatches" format="card" type="all-done" size="small">
       <span> {{ t('all-good') }} </span>
       <span>{{ t('patches-up-to-date') }}</span>

--- a/@xen-orchestra/web/src/components/pool/dashboard/PoolDashboardRamUsage.vue
+++ b/@xen-orchestra/web/src/components/pool/dashboard/PoolDashboardRamUsage.vue
@@ -9,7 +9,7 @@
         {{ t('top-#', 5) }}
       </template>
     </UiCardSubtitle>
-    <VtsStateHero v-if="!areHostsRamUsageReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areHostsRamUsageReady" format="card" type="busy" size="medium" />
     <template v-else>
       <HostsRamUsage :top-five-ram="poolDashboard?.hosts?.topFiveUsage?.ram" :has-error />
     </template>
@@ -19,7 +19,7 @@
         {{ t('top-#', 5) }}
       </template>
     </UiCardSubtitle>
-    <VtsStateHero v-if="!areVmsRamUsageReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areVmsRamUsageReady" format="card" type="busy" size="medium" />
     <template v-else>
       <VmsRamUsage :top-five-ram="poolDashboard?.vms?.topFiveUsage?.ram" :has-error />
     </template>

--- a/@xen-orchestra/web/src/components/pool/dashboard/PoolDashboardStatus.vue
+++ b/@xen-orchestra/web/src/components/pool/dashboard/PoolDashboardStatus.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCard :has-error>
     <UiCardTitle>{{ t('status') }}</UiCardTitle>
-    <VtsStateHero v-if="!areHostsStatusReady || !areVmsStatusReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areHostsStatusReady || !areVmsStatusReady" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="hasError" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/web/src/components/pool/dashboard/PoolDashboardStoragesUsage.vue
+++ b/@xen-orchestra/web/src/components/pool/dashboard/PoolDashboardStoragesUsage.vue
@@ -6,7 +6,7 @@
         {{ t('top-#', 5) }}
       </template>
     </UiCardTitle>
-    <VtsStateHero v-if="!areStoragesUsageReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areStoragesUsageReady" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="hasError" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/web/src/components/pool/dashboard/chart-usage/PoolDashboardCpuChart.vue
+++ b/@xen-orchestra/web/src/components/pool/dashboard/chart-usage/PoolDashboardCpuChart.vue
@@ -4,7 +4,7 @@
       {{ t('pool-cpu-usage') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading || data === null" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading || data === null" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/web/src/components/pool/dashboard/chart-usage/PoolDashboardNetworkChart.vue
+++ b/@xen-orchestra/web/src/components/pool/dashboard/chart-usage/PoolDashboardNetworkChart.vue
@@ -4,7 +4,7 @@
       {{ t('network-throughput') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading || data === null" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading || data === null" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/web/src/components/pool/dashboard/chart-usage/PoolDashboardRamChart.vue
+++ b/@xen-orchestra/web/src/components/pool/dashboard/chart-usage/PoolDashboardRamChart.vue
@@ -4,7 +4,7 @@
       {{ t('pool-ram-usage') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading || data === null" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading || data === null" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/web/src/components/pool/system/PoolConnections.vue
+++ b/@xen-orchestra/web/src/components/pool/system/PoolConnections.vue
@@ -3,7 +3,7 @@
     <UiTitle>
       {{ t('connections') }}
     </UiTitle>
-    <VtsStateHero v-if="!areServersReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areServersReady" format="card" type="busy" size="medium" />
     <template v-else>
       <VtsQuickInfoRow :label="t('ip-address')" :value="server?.host" />
       <VtsQuickInfoRow :label="t('proxy-url')" :value="server?.httpProxy" />

--- a/@xen-orchestra/web/src/components/pool/system/PoolManagement.vue
+++ b/@xen-orchestra/web/src/components/pool/system/PoolManagement.vue
@@ -3,7 +3,7 @@
     <UiTitle>
       {{ t('pool-management') }}
     </UiTitle>
-    <VtsStateHero v-if="!areHostsReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areHostsReady" format="card" type="busy" size="medium" />
     <template v-else>
       <VtsQuickInfoRow :label="t('master')">
         <template #value>

--- a/@xen-orchestra/web/src/components/pool/system/PoolNetworking.vue
+++ b/@xen-orchestra/web/src/components/pool/system/PoolNetworking.vue
@@ -3,7 +3,7 @@
     <UiTitle>
       {{ t('networking') }}
     </UiTitle>
-    <VtsStateHero v-if="!areNetworksReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areNetworksReady" format="card" type="busy" size="medium" />
     <template v-else>
       <VtsQuickInfoRow :label="t('backup-network')">
         <template #value>

--- a/@xen-orchestra/web/src/components/pool/system/PoolStorageConfiguration.vue
+++ b/@xen-orchestra/web/src/components/pool/system/PoolStorageConfiguration.vue
@@ -3,7 +3,7 @@
     <UiTitle>
       {{ t('storage-configuration') }}
     </UiTitle>
-    <VtsStateHero v-if="!areSrsReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areSrsReady" format="card" type="busy" size="medium" />
     <template v-else>
       <VtsQuickInfoRow :label="t('default-storage-repository')">
         <template #value>

--- a/@xen-orchestra/web/src/components/site/dashboard/BackupIssues.vue
+++ b/@xen-orchestra/web/src/components/site/dashboard/BackupIssues.vue
@@ -5,7 +5,7 @@
       <UiCounter :value="nBackupIssues" accent="danger" size="medium" variant="primary" />
       <template #description>{{ t('in-last-three-jobs') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="!areBackupIssuesReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areBackupIssuesReady" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="!hasBackupIssues" format="card" type="no-data" size="small" horizontal>
       {{ t('no-data-to-calculate') }}
     </VtsStateHero>

--- a/@xen-orchestra/web/src/components/site/dashboard/Backups.vue
+++ b/@xen-orchestra/web/src/components/site/dashboard/Backups.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCard :has-error>
     <UiCardTitle>{{ t('backups') }}</UiCardTitle>
-    <VtsStateHero v-if="!areBackupsReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areBackupsReady" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="hasError" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/web/src/components/site/dashboard/HostsStatus.vue
+++ b/@xen-orchestra/web/src/components/site/dashboard/HostsStatus.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCard :has-error>
     <UiCardTitle>{{ t('hosts-status') }}</UiCardTitle>
-    <VtsStateHero v-if="!areHostsStatusReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areHostsStatusReady" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="hasError" format="card" type="error" size="extra-small" horizontal>
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/web/src/components/site/dashboard/Patches.vue
+++ b/@xen-orchestra/web/src/components/site/dashboard/Patches.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCard :has-error>
     <UiCardTitle>{{ t('patches') }}</UiCardTitle>
-    <VtsStateHero v-if="!arePatchesReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!arePatchesReady" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="hasError" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/web/src/components/site/dashboard/PoolsStatus.vue
+++ b/@xen-orchestra/web/src/components/site/dashboard/PoolsStatus.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCard :has-error>
     <UiCardTitle>{{ t('pools-status') }}</UiCardTitle>
-    <VtsStateHero v-if="!arePoolsStatusReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!arePoolsStatusReady" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="hasError" format="card" type="error" size="extra-small" horizontal>
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/web/src/components/site/dashboard/ResourcesOverview.vue
+++ b/@xen-orchestra/web/src/components/site/dashboard/ResourcesOverview.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCard :has-error>
     <UiCardTitle>{{ t('resources-overview') }}</UiCardTitle>
-    <VtsStateHero v-if="!areResourcesOverviewReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areResourcesOverviewReady" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="hasError" format="card" type="error" size="extra-small" horizontal>
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/web/src/components/site/dashboard/StorageRepository.vue
+++ b/@xen-orchestra/web/src/components/site/dashboard/StorageRepository.vue
@@ -4,7 +4,7 @@
       {{ t('storage-repository') }}
       <template #description>{{ t('for-replication') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="!areStorageRepositoriesReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areStorageRepositoriesReady" format="card" type="busy" size="medium" />
     <template v-else>
       <VtsStackedBarWithLegend :max-value="maxValue" :segments />
       <div class="numbers">

--- a/@xen-orchestra/web/src/components/site/dashboard/VmsStatus.vue
+++ b/@xen-orchestra/web/src/components/site/dashboard/VmsStatus.vue
@@ -1,7 +1,7 @@
 <template>
   <UiCard :has-error>
     <UiCardTitle>{{ t('vms-status') }}</UiCardTitle>
-    <VtsStateHero v-if="!areVmsStatusReady" format="card" busy size="medium" />
+    <VtsStateHero v-if="!areVmsStatusReady" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="hasError" format="card" type="error" size="extra-small" horizontal>
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/web/src/components/site/pools/PoolsSidePanel.vue
+++ b/@xen-orchestra/web/src/components/site/pools/PoolsSidePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsStateHero v-if="!arePoolsReady" format="panel" busy size="medium" />
+  <VtsStateHero v-if="!arePoolsReady" format="panel" type="busy" size="medium" />
   <UiPanel v-else :class="{ 'mobile-drawer': uiStore.isMobile }">
     <template #header>
       <div :class="{ 'action-buttons-container': uiStore.isMobile }">

--- a/@xen-orchestra/web/src/components/storage-repositories/panel/StorageRepositoriesSidePanel.vue
+++ b/@xen-orchestra/web/src/components/storage-repositories/panel/StorageRepositoriesSidePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsStateHero v-if="!isReady" format="panel" busy size="medium" />
+  <VtsStateHero v-if="!isReady" format="panel" type="busy" size="medium" />
   <UiPanel v-else :class="{ 'mobile-drawer': uiStore.isMobile }">
     <template #header>
       <div :class="{ 'action-buttons-container': uiStore.isMobile }">

--- a/@xen-orchestra/web/src/components/vm/dashboard/VmDashboardCpuUsageChart.vue
+++ b/@xen-orchestra/web/src/components/vm/dashboard/VmDashboardCpuUsageChart.vue
@@ -4,7 +4,7 @@
       {{ t('cpu-usage') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/web/src/components/vm/dashboard/VmDashboardNetworkUsageChart.vue
+++ b/@xen-orchestra/web/src/components/vm/dashboard/VmDashboardNetworkUsageChart.vue
@@ -4,7 +4,7 @@
       {{ t('network-throughput') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/web/src/components/vm/dashboard/VmDashboardRamUsageChart.vue
+++ b/@xen-orchestra/web/src/components/vm/dashboard/VmDashboardRamUsageChart.vue
@@ -4,7 +4,7 @@
       {{ t('ram-usage') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/web/src/components/vm/dashboard/VmDashboardVdiUsageChart.vue
+++ b/@xen-orchestra/web/src/components/vm/dashboard/VmDashboardVdiUsageChart.vue
@@ -4,7 +4,7 @@
       {{ t('vdi-throughput') }}
       <template #description>{{ t('last-week') }}</template>
     </UiCardTitle>
-    <VtsStateHero v-if="loading" format="card" busy size="medium" />
+    <VtsStateHero v-if="loading" format="card" type="busy" size="medium" />
     <VtsStateHero v-else-if="error" format="card" type="error" size="medium">
       {{ t('error-no-data') }}
     </VtsStateHero>

--- a/@xen-orchestra/web/src/layouts/AppLayout.vue
+++ b/@xen-orchestra/web/src/layouts/AppLayout.vue
@@ -26,7 +26,7 @@
       <VtsTreeList v-if="!isReady">
         <VtsTreeLoadingItem v-for="i in 5" :key="i" icon="fa:city" />
       </VtsTreeList>
-      <VtsStateHero v-else-if="isSearching" format="card" busy size="medium" class="loader" />
+      <VtsStateHero v-else-if="isSearching" format="card" size="medium" type="busy" class="loader" />
       <VtsStateHero v-else-if="sites.length === 0" format="card" size="medium" type="no-result">
         {{ t('no-results') }}
       </VtsStateHero>

--- a/@xen-orchestra/web/src/pages/(site).vue
+++ b/@xen-orchestra/web/src/pages/(site).vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsStateHero v-if="!arePoolsReady" format="page" busy size="large" />
+  <VtsStateHero v-if="!arePoolsReady" format="page" type="busy" size="large" />
   <RouterView v-slot="{ Component }">
     <SiteHeader />
     <component :is="Component" />

--- a/@xen-orchestra/web/src/pages/backup/[id].vue
+++ b/@xen-orchestra/web/src/pages/backup/[id].vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsStateHero v-if="!areBackupJobsReady" format="page" busy size="large" />
+  <VtsStateHero v-if="!areBackupJobsReady" format="page" type="busy" size="large" />
   <VtsStateHero v-else-if="!backupJob" format="page" type="not-found" size="large">
     {{ t('object-not-found', { id: route.params.id }) }}
   </VtsStateHero>

--- a/@xen-orchestra/web/src/pages/host/[id].vue
+++ b/@xen-orchestra/web/src/pages/host/[id].vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsStateHero v-if="!areHostsReady" format="page" busy size="large" />
+  <VtsStateHero v-if="!areHostsReady" format="page" type="busy" size="large" />
   <VtsStateHero v-else-if="!host" format="page" type="not-found" size="large">
     {{ t('object-not-found', { id: route.params.id }) }}
   </VtsStateHero>

--- a/@xen-orchestra/web/src/pages/pool/[id].vue
+++ b/@xen-orchestra/web/src/pages/pool/[id].vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsStateHero v-if="!arePoolsReady" format="page" busy size="large" />
+  <VtsStateHero v-if="!arePoolsReady" format="page" type="busy" size="large" />
   <VtsStateHero v-else-if="!pool" format="page" type="not-found" size="large">
     {{ t('object-not-found', { id: route.params.id }) }}
   </VtsStateHero>

--- a/@xen-orchestra/web/src/pages/pool/[id]/system.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/system.vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsStateHero v-if="!isReady" format="card" busy size="medium" />
+  <VtsStateHero v-if="!isReady" format="card" type="busy" size="medium" />
   <VtsColumns v-else>
     <VtsColumn>
       <PoolGeneralInfo :pool />

--- a/@xen-orchestra/web/src/pages/vm/[id].vue
+++ b/@xen-orchestra/web/src/pages/vm/[id].vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsStateHero v-if="!areVmsReady" format="page" busy size="large" />
+  <VtsStateHero v-if="!areVmsReady" format="page" type="busy" size="large" />
   <VtsStateHero v-else-if="!vm" format="page" type="not-found" size="large">
     {{ t('object-not-found', { id: route.params.id }) }}
   </VtsStateHero>

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,5 +34,6 @@
 <!--packages-start-->
 
 - @xen-orchestra/web patch
+- @xen-orchestra/web-core patch
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

This PR removes the separate `busy` boolean prop simplify state management.

The loading state is now handled directly via the `type` prop by setting it to `'busy'`.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
