### PR TITLE
fix(xo-server-openmetrics): hardcode port and bind address for security

### DIFF
--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -173,6 +173,7 @@ requestTimeout = 0
 '/v5/api' = '[protocol]//localhost:[port]/api'
 '/v5/api/updater' = 'ws://localhost:9001'
 '/v5/rest' = 'http://localhost:[port]/rest'
+'/openmetrics' = 'http://localhost:9004'
 
 [logs]
 # Display all logs matching this filter, regardless of their level


### PR DESCRIPTION
### Description

  The OpenMetrics server now runs behind xo-server's proxy (`/openmetrics`), so exposing `port` and `bindAddress` as configurable options is unnecessary and poses a security risk.                                                           
                                                                                                                                                                                                                                              
  **Changes:**                                                                                                                                                                                                                                
  - Remove `port` and `bindAddress` from configuration schema (only `secret` remains configurable)                                                                                                                                            
  - Hardcode port to `9004` and bind address to `127.0.0.1`                                                                                                                                                                                                                                                                                                                                        
  - Clean up unused `staticConfig` handling 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
