### PR TITLE
fix(@xen-orchestra/rest-api): vmProtected -> vmProtection

### DIFF
--- a/@xen-orchestra/rest-api/src/vms/vm.service.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.service.mts
@@ -295,7 +295,7 @@ export class VmService {
     }
   }
 
-  async #getBackupsInfo(id: XoVm['id']): Promise<Pick<VmDashboard['backupsInfo'], 'vmProtected' | 'lastRuns'>> {
+  async #getBackupsInfo(id: XoVm['id']): Promise<Pick<VmDashboard['backupsInfo'], 'vmProtection' | 'lastRuns'>> {
     const vm = this.#restApi.getObject<XoVm>(id, 'VM')
 
     const allBackupJobs = await this.#restApi.xoApp.getAllJobs('backup')
@@ -339,21 +339,23 @@ export class VmService {
         }
       }) as { backupJobId: XoVmBackupJob['id']; timestamp: number; status: string }[]
 
-    let isProtected = false
+    let vmProtection: VmDashboard['backupsInfo']['vmProtection'] = 'not-in-job'
     if (!vmContainsNoBakTag(vm)) {
       const backupLogsByJob = groupBy(backupLogs, 'jobId')
 
       for (const backupJob of relevantJobsWithSchedule) {
-        if (isProtected) {
+        if (vmProtection === 'protected') {
           break
         }
+
+        vmProtection = 'unprotected'
         // can be undefined if the backup did run for now
         const jobLogs: XoBackupLog[] | undefined = backupLogsByJob[backupJob.id]
           ?.filter(log => log.status !== 'pending')
           .slice(-3)
 
         if (jobLogs !== undefined) {
-          isProtected = jobLogs.every(log => {
+          vmProtection = jobLogs.every(log => {
             if (log.status === 'success') {
               return true
             }
@@ -361,11 +363,13 @@ export class VmService {
             const vmTaskLog = this.#backupLogService.getVmBackupTaskLog(log, id)
             return vmTaskLog?.status === 'success'
           })
+            ? 'protected'
+            : 'unprotected'
         }
       }
     }
 
-    return { lastRuns: lastBackupRuns, vmProtected: isProtected }
+    return { lastRuns: lastBackupRuns, vmProtection }
   }
 
   async #getLastVmBackupArchives(id: XoVm['id']): Promise<VmDashboard['backupsInfo']['backupArchives']> {
@@ -382,7 +386,7 @@ export class VmService {
   }
 
   async getVmDashboard(id: XoVm['id'], { stream }: { stream?: Writable } = {}): Promise<VmDashboard> {
-    const [quickInfo, alarms, lastReplication, { lastRuns, vmProtected }, lastBackupArchives] = await Promise.all([
+    const [quickInfo, alarms, lastReplication, { lastRuns, vmProtection }, lastBackupArchives] = await Promise.all([
       promiseWriteInStream({ maybePromise: this.#getDashboardQuickInfo(id), path: 'quickInfo', stream }),
       promiseWriteInStream({ maybePromise: Object.keys(this.getVmAlarms(id)), path: 'alarms', stream }),
       promiseWriteInStream({ maybePromise: this.#getLastReplication(id), path: 'backupsInfo.replication', stream }),
@@ -399,7 +403,7 @@ export class VmService {
       alarms: alarms as XoAlarm['id'][],
       backupsInfo: {
         lastRuns,
-        vmProtected,
+        vmProtection,
         replication: lastReplication,
         backupArchives: lastBackupArchives,
       },

--- a/@xen-orchestra/rest-api/src/vms/vm.type.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.type.mts
@@ -43,7 +43,7 @@ export type VmDashboard = {
   alarms: XoAlarm['id'][]
   backupsInfo: {
     lastRuns: VmDashboardRun[]
-    vmProtected: boolean
+    vmProtection: 'protected' | 'unprotected' | 'not-in-job'
     replication?: { id: XoVm['id']; timestamp: number; sr?: XoSr['id'] }
     backupArchives: VmDashboardBackupArchive[]
   }
@@ -56,7 +56,7 @@ export type UnbrandedVmDashboard = {
   alarms: Unbrand<XoAlarm>['id'][]
   backupsInfo: {
     lastRuns: Unbrand<VmDashboardRun>[]
-    vmProtected: boolean
+    vmProtection: VmDashboard['backupsInfo']['vmProtection']
     replication?: Unbrand<VmDashboard['backupsInfo']['replication']>
     backupArchives: Unbrand<VmDashboardBackupArchive>[]
   }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,7 +19,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [VDIs] Fix broken fallback link to XO 5 VDIs page (PR [#9267](https://github.com/vatesfr/xen-orchestra/pull/9267))
-- [REST API/VM Dashboard] Return `vmProtection: 'protected' | 'unprotected' | 'not-in-job'` instead of `vmProtected: boolean`
+- [REST API/VM Dashboard] Return `vmProtection: 'protected' | 'unprotected' | 'not-in-job'` instead of `vmProtected: boolean` (PR [#9288](https://github.com/vatesfr/xen-orchestra/pull/9288))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [VDIs] Fix broken fallback link to XO 5 VDIs page (PR [#9267](https://github.com/vatesfr/xen-orchestra/pull/9267))
+- [REST API/VM Dashboard] Return `vmProtection: 'protected' | 'unprotected' | 'not-in-job'` instead of `vmProtected: boolean`
 
 ### Packages to release
 
@@ -36,6 +37,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/rest-api patch
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
 


### PR DESCRIPTION
### Description

Introduced by 6cfefc91e47db7fb264705bc2def1f1b70bc537b

XO6 needs more precise information and not just a boolean value

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
