### PR TITLE
fix(xo-server-openmetrics): add sr_name label to VM disk metrics

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [OpenMetrics] Add missing `sr_name` label to VM disk metrics (PR [#9353](https://github.com/vatesfr/xen-orchestra/pull/9353))
 - [REST API] Fix `/vms/:id/dashboard` _cannot read properties of undefined (reading 'id')_ (PR [#9380](https://github.com/vatesfr/xen-orchestra/pull/9380))
 - [REST API] `vms/:id/dashboard` return now an empty object for the `replication` key instead of undefined (in case of no replication) (PR [#9380](https://github.com/vatesfr/xen-orchestra/pull/9380))
 - [REST API] `vms/:id/dashboard` rename `not-in-job` into `not-in-active-job` for the `vmProtection` key to avoid confusion (PR [#9380](https://github.com/vatesfr/xen-orchestra/pull/9380))
@@ -27,7 +28,6 @@
 - [Plugins/Backup-reports] Prevent succesful backups from occasionally being reported as interrupted [Forum#11721](https://xcp-ng.org/forum/topic/11721) (PR [#9400](https://github.com/vatesfr/xen-orchestra/pull/9400))
 - [REST API] `/dashboard` return now `{isEmpty: true}` instead of undefined in case there is no data to compute (PR [#9395](https://github.com/vatesfr/xen-orchestra/pull/9395))
 - [Backup] Fix `read xxx bytes, maximum size allowed is yyy` for full backup on S3 (PR [#9396](https://github.com/vatesfr/xen-orchestra/pull/9396))
-
 - **XO 6:**
   - [Sidebar] Removal borders top and right of sidebar in mobile (PR [#9366](https://github.com/vatesfr/xen-orchestra/pull/9366))
 

--- a/packages/xo-server-openmetrics/src/index.mts
+++ b/packages/xo-server-openmetrics/src/index.mts
@@ -50,26 +50,28 @@ interface HostCredentials {
 }
 
 // Label lookup types for enriching metrics with human-readable names
-interface VmLabelInfo {
+export interface VmLabelInfo {
   name_label: string
   vbdDeviceToVdiName: Record<string, string> // { "xvda": "System Disk" }
+  vbdDeviceToVdiUuid: Record<string, XoVdi['uuid']> // { "xvda": "vdi-uuid-123" }
   vifIndexToNetworkName: Record<string, string> // { "0": "Pool-wide network" }
 }
 
-interface HostLabelInfo {
+export interface HostLabelInfo {
   name_label: string
   pifDeviceToNetworkName: Record<string, string> // { "eth0": "Management" }
 }
 
-interface SrLabelInfo {
+export interface SrLabelInfo {
   name_label: string
 }
 
-interface LabelLookupData {
-  vms: Record<string, VmLabelInfo> // keyed by VM UUID
-  hosts: Record<string, HostLabelInfo> // keyed by Host UUID
-  srs: Record<string, SrLabelInfo> // keyed by SR UUID
-  srSuffixToUuid: Record<string, string> // maps UUID suffix to full UUID
+export interface LabelLookupData {
+  vms: Record<XoVm['uuid'], VmLabelInfo>
+  hosts: Record<XoHost['uuid'], HostLabelInfo>
+  srs: Record<XoSr['uuid'], SrLabelInfo>
+  srSuffixToUuid: Record<string, XoSr['uuid']> // maps UUID suffix to full SR UUID
+  vdiUuidToSrUuid: Record<XoVdi['uuid'], XoSr['uuid']> // maps VDI UUID to parent SR UUID
 }
 
 interface XapiCredentialsPayload {
@@ -459,6 +461,7 @@ class OpenMetricsPlugin {
       hosts: {},
       srs: {},
       srSuffixToUuid: {},
+      vdiUuidToSrUuid: {},
     }
 
     // Get all objects and categorize them by type in a single pass
@@ -508,26 +511,36 @@ class OpenMetricsPlugin {
       networkNameById.set(network.id, network.name_label)
     }
 
-    // Build VDI name map (id -> name_label)
-    const vdiNameById = new Map<NonNullable<XoVbd['VDI']>, string>()
+    // Build VDI name map (uuid -> name_label) and VDI UUID to SR UUID map
+    // Note: vdi.id === vdi.uuid for VDI objects
+    const vdiNameByUuid = new Map<XoVdi['uuid'], string>()
     for (const vdi of vdis) {
-      vdiNameById.set(vdi.id, vdi.name_label)
+      vdiNameByUuid.set(vdi.uuid, vdi.name_label)
+      // Build VDI UUID -> SR UUID mapping
+      if (vdi.$SR !== undefined) {
+        const srObj = allObjects[vdi.$SR]
+        if (srObj !== undefined && srObj.type === 'SR') {
+          labels.vdiUuidToSrUuid[vdi.uuid] = srObj.uuid
+        }
+      }
     }
 
-    // Build VBD map (VM id -> device -> VDI name)
-    const vbdMap = new Map<XoVbd['VM'], Map<string, string>>()
+    // Build VBD map (VM id -> device -> VDI info)
+    // Note: vbd.VDI is already the VDI UUID (id === uuid for VDI objects)
+    const vbdMap = new Map<XoVbd['VM'], Map<string, { name: string; uuid: string }>>()
     for (const vbd of vbds) {
       if (vbd.device === null || vbd.device === '' || vbd.VDI == null) continue
 
       let vmVbds = vbdMap.get(vbd.VM)
       if (vmVbds === undefined) {
-        vmVbds = new Map<string, string>()
+        vmVbds = new Map<string, { name: string; uuid: string }>()
         vbdMap.set(vbd.VM, vmVbds)
       }
 
-      const vdiName = vdiNameById.get(vbd.VDI)
+      const vdiUuid = vbd.VDI
+      const vdiName = vdiNameByUuid.get(vdiUuid)
       if (vdiName !== undefined) {
-        vmVbds.set(vbd.device, vdiName)
+        vmVbds.set(vbd.device, { name: vdiName, uuid: vdiUuid })
       }
     }
 
@@ -567,10 +580,12 @@ class OpenMetricsPlugin {
     // Build VM labels
     for (const vm of vms) {
       const vbdDeviceToVdiName: Record<string, string> = {}
+      const vbdDeviceToVdiUuid: Record<string, string> = {}
       const vmVbds = vbdMap.get(vm.id)
       if (vmVbds !== undefined) {
-        for (const [device, vdiName] of vmVbds) {
-          vbdDeviceToVdiName[device] = vdiName
+        for (const [device, vdiInfo] of vmVbds) {
+          vbdDeviceToVdiName[device] = vdiInfo.name
+          vbdDeviceToVdiUuid[device] = vdiInfo.uuid
         }
       }
 
@@ -585,6 +600,7 @@ class OpenMetricsPlugin {
       labels.vms[vm.uuid] = {
         name_label: vm.name_label,
         vbdDeviceToVdiName,
+        vbdDeviceToVdiUuid,
         vifIndexToNetworkName,
       }
     }

--- a/packages/xo-server-openmetrics/src/open-metric-server.mts
+++ b/packages/xo-server-openmetrics/src/open-metric-server.mts
@@ -60,6 +60,7 @@ interface HostCredentials {
 interface VmLabelInfo {
   name_label: string
   vbdDeviceToVdiName: Record<string, string>
+  vbdDeviceToVdiUuid: Record<string, string>
   vifIndexToNetworkName: Record<string, string>
 }
 
@@ -77,6 +78,7 @@ interface LabelLookupData {
   hosts: Record<string, HostLabelInfo>
   srs: Record<string, SrLabelInfo>
   srSuffixToUuid: Record<string, string>
+  vdiUuidToSrUuid: Record<string, string>
 }
 
 interface XapiCredentialsPayload {


### PR DESCRIPTION
### Description

Introduced by [0005a4f](https://github.com/vatesfr/xen-orchestra/pull/9353/commits/0005a4f4cc1990e9a20eb48becb5943b5bf15c43)

[XO-1790](https://project.vates.tech/vates-global/browse/XO-1790/)

VM disk metrics (`vm_disk_iops_*`, `vm_disk_*_latency_seconds`, `vm_disk_iowait`, etc.) were missing the `sr_name` label, while host SR metrics had it correctly.

**Root cause**: Host SR metrics use an SR UUID suffix directly in the RRD metric name (e.g., `iops_read_abc123`), which allows resolving `sr_name` via `srSuffixToUuid`. For VM metrics, there was no data structure linking VDI to SR.

**Fix**: Added VDI-to-SR mapping to resolve `sr_name` via the chain:
```
device → vbdDeviceToVdiUuid → vdiUuidToSrUuid → srs[uuid].name_label
```

Also improved type safety in `LabelLookupData` using XO types from `@vates/types`.

#### Example output

**Before:**
```
xcp_vm_disk_iops_read{pool_id="...",uuid="...",type="vm",vm_name="Web Server",device="xvda",vdi_name="System Disk"} 150 1700000000
```

**After:**
```
xcp_vm_disk_iops_read{pool_id="...",uuid="...",type="vm",vm_name="Web Server",device="xvda",vdi_name="System Disk",sr_name="Local Storage"} 150 1700000000
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
