### PR TITLE
feat(@vates/types,xo-server-openmetrics): use centralized XoApp type

### DIFF
--- a/@vates/types/src/xo-app.mts
+++ b/@vates/types/src/xo-app.mts
@@ -46,6 +46,13 @@ import {
   XenApiVtpmWrapped,
 } from './index.mjs'
 
+export type XapiConnection = Xapi & {
+  status: string
+  pool?: { uuid: string }
+  sessionId: string
+  _url?: { protocol: string; hostname: string; port?: string }
+}
+
 type XapiRecordByXapiXoRecord = {
   gpuGroup: XenApiGpuGroupWrapped
   host: XenApiHostWrapped
@@ -244,4 +251,6 @@ export type XoApp = {
       name?: string
     }
   ): void
+  getAllXapis(): Record<string, XapiConnection>
+  getObjects(opts?: { filter?: Record<string, unknown>; limit?: number }): Record<string, XapiXoRecord>
 }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,6 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [@vates/types] Add `XapiConnection` type and `getAllXapis`/`getObjects` methods to `XoApp` (PR [#xxxx](https://github.com/vatesfr/xen-orchestra/pull/xxxx))
 - [OpenMetrics] Expose SR capacity metrics: `xcp_sr_virtual_size_bytes`, `xcp_sr_physical_size_bytes`, `xcp_sr_physical_usage_bytes` (PR [#9360](https://github.com/vatesfr/xen-orchestra/pull/9360))
 - [REST API] Update `/dashboard` endpoint to also return disconnected servers, disabled hosts, the status of all VMs, and compute `jobs` from the last seven days (PR [#9207](https://github.com/vatesfr/xen-orchestra/pull/9207))
 - [vhd-cli] Prevent using invalid options (PR [#9386](https://github.com/vatesfr/xen-orchestra/pull/9386))

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [@vates/types] Add `XapiConnection` type and `getAllXapis`/`getObjects` methods to `XoApp` (PR [#xxxx](https://github.com/vatesfr/xen-orchestra/pull/xxxx))
 - [OpenMetrics] Expose SR capacity metrics: `xcp_sr_virtual_size_bytes`, `xcp_sr_physical_size_bytes`, `xcp_sr_physical_usage_bytes` (PR [#9360](https://github.com/vatesfr/xen-orchestra/pull/9360))
 - [REST API] Update `/dashboard` endpoint to also return disconnected servers, disabled hosts, the status of all VMs, and compute `jobs` from the last seven days (PR [#9207](https://github.com/vatesfr/xen-orchestra/pull/9207))
 - [vhd-cli] Prevent using invalid options (PR [#9386](https://github.com/vatesfr/xen-orchestra/pull/9386))

--- a/packages/xo-server-openmetrics/src/index.mts
+++ b/packages/xo-server-openmetrics/src/index.mts
@@ -6,7 +6,7 @@
  * RRD data directly from connected XAPI pools.
  */
 
-import type { XoHost, XoNetwork, XoPif, XoPool, XoSr, XoVbd, XoVdi, XoVif, XoVm } from '@vates/types'
+import type { XoApp, XoHost, XoNetwork, XoPif, XoPool, XoSr, XoVbd, XoVdi, XoVif, XoVm } from '@vates/types'
 import { createLogger } from '@xen-orchestra/log'
 import { fork, type ChildProcess } from 'node:child_process'
 import { dirname, join } from 'node:path'
@@ -91,21 +91,6 @@ interface SrDataPayload {
 // Union type for all XO objects we handle
 type XoObject = XoHost | XoPool | XoVm | XoVbd | XoVdi | XoVif | XoPif | XoSr | XoNetwork
 
-// Minimal type for XAPI connection
-interface Xapi {
-  status: string
-  pool?: { uuid: string }
-  sessionId: string
-  _url?: { protocol: string; hostname: string; port?: string }
-}
-
-// Minimal type for xo-server instance
-interface XoServer {
-  getAllXapis(): Record<string, Xapi>
-  checkFeatureAuthorization(code: string): Promise<void>
-  getObjects(filter?: { filter?: Record<string, unknown> }): Record<string, unknown>
-}
-
 // ============================================================================
 // Constants
 // ============================================================================
@@ -153,9 +138,9 @@ class OpenMetricsPlugin {
   #childProcess: ChildProcess | undefined
   #pendingRequests = new Map<string, PendingRequest>()
   #requestIdCounter = 0
-  readonly #xo: XoServer
+  readonly #xo: XoApp
 
-  constructor(xo: XoServer) {
+  constructor(xo: XoApp) {
     this.#xo = xo
     logger.info('Plugin initialized')
   }
@@ -718,7 +703,7 @@ class OpenMetricsPlugin {
 // ============================================================================
 
 interface PluginOptions {
-  xo: XoServer
+  xo: XoApp
 }
 
 function pluginFactory({ xo }: PluginOptions): OpenMetricsPlugin {


### PR DESCRIPTION
### Description

Replace local `XoServer` interface in OpenMetrics plugin with centralized `XoApp` type from `@vates/types`.

**@vates/types:** [ec4da0a](https://github.com/vatesfr/xen-orchestra/pull/9404/commits/ec4da0a55896e40c3a661afccda7808fd44f2234)
- Add `XapiConnection` type that extends `Xapi` with runtime connection properties (`status`, `pool`, `sessionId`, `_url`)
- Add `getAllXapis()` and `getObjects()` methods to `XoApp`

**xo-server-openmetrics:** [e0957d3](https://github.com/vatesfr/xen-orchestra/pull/9404/commits/e0957d3c4c076eb463d3e225483fe5b939880ef2)
- Import `XoApp` and `XapiConnection` from `@vates/types`
- Remove local `XoServer` and `Xapi` interfaces
- Update all type references

See #9322

[XO-1810](https://project.vates.tech/vates-global/browse/XO-1810/)

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - [ ] If bug fix, add `Introduced by`
- Changelog
  - [ ] If visible by XOA users, add changelog entry
  - [ ] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [ ] If UI changes, add screenshots
  - [ ] If not finished or not tested, open as _Draft_


### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
