### PR TITLE
fix(xo-server): fix NFSv4 ISO SR creation

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [V2V] Fix `VDI_IO_ERROR` when importing some unaligned disks into a qcow2 storage (PR [#9411](https://github.com/vatesfr/xen-orchestra/pull/9411))
+- [New/SR] Fix `Require "-o" along with xe-mount-iso-sr` error during NFS ISO SR creation (PR [#9425](https://github.com/vatesfr/xen-orchestra/pull/9425))
 
 ### Packages to release
 

--- a/packages/xo-server/src/api/sr.mjs
+++ b/packages/xo-server/src/api/sr.mjs
@@ -117,6 +117,8 @@ disconnectAllPbds.resolve = {
 
 // -------------------------------------------------------------------
 
+// In case of error 'Require "-o" along with xe-mount-iso-sr' for NFS ISO creation, the NFS share is probably incorrectly configured
+
 export async function createIso({
   host,
   nameLabel,
@@ -196,6 +198,7 @@ createIso.resolve = {
 // NFS SR
 
 // This functions creates a NFS SR
+// In case of error 'Require "-o" along with xe-mount-iso-sr', the NFS share is probably incorrectly configured
 
 export async function createNfs({
   host,
@@ -527,7 +530,8 @@ export async function probeNfs({ host, nfsVersion, server }) {
   const nfsExports = []
   forEach(ensureArray(xml['nfs-exports'].Export), nfsExport => {
     nfsExports.push({
-      path: nfsExport.Path.trim(),
+      // NFSv4 doesn't return the full path, and we need to add a slash at the beginning of it, or SR creation with this path will fail
+      path: nfsExport.Path.trim().replace(/^\/?/, '/'),
       acl: nfsExport.Accesslist.trim(),
     })
   })


### PR DESCRIPTION
### Description

As discussed here: https://team.vates.fr/vates/pl/7r3gpxdtpfbzxdiq4r5iqnh73y and reported on [zammad #49894](https://help.vates.tech/#ticket/zoom/49894), NFS ISO SR creation fails with NFSv4 with error `Require "-o" along with xe-mount-iso-sr`.

This is because the SR.probe command does not return the full path for NFSv4, and a slash needs to be added at the beginning of it for the SR.create command to work.

We may encounter this error again when a NFSv4 is incorrectly configured, so I added a couple of comments in the code related to that error to avoid losing time on that again in the future.

[XO-1881](https://project.vates.tech/vates-global/browse/XO-1881/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
