### PR TITLE
feat(fs): autodetect object lock/immutability on s3

### DIFF
--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -613,6 +613,11 @@ export class RemoteAdapter {
   // if cache is missing  or broken  => regenerate it and return
 
   async _readCacheListVmBackups(vmUuid) {
+    // immutable remote can't use any caching
+    // since the cache file may be non modifiable
+    if (this._handler.isImmutable()) {
+      return this.#getCacheableDataListVmBackups(`${BACKUP_DIR}/${vmUuid}`)
+    }
     const path = this.#getVmBackupsCache(vmUuid)
 
     const cache = await this._readCache(path)

--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -792,7 +792,7 @@ export default class RemoteHandlerAbstract {
     return this.#encryptor?.algorithm ?? UNENCRYPTED_ALGORITHM
   }
 
-  get isImmutable() {
+  isImmutable() {
     return this._remote.immutable === true
   }
 }

--- a/@xen-orchestra/fs/src/abstract.js
+++ b/@xen-orchestra/fs/src/abstract.js
@@ -693,7 +693,7 @@ export default class RemoteHandlerAbstract {
       if (validator !== undefined) {
         await validator.call(this, tmpPath)
       }
-      if (this.isImmutable()) {
+      if (!this.isImmutable()) {
         await this.__rename(tmpPath, path)
       }
     } catch (error) {

--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -40,10 +40,6 @@ export default class S3Handler extends RemoteHandlerAbstract {
   #s3
   #immutable = false
 
-  get isImmutable() {
-    return super.isImmutable() || this.#immutable
-  }
-
   constructor(remote, _opts) {
     super(remote, _opts)
     const {
@@ -144,6 +140,9 @@ export default class S3Handler extends RemoteHandlerAbstract {
     }
   }
 
+  isImmutable() {
+    return super.isImmutable() || this.#immutable
+  }
   _conditionRetry(error) {
     return ![401, 403, 404, 405].includes(error?.$metadata?.httpStatusCode) && super._conditionRetry(error)
   }

--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -38,6 +38,11 @@ export default class S3Handler extends RemoteHandlerAbstract {
   #bucket
   #dir
   #s3
+  #immutable = false
+
+  get isImmutable() {
+    return super.isImmutable() || this.#immutable
+  }
 
   constructor(remote, _opts) {
     super(remote, _opts)
@@ -416,6 +421,7 @@ export default class S3Handler extends RemoteHandlerAbstract {
         // will automatically add the contentMD5 header to any upload to S3
         debug(`Object Lock is enable, enable content md5 header`)
         this.#s3.middlewareStack.use(getApplyMd5BodyChecksumPlugin(this.#s3.config))
+        this.#immutable = true
       }
     } catch (error) {
       // maybe the account doesn't have enough privilege to query the object lock configuration


### PR DESCRIPTION
### Description

add a settings on the remote to declare immutable remote

this will disable caching ( cache.json.gz ) since they  won't be updatable

this also disable upload to a temporary file and then move the files ( for full backup for example ) 

object lock is auto detected on s3 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
