### PR TITLE
feat(openmetrics): add xcp_host_status metric

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: "Nice enhancement, I'm eager to test it"
 
 - [OpenMetrics] Add `is_control_domain` label to VM metrics to differentiate dom0 VMs from regular VMs (PR [#9474](https://github.com/vatesfr/xen-orchestra/pull/9474))
+- [OpenMetrics] Add `xcp_host_status` metric exposing host status (running/maintenance/halted/unknown) for all hosts, including non-running ones (PR [#9457](https://github.com/vatesfr/xen-orchestra/pull/9457))
 - [REST API] Add `objectType` to tasks for resolved object references (PR [#9429](https://github.com/vatesfr/xen-orchestra/pull/9429))
 - [Warm Migration] the api call now return the new VM uuid (PR [#94653](https://github.com/vatesfr/xen-orchestra/pull/9465))
 - [Warm Migration] stopped VM can be warm migrated (PR [#94653](https://github.com/vatesfr/xen-orchestra/pull/9465))

--- a/packages/xo-server-openmetrics/src/open-metric-server.mts
+++ b/packages/xo-server-openmetrics/src/open-metric-server.mts
@@ -22,8 +22,10 @@ import { createLogger } from '@xen-orchestra/log'
 import { parseRrdResponse, type ParsedRrdData } from './rrd-parser.mjs'
 import {
   formatAllPoolsToOpenMetrics,
+  formatHostStatusMetrics,
   formatSrMetrics,
   formatToOpenMetrics,
+  type HostStatusItem,
   type SrDataItem,
 } from './openmetric-formatter.mjs'
 
@@ -91,6 +93,10 @@ interface SrDataPayload {
   srs: SrDataItem[]
 }
 
+interface HostStatusPayload {
+  hosts: HostStatusItem[]
+}
+
 interface PendingRequest<T> {
   resolve: (value: T) => void
   reject: (error: Error) => void
@@ -152,6 +158,10 @@ function handleParentMessage(rawMessage: unknown): void {
       handleSrDataResponse(message)
       break
 
+    case 'HOST_STATUS':
+      handleHostStatusResponse(message)
+      break
+
     default:
       logger.warn('Unknown message type from parent', { type: message.type })
   }
@@ -197,6 +207,20 @@ function handleCredentialsResponse(message: IpcMessage): void {
 }
 
 function handleSrDataResponse(message: IpcMessage): void {
+  const requestId = message.requestId
+  if (requestId === undefined) {
+    return
+  }
+
+  const pending = pendingRequests.get(requestId)
+  if (pending !== undefined) {
+    clearTimeout(pending.timer)
+    pendingRequests.delete(requestId)
+    pending.resolve(message.payload)
+  }
+}
+
+function handleHostStatusResponse(message: IpcMessage): void {
   const requestId = message.requestId
   if (requestId === undefined) {
     return
@@ -272,6 +296,25 @@ async function requestSrData(): Promise<SrDataPayload> {
     })
 
     sendToParent({ type: 'GET_SR_DATA', requestId })
+  })
+}
+
+async function requestHostStatusData(): Promise<HostStatusPayload> {
+  const requestId = `host-status-${++requestIdCounter}`
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      pendingRequests.delete(requestId)
+      reject(new Error('Timeout waiting for host status data from parent'))
+    }, IPC_REQUEST_TIMEOUT_MS)
+
+    pendingRequests.set(requestId, {
+      resolve: value => resolve(value as HostStatusPayload),
+      reject,
+      timer,
+    })
+
+    sendToParent({ type: 'GET_HOST_STATUS', requestId })
   })
 }
 
@@ -353,10 +396,17 @@ async function fetchRrdFromHost(host: HostCredentials): Promise<ParsedRrdData | 
  * @returns OpenMetrics-formatted string
  */
 async function collectMetrics(): Promise<string> {
-  const credentials = await requestXapiCredentials()
-  const srData = await requestSrData()
+  const [credentials, srData, hostStatusData] = await Promise.all([
+    requestXapiCredentials(),
+    requestSrData(),
+    requestHostStatusData(),
+  ])
 
-  logger.debug('Collecting metrics', { hostCount: credentials.hosts.length, srCount: srData.srs.length })
+  logger.debug('Collecting metrics', {
+    hostCount: credentials.hosts.length,
+    srCount: srData.srs.length,
+    hostStatusCount: hostStatusData.hosts.length,
+  })
 
   if (credentials.hosts.length === 0) {
     return '# No connected hosts\n# EOF'
@@ -410,7 +460,12 @@ async function collectMetrics(): Promise<string> {
   const srMetricsOutput = srMetrics.length > 0 ? formatToOpenMetrics(srMetrics) : ''
   logger.debug('Formatted SR metrics', { srCount: srMetrics.length })
 
-  // Combine pool metrics with RRD metrics and SR metrics
+  // Format host status metrics
+  const hostStatusMetrics = formatHostStatusMetrics(hostStatusData.hosts)
+  const hostStatusOutput = hostStatusMetrics.length > 0 ? formatToOpenMetrics(hostStatusMetrics) : ''
+  logger.debug('Formatted host status metrics', { hostCount: hostStatusMetrics.length })
+
+  // Combine pool metrics with RRD metrics, SR metrics, and host status metrics
   // Remove the # EOF from rrdMetrics if present (we'll add our own)
   const rrdMetricsWithoutEof = rrdMetrics.replace(/\n# EOF$/, '')
 
@@ -422,6 +477,10 @@ async function collectMetrics(): Promise<string> {
 
   if (srMetricsOutput !== '') {
     allMetricsSections.push(srMetricsOutput)
+  }
+
+  if (hostStatusOutput !== '') {
+    allMetricsSections.push(hostStatusOutput)
   }
 
   return allMetricsSections.join('\n') + '\n# EOF'


### PR DESCRIPTION
### Description

Add a new `xcp_host_status` OpenMetrics gauge metric that exposes host status for **all** hosts, including non-running ones.

Each host emits a single metric with value `1` and `power_state` / `enabled` labels reflecting the host's current state:

```
# HELP xcp_host_status Host status (1 = current state)
# TYPE xcp_host_status gauge
xcp_host_status{pool_id="...",pool_name="...",uuid="...",host_name="...",power_state="Running",enabled="true"} 1
```

[XO-1919](https://project.vates.tech/vates-global/browse/XO-1919/)

**Labels:**

| Label | Type | Description |
|-------|------|-------------|
| `power_state` | `HOST_POWER_STATE` | Host power state from XAPI (`Running`, `Halted`, `Unknown`) |
| `enabled` | `boolean` | Whether the host is enabled (`true`) or in maintenance mode (`false`) |

**Implementation:**
- New IPC message `GET_HOST_STATUS` / `HOST_STATUS` following the existing `SR_DATA` pattern
- Parent process collects `power_state` and `enabled` from XO host objects (using `@vates/types`)
- IPC requests are now parallelized with `Promise.all` (credentials, SR data, host status)
- Includes unit tests for the formatter function

<img width="1267" height="187" alt="Capture d'écran du 2026-02-10 11-27-29" src="https://github.com/user-attachments/assets/fcf8e264-e1ec-4776-9601-4a0d9611cfd2" />


### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [ ] Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - [ ] If bug fix, add `Introduced by`
- Changelog
  - [x] If visible by XOA users, add changelog entry
  - [x] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [ ] If UI changes, add screenshots
  - [ ] If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.