### PR TITLE
feat(fs): add tree cache

### DIFF
--- a/@xen-orchestra/fs/src/fs.test.js
+++ b/@xen-orchestra/fs/src/fs.test.js
@@ -41,7 +41,6 @@ const skipFsNotInAzure = () => {
 }
 // TODO : add tests on encrypted remote
 const handlers = [`file://${tmp.dirSync().name}`]
-const handlers = [`file://${tmpdir()}`]
 if (process.env.xo_fs_nfs) handlers.push(process.env.xo_fs_nfs)
 if (process.env.xo_fs_smb) handlers.push(process.env.xo_fs_smb)
 if (process.env.xo_fs_azure) handlers.push(process.env.xo_fs_azure)
@@ -82,287 +81,287 @@ handlers.forEach(url => {
       await handler.rmtree('.')
     })
 
-    // describe('#type', () => {
-    //   it('returns the type of the remote', () => {
-    //     assert.equal(typeof handler.type, 'string')
-    //   })
-    // })
+    describe('#type', () => {
+      it('returns the type of the remote', () => {
+        assert.equal(typeof handler.type, 'string')
+      })
+    })
 
-    // describe('#getInfo()', () => {
-    //   let info
-    //   before(async () => {
-    //     info = await handler.getInfo()
-    //   })
+    describe('#getInfo()', () => {
+      let info
+      before(async () => {
+        info = await handler.getInfo()
+      })
 
-    //   it('should return an object with info', { skip: skipFsNotInAzure() }, async () => {
-    //     assert.equal(typeof info, 'object')
-    //   })
+      it('should return an object with info', { skip: skipFsNotInAzure() }, async () => {
+        assert.equal(typeof info, 'object')
+      })
 
-    //   it('should return correct type of attribute', { skip: skipFsNotInAzure() }, async () => {
-    //     if (info.size !== undefined) {
-    //       assert.equal(typeof info.size, 'number')
-    //     }
-    //     if (info.used !== undefined) {
-    //       assert.equal(typeof info.used, 'number')
-    //     }
-    //   })
-    // })
+      it('should return correct type of attribute', { skip: skipFsNotInAzure() }, async () => {
+        if (info.size !== undefined) {
+          assert.equal(typeof info.size, 'number')
+        }
+        if (info.used !== undefined) {
+          assert.equal(typeof info.used, 'number')
+        }
+      })
+    })
 
-    // // TODO : add test "should throw if remote is encrypted" on #getSize()
-    // describe('#getSizeOnDisk()', () => {
-    //   beforeEach(() => handler.outputFile('file', TEST_DATA))
+    // TODO : add test "should throw if remote is encrypted" on #getSize()
+    describe('#getSizeOnDisk()', () => {
+      beforeEach(() => handler.outputFile('file', TEST_DATA))
 
-    //   testWithFileDescriptor('file', 'r', async () => {
-    //     assert.equal(await handler.getSizeOnDisk('file'), TEST_DATA_LEN)
-    //   })
-    // })
+      testWithFileDescriptor('file', 'r', async () => {
+        assert.equal(await handler.getSizeOnDisk('file'), TEST_DATA_LEN)
+      })
+    })
 
     describe('#list()', () => {
-      // it(`should list the content of folder`, async () => {
-      //   await handler.outputFile('file', TEST_DATA)
-      //   assert.deepEqual(await handler.list('.'), ['file'])
-      // })
+      it(`should list the content of folder`, async () => {
+        await handler.outputFile('file', TEST_DATA)
+        assert.deepEqual(await handler.list('.'), ['file'])
+      })
 
-      // it('can prepend the directory to entries', async () => {
-      //   await handler.outputFile('dir/file', '')
-      //   assert.deepEqual(await handler.list('dir', { prependDir: true }), ['/dir/file'])
-      // })
+      it('can prepend the directory to entries', async () => {
+        await handler.outputFile('dir/file', '')
+        assert.deepEqual(await handler.list('dir', { prependDir: true }), ['/dir/file'])
+      })
 
       it('throws ENOENT if no such directory', async () => {
         console.log("TEEEEST", await handler.list('dir'))
         assert.equal((await rejectionOf(handler.list('dir'))).code, 'ENOENT')
       })
 
-      // it('can returns empty for missing directory', async () => {
-      //   assert.deepEqual(await handler.list('dir', { ignoreMissing: true }), [])
-      // })
+      it('can returns empty for missing directory', async () => {
+        assert.deepEqual(await handler.list('dir', { ignoreMissing: true }), [])
+      })
     })
 
-  //   describe('#mkdir()', () => {
-  //     it('creates a directory', { skip: skipFsNotInAzure() }, async () => {
-  //       await handler.mkdir('dir')
-  //       assert.deepEqual(await handler.list('.'), ['dir'])
-  //     })
+    describe('#mkdir()', () => {
+      it('creates a directory', { skip: skipFsNotInAzure() }, async () => {
+        await handler.mkdir('dir')
+        assert.deepEqual(await handler.list('.'), ['dir'])
+      })
 
-  //     it('does not throw on existing directory', async () => {
-  //       await handler.mkdir('dir')
-  //       await handler.mkdir('dir')
-  //     })
+      it('does not throw on existing directory', async () => {
+        await handler.mkdir('dir')
+        await handler.mkdir('dir')
+      })
 
-  //     it('throws ENOTDIR on existing file', async () => {
-  //       await handler.outputFile('file', '')
-  //       const error = await rejectionOf(handler.mkdir('file'))
-  //       assert.equal(error.code, 'ENOTDIR')
-  //     })
-  //   })
+      it('throws ENOTDIR on existing file', async () => {
+        await handler.outputFile('file', '')
+        const error = await rejectionOf(handler.mkdir('file'))
+        assert.equal(error.code, 'ENOTDIR')
+      })
+    })
 
