### PR TITLE
docs(openmetrics): add SR capacity metrics and complete VM metrics

### DIFF
--- a/docs/docs/advanced.md
+++ b/docs/docs/advanced.md
@@ -456,28 +456,41 @@ All metrics are prefixed with `xcp_` and include enriched labels for easy filter
 
 #### VM Metrics
 
-| Metric                                 | Type    | Description                       |
-| -------------------------------------- | ------- | --------------------------------- |
-| `xcp_vm_memory_bytes`                  | gauge   | Memory usage in bytes             |
-| `xcp_vm_memory_internal_free_bytes`    | gauge   | Internal free memory              |
-| `xcp_vm_memory_target_bytes`           | gauge   | Memory target                     |
-| `xcp_vm_cpu_usage`                     | gauge   | CPU usage ratio                   |
-| `xcp_vm_cpu_core_usage`                | gauge   | Per-vCPU usage                    |
-| `xcp_vm_runstate_fullrun`              | gauge   | Runstate: full run ratio          |
-| `xcp_vm_runstate_blocked`              | gauge   | Runstate: blocked ratio           |
-| `xcp_vm_network_receive_bytes_total`   | counter | Network bytes received per VIF    |
-| `xcp_vm_network_transmit_bytes_total`  | counter | Network bytes transmitted per VIF |
-| `xcp_vm_network_receive_errors_total`  | counter | Network receive errors            |
-| `xcp_vm_network_transmit_errors_total` | counter | Network transmit errors           |
-| `xcp_vm_disk_read_bytes_total`         | counter | Disk read bytes per device        |
-| `xcp_vm_disk_write_bytes_total`        | counter | Disk write bytes per device       |
-| `xcp_vm_disk_iops_read`                | gauge   | Disk read IOPS                    |
-| `xcp_vm_disk_iops_write`               | gauge   | Disk write IOPS                   |
-| `xcp_vm_disk_read_latency_seconds`     | gauge   | Disk read latency                 |
-| `xcp_vm_disk_write_latency_seconds`    | gauge   | Disk write latency                |
-| `xcp_vm_disk_iowait`                   | gauge   | Disk IO wait ratio                |
-| `xcp_vm_disk_inflight`                 | gauge   | In-flight disk operations         |
-| `xcp_vm_disk_queue_size`               | gauge   | Disk queue size                   |
+| Metric                                 | Type    | Description                        |
+| -------------------------------------- | ------- | ---------------------------------- |
+| `xcp_vm_memory_bytes`                  | gauge   | Memory usage in bytes              |
+| `xcp_vm_memory_internal_free_bytes`    | gauge   | Internal free memory               |
+| `xcp_vm_memory_target_bytes`           | gauge   | Memory target                      |
+| `xcp_vm_cpu_usage`                     | gauge   | CPU usage ratio                    |
+| `xcp_vm_cpu_core_usage`                | gauge   | Per-vCPU usage                     |
+| `xcp_vm_runstate_fullrun`              | gauge   | Runstate: full run ratio           |
+| `xcp_vm_runstate_full_contention`      | gauge   | Runstate: full contention ratio    |
+| `xcp_vm_runstate_partial_run`          | gauge   | Runstate: partial run ratio        |
+| `xcp_vm_runstate_partial_contention`   | gauge   | Runstate: partial contention ratio |
+| `xcp_vm_runstate_concurrency_hazard`   | gauge   | Runstate: concurrency hazard ratio |
+| `xcp_vm_runstate_blocked`              | gauge   | Runstate: blocked ratio            |
+| `xcp_vm_network_receive_bytes_total`   | counter | Network bytes received per VIF     |
+| `xcp_vm_network_transmit_bytes_total`  | counter | Network bytes transmitted per VIF  |
+| `xcp_vm_network_receive_errors_total`  | counter | Network receive errors             |
+| `xcp_vm_network_transmit_errors_total` | counter | Network transmit errors            |
+| `xcp_vm_disk_read_bytes_total`         | counter | Disk read bytes per device         |
+| `xcp_vm_disk_write_bytes_total`        | counter | Disk write bytes per device        |
+| `xcp_vm_disk_iops_read`                | gauge   | Disk read IOPS                     |
+| `xcp_vm_disk_iops_write`               | gauge   | Disk write IOPS                    |
+| `xcp_vm_disk_iops_total`               | gauge   | Disk total IOPS                    |
+| `xcp_vm_disk_read_latency_seconds`     | gauge   | Disk read latency                  |
+| `xcp_vm_disk_write_latency_seconds`    | gauge   | Disk write latency                 |
+| `xcp_vm_disk_iowait`                   | gauge   | Disk IO wait ratio                 |
+| `xcp_vm_disk_inflight`                 | gauge   | In-flight disk operations          |
+| `xcp_vm_disk_queue_size`               | gauge   | Disk queue size                    |
+
+#### SR Capacity Metrics
+
+| Metric                        | Type  | Description                        |
+| ----------------------------- | ----- | ---------------------------------- |
+| `xcp_sr_virtual_size_bytes`   | gauge | SR virtual allocated size in bytes |
+| `xcp_sr_physical_size_bytes`  | gauge | SR physical size in bytes          |
+| `xcp_sr_physical_usage_bytes` | gauge | SR physical space used in bytes    |
 
 #### Connection Metrics
 
