### PR TITLE
docs(openmetrics): update documentation for host uptime, host status and is_control_domain

### DIFF
--- a/docs/docs/advanced.md
+++ b/docs/docs/advanced.md
@@ -437,22 +437,24 @@ All metrics are prefixed with `xcp_` and include enriched labels for easy filter
 
 #### Host Metrics
 
-| Metric                                  | Type    | Description                             |
-| --------------------------------------- | ------- | --------------------------------------- |
-| `xcp_host_load_average`                 | gauge   | Host load average                       |
-| `xcp_host_memory_free_bytes`            | gauge   | Free memory in bytes                    |
-| `xcp_host_memory_total_bytes`           | gauge   | Total memory in bytes                   |
-| `xcp_host_cpu_average`                  | gauge   | Average CPU usage (0-1)                 |
-| `xcp_host_cpu_core_usage`               | gauge   | Per-core CPU usage                      |
-| `xcp_host_network_receive_bytes_total`  | counter | Network bytes received per interface    |
-| `xcp_host_network_transmit_bytes_total` | counter | Network bytes transmitted per interface |
-| `xcp_host_disk_iops_read`               | gauge   | Disk read IOPS per SR                   |
-| `xcp_host_disk_iops_write`              | gauge   | Disk write IOPS per SR                  |
-| `xcp_host_disk_throughput_read_bytes`   | gauge   | Disk read throughput (bytes/s)          |
-| `xcp_host_disk_throughput_write_bytes`  | gauge   | Disk write throughput (bytes/s)         |
-| `xcp_host_disk_read_latency_seconds`    | gauge   | Disk read latency                       |
-| `xcp_host_disk_write_latency_seconds`   | gauge   | Disk write latency                      |
-| `xcp_host_disk_iowait`                  | gauge   | Disk IO wait ratio                      |
+| Metric                                  | Type    | Description                                                            |
+| --------------------------------------- | ------- | ---------------------------------------------------------------------- |
+| `xcp_host_load_average`                 | gauge   | Host load average                                                      |
+| `xcp_host_memory_free_bytes`            | gauge   | Free memory in bytes                                                   |
+| `xcp_host_memory_total_bytes`           | gauge   | Total memory in bytes                                                  |
+| `xcp_host_cpu_average`                  | gauge   | Average CPU usage (0-1)                                                |
+| `xcp_host_cpu_core_usage`               | gauge   | Per-core CPU usage                                                     |
+| `xcp_host_network_receive_bytes_total`  | counter | Network bytes received per interface                                   |
+| `xcp_host_network_transmit_bytes_total` | counter | Network bytes transmitted per interface                                |
+| `xcp_host_disk_iops_read`               | gauge   | Disk read IOPS per SR                                                  |
+| `xcp_host_disk_iops_write`              | gauge   | Disk write IOPS per SR                                                 |
+| `xcp_host_disk_throughput_read_bytes`   | gauge   | Disk read throughput (bytes/s)                                         |
+| `xcp_host_disk_throughput_write_bytes`  | gauge   | Disk write throughput (bytes/s)                                        |
+| `xcp_host_disk_read_latency_seconds`    | gauge   | Disk read latency                                                      |
+| `xcp_host_disk_write_latency_seconds`   | gauge   | Disk write latency                                                     |
+| `xcp_host_disk_iowait`                  | gauge   | Disk IO wait ratio                                                     |
+| `xcp_host_uptime_seconds`               | gauge   | Host uptime in seconds since boot                                      |
+| `xcp_host_status`                       | gauge   | Host status (1 = current state, `power_state` and `enabled` in labels) |
 
 #### VM Metrics
 
@@ -494,29 +496,35 @@ All metrics are prefixed with `xcp_` and include enriched labels for easy filter
 
 #### Connection Metrics
 
