### PR TITLE
feat(rest-api): add createVtpm parameter to VM creation endpoint

### DIFF
--- a/@vates/types/src/lib/xen-orchestra-xapi.mts
+++ b/@vates/types/src/lib/xen-orchestra-xapi.mts
@@ -9,6 +9,7 @@ import {
   XenApiVdi,
   XenApiVm,
   XenApiVmWrapped,
+  XenApiVtpm,
 } from '../xen-api.mjs'
 import type { OPAQUE_REF_NULL, VBD_MODE, VBD_TYPE } from '../common.mjs'
 import type { PassThrough, Readable } from 'node:stream'
@@ -222,4 +223,5 @@ export interface Xapi {
     params?: { host?: XenApiHost; query?: Record<string, unknown>; task?: boolean | XenApiTask['$ref'] }
   ): Promise<{ body: Readable }>
   isHyperThreadingEnabled(hostId: XoHost['id']): Promise<boolean | null>
+  VTPM_create(params: { VM: XenApiVm['$ref']; is_unique?: boolean; contents?: string }): Promise<XenApiVtpm['$ref']>
 }

--- a/@xen-orchestra/rest-api/src/pools/pool.type.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.type.mts
@@ -25,6 +25,7 @@ export type CreateVmAfterCreateParams = {
   network_config?: string
   boot?: boolean
   destroy_cloud_config_vdi?: boolean
+  createVtpm?: boolean
 }
 export type CreateVmBody = Omit<
   CreateVmParams,

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
 - [REST API] Add endpoints to reconfigure management interface for hosts and pools (PR [#9369](https://github.com/vatesfr/xen-orchestra/pull/9369))
 - [VM] Add "Change state" button on VM view (PR [#9317](https://github.com/vatesfr/xen-orchestra/pull/9317))
 - [REST API] Add `POST /vbds` endpoint to create a VBD (attach a VDI to a VM) (PR [#9391](https://github.com/vatesfr/xen-orchestra/pull/9391))
+- [REST API] Add `createVtpm` parameter to VM creation endpoint (PR [#9412](https://github.com/vatesfr/xen-orchestra/pull/9412))
 
 ### Bug fixes
 


### PR DESCRIPTION
### Description

[XO-1769](https://project.vates.tech/vates-global/browse/XO-1769/)

Add `createVtpm` parameter to the VM creation endpoint (`POST /pools/{id}/actions/create_vm`) to allow creating a vTPM alongside a new VM.

This aligns the REST API with the existing RPC API functionality in `packages/xo-server/src/api/vm.mjs`.

**Usage:**
```json
POST /pools/{pool_id}/actions/create_vm
{
  "name_label": "My VM",
  "template": "template-uuid",
  "createVtpm": true,
  "hvmBootFirmware": "uefi"
}
```

**Changes:**
- `@xen-orchestra/rest-api/src/pools/pool.type.mts`: Add `createVtpm` to `CreateVmAfterCreateParams`
- `@xen-orchestra/rest-api/src/vms/vm.service.mts`: Implement VTPM creation after VM creation
- `@vates/types/src/lib/xen-orchestra-xapi.mts`: Add `VTPM_create` type signature

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [ ] Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - N/A - Not a bug fix
- Changelog
  - [ ] If visible by XOA users, add changelog entry
  - [x] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - N/A - No UI changes
  - [x] Ready for review

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
