### PR TITLE
fix(xo-server): race condition on XOA WebSocket during plugin loading

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Backup] snapshots of VM with a CDROM mounted are not removed (PR [#9570](https://github.com/vatesfr/xen-orchestra/pull/9570))
+- [OpenMetrics] Fix plugin failing to auto-start after xo-server restart due to XOA WebSocket connection race condition (PR [#9402](https://github.com/vatesfr/xen-orchestra/pull/9402))
 
 ### Packages to release
 
@@ -34,4 +35,5 @@
 <!--packages-start-->
 
 - @xen-orchestra/backups patch
+- xo-server patch
 <!--packages-end-->


### PR DESCRIPTION
### Description

Fix a race condition where the OpenMetrics plugin fails to auto-start after xo-server restart because the XOA WebSocket connection is not yet established when `getXoaPlan()` is called during plugin loading.

The `#getCurrentPlan()` method in `authorization.mjs` now uses `retry` from `promise-toolbox` to retry when the WebSocket connection is in `connecting` state, allowing plugins that require authorization checks to start correctly even if the XOA connection isn't ready yet.

Introduced by 980e4b588768f43aa7d661bba299c53e18f6365a (Feature openmetrics #9323)

See [XO-1855](https://project.vates.tech/vates-global/browse/XO-1855/)

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - [x] If bug fix, add `Introduced by`
- Changelog
  - [x] If visible by XOA users, add changelog entry
  - [x] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [ ] If UI changes, add screenshots
  - [ ] If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