-| Metric               | Type  | Description                                          |
-| -------------------- | ----- | ---------------------------------------------------- |
-| `xcp_pool_connected` | gauge | Pool connection status (1=connected, 0=disconnected) |
+| Metric               | Type  | Description                                                         |
+| -------------------- | ----- | ------------------------------------------------------------------- |
+| `xcp_pool_connected` | gauge | Pool connection status (1 when connected, absent when disconnected) |
 
 #### Labels
 
 All metrics include these labels for filtering:
 
-| Label          | Description                                |
-| -------------- | ------------------------------------------ |
-| `pool_id`      | Pool UUID                                  |
-| `pool_name`    | Pool name                                  |
-| `uuid`         | Object UUID (host or VM)                   |
-| `type`         | Object type (`host` or `vm`)               |
-| `host_name`    | Host name (for host metrics)               |
-| `vm_name`      | VM name (for VM metrics)                   |
-| `sr_uuid`      | Storage Repository UUID (for SR metrics)   |
-| `sr_name`      | Storage Repository name (for disk metrics) |
-| `vdi_name`     | Virtual Disk name (for VM disk metrics)    |
-| `network_name` | Network name (for network metrics)         |
-| `interface`    | Network interface name                     |
-| `device`       | Disk device (xvda, xvdb, etc.)             |
-| `core`         | CPU core number                            |
+| Label               | Description                                                              |
+| ------------------- | ------------------------------------------------------------------------ |
+| `pool_id`           | Pool UUID                                                                |
+| `pool_name`         | Pool name                                                                |
+| `uuid`              | Object UUID (host or VM)                                                 |
+| `type`              | Object type (`host` or `vm`)                                             |
+| `host_name`         | Host name (for host metrics)                                             |
+| `vm_name`           | VM name (for VM metrics)                                                 |
+| `sr_uuid`           | Storage Repository UUID (for SR metrics)                                 |
+| `sr_name`           | Storage Repository name (for disk metrics)                               |
+| `vdi_name`          | Virtual Disk name (for VM disk metrics)                                  |
+| `network_name`      | Network name (for network metrics)                                       |
+| `interface`         | Network interface name                                                   |
+| `device`            | Disk device (xvda, xvdb, etc.)                                           |
+| `core`              | CPU core number                                                          |
+| `vif`               | VIF index (for VM network metrics)                                       |
+| `sr`                | SR UUID suffix (for host disk metrics)                                   |
+| `host_id`           | Host UUID (for local SR capacity metrics)                                |
+| `is_control_domain` | Whether the VM is a control domain / dom0 (`true`/`false`)               |
+| `power_state`       | Host power state: `Running`, `Halted`, `Unknown` (for `xcp_host_status`) |
+| `enabled`           | Whether the host is enabled: `true`/`false` (for `xcp_host_status`)      |
 
 ### PromQL Query Examples
 
@@ -548,6 +556,21 @@ sum by (sr_name) (xcp_host_disk_iops_read + xcp_host_disk_iops_write)
 
 # Over-provisioning ratio (virtual vs physical)
 xcp_sr_virtual_size_bytes / xcp_sr_physical_size_bytes
