### PR TITLE
feat(openmetrics): add host uptime metric

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
 - [Plugins/load balancer] Add configurable VM migration cooldown to prevent oscillation (default 30min) (PR [#9388](https://github.com/vatesfr/xen-orchestra/pull/9388))
 - [REST API] Expose `POST /rest/v0/vms/:id/actions/migrate` to migrate a VM (PR [#9414](https://github.com/vatesfr/xen-orchestra/pull/9414))
 - [Netbox] Support version 4.5.x (PR [#9445](https://github.com/vatesfr/xen-orchestra/pull/9445))
+- [OpenMetrics] Add host uptime metric (`xcp_host_uptime_seconds`) (PR [#9449](https://github.com/vatesfr/xen-orchestra/pull/9449))
 
 ### Bug fixes
 

--- a/packages/xo-server-openmetrics/src/index.mts
+++ b/packages/xo-server-openmetrics/src/index.mts
@@ -73,6 +73,7 @@ export interface VmLabelInfo {
 export interface HostLabelInfo {
   name_label: string
   pifDeviceToNetworkName: Record<string, string> // { "eth0": "Management" }
+  startTime: number | null // Unix timestamp of host boot (from host.startTime)
 }
 
 export interface SrLabelInfo {
@@ -667,6 +668,7 @@ class OpenMetricsPlugin {
       labels.hosts[host.uuid] = {
         name_label: host.name_label,
         pifDeviceToNetworkName,
+        startTime: host.startTime,
       }
     }
 

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
@@ -13,6 +13,7 @@ import {
   formatToOpenMetrics,
   formatAllPoolsToOpenMetrics,
   formatHostStatusMetrics,
+  formatHostUptimeMetrics,
   type FormattedMetric,
   type LabelContext,
 } from './openmetric-formatter.mjs'
@@ -543,6 +544,7 @@ describe('transformMetric with labelContext', () => {
         'host-uuid-123': {
           name_label: 'Host 1',
           pifDeviceToNetworkName: { eth0: 'Pool-wide network', eth1: 'Storage network' },
+          startTime: null,
         },
       },
       srs: {
@@ -854,6 +856,7 @@ describe('formatAllPoolsToOpenMetrics with labelContext', () => {
         'host-1': {
           name_label: 'Host 1',
           pifDeviceToNetworkName: { eth0: 'Management' },
+          startTime: null,
         },
       },
       srs: {},
@@ -1346,5 +1349,217 @@ describe('formatHostStatusMetrics', () => {
     const output = formatToOpenMetrics(metrics)
 
     assert.ok(output.includes('host_name="Host \\"with quotes\\""'))
+  })
+})
+
+// ============================================================================
+// Host Uptime Metrics Tests
+// ============================================================================
+
+describe('formatHostUptimeMetrics', () => {
+  const createLabelContextWithUptime = (startTime: number | null): LabelContext => ({
+    hosts: [
+      {
+        hostId: 'host-uuid-123',
+        hostAddress: '192.168.1.1',
+        hostLabel: 'Host 1',
+        poolId: 'pool-456',
+        poolLabel: 'Production Pool',
+        sessionId: 'session-123',
+        protocol: 'https:',
+      },
+    ],
+    labels: {
+      vms: {},
+      hosts: {
+        'host-uuid-123': {
+          name_label: 'Host 1',
+          pifDeviceToNetworkName: {},
+          startTime,
+        },
+      },
+      srs: {},
+      srSuffixToUuid: {},
+      vdiUuidToSrUuid: {},
+    },
+  })
+
+  it('should generate uptime metric for host with valid startTime', () => {
+    const now = Math.floor(Date.now() / 1000)
+    const bootTime = now - 3600 // 1 hour ago
+    const labelContext = createLabelContextWithUptime(bootTime)
+
+    const metrics = formatHostUptimeMetrics(labelContext)
+
+    assert.equal(metrics.length, 1)
+    const metric = metrics[0]!
+    assert.equal(metric.name, 'xcp_host_uptime_seconds')
+    assert.equal(metric.type, 'gauge')
+    assert.equal(metric.help, 'Host uptime in seconds since boot')
+    assert.equal(metric.labels.pool_id, 'pool-456')
+    assert.equal(metric.labels.pool_name, 'Production Pool')
+    assert.equal(metric.labels.uuid, 'host-uuid-123')
+    assert.equal(metric.labels.host_name, 'Host 1')
+    // Value should be approximately 3600 (1 hour)
+    assert.ok(metric.value >= 3599 && metric.value <= 3601)
+  })
+
+  it('should skip host with null startTime', () => {
+    const labelContext = createLabelContextWithUptime(null)
+
+    const metrics = formatHostUptimeMetrics(labelContext)
+
+    assert.equal(metrics.length, 0)
+  })
+
+  it('should skip host not found in labels', () => {
+    const labelContext: LabelContext = {
+      hosts: [
+        {
+          hostId: 'unknown-host',
+          hostAddress: '192.168.1.1',
+          hostLabel: 'Unknown Host',
+          poolId: 'pool-456',
+          poolLabel: 'Production',
+          sessionId: 'session-123',
+          protocol: 'https:',
+        },
+      ],
+      labels: {
+        vms: {},
+        hosts: {},
+        srs: {},
+        srSuffixToUuid: {},
+        vdiUuidToSrUuid: {},
+      },
+    }
+
+    const metrics = formatHostUptimeMetrics(labelContext)
+
+    assert.equal(metrics.length, 0)
+  })
+
+  it('should generate metrics for multiple hosts', () => {
+    const now = Math.floor(Date.now() / 1000)
+    const labelContext: LabelContext = {
+      hosts: [
+        {
+          hostId: 'host-1',
+          hostAddress: '192.168.1.1',
+          hostLabel: 'Host 1',
+          poolId: 'pool-1',
+          poolLabel: 'Pool A',
+          sessionId: 'session-1',
+          protocol: 'https:',
+        },
+        {
+          hostId: 'host-2',
+          hostAddress: '192.168.1.2',
+          hostLabel: 'Host 2',
+          poolId: 'pool-1',
+          poolLabel: 'Pool A',
+          sessionId: 'session-1',
+          protocol: 'https:',
+        },
+      ],
+      labels: {
+        vms: {},
+        hosts: {
+          'host-1': {
+            name_label: 'Host 1',
+            pifDeviceToNetworkName: {},
+            startTime: now - 7200, // 2 hours
+          },
+          'host-2': {
+            name_label: 'Host 2',
+            pifDeviceToNetworkName: {},
+            startTime: now - 1800, // 30 minutes
+          },
+        },
+        srs: {},
+        srSuffixToUuid: {},
+        vdiUuidToSrUuid: {},
+      },
+    }
+
+    const metrics = formatHostUptimeMetrics(labelContext)
+
+    assert.equal(metrics.length, 2)
+    const host1Metric = metrics.find(m => m.labels.uuid === 'host-1')
+    const host2Metric = metrics.find(m => m.labels.uuid === 'host-2')
+    assert.ok(host1Metric)
+    assert.ok(host2Metric)
+    assert.ok(host1Metric.value >= 7199 && host1Metric.value <= 7201)
+    assert.ok(host2Metric.value >= 1799 && host2Metric.value <= 1801)
+  })
+
+  it('should omit pool_name label when empty', () => {
+    const now = Math.floor(Date.now() / 1000)
+    const labelContext: LabelContext = {
+      hosts: [
+        {
+          hostId: 'host-1',
+          hostAddress: '192.168.1.1',
+          hostLabel: 'Host 1',
+          poolId: 'pool-1',
+          poolLabel: '', // Empty pool label
+          sessionId: 'session-1',
+          protocol: 'https:',
+        },
+      ],
+      labels: {
+        vms: {},
+        hosts: {
+          'host-1': {
+            name_label: 'Host 1',
+            pifDeviceToNetworkName: {},
+            startTime: now - 3600,
+          },
+        },
+        srs: {},
+        srSuffixToUuid: {},
+        vdiUuidToSrUuid: {},
+      },
+    }
+
+    const metrics = formatHostUptimeMetrics(labelContext)
+
+    assert.equal(metrics.length, 1)
+    assert.equal(metrics[0]!.labels.pool_name, undefined)
+  })
+
+  it('should omit host_name label when empty', () => {
+    const now = Math.floor(Date.now() / 1000)
+    const labelContext: LabelContext = {
+      hosts: [
+        {
+          hostId: 'host-1',
+          hostAddress: '192.168.1.1',
+          hostLabel: 'Host 1',
+          poolId: 'pool-1',
+          poolLabel: 'Pool A',
+          sessionId: 'session-1',
+          protocol: 'https:',
+        },
+      ],
+      labels: {
+        vms: {},
+        hosts: {
+          'host-1': {
+            name_label: '', // Empty host name
+            pifDeviceToNetworkName: {},
+            startTime: now - 3600,
+          },
+        },
+        srs: {},
+        srSuffixToUuid: {},
+        vdiUuidToSrUuid: {},
+      },
+    }
+
+    const metrics = formatHostUptimeMetrics(labelContext)
+
+    assert.equal(metrics.length, 1)
+    assert.equal(metrics[0]!.labels.host_name, undefined)
   })
 })


### PR DESCRIPTION
### Description

[XO-1918](https://project.vates.tech/vates-global/browse/XO-1918/)

Expose host uptime as an OpenMetrics gauge metric (`xcp_host_uptime_seconds`).

The uptime is calculated from `host.startTime` (which comes from `host.other_config.boot_time` in XAPI).

**New metric:**
```
# HELP xcp_host_uptime_seconds Host uptime in seconds since boot
# TYPE xcp_host_uptime_seconds gauge
xcp_host_uptime_seconds{pool_id="...",pool_name="...",uuid="...",host_name="..."} 3600 1706889600
```

**Labels:**
- `pool_id` - Pool UUID
- `pool_name` - Pool name (omitted if empty)
- `uuid` - Host UUID
- `host_name` - Host name (omitted if empty)

<img width="1044" height="306" alt="Capture d’écran du 2026-02-02 16-40-19" src="https://github.com/user-attachments/assets/135f5e4b-e7aa-40d9-9a13-07f3277ac792" />


### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [ ] Reference the relevant issue
  - [ ] If bug fix, add `Introduced by`
- Changelog
  - [x] If visible by XOA users, add changelog entry
  - [x] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [x] If UI changes, add screenshots
  - [ ] If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
