### PR TITLE
fix(backups): cleanup .vhd.checksum files

### DIFF
--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -709,7 +709,7 @@ export class RemoteAdapter {
       })
     } else {
       const stream = await toVhdStream(disk)
-      await this.outputStream(path, stream, { validator })
+      await this.outputStream(path, stream, { validator, checksum: false })
       await validator(path)
     }
   }

--- a/@xen-orchestra/backups/_backupType.mjs
+++ b/@xen-orchestra/backups/_backupType.mjs
@@ -1,4 +1,5 @@
 export const isMetadataFile = filename => filename.endsWith('.json')
 export const isVhdFile = filename => filename.endsWith('.vhd')
+export const isVhdSumFile = filename => filename.endsWith('.vhd.checksum')
 export const isXvaFile = filename => filename.endsWith('.xva')
 export const isXvaSumFile = filename => filename.endsWith('.xva.checksum')

--- a/@xen-orchestra/backups/_cleanVm.mjs
+++ b/@xen-orchestra/backups/_cleanVm.mjs
@@ -87,13 +87,13 @@ const listVhds = async (handler, vmDir, logWarn) => {
         }),
         async vdiDir => {
           const list = await handler.list(vdiDir, {
-            filter: file => isVhdFile(file) || INTERRUPTED_VHDS_REG.test(file || isVhdSumFile(file)),
+            filter: file => isVhdFile(file) || INTERRUPTED_VHDS_REG.test(file) || isVhdSumFile(file),
           })
           aliases[vdiDir] = list.filter(vhd => isVhdAlias(vhd)).map(file => `${vdiDir}/${file}`)
 
           await asyncMap(list, async file => {
             if (isVhdSumFile(file)) {
-              checksums.add(file)
+              checksums.add(`${vdiDir}/${file}`)
               return
             }
             const res = INTERRUPTED_VHDS_REG.exec(file)

--- a/@xen-orchestra/backups/_cleanVm.mjs
+++ b/@xen-orchestra/backups/_cleanVm.mjs
@@ -236,8 +236,8 @@ export async function cleanVm(
 
   const { vhds, interruptedVhds, aliases, checksums } = await listVhds(handler, vmDir, logWarn)
 
-  // from 5.110 to 5.113 we cmputed checkseum for vhd file
-  // but never use nor remove them
+  // from 5.110 to 5.113 we computed checksum for vhd file
+  // but never used nor removed them
   await asyncMap(checksums, async path => {
     if (remove) {
       logInfo('deleting checksum file ', { path })

--- a/@xen-orchestra/backups/_cleanVm.mjs
+++ b/@xen-orchestra/backups/_cleanVm.mjs
@@ -4,7 +4,7 @@ import { asyncMap } from '@xen-orchestra/async-map'
 import { Constants, openVhd, VhdAbstract, VhdFile } from 'vhd-lib'
 import { isVhdAlias, resolveVhdAlias } from 'vhd-lib/aliases.js'
 import { basename, dirname, resolve } from 'node:path'
-import { isMetadataFile, isVhdFile, isXvaFile, isXvaSumFile } from './_backupType.mjs'
+import { isMetadataFile, isVhdFile, isVhdSumFile, isXvaFile, isXvaSumFile } from './_backupType.mjs'
 import { limitConcurrency } from 'limit-concurrency-decorator'
 import { mergeVhdChain } from 'vhd-lib/merge.js'
 
@@ -68,10 +68,12 @@ async function _mergeVhdChain(handler, chain, { logInfo, remove, mergeBlockConcu
 const noop = Function.prototype
 
 const INTERRUPTED_VHDS_REG = /^\.(.+)\.merge.json$/
+
 const listVhds = async (handler, vmDir, logWarn) => {
   const vhds = new Set()
   const aliases = {}
   const interruptedVhds = new Map()
+  const checksums = new Set()
 
   await asyncMap(
     await handler.list(`${vmDir}/vdis`, {
@@ -85,11 +87,15 @@ const listVhds = async (handler, vmDir, logWarn) => {
         }),
         async vdiDir => {
           const list = await handler.list(vdiDir, {
-            filter: file => isVhdFile(file) || INTERRUPTED_VHDS_REG.test(file),
+            filter: file => isVhdFile(file) || INTERRUPTED_VHDS_REG.test(file || isVhdSumFile(file)),
           })
           aliases[vdiDir] = list.filter(vhd => isVhdAlias(vhd)).map(file => `${vdiDir}/${file}`)
 
           await asyncMap(list, async file => {
+            if (isVhdSumFile(file)) {
+              checksums.add(file)
+              return
+            }
             const res = INTERRUPTED_VHDS_REG.exec(file)
             if (res === null) {
               vhds.add(`${vdiDir}/${file}`)
@@ -111,7 +117,7 @@ const listVhds = async (handler, vmDir, logWarn) => {
       )
   )
 
-  return { vhds, interruptedVhds, aliases }
+  return { vhds, interruptedVhds, aliases, checksums }
 }
 
 export async function checkAliases(
@@ -228,7 +234,16 @@ export async function cleanVm(
   const vhdParents = { __proto__: null }
   const vhdChildren = { __proto__: null }
 
-  const { vhds, interruptedVhds, aliases } = await listVhds(handler, vmDir, logWarn)
+  const { vhds, interruptedVhds, aliases, checksums } = await listVhds(handler, vmDir, logWarn)
+
+  // from 5.110 to 5.113 we cmputed checkseum for vhd file
+  // but never use nor remove them
+  await asyncMap(checksums, async path => {
+    if (remove) {
+      logInfo('deleting checksum file ', { path })
+      return handler.unlink(path)
+    }
+  })
 
   // remove broken VHDs
   await asyncMap(vhds, async path => {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [VDIs] Fix broken fallback link to XO 5 VDIs page (PR [#9267](https://github.com/vatesfr/xen-orchestra/pull/9267))
+- [Backup]clean up .vhd.checksum files (PR [#9291](https://github.com/vatesfr/xen-orchestra/pull/9291))
 
 ### Packages to release
 
@@ -36,6 +37,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
 


### PR DESCRIPTION
from 5.110 to 5.113 we cmputed checksum for vhd file
but never use nor remove them

Theses checksum are useless since they are broken
after any merge that changes the vhd

This PR cleanup the existing checksum , and stop creating
them

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
