### PR TITLE
feat(xo-lite): scroll to selected item in treeview

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## **next**
 
 - [VM/New] Fix wording in "Memory" section (PR [#9309](https://github.com/vatesfr/xen-orchestra/pull/9309))
-- [TreeView] Scroll to current item in list view (PR [#9294](https://github.com/vatesfr/xen-orchestra/pull/9294))
+- [TreeView] Scroll to current item in list view (PR [#9332](https://github.com/vatesfr/xen-orchestra/pull/9332))
 
 ## **0.17.0** (2025-11-27)
 

--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## **next**
 
 - [VM/New] Fix wording in "Memory" section (PR [#9309](https://github.com/vatesfr/xen-orchestra/pull/9309))
+- [TreeView] Scroll to current item in list view (PR [#9294](https://github.com/vatesfr/xen-orchestra/pull/9294))
 
 ## **0.17.0** (2025-11-27)
 

--- a/@xen-orchestra/lite/src/components/AppNavigation.vue
+++ b/@xen-orchestra/lite/src/components/AppNavigation.vue
@@ -67,10 +67,18 @@ const scrollToCurrent = async () => {
 
   const container = navElement.value as HTMLElement | undefined
   const target = container?.querySelector<HTMLElement>(`[data-node-id="${CSS.escape(id)}"]`)
+  const hasChildren = !id.startsWith('vm:')
 
   if (target) {
     useTimeoutFn(async () => {
-      target.scrollIntoView({ block: !id.startsWith('vm:') ? 'start' : 'center', behavior: 'smooth' })
+      if (hasChildren) {
+        target.style.scrollMarginTop = '0.8rem'
+
+        useTimeoutFn(async () => {
+          target.style.scrollMarginTop = ''
+        }, 1000)
+      }
+      target.scrollIntoView({ block: hasChildren ? 'start' : 'center', behavior: 'smooth' })
     }, 200)
   } else {
     useTimeoutFn(async () => {

--- a/@xen-orchestra/lite/src/components/infra/InfraHostItem.vue
+++ b/@xen-orchestra/lite/src/components/infra/InfraHostItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsTreeItem v-if="host !== undefined" :expanded="isExpanded" class="infra-host-item">
+  <VtsTreeItem v-if="host !== undefined" :expanded="isExpanded" class="infra-host-item" :node-id="`host:${host.uuid}`">
     <UiTreeItemLabel :route="{ name: '/host/[uuid]', params: { uuid: host.uuid } }" icon="fa:server" @toggle="toggle()">
       {{ host.name_label || '(Host)' }}
       <template #addons>

--- a/@xen-orchestra/lite/src/components/infra/InfraPoolList.vue
+++ b/@xen-orchestra/lite/src/components/infra/InfraPoolList.vue
@@ -1,6 +1,6 @@
 <template>
   <VtsTreeList class="infra-pool-list">
-    <VtsTreeItem :expanded="isExpanded">
+    <VtsTreeItem :expanded="isExpanded" :node-id="`pool:${pool?.uuid}`">
       <VtsTreeItemError v-if="hasError">
         {{ t('error-no-data') }}
       </VtsTreeItemError>

--- a/@xen-orchestra/lite/src/components/infra/InfraVmItem.vue
+++ b/@xen-orchestra/lite/src/components/infra/InfraVmItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsTreeItem v-if="vm !== undefined" ref="rootElement" expanded class="infra-vm-item">
+  <VtsTreeItem v-if="vm !== undefined" ref="rootElement" expanded class="infra-vm-item" :node-id="`vm:${vm.uuid}`">
     <UiTreeItemLabel v-if="isVisible" :route="{ name: '/vm/[uuid]', params: { uuid: vm.uuid } }" no-indent>
       {{ vm.name_label || '(VM)' }}
       <template #icon>

--- a/@xen-orchestra/web-core/lib/components/tree/VtsTreeItem.vue
+++ b/@xen-orchestra/web-core/lib/components/tree/VtsTreeItem.vue
@@ -1,17 +1,19 @@
 <template>
-  <div class="vts-tree-item" @click="handleClick()">
+  <div class="vts-tree-item" :data-node-id="nodeId" @click="handleClick()">
     <slot />
     <slot v-if="expanded" name="sublist" />
   </div>
 </template>
 
 <script lang="ts" setup>
+import type { TreeNodeId } from '@core/packages/tree/types.ts'
 import { useSidebarStore } from '@core/stores/sidebar.store'
 import { useUiStore } from '@core/stores/ui.store'
 import { IK_TREE_ITEM_EXPANDED, IK_TREE_ITEM_HAS_CHILDREN } from '@core/utils/injection-keys.util'
 import { onBeforeMount, onBeforeUpdate, provide, ref, toRef, useSlots } from 'vue'
 
 const props = defineProps<{
+  nodeId?: TreeNodeId
   expanded?: boolean
 }>()
 


### PR DESCRIPTION
### Description

When navigating to a specific item in the lateral treeview, it now automatically scrolls to the selected item, centered into view, or to the top of the view if the item has child items to display.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
