### PR TITLE
feat(rest-api): expose privileges endpoints

### DIFF
--- a/@vates/types/src/lib/xen-orchestra-acl.mts
+++ b/@vates/types/src/lib/xen-orchestra-acl.mts
@@ -1,3 +1,4 @@
+import * as CMType from './complex-matcher.mjs'
 import { Branded } from '../common.mjs'
 
 export type XoAclRole =
@@ -13,3 +14,48 @@ export type XoAclRole =
       isTemplate: true
       roleTemplateId: number
     }
+
+export type XoAclSupportedActionsByResource = {
+  [resource: string]: Record<string, unknown>
+}
+
+/**
+ * E.g
+ * vms {
+ *   shutdown: {
+ *    clean: true,
+ *    hard: true,
+ *  }
+ * }
+ *
+ * `shutdown | shutdown:clean | shutdown:hard`
+ */
+export type GetKeysRecursively<T, Prefix extends string = ''> = {
+  [K in keyof T]: T[K] extends object
+    ? K extends string
+      ? `${Prefix}${K}` | GetKeysRecursively<T[K], `${Prefix}${K}:`>
+      : never
+    : K extends string
+      ? `${Prefix}${K}`
+      : never
+}[keyof T]
+
+export type XoAclSupportedResource<TActionsByResource extends XoAclSupportedActionsByResource> =
+  keyof TActionsByResource
+
+export type XoAclSupportedActions<
+  TActionsByResource extends XoAclSupportedActionsByResource,
+  TResource extends XoAclSupportedResource<TActionsByResource>,
+> = (GetKeysRecursively<TActionsByResource[TResource]> & string) | '*'
+
+export type XoAclPrivilege<
+  TActionsByResource extends XoAclSupportedActionsByResource,
+  TResource extends XoAclSupportedResource<TActionsByResource>,
+> = {
+  id: Branded<'acl-v2-privilege'>
+  resource: TResource
+  action: XoAclSupportedActions<TActionsByResource, TResource>
+  selector?: CMType.Id<string> | Record<string, unknown>
+  effect: 'allow' | 'deny'
+  roleId: XoAclRole['id']
+}

--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -19,7 +19,7 @@ import type {
   VM_POWER_STATE,
 } from './common.mjs'
 import type * as CMType from './lib/complex-matcher.mjs'
