### PR TITLE
fix(backups): ensure vm created by backups are removable by backups : halthcheck/replication

### DIFF
--- a/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
@@ -100,7 +100,7 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
   }
 
   async _deleteOldEntries() {
-    return asyncMapSettled(this._oldEntries, vm => vm.$destroy())
+    return asyncMapSettled(this._oldEntries, vm => vm.$destroy({ bypassBlockedOperation: true }))
   }
 
   #decorateVmMetadata(backup, timestamp) {
@@ -175,7 +175,7 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
     const job = this._job
     const scheduleId = this._scheduleId
     const { uuid: srUuid, $xapi: xapi } = sr
-    
+
     let targetVmRef
     await Task.run({ name: 'transfer' }, async () => {
       targetVmRef = await importIncrementalVm(this.#decorateVmMetadata(deltaExport, timestamp), sr)

--- a/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/_MixinRemoteWriter.mjs
@@ -130,7 +130,7 @@ export const MixinRemoteWriter = (BaseClass = Object) =>
               xapi,
             }).run()
           } finally {
-            await xapi.VM_destroy(restoredVm.$ref)
+            await xapi.VM_destroy(restoredVm.$ref, { bypassBlockedOperation: true })
           }
         }
       )

--- a/@xen-orchestra/backups/_runners/_writers/_MixinXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/_MixinXapiWriter.mjs
@@ -72,7 +72,7 @@ export const MixinXapiWriter = (BaseClass = Object) =>
               xapi,
             }).run()
           } finally {
-            healthCheckVmRef && (await xapi.VM_destroy(healthCheckVmRef))
+            healthCheckVmRef && (await xapi.VM_destroy(healthCheckVmRef, { bypassBlockedOperation: true }))
           }
         }
       )

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,9 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [xo-server] Force delete a running VM now bypass `hard_shutdown` blocked operations (PR [#9473](https://github.com/vatesfr/xen-orchestra/pull/9473))
+- [Backup] Ensure VM created by healthcheck are removed by backup process (PR [#9473](https://github.com/vatesfr/xen-orchestra/pull/9473))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -30,5 +33,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- @xen-orchestra/xapi patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,6 +34,8 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
 - @xen-orchestra/xapi patch
+- xo-server patch
 
 <!--packages-end-->

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
@@ -646,7 +646,7 @@ export default class BackupNg {
             xapi,
           }).run()
         } finally {
-          await xapi.VM_destroy(restoredVm.$ref)
+          await xapi.VM_destroy(restoredVm.$ref, { bypassBlockedOperation: true })
         }
       })
   }


### PR DESCRIPTION
### Description

since https://github.com/vatesfr/xen-orchestra/commit/0a042d2f54a74ecc11a377809272337cb5c880d9 blocked operations are enforced more strictly when importing a VM, from backups, from replication or healthcheck

This PR ensure that the VM created by the replications and healthcheck are really deleteable by the backup process 


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
