### PR TITLE
fix(xo-server-openmetrics): use correct timestamp property name in computeVmCpuUsageFallback

### DIFF
--- a/packages/xo-server-openmetrics/src/openmetric-formatter.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.mts
@@ -516,10 +516,10 @@ function computeVmCpuUsageFallback(metrics: FormattedMetric[]): FormattedMetric[
         vmCoreMetrics.set(vmUuid, vmTimestamps)
       }
 
-      let coreValues = vmTimestamps.get(metric.timestampMs)
+      let coreValues = vmTimestamps.get(metric.timestamp)
       if (coreValues === undefined) {
         coreValues = new Map()
-        vmTimestamps.set(metric.timestampMs, coreValues)
+        vmTimestamps.set(metric.timestamp, coreValues)
       }
 
       coreValues.set(metric.labels.core, { value: metric.value, metric })
@@ -536,7 +536,7 @@ function computeVmCpuUsageFallback(metrics: FormattedMetric[]): FormattedMetric[
     }
 
     // For each timestamp, compute average of all cores
-    for (const [timestampMs, coreValues] of timestamps) {
+    for (const [timestamp, coreValues] of timestamps) {
       if (coreValues.size === 0) {
         continue
       }
@@ -569,7 +569,7 @@ function computeVmCpuUsageFallback(metrics: FormattedMetric[]): FormattedMetric[
         type: 'gauge',
         labels,
         value: averageUsage,
-        timestampMs,
+        timestamp,
       })
     }
   }


### PR DESCRIPTION
### Description

Remove redundant TypeScript type assertion in `computeVmCpuUsageFallback`.

The `coreValues` variable is already typed as `Map<string, { value: number; metric: FormattedMetric }>`, so the explicit `as` cast on `.values().next().value` is unnecessary - TypeScript can infer the correct type automatically.

Introduced by [29fa4b2](https://github.com/vatesfr/xen-orchestra/pull/9384/commits/29fa4b24a8718fff9283118ad6333a7057c6cad2)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
