### PR TITLE
feat(rest-api): add relaim_space action to sr

### DIFF
--- a/@vates/types/src/lib/xen-orchestra-xapi.mts
+++ b/@vates/types/src/lib/xen-orchestra-xapi.mts
@@ -121,6 +121,7 @@ export interface Xapi {
       xenstore_data?: Record<string, string>
     }
   ): Promise<XenApiVdi['$ref']>
+  SR_reclaimSpace(ref: XenApiSr['$ref']): Promise<void>
   startVm(
     id: XoVm['id'],
     opts?: {

--- a/@xen-orchestra/rest-api/src/srs/sr.controller.mts
+++ b/@xen-orchestra/rest-api/src/srs/sr.controller.mts
@@ -225,10 +225,11 @@ export class SrController extends XapiXoController<XoSr> {
    */
   @Post('{id}/actions/reclaim_space')
   @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(invalidParametersResp.status, invalidParametersResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
-  async plugPbd(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
+  async reclaimSpaceSr(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const srId = id as XoSr['id']
     const action = async () => {
       const sr = this.getXapiObject(srId)
@@ -239,7 +240,7 @@ export class SrController extends XapiXoController<XoSr> {
       sync,
       statusCode: noContentResp.status,
       taskProperties: {
-        name: 'sr reclaim space',
+        name: 'SR reclaim space',
         objectId: srId,
       },
     })

--- a/@xen-orchestra/rest-api/src/srs/sr.controller.mts
+++ b/@xen-orchestra/rest-api/src/srs/sr.controller.mts
@@ -24,8 +24,11 @@ import { BASE_URL } from '../index.mjs'
 import { escapeUnsafeComplexMatcher } from '../helpers/utils.helper.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
 import {
+  asynchronousActionResp,
   badRequestResp,
   createdResp,
+  internalServerErrorResp,
+  invalidParameters as invalidParametersResp,
   noContentResp,
   notFoundResp,
   unauthorizedResp,
@@ -38,6 +41,7 @@ import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 import { messageIds, partialMessages } from '../open-api/oa-examples/message.oa-example.mjs'
 import { taskIds, partialTasks } from '../open-api/oa-examples/task.oa-example.mjs'
+import { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
 
 @Route('srs')
 @Security('*')
@@ -214,5 +218,30 @@ export class SrController extends XapiXoController<XoSr> {
   async deleteSrTag(@Path() id: string, @Path() tag: string): Promise<void> {
     const sr = this.getXapiObject(id as XoSr['id'])
     await sr.$call('remove_tags', tag)
+  }
+
+  /**
+   * @example id "b61a5c92-700e-4966-a13b-00633f03eea8"
+   */
+  @Post('{id}/actions/reclaim_space')
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  @Response(invalidParametersResp.status, invalidParametersResp.description)
+  @Response(internalServerErrorResp.status, internalServerErrorResp.description)
+  async plugPbd(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
+    const srId = id as XoSr['id']
+    const action = async () => {
+      const sr = this.getXapiObject(srId)
+      await sr.$xapi.SR_reclaimSpace(sr.$ref)
+    }
+
+    return this.createAction<void>(action, {
+      sync,
+      statusCode: noContentResp.status,
+      taskProperties: {
+        name: 'sr reclaim space',
+        objectId: srId,
+      },
+    })
   }
 }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,6 +27,8 @@
 
 - [Storage] Add possibility to create VDI in qcow2 format if size > 2TB - 8KB (PR [#9493](https://github.com/vatesfr/xen-orchestra/pull/9493))
 
+- [REST API] Added POST `/srs/{id}/actions/reclaim_space` rest route (PR [#9486](https://github.com/vatesfr/xen-orchestra/pull/9486))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”


### PR DESCRIPTION
### Description

Add reclaim_space action rest route for srs.

<img width="1423" height="963" alt="RECLAIM_SPACE SR" src="https://github.com/user-attachments/assets/95f1a2c7-e3a5-466e-b14d-8c04fa6917a6" />

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
