### PR TITLE
fix(xo-server-sdn-controller): communicate with enabled hosts only

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,6 +36,7 @@
 - [HUB Recipe] A bug in the Pyrgos recipe requires to remove the DHCP option of the recipe form (PR [#9454](https://github.com/vatesfr/xen-orchestra/pull/9454))
 - [OpenMetrics] Fix ECONNREFUSED on IPv6-only systems by binding to `localhost` instead of `127.0.0.1` (PR [#9489](https://github.com/vatesfr/xen-orchestra/pull/9489))
 - [REST API] Exclude removable and ISO storage from top 5 SRs usage (PR [#9495](https://github.com/vatesfr/xen-orchestra/pull/9495))
+- [xo-server-sdn-controller] traffic rules robustness (PR [#9442](https://github.com/vatesfr/xen-orchestra/pull/9442))
 
 ### Packages to release
 
@@ -63,7 +64,8 @@
 - xo-server minor
 - xo-server-load-balancer minor
 - xo-server-netbox minor
-- xo-server-openmetrics minor 
+- xo-server-openmetrics minor
+- xo-server-sdn-controller patch
 - xo-web minor
 
 <!--packages-end-->

--- a/packages/xo-server-sdn-controller/src/openflow-plugin.js
+++ b/packages/xo-server-sdn-controller/src/openflow-plugin.js
@@ -16,7 +16,7 @@ export class OpenFlowPlugin {
     return asyncEach(network.$PIFs, async PIF => {
       const host = PIF.$host
       return host.$xapi.call('host.call_plugin', host.$ref, PLUGIN_NAME, method, { ...parameters, bridge })
-    })
+    }, { stopOnError: false })
   }
 
   async addRule({ vif, allow, protocol, ipRange, direction, port }) {

--- a/packages/xo-server-sdn-controller/src/protocol/openflow-channel.js
+++ b/packages/xo-server-sdn-controller/src/protocol/openflow-channel.js
@@ -116,7 +116,14 @@ export class OpenFlowChannel extends EventEmitter {
     const { dlType, nwProto } = dlAndNwProtocolFromString(protocol)
     const mac = vif.MAC
 
-    await this._coalesceConnect()
+    try {
+      await this._coalesceConnect()
+    } catch (error) {
+      log.error("addRule: _coalesceConnect", {
+        error
+      })
+      return
+    }
     if (direction.includes('from')) {
       this._addFlow(
         {
@@ -190,7 +197,15 @@ export class OpenFlowChannel extends EventEmitter {
     const { dlType, nwProto } = dlAndNwProtocolFromString(protocol)
     const mac = vif.MAC
 
-    await this._coalesceConnect()
+    try {
+      await this._coalesceConnect()
+    } catch (error) {
+      log.error("addRule: _coalesceConnect", {
+        error
+      })
+      return
+    }
+
     if (direction.includes('from')) {
       this._removeFlows({
         type: ofProtocol.matchType.standard,

--- a/packages/xo-server-sdn-controller/src/protocol/ovsdb-client.js
+++ b/packages/xo-server-sdn-controller/src/protocol/ovsdb-client.js
@@ -189,7 +189,13 @@ export class OvsdbClient {
   }
 
   async resetForNetwork(network, privateNetworkUuid) {
-    const socket = await this._connect()
+    let socket
+    try {
+      socket = await this._connect()
+    } catch (error) {
+      log.error('Error while connecting', { error })
+      return
+    }
     const bridge = await this._getBridgeForNetwork(network, socket)
     if (bridge.uuid === undefined) {
       socket.destroy()
@@ -245,7 +251,14 @@ export class OvsdbClient {
   }
 
   async setBridgeController() {
-    const socket = await this._connect()
+    let socket
+    try {
+      socket = await this._connect()
+    } catch (error) {
+      log.error('Error while connecting', { error })
+      return
+    }
+
     // Add controller to openvswitch table if needed
     const params = ['Open_vSwitch']
 
@@ -305,7 +318,14 @@ export class OvsdbClient {
   }
 
   async setBridgeControllerForNetwork(network) {
-    const socket = await this._connect()
+    let socket
+    try {
+      socket = await this._connect()
+    } catch (error) {
+      log.error('Error while connecting', { error })
+      return
+    }
+
     if (this._controllerUuid === undefined) {
       const where = [['target', '==', TARGET]]
       const selectResult = await this._select('Controller', ['_uuid'], where, socket)
@@ -360,7 +380,14 @@ export class OvsdbClient {
 
   async getOfPortForVif(vif) {
     const where = [['external_ids', 'includes', toMap({ 'xs-vif-uuid': vif.uuid })]]
-    const socket = await this._connect()
+    let socket
+    try {
+      socket = await this._connect()
+    } catch (error) {
+      log.error('Error while connecting', { error })
+      return
+    }
+
     const selectResult = await this._select(
       'Interface',
       ['name', 'ofport'],


### PR DESCRIPTION
permit to have working traffic rules when a pool is in a 'degraded' mode (for 
example, one host temporary down or unreachable).

currently, exceptions occurs and nothing happens (no rules added or deleted). 
with it, unreachable hosts are ignored and reachable hosts properly updated.

and while here, fix `npm install` on fresh checkout (in a separated commit).