### PR TITLE
docs(immutable-backups): fix app name in documentation

### DIFF
--- a/@xen-orchestra/immutable-backups/doc.md
+++ b/@xen-orchestra/immutable-backups/doc.md
@@ -44,7 +44,7 @@ List of protected files :
 
 ```js
 const PATHS = [
-  // xo-pool-config-backups/scheduleId/date/metadata.json
+  // xo-config-backups/scheduleId/date/metadata.json
   'xo-config-backups/*/*/data',
   'xo-config-backups/*/*/data.json',
   'xo-config-backups/*/*/metadata.json',

--- a/@xen-orchestra/immutable-backups/doc.md
+++ b/@xen-orchestra/immutable-backups/doc.md
@@ -44,14 +44,14 @@ List of protected files :
 
 ```js
 const PATHS = [
-  // xo configuration backupq
+  // xo-pool-config-backups/scheduleId/date/metadata.json
   'xo-config-backups/*/*/data',
   'xo-config-backups/*/*/data.json',
   'xo-config-backups/*/*/metadata.json',
-  // pool backupq
-  'xo-pool-metadata-backups/*/metadata.json',
-  'xo-pool-metadata-backups/*/data',
-  // vm backups , xo-vm-backups/<vmuuid>/
+  // xo-pool-metadata-backups/backupId/scheduleId/date/metadata.json
+  'xo-pool-metadata-backups/*/*/*/metadata.json',
+  'xo-pool-metadata-backups/*/*/*/data',
+  // xo-vm-backups/<vmuuid>/
   'xo-vm-backups/*/*.json',
   'xo-vm-backups/*/*.xva',
   'xo-vm-backups/*/*.xva.checksum',

--- a/@xen-orchestra/immutable-backups/protectRemotes.mjs
+++ b/@xen-orchestra/immutable-backups/protectRemotes.mjs
@@ -137,11 +137,13 @@ export async function watchRemote(remoteId, { root, immutabilityDuration, rebuil
 
   // watch the remote for any new VM metadata json file
   const PATHS = [
+    // xo-config-backups/scheduleId/date/metadata.json
     'xo-config-backups/*/*/data',
     'xo-config-backups/*/*/data.json',
     'xo-config-backups/*/*/metadata.json',
-    'xo-pool-metadata-backups/*/metadata.json',
-    'xo-pool-metadata-backups/*/data',
+    // xo-pool-metadata-backups/backupId/scheduleId/date/metadata.json
+    'xo-pool-metadata-backups/*/*/*/metadata.json',
+    'xo-pool-metadata-backups/*/*/*/data',
     // xo-vm-backups/<vmuuid>/
     'xo-vm-backups/*/*.json',
     'xo-vm-backups/*/*.xva',

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -50,6 +50,7 @@
 
 - @vates/types minor
 - @xen-orchestra/backups patch
+- @xen-orchestra/immutable-backups patch
 - @xen-orchestra/rest-api patch
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor

--- a/docs/docs/immutability.md
+++ b/docs/docs/immutability.md
@@ -6,7 +6,7 @@ This page covers the immutability feature: what it is, why it’s important, and
 
 ## What Is Immutability?
 
-In backup systems, immutability means that once a backup is created, it cannot be altered or deleted for a set period. This safeguards your backups against ransomware attacks, accidental deletion, or data corruption. 
+In backup systems, immutability means that once a backup is created, it cannot be altered or deleted for a set period. This safeguards your backups against ransomware attacks, accidental deletion, or data corruption.
 
 Here’s how it works: You designate a storage repository that Xen Orchestra can write to, but cannot modify during the specified immutability period. Even if an attacker compromises XO, your backups remain untouched. The goal is to ensure that your backup data cannot be deleted, encrypted, or tampered with, unless someone with direct physical or root access to the storage intervenes.
 
@@ -21,6 +21,7 @@ Immutability offers two distinct approaches in data protection, to meet differen
 Immutability guarantees that your backups stay secure and verifiable over time. It acts as a critical defense against ransomware, human mistakes, or intentional tampering. Additionally, it helps organizations comply with legal requirements by ensuring that data remains unaltered for mandatory retention periods. In essence, immutability turns your backup storage into a write-once, read-many (WORM) archive, protecting your data when it matters most.
 
 ## Immutability Approaches
+
 There are two primary models for achieving immutability:
 
 ### Object Storage
@@ -46,7 +47,7 @@ npm install -g @xen-orchestra/immutable-backups
 
 ### 2. Configure the Immutability Settings
 
-Create a configuration file at `/etc/xo-immutable-remote/config.toml`, with the following structure:
+Create a configuration file at `/etc/xo-immutable-backups/config.toml`, with the following structure:
 
 ```toml
 [remotes.remote1]
@@ -62,15 +63,19 @@ immutabilityDuration = "7d"
 #### Optional Parameters
 
 For additional validation, you can enable:
+
 ```toml
 rebuildIndexOnStart = true
 ```
+
 This option scans and validates existing files when the service starts. It can be resource-intensive.
 
 ### 3. Start the Service
+
 Launch the `xo-immutable-remote` service and check its logs (use `systemd`, for example) to confirm it is running correctly. For persistent operation, configure it as a system service.
 
 ## How It Works
+
 Once active, any backups written by Xen Orchestra to this repository will be protected for the specified duration. Even if Xen Orchestra is compromised, the immutability configuration remains secure, as it is managed entirely on the backup host.
 
 ## Working With Immutable Backups
@@ -80,19 +85,23 @@ When setting up backup jobs in Xen Orchestra, select your configured immutable r
 ## Best Practices
 
 ### Define a Clear Immutability Policy
+
 Align the **lock duration** with your data retention strategy, compliance requirements, and disaster recovery goals. Make sure the policy reflects both legal obligations and operational needs.
 
 ### Secure Your Encryption Keys
-Store encryption keys **separately** from your backup data. 
+
+Store encryption keys **separately** from your backup data.
 
 :::warning
 Losing encryption keys will render backups **permanently unrecoverable**.
 :::
 
 ### Maintain Independence from Xen Orchestra
+
 The immutability enforcement mechanism **must** operate independently of Xen Orchestra. This ensures that even if an attacker compromises XO, they **cannot** delete or alter existing backups.
 
 ### Monitor Storage and Test Recovery
+
 - Track storage capacity closely, as immutability prevents immediate deletion of older backups.
 - Plan for additional space to accommodate protected backups over time.
 - Test recovery procedures regularly, to make sure immutability does not disrupt your ability to restore data when needed.


### PR DESCRIPTION
Do not squash 

changelog that wasn't in previous PR
also fix a path for pool config backup
 
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