-  //   describe('#mktree()', () => {
-  //     it('creates a tree of directories', { skip: skipFsNotInAzure() }, async () => {
-  //       await handler.mktree('dir/dir')
-  //       assert.deepEqual(await handler.list('.'), ['dir'])
-  //       assert.deepEqual(await handler.list('dir'), ['dir'])
-  //     })
+    describe('#mktree()', () => {
+      it('creates a tree of directories', { skip: skipFsNotInAzure() }, async () => {
+        await handler.mktree('dir/dir')
+        assert.deepEqual(await handler.list('.'), ['dir'])
+        assert.deepEqual(await handler.list('dir'), ['dir'])
+      })
 
-  //     it('does not throw on existing directory', { skip: skipFsNotInAzure() }, async () => {
-  //       await handler.mktree('dir/dir')
-  //       await handler.mktree('dir/dir')
-  //     })
+      it('does not throw on existing directory', { skip: skipFsNotInAzure() }, async () => {
+        await handler.mktree('dir/dir')
+        await handler.mktree('dir/dir')
+      })
 
-  //     it('throws ENOTDIR on existing file', { skip: skipFsNotInAzure() }, async () => {
-  //       await handler.outputFile('dir/file', '')
-  //       const error = await rejectionOf(handler.mktree('dir/file'))
-  //       assert.equal(error.code, 'ENOTDIR')
-  //     })
+      it('throws ENOTDIR on existing file', { skip: skipFsNotInAzure() }, async () => {
+        await handler.outputFile('dir/file', '')
+        const error = await rejectionOf(handler.mktree('dir/file'))
+        assert.equal(error.code, 'ENOTDIR')
+      })
 
-  //     it('throws ENOTDIR on existing file in path', { skip: skipFsNotInAzure() }, async () => {
-  //       await handler.outputFile('file', '')
-  //       const error = await rejectionOf(handler.mktree('file/dir'))
-  //       assert.equal(error.code, 'ENOTDIR')
-  //     })
-  //   })
+      it('throws ENOTDIR on existing file in path', { skip: skipFsNotInAzure() }, async () => {
+        await handler.outputFile('file', '')
+        const error = await rejectionOf(handler.mktree('file/dir'))
+        assert.equal(error.code, 'ENOTDIR')
+      })
+    })
 
-  //   describe('#outputFile()', () => {
-  //     it('writes data to a file', async () => {
-  //       await handler.outputFile('file', TEST_DATA)
-  //       assert.deepEqual(await handler.readFile('file'), TEST_DATA)
-  //     })
+    describe('#outputFile()', () => {
+      it('writes data to a file', async () => {
+        await handler.outputFile('file', TEST_DATA)
+        assert.deepEqual(await handler.readFile('file'), TEST_DATA)
+      })
 
-  //     it('throws on existing files', { skip: skipFsNotInAzure() }, async () => {
-  //       await handler.outputFile('file', '')
-  //       const error = await rejectionOf(handler.outputFile('file', ''))
-  //       assert.equal(error.code, 'EEXIST')
-  //     })
+      it('throws on existing files', { skip: skipFsNotInAzure() }, async () => {
+        await handler.outputFile('file', '')
+        const error = await rejectionOf(handler.outputFile('file', ''))
+        assert.equal(error.code, 'EEXIST')
+      })
 
-  //     it("shouldn't timeout in case of the respect of the parallel execution restriction", async () => {
-  //       const handler = getHandler({ url }, { maxParallelOperations: 1 })
-  //       await handler.sync()
-  //       await handler.outputFile(`xo-fs-tests-${Date.now()}/test`, '')
-  //     }, 40)
-  //   })
+      it("shouldn't timeout in case of the respect of the parallel execution restriction", async () => {
+        const handler = getHandler({ url }, { maxParallelOperations: 1 })
+        await handler.sync()
+        await handler.outputFile(`xo-fs-tests-${Date.now()}/test`, '')
+      }, 40)
+    })
 
-  //   describe('#read()', () => {
-  //     beforeEach(() => handler.outputFile('file', TEST_DATA))
+    describe('#read()', () => {
+      beforeEach(() => handler.outputFile('file', TEST_DATA))
 
-  //     const start = random(TEST_DATA_LEN - 1)
-  //     const size = random(TEST_DATA_LEN - start)
+      const start = random(TEST_DATA_LEN - 1)
+      const size = random(TEST_DATA_LEN - start)
 
-  //     testWithFileDescriptor('file', 'r', async ({ file }) => {
-  //       const buffer = Buffer.alloc(size)
-  //       const result = await handler.read(file, buffer, start)
-  //       assert.deepEqual(result.buffer, buffer)
-  //       assert.deepEqual(result, {
-  //         buffer,
-  //         bytesRead: Math.min(size, TEST_DATA_LEN - start),
-  //       })
-  //     })
-  //   })
+      testWithFileDescriptor('file', 'r', async ({ file }) => {
+        const buffer = Buffer.alloc(size)
+        const result = await handler.read(file, buffer, start)
+        assert.deepEqual(result.buffer, buffer)
+        assert.deepEqual(result, {
+          buffer,
+          bytesRead: Math.min(size, TEST_DATA_LEN - start),
+        })
+      })
+    })
 
-  //   describe('#readFile', () => {
-  //     it('returns a buffer containing the contents of the file', async () => {
-  //       await handler.outputFile('file', TEST_DATA)
-  //       assert.deepEqual(await handler.readFile('file'), TEST_DATA)
-  //     })
+    describe('#readFile', () => {
+      it('returns a buffer containing the contents of the file', async () => {
+        await handler.outputFile('file', TEST_DATA)
+        assert.deepEqual(await handler.readFile('file'), TEST_DATA)
+      })
 
-  //     it('throws on missing file', async () => {
-  //       await handler.unlink('file')
-  //       const error = await rejectionOf(handler.readFile('file'))
-  //       assert.equal(error.code, 'ENOENT')
-  //     })
-  //   })
+      it('throws on missing file', async () => {
+        await handler.unlink('file')
+        const error = await rejectionOf(handler.readFile('file'))
+        assert.equal(error.code, 'ENOENT')
+      })
+    })
 
