### PR TITLE
feat(fs/s3): DeleteObjectsCommand

### DIFF
--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -71,6 +71,7 @@ export default class S3Handler extends RemoteHandlerAbstract {
           keepAlive: true,
         }),
       }),
+      logger: console,
       // from https://github.com/aws/aws-sdk-js-v3/issues/6810
       // some non AWS services like backblaze or cloudflare don't expect the new headers
       requestChecksumCalculation: 'WHEN_REQUIRED',
@@ -384,10 +385,14 @@ export default class S3Handler extends RemoteHandlerAbstract {
       )
 
       NextContinuationToken = result.IsTruncated ? result.NextContinuationToken : undefined
+      // const contents = (result.Contents ?? []).map(({ Key }) => ({ Key }))
+      // console.log("CONTENTS", contents)
       await this.#s3.send(
         new DeleteObjectsCommand({
           Bucket: this.#bucket,
-          Objects: result.Contents ?? [],
+          Delete: {
+            Objects: result.Contents ?? [],
+          },
         })
       )
     } while (NextContinuationToken !== undefined)

--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -71,7 +71,6 @@ export default class S3Handler extends RemoteHandlerAbstract {
           keepAlive: true,
         }),
       }),
-      logger: console,
       // from https://github.com/aws/aws-sdk-js-v3/issues/6810
       // some non AWS services like backblaze or cloudflare don't expect the new headers
       requestChecksumCalculation: 'WHEN_REQUIRED',

--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -385,8 +385,6 @@ export default class S3Handler extends RemoteHandlerAbstract {
       )
 
       NextContinuationToken = result.IsTruncated ? result.NextContinuationToken : undefined
-      // const contents = (result.Contents ?? []).map(({ Key }) => ({ Key }))
-      // console.log("CONTENTS", contents)
       await this.#s3.send(
         new DeleteObjectsCommand({
           Bucket: this.#bucket,

--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -4,6 +4,7 @@ import {
   CopyObjectCommand,
   CreateMultipartUploadCommand,
   DeleteObjectCommand,
+  DeleteObjectsCommand,
   GetObjectCommand,
   GetObjectLockConfigurationCommand,
   HeadObjectCommand,
@@ -24,7 +25,6 @@ import copyStreamToBuffer from './_copyStreamToBuffer.js'
 import guessAwsRegion from './_guessAwsRegion.js'
 import RemoteHandlerAbstract from './abstract'
 import { basename, join, split } from './path'
-import { asyncEach } from '@vates/async-each'
 
 // endpoints https://docs.aws.amazon.com/general/latest/gr/s3.html
 
@@ -384,21 +384,11 @@ export default class S3Handler extends RemoteHandlerAbstract {
       )
 
       NextContinuationToken = result.IsTruncated ? result.NextContinuationToken : undefined
-      await asyncEach(
-        result.Contents ?? [],
-        async ({ Key }) => {
-          // _unlink will add the prefix, but Key contains everything
-          // also we don't need to check if we delete a directory, since the list only return files
-          await this.#s3.send(
-            new DeleteObjectCommand({
-              Bucket: this.#bucket,
-              Key,
-            })
-          )
-        },
-        {
-          concurrency: 16,
-        }
+      await this.#s3.send(
+        new DeleteObjectsCommand({
+          Bucket: this.#bucket,
+          Objects: result.Contents ?? [],
+        })
       )
     } while (NextContinuationToken !== undefined)
   }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,8 @@
 - **XO 6:**
   - [Navigation] Navigation state is now persisted in localStorage and items are now collapsible while filtering. (PR [#9277](https://github.com/vatesfr/xen-orchestra/pull/9277))
 
+- [Backups/s3] Update filesystem handling to use DeleteObjectsCommand in order to improve performance (PR [#9281](https://github.com/vatesfr/xen-orchestra/pull/9281))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”


### PR DESCRIPTION
use DeleteObjectsCommand to use server side and avoid too many parallel requests

Tested with localstack

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
