### PR TITLE
feat(openmetrics): add is_control_domain label to differentiate dom0 VMs

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -9,7 +9,9 @@
 
 ### Enhancements
 
-> Users must be able to say: “Nice enhancement, I'm eager to test it”
+> Users must be able to say: "Nice enhancement, I'm eager to test it"
+
+- [OpenMetrics] Add `is_control_domain` label to VM metrics to differentiate dom0 VMs from regular VMs (PR [#9474](https://github.com/vatesfr/xen-orchestra/pull/9474))
 
 ### Bug fixes
 
@@ -34,4 +36,5 @@
 <!--packages-start-->
 
 - @xen-orchestra/fs patch
+- xo-server-openmetrics minor
 <!--packages-end-->

--- a/packages/xo-server-openmetrics/src/open-metric-server.mts
+++ b/packages/xo-server-openmetrics/src/open-metric-server.mts
@@ -59,6 +59,7 @@ interface HostCredentials {
 // Label lookup types for enriching metrics with human-readable names
 interface VmLabelInfo {
   name_label: string
+  is_control_domain: boolean
   vbdDeviceToVdiName: Record<string, string>
   vbdDeviceToVdiUuid: Record<string, string>
   vifIndexToNetworkName: Record<string, string>

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.mts
@@ -682,6 +682,7 @@ export function transformMetric(
         if (vmInfo.name_label !== '') {
           labels.vm_name = vmInfo.name_label
         }
+        labels.is_control_domain = vmInfo.is_control_domain ? 'true' : 'false'
 
         // For VBD metrics, add vdi_name and sr_name
         if (extractedLabels.device !== undefined) {


### PR DESCRIPTION
### Description

[XO-1920](https://project.vates.tech/vates-global/browse/XO-1920/)
Add `is_control_domain` label to VM metrics in the OpenMetrics export to differentiate dom0 VMs (control domains) from regular VMs.

The dom0 VM (`is_control_domain = true` in XAPI) is the specific VM running the hypervisor tools on each host. Until now, it was indistinguishable from regular VMs in the Prometheus metrics output.

**Changes:**
- Add `is_control_domain` boolean to `VmLabelInfo` interface
- Include `VM-controller` type objects in the label lookup (so dom0 VMs get proper `vm_name` enrichment)
- Emit `is_control_domain="true"` or `is_control_domain="false"` label on all VM metrics

**Usage in Prometheus/Grafana:**
```promql
# Exclude dom0 VMs
xcp_vm_cpu_usage{is_control_domain="false"}

# Only dom0 VMs
xcp_vm_cpu_usage{is_control_domain="true"}
```

<img width="1203" height="665" alt="Capture d’écran du 2026-02-06 11-11-20" src="https://github.com/user-attachments/assets/49287efa-1c34-4cd3-8371-7172f94dc4b7" />


### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [ ] Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - [ ] If bug fix, add `Introduced by`
- Changelog
  - [x] If visible by XOA users, add changelog entry
  - [x] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [ ] If UI changes, add screenshots
  - [ ] If not finished or not tested, open as _Draft_


### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
