### PR TITLE
fix(backups): set other_config on incremental replication vm creation

### DIFF
--- a/@xen-orchestra/backups/_incrementalVm.mjs
+++ b/@xen-orchestra/backups/_incrementalVm.mjs
@@ -291,10 +291,16 @@ export const importIncrementalVm = defer(async function importIncrementalVm(
       await xapi.VTPM_create({ VM: vmRef, contents })
     })
   )
-
+  const vm = await xapi.getRecord('VM', vmRef)
   await Promise.all([
-    incrementalVm.vm.ha_always_run && xapi.setField('VM', vmRef, 'ha_always_run', true),
-    xapi.setField('VM', vmRef, 'name_label', incrementalVm.vm.name_label),
+    vmRecord.ha_always_run && xapi.setField('VM', vmRef, 'ha_always_run', true),
+    xapi.setField('VM', vmRef, 'name_label', vmRecord.name_label),
+    // correctly unlock the VM and reapply the target blocked operations
+    vm.update_blocked_operations({
+      start: null,
+      start_on: null,
+      ...vmRecord.blocked_operations,
+    }),
   ])
 
   return vmRef

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
@@ -1,7 +1,6 @@
-import { asyncMap, asyncMapSettled } from '@xen-orchestra/async-map'
+import { asyncMapSettled } from '@xen-orchestra/async-map'
 import ignoreErrors from 'promise-toolbox/ignoreErrors'
 
-import { formatFilenameDate } from '../../_filenameDate.mjs'
 import { getOldEntries } from '../../_getOldEntries.mjs'
 import { importIncrementalVm } from '../../_incrementalVm.mjs'
 import { Task } from '../../Task.mjs'
@@ -9,8 +8,18 @@ import { Task } from '../../Task.mjs'
 import { AbstractIncrementalWriter } from './_AbstractIncrementalWriter.mjs'
 import { MixinXapiWriter } from './_MixinXapiWriter.mjs'
 import { listReplicatedVms } from './_listReplicatedVms.mjs'
-import { COPY_OF, setVmOtherConfig, BASE_DELTA_VDI } from '../../_otherConfig.mjs'
+import {
+  COPY_OF,
+  setVmOtherConfig,
+  BASE_DELTA_VDI,
+  JOB_ID,
+  SCHEDULE_ID,
+  REPLICATED_TO_SR_UUID,
+  DATETIME,
+  VM_UUID,
+} from '../../_otherConfig.mjs'
 import assert from 'node:assert'