@@ -497,6 +510,7 @@ All metrics include these labels for filtering:
 | `type`         | Object type (`host` or `vm`)               |
 | `host_name`    | Host name (for host metrics)               |
 | `vm_name`      | VM name (for VM metrics)                   |
+| `sr_uuid`      | Storage Repository UUID (for SR metrics)   |
 | `sr_name`      | Storage Repository name (for disk metrics) |
 | `vdi_name`     | Virtual Disk name (for VM disk metrics)    |
 | `network_name` | Network name (for network metrics)         |
@@ -525,6 +539,15 @@ xcp_vm_disk_read_latency_seconds > 0.01
 
 # Total IOPS per Storage Repository
 sum by (sr_name) (xcp_host_disk_iops_read + xcp_host_disk_iops_write)
+
+# SR usage percentage
+(xcp_sr_physical_usage_bytes / xcp_sr_physical_size_bytes) * 100
+
+# SR free space in GB
+(xcp_sr_physical_size_bytes - xcp_sr_physical_usage_bytes) / 1024 / 1024 / 1024
+
+# Over-provisioning ratio (virtual vs physical)
+xcp_sr_virtual_size_bytes / xcp_sr_physical_size_bytes
 ```
 
 ### Grafana Integration
@@ -553,6 +576,12 @@ label_values(xcp_host_cpu_average{pool_name="$pool"}, host_name)
 label_values(xcp_vm_cpu_usage{pool_name="$pool"}, vm_name)
 ```
 
+**SR variable:**
+
+```promql
+label_values(xcp_sr_physical_size_bytes{pool_name="$pool"}, sr_name)
+```
+
 #### Example Panels
 
 **Host CPU Overview:**
@@ -565,6 +594,21 @@ xcp_host_cpu_average{pool_name="$pool"} * 100
 
 ```promql
 xcp_vm_memory_bytes{vm_name="$vm"} / 1024 / 1024 / 1024
+```
+
+**SR Usage Percentage:**
+
+```promql
+(xcp_sr_physical_usage_bytes{sr_name="$sr"} / xcp_sr_physical_size_bytes{sr_name="$sr"}) * 100
+```
+
+**SR Capacity Overview (stacked bar):**
+
+```promql
+# Used space
+xcp_sr_physical_usage_bytes{pool_name="$pool"}
+# Free space
+xcp_sr_physical_size_bytes{pool_name="$pool"} - xcp_sr_physical_usage_bytes{pool_name="$pool"}
 ```
 
 ### Alerting with Alertmanager
@@ -619,6 +663,24 @@ groups:
         annotations:
           summary: 'Pool {{ $labels.pool_name }} disconnected'
           description: 'XO lost connection to pool {{ $labels.pool_name }}.'
+
+      - alert: SRHighUsage
+        expr: (xcp_sr_physical_usage_bytes / xcp_sr_physical_size_bytes) > 0.85
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'High storage usage on {{ $labels.sr_name }}'
+          description: 'Storage Repository {{ $labels.sr_name }} is above 85% capacity.'
+
+      - alert: SRCriticalUsage
+        expr: (xcp_sr_physical_usage_bytes / xcp_sr_physical_size_bytes) > 0.95
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Critical storage usage on {{ $labels.sr_name }}'
+          description: 'Storage Repository {{ $labels.sr_name }} is above 95% capacity. Immediate action required.'
 ```
 
 ### Security Recommendations


### PR DESCRIPTION
### Description

Update OpenMetrics user documentation to include features added since the initial plugin release.

**Added to documentation:**

- **SR Capacity Metrics** (See #9360)
  - `xcp_sr_virtual_size_bytes`
  - `xcp_sr_physical_size_bytes`
  - `xcp_sr_physical_usage_bytes`

- **Missing VM runstate metrics**
  - `xcp_vm_runstate_full_contention`
  - `xcp_vm_runstate_partial_run`
  - `xcp_vm_runstate_partial_contention`
  - `xcp_vm_runstate_concurrency_hazard`

- **Missing VM disk metric**
  - `xcp_vm_disk_iops_total`

- **New label**
  - `sr_uuid` for SR metrics

- **PromQL examples for SR monitoring**
  - SR usage percentage
  - SR free space
  - Over-provisioning ratio

- **Grafana integration for SR**
  - SR variable for filtering
  - SR Usage Percentage panel
  - SR Capacity Overview panel

- **Alerting rules for storage**
  - `SRHighUsage` (>85%)
  - `SRCriticalUsage` (>95%)

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue: See #9360, See #9353, See #9331
  - [ ] If bug fix, add `Introduced by` - N/A (documentation update)
- Changelog
  - [ ] If visible by XOA users, add changelog entry - N/A (documentation only)
  - [ ] Update "Packages to release" in `CHANGELOG.unreleased.md` - N/A
- PR
  - [ ] If UI changes, add screenshots - N/A
  - [ ] If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
