### PR TITLE
fix(backups): rework snapshot listing

### DIFF
--- a/@xen-orchestra/backups/_otherConfig.mjs
+++ b/@xen-orchestra/backups/_otherConfig.mjs
@@ -93,39 +93,6 @@ export function resetVmOtherConfig(xapi, vmRef) {
 
 /**
  *
- * used to ensure compatibility with the previous snapshots that were having the config stored only into VM
- *
- * @param {Xapi} xapi
- * @param {String} vmRef
- * @returns {Promise}
- */
-export async function populateVdisOtherConfig(xapi, vmRef) {
-  const otherConfig = await xapi.getField('VM', vmRef, 'other_config')
-  const {
-    [DATETIME]: datetime,
-    [DELTA_CHAIN_LENGTH]: chainLength,
-    [EXPORTED_SUCCESSFULLY]: successfully,
-    [JOB_ID]: jobId,
-    [REPLICATED_TO_SR_UUID]: replicatedTo,
-    [SCHEDULE_ID]: scheduleId,
-    [VM_UUID]: vmUuid,
-  } = otherConfig
-
-  return applyToVmAndVdis(xapi, vmRef, (type, ref) =>
-    xapi.setFieldEntries(type, ref, 'other_config', {
-      [DATETIME]: datetime,
-      [DELTA_CHAIN_LENGTH]: chainLength,
-      [EXPORTED_SUCCESSFULLY]: successfully,
-      [JOB_ID]: jobId,
-      [REPLICATED_TO_SR_UUID]: replicatedTo,
-      [SCHEDULE_ID]: scheduleId,
-      [VM_UUID]: vmUuid,
-    })
-  )
-}
-
-/**
- *
  * set the other_config key related to a backup of a VM and its associated VDIs
  *
  * @param {Xapi} xapi

--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
@@ -212,7 +212,7 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
         // orphan vdi snapshot
         info(
           `disk snapshot ${vdi.name_label} is orphan or attached only to control domain,
-          it will be removed at the end of a successfull backup run`,
+          it will be removed at the end of a successful backup run`,
           { vdi, attachedto: vdi.$VBDs.map(vbd => vbd?.$VM) }
         )
         continue
@@ -221,7 +221,7 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
       if (vbds.length > 1) {
         warn(
           `vdi ${vdi.name_label} (${vdi.uuid}) is linked to multipe vms :  ${userVms.map(({ name_label, uuid }) => `${name_label} ${uuid}`).join(', ')}. 
-              This disk snapshot will be excluded from the backup cleaining`,
+              This disk snapshot will be excluded from the backup cleaning`,
           { vdi, userVms }
         )
         delete vdiCandidates[vdi.uuid]
@@ -236,7 +236,7 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
       if (!vm.is_a_snapshot) {
         warn(
           `vdi ${vdi.name_label} (${vdi.uuid}) is a snapshot linked to a non snapshot vm ${vm.name_label} ${vm.uuid}. 
-          This disk snapshot will be excluded from the backup cleaining`,
+          This disk snapshot will be excluded from the backup cleaning`,
           { vdi, vm }
         )
         delete vdiCandidates[vdi.uuid]
@@ -252,7 +252,7 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
           warn(
             `vdi ${vdi.name_label} ${vdi.uuid} is recognized as a snapshot of the backup job,
            linked to vm ${vm.name_label} ${vm.uuid} but vdi ${outOfSnapshotsVdi.name_label} ${outOfSnapshotsVdi.uuid} 
-           is not linked to the job. This disk snapshot will be excluded from the backup cleaining`,
+           is not linked to the job. This disk snapshot will be excluded from the backup cleaning`,
             { vdi, vm, vbds, outOfSnapshotsVdi }
           )
           // this will be called multiple time but it is not really an issue

--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
@@ -9,14 +9,7 @@ import { defer } from 'golike-defer'
 import { getOldEntries } from '../../_getOldEntries.mjs'
 import { Task } from '../../Task.mjs'
 import { Abstract } from './_Abstract.mjs'
-import {
-  DATETIME,
-  JOB_ID,
-  SCHEDULE_ID,
-  populateVdisOtherConfig,
-  resetVmOtherConfig,
-  setVmOtherConfig,
-} from '../../_otherConfig.mjs'
+import { DATETIME, JOB_ID, SCHEDULE_ID, resetVmOtherConfig, setVmOtherConfig } from '../../_otherConfig.mjs'
 
 const { warn } = createLogger('xo:backups:AbstractXapi')
 
@@ -184,23 +177,7 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
 
   async _fetchJobSnapshots() {
     const jobId = this._jobId
-    const vmRef = this._vm.$ref
     const xapi = this._xapi
-
-    // to ensure compatibility with snapshots older than CBT implementation
-    // update vdi data to ensure the vdi are correctly fetched in _jobSnapshotVdis
-    // remove by then end of 2024
-    const vmSnapshotsRef = await xapi.getField('VM', vmRef, 'snapshots')
-    const vmSnapshotsOtherConfig = await asyncMap(vmSnapshotsRef, ref => xapi.getField('VM', ref, 'other_config'))
-
-    const vmSnapshots = []
-    vmSnapshotsOtherConfig.forEach((other_config, i) => {
-      if (other_config[JOB_ID] === jobId) {
-        vmSnapshots.push({ other_config, $ref: vmSnapshotsRef[i] })
-      }
-    })
-    await Promise.all(vmSnapshots.map(snapshot => populateVdisOtherConfig(xapi, snapshot.$ref)))
-    // end of compatibility handling
 
     // handle snapshot by VDI
     this._jobSnapshotVdis = []


### PR DESCRIPTION

### Description

the goal of this commit is to remove as much broken vdi/vm from the
backup snapshot handling , ensuring we keep the snapshot if we
are not sure how to delete them later

this may leave "dangling" snapshots, but at least this will make the
issue visible, and allow the user to decide what to do with this
out of spec disks

These invalid/suspicious disk/vm will be reported as warning


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
