### PR TITLE
feat(open-metrics): compute vm_cpu_usage from per-core metrics

### DIFF
--- a/packages/xo-server-openmetrics/src/openmetric-formatter.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.mts
@@ -470,12 +470,8 @@ function computeVmCpuUsageFallback(metrics: FormattedMetric[]): FormattedMetric[
   const vmCoreMetrics = new Map<string, Map<number, Map<string, { value: number; metric: FormattedMetric }>>>()
 
   for (const metric of metrics) {
-    if (metric.labels.type !== 'vm') {
-      continue
-    }
-
     const vmUuid = metric.labels.uuid
-    if (vmUuid === undefined) {
+    if (metric.labels.type !== 'vm' || vmUuid === undefined) {
       continue
     }
 

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.mts
@@ -449,6 +449,115 @@ export function findMetricDefinition(
 }
 
 // ============================================================================
+// CPU Usage Fallback
+// ============================================================================
+
+/**
+ * Compute vm_cpu_usage from per-core metrics when cpu_usage is not available.
+ *
+ * Some VMs (particularly on XCP-ng 8.2) don't report a single cpu_usage metric,
+ * but they do report individual per-core CPU metrics (cpu0, cpu1, cpu2, etc.).
+ * This function creates synthetic vm_cpu_usage metrics by averaging the per-core values.
+ *
+ * @param metrics - Array of formatted metrics
+ * @returns Array of synthetic vm_cpu_usage metrics for VMs missing the native metric
+ */
+function computeVmCpuUsageFallback(metrics: FormattedMetric[]): FormattedMetric[] {
+  // Track VMs that have vm_cpu_usage
+  const vmsWithCpuUsage = new Set<string>()
+
+  // Track per-core metrics by VM UUID: { uuid -> { timestamp -> { core -> value } } }
+  const vmCoreMetrics = new Map<string, Map<number, Map<string, { value: number; metric: FormattedMetric }>>>()
+
+  for (const metric of metrics) {
+    if (metric.labels.type !== 'vm') {
+      continue
+    }
+
+    const vmUuid = metric.labels.uuid
+    if (vmUuid === undefined) {
+      continue
+    }
+
+    if (metric.name === 'xcp_vm_cpu_usage') {
+      vmsWithCpuUsage.add(vmUuid)
+    } else if (metric.name === 'xcp_vm_cpu_core_usage' && metric.labels.core !== undefined) {
+      // Store per-core metrics grouped by VM and timestamp
+      let vmTimestamps = vmCoreMetrics.get(vmUuid)
+      if (vmTimestamps === undefined) {
+        vmTimestamps = new Map()
+        vmCoreMetrics.set(vmUuid, vmTimestamps)
+      }
+
+      let coreValues = vmTimestamps.get(metric.timestampMs)
+      if (coreValues === undefined) {
+        coreValues = new Map()
+        vmTimestamps.set(metric.timestampMs, coreValues)
+      }
+
+      coreValues.set(metric.labels.core, { value: metric.value, metric })
+    }
+  }
+
+  // Generate synthetic vm_cpu_usage for VMs that don't have the native metric
+  const syntheticMetrics: FormattedMetric[] = []
+
+  for (const [vmUuid, timestamps] of vmCoreMetrics) {
+    // Skip VMs that already have cpu_usage
+    if (vmsWithCpuUsage.has(vmUuid)) {
+      continue
+    }
+
+    // For each timestamp, compute average of all cores
+    for (const [timestampMs, coreValues] of timestamps) {
+      if (coreValues.size === 0) {
+        continue
+      }
+
+      // Calculate average CPU usage across all cores
+      let sum = 0
+      for (const { value } of coreValues.values()) {
+        sum += value
+      }
+      const averageUsage = sum / coreValues.size
+
+      // Get a sample metric to copy labels from (without core label)
+      const sampleEntry = coreValues.values().next().value
+      if (sampleEntry === undefined) {
+        continue
+      }
+      const sampleMetric = sampleEntry.metric
+
+      // Create synthetic metric with same labels (excluding core)
+      const labels: Record<string, string> = {}
+      for (const [key, value] of Object.entries(sampleMetric.labels)) {
+        if (key !== 'core') {
+          labels[key] = value
+        }
+      }
+
+      syntheticMetrics.push({
+        name: 'xcp_vm_cpu_usage',
+        help: 'VM CPU usage ratio (computed from per-core average)',
+        type: 'gauge',
+        labels,
+        value: averageUsage,
+        timestampMs,
+      })
+    }
+  }
+
+  if (syntheticMetrics.length > 0) {
+    logger.debug('Generated synthetic vm_cpu_usage metrics', {
+      count: syntheticMetrics.length,
+      vms: [...new Set(syntheticMetrics.map(m => m.labels.uuid))],
+    })
+  }
+
+  return syntheticMetrics
+}
+
+// ============================================================================
 // Formatting Functions
 // ============================================================================
 
@@ -684,6 +793,11 @@ export function formatAllPoolsToOpenMetrics(rrdDataList: ParsedRrdData[], labelC
   if (unmatchedMetrics.size > 0) {
     logger.debug('Unmatched RRD metrics', { metrics: Array.from(unmatchedMetrics).sort() })
   }
+
+  // Compute fallback vm_cpu_usage for VMs that don't have the native metric
+  // This handles XCP-ng 8.2 and other versions that only report per-core metrics
+  const syntheticCpuMetrics = computeVmCpuUsageFallback(allMetrics)
+  allMetrics.push(...syntheticCpuMetrics)
 
   // Sort metrics by name for consistent output
   allMetrics.sort((a, b) => {

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
@@ -833,3 +833,246 @@ describe('formatAllPoolsToOpenMetrics with labelContext', () => {
     assert.ok(result.includes('vm_name="Web Server"'))
   })
 })
+
+// ============================================================================
+// CPU Usage Fallback Tests
+// ============================================================================
+
+describe('CPU usage fallback', () => {
+  it('should not generate fallback when vm_cpu_usage is present', () => {
+    const rrdDataList: ParsedRrdData[] = [
+      {
+        poolId: 'pool-1',
+        timestamp: 1700000000,
+        metrics: [
+          {
+            legend: {
+              cf: 'AVERAGE',
+              objectType: 'vm',
+              uuid: 'vm-1',
+              metricName: 'cpu_usage',
+              rawLegend: 'AVERAGE:vm:vm-1:cpu_usage',
+            },
+            value: 0.5,
+            timestamp: 1700000000,
+          },
+          {
+            legend: {
+              cf: 'AVERAGE',
+              objectType: 'vm',
+              uuid: 'vm-1',
+              metricName: 'cpu0',
+              rawLegend: 'AVERAGE:vm:vm-1:cpu0',
+            },
+            value: 0.6,
+            timestamp: 1700000000,
+          },
+          {
+            legend: {
+              cf: 'AVERAGE',
+              objectType: 'vm',
+              uuid: 'vm-1',
+              metricName: 'cpu1',
+              rawLegend: 'AVERAGE:vm:vm-1:cpu1',
+            },
+            value: 0.4,
+            timestamp: 1700000000,
+          },
+        ],
+      },
+    ]
+
+    const result = formatAllPoolsToOpenMetrics(rrdDataList)
+    const lines = result.split('\n')
+
+    // Should have exactly one vm_cpu_usage metric (the native one, not synthetic)
+    const cpuUsageLines = lines.filter(l => l.includes('xcp_vm_cpu_usage{'))
+    assert.equal(cpuUsageLines.length, 1)
+    assert.ok(cpuUsageLines[0]?.includes('0.5'))
+  })
+
+  it('should generate fallback vm_cpu_usage from per-core metrics', () => {
+    const rrdDataList: ParsedRrdData[] = [
+      {
+        poolId: 'pool-1',
+        timestamp: 1700000000,
+        metrics: [
+          {
+            legend: {
+              cf: 'AVERAGE',
+              objectType: 'vm',
+              uuid: 'vm-1',
+              metricName: 'cpu0',
+              rawLegend: 'AVERAGE:vm:vm-1:cpu0',
+            },
+            value: 0.6,
+            timestamp: 1700000000,
+          },
+          {
+            legend: {
+              cf: 'AVERAGE',
+              objectType: 'vm',
+              uuid: 'vm-1',
+              metricName: 'cpu1',
+              rawLegend: 'AVERAGE:vm:vm-1:cpu1',
+            },
+            value: 0.4,
+            timestamp: 1700000000,
+          },
+        ],
+      },
+    ]
+
+    const result = formatAllPoolsToOpenMetrics(rrdDataList)
+
+    // Should have vm_cpu_usage metric generated from average of cores
+    assert.ok(result.includes('xcp_vm_cpu_usage'))
+
+    const lines = result.split('\n')
+    const cpuUsageLine = lines.find(l => l.includes('xcp_vm_cpu_usage{'))
+    assert.ok(cpuUsageLine)
+    // Average of 0.6 and 0.4 = 0.5
+    assert.ok(cpuUsageLine.includes('0.5'))
+  })
+
+  it('should generate fallback for multiple VMs', () => {
+    const rrdDataList: ParsedRrdData[] = [
+      {
+        poolId: 'pool-1',
+        timestamp: 1700000000,
+        metrics: [
+          // VM 1: only per-core metrics
+          {
+            legend: {
+              cf: 'AVERAGE',
+              objectType: 'vm',
+              uuid: 'vm-1',
+              metricName: 'cpu0',
+              rawLegend: 'AVERAGE:vm:vm-1:cpu0',
+            },
+            value: 0.8,
+            timestamp: 1700000000,
+          },
+          {
+            legend: {
+              cf: 'AVERAGE',
+              objectType: 'vm',
+              uuid: 'vm-1',
+              metricName: 'cpu1',
+              rawLegend: 'AVERAGE:vm:vm-1:cpu1',
+            },
+            value: 0.2,
+            timestamp: 1700000000,
+          },
+          // VM 2: has native cpu_usage (should not get fallback)
+          {
+            legend: {
+              cf: 'AVERAGE',
+              objectType: 'vm',
+              uuid: 'vm-2',
+              metricName: 'cpu_usage',
+              rawLegend: 'AVERAGE:vm:vm-2:cpu_usage',
+            },
+            value: 0.3,
+            timestamp: 1700000000,
+          },
+          // VM 3: only per-core metrics
+          {
+            legend: {
+              cf: 'AVERAGE',
+              objectType: 'vm',
+              uuid: 'vm-3',
+              metricName: 'cpu0',
+              rawLegend: 'AVERAGE:vm:vm-3:cpu0',
+            },
+            value: 0.9,
+            timestamp: 1700000000,
+          },
+        ],
+      },
+    ]
+
+    const result = formatAllPoolsToOpenMetrics(rrdDataList)
+    const lines = result.split('\n')
+
+    // VM 1 should have synthetic cpu_usage (average of 0.8 and 0.2 = 0.5)
+    const vm1CpuUsage = lines.find(l => l.includes('xcp_vm_cpu_usage') && l.includes('uuid="vm-1"'))
+    assert.ok(vm1CpuUsage)
+    assert.ok(vm1CpuUsage.includes('0.5'))
+
+    // VM 2 should have its native cpu_usage (0.3)
+    const vm2CpuUsage = lines.find(l => l.includes('xcp_vm_cpu_usage') && l.includes('uuid="vm-2"'))
+    assert.ok(vm2CpuUsage)
+    assert.ok(vm2CpuUsage.includes('0.3'))
+
+    // VM 3 should have synthetic cpu_usage (0.9 single core)
+    const vm3CpuUsage = lines.find(l => l.includes('xcp_vm_cpu_usage') && l.includes('uuid="vm-3"'))
+    assert.ok(vm3CpuUsage)
+    assert.ok(vm3CpuUsage.includes('0.9'))
+  })
+
+  it('should preserve labels in fallback metric', () => {
+    const labelContext: LabelContext = {
+      hosts: [
+        {
+          hostId: 'host-1',
+          hostAddress: '192.168.1.1',
+          hostLabel: 'Host 1',
+          poolId: 'pool-1',
+          poolLabel: 'Production',
+          sessionId: 'session-1',
+          protocol: 'https:',
+        },
+      ],
+      labels: {
+        vms: {
+          'vm-1': {
+            name_label: 'XCP-ng 8.2 VM',
+            vbdDeviceToVdiName: {},
+            vifIndexToNetworkName: {},
+          },
+        },
+        hosts: {},
+        srs: {},
+        srSuffixToUuid: {},
+      },
+    }
+
+    const rrdDataList: ParsedRrdData[] = [
+      {
+        poolId: 'pool-1',
+        timestamp: 1700000000,
+        metrics: [
+          {
+            legend: {
+              cf: 'AVERAGE',
+              objectType: 'vm',
+              uuid: 'vm-1',
+              metricName: 'cpu0',
+              rawLegend: 'AVERAGE:vm:vm-1:cpu0',
+            },
+            value: 0.75,
+            timestamp: 1700000000,
+          },
+        ],
+      },
+    ]
+
+    const result = formatAllPoolsToOpenMetrics(rrdDataList, labelContext)
+
+    // Fallback metric should have all the labels (pool_id, uuid, type, vm_name, pool_name)
+    // but NOT the core label
+    assert.ok(result.includes('xcp_vm_cpu_usage'))
+    assert.ok(result.includes('pool_id="pool-1"'))
+    assert.ok(result.includes('uuid="vm-1"'))
+    assert.ok(result.includes('type="vm"'))
+    assert.ok(result.includes('vm_name="XCP-ng 8.2 VM"'))
+    assert.ok(result.includes('pool_name="Production"'))
+
+    // Should NOT have core label in the fallback metric
+    const lines = result.split('\n')
+    const cpuUsageLine = lines.find(l => l.includes('xcp_vm_cpu_usage{'))
+    assert.ok(cpuUsageLine)
+    assert.ok(!cpuUsageLine.includes('core='))
+  })
+})


### PR DESCRIPTION
### Description

Some VMs (particularly on XCP-ng 8.2) don't report a single `cpu_usage` metric but do report individual per-core CPU metrics (`cpu0`, `cpu1`, etc.).

This PR adds fallback logic to compute `vm_cpu_usage` by averaging per-core values when the native metric is unavailable.

This is similar to what is already done in `xo-server-perf-alert` (see `RrdHostVm.js:238-250`).

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
