### PR TITLE
fix(web-core/lite): UiInput v-model modifiers and reactivity

### DIFF
--- a/@xen-orchestra/lite/src/components/form/FormByteSize.vue
+++ b/@xen-orchestra/lite/src/components/form/FormByteSize.vue
@@ -1,6 +1,6 @@
 <template>
   <VtsInputGroup>
-    <UiInput v-model="sizeInput" accent="brand" type="number" :max-decimals="3" />
+    <UiInput v-model.number="sizeInput" accent="brand" type="number" :max-decimals="3" />
     <VtsSelect :id="prefixSelectId" accent="brand" />
   </VtsInputGroup>
 </template>

--- a/@xen-orchestra/lite/src/pages/vm/new.vue
+++ b/@xen-orchestra/lite/src/pages/vm/new.vue
@@ -94,11 +94,11 @@
             <div class="system-container">
               <div class="column">
                 <VtsInputWrapper :label="t('new-vm:name')">
-                  <UiInput v-model="vmState.name" accent="brand" />
+                  <UiInput v-model.trim="vmState.name" accent="brand" />
                 </VtsInputWrapper>
                 <VtsInputWrapper :label="t('tags')">
                   <!-- TODO Change input text into select when Thierry's component is available -->
-                  <UiInput v-model="vmState.tag" accent="brand" @keydown.enter.prevent="addTag" />
+                  <UiInput v-model.trim="vmState.tag" accent="brand" @keydown.enter.prevent="addTag" />
                 </VtsInputWrapper>
                 <div v-if="vmState.tags.length > 0" class="chips">
                   <UiChip v-for="(tag, index) in vmState.tags" :key="index" accent="info" @remove="removeTag(index)">
@@ -141,11 +141,11 @@
             <UiTitle>{{ t('resource-management') }}</UiTitle>
             <div class="memory-container">
               <VtsInputWrapper :label="t('vcpus')">
-                <UiInput v-model="vmState.vCPU" accent="brand" />
+                <UiInput v-model.number="vmState.vCPU" type="number" accent="brand" />
               </VtsInputWrapper>
               <!-- TODO remove (GB) when we can use new selector -->
               <VtsInputWrapper :label="`${t('ram')} (GB)`">
-                <UiInput v-model="ramFormatted" accent="brand" />
+                <UiInput v-model.number="ramFormatted" type="number" accent="brand" />
               </VtsInputWrapper>
               <VtsInputWrapper :label="t('topology')">
                 <div class="topology">

--- a/@xen-orchestra/web-core/lib/components/ui/input/UiInput.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/input/UiInput.vue
@@ -4,12 +4,13 @@
     <input
       :id="wrapperController?.id ?? id"
       ref="inputRef"
-      v-model.trim="modelValue"
+      :value="modelValue"
       :disabled
       :required
       :type
       class="typo-body-regular input text-ellipsis"
       v-bind="attrs"
+      @input="event => handleInput(event)"
     />
     <UiButtonIcon
       v-if="!disabled && modelValue && clearable"
@@ -42,7 +43,6 @@ export type InputType = 'text' | 'number' | 'password' | 'search'
 defineOptions({
   inheritAttrs: false,
 })
-
 const {
   accent: _accent,
   required,
@@ -65,6 +65,10 @@ const slots = defineSlots<{
   'right-icon'?(): any
 }>()
 
+function handleInput(event: Event) {
+  modelValue.value = (event.target as HTMLInputElement).value
+}
+
 const attrs = useAttrs()
 
 const inputRef = ref<HTMLInputElement>()
@@ -73,11 +77,11 @@ const wrapperController = inject(IK_INPUT_WRAPPER_CONTROLLER, undefined)
 
 const accent = useMapper<LabelAccent, InputAccent>(
   () => wrapperController?.labelAccent,
-  {
+  () => ({
     neutral: _accent,
     warning: 'warning',
     danger: 'danger',
-  },
+  }),
   'neutral'
 )
 

--- a/@xen-orchestra/web/src/components/pool/connect/ConnectionForm.vue
+++ b/@xen-orchestra/web/src/components/pool/connect/ConnectionForm.vue
@@ -5,18 +5,18 @@
       <div class="inputs-container">
         <VtsInputWrapper :label="t('ip-address')">
           <!-- TODO validation -->
-          <UiInput v-model="form.host" accent="brand" required :placeholder="t('ip-port-placeholder')" />
+          <UiInput v-model.trim="form.host" accent="brand" required :placeholder="t('ip-port-placeholder')" />
           <UiInfo accent="info" wrap>
             {{ t('pool-connection-ip-info') }}
           </UiInfo>
         </VtsInputWrapper>
         <!-- TODO validation -->
         <VtsInputWrapper :label="t('proxy-url')">
-          <UiInput v-model="form.httpProxy" accent="brand" />
+          <UiInput v-model.trim="form.httpProxy" accent="brand" />
         </VtsInputWrapper>
         <!-- TODO validation -->
         <VtsInputWrapper :label="t('username')">
-          <UiInput v-model="form.username" accent="brand" required />
+          <UiInput v-model.trim="form.username" accent="brand" required />
           <UiInfo accent="info" wrap>
             {{ t('root-by-default') }}
           </UiInfo>

--- a/@xen-orchestra/web/src/pages/vm/new.vue
+++ b/@xen-orchestra/web/src/pages/vm/new.vue
@@ -103,7 +103,7 @@
             <div class="system-container">
               <div class="column">
                 <VtsInputWrapper :label="t('new-vm:name')">
-                  <UiInput v-model="vmState.name" accent="brand" />
+                  <UiInput v-model.trim="vmState.name" accent="brand" />
                 </VtsInputWrapper>
                 <!-- <UiInput v-model="vmState.tags" :label-icon="faTags" accent="brand" :label=" t('tags')" /> -->
                 <VtsInputWrapper :label="t('boot-firmware')">
@@ -128,14 +128,14 @@
             <UiTitle>{{ t('resource-management') }}</UiTitle>
             <div class="memory-container">
               <VtsInputWrapper :label="t('vcpus')">
-                <UiInput v-model="vmState.vCPU" accent="brand" />
+                <UiInput v-model.number="vmState.vCPU" type="number" accent="brand" />
               </VtsInputWrapper>
               <!-- TODO remove (GB) when we can use new selector -->
               <VtsInputWrapper :label="`${t('ram')} (GB)`">
-                <UiInput v-model="ramFormatted" accent="brand" />
+                <UiInput v-model.number="ramFormatted" type="number" accent="brand" />
               </VtsInputWrapper>
               <VtsInputWrapper :label="t('topology')">
-                <UiInput v-model="vmState.topology" accent="brand" disabled />
+                <UiInput v-model.trim="vmState.topology" accent="brand" disabled />
               </VtsInputWrapper>
             </div>
             <!-- NETWORK SECTION -->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,9 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- **XO 6:**
+  - [Select component] Fix randomly empty select component at initialization (PR [#9282](https://github.com/vatesfr/xen-orchestra/pull/9282))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -30,5 +33,8 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- @xen-orchestra/web patch
+- @xen-orchestra/web-core patch
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

This PR adds manual input handling to fix issue where the `UiInput` element randomly becomes blank.

It also removes the `.trim` modifier inside `UiInput` and let the consumers pass the required modifiers themselves.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