-  //   describe('#rename()', () => {
-  //     it(`should rename the file`, async () => {
-  //       await handler.outputFile('file', TEST_DATA)
-  //       await handler.rename('file', `file2`)
+    describe('#rename()', () => {
+      it(`should rename the file`, async () => {
+        await handler.outputFile('file', TEST_DATA)
+        await handler.rename('file', `file2`)
 
-  //       assert.deepEqual(await handler.list('.'), ['file2'])
-  //       assert.deepEqual(await handler.readFile(`file2`), TEST_DATA)
-  //     })
-  //     it(`should rename the file and create dest directory`, async () => {
-  //       await handler.outputFile('file', TEST_DATA)
-  //       await handler.rename('file', `sub/file2`)
+        assert.deepEqual(await handler.list('.'), ['file2'])
+        assert.deepEqual(await handler.readFile(`file2`), TEST_DATA)
+      })
+      it(`should rename the file and create dest directory`, async () => {
+        await handler.outputFile('file', TEST_DATA)
+        await handler.rename('file', `sub/file2`)
 
-  //       assert.deepEqual(await handler.list('sub'), ['file2'])
-  //       assert.deepEqual(await handler.readFile(`sub/file2`), TEST_DATA)
-  //     })
-  //     it(`should fail with enoent if source file is missing`, async () => {
-  //       const error = await rejectionOf(handler.rename('file', `sub/file2`))
-  //       assert.equal(error.code, 'ENOENT')
-  //     })
-  //   })
+        assert.deepEqual(await handler.list('sub'), ['file2'])
+        assert.deepEqual(await handler.readFile(`sub/file2`), TEST_DATA)
+      })
+      it(`should fail with enoent if source file is missing`, async () => {
+        const error = await rejectionOf(handler.rename('file', `sub/file2`))
+        assert.equal(error.code, 'ENOENT')
+      })
+    })
 
-  //   describe('#rmdir()', () => {
-  //     it('should remove an empty directory', { skip: skipFsNotInAzure() }, async () => {
-  //       await handler.mkdir('dir')
-  //       await handler.rmdir('dir')
-  //       assert.deepEqual(await handler.list('.'), [])
-  //     })
+    describe('#rmdir()', () => {
+      it('should remove an empty directory', { skip: skipFsNotInAzure() }, async () => {
+        await handler.mkdir('dir')
+        await handler.rmdir('dir')
+        assert.deepEqual(await handler.list('.'), [])
+      })
 
-  //     it(`should throw on non-empty directory`, { skip: skipFsNotInAzure() }, async () => {
-  //       await handler.outputFile('dir/file', '')
+      it(`should throw on non-empty directory`, { skip: skipFsNotInAzure() }, async () => {
+        await handler.outputFile('dir/file', '')
 
-  //       const error = await rejectionOf(handler.rmdir('.'))
-  //       assert.equal(error.code, 'ENOTEMPTY')
-  //     })
+        const error = await rejectionOf(handler.rmdir('.'))
+        assert.equal(error.code, 'ENOTEMPTY')
+      })
 
-  //     it('does not throw on missing directory', { skip: skipFsNotInAzure() }, async () => {
-  //       await handler.rmdir('dir')
-  //     })
-  //   })
+      it('does not throw on missing directory', { skip: skipFsNotInAzure() }, async () => {
+        await handler.rmdir('dir')
+      })
+    })
 
-  //   describe('#rmtree', () => {
-  //     it(`should remove a directory resursively`, async () => {
-  //       await handler.outputFile('dir/file', '')
-  //       await handler.rmtree('dir')
-  //       assert.deepEqual(await handler.list('.', { ignoreMissing: true }), [])
-  //     })
-  //   })
+    describe('#rmtree', () => {
+      it(`should remove a directory resursively`, async () => {
+        await handler.outputFile('dir/file', '')
+        await handler.rmtree('dir')
+        assert.deepEqual(await handler.list('.', { ignoreMissing: true }), [])
+      })
+    })
 
-  //   describe('#test()', () => {
-  //     it('tests the remote appears to be working', { skip: skipFsNotInAzure() }, async () => {
-  //       const answer = await handler.test()
+    describe('#test()', () => {
+      it('tests the remote appears to be working', { skip: skipFsNotInAzure() }, async () => {
+        const answer = await handler.test()
 
-  //       assert.equal(answer.success, true)
-  //       assert.equal(typeof answer.writeRate, 'number')
-  //       assert.equal(typeof answer.readRate, 'number')
-  //     })
-  //   })
+        assert.equal(answer.success, true)
+        assert.equal(typeof answer.writeRate, 'number')
+        assert.equal(typeof answer.readRate, 'number')
+      })
+    })
 
-  //   describe('#unlink()', () => {
-  //     it(`should remove the file`, async () => {
-  //       await handler.outputFile('file', TEST_DATA)
-  //       await handler.unlink('file')
+    describe('#unlink()', () => {
+      it(`should remove the file`, async () => {
+        await handler.outputFile('file', TEST_DATA)
+        await handler.unlink('file')
 
-  //       assert.deepEqual(await handler.list('.', { ignoreMissing: true }), [])
-  //     })
+        assert.deepEqual(await handler.list('.', { ignoreMissing: true }), [])
+      })
 
-  //     it('does not throw on missing file', async () => {
-  //       await handler.unlink('file')
-  //     })
-  //   })
+      it('does not throw on missing file', async () => {
+        await handler.unlink('file')
+      })
+    })
 
