### PR TITLE
fix(rest-api): various vm dashboard fixes

### DIFF
--- a/@xen-orchestra/rest-api/eslint.config.mjs
+++ b/@xen-orchestra/rest-api/eslint.config.mjs
@@ -15,5 +15,6 @@ export default tseslint.config(eslint.configs.recommended, tseslint.configs.reco
   },
   rules: {
     'no-unused-vars': ['off'], // In order to define the OpenAPI specification, we sometimes need to declare variables that will not be used.
+    '@typescript-eslint/no-empty-object-type': ['off'], // It can be useful to return an empty object instead of `undefined` (to differentiate between "no data" and an error case).
   },
 })

--- a/@xen-orchestra/rest-api/src/vms/vm.service.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.service.mts
@@ -272,7 +272,7 @@ export class VmService {
     }
 
     if (lastReplica === undefined) {
-      return
+      return {}
     }
 
     const vdis = this.getVmVdis(id, 'VM')
@@ -341,7 +341,7 @@ export class VmService {
         }
       }) as { backupJobId: XoVmBackupJob['id']; timestamp: number; status: string }[]
 
-    let vmProtection: VmDashboard['backupsInfo']['vmProtection'] = 'not-in-job'
+    let vmProtection: VmDashboard['backupsInfo']['vmProtection'] = 'not-in-active-job'
     if (!vmContainsNoBakTag(vm)) {
       const backupLogsByJob = groupBy(backupLogs, 'jobId')
 
@@ -382,7 +382,7 @@ export class VmService {
 
     return Object.values(backupArchivesByVmByBr)
       .filter(backupArchiveByVm => backupArchiveByVm !== undefined)
-      .flatMap(backupArchiveByVm => backupArchiveByVm[vm.id])
+      .flatMap(backupArchiveByVm => backupArchiveByVm[vm.id] ?? [])
       .sort((a, b) => b.timestamp - a.timestamp)
       .splice(0, 3)
       .map(ba => ({ id: ba.id, timestamp: ba.timestamp, backupRepository: ba.backupRepository, size: ba.size }))

--- a/@xen-orchestra/rest-api/src/vms/vm.type.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.type.mts
@@ -43,8 +43,8 @@ export type VmDashboard = {
   alarms: XoAlarm['id'][]
   backupsInfo: {
     lastRuns: VmDashboardRun[]
-    vmProtection: 'protected' | 'unprotected' | 'not-in-job'
-    replication?: { id: XoVm['id']; timestamp: number; sr?: XoSr['id'] }
+    vmProtection: 'protected' | 'unprotected' | 'not-in-active-job'
+    replication: { id: XoVm['id']; timestamp: number; sr?: XoSr['id'] } | {}
     backupArchives: VmDashboardBackupArchive[]
   }
 }
@@ -57,7 +57,7 @@ export type UnbrandedVmDashboard = {
   backupsInfo: {
     lastRuns: Unbrand<VmDashboardRun>[]
     vmProtection: VmDashboard['backupsInfo']['vmProtection']
-    replication?: Unbrand<VmDashboard['backupsInfo']['replication']>
+    replication: Unbrand<VmDashboard['backupsInfo']['replication']>
     backupArchives: Unbrand<VmDashboardBackupArchive>[]
   }
 }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,10 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [REST API] Fix `/vms/:id/dashboard` _cannot read properties of undefined (reading 'id')_ (PR [#9380](https://github.com/vatesfr/xen-orchestra/pull/9380))
+- [REST API] `vms/:id/dashboard` return now an empty object for the `replication` key instead of undefined (in case of no replication) (PR [#9380](https://github.com/vatesfr/xen-orchestra/pull/9380))
+- [REST API] `vms/:id/dashboard` rename `in-no-job` into `in-no-active-job` for the `vmProtection` key to avoid confusion (PR [#9380](https://github.com/vatesfr/xen-orchestra/pull/9380))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,7 +19,7 @@
 
 - [REST API] Fix `/vms/:id/dashboard` _cannot read properties of undefined (reading 'id')_ (PR [#9380](https://github.com/vatesfr/xen-orchestra/pull/9380))
 - [REST API] `vms/:id/dashboard` return now an empty object for the `replication` key instead of undefined (in case of no replication) (PR [#9380](https://github.com/vatesfr/xen-orchestra/pull/9380))
-- [REST API] `vms/:id/dashboard` rename `in-no-job` into `in-no-active-job` for the `vmProtection` key to avoid confusion (PR [#9380](https://github.com/vatesfr/xen-orchestra/pull/9380))
+- [REST API] `vms/:id/dashboard` rename `not-in-job` into `not-in-active-job` for the `vmProtection` key to avoid confusion (PR [#9380](https://github.com/vatesfr/xen-orchestra/pull/9380))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

- fix cannot read properties of undefined when a VM is in a backup job, but no backup-archives for this VM
- return an empty object instead undefined for the `replication` key, so we can know if there is no value or if there is an error
- rename `not-in-job` to `not-in-active-job` to avoid confusion

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
