### PR TITLE
docs(xo): Add instructions for fetching deps on RHEL 10 distros

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -120,6 +120,21 @@ On Fedora/CentOS like:
 dnf install redis libpng-devel git lvm2 cifs-utils make automake gcc gcc-c++ nfs-utils ntfs-3g openssl
 ```
 
+Starting with release 10 of CentOS, AlmaLinux, Rocky Linux (June 2025), Redis is no longer offered as a package.
+Valkey is a drop-in replacement key-value database.
+These distributions also include a package to ensure compatibility between Valkey and Redis called valkey-compat-redis.
+valkey-compat-redis is found in the `devel` repository in DNF.
+
+Additionally, the `ntfs-3g` program has been moved to the EPEL repository.
+
+```sh
+dnf install epel-release
+
+dnf config-manager --enable devel
+
+dnf install valkey valkey-compat-redis libpng-devel git lvm2 cifs-utils make automake gcc gcc-c++ nfs-utils ntfs-3g openssl
+```
+
 ### Make sure Redis is running
 
 Start the service:
@@ -128,12 +143,20 @@ Start the service:
 systemctl restart redis.service
 ```
 
+or if you installed valkey
+
+```sh
+systemctl restart valkey.service
+```
+
 Ensure it's working:
 
 ```console
 $ redis-cli ping
 PONG
 ```
+
+If you installed the valkey-compat-redis package, then `redis-cli` will be installed as a compatibility script.
 
 ### Fetching the Code
 
@@ -395,10 +418,10 @@ If you are running `xo-server` as a non-root user, you need to use `sudo` to be 
 useSudo = true
 ```
 
-You need to configure `sudo` to allow the user of your choice to run mount/umount commands without asking for a password. 
+You need to configure `sudo` to allow the user of your choice to run mount/umount commands without asking for a password.
 
 :::tip
-Depending on your operating system or `sudo` version, the location of this configuration may change. 
+Depending on your operating system or `sudo` version, the location of this configuration may change.
 
 Regardless, you can use:
 


### PR DESCRIPTION
### Description

RHEL 10 and co. (AlmaLinux, Rocky, CentOS), released in June 2025, stopped shipping redis and moved some packages around. Update the docs to reflect that.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
