### PR TITLE
fix(xo-server): check certificate instead port to define secure protocol

### DIFF
--- a/packages/xo-server/src/index.mjs
+++ b/packages/xo-server/src/index.mjs
@@ -551,10 +551,10 @@ const setUpProxies = (express, opts, xo) => {
   }
 
   const userHttpConfig = xo.config.get('http.listen.0')
-  const userPort = userHttpConfig.port
+  const isSecure = userHttpConfig.key !== undefined
 
   const dynamicProxyOptions = {}
-  if (userPort === 443) {
+  if (isSecure) {
     const cert = userHttpConfig.cert ?? userHttpConfig.certificate
     const key = userHttpConfig.key
     dynamicProxyOptions.ssl = {
@@ -597,14 +597,14 @@ const setUpProxies = (express, opts, xo) => {
     let target = url
 
     if (target.includes('[port]')) {
-      target = target.replace(/\[port\]/g, userPort)
+      target = target.replace(/\[port\]/g, userHttpConfig.port)
     }
     if (target.includes('[protocol]')) {
       target = target.replace(/\[protocol\]/g, protocol)
     }
 
     const targetUrl = new URL(target)
-    if (targetUrl.port === '443') {
+    if (isSecure) {
       targetUrl.protocol = targetUrl.protocol === 'ws:' ? 'wss:' : 'https:'
     }
 


### PR DESCRIPTION
### Description

introduced by 7c1764a39eadf2796d5b0e08fda28aa385d21f0c
fix [forum#11681](https://xcp-ng.org/forum/topic/11681/xo5-breaks-after-defaulting-to-xo6-from-source/32?_=1765897419550)
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
