### PR TITLE
fix(xo-server-openmetrics): bind to localhost instead of 127.0.0.1

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [OpenMetrics] Fix ECONNREFUSED on IPv6-only systems by binding to `localhost` instead of `127.0.0.1` (PR [#9489](https://github.com/vatesfr/xen-orchestra/pull/9489))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/packages/xo-server-openmetrics/src/index.mts
+++ b/packages/xo-server-openmetrics/src/index.mts
@@ -129,7 +129,7 @@ const logger = createLogger('xo:xo-server-openmetrics')
 const DEFAULT_PORT = 9004
 
 /** Default bind address for the OpenMetrics HTTP server */
-const DEFAULT_BIND_ADDRESS = '127.0.0.1'
+const DEFAULT_BIND_ADDRESS = 'localhost'
 
 /** Default timeout for IPC operations in milliseconds */
 const IPC_TIMEOUT_MS = 10_000


### PR DESCRIPTION
### Description

On systems where `localhost` resolves to `::1` (IPv6) before `127.0.0.1` (IPv4), the xo-server proxy (`http://localhost:9004` in `config.toml`) connects to `::1:9004` but the OpenMetrics child process only listens on `127.0.0.1:9004`, resulting in `ECONNREFUSED`.

Fix: bind to `localhost` instead of `127.0.0.1` so the child process listens on whichever address the OS resolves `localhost` to, matching the proxy target.

Fixes [xoa-support#7752082](https://help.vates.tech/#ticket/zoom/52258)

Introduced by 86ddff46a

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue
  - [x] Bug fix: added `Introduced by`
- Changelog
  - [x] Added changelog entry in `CHANGELOG.unreleased.md`
  - [x] Updated "Packages to release": `xo-server-openmetrics patch`
- PR
  - [ ] No UI changes
  - [x] Tested: reproduced ECONNREFUSED with `autoSelectFamily: false` on IPv6-first system, confirmed fix resolves the issue
  
 
### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
