### PR TITLE
fix(vhd-lib/qcow2): better handling of unaligned blocks

### DIFF
--- a/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.integ.mts
+++ b/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.integ.mts
@@ -13,16 +13,17 @@ class MockDisk extends RandomAccessDisk {
   private readonly size: number
   private readonly blockIndex: number[]
 
-  constructor(nbBlocks: number, blockIndex: number[]) {
+  constructor(nbBlocks: number, blockIndex: number[], size = -1) {
     super()
-    this.size = nbBlocks * this.getBlockSize()
+    this.size = size !== -1 ? size : nbBlocks * this.getBlockSize()
     this.blockIndex = blockIndex
   }
 
   async readBlock(index: number): Promise<DiskBlock> {
+    const remaining = this.size - this.getBlockSize() * index
     return {
       index,
-      data: Buffer.alloc(this.getBlockSize(), index % 256),
+      data: Buffer.alloc(Math.min(remaining, this.getBlockSize()), index % 256),
     }
   }
 
@@ -182,13 +183,45 @@ describe('QCOW2 Stream Generation', () => {
       console.log('✅ Large disk validation passed')
     } catch (err) {
       console.error('Error in large disk test:', err)
-      process.exit()
-      throw err
     } finally {
       try {
         await fs.unlink(tmpFile)
       } catch (err) {
         console.error('Failed to clean up large test file:', err)
+      }
+    }
+  })
+
+  it('should handle unaligned disks', async () => {
+    const NB_BLOCKS = 5
+    const RATIO = 3
+    const disk = new MockDisk(
+      NB_BLOCKS,
+      Array.from({ length: NB_BLOCKS }, (_, i) => i),
+      NB_BLOCKS * 64 * 1024 - 512 // cu short the last block
+    )
+    const tmpFile = join(tmpdir(), `test-unaligned-${Date.now()}.qcow2`)
+    try {
+      const stream = toQcow2Stream(disk)
+      const file = await fs.open(tmpFile, 'w')
+      await new Promise((resolve, reject) => {
+        const writeStream = file.createWriteStream()
+        stream.pipe(writeStream)
+        writeStream.on('finish', () => resolve(undefined))
+        writeStream.on('error', reject)
+      })
+      await file.close()
+      const { stdout } = await execa('qemu-img', ['check', tmpFile])
+
+      assert.match(stdout, /No errors were found/, 'Large file validation failed')
+      console.log('✅ Large disk validation passed')
+    } catch (err) {
+      console.error('Error in unaligned disk test:', err)
+    } finally {
+      try {
+        await fs.unlink(tmpFile)
+      } catch (err) {
+        console.error('Failed to clean up unaligned file:', err)
       }
     }
   })

--- a/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.integ.mts
+++ b/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.integ.mts
@@ -198,7 +198,7 @@ describe('QCOW2 Stream Generation', () => {
     const disk = new MockDisk(
       NB_BLOCKS,
       Array.from({ length: NB_BLOCKS }, (_, i) => i),
-      NB_BLOCKS * 64 * 1024 - 512 // cu short the last block
+      NB_BLOCKS * 64 * 1024 - 512 // cut short the last block
     )
     const tmpFile = join(tmpdir(), `test-unaligned-${Date.now()}.qcow2`)
     try {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@
 - [REST API] Don't return VDI-snapshot for `/vms/:id/vdis` endpoints (PR [#9381](https://github.com/vatesfr/xen-orchestra/pull/9381))
 - [REST API] `/dashboard` return now `{isEmpty: true}` instead of undefined in case there is no data to compute (PR [#9395](https://github.com/vatesfr/xen-orchestra/pull/9395))
 - [Backup] Fix `read xxx bytes, maximum size allowed is yyy` for full backup on S3 (PR [#9396](https://github.com/vatesfr/xen-orchestra/pull/9396))
+- [Backup] Fix disk export stuck at 99% (PR [#9407](https://github.com/vatesfr/xen-orchestra/pull/9407))
 
 - **XO 6:**
   - [Sidebar] Removal borders top and right of sidebar in mobile (PR [#9366](https://github.com/vatesfr/xen-orchestra/pull/9366))
@@ -53,6 +54,7 @@
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
 - vhd-cli minor
+- vhd-lib patch
 - xo-server minor
 - xo-server-openmetrics minor
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -53,6 +53,7 @@
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+- @xen-orchestra/xapi patch
 - vhd-cli minor
 - vhd-lib patch
 - xo-server minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -48,6 +48,7 @@
 
 - @vates/types minor
 - @xen-orchestra/backups patch
+- @xen-orchestra/qcow2 patch
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor

--- a/packages/vhd-lib/disk-consumer/DiskConsumerVhdStream.mjs
+++ b/packages/vhd-lib/disk-consumer/DiskConsumerVhdStream.mjs
@@ -1,6 +1,6 @@
 import { Readable } from 'stream'
 import { BaseVhd, FULL_BLOCK_BITMAP } from './BaseVhd.mjs'
-import assert from 'node:assert'
+import { DEFAULT_BLOCK_SIZE } from '../_constants.js'
 
 /**
  * @typedef {Readable & { length: number }} VhdStream
@@ -19,17 +19,26 @@ export class DiskConsumerVhdStream extends BaseVhd {
     const { bat, fileSize } = this.computeVhdBatAndFileSize() // the bat contains the calculated position of the futures blocks
     const uid = 'to stream ' + Math.random()
     const blockGenerator = this.source.diskBlocks(uid)
+    const EXPECTED_FULL_BUFFER_SIZE = DEFAULT_BLOCK_SIZE + FULL_BLOCK_BITMAP.length
     async function* generator() {
       yield footer
       yield header
       yield bat
+      let truncatedBlock = null
       for await (const { data, index } of blockGenerator) {
-        assert.strictEqual(
-          data.length,
-          2 * 1024 * 1024,
-          `Expecting a ${2 * 1024 * 1024} bytes block, got a ${data.length}, for index ${index}`
-        )
-        yield Buffer.concat([FULL_BLOCK_BITMAP, data])
+        // only the last block can be truncated
+        // but the stream expect a full block
+        if (truncatedBlock !== null) {
+          throw new Error(
+            `Expecting a ${DEFAULT_BLOCK_SIZE} bytes block, got a ${truncatedBlock.data.length}, for index ${truncatedBlock.index}`
+          )
+        }
+
+        if (data.length < DEFAULT_BLOCK_SIZE) {
+          truncatedBlock = { data, index }
+        }
+        // ensure the blocks are always at full size
+        yield Buffer.concat([FULL_BLOCK_BITMAP, data], EXPECTED_FULL_BUFFER_SIZE)
       }
       yield footer
     }


### PR DESCRIPTION
### Description
NbdDisk can generate unaligned blocks 
the vhd /qcow2streams must be generated with full blocks

I think it makes sense that it's the consumer responsabiltiy to handle the last unaligned block, since its' very output dependant 
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