-import { XoAclRole } from './lib/xen-orchestra-acl.mjs'
+import { XoAclPrivilege, XoAclRole, XoAclSupportedActionsByResource } from './lib/xen-orchestra-acl.mjs'
 import type { XenApiHost, XenApiPool } from './xen-api.mjs'
 
 type BaseXapiXo = {
@@ -831,7 +831,10 @@ export type XapiXoRecord =
   | XoVtpm
   | XoSm
 
-export type NonXapiXoRecord =
+export type NonXapiXoRecord<
+  TActionsByResource extends XoAclSupportedActionsByResource = never,
+  TResource extends string = never,
+> =
   | AnyXoBackupArchive
   | AnyXoJob
   | AnyXoLog
@@ -846,8 +849,12 @@ export type NonXapiXoRecord =
   | XoTask
   | XoUser
   | XoAclRole
+  | XoAclPrivilege<TActionsByResource, TResource>
 
-export type XoRecord = XapiXoRecord | NonXapiXoRecord
+export type XoRecord<
+  TActionsByResource extends XoAclSupportedActionsByResource = never,
+  TResource extends string = never,
+> = XapiXoRecord | NonXapiXoRecord<TActionsByResource, TResource>
 
 export type AnyXoVm = XoVm | XoVmSnapshot | XoVmTemplate | XoVmController
 

--- a/@xen-orchestra/acl/src/class/privilege.mts
+++ b/@xen-orchestra/acl/src/class/privilege.mts
@@ -1,32 +1,12 @@
 import { createPredicate } from 'value-matcher'
-import type { Privilege as TPrivilege } from '../index.mjs'
+import type { XoAclPrivilege, XoAclSupportedActions, XoAclSupportedResource } from '@vates/types/lib/xen-orchestra/acl'
+
 import { SUPPORTED_ACTIONS_BY_RESOURCE } from '../actions/index.mjs'
 
-/**
- * E.g
- * vms {
- *   shutdown: {
- *    clean: true,
- *    hard: true,
- *  }
- * }
- *
- * `shutdown | shutdown:clean | shutdown:hard`
- */
-type GetKeysRecursively<T, Prefix extends string = ''> = {
-  [K in keyof T]: T[K] extends object
-    ? K extends string
-      ? `${Prefix}${K}` | GetKeysRecursively<T[K], `${Prefix}${K}:`>
-      : never
-    : K extends string
-      ? `${Prefix}${K}`
-      : never
-}[keyof T]
-
-export type SupportedResource = keyof typeof SUPPORTED_ACTIONS_BY_RESOURCE
-export type SupportedActions<T extends SupportedResource> =
-  | (GetKeysRecursively<(typeof SUPPORTED_ACTIONS_BY_RESOURCE)[T]> & string)
-  | '*'
+export type SupportedActionsByResource = typeof SUPPORTED_ACTIONS_BY_RESOURCE
+export type SupportedResource = XoAclSupportedResource<SupportedActionsByResource>
+export type SupportedActions<T extends SupportedResource> = XoAclSupportedActions<SupportedActionsByResource, T>
+export type TPrivilege<T extends SupportedResource> = XoAclPrivilege<SupportedActionsByResource, T>
 
 export class Privilege<T extends SupportedResource> {
   #action: TPrivilege<T>['action']

--- a/@xen-orchestra/acl/src/index.mts
+++ b/@xen-orchestra/acl/src/index.mts
@@ -1,14 +1,20 @@
-import type * as CMType from '@vates/types/lib/complex-matcher'
 import assert from 'node:assert'
-import type { Branded } from '@vates/types/common'
-import type { XoAclRole as Role } from '@vates/types/lib/xen-orchestra/acl'
 import type { XoUser } from '@vates/types/xo'
 
-import { Privilege as CPrivilege, SupportedActions, SupportedResource } from './class/privilege.mjs'
+import { SUPPORTED_ACTIONS_BY_RESOURCE } from './actions/index.mjs'
+import {
+  Privilege as CPrivilege,
+  TPrivilege as Privilege,
+  SupportedActions,
+  SupportedActionsByResource,
+  SupportedResource,
+} from './class/privilege.mjs'
 
-export type { SupportedActions, SupportedResource } from './class/privilege.mjs'
+// Export all types constructed using SUPPORTED_ACTIONS_BY_RESOURCE
+export type { Privilege, SupportedActions, SupportedActionsByResource, SupportedResource }
+export { SUPPORTED_ACTIONS_BY_RESOURCE }
 
-type AnyPrivilege = {
+export type AnyPrivilege = {
   [Resource in SupportedResource]: Privilege<Resource>
 }[SupportedResource]
 
@@ -20,18 +26,6 @@ type AnyPrivilegeOnParam = {
     objects: object | object[]
   }
 }[SupportedResource]
-
-export type Privilege<T extends SupportedResource> = {
-  id: Branded<'acl-v2-privilege'>
-  action: SupportedActions<T>
-  /**
-   * If undefined, target ALL objects of the resource
-   */
-  selector?: CMType.Id<string> | Record<string, unknown>
-  effect: 'allow' | 'deny'
-  resource: T
-  roleId: Role['id']
-}
 
 export function hasPrivilegeOn<T extends SupportedResource>({
   user,

--- a/@xen-orchestra/rest-api/package.json
+++ b/@xen-orchestra/rest-api/package.json
@@ -36,6 +36,7 @@
     "@vates/async-each": "^1.0.1",
     "@vates/task": "^0.6.1",
     "@vates/types": "^1.16.0",
+    "@xen-orchestra/acl": "^0.0.0",
     "@xen-orchestra/backups": "^0.67.1",
     "@xen-orchestra/log": "^0.7.1",
     "@xen-orchestra/xapi": "^8.6.2",

--- a/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
@@ -3,6 +3,7 @@ import { createGzip } from 'node:zlib'
 import { pipeline } from 'node:stream/promises'
 import { Readable, type Transform } from 'node:stream'
 import { Request } from 'express'
+import type { SupportedActionsByResource, SupportedResource } from '@xen-orchestra/acl'
 import type { VatesTask } from '@vates/types/lib/vates/task'
 import type { XapiXoRecord, XoRecord, XoTask } from '@vates/types/xo'
 import type { Xapi } from '@vates/types/lib/xen-orchestra/xapi'
@@ -13,13 +14,15 @@ import { RestApi } from '../rest-api/rest-api.mjs'
 import { makeObjectMapper } from '../helpers/object-wrapper.helper.mjs'
 import type { MaybePromise, SendObjects, WithHref } from '../helpers/helper.type.mjs'
 import type { Response as ExResponse } from 'express'
+import type { RestAnyPrivilege } from '../acl-privileges/acl-privilege.type.mjs'
 import { NDJSON_CONTENT_TYPE, safeParseComplexMatcher } from '../helpers/utils.helper.mjs'
 
 const noop = () => {}
 
 export type CreateActionReturnType<CbType> = Promise<{ taskId: string } | CbType>
+export type RestXoRecord = XoRecord<SupportedActionsByResource, SupportedResource> | RestAnyPrivilege
 
-export abstract class BaseController<T extends XoRecord, IsSync extends boolean> extends Controller {
+export abstract class BaseController<T extends RestXoRecord, IsSync extends boolean> extends Controller {
   abstract getObjects(): IsSync extends false ? Promise<Record<T['id'], T>> : Record<T['id'], T>
   abstract getObject(id: T['id']): IsSync extends false ? Promise<T> : T
 
@@ -30,7 +33,7 @@ export abstract class BaseController<T extends XoRecord, IsSync extends boolean>
     this.restApi = restApi
   }
 
-  sendObjects<Objects extends XoRecord = T>(
+  sendObjects<Objects extends RestXoRecord = T>(
     objects: Objects[],
     req: Request,
     path?: string | ((obj: Objects) => string)

--- a/@xen-orchestra/rest-api/src/abstract-classes/xo-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/xo-controller.mts
@@ -1,12 +1,16 @@
 import { inject } from 'inversify'
 import type { NonXapiXoRecord } from '@vates/types/xo'
+import type { SupportedActionsByResource, SupportedResource } from '@xen-orchestra/acl'
 
 import { BaseController } from './base-controller.mjs'
 
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { limitAndFilterArray } from '../helpers/utils.helper.mjs'
+import type { RestAnyPrivilege } from '../acl-privileges/acl-privilege.type.mjs'
 
-export abstract class XoController<T extends NonXapiXoRecord> extends BaseController<T, false> {
+export abstract class XoController<
+  T extends NonXapiXoRecord<SupportedActionsByResource, SupportedResource> | RestAnyPrivilege,
+> extends BaseController<T, false> {
   abstract getAllCollectionObjects(opts: Record<string, unknown>): Promise<T[]>
   abstract getCollectionObject(id: T['id']): Promise<T>
 

--- a/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
@@ -1,0 +1,55 @@
+import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import { provide } from 'inversify-binding-decorators'
+import type { Request as ExRequest } from 'express'
+
+import {
+  aclPrivilege,
+  aclPrivilegeIds,
+  partialAclPrivileges,
+} from '../open-api/oa-examples/acl-privilege.oa-example.mjs'
+import { badRequestResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
+import type { RestAnyPrivilege } from './acl-privilege.type.mjs'
+import type { SendObjects } from '../helpers/helper.type.mjs'
+import { XoController } from '../abstract-classes/xo-controller.mjs'
+
+@Route('acl-privileges')
+@Security('*')
+@Response(badRequestResp.status, badRequestResp.description)
+@Response(unauthorizedResp.status, unauthorizedResp.description)
+@Tags('acls')
+@provide(AclPrivilegeController)
+export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
+  getAllCollectionObjects(): Promise<RestAnyPrivilege[]> {
+    return this.restApi.xoApp.getAclV2Privileges() as Promise<RestAnyPrivilege[]>
+  }
+  getCollectionObject(id: RestAnyPrivilege['id']): Promise<RestAnyPrivilege> {
+    return this.restApi.xoApp.getAclV2Privilege(id) as Promise<RestAnyPrivilege>
+  }
+
+  /**
+   * @example fields "id,action,resource"
+   * @example filter "action:create"
+   * @example limit 42
+   */
+  @Example(aclPrivilegeIds)
+  @Example(partialAclPrivileges)
+  @Get('')
+  async getAclV2Privileges(
+    @Request() req: ExRequest,
+    @Query() fields?: string,
+    @Query() ndjson?: boolean,
+    @Query() filter?: string,
+    @Query() limit?: number
+  ): Promise<SendObjects<Partial<Unbrand<RestAnyPrivilege>>>> {
+    return this.sendObjects(Object.values(await this.getObjects({ filter, limit })), req)
+  }
+
+  /**
+   * @example id "c5d89d1a-df1e-4b72-98a0-c40adfdf49c1"
+   */
+  @Example(aclPrivilege)
+  @Get('{id}')
+  getAclV2Privilege(@Path() id: string): Promise<Unbrand<RestAnyPrivilege>> {
+    return this.getObject(id as RestAnyPrivilege['id'])
+  }
+}

--- a/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
@@ -7,7 +7,7 @@ import {
   aclPrivilegeIds,
   partialAclPrivileges,
 } from '../open-api/oa-examples/acl-privilege.oa-example.mjs'
-import { badRequestResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
+import { badRequestResp, notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
 import type { RestAnyPrivilege } from './acl-privilege.type.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
@@ -49,6 +49,7 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
    */
   @Example(aclPrivilege)
   @Get('{id}')
+  @Response(notFoundResp.status, notFoundResp.description)
   getAclV2Privilege(@Path() id: string): Promise<Unbrand<RestAnyPrivilege>> {
     return this.getObject(id as RestAnyPrivilege['id'])
   }

--- a/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.type.mts
+++ b/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.type.mts
@@ -1,0 +1,135 @@
+import type { GetKeysRecursively, XoAclPrivilege } from '@vates/types'
+import type { SUPPORTED_ACTIONS_BY_RESOURCE, SupportedActionsByResource, SupportedResource } from '@xen-orchestra/acl'
+
+type XoPrivilege = XoAclPrivilege<SupportedActionsByResource, SupportedResource>
+
+type BasePrivilege = {
+  id: XoPrivilege['id']
+  selector?: XoPrivilege['selector']
+  effect: XoPrivilege['effect']
+  roleId: XoPrivilege['roleId']
+}
+
+// even if `@xen-orchestra/acl`already expose `AnyPrivilege`, we sadly need to re-export the type.
+// `AnyPrivilege` is too complex to be used for the openAPI spec generation
+export type RestAnyPrivilege =
+  | (BasePrivilege & { resource: 'alarm'; action: ActionsByResource['alarm'] })
+  | (BasePrivilege & { resource: 'backup-archive'; action: ActionsByResource['backup-archive'] })
+  | (BasePrivilege & { resource: 'backup-job'; action: ActionsByResource['backup-job'] })
+  | (BasePrivilege & { resource: 'backup-log'; action: ActionsByResource['backup-log'] })
+  | (BasePrivilege & { resource: 'backup-log'; action: ActionsByResource['backup-log'] })
+  | (BasePrivilege & { resource: 'backup-repository'; action: ActionsByResource['backup-repository'] })
+  | (BasePrivilege & { resource: 'group'; action: ActionsByResource['group'] })
+  | (BasePrivilege & { resource: 'host'; action: ActionsByResource['host'] })
+  | (BasePrivilege & { resource: 'message'; action: ActionsByResource['message'] })
+  | (BasePrivilege & { resource: 'network'; action: ActionsByResource['network'] })
+  | (BasePrivilege & { resource: 'pbd'; action: ActionsByResource['pbd'] })
+  | (BasePrivilege & { resource: 'pci'; action: ActionsByResource['pci'] })
+  | (BasePrivilege & { resource: 'pgpu'; action: ActionsByResource['pgpu'] })
+  | (BasePrivilege & { resource: 'pif'; action: ActionsByResource['pif'] })
+  | (BasePrivilege & { resource: 'pool'; action: ActionsByResource['pool'] })
+  | (BasePrivilege & { resource: 'proxy'; action: ActionsByResource['proxy'] })
+  | (BasePrivilege & { resource: 'restore-log'; action: ActionsByResource['restore-log'] })
+  | (BasePrivilege & { resource: 'schedule'; action: ActionsByResource['schedule'] })
+  | (BasePrivilege & { resource: 'server'; action: ActionsByResource['server'] })
+  | (BasePrivilege & { resource: 'sm'; action: ActionsByResource['sm'] })
+  | (BasePrivilege & { resource: 'sr'; action: ActionsByResource['sr'] })
+  | (BasePrivilege & { resource: 'task'; action: ActionsByResource['task'] })
+  | (BasePrivilege & { resource: 'user'; action: ActionsByResource['user'] })
+  | (BasePrivilege & { resource: 'vbd'; action: ActionsByResource['vbd'] })
+  | (BasePrivilege & { resource: 'vdi'; action: ActionsByResource['vdi'] })
+  | (BasePrivilege & { resource: 'vdi-snapshot'; action: ActionsByResource['vdi-snapshot'] })
+  | (BasePrivilege & { resource: 'vif'; action: ActionsByResource['vif'] })
+  | (BasePrivilege & { resource: 'vm'; action: ActionsByResource['vm'] })
+  | (BasePrivilege & { resource: 'vm-controller'; action: ActionsByResource['vm-controller'] })
+  | (BasePrivilege & { resource: 'vm-snapshot'; action: ActionsByResource['vm-snapshot'] })
+  | (BasePrivilege & { resource: 'vm-template'; action: ActionsByResource['vm-template'] })
+
+// As explained just above, we need to redefine all privileges.
+// This type is used to create the `RestAnyPrivilge` union type
+// And also to ensure type from `@xen-orchestra/acl` and type from here are the same
+// type sync validation is done after this type
+type ActionsByResource = {
+  alarm: 'read'
+  'backup-archive': 'read'
+  'backup-job': 'read'
+  'backup-log': 'read'
+  'backup-repository': 'read'
+  group: 'read'
+  host: 'read' | 'allow-vm'
+  message: 'read'
+  network: 'read'
+  pbd: 'read'
+  pci: 'read'
+  pgpu: 'read'
+  pif: 'read'
+  pool: 'read'
+  proxy: 'read'
+  'restore-log': 'read'
+  schedule: 'read'
+  server: 'read'
+  sm: 'read'
+  sr: 'read'
+  task: 'read'
+  user: 'read'
+  vbd: 'read'
+  'vdi-snapshot': 'read'
+  vdi: 'read' | 'create' | 'boot'
+  vif: 'read' | 'create'
+  'vm-controller': 'read'
+  'vm-snapshot': 'read'
+  'vm-template': 'read' | 'instantiate'
+  vm:
+    | 'read'
+    | 'start'
+    | 'shutdown'
+    | 'shutdown:clean'
+    | 'shutdown:hard'
+    | 'reboot'
+    | 'reboot:clean'
+    | 'reboot:hard'
+    | 'pause'
+    | 'suspend'
+    | 'resume'
+    | 'unpause'
+}
+
+// ------ RESOURCES CHECK
+// If a resource is missing, will throw a TS error as it will not match never
+type AssertNever<T extends never> = T
+// Ensure all resources match
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _EnsureAllResourcesHandled = AssertNever<
+  Exclude<keyof typeof SUPPORTED_ACTIONS_BY_RESOURCE, keyof ActionsByResource>
+>
+// ------ RESOURCES CHECK
+// ------ ACTIONS CHECK
+type AllActionsFor<R extends keyof typeof SUPPORTED_ACTIONS_BY_RESOURCE> = GetKeysRecursively<
+  (typeof SUPPORTED_ACTIONS_BY_RESOURCE)[R]
+>
+
+// in case the action don't match
+// we populate the type with the resource and the action (extra/missing)
+// so it help to debug and instantly see what's wrong
+type EnsureAllActionsHandledStrict<T extends ActionsByResource> = {
+  [R in keyof T]: Exclude<AllActionsFor<R & keyof typeof SUPPORTED_ACTIONS_BY_RESOURCE>, T[R]> extends never
+    ? Exclude<T[R], AllActionsFor<R & keyof typeof SUPPORTED_ACTIONS_BY_RESOURCE>> extends never
+      ? true // <- actions match
+      : {
+          error: 'Extra actions found'
+          resource: R
+          extra: Exclude<T[R], AllActionsFor<R & keyof typeof SUPPORTED_ACTIONS_BY_RESOURCE>>
+        }
+    : {
+        error: 'Missing actions'
+        resource: R
+        missing: Exclude<AllActionsFor<R & keyof typeof SUPPORTED_ACTIONS_BY_RESOURCE>, T[R]>
+      }
+}
+// If an action is missing/extra, it will throw a TS error as it will not match Record<string, boolean>
+type ActionsValidator<T extends Record<string, boolean>> = T
+
+// Ensure all actions match
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type ActionsValidation = ActionsValidator<EnsureAllActionsHandledStrict<ActionsByResource>>
+// ------ ACTIONS CHECK

--- a/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.type.mts
+++ b/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.type.mts
@@ -17,7 +17,6 @@ export type RestAnyPrivilege =
   | (BasePrivilege & { resource: 'backup-archive'; action: ActionsByResource['backup-archive'] })
   | (BasePrivilege & { resource: 'backup-job'; action: ActionsByResource['backup-job'] })
   | (BasePrivilege & { resource: 'backup-log'; action: ActionsByResource['backup-log'] })
-  | (BasePrivilege & { resource: 'backup-log'; action: ActionsByResource['backup-log'] })
   | (BasePrivilege & { resource: 'backup-repository'; action: ActionsByResource['backup-repository'] })
   | (BasePrivilege & { resource: 'group'; action: ActionsByResource['group'] })
   | (BasePrivilege & { resource: 'host'; action: ActionsByResource['host'] })
@@ -46,7 +45,7 @@ export type RestAnyPrivilege =
   | (BasePrivilege & { resource: 'vm-template'; action: ActionsByResource['vm-template'] })
 
 // As explained just above, we need to redefine all privileges.
-// This type is used to create the `RestAnyPrivilge` union type
+// This type is used to create the `RestAnyPrivilege` union type
 // And also to ensure type from `@xen-orchestra/acl` and type from here are the same
 // type sync validation is done after this type
 type ActionsByResource = {

--- a/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
@@ -86,6 +86,7 @@ export class AclRoleController extends XoController<XoAclRole> {
   @Example(aclPrivilegeIds)
   @Example(partialAclPrivileges)
   @Get('{id}/privileges')
+  @Response(notFoundResp.status, notFoundResp.description)
   async getAclV2RolePrivileges(
     @Request() req: ExRequest,
     @Path() id: string,

--- a/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
@@ -17,6 +17,7 @@ import { provide } from 'inversify-binding-decorators'
 import { type Request as ExRequest, json } from 'express'
 import type { XoAclRole } from '@vates/types'
 
+import { aclPrivilegeIds, partialAclPrivileges } from '../open-api/oa-examples/acl-privilege.oa-example.mjs'
 import { aclRole, aclRoleIds, partialAclRoles } from '../open-api/oa-examples/acl-role.oa-example.mjs'
 import {
   asynchronousActionResp,
@@ -28,6 +29,8 @@ import {
 } from '../open-api/common/response.common.mjs'
 import { BASE_URL } from '../index.mjs'
 import { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
+import { limitAndFilterArray } from '../helpers/utils.helper.mjs'
+import type { RestAnyPrivilege } from '../acl-privileges/acl-privilege.type.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { taskLocation } from '../open-api/oa-examples/task.oa-example.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
@@ -72,6 +75,27 @@ export class AclRoleController extends XoController<XoAclRole> {
   @Response(notFoundResp.status, notFoundResp.description)
   getAclV2Role(@Path() id: string): Promise<Unbrand<XoAclRole>> {
     return this.getObject(id as XoAclRole['id'])
+  }
+
+  /**
+   * @example id "426622cc-b2db-4545-a2f0-6ec47b3a6450"
+   * @example fields "id,action,resource"
+   * @example filter "action:create"
+   * @example limit 42
+   */
+  @Example(aclPrivilegeIds)
+  @Example(partialAclPrivileges)
+  @Get('{id}/privileges')
+  async getAclV2RolePrivileges(
+    @Request() req: ExRequest,
+    @Path() id: string,
+    @Query() fields?: string,
+    @Query() ndjson?: boolean,
+    @Query() filter?: string,
+    @Query() limit?: number
+  ): Promise<SendObjects<Partial<Unbrand<RestAnyPrivilege>>>> {
+    const privileges = (await this.restApi.xoApp.getAclV2RolePrivileges(id as XoAclRole['id'])) as RestAnyPrivilege[]
+    return this.sendObjects(limitAndFilterArray(privileges, { filter, limit }), req, 'acl-privileges')
   }
 
   /**

--- a/@xen-orchestra/rest-api/src/helpers/object-wrapper.helper.mts
+++ b/@xen-orchestra/rest-api/src/helpers/object-wrapper.helper.mts
@@ -1,14 +1,14 @@
 import path from 'node:path'
 import pick from 'lodash/pick.js'
 import { Request } from 'express'
-import type { XoRecord } from '@vates/types'
 
 import { BASE_URL } from '../index.mjs'
+import type { RestXoRecord } from '../abstract-classes/base-controller.mjs'
 import type { WithHref } from './helper.type.mjs'
 
 const { join } = path.posix
 
-export function makeObjectMapper<T extends XoRecord>(req: Request, path?: string | ((obj: T) => string)) {
+export function makeObjectMapper<T extends RestXoRecord>(req: Request, path?: string | ((obj: T) => string)) {
   const makeUrl = (obj: T) => {
     let _path: string
     if (path === undefined) {

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/acl-privilege.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/acl-privilege.oa-example.mts
@@ -1,0 +1,27 @@
+export const aclPrivilegeIds = [
+  '/rest/v0/acl-privileges/6d16ac11-ad48-483a-a926-3d9655648b28',
+  '/rest/v0/acl-privileges/7a81ac36-264e-468e-ad4d-63d9a10aee6a',
+]
+
+export const partialAclPrivileges = [
+  {
+    id: '6d16ac11-ad48-483a-a926-3d9655648b28',
+    action: 'create',
+    resource: 'vif',
+    href: '/rest/v0/acl-privileges/6d16ac11-ad48-483a-a926-3d9655648b28',
+  },
+  {
+    id: '7a81ac36-264e-468e-ad4d-63d9a10aee6a',
+    action: 'create',
+    resource: 'vdi',
+    href: '/rest/v0/acl-privileges/7a81ac36-264e-468e-ad4d-63d9a10aee6a',
+  },
+]
+
+export const aclPrivilege = {
+  action: 'create',
+  effect: 'allow',
+  resource: 'vif',
+  roleId: 'ccaab6e6-bae6-4d9c-9866-911dfc88bdc6',
+  id: '6d16ac11-ad48-483a-a926-3d9655648b28',
+}

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -1,3 +1,4 @@
+import type { AnyPrivilege } from '@xen-orchestra/acl'
 import type { EventEmitter } from 'node:events'
 import type { VatesTask } from '@vates/types/lib/vates/task'
 import type { Xapi } from '@vates/types/lib/xen-orchestra/xapi'
@@ -150,6 +151,9 @@ export type XoApp = {
   /* disconnect a server (XCP-ng/XenServer) */
   createGroup(params: { name: string; provider?: string; providerGroup?: string }): Promise<XoGroup>
   disconnectXenServer(id: XoServer['id']): Promise<void>
+  getAclV2Privilege(id: AnyPrivilege['id']): Promise<AnyPrivilege>
+  getAclV2Privileges(): Promise<AnyPrivilege[]>
+  getAclV2RolePrivileges(roleId: XoAclRole['id']): Promise<AnyPrivilege[]>
   getAclV2Roles(): Promise<XoAclRole[]>
   getAclV2Role(id: XoAclRole['id']): Promise<XoAclRole>
   getAllGroups(): Promise<XoGroup[]>

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -154,8 +154,8 @@ export type XoApp = {
   getAclV2Privilege(id: AnyPrivilege['id']): Promise<AnyPrivilege>
   getAclV2Privileges(): Promise<AnyPrivilege[]>
   getAclV2RolePrivileges(roleId: XoAclRole['id']): Promise<AnyPrivilege[]>
-  getAclV2Roles(): Promise<XoAclRole[]>
   getAclV2Role(id: XoAclRole['id']): Promise<XoAclRole>
+  getAclV2Roles(): Promise<XoAclRole[]>
   getAllGroups(): Promise<XoGroup[]>
   getAllProxies(): Promise<XoProxy[]>
   getAllJobs<T extends AnyXoBackupJob['type']>(type: T): Promise<Extract<AnyXoBackupJob, { type: T }>[]>


### PR DESCRIPTION
### Screenshot

<img width="592" height="841" alt="Capture d’écran de 2026-02-10 12-16-29" src="https://github.com/user-attachments/assets/ba36aba4-2f68-4be8-9661-91f78fc81c87" />

### Description

- Types have been moved to `vates/types` to make them compatible with XoRecord
- `@xen-orchestra/acl` exposes constructed types that come from `vates/types`
- Types coming from `@xen-orchestra/acl` are too complex to be used to automatically generate the OpenAPI spec.
Therefore, I had to recreate “raw types” in the rest-api, and I added two checks to ensure that the rest-api acl's types stay in sync with the `@xen-orchestra/acl` types.
`RestAnyPrivilege` must be used only for OpenAPI spec generation (i.e. REST API input/output).


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
