### PR TITLE
fix(xo-server/v2v): more block alignment fixes

### DIFF
--- a/@xen-orchestra/disk-transform/src/DiskSmallerBlock.mts
+++ b/@xen-orchestra/disk-transform/src/DiskSmallerBlock.mts
@@ -17,7 +17,7 @@ export class DiskSmallerBlock extends DiskPassthrough {
     assert.strictEqual(
       source.getBlockSize() % blockSize,
       0,
-      `target block size ${blockSize} must be a multiple of the source block size ${source.getBlockSize()} `
+      `source block size ${blockSize} must be a multiple of the target block size ${source.getBlockSize()} `
     )
     this.#blockSize = blockSize
   }

--- a/@xen-orchestra/disk-transform/src/DiskSmallerBlock.test.mts
+++ b/@xen-orchestra/disk-transform/src/DiskSmallerBlock.test.mts
@@ -160,8 +160,8 @@ test('hasBlock behavior', async () => {
 
 test('getBlockIndexes', async () => {
   const source = new MockDisk(512, 2048, [
-    [0, Buffer.alloc(512)],
-    [2, Buffer.alloc(512)],
+    [0, Buffer.alloc(2048)],
+    [2, Buffer.alloc(2048)],
   ])
   await source.init()
 
@@ -184,17 +184,26 @@ test('close propagation', async () => {
 })
 
 test('unaligned END ', async () => {
-  const source = new MockDisk(512, 1024 + 256, [
-    [0, Buffer.alloc(512)],
-    [2, Buffer.alloc(256)],
+  const source = new MockDisk(1024, 2048 + 256, [
+    [0, Buffer.alloc(1024)],
+    [2, Buffer.alloc(1024)],
   ])
   await source.init()
 
   const disk = new DiskSmallerBlock(source, 256)
   await disk.init()
+  assert.strictEqual(source.getVirtualSize(), disk.getVirtualSize())
 
   const indexes = disk.getBlockIndexes()
-  assert.deepStrictEqual(indexes, [0, 1, 4])
-  assert.strictEqual(disk.hasBlock(4), true)
-  assert.strictEqual(disk.hasBlock(5), false)
+  const expecteBlockIndex = [0, 1, 2, 3, 8]
+  assert.deepStrictEqual(indexes, expecteBlockIndex)
+  assert.strictEqual(disk.hasBlock(8), true)
+  assert.strictEqual(disk.hasBlock(9), false) //After the end of small block disk
+  assert.strictEqual(disk.hasBlock(12), false) //After the end of source disk
+
+  // ensure disk blocks also handle the unaligned part
+  for await (const { index, data } of disk.diskBlocks()) {
+    assert.ok(expecteBlockIndex.includes(index))
+    assert.equal(data.length, 256)
+  }
 })

--- a/@xen-orchestra/disk-transform/src/DiskSmallerBlock.test.mts
+++ b/@xen-orchestra/disk-transform/src/DiskSmallerBlock.test.mts
@@ -182,3 +182,19 @@ test('close propagation', async () => {
   await disk.close()
   assert(source.closed)
 })
+
+test('unaligned END ', async () => {
+  const source = new MockDisk(512, 1024 + 256, [
+    [0, Buffer.alloc(512)],
+    [2, Buffer.alloc(256)],
+  ])
+  await source.init()
+
+  const disk = new DiskSmallerBlock(source, 256)
+  await disk.init()
+
+  const indexes = disk.getBlockIndexes()
+  assert.deepStrictEqual(indexes, [0, 1, 4])
+  assert.strictEqual(disk.hasBlock(4), true)
+  assert.strictEqual(disk.hasBlock(5), false)
+})

--- a/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.mts
+++ b/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.mts
@@ -241,7 +241,7 @@ export class QcowStreamGenerator {
   stream(): WithLength<Readable> {
     const disk = this.#disk
     const nbAllocatedBlocks = disk.getBlockIndexes().length
-    const nbTotalBlock = disk.getVirtualSize() / disk.getBlockSize()
+    const nbTotalBlock = Math.ceil(disk.getVirtualSize() / disk.getBlockSize())
 
     // Compute table sizes
     const { size: addressTableSize, nbL1Entries } = this.#computeAddressingSpace()
@@ -254,7 +254,7 @@ export class QcowStreamGenerator {
     header.writeBigUint64BE(0n, 8) // backing_file_offset (none)
     header.writeUInt32BE(0, 16) // backing_file_size (none)
     header.writeUInt32BE(Math.log2(CLUSTER_SIZE), 20) // cluster_bits
-    header.writeBigUInt64BE(BigInt(disk.getVirtualSize()), 24) // size
+    header.writeBigUInt64BE(BigInt(nbTotalBlock * disk.getBlockSize()), 24) //aligned size
     header.writeUInt32BE(0, 32) // crypt_method: none
     header.writeUInt32BE(nbL1Entries, 36) // l1_size
     header.writeBigUInt64BE(BigInt(header.length + refCountL1Size + refCountL2Size), 40) // l1_table_offset

--- a/@xen-orchestra/xapi/index.mjs
+++ b/@xen-orchestra/xapi/index.mjs
@@ -18,6 +18,8 @@ export const VDI_FORMAT_VHD = 'vhd'
 export const VDI_FORMAT_QCOW2 = 'qcow2'
 export const SUPPORTED_VDI_FORMAT = [VDI_FORMAT_RAW, VDI_FORMAT_VHD, VDI_FORMAT_QCOW2]
 export const VHD_MAX_SIZE = 2 * 1024 * 1024 * 1024 * 1024 /* 2TB */ - 8 * 1024 /* metadata */
+export const VHD_BLOCK_SIZE = 2 * 1024 * 1024
+export const QCOW2_CLUSTER_SIZE = 64 * 1024
 
 // Format a date (pseudo ISO 8601) from one XenServer get by
 // xapi.call('host.get_servertime', host.$ref) for example

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,5 +32,6 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+- xo-server patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
-- [V2V] Better handling of block alignment (PR [#9288](https://github.com/vatesfr/xen-orchestra/pull/9288))
+- [V2V] Better handling of block alignment (PR [#9293](https://github.com/vatesfr/xen-orchestra/pull/9293))
 
 ### Packages to release
 
@@ -32,6 +32,10 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- @xen-orchestra/disk-transform patch
+- @xen-orchestra/qcow2 patch
+- @xen-orchestra/xapi patch
 - xo-server patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [V2V] Better handling of block alignment (PR [#9288](https://github.com/vatesfr/xen-orchestra/pull/9288))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/packages/xo-server/src/xo-mixins/vmware/importDisksfromDatastore.mjs
+++ b/packages/xo-server/src/xo-mixins/vmware/importDisksfromDatastore.mjs
@@ -58,7 +58,7 @@ async function importDiskChain({ esxi, sr, vm, chainByNode, userdevice, vmId }) 
   try {
     // we read the data from the full chain to ensure we don't have partial blocks ( blocks with 0 when clusters are in parent only)
     const { nbdInfos } = await esxi.spanwNbdKitProcess(vmId, `[${datastoreName}] ${diskPath}`)
-    vmdk = new NbdDisk(nbdInfos, blockSize, { dataMap })
+    vmdk = new NbdDisk(nbdInfos, 2 * 1024 * 1024, { dataMap })
 
     await vmdk.init()
     vmdk = new ReadAhead(vmdk)


### PR DESCRIPTION
from #45336


review by commit 
* this lower memory consumption and ensure we don't have to do block conversion
* fixing an error message
* the root cause, an alignement at the end of the file, when producing blocks smaller than source ( from vhd to qcow2 for example )
### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
