### PR TITLE
feat(backups): expose LTR tags to VM backups 

### DIFF
--- a/@xen-orchestra/backups/_getOldEntries.mjs
+++ b/@xen-orchestra/backups/_getOldEntries.mjs
@@ -1,5 +1,57 @@
+// @ts-check
+
 import moment from 'moment-timezone'
 import assert from 'node:assert'
+/**
+ * @typedef {import('moment-timezone').Moment} Moment
+ */
+/**
+ * @typedef {Object} LTRSettings
+ * @property {number} [firstHourOfTheDay] - First hour of the day (for daily retention)
+ * @property {number} [firstDayOfWeek] - First day of the week (for weekly retention)
+ * @property {number} [firstDayOfMonth] - First day of the month (for monthly retention)
+ * @property {number} [firstDayOfYear] - First day of the year (for yearly retention)
+ */
+
+/**
+ * @typedef {Object} LTRConfig
+ * @property {number} retention - Number of time buckets to retain
+ * @property {LTRSettings} [settings] - Optional settings for the retention period
+ */
+
+/**
+ * @typedef {Object} LongTermRetention
+ * @property {LTRConfig} [daily] - Daily retention configuration
+ * @property {LTRConfig} [weekly] - Weekly retention configuration
+ * @property {LTRConfig} [monthly] - Monthly retention configuration
+ * @property {LTRConfig} [yearly] - Yearly retention configuration
+ */
+
+/**
+ * @typedef {Object} WithTimeStamp
+ * @property {number} timestamp - Unix timestamp of the entry
+ * @property {*} [key] - Any other properties
+ */
+
+/**
+ * @typedef {Object} DateBucket
+ * @property {number} remaining - Number of remaining buckets to fill
+ * @property {string|null} lastMatchingBucket - Last bucket key that was matched
+ * @property {(date: Moment) => string} formatter - Function to format date into bucket key
+ * @property {Object.<string, WithTimeStamp>} entries - Map of bucket keys to entries
+ */
+
+/**
+ * @typedef {Object} LTRDefinition
+ * @property {(options: {firstHourOfTheDay?: number, firstDayOfWeek?: number, firstDayOfMonth?: number, firstDayOfYear?: number, dateCreator: (date: Moment) => Moment}) => (date: Moment) => string} makeDateFormatter
+ * @property {string} [ancestor] - Name of the parent retention period
+ */
+
+/**
+ * Creates a function that converts dates to moment objects in a specific timezone
+ * @param {string|undefined} timezone - IANA timezone string (e.g., 'America/New_York')
+ * @returns {(date: Moment | number) => Moment} Function that creates timezoned moment objects
+ */
 
 function instantiateTimezonedDateCreator(timezone) {
   return date => {
@@ -9,9 +61,12 @@ function instantiateTimezonedDateCreator(timezone) {
   }
 }
 
+/**
+ * @type {Object.<string, LTRDefinition>}
+ */
 const LTR_DEFINITIONS = {
   daily: {
-    makeDateFormatter: ({ firstHourOfTheDay = 0, dateCreator } = {}) => {
+    makeDateFormatter: ({ firstHourOfTheDay = 0, dateCreator }) => {
       return date => {
         const copy = dateCreator(date)
         copy.hour(copy.hour() - firstHourOfTheDay)
@@ -20,11 +75,11 @@ const LTR_DEFINITIONS = {
     },
   },
   weekly: {
-    makeDateFormatter: ({ firstDayOfWeek = 0 /* relative to timezone week start */, dateCreator } = {}) => {
+    makeDateFormatter: ({ firstDayOfWeek = 0 /* relative to timezone week start */, dateCreator }) => {
       return date => {
         const copy = dateCreator(date)
 
-        copy.date(date.date() - firstDayOfWeek)
+        copy.date(copy.date() - firstDayOfWeek)
         // warning, the year in term of week may different from YYYY
         // since the computation of the first week of a year is timezone dependent
         return copy.format('gggg-ww')
@@ -33,7 +88,7 @@ const LTR_DEFINITIONS = {
     ancestor: 'daily',
   },
   monthly: {
-    makeDateFormatter: ({ firstDayOfMonth = 0, dateCreator } = {}) => {
+    makeDateFormatter: ({ firstDayOfMonth = 0, dateCreator }) => {
       return date => {
         const copy = dateCreator(date)
         copy.date(copy.date() - firstDayOfMonth)
@@ -43,7 +98,7 @@ const LTR_DEFINITIONS = {
     ancestor: 'weekly',
   },
   yearly: {
-    makeDateFormatter: ({ firstDayOfYear = 0, dateCreator } = {}) => {
+    makeDateFormatter: ({ firstDayOfYear = 0, dateCreator }) => {
       return date => {
         const copy = dateCreator(date)
         copy.date(copy.date() - firstDayOfYear)
@@ -53,27 +108,23 @@ const LTR_DEFINITIONS = {
     ancestor: 'monthly',
   },
 }
-
-// returns all entries but the last retention-th
 /**
- * return the entries too old to be kept
- *  if multiple entries are i the same time bucket : keep only the most recent one
- *  if an entry is valid in any of the bucket OR the  minRetentionCount : keep it
- *  if a bucket is completely empty : it does not count as one, thus it may extend the retention
- * @returns Array<Backup>
+ * Groups entries into date buckets based on long-term retention configuration
+ * @template {WithTimeStamp} T
+ * @param {Array<T>} entries - Array of entries sorted in descending order by timestamp
+ * @param {LongTermRetention} longTermRetention - Configuration for retention periods
+ * @param {string | undefined} timezone - IANA timezone string
+ * @returns {Object.<string, DateBucket>} Map of retention period names to their date buckets
  */
-export function getOldEntries(minRetentionCount, entries, { longTermRetention = {}, timezone } = {}) {
-  assert.strictEqual(
-    typeof minRetentionCount,
-    'number',
-    `minRetentionCount must be a number, got ${JSON.stringify(minRetentionCount)}`
-  )
-  assert.strictEqual(
-    minRetentionCount >= 0,
-    true,
-    `minRetentionCount must be a positive number, got ${JSON.stringify(minRetentionCount)}`
-  )
+
+export function getLtrEntries(entries, longTermRetention, timezone) {
+  /**
+   * @type  {Object.<string, DateBucket>}
+   */
   const dateBuckets = {}
+  if (!longTermRetention || Object.keys(longTermRetention).length === 0) {
+    return {}
+  }
   const dateCreator = instantiateTimezonedDateCreator(timezone)
   // only check buckets that have a retention set
   for (const [duration, { retention, settings }] of Object.entries(longTermRetention)) {
@@ -81,7 +132,7 @@ export function getOldEntries(minRetentionCount, entries, { longTermRetention = 
     assert.notStrictEqual(
       timezone,
       undefined,
-      `timezone must defined for ltr, got ${JSON.stringify({ minRetentionCount, longTermRetention, timezone })}`
+      `timezone must defined for ltr, got ${JSON.stringify({ longTermRetention, timezone })}`
     )
     assert.strictEqual(
       typeof retention,
@@ -101,45 +152,68 @@ export function getOldEntries(minRetentionCount, entries, { longTermRetention = 
     }
   }
   const nb = entries.length
-  const minDurationEntries = []
   let previousTimestamp = -1
   for (let i = nb - 1; i >= 0; i--) {
     const entry = entries[i]
-    if (entry.timestamp !== undefined) {
-      // we go through the entries from the last (most recent) to the first (oldest)
-      assert.ok(
-        previousTimestamp === -1 || entry.timestamp < previousTimestamp,
-        `entries must be sorted in desc order ${new Date(entry.timestamp)} , previous :  > ${new Date(previousTimestamp)} `
-      )
-      previousTimestamp = entry.timestamp
-      const entryDate = dateCreator(entry.timestamp)
-      for (const [duration, { remaining, lastMatchingBucket, formatter }] of Object.entries(dateBuckets)) {
-        const bucket = formatter(entryDate)
-        if (lastMatchingBucket !== bucket) {
-          if (remaining === 0) {
-            continue
-          }
-          dateBuckets[duration].lastMatchingBucket = bucket
-          dateBuckets[duration].remaining -= 1
+    assert.notEqual(entry.timestamp, `Can't compute long term retention if entries don't have a timestamp`)
+    assert.ok(
+      previousTimestamp === -1 || entry.timestamp < previousTimestamp,
+      `entries must be sorted in desc order ${new Date(entry.timestamp)} , previous :  > ${new Date(previousTimestamp)} `
+    )
+    // we go through the entries from the last (most recent) to the first (oldest)
+    assert.ok(
+      previousTimestamp === -1 || entry.timestamp < previousTimestamp,
+      `entries must be sorted in desc order ${new Date(entry.timestamp)} , previous :  > ${new Date(previousTimestamp)} `
+    )
+    previousTimestamp = entry.timestamp
+    const entryDate = dateCreator(entry.timestamp)
+    for (const [duration, { remaining, lastMatchingBucket, formatter }] of Object.entries(dateBuckets)) {
+      const bucket = formatter(entryDate)
+      if (lastMatchingBucket !== bucket) {
+        if (remaining === 0) {
+          continue
         }
-        dateBuckets[duration].entries[bucket] = entry
+        dateBuckets[duration].lastMatchingBucket = bucket
+        dateBuckets[duration].remaining -= 1
       }
-    } else {
-      // replicated VM entries or snapshot retention don't have a timestamp
-      // but also can't have LTR
-      assert.deepStrictEqual(
-        longTermRetention,
-        {},
-        "Can't compute long term retention if entries don't have a timestamp"
-      )
-    }
-
-    // also keep it on retention
-    if (i >= nb - minRetentionCount) {
-      minDurationEntries.push(entry)
+      dateBuckets[duration].entries[bucket] = entry
     }
   }
-  const kept = new Set(minDurationEntries)
+
+  return dateBuckets
+}
+
+// returns all entries but the last retention-th
+/**
+ * return the entries too old to be kept
+ *  if multiple entries are i the same time bucket : keep only the oldest one
+ *  if an entry is valid in any of the bucket OR the  minRetentionCount : keep it
+ *  if a bucket is completely empty : it does not count as one, thus it may extend the retention
+ *
+ * @param {number} minRetentionCount - Minimum number of most recent entries to always keep
+ * @param {Array<WithTimeStamp>} entries - Array of entries sorted in descending order by timestamp
+ * @param {Object} options - Additional options
+ * @param {LongTermRetention} [options.longTermRetention={}] - Configuration for retention periods
+ * @param {string | undefined} [options.timezone] - IANA timezone string
+ * @returns {Array<WithTimeStamp>} Array of entries that can be removed
+ */
+export function getOldEntries(minRetentionCount, entries, { longTermRetention = {}, timezone } = {}) {
+  assert.strictEqual(
+    typeof minRetentionCount,
+    'number',
+    `minRetentionCount must be a number, got ${JSON.stringify(minRetentionCount)}`
+  )
+  assert.strictEqual(
+    minRetentionCount >= 0,
+    true,
+    `minRetentionCount must be a positive number, got ${JSON.stringify(minRetentionCount)}`
+  )
+  const dateBuckets = getLtrEntries(entries, longTermRetention, timezone)
+
+  const kept = new Set(entries.filter((_, index) => index >= entries.length - minRetentionCount))
+  /**
+   * @type {Set<WithTimeStamp>}
+   */
   for (const { entries } of Object.values(dateBuckets)) {
     for (const entry of Object.values(entries)) {
       kept.add(entry)
@@ -147,7 +221,7 @@ export function getOldEntries(minRetentionCount, entries, { longTermRetention = 
   }
 
   // ensure order is the same as the source
-  const oldEntries = entries.filter(entry => {
+  const oldEntries = entries.filter((entry, index) => {
     return !kept.has(entry)
   })
 

--- a/@xen-orchestra/backups/_getOldEntries.mjs
+++ b/@xen-orchestra/backups/_getOldEntries.mjs
@@ -165,10 +165,6 @@ export function getLtrEntries(entries, longTermRetention, timezone) {
       )
       continue
     }
-    assert.ok(
-      previousTimestamp === -1 || entry.timestamp < previousTimestamp,
-      `entries must be sorted in desc order ${new Date(entry.timestamp)} , previous :  > ${new Date(previousTimestamp)} `
-    )
     // we go through the entries from the last (most recent) to the first (oldest)
     assert.ok(
       previousTimestamp === -1 || entry.timestamp < previousTimestamp,
@@ -213,12 +209,12 @@ export function getEntryStatus(entries, entry, longTermRetention, timezone) {
   return entryBuckets
 }
 
-// returns all entries but the last retention-th
 /**
  * return the entries too old to be kept
- *  if multiple entries are i the same time bucket : keep only the oldest one
- *  if an entry is valid in any of the bucket OR the  minRetentionCount : keep it
- *  if a bucket is completely empty : it does not count as one, thus it may extend the retention
+ *  if multiple entries are in the same time bucket: keep only the oldest one
+ *  if an entry is valid in any of the bucket OR the minRetentionCount: keep it
+ *  if a bucket is completely empty: it does not count as one, thus it may extend the retention
+ * if an entry is within the most recents minRetentionCount entries : keep it
  *
  * @param {number} minRetentionCount - Minimum number of most recent entries to always keep
  * @param {Array<Entry>} entries - Array of entries sorted in descending order by timestamp
@@ -233,9 +229,8 @@ export function getOldEntries(minRetentionCount, entries, { longTermRetention = 
     'number',
     `minRetentionCount must be a number, got ${JSON.stringify(minRetentionCount)}`
   )
-  assert.strictEqual(
+  assert.ok(
     minRetentionCount >= 0,
-    true,
     `minRetentionCount must be a positive number, got ${JSON.stringify(minRetentionCount)}`
   )
   const dateBuckets = getLtrEntries(entries, longTermRetention, timezone)

--- a/@xen-orchestra/backups/_getOldEntries.test.mjs
+++ b/@xen-orchestra/backups/_getOldEntries.test.mjs
@@ -22,7 +22,6 @@ describe('_getOldEntries() should succeed', () => {
       expectedIds: [1],
       testLabel: 'should  handle number based retention without timestamp  ',
     },
-
     {
       args: [
         0,

--- a/@xen-orchestra/backups/_runners/_writers/FullRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/FullRemoteWriter.mjs
@@ -73,6 +73,7 @@ export class FullRemoteWriter extends MixinRemoteWriter(AbstractFullWriter) {
       return { size: sizeContainer.size }
     })
     metadata.size = sizeContainer.size
+    metadata.tags = await this.getLongTermRetentionTags(metadata)
     this._metadataFileName = await adapter.writeVmBackupMetadata(vm.uuid, metadata)
 
     if (!deleteFirst) {

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
@@ -244,6 +244,7 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
 
       return { size }
     })
+    metadataContent.tags = await this.getLongTermRetentionTags(metadataContent)
     metadataContent.size = size // @todo return exactly the size written by this writer
     this._metadataFileName = await adapter.writeVmBackupMetadata(vm.uuid, metadataContent)
 

--- a/@xen-orchestra/backups/formatVmBackups.mjs
+++ b/@xen-orchestra/backups/formatVmBackups.mjs
@@ -45,7 +45,7 @@ function formatVmBackup(backup) {
       name_label: backup.vm.name_label,
       tags: backup.vm.tags,
     },
-    tags: backup.tags,
+    tags: backup.tags ?? [],
     differencingVhds,
     dynamicVhds,
     withMemory,

--- a/@xen-orchestra/backups/formatVmBackups.mjs
+++ b/@xen-orchestra/backups/formatVmBackups.mjs
@@ -45,7 +45,7 @@ function formatVmBackup(backup) {
       name_label: backup.vm.name_label,
       tags: backup.vm.tags,
     },
-
+    tags: backup.tags,
     differencingVhds,
     dynamicVhds,
     withMemory,

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@
 - [REST API] Update `/dashboard` endpoint to also return disconnected servers, disabled hosts, the status of all VMs, and compute `jobs` from the last seven days (PR [#9207](https://github.com/vatesfr/xen-orchestra/pull/9207))
 - [vhd-cli] Prevent using invalid options (PR [#9386](https://github.com/vatesfr/xen-orchestra/pull/9386))
 - [REST API] Add endpoints to reconfigure management interface for hosts and pools (PR [#9369](https://github.com/vatesfr/xen-orchestra/pull/9369))
+- [Backup] show the backup archive that will be kept for Long Term Retention (PR [#9364](https://github.com/vatesfr/xen-orchestra/pull/9364))
 
 ### Bug fixes
 
@@ -48,7 +49,7 @@
 <!--packages-start-->
 
 - @vates/types minor
-- @xen-orchestra/backups patch
+- @xen-orchestra/backups minor
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -56,5 +56,6 @@
 - vhd-cli minor
 - xo-server minor
 - xo-server-openmetrics minor
+- xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-web/src/common/render-xo-item.js
+++ b/packages/xo-web/src/common/render-xo-item.js
@@ -744,6 +744,13 @@ const xoItemToRender = {
       )}
       {backup.withMemory && <span className='tag tag-info'>{_('withMemory')} </span>}
       {backup.size !== undefined && <span className='tag tag-info'>{formatSize(backup.size)}</span>}{' '}
+      {backup.tags.map((tag, index) => {
+        return (
+          <span className='tag tag-info' key={index}>
+            {tag}
+          </span>
+        )
+      })}{' '}
       <NumericDate timestamp={backup.timestamp} />
     </span>
   ),


### PR DESCRIPTION
### Description
(how can I do a screenshot of a selector ? )
<img width="788" height="399" alt="image" src="https://github.com/user-attachments/assets/5eeab33d-eb20-4676-824b-445c3f335a1b" />

Add tags to show which backup will be kept for LTR 

This implementation won't update the previous backup ( because this will create new issues with immutability) , so a backup that is kept as a daily and yearly, will keep its daily tags, even if it's only kept by its yearly tag 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
