### PR TITLE
feat(vhd-cli): prevent using invalid options

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -44,6 +44,7 @@
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+- vhd-cli minor
 - xo-server-openmetrics minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,7 @@
 
 - [OpenMetrics] Expose SR capacity metrics: `xcp_sr_virtual_size_bytes`, `xcp_sr_physical_size_bytes`, `xcp_sr_physical_usage_bytes` (PR [#9360](https://github.com/vatesfr/xen-orchestra/pull/9360))
 - [REST API] Update `/dashboard` endpoint to also return disconnected servers, disabled hosts, the status of all VMs, and compute `jobs` from the last seven days (PR [#9207](https://github.com/vatesfr/xen-orchestra/pull/9207))
+- [vhd-cli] Prevent using invalid options (PR [#9386](https://github.com/vatesfr/xen-orchestra/pull/9386))
 
 ### Bug fixes
 

--- a/packages/vhd-cli/commands/check.js
+++ b/packages/vhd-cli/commands/check.js
@@ -10,8 +10,11 @@ const checkVhd = (handler, path) => new VhdFile(handler, path).readHeaderAndFoot
 module.exports = async function check(rawArgs) {
   const {
     chain,
+    c,
     help,
+    h,
     _: args,
+    ...unexpectedArgs
   } = getopts(rawArgs, {
     alias: {
       chain: 'c',
@@ -28,6 +31,10 @@ module.exports = async function check(rawArgs) {
     return `Checks for the integrity of one or more VHDs.
     Use option --chain to check for VHD directory/ies.
     Usage: ${this.command} [--chain] <remote URL> <VHD path on remote> <another VHD path (optional)> ...`
+  }
+  const unexpectedArgsList = Object.keys(unexpectedArgs)
+  if (unexpectedArgsList.length > 0) {
+    return `Option${unexpectedArgsList.length > 1 ? 's' : ''} ${unexpectedArgsList} unsupported, use --help for details.`
   }
 
   const check = chain ? checkVhdChain : checkVhd

--- a/packages/vhd-cli/commands/compare.js
+++ b/packages/vhd-cli/commands/compare.js
@@ -36,6 +36,10 @@ module.exports = async function compare(args) {
     return `Tells if two VHDs are identical.
     Usage: ${this.command} <sourceRemoteUrl> <source VHD> <destinationRemoteUrl> <destination>`
   }
+  const unexpectedArgs = args.filter(arg => arg.startsWith('-'))
+  if (unexpectedArgs.length > 0) {
+    return `Option${unexpectedArgs.length > 1 ? 's' : ''} ${unexpectedArgs} unsupported, use --help for details.`
+  }
   const [sourceRemoteUrl, sourcePath, destRemoteUrl, destPath] = args
 
   await Disposable.use(async function* () {

--- a/packages/vhd-cli/commands/copy.js
+++ b/packages/vhd-cli/commands/copy.js
@@ -8,8 +8,11 @@ const getopts = require('getopts')
 module.exports = async function copy(rawArgs) {
   const {
     directory,
+    d,
     help,
+    h,
     _: args,
+    ...unexpectedArgs
   } = getopts(rawArgs, {
     alias: {
       directory: 'd',
@@ -24,6 +27,10 @@ module.exports = async function copy(rawArgs) {
   if (args.length < 4 || help) {
     return `Copies a VHD. Use --directory if copied VHD is a VHD direcory.
     Usage: ${this.command} <sourceRemoteUrl> <source VHD> <destinationRemoteUrl> <destination> [--directory]`
+  }
+  const unexpectedArgsList = Object.keys(unexpectedArgs)
+  if (unexpectedArgsList.length > 0) {
+    return `Option${unexpectedArgsList.length > 1 ? 's' : ''} ${unexpectedArgsList} unsupported, use --help for details.`
   }
   const [sourceRemoteUrl, sourcePath, destRemoteUrl, destPath] = args
 

--- a/packages/vhd-cli/commands/info.js
+++ b/packages/vhd-cli/commands/info.js
@@ -94,6 +94,10 @@ module.exports = async function info(args) {
     return `Displays infos on one or more VHDs.
     Usage: ${this.command} <remote URL> <VHD path on remote> <another VHD path (optional)> ...`
   }
+  const unexpectedArgs = args.filter(arg => arg.startsWith('-'))
+  if (unexpectedArgs.length > 0) {
+    return `Option${unexpectedArgs.length > 1 ? 's' : ''} ${unexpectedArgs} unsupported, use --help for details.`
+  }
 
   await Disposable.use(getSyncedHandler({ url: args.shift() }), async handler => {
     if (args.length === 1) {

--- a/packages/vhd-cli/commands/merge.js
+++ b/packages/vhd-cli/commands/merge.js
@@ -10,6 +10,10 @@ module.exports = async function merge(args) {
     return `Merges two VHDs.
     Usage: ${this.command} <remote URL> <child VHD path on remote> <parent VHD path on remote>`
   }
+  const unexpectedArgs = args.filter(arg => arg.startsWith('-'))
+  if (unexpectedArgs.length > 0) {
+    return `Option${unexpectedArgs.length > 1 ? 's' : ''} ${unexpectedArgs} unsupported, use --help for details.`
+  }
 
   await Disposable.use(getSyncedHandler({ url: args[0] }), async handler => {
     let bar

--- a/packages/vhd-cli/commands/raw.js
+++ b/packages/vhd-cli/commands/raw.js
@@ -12,6 +12,10 @@ module.exports = async function raw(args) {
     return `Exports VHD as raw file.
     Usage: ${this.command} <remote URL> <input VHD path on remote> [<output raw>]`
   }
+  const unexpectedArgs = args.filter(arg => arg.startsWith('-'))
+  if (unexpectedArgs.length > 0) {
+    return `Option${unexpectedArgs.length > 1 ? 's' : ''} ${unexpectedArgs} unsupported, use --help for details.`
+  }
 
   await Disposable.use(async function* () {
     const handler = yield getSyncedHandler({ url: args[0] })

--- a/packages/vhd-cli/commands/repl.js
+++ b/packages/vhd-cli/commands/repl.js
@@ -11,6 +11,10 @@ module.exports = async function repl(args) {
     return `Starts REPL on given remote, or on remote at current path if no param is passed. (works only for unencrypted remotes)
     Usage: ${this.command} <remote URL (optional)>`
   }
+  const unexpectedArgs = args.filter(arg => arg.startsWith('-'))
+  if (unexpectedArgs.length > 0) {
+    return `Option${unexpectedArgs.length > 1 ? 's' : ''} ${unexpectedArgs} unsupported, use --help for details.`
+  }
   const cwd = process.cwd()
   const url = args.length === 0 ? 'file://' + cwd : args[0]
   const handler = getHandler({ url })


### PR DESCRIPTION
### Description

As seen in https://xcp-ng.org/forum/topic/11589, using an incorrect option in a `vhd-cli` command makes it fail with an error message that makes the user think the command arguments were good but the command failed.

This PR makes it rather display an explicit message.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