-  //   describe('#write()', () => {
-  //     beforeEach(() => handler.outputFile('file', TEST_DATA))
-  //     afterEach(() => handler.unlink('file'))
+    describe('#write()', () => {
+      beforeEach(() => handler.outputFile('file', TEST_DATA))
+      afterEach(() => handler.unlink('file'))
 
-  //     const PATCH_DATA_LEN = Math.ceil(TEST_DATA_LEN / 2)
-  //     const PATCH_DATA = unsecureRandomBytes(PATCH_DATA_LEN)
+      const PATCH_DATA_LEN = Math.ceil(TEST_DATA_LEN / 2)
+      const PATCH_DATA = unsecureRandomBytes(PATCH_DATA_LEN)
 
-  //     forOwn(
-  //       {
-  //         'dont increase file size': (() => {
-  //           const offset = random(0, TEST_DATA_LEN - PATCH_DATA_LEN)
+      forOwn(
+        {
+          'dont increase file size': (() => {
+            const offset = random(0, TEST_DATA_LEN - PATCH_DATA_LEN)
 
-  //           const expected = Buffer.from(TEST_DATA)
-  //           PATCH_DATA.copy(expected, offset)
+            const expected = Buffer.from(TEST_DATA)
+            PATCH_DATA.copy(expected, offset)
 
-  //           return { offset, expected }
-  //         })(),
-  //         'increase file size': (() => {
-  //           const offset = random(TEST_DATA_LEN - PATCH_DATA_LEN + 1, TEST_DATA_LEN)
+            return { offset, expected }
+          })(),
+          'increase file size': (() => {
+            const offset = random(TEST_DATA_LEN - PATCH_DATA_LEN + 1, TEST_DATA_LEN)
 
-  //           const expected = Buffer.alloc(offset + PATCH_DATA_LEN)
-  //           TEST_DATA.copy(expected)
-  //           PATCH_DATA.copy(expected, offset)
+            const expected = Buffer.alloc(offset + PATCH_DATA_LEN)
+            TEST_DATA.copy(expected)
+            PATCH_DATA.copy(expected, offset)
 
-  //           return { offset, expected }
-  //         })(),
-  //       },
-  //       ({ offset, expected }, title) => {
-  //         describe(title, () => {
-  //           testWithFileDescriptor('file', 'r+', async ({ file }) => {
-  //             await handler.write(file, PATCH_DATA, offset)
-  //             assert.deepEqual(await handler.readFile('file'), expected)
-  //           })
-  //         })
-  //       }
-  //     )
-  //   })
+            return { offset, expected }
+          })(),
+        },
+        ({ offset, expected }, title) => {
+          describe(title, () => {
+            testWithFileDescriptor('file', 'r+', async ({ file }) => {
+              await handler.write(file, PATCH_DATA, offset)
+              assert.deepEqual(await handler.readFile('file'), expected)
+            })
+          })
+        }
+      )
+    })
 
-  //   describe('#truncate()', () => {
-  //     afterEach(() => handler.unlink('file'))
-  //     forOwn(
-  //       {
-  //         'shrinks file': (() => {
-  //           const length = random(0, TEST_DATA_LEN)
-  //           const expected = TEST_DATA.slice(0, length)
-  //           return { length, expected }
-  //         })(),
-  //         'grows file': (() => {
-  //           const length = random(TEST_DATA_LEN, TEST_DATA_LEN * 2)
-  //           const expected = Buffer.alloc(length)
-  //           TEST_DATA.copy(expected)
-  //           return { length, expected }
-  //         })(),
-  //       },
-  //       ({ length, expected }, title) => {
-  //         it(title, { skip: skipFsNotInAzure() }, async () => {
-  //           await handler.outputFile('file', TEST_DATA)
-  //           await handler.truncate('file', length)
-  //           assert.deepEqual(await handler.readFile('file'), expected)
-  //         })
-  //       }
-  //     )
-  //   })
+    describe('#truncate()', () => {
+      afterEach(() => handler.unlink('file'))
+      forOwn(
+        {
+          'shrinks file': (() => {
+            const length = random(0, TEST_DATA_LEN)
+            const expected = TEST_DATA.slice(0, length)
+            return { length, expected }
+          })(),
+          'grows file': (() => {
+            const length = random(TEST_DATA_LEN, TEST_DATA_LEN * 2)
+            const expected = Buffer.alloc(length)
+            TEST_DATA.copy(expected)
+            return { length, expected }
+          })(),
+        },
+        ({ length, expected }, title) => {
+          it(title, { skip: skipFsNotInAzure() }, async () => {
+            await handler.outputFile('file', TEST_DATA)
+            await handler.truncate('file', length)
+            assert.deepEqual(await handler.readFile('file'), expected)
+          })
+        }
+      )
+    })
   })
 })

--- a/@xen-orchestra/fs/src/fs.test.js
+++ b/@xen-orchestra/fs/src/fs.test.js
@@ -4,8 +4,11 @@ import { strict as assert } from 'assert'
 import 'dotenv/config'
 import { forOwn, random } from 'lodash'
 import { tmpdir } from 'os'
+import { pFromCallback } from 'promise-toolbox'
+import tmp from 'tmp'
 
 import { getHandler } from '.'