+import { formatFilenameDate } from '../../_filenameDate.mjs'
 
 export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWriter) {
   async checkBaseVdis(baseUuidToSrcVdi) {
@@ -94,12 +103,28 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
     return asyncMapSettled(this._oldEntries, vm => vm.$destroy())
   }
 
-  #decorateVmMetadata(backup) {
+  #decorateVmMetadata(backup, timestamp) {
     const { _warmMigration } = this._settings
     const sr = this._sr
     const vm = backup.vm
+    const job = this._job
+    const scheduleId = this._scheduleId
 
+    vm.name_label = `${vm.name_label} - ${job.name} - (${formatFilenameDate(timestamp)})`
+    // update other_config data as soon as possible to ensure the next job
+    // will be able to detect any partial transfer and lean them
     vm.other_config[COPY_OF] = vm.uuid
+    vm.other_config[JOB_ID] = job.id
+    vm.other_config[SCHEDULE_ID] = scheduleId
+    vm.other_config[REPLICATED_TO_SR_UUID] = sr.uuid
+    // set the timestamp in the past to ensure any incomplete VM will be deleted on next run
+    vm.other_config[DATETIME] = formatFilenameDate(0)
+
+    vm.blocked_operations = {
+      start: 'Start operation for this vm is blocked, clone it if you want to use it.',
+      start_on: 'Start operation for this vm is blocked, clone it if you want to use it.',
+    }
+
     if (!_warmMigration) {
       vm.tags.push('Continuous Replication')
     }
@@ -118,6 +143,11 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
 
     Object.values(backup.vdis).forEach(vdi => {
       vdi.other_config[COPY_OF] = vdi.uuid
+      vdi.other_config[JOB_ID] = job.id
+      vdi.other_config[SCHEDULE_ID] = scheduleId
+      vdi.other_config[REPLICATED_TO_SR_UUID] = sr.uuid
+      vdi.other_config[VM_UUID] = vm.uuid
+
       if (sourceVdiUuids.length > 0) {
         const baseReplicatedTo = replicatedVdis.filter(
           replicatedVdi => replicatedVdi.other_config[COPY_OF] === vdi.other_config[BASE_DELTA_VDI]
@@ -144,12 +174,11 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
     const sr = this._sr
     const job = this._job
     const scheduleId = this._scheduleId
-
     const { uuid: srUuid, $xapi: xapi } = sr
-
+    
     let targetVmRef
     await Task.run({ name: 'transfer' }, async () => {
-      targetVmRef = await importIncrementalVm(this.#decorateVmMetadata(deltaExport), sr)
+      targetVmRef = await importIncrementalVm(this.#decorateVmMetadata(deltaExport, timestamp), sr)
       // size is mandatory to ensure the task have the right data
       return {
         size: Object.values(deltaExport.disks).reduce(
@@ -166,15 +195,8 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
       !_warmMigration &&
         targetVm.ha_restart_priority !== '' &&
         Promise.all([targetVm.set_ha_restart_priority(''), targetVm.add_tags('HA disabled')]),
-      targetVm.set_name_label(`${vm.name_label} - ${job.name} - (${formatFilenameDate(timestamp)})`),
-      asyncMap(['start', 'start_on'], op =>
-        targetVm.update_blocked_operations(
-          op,
-          'Start operation for this vm is blocked, clone it if you want to use it.'
-        )
-      ),
       setVmOtherConfig(xapi, targetVmRef, {
-        timestamp,
+        timestamp, // updated at the end to mark the transfer as complete
         jobId: job.id,
         scheduleId,
         vmUuid: vm.uuid,

--- a/@xen-orchestra/backups/_runners/_writers/_listReplicatedVms.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/_listReplicatedVms.mjs
@@ -20,9 +20,7 @@ export function listReplicatedVms(xapi, scheduleOrJobId, srUuid, vmUuid) {
       'start' in object.blocked_operations &&
       (oc[JOB_ID] === scheduleOrJobId || oc[SCHEDULE_ID] === scheduleOrJobId) &&
       oc[REPLICATED_TO_SR_UUID] === srUuid &&
-      (oc[VM_UUID] === vmUuid ||
-        // 2018-03-28, JFT: to catch VMs replicated before this fix
-        oc[VM_UUID] === undefined)
+      oc[VM_UUID] === vmUuid
     ) {
       vms[object.$id] = object
     }

--- a/@xen-orchestra/xapi/vm.mjs
+++ b/@xen-orchestra/xapi/vm.mjs
@@ -390,6 +390,11 @@ class Vm {
       power_state: suspend_VDI !== undefined ? 'Suspended' : undefined,
       suspend_VDI,
     })
+
+    if (blocked_operations) {
+      const vm = await this.getRecord('VM', ref)
+      await vm.update_blocked_operations(blocked_operations)
+    }
     $defer.onFailure.call(this, 'call', 'VM.destroy', ref)
 
     bios_strings = cleanBiosStrings(bios_strings)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@
 - [REST API] `message` objects are no longer sent via the SSE when subscribing to the`alarm` collection (PR [#9439](https://github.com/vatesfr/xen-orchestra/pull/9439))
 - [REST API] Do no longer create an `XO user authentication` task, when using an authentication token (PR [#9439](https://github.com/vatesfr/xen-orchestra/pull/9439))
 - [Backup] ensure no snapshot are left unattended after a job (PR [#9434](https://github.com/vatesfr/xen-orchestra/pull/9434))
+- [Backup] Fix replication leaving replica after partial incremental replication (PR [#9435](https://github.com/vatesfr/xen-orchestra/pull/9435))
 
 ### Packages to release
 


### PR DESCRIPTION
Don't squash and merge, I will rebase the commit to keep track of the 2 first commits 

### Description

this will ensure that any partial transfer will ben cleaned on next run

review by commit : 
 * remove a todo from 2018
 * real implementation of the fix
 * fix a blocked_operations issue 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