+
+# Host uptime in days
+xcp_host_uptime_seconds / 86400
+
+# Non-running hosts
+xcp_host_status{power_state!="Running"}
+
+# Hosts in maintenance mode
+xcp_host_status{power_state="Running", enabled="false"}
+
+# VM CPU usage excluding dom0
+xcp_vm_cpu_usage{is_control_domain="false"} * 100
+
+# Top 5 user VMs by CPU (excluding dom0)
+topk(5, xcp_vm_cpu_usage{is_control_domain="false"}) * 100
 ```
 
 ### Grafana Integration
@@ -656,13 +679,12 @@ groups:
           description: 'VM {{ $labels.vm_name }} has sustained high CPU usage.'
 
       - alert: PoolDisconnected
-        expr: xcp_pool_connected == 0
-        for: 1m
+        expr: absent_over_time(xcp_pool_connected[5m])
         labels:
           severity: critical
         annotations:
-          summary: 'Pool {{ $labels.pool_name }} disconnected'
-          description: 'XO lost connection to pool {{ $labels.pool_name }}.'
+          summary: 'Pool metrics unavailable'
+          description: 'No pool connection metrics received for 5 minutes. Check XO connectivity.'
 
       - alert: SRHighUsage
         expr: (xcp_sr_physical_usage_bytes / xcp_sr_physical_size_bytes) > 0.85
@@ -681,6 +703,24 @@ groups:
         annotations:
           summary: 'Critical storage usage on {{ $labels.sr_name }}'
           description: 'Storage Repository {{ $labels.sr_name }} is above 95% capacity. Immediate action required.'
+
+      - alert: HostNotRunning
+        expr: xcp_host_status{power_state!="Running"} == 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Host {{ $labels.host_name }} is {{ $labels.power_state }}'
+          description: 'Host {{ $labels.host_name }} in pool {{ $labels.pool_name }} has power state {{ $labels.power_state }}.'
+
+      - alert: HostRecentlyRebooted
+        expr: xcp_host_uptime_seconds < 600
+        for: 1m
+        labels:
+          severity: info
+        annotations:
+          summary: 'Host {{ $labels.host_name }} recently rebooted'
+          description: 'Host {{ $labels.host_name }} has been up for less than 10 minutes.'
 ```
 
 ### Security Recommendations

--- a/packages/xo-server-openmetrics/.USAGE.md
+++ b/packages/xo-server-openmetrics/.USAGE.md
@@ -9,6 +9,9 @@ This plugin creates an HTTP server that exposes a `/metrics` endpoint compatible
 
 - Real-time metrics from all connected pools
 - Host metrics: CPU, memory, network, disk IOPS/throughput/latency
+- Host uptime metric (`xcp_host_uptime_seconds`)
+- Host status metric (`xcp_host_status`) with `power_state` and `enabled` labels, including non-running hosts
 - VM metrics: CPU, memory, network, disk, runstate
+- `is_control_domain` label on all VM metrics to distinguish dom0 from user VMs
 - Bearer token authentication
 - OpenMetrics format with EOF marker

--- a/packages/xo-server-openmetrics/README.md
+++ b/packages/xo-server-openmetrics/README.md
@@ -17,7 +17,10 @@ This plugin creates an HTTP server that exposes a `/metrics` endpoint compatible
 
 - Real-time metrics from all connected pools
 - Host metrics: CPU, memory, network, disk IOPS/throughput/latency
+- Host uptime metric (`xcp_host_uptime_seconds`)
+- Host status metric (`xcp_host_status`) with `power_state` and `enabled` labels, including non-running hosts
 - VM metrics: CPU, memory, network, disk, runstate
+- `is_control_domain` label on all VM metrics to distinguish dom0 from user VMs
 - Bearer token authentication
 - OpenMetrics format with EOF marker
 


### PR DESCRIPTION
### Description

Update OpenMetrics documentation to reflect three new features:

- **Host uptime metric** (`xcp_host_uptime_seconds`) from PR #9449
- **Host status metric** (`xcp_host_status`) with `power_state` and `enabled` labels from PR #9457
- **`is_control_domain` label** on all VM metrics to distinguish dom0 from user VMs from PR #9474

Also fixes pre-existing documentation issues found during audit:

- Add missing `vif`, `sr`, `host_id` labels to the Labels reference table
- Fix `PoolDisconnected` alert expression: the metric is never `0` (it becomes absent when a pool disconnects), replaced `xcp_pool_connected == 0` with `absent_over_time(xcp_pool_connected[5m])`

See #9449, See #9457, See #9474

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - [ ] ~~If bug fix, add `Introduced by`~~ (not a bug fix)
- Changelog
  - [ ] ~~If visible by XOA users, add changelog entry~~ (documentation only)
  - [ ] ~~Update "Packages to release" in `CHANGELOG.unreleased.md`~~ (documentation only)
- PR
  - [ ] ~~If UI changes, add screenshots~~ (no UI changes)
  - [x] If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
