### PR TITLE
feat(@xen-orchestra/rest-api): display URL of the openApi spec

### DIFF
--- a/@xen-orchestra/rest-api/src/index.mts
+++ b/@xen-orchestra/rest-api/src/index.mts
@@ -18,6 +18,7 @@ export const BASE_URL = '/rest/v0'
 
 const SWAGGER_UI_OPTIONS = {
   swaggerOptions: {
+    url: `${BASE_URL}/docs/swagger.json`,
     displayRequestDuration: true,
     docExpansion: 'none', // collapse all tags by default
     filter: true, // add a tags searchbar,
@@ -54,7 +55,11 @@ export default function setupRestApi(express: Express, xoApp: XoApp) {
 
   // do not register the doc at the root level, or it may lead to unwanted behaviour
   express.get('/rest/v0', (_req, res) => res.redirect('/rest/v0/docs'))
-  express.use(`${BASE_URL}/docs`, swaggerUi.serve, swaggerUi.setup(swaggerOpenApiSpec, SWAGGER_UI_OPTIONS))
+  express.use(
+    `${BASE_URL}/docs`,
+    swaggerUi.serveFiles(undefined, SWAGGER_UI_OPTIONS),
+    swaggerUi.setup(null, SWAGGER_UI_OPTIONS)
+  )
 
   express.use(BASE_URL, tsoaToXoErrorHandler)
   express.use(BASE_URL, genericErrorHandler)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,8 @@
 - **XO 6:**
   - [Navigation] Navigation state is now persisted in localStorage and items are now collapsible while filtering. (PR [#9277](https://github.com/vatesfr/xen-orchestra/pull/9277))
 
+- [REST API] Add link to the openAPI JSON directly in the swagger description (PR [#9285](https://github.com/vatesfr/xen-orchestra/pull/9285))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -36,6 +38,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/rest-api patch
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
 


### PR DESCRIPTION
### Screenshot

<img width="436" height="149" alt="Capture d’écran de 2025-12-08 14-15-08" src="https://github.com/user-attachments/assets/25814a26-912a-49ec-b229-265133da39a2" />


### Description

Zammad#48788

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