+import { rimraf } from 'rimraf'
 
 // https://gist.github.com/julien-f/3228c3f34fdac01ade09
 const unsecureRandomBytes = n => {
@@ -37,12 +40,16 @@ const skipFsNotInAzure = () => {
   return !!process.env.xo_fs_azure
 }
 // TODO : add tests on encrypted remote
+const handlers = [`file://${tmp.dirSync().name}`]
 const handlers = [`file://${tmpdir()}`]
 if (process.env.xo_fs_nfs) handlers.push(process.env.xo_fs_nfs)
 if (process.env.xo_fs_smb) handlers.push(process.env.xo_fs_smb)
 if (process.env.xo_fs_azure) handlers.push(process.env.xo_fs_azure)
 
 handlers.forEach(url => {
+  after(url, async () => {
+    await rimraf(url)
+  })
   describe(url, () => {
     let handler
 
@@ -75,286 +82,287 @@ handlers.forEach(url => {
       await handler.rmtree('.')
     })
 
-    describe('#type', () => {
-      it('returns the type of the remote', () => {
-        assert.equal(typeof handler.type, 'string')
-      })
-    })
+    // describe('#type', () => {
+    //   it('returns the type of the remote', () => {
+    //     assert.equal(typeof handler.type, 'string')
+    //   })
+    // })
 
-    describe('#getInfo()', () => {
-      let info
-      before(async () => {
-        info = await handler.getInfo()
-      })
+    // describe('#getInfo()', () => {
+    //   let info
+    //   before(async () => {
+    //     info = await handler.getInfo()
+    //   })
 
-      it('should return an object with info', { skip: skipFsNotInAzure() }, async () => {
-        assert.equal(typeof info, 'object')
-      })
+    //   it('should return an object with info', { skip: skipFsNotInAzure() }, async () => {
+    //     assert.equal(typeof info, 'object')
+    //   })
 
-      it('should return correct type of attribute', { skip: skipFsNotInAzure() }, async () => {
-        if (info.size !== undefined) {
-          assert.equal(typeof info.size, 'number')
-        }
-        if (info.used !== undefined) {
-          assert.equal(typeof info.used, 'number')
-        }
-      })
-    })
+    //   it('should return correct type of attribute', { skip: skipFsNotInAzure() }, async () => {
+    //     if (info.size !== undefined) {
+    //       assert.equal(typeof info.size, 'number')
+    //     }
+    //     if (info.used !== undefined) {
+    //       assert.equal(typeof info.used, 'number')
+    //     }
+    //   })
+    // })
 
-    // TODO : add test "should throw if remote is encrypted" on #getSize()
-    describe('#getSizeOnDisk()', () => {
-      beforeEach(() => handler.outputFile('file', TEST_DATA))
+    // // TODO : add test "should throw if remote is encrypted" on #getSize()
+    // describe('#getSizeOnDisk()', () => {
+    //   beforeEach(() => handler.outputFile('file', TEST_DATA))
 
-      testWithFileDescriptor('file', 'r', async () => {
-        assert.equal(await handler.getSizeOnDisk('file'), TEST_DATA_LEN)
-      })
-    })
+    //   testWithFileDescriptor('file', 'r', async () => {
+    //     assert.equal(await handler.getSizeOnDisk('file'), TEST_DATA_LEN)
+    //   })
+    // })
 
     describe('#list()', () => {
-      it(`should list the content of folder`, async () => {
-        await handler.outputFile('file', TEST_DATA)
-        assert.deepEqual(await handler.list('.'), ['file'])
-      })
+      // it(`should list the content of folder`, async () => {
+      //   await handler.outputFile('file', TEST_DATA)
+      //   assert.deepEqual(await handler.list('.'), ['file'])
+      // })
 
-      it('can prepend the directory to entries', async () => {
-        await handler.outputFile('dir/file', '')
-        assert.deepEqual(await handler.list('dir', { prependDir: true }), ['/dir/file'])
-      })
+      // it('can prepend the directory to entries', async () => {
+      //   await handler.outputFile('dir/file', '')
+      //   assert.deepEqual(await handler.list('dir', { prependDir: true }), ['/dir/file'])
+      // })
 
       it('throws ENOENT if no such directory', async () => {
+        console.log("TEEEEST", await handler.list('dir'))
         assert.equal((await rejectionOf(handler.list('dir'))).code, 'ENOENT')
       })
 
-      it('can returns empty for missing directory', async () => {
-        assert.deepEqual(await handler.list('dir', { ignoreMissing: true }), [])
-      })
+      // it('can returns empty for missing directory', async () => {
+      //   assert.deepEqual(await handler.list('dir', { ignoreMissing: true }), [])
+      // })
     })
 
-    describe('#mkdir()', () => {
-      it('creates a directory', { skip: skipFsNotInAzure() }, async () => {
-        await handler.mkdir('dir')
-        assert.deepEqual(await handler.list('.'), ['dir'])
-      })
+  //   describe('#mkdir()', () => {
+  //     it('creates a directory', { skip: skipFsNotInAzure() }, async () => {
+  //       await handler.mkdir('dir')
+  //       assert.deepEqual(await handler.list('.'), ['dir'])
+  //     })
 
-      it('does not throw on existing directory', async () => {
-        await handler.mkdir('dir')
-        await handler.mkdir('dir')
-      })
+  //     it('does not throw on existing directory', async () => {
+  //       await handler.mkdir('dir')
+  //       await handler.mkdir('dir')
+  //     })
 
-      it('throws ENOTDIR on existing file', async () => {
-        await handler.outputFile('file', '')
-        const error = await rejectionOf(handler.mkdir('file'))
-        assert.equal(error.code, 'ENOTDIR')
-      })
-    })
+  //     it('throws ENOTDIR on existing file', async () => {
+  //       await handler.outputFile('file', '')
+  //       const error = await rejectionOf(handler.mkdir('file'))
+  //       assert.equal(error.code, 'ENOTDIR')
+  //     })
+  //   })
 
-    describe('#mktree()', () => {
-      it('creates a tree of directories', { skip: skipFsNotInAzure() }, async () => {
-        await handler.mktree('dir/dir')
-        assert.deepEqual(await handler.list('.'), ['dir'])
-        assert.deepEqual(await handler.list('dir'), ['dir'])
-      })
+  //   describe('#mktree()', () => {
+  //     it('creates a tree of directories', { skip: skipFsNotInAzure() }, async () => {
+  //       await handler.mktree('dir/dir')
+  //       assert.deepEqual(await handler.list('.'), ['dir'])
+  //       assert.deepEqual(await handler.list('dir'), ['dir'])
+  //     })
 
-      it('does not throw on existing directory', { skip: skipFsNotInAzure() }, async () => {
-        await handler.mktree('dir/dir')
-        await handler.mktree('dir/dir')
-      })
+  //     it('does not throw on existing directory', { skip: skipFsNotInAzure() }, async () => {
+  //       await handler.mktree('dir/dir')
+  //       await handler.mktree('dir/dir')
+  //     })
 
-      it('throws ENOTDIR on existing file', { skip: skipFsNotInAzure() }, async () => {
-        await handler.outputFile('dir/file', '')
-        const error = await rejectionOf(handler.mktree('dir/file'))
-        assert.equal(error.code, 'ENOTDIR')
-      })
+  //     it('throws ENOTDIR on existing file', { skip: skipFsNotInAzure() }, async () => {
+  //       await handler.outputFile('dir/file', '')
+  //       const error = await rejectionOf(handler.mktree('dir/file'))
+  //       assert.equal(error.code, 'ENOTDIR')
+  //     })
 
-      it('throws ENOTDIR on existing file in path', { skip: skipFsNotInAzure() }, async () => {
-        await handler.outputFile('file', '')
-        const error = await rejectionOf(handler.mktree('file/dir'))
-        assert.equal(error.code, 'ENOTDIR')
-      })
-    })
+  //     it('throws ENOTDIR on existing file in path', { skip: skipFsNotInAzure() }, async () => {
+  //       await handler.outputFile('file', '')
+  //       const error = await rejectionOf(handler.mktree('file/dir'))
+  //       assert.equal(error.code, 'ENOTDIR')
+  //     })
+  //   })
 
-    describe('#outputFile()', () => {
-      it('writes data to a file', async () => {
-        await handler.outputFile('file', TEST_DATA)
-        assert.deepEqual(await handler.readFile('file'), TEST_DATA)
-      })
+  //   describe('#outputFile()', () => {
+  //     it('writes data to a file', async () => {
+  //       await handler.outputFile('file', TEST_DATA)
+  //       assert.deepEqual(await handler.readFile('file'), TEST_DATA)
+  //     })
 
-      it('throws on existing files', { skip: skipFsNotInAzure() }, async () => {
-        await handler.outputFile('file', '')
-        const error = await rejectionOf(handler.outputFile('file', ''))
-        assert.equal(error.code, 'EEXIST')
-      })
+  //     it('throws on existing files', { skip: skipFsNotInAzure() }, async () => {
+  //       await handler.outputFile('file', '')
+  //       const error = await rejectionOf(handler.outputFile('file', ''))
+  //       assert.equal(error.code, 'EEXIST')
+  //     })
 
-      it("shouldn't timeout in case of the respect of the parallel execution restriction", async () => {
-        const handler = getHandler({ url }, { maxParallelOperations: 1 })
-        await handler.sync()
-        await handler.outputFile(`xo-fs-tests-${Date.now()}/test`, '')
-      }, 40)
-    })
+  //     it("shouldn't timeout in case of the respect of the parallel execution restriction", async () => {
+  //       const handler = getHandler({ url }, { maxParallelOperations: 1 })
+  //       await handler.sync()
+  //       await handler.outputFile(`xo-fs-tests-${Date.now()}/test`, '')
+  //     }, 40)
+  //   })
 
-    describe('#read()', () => {
-      beforeEach(() => handler.outputFile('file', TEST_DATA))
+  //   describe('#read()', () => {
+  //     beforeEach(() => handler.outputFile('file', TEST_DATA))
 
-      const start = random(TEST_DATA_LEN - 1)
-      const size = random(TEST_DATA_LEN - start)
+  //     const start = random(TEST_DATA_LEN - 1)
+  //     const size = random(TEST_DATA_LEN - start)
 
-      testWithFileDescriptor('file', 'r', async ({ file }) => {
-        const buffer = Buffer.alloc(size)
-        const result = await handler.read(file, buffer, start)
-        assert.deepEqual(result.buffer, buffer)
-        assert.deepEqual(result, {
-          buffer,
-          bytesRead: Math.min(size, TEST_DATA_LEN - start),
-        })
-      })
-    })
+  //     testWithFileDescriptor('file', 'r', async ({ file }) => {
+  //       const buffer = Buffer.alloc(size)
+  //       const result = await handler.read(file, buffer, start)
+  //       assert.deepEqual(result.buffer, buffer)
+  //       assert.deepEqual(result, {
+  //         buffer,
+  //         bytesRead: Math.min(size, TEST_DATA_LEN - start),
+  //       })
+  //     })
+  //   })
 
-    describe('#readFile', () => {
-      it('returns a buffer containing the contents of the file', async () => {
-        await handler.outputFile('file', TEST_DATA)
-        assert.deepEqual(await handler.readFile('file'), TEST_DATA)
-      })
+  //   describe('#readFile', () => {
+  //     it('returns a buffer containing the contents of the file', async () => {
+  //       await handler.outputFile('file', TEST_DATA)
+  //       assert.deepEqual(await handler.readFile('file'), TEST_DATA)
+  //     })
 
-      it('throws on missing file', async () => {
-        await handler.unlink('file')
-        const error = await rejectionOf(handler.readFile('file'))
-        assert.equal(error.code, 'ENOENT')
-      })
-    })
+  //     it('throws on missing file', async () => {
+  //       await handler.unlink('file')
+  //       const error = await rejectionOf(handler.readFile('file'))
+  //       assert.equal(error.code, 'ENOENT')
+  //     })
+  //   })
 
-    describe('#rename()', () => {
-      it(`should rename the file`, async () => {
-        await handler.outputFile('file', TEST_DATA)
-        await handler.rename('file', `file2`)
+  //   describe('#rename()', () => {
+  //     it(`should rename the file`, async () => {
+  //       await handler.outputFile('file', TEST_DATA)
+  //       await handler.rename('file', `file2`)
 
-        assert.deepEqual(await handler.list('.'), ['file2'])
-        assert.deepEqual(await handler.readFile(`file2`), TEST_DATA)
-      })
-      it(`should rename the file and create dest directory`, async () => {
-        await handler.outputFile('file', TEST_DATA)
-        await handler.rename('file', `sub/file2`)
+  //       assert.deepEqual(await handler.list('.'), ['file2'])
+  //       assert.deepEqual(await handler.readFile(`file2`), TEST_DATA)
+  //     })
+  //     it(`should rename the file and create dest directory`, async () => {
+  //       await handler.outputFile('file', TEST_DATA)
+  //       await handler.rename('file', `sub/file2`)
 
-        assert.deepEqual(await handler.list('sub'), ['file2'])
-        assert.deepEqual(await handler.readFile(`sub/file2`), TEST_DATA)
-      })
-      it(`should fail with enoent if source file is missing`, async () => {
-        const error = await rejectionOf(handler.rename('file', `sub/file2`))
-        assert.equal(error.code, 'ENOENT')
-      })
-    })
+  //       assert.deepEqual(await handler.list('sub'), ['file2'])
+  //       assert.deepEqual(await handler.readFile(`sub/file2`), TEST_DATA)
+  //     })
+  //     it(`should fail with enoent if source file is missing`, async () => {
+  //       const error = await rejectionOf(handler.rename('file', `sub/file2`))
+  //       assert.equal(error.code, 'ENOENT')
+  //     })
+  //   })
 
-    describe('#rmdir()', () => {
-      it('should remove an empty directory', { skip: skipFsNotInAzure() }, async () => {
-        await handler.mkdir('dir')
-        await handler.rmdir('dir')
-        assert.deepEqual(await handler.list('.'), [])
-      })
+  //   describe('#rmdir()', () => {
+  //     it('should remove an empty directory', { skip: skipFsNotInAzure() }, async () => {
+  //       await handler.mkdir('dir')
+  //       await handler.rmdir('dir')
+  //       assert.deepEqual(await handler.list('.'), [])
+  //     })
 
-      it(`should throw on non-empty directory`, { skip: skipFsNotInAzure() }, async () => {
-        await handler.outputFile('dir/file', '')
+  //     it(`should throw on non-empty directory`, { skip: skipFsNotInAzure() }, async () => {
+  //       await handler.outputFile('dir/file', '')
 
-        const error = await rejectionOf(handler.rmdir('.'))
-        assert.equal(error.code, 'ENOTEMPTY')
-      })
+  //       const error = await rejectionOf(handler.rmdir('.'))
+  //       assert.equal(error.code, 'ENOTEMPTY')
+  //     })
 
-      it('does not throw on missing directory', { skip: skipFsNotInAzure() }, async () => {
-        await handler.rmdir('dir')
-      })
-    })
+  //     it('does not throw on missing directory', { skip: skipFsNotInAzure() }, async () => {
+  //       await handler.rmdir('dir')
+  //     })
+  //   })
 
-    describe('#rmtree', () => {
-      it(`should remove a directory resursively`, async () => {
-        await handler.outputFile('dir/file', '')
-        await handler.rmtree('dir')
-        assert.deepEqual(await handler.list('.', { ignoreMissing: true }), [])
-      })
-    })
+  //   describe('#rmtree', () => {
+  //     it(`should remove a directory resursively`, async () => {
+  //       await handler.outputFile('dir/file', '')
+  //       await handler.rmtree('dir')
+  //       assert.deepEqual(await handler.list('.', { ignoreMissing: true }), [])
+  //     })
+  //   })
 
-    describe('#test()', () => {
-      it('tests the remote appears to be working', { skip: skipFsNotInAzure() }, async () => {
-        const answer = await handler.test()
+  //   describe('#test()', () => {
+  //     it('tests the remote appears to be working', { skip: skipFsNotInAzure() }, async () => {
+  //       const answer = await handler.test()
 
-        assert.equal(answer.success, true)
-        assert.equal(typeof answer.writeRate, 'number')
-        assert.equal(typeof answer.readRate, 'number')
-      })
-    })
+  //       assert.equal(answer.success, true)
+  //       assert.equal(typeof answer.writeRate, 'number')
+  //       assert.equal(typeof answer.readRate, 'number')
+  //     })
+  //   })
 
-    describe('#unlink()', () => {
-      it(`should remove the file`, async () => {
-        await handler.outputFile('file', TEST_DATA)
-        await handler.unlink('file')
+  //   describe('#unlink()', () => {
+  //     it(`should remove the file`, async () => {
+  //       await handler.outputFile('file', TEST_DATA)
+  //       await handler.unlink('file')
 
-        assert.deepEqual(await handler.list('.', { ignoreMissing: true }), [])
-      })
+  //       assert.deepEqual(await handler.list('.', { ignoreMissing: true }), [])
+  //     })
 
-      it('does not throw on missing file', async () => {
-        await handler.unlink('file')
-      })
-    })
+  //     it('does not throw on missing file', async () => {
+  //       await handler.unlink('file')
+  //     })
+  //   })
 
-    describe('#write()', () => {
-      beforeEach(() => handler.outputFile('file', TEST_DATA))
-      afterEach(() => handler.unlink('file'))
+  //   describe('#write()', () => {
+  //     beforeEach(() => handler.outputFile('file', TEST_DATA))
+  //     afterEach(() => handler.unlink('file'))
 
-      const PATCH_DATA_LEN = Math.ceil(TEST_DATA_LEN / 2)
-      const PATCH_DATA = unsecureRandomBytes(PATCH_DATA_LEN)
+  //     const PATCH_DATA_LEN = Math.ceil(TEST_DATA_LEN / 2)
+  //     const PATCH_DATA = unsecureRandomBytes(PATCH_DATA_LEN)
 
-      forOwn(
-        {
-          'dont increase file size': (() => {
-            const offset = random(0, TEST_DATA_LEN - PATCH_DATA_LEN)
+  //     forOwn(
+  //       {
+  //         'dont increase file size': (() => {
+  //           const offset = random(0, TEST_DATA_LEN - PATCH_DATA_LEN)
 
-            const expected = Buffer.from(TEST_DATA)
-            PATCH_DATA.copy(expected, offset)
+  //           const expected = Buffer.from(TEST_DATA)
+  //           PATCH_DATA.copy(expected, offset)
 
-            return { offset, expected }
-          })(),
-          'increase file size': (() => {
-            const offset = random(TEST_DATA_LEN - PATCH_DATA_LEN + 1, TEST_DATA_LEN)
+  //           return { offset, expected }
+  //         })(),
+  //         'increase file size': (() => {
+  //           const offset = random(TEST_DATA_LEN - PATCH_DATA_LEN + 1, TEST_DATA_LEN)
 
-            const expected = Buffer.alloc(offset + PATCH_DATA_LEN)
-            TEST_DATA.copy(expected)
-            PATCH_DATA.copy(expected, offset)
+  //           const expected = Buffer.alloc(offset + PATCH_DATA_LEN)
+  //           TEST_DATA.copy(expected)
+  //           PATCH_DATA.copy(expected, offset)
 
-            return { offset, expected }
-          })(),
-        },
-        ({ offset, expected }, title) => {
-          describe(title, () => {
-            testWithFileDescriptor('file', 'r+', async ({ file }) => {
-              await handler.write(file, PATCH_DATA, offset)
-              assert.deepEqual(await handler.readFile('file'), expected)
-            })
-          })
-        }
-      )
-    })
+  //           return { offset, expected }
+  //         })(),
+  //       },
+  //       ({ offset, expected }, title) => {
+  //         describe(title, () => {
+  //           testWithFileDescriptor('file', 'r+', async ({ file }) => {
+  //             await handler.write(file, PATCH_DATA, offset)
+  //             assert.deepEqual(await handler.readFile('file'), expected)
+  //           })
+  //         })
+  //       }
+  //     )
+  //   })
 
-    describe('#truncate()', () => {
-      afterEach(() => handler.unlink('file'))
-      forOwn(
-        {
-          'shrinks file': (() => {
-            const length = random(0, TEST_DATA_LEN)
-            const expected = TEST_DATA.slice(0, length)
-            return { length, expected }
-          })(),
-          'grows file': (() => {
-            const length = random(TEST_DATA_LEN, TEST_DATA_LEN * 2)
-            const expected = Buffer.alloc(length)
-            TEST_DATA.copy(expected)
-            return { length, expected }
-          })(),
-        },
-        ({ length, expected }, title) => {
-          it(title, { skip: skipFsNotInAzure() }, async () => {
-            await handler.outputFile('file', TEST_DATA)
-            await handler.truncate('file', length)
-            assert.deepEqual(await handler.readFile('file'), expected)
-          })
-        }
-      )
-    })
+  //   describe('#truncate()', () => {
+  //     afterEach(() => handler.unlink('file'))
+  //     forOwn(
+  //       {
+  //         'shrinks file': (() => {
+  //           const length = random(0, TEST_DATA_LEN)
+  //           const expected = TEST_DATA.slice(0, length)
+  //           return { length, expected }
+  //         })(),
+  //         'grows file': (() => {
+  //           const length = random(TEST_DATA_LEN, TEST_DATA_LEN * 2)
+  //           const expected = Buffer.alloc(length)
+  //           TEST_DATA.copy(expected)
+  //           return { length, expected }
+  //         })(),
+  //       },
+  //       ({ length, expected }, title) => {
+  //         it(title, { skip: skipFsNotInAzure() }, async () => {
+  //           await handler.outputFile('file', TEST_DATA)
+  //           await handler.truncate('file', length)
+  //           assert.deepEqual(await handler.readFile('file'), expected)
+  //         })
+  //       }
+  //     )
+  //   })
   })
 })

--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -311,6 +311,42 @@ export default class S3Handler extends RemoteHandlerAbstract {
     return [...uniq]
   }
 
+  async _tree(dir) {
+    const entries = new Set()
+    let NextContinuationToken
+    const Prefix = this.#makePrefix(dir)
+    
+    do {
+      const result = await this.#s3.send(
+        new ListObjectsV2Command({
+          Bucket: this.#bucket,
+          Prefix,
+          ContinuationToken: NextContinuationToken,
+        })
+      )
+      
+      NextContinuationToken = result.IsTruncated 
+        ? result.NextContinuationToken 
+        : undefined
+      
+      for (const entry of result.Contents ?? []) {
+        let relativePath = entry.Key.slice(this.#dir.length)
+        if (!relativePath.startsWith('/')) {
+          relativePath = '/' + relativePath
+        }
+        entries.add(relativePath)
+        const parts = split(relativePath)
+        let currentPath = ''
+        for (let i = 0; i < parts.length - 1; i++) {
+          currentPath = join(currentPath, parts[i])
+          entries.add(currentPath)
+        }
+      }
+    } while (NextContinuationToken !== undefined)
+    
+    return entries
+  }
+
   async _mkdir(path) {
     if (await this.#isFile(path)) {
       const error = new Error(`ENOTDIR: file already exists, mkdir '${path}'`)
@@ -437,5 +473,9 @@ export default class S3Handler extends RemoteHandlerAbstract {
 
   useVhdDirectory() {
     return true
+  }
+
+  useTreeCache() {
+    return true  // Enable by default for S3
   }
 }


### PR DESCRIPTION
### Description

Add cache for s3 (especially backblaze) to avoid listing all files every time

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
