### PR TITLE
fix(xo-stack): fix VM creation on small screen

### DIFF
--- a/@xen-orchestra/lite/src/pages/vm/new.vue
+++ b/@xen-orchestra/lite/src/pages/vm/new.vue
@@ -13,7 +13,7 @@
               <VtsSelect :id="templateSelectId" accent="brand" />
             </VtsInputWrapper>
           </div>
-          <div v-if="vmState.new_vm_template" class="form-container">
+          <div v-if="vmState.new_vm_template" class="form-container" :class="{ mobile: uiStore.isMobile }">
             <!-- INSTALL SETTINGS SECTION -->
             <UiTitle>{{ t('install-settings') }}</UiTitle>
             <div>
@@ -121,7 +121,7 @@
             <NewVmSrTable :srs :vm-state @add="addStorageEntry()" @remove="index => deleteItem(vmState.vdis, index)" />
             <!-- SETTINGS SECTION -->
             <UiTitle>{{ t('settings') }}</UiTitle>
-            <UiCheckboxGroup accent="brand">
+            <UiCheckboxGroup accent="brand" :vertical="uiStore.isMobile">
               <UiCheckbox v-model="vmState.boot_vm" accent="brand">{{ t('action:boot-vm') }}</UiCheckbox>
               <UiCheckbox v-model="vmState.auto_power" accent="brand">{{ t('auto-power') }}</UiCheckbox>
               <UiCheckbox v-if="isDiskTemplate" v-model="vmState.fast_clone" accent="brand">
@@ -204,6 +204,7 @@ import UiTitle from '@core/components/ui/title/UiTitle.vue'
 import UiToaster from '@core/components/ui/toaster/UiToaster.vue'
 import { vTooltip } from '@core/directives/tooltip.directive.ts'
 import { useFormSelect } from '@core/packages/form-select'
+import { useUiStore } from '@core/stores/ui.store'
 
 // Vue imports
 import { type DOMAIN_TYPE, OPAQUE_REF, VBD_TYPE } from '@vates/types'
@@ -223,6 +224,7 @@ const { getByOpaqueRef: getVbdByOpaqueRef } = useVbdStore().subscribe()
 const { getByOpaqueRef: getVdiByOpaqueRef } = useVdiStore().subscribe()
 const { getByOpaqueRef: getVifByOpaqueRef } = useVifStore().subscribe()
 const { getByOpaqueRef: getPifByOpaqueRef } = usePifStore().subscribe()
+const uiStore = useUiStore()
 
 // i18n setup
 const { t } = useI18n()
