### PR TITLE
fix(rest-api): exclude removable storage from top 5 SRs usage

### DIFF
--- a/@xen-orchestra/rest-api/src/pools/pool.service.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.service.mts
@@ -14,7 +14,7 @@ import type { RestApi } from '../rest-api/rest-api.mjs'
 import { HostService } from '../hosts/host.service.mjs'
 import { VmService } from '../vms/vm.service.mjs'
 import { AlarmService } from '../alarms/alarm.service.mjs'
-import { getTopPerProperty, isSrWritableOrIso, promiseWriteInStream } from '../helpers/utils.helper.mjs'
+import { getTopPerProperty, isSrWritable, promiseWriteInStream } from '../helpers/utils.helper.mjs'
 import { type AsyncCacheEntry, getFromAsyncCache } from '../helpers/cache.helper.mjs'
 import type { PoolDashboard } from './pool.type.mjs'
 import { MissingPatchesInfo } from '../hosts/host.type.mjs'
@@ -94,7 +94,7 @@ export class PoolService {
   #getTopFiveSrsUsage(poolId: XoPool['id']): PoolDashboard['srs']['topFiveUsage'] {
     const srs = Object.values(
       this.#restApi.getObjectsByType<XoSr>('SR', {
-        filter: sr => sr.$pool === poolId && isSrWritableOrIso(sr),
+        filter: sr => sr.$pool === poolId && isSrWritable(sr) && sr.SR_type !== 'udev',
       })
     )
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [OpenMetrics] Fix ECONNREFUSED on IPv6-only systems by binding to `localhost` instead of `127.0.0.1` (PR [#9489](https://github.com/vatesfr/xen-orchestra/pull/9489))
+- [REST API] Exclude removable and ISO storage from top 5 SRs usage (PR [#9495](https://github.com/vatesfr/xen-orchestra/pull/9495))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

Exclude removable storage (`udev` type SRs) from the top 5 storage usage calculation in the pool dashboard REST API.

When a USB device is plugged into a host, its `udev` SR can have `size > 0`, causing it to appear in the pool dashboard's "Storage usage" widget. This doesn't make sense at the pool level.

The old dashboard already handled this case:
`packages/xo-web/src/xo-app/dashboard/overview/index.js:76`
```js
srs: createGetObjectsOfType('SR').filter([sr => isSrWritable(sr) && sr.SR_type !== 'udev'])
```

This fix applies the same `sr.SR_type !== 'udev'` filter to the REST API's `#getTopFiveSrsUsage()` method.

Introduced by e5702e407
[XO-1949](https://project.vates.tech/vates-global/browse/XO-1949/)

See https://feedback.vates.tech/posts/31/ability-to-modify-the-dashboard-widgets

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue
  - [x] If bug fix, add `Introduced by`
- Changelog
  - [x] If visible by XOA users, add changelog entry
  - [x] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [ ] If UI changes, add screenshots
  - [x] If not finished or not tested, open as _Draft_


### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
