### PR TITLE
docs(metadata_backup): clarify the two types of metadata backups

### DIFF
--- a/docs/docs/metadata_backup.md
+++ b/docs/docs/metadata_backup.md
@@ -4,8 +4,8 @@ XCP-ng and Citrix Hypervisor (Xenserver) hosts use a database to store metadata 
 
 In Xen Orchestra, Metadata backup is divided into two different options:
 
-- Pool metadata backup
-- XO configuration backup
+- **Pool metadata backup:** backup metadata of your physical XCP-ng host
+- **XO configuration backup:** backup metadata of your Xen Orchestra instance
 
 ## Performing a backup
 

--- a/docs/docs/metadata_backup.md
+++ b/docs/docs/metadata_backup.md
@@ -4,8 +4,8 @@ XCP-ng and Citrix Hypervisor (Xenserver) hosts use a database to store metadata 
 
 In Xen Orchestra, Metadata backup is divided into two different options:
 
-- **Pool metadata backup:** backup metadata of your physical XCP-ng host
-- **XO configuration backup:** backup metadata of your Xen Orchestra instance
+- **Pool metadata backup** - Backup metadata of your physical XCP-ng host: VMs, storage repositories, networks, etc.
+- **XO configuration backup:** - Backup metadata of your Xen Orchestra instance: Users, authorizations and ressource sets, backup job settings, hosts and plugin settings, etc.
 
 ## Performing a backup
 


### PR DESCRIPTION
This pull request clarifies the two types of metadata backups, following this [forum discussion](https://xcp-ng.org/forum/topic/11853/difference-between-types-of-metadata-backup/4).

Previously, we only mentioned "pool metadata backup" and "XO configuration backup", without further details, which led some users unsure of what they are used for.