### PR TITLE
fix(openmetrics): add secrets

### DIFF
--- a/packages/xo-server-openmetrics/package.json
+++ b/packages/xo-server-openmetrics/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist/",
-    "dev": "yarn run clean && yarn run build",
+    "dev": "yarn run clean && tsc --watch",
     "prebuild": "yarn run clean",
     "prepublishOnly": "yarn run build",
     "test": "cd dist && node --test"


### PR DESCRIPTION
/metrics endpoint cost a lot of resource. To ensure a minimal level of security, this PR add a berear authentication mode, with a shared secret between XO and prometheus

The secret can be set in the plugin UI and in the configuration of prometheus

Also :
* average instead of last
* add start
* asynceach can fail and it's ok


Config on prometheus should be :

```
scrape_configs:
  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
  - job_name: 'xapi-xo'

    # Override the global default and scrape targets from this job every 5 seconds.
    scrape_interval: 60s
    scrape_timeout: 10s

    # metrics_path defaults to '/metrics'
    # scheme defaults to 'http'.

    static_configs:
      - targets: ['XO_URL:XO_PORT']

    authorization:
      type: Bearer
      credentials: 'SECRET_IN_PLUGIN'
```

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
