### PR TITLE
fix(xo-server-perf-alert): improve email alert subject

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [VDIs] Fix broken fallback link to XO 5 VDIs page (PR [#9267](https://github.com/vatesfr/xen-orchestra/pull/9267))
+- [perf-alert] Improve email subject (PR [#9283](https://github.com/vatesfr/xen-orchestra/pull/9283))
 
 ### Packages to release
 
@@ -38,5 +39,6 @@
 
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+- xo-server-perf-alert patch
 
 <!--packages-end-->

--- a/packages/xo-server-perf-alert/src/index.js
+++ b/packages/xo-server-perf-alert/src/index.js
@@ -70,7 +70,24 @@ class PerfAlertXoPlugin {
         notificationType: 'closed',
       })
     })
-    const subject = newAlarms.size > 0 ? `Performance Alerts : new Alerts` : `Performance Alerts : end of all Alerts`
+
+    let subject = ''
+    if (newAlarms.size > 0) {
+      if (activeAlarms.size === 0) {
+        subject = 'Performance Alerts: Alerting has started'
+      } else {
+        subject = `Performance Alerts: ${newAlarms.size} new alert(s) detected`
+        if (closedAlarms.size > 0) {
+          subject += `, ${closedAlarms.size} alert(s) resolved`
+        }
+      }
+    } else {
+      if (activeAlarms.size === 0) {
+        subject = 'Performance Alerts: All alerts resolved'
+      } else {
+        subject = `Performance Alerts: ${closedAlarms.size} alert(s) resolved`
+      }
+    }
     const { html } = await templates.mjml.transform(templates.mjml.$newAlarms({ byRules }))
     const text = await templates.markdown.$newAlarms({ byRules })
     return this._sendAlertEmail(subject, html, text)


### PR DESCRIPTION
error was `Performance Alerts : end of all Alerts` as long there was one
alert closing and no more new one

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
