### PR TITLE
fix(@xen-orchestra/rest-api): add isEmpty prop for xoa dashboard

### DIFF
--- a/@xen-orchestra/rest-api/src/helpers/helper.type.mts
+++ b/@xen-orchestra/rest-api/src/helpers/helper.type.mts
@@ -29,3 +29,7 @@ export type AuthenticatedRequest = Request & {
     }
   }
 }
+
+export type IsEmptyData = { isEmpty: true }
+
+export type IsMaybeExpired<T> = T & { isExpired?: true }

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/xoa.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/xoa.oa-example.mts
@@ -1,7 +1,9 @@
 export const xoaDashboard = {
   nPools: 2,
   nHosts: 5,
-  backupRepositories: {},
+  backupRepositories: {
+    isEmpty: true,
+  },
   resourcesOverview: {
     nCpus: 52,
     memorySize: 111669149696,

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/xoa.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/xoa.oa-example.mts
@@ -1,61 +1,49 @@
 export const xoaDashboard = {
   nPools: 2,
   nHosts: 5,
-  backupRepositories: {
-    s3: {
-      size: {
-        backups: 286295393792,
-      },
-    },
-    other: {
-      size: {
-        available: 62630354944,
-        backups: 20684251648,
-        other: 66875031040,
-        total: 150189637632,
-        used: 87559282688,
-      },
-    },
-  },
+  backupRepositories: {},
   resourcesOverview: {
     nCpus: 52,
-    memorySize: 107374182400,
-    srSize: 751123595264,
+    memorySize: 111669149696,
+    srSize: 1132693933056,
   },
   poolsStatus: {
     connected: 2,
-    unreachable: 7,
+    disconnected: 1,
+    unreachable: 0,
     unknown: 0,
+    total: 3,
   },
-  nHostsEol: 0,
   missingPatches: {
-    hasAuthorization: true,
-    nHostsFailed: 1,
-    nHostsWithMissingPatches: 4,
-    nPoolsWithMissingPatches: 2,
+    hasAuthorization: false,
   },
   storageRepositories: {
     size: {
-      available: 628454834176,
-      other: 122641256960,
-      replicated: 27504128,
-      total: 751123595264,
-      used: 122668761088,
+      available: 622560659456,
+      other: 494094312448,
+      replicated: 16038961152,
+      total: 1132693933056,
+      used: 510133273600,
     },
   },
   backups: {
-    jobs: {
-      disabled: 8,
-      failed: 0,
-      skipped: 0,
-      successful: 0,
-      total: 8,
-    },
-    issues: [],
-    vmsProtection: {
-      protected: 0,
-      unprotected: 0,
-      notInJob: 20,
-    },
+    isEmpty: true,
+  },
+  hostsStatus: {
+    disabled: 0,
+    running: 4,
+    halted: 1,
+    unknown: 0,
+    total: 5,
+  },
+  vmsStatus: {
+    active: 11,
+    inactive: 39,
+    running: 11,
+    halted: 39,
+    paused: 0,
+    suspended: 0,
+    unknown: 0,
+    total: 50,
   },
 }

--- a/@xen-orchestra/rest-api/src/xoa/xoa.service.mts
+++ b/@xen-orchestra/rest-api/src/xoa/xoa.service.mts
@@ -136,6 +136,11 @@ export class XoaService {
           }
         }
 
+        // if only disabled BR
+        if (otherBrSize === undefined && s3Brsize === undefined) {
+          return { isEmpty: true }
+        }
+
         const result: DashboardBackupRepositoriesSizeInfo = {}
         if (s3Brsize !== undefined) {
           result.s3 = s3Brsize

--- a/@xen-orchestra/rest-api/src/xoa/xoa.service.mts
+++ b/@xen-orchestra/rest-api/src/xoa/xoa.service.mts
@@ -21,9 +21,9 @@ import { parse } from 'xo-remote-parser'
 import { Writable } from 'node:stream'
 
 import { type AsyncCacheEntry, getFromAsyncCache } from '../helpers/cache.helper.mjs'
-import { DashboardBackupRepositoriesSizeInfo, DashboardBackupsInfo, XoaDashboard } from './xoa.type.mjs'
+import { DashboardBackupRepositoriesSizeInfo, DashboardBackupsInfo, SrSizeInfo, XoaDashboard } from './xoa.type.mjs'
 import { isReplicaVm, isSrWritableOrIso, promiseWriteInStream, vmContainsNoBakTag } from '../helpers/utils.helper.mjs'
-import type { MaybePromise } from '../helpers/helper.type.mjs'
+import type { IsEmptyData, MaybePromise } from '../helpers/helper.type.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { HostService } from '../hosts/host.service.mjs'
 import type { HasNoAuthorization } from '../rest-api/rest-api.type.mjs'
@@ -34,8 +34,8 @@ import { BackupJobService } from '../backup-jobs/backup-job.service.mjs'
 const log = createLogger('xo:rest-api:xoa-service')
 
 type DashboardAsyncCache = {
-  backupRepositories: MaybePromise<DashboardBackupRepositoriesSizeInfo | undefined>
-  backups: MaybePromise<DashboardBackupsInfo>
+  backupRepositories: MaybePromise<DashboardBackupRepositoriesSizeInfo | IsEmptyData | undefined>
+  backups: MaybePromise<DashboardBackupsInfo | IsEmptyData>
 }
 
 export class XoaService {
@@ -63,7 +63,7 @@ export class XoaService {
   }
 
   async #getBackupRepositoriesSizeInfo(): Promise<
-    (DashboardBackupRepositoriesSizeInfo & { isExpired?: true }) | undefined
+    (DashboardBackupRepositoriesSizeInfo & { isExpired?: true }) | (IsEmptyData & { isExpired?: true }) | undefined
   > {
     const brResult = await getFromAsyncCache<DashboardAsyncCache['backupRepositories']>(
       this.#dashboardAsyncCache as Map<
@@ -83,7 +83,7 @@ export class XoaService {
 
         const backupRepositories = await xoApp.getAllRemotes()
         if (backupRepositories.length === 0) {
-          return undefined
+          return { isEmpty: true }
         }
 
         const backupRepositoriesInfo = await xoApp.getAllRemotesInfo()
@@ -173,6 +173,10 @@ export class XoaService {
       })
     )
 
+    if (pools === undefined && hosts === undefined && srs === undefined) {
+      return { isEmpty: true }
+    }
+
     const maxLenght = Math.max(hosts.length, srs.length)
 
     const resourcesOverview = { nCpus: 0, memorySize: 0, srSize: 0 }
@@ -238,11 +242,11 @@ export class XoaService {
     }
   }
 
-  async #getNumberOfEolHosts(): Promise<XoaDashboard['nHostsEol']> {
+  async #getNumberOfEolHosts(): Promise<number | IsEmptyData> {
     const getHVSupportedVersions = this.#restApi.xoApp.getHVSupportedVersions
 
     if (getHVSupportedVersions === undefined) {
-      return
+      return { isEmpty: true }
     }
 
     const hvSupportedVersions = await getHVSupportedVersions()
@@ -265,13 +269,17 @@ export class XoaService {
    */
   async #getMissingPatchesInfo(): Promise<XoaDashboard['missingPatches']> {
     const missingPatchesInfo = await this.#hostService.getMissingPatchesInfo()
+    const eolHosts = await this.#getNumberOfEolHosts()
 
     const { hasAuthorization, nHostsFailed, nHostsWithMissingPatches, nPoolsWithMissingPatches } = missingPatchesInfo
 
     return {
       hasAuthorization,
+      nHosts: this.#getNumberOfHosts(),
       nHostsFailed,
       nHostsWithMissingPatches,
+      nHostsEol: eolHosts,
+      nPools: this.#getNumberOfPools(),
       nPoolsWithMissingPatches,
     }
   }
@@ -315,18 +323,22 @@ export class XoaService {
     return replicaUsage + parentUsage
   }
 
-  #getStorageRepositoriesSizeInfo() {
+  #getStorageRepositoriesSizeInfo(): SrSizeInfo | IsEmptyData {
     const writableSrs = this.#restApi.getObjectsByType<XoSr>('SR', {
       filter: isSrWritableOrIso,
     })
+
+    const srs = Object.values(writableSrs)
+
+    if (srs.length === 0) {
+      return { isEmpty: true }
+    }
 
     let replicated = 0
     let total = 0
     let used = 0
 
-    for (const srId in writableSrs) {
-      const sr = writableSrs[srId as XoSr['id']]
-
+    for (const sr of srs) {
       const cache = new Set<AnyXoVdi['id']>()
       const { VDIs } = sr
 
@@ -340,7 +352,9 @@ export class XoaService {
     }
   }
 
-  async #getbackupsInfo(): Promise<(DashboardBackupsInfo & { isExpired?: true }) | undefined> {
+  async #getbackupsInfo(): Promise<
+    (DashboardBackupsInfo & { isExpired?: true }) | (IsEmptyData & { isExpired?: true }) | undefined
+  > {
     const vmIdsProtected = new Set<XoVm['id']>()
     const vmIdsUnprotected = new Set<XoVm['id']>()
     const nonReplicaVms = Object.values(this.#restApi.getObjectsByType<XoVm>('VM', { filter: vm => !isReplicaVm(vm) }))
@@ -398,6 +412,11 @@ export class XoaService {
             xoApp.getAllJobs('metadataBackup'),
           ]).then(jobs => jobs.flat(1)) as Promise<XoVmBackupJob[]>,
         ])
+
+        if (jobs.length === 0) {
+          return { isEmpty: true }
+        }
+
         const logsByJob = groupBy(logs, 'jobId')
 
         let disabledJobs = 0
@@ -570,7 +589,6 @@ export class XoaService {
       poolsStatus,
       missingPatches,
       backupRepositories,
-      nHostsEol,
       backups,
     ] = await Promise.all([
       promiseWriteInStream({ maybePromise: this.#getNumberOfPools(), path: 'nPools', stream }),
@@ -595,16 +613,11 @@ export class XoaService {
         }),
         path: 'missingPatches',
         stream,
+        handleError: true,
       }),
       promiseWriteInStream({
         maybePromise: this.#getBackupRepositoriesSizeInfo(),
         path: 'backupRepositories',
-        stream,
-        handleError: true,
-      }),
-      promiseWriteInStream({
-        maybePromise: this.#getNumberOfEolHosts(),
-        path: 'nHostsEol',
         stream,
         handleError: true,
       }),
@@ -622,7 +635,6 @@ export class XoaService {
       backupRepositories,
       resourcesOverview,
       poolsStatus,
-      nHostsEol,
       missingPatches,
       storageRepositories,
       backups,

--- a/@xen-orchestra/rest-api/src/xoa/xoa.type.mts
+++ b/@xen-orchestra/rest-api/src/xoa/xoa.type.mts
@@ -1,5 +1,6 @@
 import { BACKUP_TYPE } from '@vates/types'
-import type { PromiseWriteInStreamError } from '../helpers/helper.type.mjs'
+import type { IsEmptyData, IsMaybeExpired, PromiseWriteInStreamError } from '../helpers/helper.type.mjs'
+import type { HasNoAuthorization } from '../rest-api/rest-api.type.mjs'
 
 export type DashboardBackupRepositoriesSizeInfo = {
   s3?: {
@@ -32,10 +33,29 @@ export type DashboardBackupsInfo = {
   }
 }
 
+export type SrSizeInfo = {
+  size: {
+    available: number
+    other: number
+    replicated: number
+    total: number
+    used: number
+  }
+}
+
+export type MissingPatchesInfo = {
+  hasAuthorization: true
+  nHosts: number
+  nHostsEol: number | IsEmptyData
+  nHostsWithMissingPatches: number
+  nHostsFailed: number
+  nPools: number
+  nPoolsWithMissingPatches: number
+}
+
 export type XoaDashboard = {
   nPools: number
   nHosts: number
-  nHostsEol?: number | PromiseWriteInStreamError
   hostsStatus: {
     disabled: number
     running: number
@@ -53,33 +73,21 @@ export type XoaDashboard = {
     unknown: number
     total: number
   }
-  missingPatches:
-    | { hasAuthorization: false }
-    | {
-        hasAuthorization: true
-        nHostsWithMissingPatches: number
-        nPoolsWithMissingPatches: number
-        nHostsFailed: number
-      }
-  backupRepositories?: DashboardBackupRepositoriesSizeInfo | PromiseWriteInStreamError
-  storageRepositories:
-    | {
-        size: {
-          available: number
-          other: number
-          replicated: number
-          total: number
-          used: number
-        }
-      }
+  missingPatches: MissingPatchesInfo | HasNoAuthorization | PromiseWriteInStreamError
+  backupRepositories?:
+    | IsMaybeExpired<DashboardBackupRepositoriesSizeInfo>
+    | IsMaybeExpired<IsEmptyData>
     | PromiseWriteInStreamError
-  backups?: DashboardBackupsInfo | PromiseWriteInStreamError
+  storageRepositories: SrSizeInfo | PromiseWriteInStreamError | IsEmptyData
 
-  resourcesOverview: {
-    nCpus: number
-    memorySize: number
-    srSize: number
-  }
+  backups?: IsMaybeExpired<DashboardBackupsInfo> | IsMaybeExpired<IsEmptyData> | PromiseWriteInStreamError
+  resourcesOverview:
+    | {
+        nCpus: number
+        memorySize: number
+        srSize: number
+      }
+    | IsEmptyData
   poolsStatus: {
     connected: number
     disconnected: number

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@
 - [REST API] `vms/:id/dashboard` return now an empty object for the `replication` key instead of undefined (in case of no replication) (PR [#9380](https://github.com/vatesfr/xen-orchestra/pull/9380))
 - [REST API] `vms/:id/dashboard` rename `not-in-job` into `not-in-active-job` for the `vmProtection` key to avoid confusion (PR [#9380](https://github.com/vatesfr/xen-orchestra/pull/9380))
 - [REST API] Don't return VDI-snapshot for `/vms/:id/vdis` endpoints (PR [#9381](https://github.com/vatesfr/xen-orchestra/pull/9381))
+- [REST API] `/dashboard` return now `{isEmpty: true}` instead of undefined in case there is no data to compute (PR [#9395](https://github.com/vatesfr/xen-orchestra/pull/9395))
 - **XO 6:**
   - [Sidebar] Removal borders top and right of sidebar in mobile (PR [#9366](https://github.com/vatesfr/xen-orchestra/pull/9366))
 


### PR DESCRIPTION
### Description

The goal of this PR is to better handle various state for the dashboard endpoint when using `ndjson` param (for the front team).
`value === undefined` -> `value is loading`
`value === {isEmpty: true}` -> `no data to compute`
`value === {error: true}`  -> `error during the data computation`

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