@@ -914,6 +916,21 @@ watch(
       display: flex;
       flex-direction: column;
       gap: 1rem;
+    }
+
+    &.mobile .system-container,
+    &.mobile .memory-container {
+      flex-direction: column;
+      gap: 2.3rem;
+    }
+
+    &.mobile .install-settings-container .radio-container {
+      flex-direction: column;
+      gap: 0.8rem;
+    }
+
+    &.mobile .system-container .column {
+      width: 100%;
     }
 
     .system-container {

--- a/@xen-orchestra/lite/src/pages/vm/new.vue
+++ b/@xen-orchestra/lite/src/pages/vm/new.vue
@@ -949,10 +949,6 @@ watch(
     .memory-container {
       display: flex;
       gap: 10.8rem;
-
-      .topology {
-        width: 32rem;
-      }
     }
 
     thead tr th:last-child {

--- a/@xen-orchestra/lite/src/pages/vm/new.vue
+++ b/@xen-orchestra/lite/src/pages/vm/new.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="new-vm-view">
+  <div class="new-vm-view" :class="{ mobile: uiStore.isMobile }">
     <UiHeadBar icon="fa:plus">
       {{ t('new-vm:add') }}
     </UiHeadBar>
@@ -13,30 +13,30 @@
               <VtsSelect :id="templateSelectId" accent="brand" />
             </VtsInputWrapper>
           </div>
-          <div v-if="vmState.new_vm_template" class="form-container" :class="{ mobile: uiStore.isMobile }">
+          <div v-if="vmState.new_vm_template" class="form-container">
             <!-- INSTALL SETTINGS SECTION -->
             <UiTitle>{{ t('install-settings') }}</UiTitle>
             <div>
               <div v-if="isDiskTemplate" class="install-settings-container">
-                <div class="radio-container">
+                <UiRadioButtonGroup accent="brand" :vertical="uiStore.isMobile">
                   <UiRadioButton v-model="vmState.installMode" accent="brand" value="noConfigDrive">
                     {{ t('no-config') }}
                   </UiRadioButton>
                   <UiRadioButton v-model="vmState.installMode" accent="brand" value="ISO">
                     {{ t('iso-dvd') }}
                   </UiRadioButton>
-                </div>
+                </UiRadioButtonGroup>
                 <VtsSelect v-if="vmState.installMode === 'ISO'" :id="vdiIsoSelectId" accent="brand" />
               </div>
               <div v-else class="install-settings-container">
-                <div class="radio-container">
+                <UiRadioButtonGroup accent="brand" :vertical="uiStore.isMobile">
                   <UiRadioButton v-model="vmState.installMode" accent="brand" value="ISO">
                     {{ t('iso-dvd') }}
                   </UiRadioButton>
                   <UiRadioButton v-model="vmState.installMode" accent="brand" value="PXE">
                     {{ t('pxe') }}
                   </UiRadioButton>
-                </div>
+                </UiRadioButtonGroup>
                 <VtsSelect v-if="vmState.installMode === 'ISO'" :id="vdiIsoSelectId" accent="brand" />
               </div>
             </div>
@@ -92,7 +92,7 @@
             </div>
             <!-- RESOURCE MANAGEMENT SECTION -->
             <UiTitle>{{ t('resource-management') }}</UiTitle>
-            <div class="memory-container">
+            <div class="resource-management-container">
               <VtsInputWrapper :label="t('vcpus')">
                 <UiInput v-model.number="vmState.vCPU" type="number" accent="brand" />
               </VtsInputWrapper>
@@ -199,6 +199,7 @@ import UiChip from '@core/components/ui/chip/UiChip.vue'
 import UiHeadBar from '@core/components/ui/head-bar/UiHeadBar.vue'
 import UiInput from '@core/components/ui/input/UiInput.vue'
 import UiRadioButton from '@core/components/ui/radio-button/UiRadioButton.vue'
+import UiRadioButtonGroup from '@core/components/ui/radio-button-group/UiRadioButtonGroup.vue'
 import UiTextarea from '@core/components/ui/text-area/UiTextarea.vue'
 import UiTitle from '@core/components/ui/title/UiTitle.vue'
 import UiToaster from '@core/components/ui/toaster/UiToaster.vue'
@@ -903,8 +904,25 @@ watch(
 
 <style lang="postcss" scoped>
 .new-vm-view {
+  &.mobile {
+    .form-container .system-container .column {
+      width: 100%;
+    }
+
+    .form-container .system-container,
+    .resource-management-container,
+    .install-settings-container {
+      flex-direction: column;
+    }
+
+    .form-container .system-container,
+    .form-container .resource-management-container {
+      gap: 2.4rem;
+    }
+  }
+
   .card-container {
-    margin: 1rem;
+    margin: 0.8rem;
   }
 
   .form-container {
@@ -915,39 +933,24 @@ watch(
     .template-container {
       display: flex;
       flex-direction: column;
-      gap: 1rem;
-    }
-
-    &.mobile .system-container,
-    &.mobile .memory-container {
-      flex-direction: column;
-      gap: 2.3rem;
-    }
-
-    &.mobile .install-settings-container .radio-container {
-      flex-direction: column;
-      gap: 0.8rem;
-    }
-
-    &.mobile .system-container .column {
-      width: 100%;
+      gap: 0.4rem;
     }
 
     .system-container {
       display: flex;
-      gap: 10.8rem;
+      gap: 8rem;
 
       .column {
         display: flex;
         flex-direction: column;
-        gap: 2.5rem;
+        gap: 2.4rem;
         width: 40%;
       }
 
       .chips {
         display: flex;
         flex-wrap: wrap;
-        gap: 0.5rem;
+        gap: 0.4rem;
         margin-block-end: 1rem;
       }
     }
@@ -956,16 +959,11 @@ watch(
       display: flex;
       flex-direction: column;
       gap: 2.4rem;
-
-      .radio-container {
-        display: flex;
-        gap: 15rem;
-      }
     }
 
-    .memory-container {
+    .resource-management-container {
       display: flex;
-      gap: 10.8rem;
+      gap: 8rem;
     }
 
     thead tr th:last-child {
@@ -977,7 +975,7 @@ watch(
     margin-top: auto;
     display: flex;
     justify-content: center;
-    gap: 1.6rem;
+    gap: 2.4rem;
   }
 }
 </style>

--- a/@xen-orchestra/lite/src/pages/vm/new.vue
+++ b/@xen-orchestra/lite/src/pages/vm/new.vue
@@ -904,23 +904,6 @@ watch(
 
 <style lang="postcss" scoped>
 .new-vm-view {
-  &.mobile {
-    .form-container .system-container .column {
-      width: 100%;
-    }
-
-    .form-container .system-container,
-    .resource-management-container,
-    .install-settings-container {
-      flex-direction: column;
-    }
-
-    .form-container .system-container,
-    .form-container .resource-management-container {
-      gap: 2.4rem;
-    }
-  }
-
   .card-container {
     margin: 0.8rem;
   }
@@ -976,6 +959,22 @@ watch(
     display: flex;
     justify-content: center;
     gap: 2.4rem;
+  }
+
+  &.mobile {
+    .system-container .column {
+      width: 100%;
+    }
+
+    .system-container,
+    .resource-management-container {
+      flex-direction: column;
+    }
+
+    .system-container,
+    .resource-management-container {
+      gap: 2.4rem;
+    }
   }
 }
 </style>

--- a/@xen-orchestra/lite/src/pages/vm/new.vue
+++ b/@xen-orchestra/lite/src/pages/vm/new.vue
@@ -969,10 +969,6 @@ watch(
     .system-container,
     .resource-management-container {
       flex-direction: column;
-    }
-
-    .system-container,
-    .resource-management-container {
       gap: 2.4rem;
     }
   }

--- a/@xen-orchestra/web-core/lib/components/input-wrapper/VtsInputWrapper.vue
+++ b/@xen-orchestra/web-core/lib/components/input-wrapper/VtsInputWrapper.vue
@@ -78,6 +78,7 @@ provide(IK_INPUT_WRAPPER_CONTROLLER, wrapperController)
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
+  min-width: 0;
 
   .label {
     min-height: 2.4rem;

--- a/@xen-orchestra/web-core/lib/components/ui/checkbox/UiCheckbox.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/checkbox/UiCheckbox.vue
@@ -78,13 +78,11 @@ const attrs = useAttrs()
       border-color 0.125s ease-in-out;
     border: 0.2rem solid transparent;
     border-radius: 0.2rem;
+    flex-shrink: 0;
 
     .icon {
-      height: 1.6rem;
-      width: 1.6rem;
       font-size: 0.75rem;
       display: flex;
-      align-items: center;
       justify-content: center;
       color: var(--color-info-txt-item);
       transition: opacity 0.125s ease-in-out;

--- a/@xen-orchestra/web-core/lib/components/ui/checkbox/UiCheckbox.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/checkbox/UiCheckbox.vue
@@ -80,8 +80,12 @@ const attrs = useAttrs()
     border-radius: 0.2rem;
 
     .icon {
+      height: 1.6rem;
+      width: 1.6rem;
       font-size: 0.75rem;
-      position: absolute;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       color: var(--color-info-txt-item);
       transition: opacity 0.125s ease-in-out;
     }

--- a/@xen-orchestra/web-core/lib/components/ui/checkbox/UiCheckbox.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/checkbox/UiCheckbox.vue
@@ -82,8 +82,6 @@ const attrs = useAttrs()
 
     .icon {
       font-size: 0.75rem;
-      display: flex;
-      justify-content: center;
       color: var(--color-info-txt-item);
       transition: opacity 0.125s ease-in-out;
     }

--- a/@xen-orchestra/web-core/lib/components/ui/head-bar/UiHeadBar.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/head-bar/UiHeadBar.vue
@@ -61,7 +61,6 @@ const slots = defineSlots<{
     display: flex;
     align-items: center;
     gap: 1.6rem;
-    min-width: 0;
   }
 
   .actions {

--- a/@xen-orchestra/web-core/lib/components/ui/head-bar/UiHeadBar.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/head-bar/UiHeadBar.vue
@@ -61,6 +61,7 @@ const slots = defineSlots<{
     display: flex;
     align-items: center;
     gap: 1.6rem;
+    min-width: 0;
   }
 
   .actions {
@@ -68,6 +69,7 @@ const slots = defineSlots<{
     display: flex;
     align-items: center;
     gap: 0.8rem;
+    min-width: 0;
   }
 }
 </style>

--- a/@xen-orchestra/web-core/lib/components/ui/radio-button/UiRadioButton.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/radio-button/UiRadioButton.vue
@@ -80,8 +80,6 @@ const isDisabled = useDisabled(() => disabled)
     /* ICON */
 
     .radio-icon {
-      display: flex;
-      justify-content: center;
       font-size: 0.8rem;
       transition: font-size 0.125s ease-in-out;
       color: var(--radio-icon-color);

--- a/@xen-orchestra/web-core/lib/components/ui/radio-button/UiRadioButton.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/radio-button/UiRadioButton.vue
@@ -79,8 +79,12 @@ const isDisabled = useDisabled(() => disabled)
     /* ICON */
 
     .radio-icon {
+      height: 1.6rem;
+      width: 1.6rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       font-size: 0.8rem;
-      position: absolute;
       transition: font-size 0.125s ease-in-out;
       color: var(--radio-icon-color);
       --radio-icon-color: var(--color-neutral-background-primary);

--- a/@xen-orchestra/web-core/lib/components/ui/radio-button/UiRadioButton.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/radio-button/UiRadioButton.vue
@@ -41,6 +41,7 @@ const isDisabled = useDisabled(() => disabled)
   .radio-container {
     display: inline-flex;
     align-items: center;
+    flex-shrink: 0;
     justify-content: center;
     border: 0.2rem solid var(--accent-color);
     background-color: transparent;
@@ -79,10 +80,7 @@ const isDisabled = useDisabled(() => disabled)
     /* ICON */
 
     .radio-icon {
-      height: 1.6rem;
-      width: 1.6rem;
       display: flex;
-      align-items: center;
       justify-content: center;
       font-size: 0.8rem;
       transition: font-size 0.125s ease-in-out;

--- a/@xen-orchestra/web/src/pages/vm/new.vue
+++ b/@xen-orchestra/web/src/pages/vm/new.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="new" :class="{ mobile: uiStore.isMobile }">
-    <UiHeadBar icon="fa:plus" class="head-bar">
+    <UiHeadBar icon="fa:plus">
       {{ t('new-vm:add') }}
       <template #actions>
         <VtsSelect :id="poolSelectId" accent="brand" class="head-select" />

--- a/@xen-orchestra/web/src/pages/vm/new.vue
+++ b/@xen-orchestra/web/src/pages/vm/new.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="new">
-    <UiHeadBar icon="fa:plus">
+    <UiHeadBar icon="fa:plus" class="head-bar">
       {{ t('new-vm:add') }}
       <template #actions>
-        <VtsSelect :id="poolSelectId" accent="brand" />
+        <VtsSelect :id="poolSelectId" accent="brand" class="head-select" />
       </template>
     </UiHeadBar>
     <UiAlert v-if="vmState.pool" accent="info" class="card-container">
@@ -20,12 +20,12 @@
         <UiCard v-if="vmState.pool">
           <!-- TEMPLATE SECTION -->
           <UiTitle>{{ t('template') }}</UiTitle>
-          <div class="template-container">
+          <div class="template-container" :class="{ mobile: uiStore.isMobile }">
             <VtsInputWrapper :label="t('action:pick-template')">
               <VtsSelect :id="templateSelectId" accent="brand" />
             </VtsInputWrapper>
           </div>
-          <div v-if="vmState.new_vm_template" class="form-container">
+          <div v-if="vmState.new_vm_template" class="form-container" :class="{ mobile: uiStore.isMobile }">
             <!-- INSTALL SETTINGS SECTION -->
             <UiTitle>{{ t('install-settings') }}</UiTitle>
             <div class="install-settings-container">
@@ -125,7 +125,7 @@
             />
             <!-- SETTINGS SECTION -->
             <UiTitle>{{ t('settings') }}</UiTitle>
-            <UiCheckboxGroup accent="brand">
+            <UiCheckboxGroup accent="brand" :vertical="uiStore.isMobile">
               <UiCheckbox v-model="vmState.boot_vm" accent="brand">{{ t('action:boot-vm') }}</UiCheckbox>
               <UiCheckbox v-model="vmState.autoPoweron" accent="brand">{{ t('auto-power') }}</UiCheckbox>
               <UiCheckbox v-if="isDiskTemplate" v-model="vmState.clone" accent="brand">
@@ -206,6 +206,7 @@ import UiToaster from '@core/components/ui/toaster/UiToaster.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
 import { vTooltip } from '@core/directives/tooltip.directive'
 import { useFormSelect } from '@core/packages/form-select'
+import { useUiStore } from '@core/stores/ui.store'
 import type { XoNetwork, XoPool, XoVdi, XoVmTemplate } from '@vates/types'
 
 import { computed, reactive, ref, toRef, watch } from 'vue'
@@ -230,6 +231,7 @@ const { getVdiById } = useXoVdiCollection()
 const { getVifById } = useXoVifCollection()
 const { hostsByPool } = useXoHostCollection()
 const { vmsTemplatesByPool } = useXoVmTemplateCollection()
+const uiStore = useUiStore()
 
 const vmState = reactive<VmState>({
   name: '',
@@ -778,6 +780,12 @@ watch(
 
 <style scoped lang="postcss">
 .new {
+  .head-bar {
+    .head-select {
+      max-width: 100%;
+    }
+  }
+
   .card-container {
     margin: 1rem;
   }
@@ -787,12 +795,31 @@ watch(
     flex-direction: column;
     gap: 0.4rem;
     width: 50%;
+    &.mobile {
+      width: 100%;
+    }
   }
 
   .form-container {
     display: flex;
     flex-direction: column;
     gap: 2.4rem;
+
+    &.mobile .system-container,
+    &.mobile .memory-container {
+      flex-direction: column;
+      gap: 2.3rem;
+    }
+
+    &.mobile .install-settings-container .radio-container {
+      flex-direction: column;
+      gap: 0.8rem;
+    }
+
+    &.mobile .system-container .column,
+    &.mobile .install-settings-container {
+      width: 100%;
+    }
 
     .system-container {
       display: flex;

--- a/@xen-orchestra/web/src/pages/vm/new.vue
+++ b/@xen-orchestra/web/src/pages/vm/new.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="new">
+  <div class="new" :class="{ mobile: uiStore.isMobile }">
     <UiHeadBar icon="fa:plus" class="head-bar">
       {{ t('new-vm:add') }}
       <template #actions>
@@ -20,16 +20,16 @@
         <UiCard v-if="vmState.pool">
           <!-- TEMPLATE SECTION -->
           <UiTitle>{{ t('template') }}</UiTitle>
-          <div class="template-container" :class="{ mobile: uiStore.isMobile }">
+          <div class="template-container">
             <VtsInputWrapper :label="t('action:pick-template')">
               <VtsSelect :id="templateSelectId" accent="brand" />
             </VtsInputWrapper>
           </div>
-          <div v-if="vmState.new_vm_template" class="form-container" :class="{ mobile: uiStore.isMobile }">
+          <div v-if="vmState.new_vm_template" class="form-container">
             <!-- INSTALL SETTINGS SECTION -->
             <UiTitle>{{ t('install-settings') }}</UiTitle>
             <div class="install-settings-container">
-              <div class="radio-container">
+              <UiRadioButtonGroup accent="brand" :vertical="uiStore.isMobile">
                 <template v-if="isDiskTemplate">
                   <UiRadioButton v-model="vmState.installMode" accent="brand" value="no-config">
                     {{ t('no-config') }}
@@ -46,7 +46,7 @@
                     {{ t('pxe') }}
                   </UiRadioButton>
                 </template>
-              </div>
+              </UiRadioButtonGroup>
               <VtsSelect v-if="vmState.installMode === 'cdrom'" :id="vdiSelectId" accent="brand" />
             </div>
             <!-- SYSTEM SECTION -->
@@ -93,7 +93,7 @@
             </div>
             <!-- RESOURCE MANAGEMENT SECTION -->
             <UiTitle>{{ t('resource-management') }}</UiTitle>
-            <div class="memory-container">
+            <div class="resource-management-container">
               <VtsInputWrapper :label="t('vcpus')">
                 <UiInput v-model.number="vmState.vCPU" type="number" accent="brand" />
               </VtsInputWrapper>
@@ -200,6 +200,7 @@ import UiHeadBar from '@core/components/ui/head-bar/UiHeadBar.vue'
 import UiInput from '@core/components/ui/input/UiInput.vue'
 import UiLink from '@core/components/ui/link/UiLink.vue'
 import UiRadioButton from '@core/components/ui/radio-button/UiRadioButton.vue'
+import UiRadioButtonGroup from '@core/components/ui/radio-button-group/UiRadioButtonGroup.vue'
 import UiTextarea from '@core/components/ui/text-area/UiTextarea.vue'
 import UiTitle from '@core/components/ui/title/UiTitle.vue'
 import UiToaster from '@core/components/ui/toaster/UiToaster.vue'
@@ -780,14 +781,31 @@ watch(
 
 <style scoped lang="postcss">
 .new {
-  .head-bar {
-    .head-select {
-      max-width: 100%;
+  &.mobile {
+    .template-container,
+    .form-container .system-container .column,
+    .form-container.install-settings-container {
+      width: 100%;
+    }
+
+    .form-container .system-container,
+    .resource-management-container,
+    .install-settings-container {
+      flex-direction: column;
+    }
+
+    .form-container .system-container,
+    .form-container .resource-management-container {
+      gap: 2.4rem;
     }
   }
 
+  .head-select {
+    max-width: 100%;
+  }
+
   .card-container {
-    margin: 1rem;
+    margin: 0.8rem;
   }
 
   .template-container {
@@ -795,9 +813,6 @@ watch(
     flex-direction: column;
     gap: 0.4rem;
     width: 50%;
-    &.mobile {
-      width: 100%;
-    }
   }
 
   .form-container {
@@ -805,30 +820,14 @@ watch(
     flex-direction: column;
     gap: 2.4rem;
 
-    &.mobile .system-container,
-    &.mobile .memory-container {
-      flex-direction: column;
-      gap: 2.3rem;
-    }
-
-    &.mobile .install-settings-container .radio-container {
-      flex-direction: column;
-      gap: 0.8rem;
-    }
-
-    &.mobile .system-container .column,
-    &.mobile .install-settings-container {
-      width: 100%;
-    }
-
     .system-container {
       display: flex;
-      gap: 10.8rem;
+      gap: 8rem;
 
       .column {
         display: flex;
         flex-direction: column;
-        gap: 2.5rem;
+        gap: 2.4rem;
         width: 40%;
       }
     }
@@ -838,16 +837,11 @@ watch(
       flex-direction: column;
       gap: 2.4rem;
       width: 50%;
-
-      .radio-container {
-        display: flex;
-        gap: 15rem;
-      }
     }
 
-    .memory-container {
+    .resource-management-container {
       display: flex;
-      gap: 10.8rem;
+      gap: 8rem;
     }
   }
 
@@ -855,7 +849,7 @@ watch(
     margin-top: auto;
     display: flex;
     justify-content: center;
-    gap: 1.6rem;
+    gap: 2.4rem;
   }
 }
 </style>

--- a/@xen-orchestra/web/src/pages/vm/new.vue
+++ b/@xen-orchestra/web/src/pages/vm/new.vue
@@ -781,25 +781,6 @@ watch(
 
 <style scoped lang="postcss">
 .new {
-  &.mobile {
-    .template-container,
-    .form-container .system-container .column,
-    .form-container.install-settings-container {
-      width: 100%;
-    }
-
-    .form-container .system-container,
-    .resource-management-container,
-    .install-settings-container {
-      flex-direction: column;
-    }
-
-    .form-container .system-container,
-    .form-container .resource-management-container {
-      gap: 2.4rem;
-    }
-  }
-
   .head-select {
     max-width: 100%;
   }
@@ -850,6 +831,29 @@ watch(
     display: flex;
     justify-content: center;
     gap: 2.4rem;
+  }
+
+  &.mobile {
+    .template-container,
+    .system-container .column,
+    .install-settings-container {
+      width: 100%;
+    }
+
+    .system-container,
+    .resource-management-container,
+    .install-settings-container {
+      flex-direction: column;
+    }
+
+    .system-container,
+    .resource-management-container {
+      gap: 2.4rem;
+    }
+
+    .install-settings-container {
+      gap: 0.8rem;
+    }
   }
 }
 </style>


### PR DESCRIPTION
### Description

Fix overflow of resource management input on little screen.
Fix width of checkbox when the container is too small. Now checkbox is a square in all cases.
Fix width of radio button when the container is too small. Now radio button is a circle in all cases.

### Screenshots
**Before**:
_Input overflow_:
<img width="1082" height="174" alt="image" src="https://github.com/user-attachments/assets/feb00b87-38b5-4879-bcd4-74d4984f5edb" />
_Not square checkbox_:
<img width="196" height="85" alt="image" src="https://github.com/user-attachments/assets/cad798f1-8fd9-467a-b0c4-d3c8f76445af" />
 _Not round radio button_:
<img width="290" height="112" alt="image" src="https://github.com/user-attachments/assets/b8f609e0-75ca-49d6-98f3-2afa49c33f8f" />
 _mobile version_:
<img width="388" height="839" alt="image" src="https://github.com/user-attachments/assets/1bf76bae-525b-4e3d-b22d-c62556581364" />

**After**:
_Input overflow_:
<img width="739" height="184" alt="image" src="https://github.com/user-attachments/assets/6ac6c24e-3ead-4b4b-9c4e-c02df33e786f" />
_square checkbox_:
<img width="287" height="99" alt="image" src="https://github.com/user-attachments/assets/6d0bdc02-c0a8-4476-9a9d-14155e53dd0e" />
 _round radio button_:
<img width="120" height="71" alt="image" src="https://github.com/user-attachments/assets/5041f9ef-29f8-47a9-b5a1-49436adb8695" />
<img width="387" height="840" alt="image" src="https://github.com/user-attachments/assets/8958460e-bd6d-40b8-acf1-9772b699e183" />

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
