### PR TITLE
fix(xo-server): fix don't call the updater with secure protocol

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,9 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- **XO5**:
+  - [XOA/Updates] Fix xoa-updater service appears to be down
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -30,5 +33,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- xo-server patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - **XO5**:
-  - [XOA/Updates] Fix xoa-updater service appears to be down
+  - [XOA/Updates] Fix xoa-updater service appears to be down (PR [#9349](https://github.com/vatesfr/xen-orchestra/pull/9349))
 
 ### Packages to release
 

--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -172,7 +172,7 @@ requestTimeout = 0
 # [port] is used to reuse the same port declared in [http.listen.0]
 '/v5/api' = '[protocol]//localhost:[port]/api'
 '/v5/api/updater' = 'ws://localhost:9001'
-'/v5/rest' = 'http://localhost:[port]/rest'
+'/v5/rest' = '[protocol]//localhost:[port]/rest'
 '/openmetrics' = 'http://localhost:9004'
 
 [logs]

--- a/packages/xo-server/src/index.mjs
+++ b/packages/xo-server/src/index.mjs
@@ -617,12 +617,14 @@ const setUpProxies = (express, opts, xo) => {
     if (target.includes('[port]')) {
       target = target.replace(/\[port\]/g, userHttpConfig.port)
     }
+    let dynamicProtocol = false
     if (target.includes('[protocol]')) {
+      dynamicProtocol = true
       target = target.replace(/\[protocol\]/g, protocol)
     }
 
     const targetUrl = new URL(target)
-    if (isSecure) {
+    if (dynamicProtocol && isSecure) {
       targetUrl.protocol = targetUrl.protocol === 'ws:' ? 'wss:' : 'https:'
     }
 


### PR DESCRIPTION
### Description

zammad#49797
[forum#11708](https://xcp-ng.org/forum/topic/11708/license-no-longer-registered-after-upgrade)
introcuced by 7c1764a39eadf2796d5b0e08fda28aa385d21f0c
When `redirectToHttps=true` internal calls should not be made via a secure protocol (updater/openmetrics) because they only listen on `ws/http`.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
