### PR TITLE
feat(rest-api): add DELETE /vbds/{id} endpoint

### DIFF
--- a/@vates/types/src/lib/xen-orchestra-xapi.mts
+++ b/@vates/types/src/lib/xen-orchestra-xapi.mts
@@ -193,6 +193,7 @@ export interface Xapi {
     VDI: XenApiVdi['$ref'] | OPAQUE_REF_NULL
     VM: XenApiVm['$ref']
   }): Promise<XenApiVbd['$ref']>
+  VBD_destroy(vbdRef: XenApiVbd['$ref']): Promise<void>
   VDI_destroy(vdiRef: XenApiVdi['$ref']): Promise<void>
   VDI_destroyCloudInitConfig(vdiRef: XenApiVdi['$ref'], opts?: { timeLimit?: number }): Promise<void>
   VDI_exportContent(

--- a/@xen-orchestra/rest-api/src/vbds/vbd.controller.mts
+++ b/@xen-orchestra/rest-api/src/vbds/vbd.controller.mts
@@ -1,5 +1,6 @@
 import {
   Body,
+  Delete,
   Example,
   Get,
   Middlewares,
@@ -27,6 +28,7 @@ import {
   badRequestResp,
   createdResp,
   invalidParameters,
+  noContentResp,
   notFoundResp,
   unauthorizedResp,
   type Unbrand,
@@ -119,6 +121,22 @@ export class VbdController extends XapiXoController<XoVbd> {
   @Response(notFoundResp.status, notFoundResp.description)
   getVbd(@Path() id: string): Unbrand<XoVbd> {
     return this.getObject(id as XoVbd['id'])
+  }
+
+  /**
+   * Delete a VBD
+   *
+   * Removes the virtual block device, detaching the VDI from the VM.
+   * The VDI itself is NOT deleted.
+   *
+   * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
+   */
+  @Delete('{id}')
+  @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  async deleteVbd(@Path() id: string): Promise<void> {
+    const xapiVbd = this.getXapiObject(id as XoVbd['id'])
+    await xapiVbd.$xapi.VBD_destroy(xapiVbd.$ref)
   }
 
   /**

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@
 - [TreeView] Scroll to current item in list view (PR [#9268](https://github.com/vatesfr/xen-orchestra/pull/9268))
 - [REST API] Add `createVtpm` parameter to VM creation endpoint (PR [#9412](https://github.com/vatesfr/xen-orchestra/pull/9412))
 - [Backup] show the backup archive that will be kept for Long Term Retention (PR [#9364](https://github.com/vatesfr/xen-orchestra/pull/9364))
+- [REST API] Add `DELETE /vbds/{id}` endpoint to remove a VBD (PR [#9394](https://github.com/vatesfr/xen-orchestra/pull/9394))
 
 ### Bug fixes
 


### PR DESCRIPTION
### Description

[XO-1743](https://project.vates.tech/vates-global/browse/XO-1743/)

Add a new REST API endpoint to delete VBDs (Virtual Block Devices).

**Endpoint:** `DELETE /rest/v0/vbds/{id}`

**Behavior:**
- Removes the virtual block device, detaching the VDI from the VM
- The VDI itself is NOT deleted
- Returns `204 No Content` on success
- Returns `404 Not Found` if VBD doesn't exist

**Changes:**
- `@xen-orchestra/rest-api`: Add `deleteVbd` method to `VbdController`
- `@vates/types`: Add `VBD_destroy` method signature to `Xapi` interface

**Example usage:**
```bash
curl -X DELETE \
  -u "user@example.com:password" \
  "https://xoa.example.com/rest/v0/vbds/f07ab729-c0e8-721c-45ec-f11276377030"
# Returns: 204 No Content
```

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [ ] Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - [ ] If bug fix, add `Introduced by`
- Changelog
  - [x] If visible by XOA users, add changelog entry
  - [x] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [x] If UI changes, add screenshots (N/A - API only)
  - [x] If not finished or not tested, open as _Draft_ (Tested manually)

### Testing

Manually tested on XOA instance:

| Test Case | Expected | Result |
|-----------|----------|--------|
| DELETE existing VBD | 204 No Content | Pass |
| DELETE non-existent VBD | 404 Not Found | Pass |
| DELETE without auth | 401 Unauthorized | Pass |

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**


Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
