### PR TITLE
Implement RRD parsing and OpenMetrics formatting for the xo-server-openmetrics plugin

### DIFF
--- a/packages/xo-server-openmetrics/package.json
+++ b/packages/xo-server-openmetrics/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@vates/async-each": "^1.0.0",
     "@xen-orchestra/log": "^0.7.1",
+    "json5": "^2.2.3",
     "undici": "^6.2.1"
   },
   "devDependencies": {
@@ -43,7 +44,8 @@
     "clean": "rimraf dist/",
     "dev": "yarn run clean && yarn run build",
     "prebuild": "yarn run clean",
-    "prepublishOnly": "yarn run build"
+    "prepublishOnly": "yarn run build",
+    "test": "cd dist && node --test"
   },
   "private": true
 }

--- a/packages/xo-server-openmetrics/src/index.mts
+++ b/packages/xo-server-openmetrics/src/index.mts
@@ -343,17 +343,14 @@ class OpenMetricsPlugin {
     // Get all pools to resolve pool labels
     const allPools = this.#xo.getObjects({ filter: { type: 'pool' } }) as Record<string, XoPool>
     const poolLabelMap = new Map<string, string>()
-    for (const poolId of Object.keys(allPools)) {
-      const pool = allPools[poolId]
+    for (const pool of Object.values(allPools)) {
       poolLabelMap.set(pool.uuid, pool.name_label)
     }
 
     // Get all hosts from XO objects
     const allHosts = this.#xo.getObjects({ filter: { type: 'host' } }) as Record<string, XoHost>
 
-    for (const hostId of Object.keys(allHosts)) {
-      const host = allHosts[hostId]
-
+    for (const host of Object.values(allHosts)) {
       // Get the session info for this host's pool
       const poolInfo = poolSessionMap.get(host.$poolId)
       if (poolInfo === undefined) {

--- a/packages/xo-server-openmetrics/src/open-metric-server.mts
+++ b/packages/xo-server-openmetrics/src/open-metric-server.mts
@@ -368,6 +368,7 @@ async function startServer(): Promise<void> {
         })
         res.end(metrics)
       } catch (error) {
+        logger.warn('Failed to collect metrics', { error })
         res.writeHead(500, { 'Content-Type': 'application/json' })
         res.end(
           JSON.stringify({

--- a/packages/xo-server-openmetrics/src/open-metric-server.mts
+++ b/packages/xo-server-openmetrics/src/open-metric-server.mts
@@ -218,18 +218,18 @@ async function requestXapiCredentials(): Promise<XapiCredentialsPayload> {
 async function fetchRrdFromHost(host: HostCredentials): Promise<ParsedRrdData | null> {
   const { hostAddress, hostLabel, sessionId, poolId, poolLabel, protocol } = host
 
-  // Calculate start time: current time minus 2 intervals (to ensure we get data)
+  // Calculate start time: current time minus 2 intervals (to ensure we get recent data)
   const now = Math.floor(Date.now() / 1000)
   const interval = 60
   const start = now - 2 * interval
 
   // Build RRD URL with query parameters
-  // cf=LAST returns the most recent value (vs AVERAGE which averages over the interval)
-  // This is more suitable for real-time monitoring with Prometheus/Grafana
+  // cf=AVERAGE is required (cf=LAST is not supported by XenServer rrd_updates endpoint)
+  // Using start parameter to get recent data points
   const baseUrl = `${protocol}//${hostAddress}`
   const url = new URL('/rrd_updates', baseUrl)
   url.searchParams.set('session_id', sessionId)
-  url.searchParams.set('cf', 'LAST')
+  url.searchParams.set('cf', 'AVERAGE')
   url.searchParams.set('interval', String(interval))
   url.searchParams.set('start', String(start))
   url.searchParams.set('host', 'true')

--- a/packages/xo-server-openmetrics/src/open-metric-server.mts
+++ b/packages/xo-server-openmetrics/src/open-metric-server.mts
@@ -330,7 +330,7 @@ async function collectMetrics(): Promise<string> {
   // Remove the # EOF from rrdMetrics if present (we'll add our own)
   const rrdMetricsWithoutEof = rrdMetrics.replace(/\n# EOF$/, '')
 
-  if (rrdMetricsWithoutEof === '' || rrdMetricsWithoutEof === '# EOF') {
+  if (rrdMetricsWithoutEof === '') {
     return poolMetrics.join('\n') + '\n# EOF'
   }
 

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.mts
@@ -1,0 +1,574 @@
+/**
+ * OpenMetrics Formatter Module
+ *
+ * Converts parsed RRD metrics to OpenMetrics/Prometheus format.
+ * Defines metric mappings with transformations and labels.
+ */
+
+import type { ParsedMetric, ParsedRrdData } from './rrd-parser.mjs'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Metric definition for transformation */
+export interface MetricDefinition {
+  /** Regex or string to match RRD metric name */
+  test: RegExp | string
+  /** OpenMetrics metric name (without xcp_ prefix) */
+  openMetricName: string
+  /** Metric type for OpenMetrics */
+  type: 'gauge' | 'counter'
+  /** Help text for the metric */
+  help: string
+  /** Transform RRD value to OpenMetrics value */
+  transformValue?: (value: number) => number
+  /** Extract additional labels from regex matches */
+  extractLabels?: (matches: RegExpMatchArray) => Record<string, string>
+}
+
+/** Formatted OpenMetrics entry */
+export interface FormattedMetric {
+  /** Full metric name with prefix */
+  name: string
+  /** Help text */
+  help: string
+  /** Metric type */
+  type: 'gauge' | 'counter'
+  /** All labels */
+  labels: Record<string, string>
+  /** Metric value */
+  value: number
+  /** Timestamp in milliseconds */
+  timestampMs: number
+}
+
+// ============================================================================
+// Metric Definitions
+// ============================================================================
+
+/**
+ * Host metric definitions.
+ *
+ * Maps RRD metric names to OpenMetrics format with transformations.
+ */
+export const HOST_METRICS: MetricDefinition[] = [
+  // Load average
+  {
+    test: 'loadavg',
+    openMetricName: 'host_load_average',
+    type: 'gauge',
+    help: 'Host load average',
+  },
+
+  // Memory metrics
+  {
+    test: 'memory_free_kib',
+    openMetricName: 'host_memory_free_bytes',
+    type: 'gauge',
+    help: 'Host free memory in bytes',
+    transformValue: v => v * 1024,
+  },
+  {
+    test: 'memory_total_kib',
+    openMetricName: 'host_memory_total_bytes',
+    type: 'gauge',
+    help: 'Host total memory in bytes',
+    transformValue: v => v * 1024,
+  },
+
+  // CPU metrics
+  {
+    test: 'cpu_avg',
+    openMetricName: 'host_cpu_average',
+    type: 'gauge',
+    help: 'Host average CPU usage ratio',
+  },
+  {
+    test: /^cpu(\d+)$/,
+    openMetricName: 'host_cpu_core_usage',
+    type: 'gauge',
+    help: 'Host CPU core usage ratio',
+    extractLabels: matches => ({ core: matches[1] }),
+  },
+
+  // Network metrics (PIF)
+  {
+    test: /^pif_(.+)_rx$/,
+    openMetricName: 'host_network_receive_bytes_total',
+    type: 'counter',
+    help: 'Host network interface received bytes',
+    extractLabels: matches => ({ interface: matches[1] }),
+  },
+  {
+    test: /^pif_(.+)_tx$/,
+    openMetricName: 'host_network_transmit_bytes_total',
+    type: 'counter',
+    help: 'Host network interface transmitted bytes',
+    extractLabels: matches => ({ interface: matches[1] }),
+  },
+
+  // Disk IOPS metrics
+  {
+    test: /^iops_read_(.+)$/,
+    openMetricName: 'host_disk_iops_read',
+    type: 'gauge',
+    help: 'Host disk read IOPS',
+    extractLabels: matches => ({ sr: matches[1] }),
+  },
+  {
+    test: /^iops_write_(.+)$/,
+    openMetricName: 'host_disk_iops_write',
+    type: 'gauge',
+    help: 'Host disk write IOPS',
+    extractLabels: matches => ({ sr: matches[1] }),
+  },
+
+  // Disk throughput metrics
+  {
+    test: /^io_throughput_read_(.+)$/,
+    openMetricName: 'host_disk_throughput_read_bytes',
+    type: 'gauge',
+    help: 'Host disk read throughput in bytes per second',
+    transformValue: v => v * Math.pow(2, 20), // MB to bytes
+    extractLabels: matches => ({ sr: matches[1] }),
+  },
+  {
+    test: /^io_throughput_write_(.+)$/,
+    openMetricName: 'host_disk_throughput_write_bytes',
+    type: 'gauge',
+    help: 'Host disk write throughput in bytes per second',
+    transformValue: v => v * Math.pow(2, 20), // MB to bytes
+    extractLabels: matches => ({ sr: matches[1] }),
+  },
+
+  // Disk latency metrics
+  {
+    test: /^read_latency_(.+)$/,
+    openMetricName: 'host_disk_read_latency_seconds',
+    type: 'gauge',
+    help: 'Host disk read latency in seconds',
+    transformValue: v => v / 1000, // ms to seconds
+    extractLabels: matches => ({ sr: matches[1] }),
+  },
+  {
+    test: /^write_latency_(.+)$/,
+    openMetricName: 'host_disk_write_latency_seconds',
+    type: 'gauge',
+    help: 'Host disk write latency in seconds',
+    transformValue: v => v / 1000, // ms to seconds
+    extractLabels: matches => ({ sr: matches[1] }),
+  },
+
+  // Disk iowait
+  {
+    test: /^iowait_(.+)$/,
+    openMetricName: 'host_disk_iowait',
+    type: 'gauge',
+    help: 'Host disk IO wait ratio',
+    extractLabels: matches => ({ sr: matches[1] }),
+  },
+]
+
+/**
+ * VM metric definitions.
+ *
+ * Maps RRD metric names to OpenMetrics format with transformations.
+ */
+export const VM_METRICS: MetricDefinition[] = [
+  // Memory metrics
+  {
+    test: /memory$/,
+    openMetricName: 'vm_memory_bytes',
+    type: 'gauge',
+    help: 'VM memory usage in bytes',
+  },
+  {
+    test: 'memory_internal_free',
+    openMetricName: 'vm_memory_internal_free_bytes',
+    type: 'gauge',
+    help: 'VM internal free memory in bytes',
+    transformValue: v => v * 1024,
+  },
+  {
+    test: 'memory_target',
+    openMetricName: 'vm_memory_target_bytes',
+    type: 'gauge',
+    help: 'VM memory target in bytes',
+  },
+
+  // CPU metrics
+  {
+    test: 'cpu_usage',
+    openMetricName: 'vm_cpu_usage',
+    type: 'gauge',
+    help: 'VM CPU usage ratio',
+  },
+  {
+    test: /^cpu(\d+)$/,
+    openMetricName: 'vm_cpu_core_usage',
+    type: 'gauge',
+    help: 'VM CPU core usage ratio',
+    extractLabels: matches => ({ core: matches[1] }),
+  },
+
+  // Runstate metrics
+  {
+    test: 'runstate_fullrun',
+    openMetricName: 'vm_runstate_fullrun',
+    type: 'gauge',
+    help: 'VM runstate fullrun ratio',
+  },
+  {
+    test: 'runstate_full_contention',
+    openMetricName: 'vm_runstate_full_contention',
+    type: 'gauge',
+    help: 'VM runstate full contention ratio',
+  },
+  {
+    test: 'runstate_partial_run',
+    openMetricName: 'vm_runstate_partial_run',
+    type: 'gauge',
+    help: 'VM runstate partial run ratio',
+  },
+  {
+    test: 'runstate_partial_contention',
+    openMetricName: 'vm_runstate_partial_contention',
+    type: 'gauge',
+    help: 'VM runstate partial contention ratio',
+  },
+  {
+    test: 'runstate_concurrency_hazard',
+    openMetricName: 'vm_runstate_concurrency_hazard',
+    type: 'gauge',
+    help: 'VM runstate concurrency hazard ratio',
+  },
+  {
+    test: 'runstate_blocked',
+    openMetricName: 'vm_runstate_blocked',
+    type: 'gauge',
+    help: 'VM runstate blocked ratio',
+  },
+
+  // Network metrics (VIF)
+  {
+    test: /^vif_(\d+)_rx$/,
+    openMetricName: 'vm_network_receive_bytes_total',
+    type: 'counter',
+    help: 'VM network interface received bytes',
+    extractLabels: matches => ({ vif: matches[1] }),
+  },
+  {
+    test: /^vif_(\d+)_tx$/,
+    openMetricName: 'vm_network_transmit_bytes_total',
+    type: 'counter',
+    help: 'VM network interface transmitted bytes',
+    extractLabels: matches => ({ vif: matches[1] }),
+  },
+  {
+    test: /^vif_(\d+)_rx_errors$/,
+    openMetricName: 'vm_network_receive_errors_total',
+    type: 'counter',
+    help: 'VM network interface receive errors',
+    extractLabels: matches => ({ vif: matches[1] }),
+  },
+  {
+    test: /^vif_(\d+)_tx_errors$/,
+    openMetricName: 'vm_network_transmit_errors_total',
+    type: 'counter',
+    help: 'VM network interface transmit errors',
+    extractLabels: matches => ({ vif: matches[1] }),
+  },
+
+  // Disk read/write bytes (VBD)
+  {
+    test: /^vbd_xvd(.)_read$/,
+    openMetricName: 'vm_disk_read_bytes_total',
+    type: 'counter',
+    help: 'VM disk read bytes',
+    extractLabels: matches => ({ device: `xvd${matches[1]}` }),
+  },
+  {
+    test: /^vbd_xvd(.)_write$/,
+    openMetricName: 'vm_disk_write_bytes_total',
+    type: 'counter',
+    help: 'VM disk write bytes',
+    extractLabels: matches => ({ device: `xvd${matches[1]}` }),
+  },
+
+  // Disk IOPS (VBD)
+  {
+    test: /^vbd_xvd(.)_iops_read$/,
+    openMetricName: 'vm_disk_iops_read',
+    type: 'gauge',
+    help: 'VM disk read IOPS',
+    extractLabels: matches => ({ device: `xvd${matches[1]}` }),
+  },
+  {
+    test: /^vbd_xvd(.)_iops_write$/,
+    openMetricName: 'vm_disk_iops_write',
+    type: 'gauge',
+    help: 'VM disk write IOPS',
+    extractLabels: matches => ({ device: `xvd${matches[1]}` }),
+  },
+  {
+    test: /^vbd_xvd(.)_iops_total$/,
+    openMetricName: 'vm_disk_iops_total',
+    type: 'gauge',
+    help: 'VM disk total IOPS',
+    extractLabels: matches => ({ device: `xvd${matches[1]}` }),
+  },
+
+  // Disk latency (VBD)
+  {
+    test: /^vbd_xvd(.)_read_latency$/,
+    openMetricName: 'vm_disk_read_latency_seconds',
+    type: 'gauge',
+    help: 'VM disk read latency in seconds',
+    transformValue: v => v / 1000, // ms to seconds
+    extractLabels: matches => ({ device: `xvd${matches[1]}` }),
+  },
+  {
+    test: /^vbd_xvd(.)_write_latency$/,
+    openMetricName: 'vm_disk_write_latency_seconds',
+    type: 'gauge',
+    help: 'VM disk write latency in seconds',
+    transformValue: v => v / 1000, // ms to seconds
+    extractLabels: matches => ({ device: `xvd${matches[1]}` }),
+  },
+
+  // Disk other metrics (VBD)
+  {
+    test: /^vbd_xvd(.)_iowait$/,
+    openMetricName: 'vm_disk_iowait',
+    type: 'gauge',
+    help: 'VM disk IO wait ratio',
+    extractLabels: matches => ({ device: `xvd${matches[1]}` }),
+  },
+  {
+    test: /^vbd_xvd(.)_inflight$/,
+    openMetricName: 'vm_disk_inflight',
+    type: 'gauge',
+    help: 'VM disk inflight operations',
+    extractLabels: matches => ({ device: `xvd${matches[1]}` }),
+  },
+  {
+    test: /^vbd_xvd(.)_avgqu_sz$/,
+    openMetricName: 'vm_disk_queue_size',
+    type: 'gauge',
+    help: 'VM disk average queue size',
+    extractLabels: matches => ({ device: `xvd${matches[1]}` }),
+  },
+]
+
+// ============================================================================
+// Metric Matching Functions
+// ============================================================================
+
+/**
+ * Test if a metric name matches a definition.
+ *
+ * @param metricName - RRD metric name
+ * @param test - String or regex to test against
+ * @returns RegExpMatchArray if matched with regex, true if string match, null otherwise
+ */
+function testMetric(metricName: string, test: string | RegExp): RegExpMatchArray | boolean | null {
+  if (typeof test === 'string') {
+    return metricName === test ? true : null
+  }
+  return test.exec(metricName)
+}
+
+/**
+ * Find matching metric definition for a given RRD metric name.
+ *
+ * @param metricName - RRD metric name
+ * @param objectType - Object type: 'host' or 'vm'
+ * @returns Matching definition with regex matches, or null
+ */
+export function findMetricDefinition(
+  metricName: string,
+  objectType: 'host' | 'vm' | 'sr'
+): { definition: MetricDefinition; matches: RegExpMatchArray | null } | null {
+  const definitions = objectType === 'host' ? HOST_METRICS : objectType === 'vm' ? VM_METRICS : []
+
+  for (const definition of definitions) {
+    const result = testMetric(metricName, definition.test)
+
+    if (result !== null) {
+      // If result is true (string match), convert to null for matches
+      const matches = result === true ? null : (result as RegExpMatchArray)
+      return { definition, matches }
+    }
+  }
+
+  return null
+}
+
+// ============================================================================
+// Formatting Functions
+// ============================================================================
+
+/** OpenMetrics prefix for all metrics */
+const METRIC_PREFIX = 'xcp'
+
+/**
+ * Escape special characters in label values.
+ *
+ * OpenMetrics requires escaping of backslash, double quote, and newline.
+ *
+ * @param value - Label value to escape
+ * @returns Escaped label value
+ */
+function escapeLabelValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n')
+}
+
+/**
+ * Format labels as OpenMetrics label string.
+ *
+ * @param labels - Label key-value pairs
+ * @returns Formatted label string (e.g., `{pool_id="abc",uuid="def"}`)
+ */
+function formatLabels(labels: Record<string, string>): string {
+  const pairs = Object.entries(labels)
+    .filter(([, value]) => value !== undefined && value !== '')
+    .map(([key, value]) => `${key}="${escapeLabelValue(value)}"`)
+
+  return pairs.length > 0 ? `{${pairs.join(',')}}` : ''
+}
+
+/**
+ * Transform a parsed metric to a formatted OpenMetrics entry.
+ *
+ * @param metric - Parsed metric from RRD
+ * @param poolId - Pool UUID
+ * @returns FormattedMetric or null if no matching definition or null value
+ */
+export function transformMetric(metric: ParsedMetric, poolId: string): FormattedMetric | null {
+  const { legend, value, timestamp } = metric
+
+  // Skip null values (NaN/Infinity)
+  if (value === null) {
+    return null
+  }
+
+  // Find matching metric definition
+  const match = findMetricDefinition(legend.metricName, legend.objectType)
+
+  if (match === null) {
+    return null
+  }
+
+  const { definition, matches } = match
+
+  // Apply value transformation if defined
+  const transformedValue = definition.transformValue !== undefined ? definition.transformValue(value) : value
+
+  // Build labels
+  const labels: Record<string, string> = {
+    pool_id: poolId,
+    uuid: legend.uuid,
+    type: legend.objectType,
+  }
+
+  // Add extracted labels from regex matches
+  if (matches !== null && definition.extractLabels !== undefined) {
+    Object.assign(labels, definition.extractLabels(matches))
+  }
+
+  return {
+    name: `${METRIC_PREFIX}_${definition.openMetricName}`,
+    help: definition.help,
+    type: definition.type,
+    labels,
+    value: transformedValue,
+    timestampMs: timestamp * 1000, // Convert to milliseconds
+  }
+}
+
+/**
+ * Group formatted metrics by metric name.
+ *
+ * This is needed to output HELP/TYPE declarations only once per metric.
+ *
+ * @param metrics - Array of formatted metrics
+ * @returns Map of metric name to array of metrics
+ */
+function groupMetricsByName(metrics: FormattedMetric[]): Map<string, FormattedMetric[]> {
+  const grouped = new Map<string, FormattedMetric[]>()
+
+  for (const metric of metrics) {
+    const existing = grouped.get(metric.name)
+    if (existing !== undefined) {
+      existing.push(metric)
+    } else {
+      grouped.set(metric.name, [metric])
+    }
+  }
+
+  return grouped
+}
+
+/**
+ * Format an array of metrics to OpenMetrics text format.
+ *
+ * @param metrics - Array of formatted metrics
+ * @returns OpenMetrics-formatted string
+ */
+export function formatToOpenMetrics(metrics: FormattedMetric[]): string {
+  if (metrics.length === 0) {
+    return ''
+  }
+
+  const grouped = groupMetricsByName(metrics)
+  const lines: string[] = []
+
+  for (const [name, metricsForName] of grouped) {
+    // Output HELP and TYPE only once per metric name
+    const first = metricsForName[0]
+    lines.push(`# HELP ${name} ${first.help}`)
+    lines.push(`# TYPE ${name} ${first.type}`)
+
+    // Output all metric values
+    for (const metric of metricsForName) {
+      const labelsStr = formatLabels(metric.labels)
+      lines.push(`${metric.name}${labelsStr} ${metric.value} ${metric.timestampMs}`)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Format all RRD data from multiple pools to OpenMetrics.
+ *
+ * @param rrdDataList - Array of ParsedRrdData from all pools
+ * @returns Complete OpenMetrics output string with EOF marker
+ */
+export function formatAllPoolsToOpenMetrics(rrdDataList: ParsedRrdData[]): string {
+  const allMetrics: FormattedMetric[] = []
+
+  for (const rrdData of rrdDataList) {
+    for (const metric of rrdData.metrics) {
+      const formatted = transformMetric(metric, rrdData.poolId)
+      if (formatted !== null) {
+        allMetrics.push(formatted)
+      }
+    }
+  }
+
+  // Sort metrics by name for consistent output
+  allMetrics.sort((a, b) => {
+    if (a.name !== b.name) {
+      return a.name.localeCompare(b.name)
+    }
+    // Sort by labels for same metric name
+    return JSON.stringify(a.labels).localeCompare(JSON.stringify(b.labels))
+  })
+
+  const output = formatToOpenMetrics(allMetrics)
+
+  // Add EOF marker as per OpenMetrics specification
+  return output !== '' ? `${output}\n# EOF` : '# EOF'
+}

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.mts
@@ -476,8 +476,8 @@ export function transformMetric(metric: ParsedMetric, poolId: string): Formatted
     type: legend.objectType,
   }
 
-  // Add extracted labels from regex matches
-  if (matches !== null && definition.extractLabels !== undefined) {
+  // Add extracted labels from regex matches (ensure capture group exists)
+  if (matches !== null && matches.length >= 2 && definition.extractLabels !== undefined) {
     Object.assign(labels, definition.extractLabels(matches))
   }
 
@@ -583,5 +583,6 @@ export function formatAllPoolsToOpenMetrics(rrdDataList: ParsedRrdData[]): strin
   const output = formatToOpenMetrics(allMetrics)
 
   // Add EOF marker as per OpenMetrics specification
-  return output !== '' ? `${output}\n# EOF` : '# EOF'
+  // Return empty string if no metrics (caller handles EOF)
+  return output !== '' ? `${output}\n# EOF` : ''
 }

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.mts
@@ -568,7 +568,7 @@ export function formatAllPoolsToOpenMetrics(rrdDataList: ParsedRrdData[]): strin
 
   // Log unmatched metrics for debugging (this helps identify missing metric definitions)
   if (unmatchedMetrics.size > 0) {
-    logger.warn('Unmatched RRD metrics', { metrics: Array.from(unmatchedMetrics).sort() })
+    logger.debug('Unmatched RRD metrics', { metrics: Array.from(unmatchedMetrics).sort() })
   }
 
   // Sort metrics by name for consistent output

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
@@ -1,0 +1,509 @@
+/**
+ * Tests for OpenMetrics Formatter Module
+ */
+
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import {
+  HOST_METRICS,
+  VM_METRICS,
+  findMetricDefinition,
+  transformMetric,
+  formatToOpenMetrics,
+  formatAllPoolsToOpenMetrics,
+  type FormattedMetric,
+} from './openmetric-formatter.mjs'
+
+import type { ParsedMetric, ParsedRrdData } from './rrd-parser.mjs'
+
+// ============================================================================
+// Metric Definitions Tests
+// ============================================================================
+
+describe('HOST_METRICS', () => {
+  it('should have metric definitions', () => {
+    assert.ok(HOST_METRICS.length > 0)
+  })
+
+  it('should include loadavg metric', () => {
+    const loadMetric = HOST_METRICS.find(m => m.openMetricName === 'host_load_average')
+    assert.ok(loadMetric)
+    assert.equal(loadMetric.type, 'gauge')
+  })
+
+  it('should include memory metrics with transformations', () => {
+    const memFree = HOST_METRICS.find(m => m.openMetricName === 'host_memory_free_bytes')
+    assert.ok(memFree)
+    assert.ok(memFree.transformValue)
+    // memory_free_kib * 1024 = bytes
+    assert.equal(memFree.transformValue!(1024), 1024 * 1024)
+  })
+
+  it('should include CPU core metric with label extraction', () => {
+    const cpuCore = HOST_METRICS.find(m => m.openMetricName === 'host_cpu_core_usage')
+    assert.ok(cpuCore)
+    assert.ok(cpuCore.extractLabels)
+
+    // Test regex and label extraction
+    const regex = cpuCore.test as RegExp
+    const match = regex.exec('cpu0')
+    assert.ok(match)
+    assert.deepEqual(cpuCore.extractLabels!(match), { core: '0' })
+  })
+
+  it('should include network metrics', () => {
+    const netRx = HOST_METRICS.find(m => m.openMetricName === 'host_network_receive_bytes_total')
+    assert.ok(netRx)
+    assert.equal(netRx.type, 'counter')
+  })
+
+  it('should include disk throughput metrics with MB to bytes transformation', () => {
+    const throughput = HOST_METRICS.find(m => m.openMetricName === 'host_disk_throughput_read_bytes')
+    assert.ok(throughput)
+    assert.ok(throughput.transformValue)
+    // 1 MB = 2^20 bytes
+    assert.equal(throughput.transformValue!(1), Math.pow(2, 20))
+  })
+
+  it('should include latency metrics with ms to seconds transformation', () => {
+    const latency = HOST_METRICS.find(m => m.openMetricName === 'host_disk_read_latency_seconds')
+    assert.ok(latency)
+    assert.ok(latency.transformValue)
+    // 1000 ms = 1 second
+    assert.equal(latency.transformValue!(1000), 1)
+  })
+})
+
+describe('VM_METRICS', () => {
+  it('should have metric definitions', () => {
+    assert.ok(VM_METRICS.length > 0)
+  })
+
+  it('should include memory metrics', () => {
+    const memMetric = VM_METRICS.find(m => m.openMetricName === 'vm_memory_bytes')
+    assert.ok(memMetric)
+  })
+
+  it('should include CPU usage metric', () => {
+    const cpuUsage = VM_METRICS.find(m => m.openMetricName === 'vm_cpu_usage')
+    assert.ok(cpuUsage)
+    assert.equal(cpuUsage.type, 'gauge')
+  })
+
+  it('should include VIF metrics with label extraction', () => {
+    const vifRx = VM_METRICS.find(m => m.openMetricName === 'vm_network_receive_bytes_total')
+    assert.ok(vifRx)
+    assert.ok(vifRx.extractLabels)
+
+    const regex = vifRx.test as RegExp
+    const match = regex.exec('vif_0_rx')
+    assert.ok(match)
+    assert.deepEqual(vifRx.extractLabels!(match), { vif: '0' })
+  })
+
+  it('should include VBD metrics with device label', () => {
+    const vbdRead = VM_METRICS.find(m => m.openMetricName === 'vm_disk_read_bytes_total')
+    assert.ok(vbdRead)
+    assert.ok(vbdRead.extractLabels)
+
+    const regex = vbdRead.test as RegExp
+    const match = regex.exec('vbd_xvda_read')
+    assert.ok(match)
+    assert.deepEqual(vbdRead.extractLabels!(match), { device: 'xvda' })
+  })
+
+  it('should include runstate metrics', () => {
+    const runstate = VM_METRICS.find(m => m.openMetricName === 'vm_runstate_fullrun')
+    assert.ok(runstate)
+    assert.equal(runstate.type, 'gauge')
+  })
+})
+
+// ============================================================================
+// findMetricDefinition Tests
+// ============================================================================
+
+describe('findMetricDefinition', () => {
+  it('should find host loadavg metric', () => {
+    const result = findMetricDefinition('loadavg', 'host')
+    assert.ok(result)
+    assert.equal(result.definition.openMetricName, 'host_load_average')
+  })
+
+  it('should find host CPU core metric and return matches', () => {
+    const result = findMetricDefinition('cpu3', 'host')
+    assert.ok(result)
+    assert.equal(result.definition.openMetricName, 'host_cpu_core_usage')
+    assert.ok(result.matches)
+    assert.equal(result.matches[1], '3')
+  })
+
+  it('should find VM cpu_usage metric', () => {
+    const result = findMetricDefinition('cpu_usage', 'vm')
+    assert.ok(result)
+    assert.equal(result.definition.openMetricName, 'vm_cpu_usage')
+  })
+
+  it('should find VM VIF metric', () => {
+    const result = findMetricDefinition('vif_2_tx', 'vm')
+    assert.ok(result)
+    assert.equal(result.definition.openMetricName, 'vm_network_transmit_bytes_total')
+    assert.ok(result.matches)
+    assert.equal(result.matches[1], '2')
+  })
+
+  it('should find VM VBD metric', () => {
+    const result = findMetricDefinition('vbd_xvdb_write', 'vm')
+    assert.ok(result)
+    assert.equal(result.definition.openMetricName, 'vm_disk_write_bytes_total')
+    assert.ok(result.matches)
+    assert.equal(result.matches[1], 'b')
+  })
+
+  it('should return null for unknown metric', () => {
+    const result = findMetricDefinition('unknown_metric', 'host')
+    assert.equal(result, null)
+  })
+
+  it('should return null for SR object type', () => {
+    const result = findMetricDefinition('iops_read', 'sr')
+    assert.equal(result, null)
+  })
+})
+
+// ============================================================================
+// transformMetric Tests
+// ============================================================================
+
+describe('transformMetric', () => {
+  it('should transform host CPU metric', () => {
+    const metric: ParsedMetric = {
+      legend: {
+        cf: 'AVERAGE',
+        objectType: 'host',
+        uuid: 'host-uuid-123',
+        metricName: 'cpu_avg',
+        rawLegend: 'AVERAGE:host:host-uuid-123:cpu_avg',
+      },
+      value: 0.75,
+      timestamp: 1700000000,
+    }
+
+    const result = transformMetric(metric, 'pool-456')
+
+    assert.ok(result)
+    assert.equal(result.name, 'xcp_host_cpu_average')
+    assert.equal(result.type, 'gauge')
+    assert.equal(result.value, 0.75)
+    assert.equal(result.timestampMs, 1700000000000)
+    assert.equal(result.labels.pool_id, 'pool-456')
+    assert.equal(result.labels.uuid, 'host-uuid-123')
+    assert.equal(result.labels.type, 'host')
+  })
+
+  it('should apply value transformation for memory', () => {
+    const metric: ParsedMetric = {
+      legend: {
+        cf: 'AVERAGE',
+        objectType: 'host',
+        uuid: 'host-uuid-123',
+        metricName: 'memory_free_kib',
+        rawLegend: 'AVERAGE:host:host-uuid-123:memory_free_kib',
+      },
+      value: 1024, // 1024 KiB
+      timestamp: 1700000000,
+    }
+
+    const result = transformMetric(metric, 'pool-456')
+
+    assert.ok(result)
+    assert.equal(result.name, 'xcp_host_memory_free_bytes')
+    assert.equal(result.value, 1024 * 1024) // 1 MiB in bytes
+  })
+
+  it('should extract labels from regex matches', () => {
+    const metric: ParsedMetric = {
+      legend: {
+        cf: 'AVERAGE',
+        objectType: 'host',
+        uuid: 'host-uuid-123',
+        metricName: 'cpu5',
+        rawLegend: 'AVERAGE:host:host-uuid-123:cpu5',
+      },
+      value: 0.25,
+      timestamp: 1700000000,
+    }
+
+    const result = transformMetric(metric, 'pool-456')
+
+    assert.ok(result)
+    assert.equal(result.name, 'xcp_host_cpu_core_usage')
+    assert.equal(result.labels.core, '5')
+  })
+
+  it('should return null for null values', () => {
+    const metric: ParsedMetric = {
+      legend: {
+        cf: 'AVERAGE',
+        objectType: 'host',
+        uuid: 'host-uuid-123',
+        metricName: 'cpu_avg',
+        rawLegend: 'AVERAGE:host:host-uuid-123:cpu_avg',
+      },
+      value: null, // NaN was converted to null
+      timestamp: 1700000000,
+    }
+
+    const result = transformMetric(metric, 'pool-456')
+
+    assert.equal(result, null)
+  })
+
+  it('should return null for unknown metrics', () => {
+    const metric: ParsedMetric = {
+      legend: {
+        cf: 'AVERAGE',
+        objectType: 'host',
+        uuid: 'host-uuid-123',
+        metricName: 'unknown_metric',
+        rawLegend: 'AVERAGE:host:host-uuid-123:unknown_metric',
+      },
+      value: 42,
+      timestamp: 1700000000,
+    }
+
+    const result = transformMetric(metric, 'pool-456')
+
+    assert.equal(result, null)
+  })
+
+  it('should transform VM VIF metric with extracted labels', () => {
+    const metric: ParsedMetric = {
+      legend: {
+        cf: 'AVERAGE',
+        objectType: 'vm',
+        uuid: 'vm-uuid-789',
+        metricName: 'vif_0_rx',
+        rawLegend: 'AVERAGE:vm:vm-uuid-789:vif_0_rx',
+      },
+      value: 1000000,
+      timestamp: 1700000000,
+    }
+
+    const result = transformMetric(metric, 'pool-456')
+
+    assert.ok(result)
+    assert.equal(result.name, 'xcp_vm_network_receive_bytes_total')
+    assert.equal(result.type, 'counter')
+    assert.equal(result.labels.vif, '0')
+    assert.equal(result.labels.type, 'vm')
+  })
+})
+
+// ============================================================================
+// formatToOpenMetrics Tests
+// ============================================================================
+
+describe('formatToOpenMetrics', () => {
+  it('should format metrics to OpenMetrics text', () => {
+    const metrics: FormattedMetric[] = [
+      {
+        name: 'xcp_host_cpu_average',
+        help: 'Host average CPU usage ratio',
+        type: 'gauge',
+        labels: { pool_id: 'pool-1', uuid: 'host-1', type: 'host' },
+        value: 0.5,
+        timestampMs: 1700000000000,
+      },
+    ]
+
+    const result = formatToOpenMetrics(metrics)
+
+    assert.ok(result.includes('# HELP xcp_host_cpu_average Host average CPU usage ratio'))
+    assert.ok(result.includes('# TYPE xcp_host_cpu_average gauge'))
+    assert.ok(result.includes('xcp_host_cpu_average{pool_id="pool-1",uuid="host-1",type="host"} 0.5 1700000000000'))
+  })
+
+  it('should group metrics by name', () => {
+    const metrics: FormattedMetric[] = [
+      {
+        name: 'xcp_host_cpu_core_usage',
+        help: 'Host CPU core usage ratio',
+        type: 'gauge',
+        labels: { pool_id: 'pool-1', uuid: 'host-1', type: 'host', core: '0' },
+        value: 0.3,
+        timestampMs: 1700000000000,
+      },
+      {
+        name: 'xcp_host_cpu_core_usage',
+        help: 'Host CPU core usage ratio',
+        type: 'gauge',
+        labels: { pool_id: 'pool-1', uuid: 'host-1', type: 'host', core: '1' },
+        value: 0.4,
+        timestampMs: 1700000000000,
+      },
+    ]
+
+    const result = formatToOpenMetrics(metrics)
+
+    // Should only have one HELP and TYPE declaration
+    const helpCount = (result.match(/# HELP xcp_host_cpu_core_usage/g) || []).length
+    const typeCount = (result.match(/# TYPE xcp_host_cpu_core_usage/g) || []).length
+
+    assert.equal(helpCount, 1)
+    assert.equal(typeCount, 1)
+
+    // Should have two value lines
+    assert.ok(result.includes('core="0"'))
+    assert.ok(result.includes('core="1"'))
+  })
+
+  it('should return empty string for empty metrics', () => {
+    const result = formatToOpenMetrics([])
+    assert.equal(result, '')
+  })
+
+  it('should escape special characters in label values', () => {
+    const metrics: FormattedMetric[] = [
+      {
+        name: 'xcp_test_metric',
+        help: 'Test metric',
+        type: 'gauge',
+        labels: { name: 'value with "quotes"' },
+        value: 1,
+        timestampMs: 1700000000000,
+      },
+    ]
+
+    const result = formatToOpenMetrics(metrics)
+
+    assert.ok(result.includes('name="value with \\"quotes\\""'))
+  })
+})
+
+// ============================================================================
+// formatAllPoolsToOpenMetrics Tests
+// ============================================================================
+
+describe('formatAllPoolsToOpenMetrics', () => {
+  it('should format RRD data from multiple pools', () => {
+    const rrdDataList: ParsedRrdData[] = [
+      {
+        poolId: 'pool-1',
+        timestamp: 1700000000,
+        metrics: [
+          {
+            legend: {
+              cf: 'AVERAGE',
+              objectType: 'host',
+              uuid: 'host-1',
+              metricName: 'cpu_avg',
+              rawLegend: 'AVERAGE:host:host-1:cpu_avg',
+            },
+            value: 0.5,
+            timestamp: 1700000000,
+          },
+        ],
+      },
+      {
+        poolId: 'pool-2',
+        timestamp: 1700000000,
+        metrics: [
+          {
+            legend: {
+              cf: 'AVERAGE',
+              objectType: 'host',
+              uuid: 'host-2',
+              metricName: 'cpu_avg',
+              rawLegend: 'AVERAGE:host:host-2:cpu_avg',
+            },
+            value: 0.7,
+            timestamp: 1700000000,
+          },
+        ],
+      },
+    ]
+
+    const result = formatAllPoolsToOpenMetrics(rrdDataList)
+
+    assert.ok(result.includes('pool_id="pool-1"'))
+    assert.ok(result.includes('pool_id="pool-2"'))
+    assert.ok(result.includes('# EOF'))
+  })
+
+  it('should return only EOF for empty data', () => {
+    const result = formatAllPoolsToOpenMetrics([])
+
+    assert.equal(result, '# EOF')
+  })
+
+  it('should skip metrics with null values', () => {
+    const rrdDataList: ParsedRrdData[] = [
+      {
+        poolId: 'pool-1',
+        timestamp: 1700000000,
+        metrics: [
+          {
+            legend: {
+              cf: 'AVERAGE',
+              objectType: 'host',
+              uuid: 'host-1',
+              metricName: 'cpu_avg',
+              rawLegend: 'AVERAGE:host:host-1:cpu_avg',
+            },
+            value: null, // NaN converted to null
+            timestamp: 1700000000,
+          },
+        ],
+      },
+    ]
+
+    const result = formatAllPoolsToOpenMetrics(rrdDataList)
+
+    // Should only contain EOF since the metric has null value
+    assert.equal(result, '# EOF')
+  })
+
+  it('should sort metrics by name for consistent output', () => {
+    const rrdDataList: ParsedRrdData[] = [
+      {
+        poolId: 'pool-1',
+        timestamp: 1700000000,
+        metrics: [
+          {
+            legend: {
+              cf: 'AVERAGE',
+              objectType: 'host',
+              uuid: 'host-1',
+              metricName: 'memory_free_kib',
+              rawLegend: 'AVERAGE:host:host-1:memory_free_kib',
+            },
+            value: 1024,
+            timestamp: 1700000000,
+          },
+          {
+            legend: {
+              cf: 'AVERAGE',
+              objectType: 'host',
+              uuid: 'host-1',
+              metricName: 'cpu_avg',
+              rawLegend: 'AVERAGE:host:host-1:cpu_avg',
+            },
+            value: 0.5,
+            timestamp: 1700000000,
+          },
+        ],
+      },
+    ]
+
+    const result = formatAllPoolsToOpenMetrics(rrdDataList)
+    const lines = result.split('\n')
+
+    // cpu_average should come before memory_free_bytes alphabetically
+    const cpuIndex = lines.findIndex(l => l.includes('xcp_host_cpu_average'))
+    const memIndex = lines.findIndex(l => l.includes('xcp_host_memory_free_bytes'))
+
+    assert.ok(cpuIndex < memIndex, 'Metrics should be sorted alphabetically')
+  })
+})

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
@@ -432,10 +432,10 @@ describe('formatAllPoolsToOpenMetrics', () => {
     assert.ok(result.includes('# EOF'))
   })
 
-  it('should return only EOF for empty data', () => {
+  it('should return empty string for empty data', () => {
     const result = formatAllPoolsToOpenMetrics([])
 
-    assert.equal(result, '# EOF')
+    assert.equal(result, '')
   })
 
   it('should skip metrics with null values', () => {
@@ -461,8 +461,8 @@ describe('formatAllPoolsToOpenMetrics', () => {
 
     const result = formatAllPoolsToOpenMetrics(rrdDataList)
 
-    // Should only contain EOF since the metric has null value
-    assert.equal(result, '# EOF')
+    // Should return empty string since the metric has null value
+    assert.equal(result, '')
   })
 
   it('should sort metrics by name for consistent output', () => {

--- a/packages/xo-server-openmetrics/src/rrd-parser.mts
+++ b/packages/xo-server-openmetrics/src/rrd-parser.mts
@@ -100,14 +100,7 @@ export function parseNumber(value: number | string): number | null {
     }
 
     // XAPI 23.31+ encodes numbers as strings
-    const asNumber = Number(value)
-
-    // Check for invalid string that doesn't parse to a valid number
-    if (Number.isNaN(asNumber) && value !== 'NaN') {
-      return null
-    }
-
-    value = asNumber
+    value = Number(value)
   }
 
   // Return null for NaN and Infinity (they can't be represented in OpenMetrics)

--- a/packages/xo-server-openmetrics/src/rrd-parser.mts
+++ b/packages/xo-server-openmetrics/src/rrd-parser.mts
@@ -1,0 +1,235 @@
+/**
+ * RRD Parser Module
+ *
+ * Parses RRD responses from XAPI /rrd_updates endpoint.
+ * Handles JSON and JSON5 formats (for XAPI < 23.31).
+ * Manages special values like NaN and Infinity.
+ */
+
+import JSON5 from 'json5'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Raw RRD response metadata from XAPI */
+export interface RrdMeta {
+  start: number
+  step: number
+  end: number
+  rows: number
+  columns: number
+  legend: string[]
+}
+
+/** Raw RRD data point from XAPI */
+export interface RrdDataPoint {
+  t: number
+  values: (number | string)[]
+}
+
+/** Raw RRD response from XAPI /rrd_updates endpoint */
+export interface RrdResponse {
+  meta: RrdMeta
+  data: RrdDataPoint[]
+}
+
+/** Parsed legend entry */
+export interface ParsedLegend {
+  /** Consolidation function (AVERAGE, MAX, etc.) */
+  cf: string
+  /** Object type: host, vm, or sr */
+  objectType: 'host' | 'vm' | 'sr'
+  /** UUID of the object */
+  uuid: string
+  /** Metric name (e.g., cpu_avg, memory_free_kib) */
+  metricName: string
+  /** Original raw legend string */
+  rawLegend: string
+}
+
+/** Parsed metric with value */
+export interface ParsedMetric {
+  /** Parsed legend information */
+  legend: ParsedLegend
+  /** Metric value (null if NaN/Infinity) */
+  value: number | null
+  /** Timestamp in seconds */
+  timestamp: number
+}
+
+/** Parsed RRD data for a single pool */
+export interface ParsedRrdData {
+  /** Pool UUID */
+  poolId: string
+  /** Timestamp of the data in seconds */
+  timestamp: number
+  /** All parsed metrics */
+  metrics: ParsedMetric[]
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Regex to parse legend format: "AVERAGE:type:uuid:metric_name" */
+const LEGEND_REGEX = /^([A-Z]+):([^:]+):([^:]+):(.+)$/
+
+/** Valid object types in RRD data */
+const VALID_OBJECT_TYPES = new Set(['host', 'vm', 'sr'])
+
+// ============================================================================
+// Parsing Functions
+// ============================================================================
+
+/**
+ * Parse a number from RRD response, handling XAPI 23.31+ string encoding.
+ *
+ * Starting from XAPI 23.31, numbers in the JSON payload are encoded as
+ * strings to support NaN, Infinity and -Infinity values.
+ *
+ * @param value - Number or string from RRD response
+ * @returns Parsed number or null if NaN/Infinity/invalid
+ */
+export function parseNumber(value: number | string): number | null {
+  if (typeof value === 'string') {
+    // Empty strings and non-numeric strings are invalid
+    const trimmed = value.trim()
+    if (trimmed === '') {
+      return null
+    }
+
+    // XAPI 23.31+ encodes numbers as strings
+    const asNumber = Number(value)
+
+    // Check for invalid string that doesn't parse to a valid number
+    if (Number.isNaN(asNumber) && value !== 'NaN') {
+      return null
+    }
+
+    value = asNumber
+  }
+
+  // Return null for NaN and Infinity (they can't be represented in OpenMetrics)
+  if (!Number.isFinite(value)) {
+    return null
+  }
+
+  return value
+}
+
+/**
+ * Parse a legend string into structured format.
+ *
+ * Legend format: "AVERAGE:type:uuid:metric_name"
+ * Example: "AVERAGE:host:abc-123-def:cpu_avg"
+ *
+ * @param legend - Raw legend string from RRD metadata
+ * @returns ParsedLegend or null if the format is invalid
+ */
+export function parseLegend(legend: string): ParsedLegend | null {
+  const match = LEGEND_REGEX.exec(legend)
+
+  if (match === null) {
+    return null
+  }
+
+  const [, cf, objectType, uuid, metricName] = match
+
+  // Validate object type
+  if (!VALID_OBJECT_TYPES.has(objectType)) {
+    return null
+  }
+
+  return {
+    cf,
+    objectType: objectType as 'host' | 'vm' | 'sr',
+    uuid,
+    metricName,
+    rawLegend: legend,
+  }
+}
+
+/**
+ * Parse raw RRD JSON text with JSON5 fallback for older XAPI versions.
+ *
+ * XAPI < 23.31 may return invalid JSON (using NaN without quotes),
+ * so we fall back to JSON5 which handles these cases.
+ *
+ * @param text - Raw response text from /rrd_updates endpoint
+ * @returns Parsed RrdResponse
+ * @throws Error if parsing fails with both JSON and JSON5
+ */
+export function parseRrdText(text: string): RrdResponse {
+  try {
+    // Try standard JSON first (XAPI 23.31+)
+    return JSON.parse(text) as RrdResponse
+  } catch {
+    // Fall back to JSON5 for older XAPI versions
+    return JSON5.parse(text) as RrdResponse
+  }
+}
+
+/**
+ * Extract all valid metrics from an RRD response.
+ *
+ * @param rrd - Parsed RRD response
+ * @param poolId - Pool UUID for labeling
+ * @returns ParsedRrdData with all valid metrics
+ */
+export function parseRrdData(rrd: RrdResponse, poolId: string): ParsedRrdData {
+  const { meta, data } = rrd
+
+  // Use the most recent data point (last in array after reversal)
+  // RRD data comes newest-first, we want the most recent
+  if (data.length === 0) {
+    return {
+      poolId,
+      timestamp: meta.end,
+      metrics: [],
+    }
+  }
+
+  // Get the most recent data point
+  const latestData = data[data.length - 1]
+  const timestamp = latestData.t
+
+  const metrics: ParsedMetric[] = []
+
+  for (let i = 0; i < meta.legend.length; i++) {
+    const legend = parseLegend(meta.legend[i])
+
+    if (legend === null) {
+      // Skip unparseable legend entries
+      continue
+    }
+
+    const value = parseNumber(latestData.values[i])
+
+    metrics.push({
+      legend,
+      value,
+      timestamp,
+    })
+  }
+
+  return {
+    poolId,
+    timestamp,
+    metrics,
+  }
+}
+
+/**
+ * Parse raw RRD text and extract metrics in one step.
+ *
+ * Convenience function that combines parseRrdText and parseRrdData.
+ *
+ * @param text - Raw response text from /rrd_updates endpoint
+ * @param poolId - Pool UUID for labeling
+ * @returns ParsedRrdData with all valid metrics
+ */
+export function parseRrdResponse(text: string, poolId: string): ParsedRrdData {
+  const rrd = parseRrdText(text)
+  return parseRrdData(rrd, poolId)
+}

--- a/packages/xo-server-openmetrics/src/rrd-parser.test.mts
+++ b/packages/xo-server-openmetrics/src/rrd-parser.test.mts
@@ -1,0 +1,320 @@
+/**
+ * Tests for RRD Parser Module
+ */
+
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import {
+  parseNumber,
+  parseLegend,
+  parseRrdText,
+  parseRrdData,
+  parseRrdResponse,
+  type RrdResponse,
+} from './rrd-parser.mjs'
+
+// ============================================================================
+// parseNumber Tests
+// ============================================================================
+
+describe('parseNumber', () => {
+  it('should parse regular numbers', () => {
+    assert.equal(parseNumber(42), 42)
+    assert.equal(parseNumber(3.14159), 3.14159)
+    assert.equal(parseNumber(0), 0)
+    assert.equal(parseNumber(-100), -100)
+  })
+
+  it('should parse string-encoded numbers (XAPI 23.31+)', () => {
+    assert.equal(parseNumber('42'), 42)
+    assert.equal(parseNumber('3.14159'), 3.14159)
+    assert.equal(parseNumber('0'), 0)
+    assert.equal(parseNumber('-100'), -100)
+    assert.equal(parseNumber('1.5e10'), 1.5e10)
+  })
+
+  it('should return null for NaN values', () => {
+    assert.equal(parseNumber(NaN), null)
+    assert.equal(parseNumber('NaN'), null)
+  })
+
+  it('should return null for Infinity values', () => {
+    assert.equal(parseNumber(Infinity), null)
+    assert.equal(parseNumber(-Infinity), null)
+    assert.equal(parseNumber('Infinity'), null)
+    assert.equal(parseNumber('-Infinity'), null)
+  })
+
+  it('should return null for invalid string values', () => {
+    assert.equal(parseNumber('not a number'), null)
+    assert.equal(parseNumber(''), null)
+  })
+})
+
+// ============================================================================
+// parseLegend Tests
+// ============================================================================
+
+describe('parseLegend', () => {
+  it('should parse host legend format', () => {
+    const result = parseLegend('AVERAGE:host:abc-123-def:cpu_avg')
+
+    assert.deepEqual(result, {
+      cf: 'AVERAGE',
+      objectType: 'host',
+      uuid: 'abc-123-def',
+      metricName: 'cpu_avg',
+      rawLegend: 'AVERAGE:host:abc-123-def:cpu_avg',
+    })
+  })
+
+  it('should parse vm legend format', () => {
+    const result = parseLegend('AVERAGE:vm:vm-uuid-456:memory_internal_free')
+
+    assert.deepEqual(result, {
+      cf: 'AVERAGE',
+      objectType: 'vm',
+      uuid: 'vm-uuid-456',
+      metricName: 'memory_internal_free',
+      rawLegend: 'AVERAGE:vm:vm-uuid-456:memory_internal_free',
+    })
+  })
+
+  it('should parse sr legend format', () => {
+    const result = parseLegend('AVERAGE:sr:sr-uuid-789:iops_read')
+
+    assert.deepEqual(result, {
+      cf: 'AVERAGE',
+      objectType: 'sr',
+      uuid: 'sr-uuid-789',
+      metricName: 'iops_read',
+      rawLegend: 'AVERAGE:sr:sr-uuid-789:iops_read',
+    })
+  })
+
+  it('should handle metric names with underscores', () => {
+    const result = parseLegend('AVERAGE:host:uuid:memory_free_kib')
+
+    assert.equal(result?.metricName, 'memory_free_kib')
+  })
+
+  it('should handle CPU core metrics', () => {
+    const result = parseLegend('AVERAGE:host:uuid:cpu0')
+
+    assert.equal(result?.metricName, 'cpu0')
+  })
+
+  it('should handle VIF metrics with numbers', () => {
+    const result = parseLegend('AVERAGE:vm:uuid:vif_0_rx')
+
+    assert.equal(result?.metricName, 'vif_0_rx')
+  })
+
+  it('should handle VBD metrics', () => {
+    const result = parseLegend('AVERAGE:vm:uuid:vbd_xvda_read')
+
+    assert.equal(result?.metricName, 'vbd_xvda_read')
+  })
+
+  it('should return null for invalid format', () => {
+    assert.equal(parseLegend('invalid'), null)
+    assert.equal(parseLegend('AVERAGE:host'), null)
+    assert.equal(parseLegend('AVERAGE:host:uuid'), null)
+    assert.equal(parseLegend(''), null)
+  })
+
+  it('should return null for unknown object types', () => {
+    assert.equal(parseLegend('AVERAGE:unknown:uuid:metric'), null)
+    assert.equal(parseLegend('AVERAGE:pool:uuid:metric'), null)
+  })
+})
+
+// ============================================================================
+// parseRrdText Tests
+// ============================================================================
+
+describe('parseRrdText', () => {
+  it('should parse valid JSON', () => {
+    const json = JSON.stringify({
+      meta: {
+        start: 1700000000,
+        step: 60,
+        end: 1700003600,
+        rows: 1,
+        columns: 60,
+        legend: ['AVERAGE:host:uuid:cpu_avg'],
+      },
+      data: [{ t: 1700003600, values: [0.5] }],
+    })
+
+    const result = parseRrdText(json)
+
+    assert.equal(result.meta.step, 60)
+    assert.equal(result.data.length, 1)
+  })
+
+  it('should parse JSON5 with NaN values (XAPI < 23.31)', () => {
+    // JSON5 allows unquoted NaN
+    const json5 = `{
+      meta: {
+        start: 1700000000,
+        step: 60,
+        end: 1700003600,
+        rows: 1,
+        columns: 60,
+        legend: ['AVERAGE:host:uuid:cpu_avg']
+      },
+      data: [{ t: 1700003600, values: [NaN] }]
+    }`
+
+    const result = parseRrdText(json5)
+
+    assert.equal(result.meta.step, 60)
+    assert.equal(result.data.length, 1)
+    assert.ok(Number.isNaN(result.data[0].values[0] as number))
+  })
+
+  it('should throw on completely invalid input', () => {
+    assert.throws(() => parseRrdText('not json at all {{{'))
+  })
+})
+
+// ============================================================================
+// parseRrdData Tests
+// ============================================================================
+
+describe('parseRrdData', () => {
+  const sampleRrd: RrdResponse = {
+    meta: {
+      start: 1700000000,
+      step: 60,
+      end: 1700003600,
+      rows: 3,
+      columns: 60,
+      legend: [
+        'AVERAGE:host:host-uuid-1:cpu_avg',
+        'AVERAGE:host:host-uuid-1:memory_free_kib',
+        'AVERAGE:vm:vm-uuid-1:cpu_usage',
+      ],
+    },
+    data: [
+      { t: 1700003540, values: [0.3, 1048576, 0.2] },
+      { t: 1700003600, values: [0.5, 2097152, 0.4] }, // Most recent
+    ],
+  }
+
+  it('should extract metrics from RRD data', () => {
+    const result = parseRrdData(sampleRrd, 'pool-123')
+
+    assert.equal(result.poolId, 'pool-123')
+    assert.equal(result.timestamp, 1700003600)
+    assert.equal(result.metrics.length, 3)
+  })
+
+  it('should use the most recent data point', () => {
+    const result = parseRrdData(sampleRrd, 'pool-123')
+
+    // Values should be from the most recent data point (last in array)
+    const cpuMetric = result.metrics.find(m => m.legend.metricName === 'cpu_avg')
+    assert.equal(cpuMetric?.value, 0.5)
+  })
+
+  it('should parse legend correctly for each metric', () => {
+    const result = parseRrdData(sampleRrd, 'pool-123')
+
+    const hostMetric = result.metrics.find(m => m.legend.metricName === 'cpu_avg')
+    assert.equal(hostMetric?.legend.objectType, 'host')
+    assert.equal(hostMetric?.legend.uuid, 'host-uuid-1')
+
+    const vmMetric = result.metrics.find(m => m.legend.metricName === 'cpu_usage')
+    assert.equal(vmMetric?.legend.objectType, 'vm')
+    assert.equal(vmMetric?.legend.uuid, 'vm-uuid-1')
+  })
+
+  it('should handle empty data array', () => {
+    const emptyRrd: RrdResponse = {
+      meta: {
+        start: 1700000000,
+        step: 60,
+        end: 1700003600,
+        rows: 0,
+        columns: 0,
+        legend: [],
+      },
+      data: [],
+    }
+
+    const result = parseRrdData(emptyRrd, 'pool-123')
+
+    assert.equal(result.metrics.length, 0)
+    assert.equal(result.timestamp, 1700003600) // Uses meta.end
+  })
+
+  it('should handle NaN values in data', () => {
+    const rrdWithNaN: RrdResponse = {
+      meta: {
+        start: 1700000000,
+        step: 60,
+        end: 1700003600,
+        rows: 2,
+        columns: 1,
+        legend: ['AVERAGE:host:uuid:cpu_avg', 'AVERAGE:host:uuid:loadavg'],
+      },
+      data: [{ t: 1700003600, values: [NaN, 0.5] }],
+    }
+
+    const result = parseRrdData(rrdWithNaN, 'pool-123')
+
+    const cpuMetric = result.metrics.find(m => m.legend.metricName === 'cpu_avg')
+    assert.equal(cpuMetric?.value, null) // NaN becomes null
+
+    const loadMetric = result.metrics.find(m => m.legend.metricName === 'loadavg')
+    assert.equal(loadMetric?.value, 0.5)
+  })
+
+  it('should skip invalid legend entries', () => {
+    const rrdWithInvalidLegend: RrdResponse = {
+      meta: {
+        start: 1700000000,
+        step: 60,
+        end: 1700003600,
+        rows: 2,
+        columns: 1,
+        legend: ['INVALID_FORMAT', 'AVERAGE:host:uuid:cpu_avg'],
+      },
+      data: [{ t: 1700003600, values: [0.5, 0.3] }],
+    }
+
+    const result = parseRrdData(rrdWithInvalidLegend, 'pool-123')
+
+    assert.equal(result.metrics.length, 1)
+    assert.equal(result.metrics[0].legend.metricName, 'cpu_avg')
+  })
+})
+
+// ============================================================================
+// parseRrdResponse Tests
+// ============================================================================
+
+describe('parseRrdResponse', () => {
+  it('should parse JSON text and extract metrics', () => {
+    const json = JSON.stringify({
+      meta: {
+        start: 1700000000,
+        step: 60,
+        end: 1700003600,
+        rows: 1,
+        columns: 1,
+        legend: ['AVERAGE:host:uuid:cpu_avg'],
+      },
+      data: [{ t: 1700003600, values: [0.75] }],
+    })
+
+    const result = parseRrdResponse(json, 'pool-456')
+
+    assert.equal(result.poolId, 'pool-456')
+    assert.equal(result.metrics.length, 1)
+    assert.equal(result.metrics[0].value, 0.75)
+  })
+})


### PR DESCRIPTION
### Description

Implement RRD parsing and OpenMetrics formatting for the xo-server-openmetrics plugin (XO-1666).

This PR completes the core functionality of the OpenMetrics plugin by:

1. **RRD Parser** (`rrd-parser.mts`): Parses XAPI RRD responses (JSON/JSON5) and extracts metrics with their metadata (type, UUID, metric name, timestamp, value).

2. **OpenMetrics Formatter** (`openmetric-formatter.mts`): Converts parsed RRD data to Prometheus/OpenMetrics format with proper metric naming, labels, and types:
   - Host metrics: CPU (average + per-core), memory, load average, network I/O, disk IOPS/latency/throughput
   - VM metrics: CPU usage, memory, network I/O (per VIF), disk I/O (per VBD)
   - All metrics include `pool_id`, `uuid`, and `type` labels

3. **Multi-host collection**: Fixed credential collection to iterate over ALL hosts in each pool, ensuring metrics are collected from every host and all running VMs.

4. **Static config support**: Added support for TOML configuration (`bindAddress`, `port`) with priority over UI config.

**Metrics exposed:**
- `xcp_pool_connected` - Pool connectivity status
- `xcp_host_cpu_average`, `xcp_host_cpu_core_usage` - Host CPU
- `xcp_host_memory_free_bytes`, `xcp_host_memory_total_bytes` - Host memory
- `xcp_host_load_average` - Host load
- `xcp_host_network_*_bytes_total` - Host network (per PIF)
- `xcp_host_disk_iops_*`, `xcp_host_disk_*_latency_seconds`, `xcp_host_disk_throughput_*_bytes` - Host storage (per SR)
- `xcp_vm_cpu_usage`, `xcp_vm_cpu_vcpu_usage` - VM CPU
- `xcp_vm_memory_bytes`, `xcp_vm_memory_internal_free_bytes` - VM memory
- `xcp_vm_network_*_bytes_total` - VM network (per VIF)
- `xcp_vm_disk_*_bytes_total` - VM disk (per VBD)

Fixes XO-1666

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue (`Fixes XO-1666`)
  - [ ] If bug fix, add `Introduced by`
- Changelog
  - [ ] If visible by XOA users, add changelog entry
  - [ ] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [ ] If UI changes, add screenshots
  - [ ] If not finished or not tested, open as _Draft_


### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
