### PR TITLE
fix(open-metrics) spec compliance

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [OpenMetrics] Fix compliance with OpenMetrics 1.0 specification: use correct Content-Type header and timestamps in seconds [#9351](https://github.com/vatesfr/xen-orchestra/pull/9351)
 - **XO 6:**
   - [Select component] Fix randomly empty select component at initialization (PR [#9282](https://github.com/vatesfr/xen-orchestra/pull/9282))
   - [TaskItem] Fix tree on task item component due to a different behavior on firefox (PR [#9352](https://github.com/vatesfr/xen-orchestra/pull/9352))
@@ -37,5 +38,6 @@
 
 - @xen-orchestra/web patch
 - @xen-orchestra/web-core patch
+- xo-server-openmetrics patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [OpenMetrics] Fix compliance with OpenMetrics 1.0 specification: use correct Content-Type header and timestamps in seconds [#9351](https://github.com/vatesfr/xen-orchestra/pull/9351)
+- [OpenMetrics] Fix authentication bypass for `/openmetrics` routes to allow Prometheus scraping with Bearer token [#9351](https://github.com/vatesfr/xen-orchestra/pull/9351)
 - **XO 6:**
   - [Select component] Fix randomly empty select component at initialization (PR [#9282](https://github.com/vatesfr/xen-orchestra/pull/9282))
   - [TaskItem] Fix tree on task item component due to a different behavior on firefox (PR [#9352](https://github.com/vatesfr/xen-orchestra/pull/9352))
@@ -38,6 +39,7 @@
 
 - @xen-orchestra/web patch
 - @xen-orchestra/web-core patch
+- xo-server patch
 - xo-server-openmetrics patch
 
 <!--packages-end-->

--- a/packages/xo-server-openmetrics/src/open-metric-server.mts
+++ b/packages/xo-server-openmetrics/src/open-metric-server.mts
@@ -404,7 +404,7 @@ async function startServer(): Promise<void> {
       try {
         const metrics = await collectMetrics()
         res.writeHead(200, {
-          'Content-Type': 'text/plain; version=0.0.4; charset=utf-8',
+          'Content-Type': 'application/openmetrics-text; version=1.0.0; charset=utf-8',
         })
         res.end(metrics)
       } catch (error) {

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.mts
@@ -43,8 +43,8 @@ export interface FormattedMetric {
   labels: Record<string, string>
   /** Metric value */
   value: number
-  /** Timestamp in milliseconds */
-  timestampMs: number
+  /** Timestamp in seconds (Unix epoch) per OpenMetrics specification */
+  timestamp: number
 }
 
 // Label lookup types for enriching metrics with human-readable names
@@ -599,7 +599,7 @@ export function transformMetric(
     type: definition.type,
     labels,
     value: transformedValue,
-    timestampMs: timestamp * 1000, // Convert to milliseconds
+    timestamp,
   }
 }
 
@@ -650,7 +650,7 @@ export function formatToOpenMetrics(metrics: FormattedMetric[]): string {
     // Output all metric values
     for (const metric of metricsForName) {
       const labelsStr = formatLabels(metric.labels)
-      lines.push(`${metric.name}${labelsStr} ${metric.value} ${metric.timestampMs}`)
+      lines.push(`${metric.name}${labelsStr} ${metric.value} ${metric.timestamp}`)
     }
   }
 

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
@@ -197,7 +197,7 @@ describe('transformMetric', () => {
     assert.equal(result.name, 'xcp_host_cpu_average')
     assert.equal(result.type, 'gauge')
     assert.equal(result.value, 0.75)
-    assert.equal(result.timestampMs, 1700000000000)
+    assert.equal(result.timestamp, 1700000000)
     assert.equal(result.labels.pool_id, 'pool-456')
     assert.equal(result.labels.uuid, 'host-uuid-123')
     assert.equal(result.labels.type, 'host')
@@ -315,7 +315,7 @@ describe('formatToOpenMetrics', () => {
         type: 'gauge',
         labels: { pool_id: 'pool-1', uuid: 'host-1', type: 'host' },
         value: 0.5,
-        timestampMs: 1700000000000,
+        timestamp: 1700000000,
       },
     ]
 
@@ -323,7 +323,7 @@ describe('formatToOpenMetrics', () => {
 
     assert.ok(result.includes('# HELP xcp_host_cpu_average Host average CPU usage ratio'))
     assert.ok(result.includes('# TYPE xcp_host_cpu_average gauge'))
-    assert.ok(result.includes('xcp_host_cpu_average{pool_id="pool-1",uuid="host-1",type="host"} 0.5 1700000000000'))
+    assert.ok(result.includes('xcp_host_cpu_average{pool_id="pool-1",uuid="host-1",type="host"} 0.5 1700000000'))
   })
 
   it('should group metrics by name', () => {
@@ -334,7 +334,7 @@ describe('formatToOpenMetrics', () => {
         type: 'gauge',
         labels: { pool_id: 'pool-1', uuid: 'host-1', type: 'host', core: '0' },
         value: 0.3,
-        timestampMs: 1700000000000,
+        timestamp: 1700000000,
       },
       {
         name: 'xcp_host_cpu_core_usage',
@@ -342,7 +342,7 @@ describe('formatToOpenMetrics', () => {
         type: 'gauge',
         labels: { pool_id: 'pool-1', uuid: 'host-1', type: 'host', core: '1' },
         value: 0.4,
-        timestampMs: 1700000000000,
+        timestamp: 1700000000,
       },
     ]
 
@@ -373,7 +373,7 @@ describe('formatToOpenMetrics', () => {
         type: 'gauge',
         labels: { name: 'value with "quotes"' },
         value: 1,
-        timestampMs: 1700000000000,
+        timestamp: 1700000000,
       },
     ]
 

--- a/packages/xo-server/src/index.mjs
+++ b/packages/xo-server/src/index.mjs
@@ -291,7 +291,7 @@ async function setUpPassport(express, xo, { authentication: authCfg, http: { coo
 
   const SIGNIN_STRATEGY_RE = /^\/signin\/([^/]+)(\/callback)?(:?\?.*)?$/
   const UNCHECKED_URL_RE =
-    /(?:^\/rest\/)|favicon|manifest\.webmanifest|fontawesome|images|styles|\.(?:css|jpg|png|svg)$/
+    /(?:^\/rest\/)|(?:^\/openmetrics\/)|favicon|manifest\.webmanifest|fontawesome|images|styles|\.(?:css|jpg|png|svg)$/
   express.use(async (req, res, next) => {
     const { url } = req
 


### PR DESCRIPTION
### Description

Fix OpenMetrics plugin to fully comply with the OpenMetrics 1.0 specification.

**Issues identified:**
1. The plugin was using Prometheus Text 0.0.4 format instead of OpenMetrics 1.0
2. Content-Type header was `text/plain; version=0.0.4` instead of `application/openmetrics-text; version=1.0.0`
3. Timestamps were in milliseconds instead of seconds (OpenMetrics spec requires Unix epoch in seconds)
Introduced by [fdec218](https://github.com/vatesfr/xen-orchestra/pull/9351/commits/fdec2188d148c237f6d530599af4773865c28d39)

5. The `/openmetrics` route was blocked by xo-server's session authentication, preventing Prometheus from scraping metrics with Bearer token auth. Introduced by [405048e](https://github.com/vatesfr/xen-orchestra/pull/9351/commits/405048eee08830cd80f7f533c5d1b4a9acf14985)

**Changes:**

`xo-server-openmetrics`:
- Change Content-Type to `application/openmetrics-text; version=1.0.0; charset=utf-8`
- Use Unix epoch seconds for timestamps (not milliseconds)
- Rename `timestampMs` to `timestamp` in FormattedMetric interface

`xo-server`:
- Add `/openmetrics/` to `UNCHECKED_URL_RE` to bypass session-based authentication
- The OpenMetrics plugin handles its own authentication via Bearer token

[XO-1812](https://project.vates.tech/vates-global/browse/XO-1812/)


<img width="910" height="421" alt="Capture d’écran du 2025-12-22 10-45-51" src="https://github.com/user-attachments/assets/70093a80-111a-426f-817e-24d45df7e5e7" />


### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [ ] Reference the relevant issue
  - [x] If bug fix, add `Introduced by`
- Changelog
  - [x] If visible by XOA users, add changelog entry
  - [x] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [ ] If UI changes, add screenshots (N/A - no UI changes)
  - [ ] If not finished or not tested, open as _Draft_

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   5. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
