### PR TITLE
feat: add qcow2 support in vdi creation

### DIFF
--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -118,6 +118,7 @@ class Vdi {
       )
       const preferredImageFormats = PBD?.device_config['preferred-image-formats']
       if (!preferredImageFormats || preferredImageFormats.includes('qcow2')) {
+        info('VDI virtual_size exceeds VHD max size, switching to qcow2', { virtual_size, SR })
         sm_config = { ...sm_config, 'image-format': 'qcow2' }
       }
     }

--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -113,12 +113,11 @@ class Vdi {
      */
     if (virtual_size > VHD_MAX_SIZE) {
       const poolMaster = await this.getRecord('host', this.pool.master)
-      const PBDs = await this.call(
-        'PBD.get_all_records_where',
-        `field "host"="${poolMaster.$ref}" and field "SR"="${SR}"`
+      const PBD = Object.values(this.objects.indexes.type.PBD).find(
+        pbd => pbd.host === poolMaster.$ref && pbd.SR === SR
       )
-      const preferredImageFormats = Object.values(PBDs)[0]?.device_config['preferred-image-formats']
-      if (!preferredImageFormats || preferredImageFormats?.includes('qcow2')) {
+      const preferredImageFormats = PBD?.device_config['preferred-image-formats']
+      if (!preferredImageFormats || preferredImageFormats.includes('qcow2')) {
         sm_config = { ...sm_config, 'image-format': 'qcow2' }
       }
     }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [Storage] Add possibility to create VDI in qcow2 format if size > 2TB - 8MB (PR [#9493](https://github.com/vatesfr/xen-orchestra/pull/9493))
+- [Storage] Add possibility to create VDI in qcow2 format if size > 2TB - 8KB (PR [#9493](https://github.com/vatesfr/xen-orchestra/pull/9493))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [Storage] Add possibility to create VDI in qcow2 format if size > 2TB - 8MB (PR [#9493](https://github.com/vatesfr/xen-orchestra/pull/9493))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”


### PR DESCRIPTION
### Description

Add qcow2 image-format when size is higher than 2TB. It will still be a VHD if PBD.preferred-image-formats do not list qcow2

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
