### PR TITLE
feat(rest-api): add CRUD rest routes for roles and privileges

### DIFF
--- a/@xen-orchestra/rest-api/README.md
+++ b/@xen-orchestra/rest-api/README.md
@@ -60,7 +60,7 @@ class Foo extends Controller {
 
 ### Examples
 
-In order not to pollute important decorators, all example structures should be in a separate file. `src/open-api/examples/<resource>.example.mts`
+In order not to pollute important decorators, all example structures should be in a separate file. `src/open-api/oa-examples/<resource>.oa-example.mts`
 
 ### ACLs
 

--- a/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
@@ -27,6 +27,7 @@ import {
   badRequestResp,
   createdResp,
   forbiddenOperationResp,
+  invalidParameters,
   noContentResp,
   notFoundResp,
   unauthorizedResp,
@@ -35,6 +36,7 @@ import {
 import type { RestAnyPrivilege } from './acl-privilege.type.mjs'
 import type { SafeOmit, SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
+import { entityId } from '../open-api/oa-examples/common.oa-example.mjs'
 
 @Route('acl-privileges')
 @Security('*')
@@ -83,15 +85,16 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
    *  "selector": {"id": "784bd959-08de-4b26-b575-92ded5aef872"}
    * }
    */
-  @Example({ id: 'c5d89d1a-df1e-4b72-98a0-c40adfdf49c1' })
+  @Example(entityId)
   @Post('')
   @Middlewares(json())
   @SuccessResponse(createdResp.status, createdResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
+  @Response(invalidParameters.status, invalidParameters.description)
   async createAclV2Privilege(
     @Body() privilege: Unbrand<SafeOmit<RestAnyPrivilege, 'id'>>
-  ): Promise<{ id: Unbrand<RestAnyPrivilege['id']> }> {
+  ): Promise<{ id: Unbrand<RestAnyPrivilege>['id'] }> {
     const newPrivilege = await this.restApi.xoApp.createAclV2Privilege(privilege as SafeOmit<RestAnyPrivilege, 'id'>)
 
     return { id: newPrivilege.id }
@@ -132,6 +135,7 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
   @SuccessResponse(noContentResp.status, noContentResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
+  @Response(invalidParameters.status, invalidParameters.description)
   async updateAclV2Privilege(
     @Path() id: string,
     @Body() privilege: Unbrand<SafeOmit<RestAnyPrivilege, 'id' | 'roleId'>>

--- a/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
@@ -1,4 +1,4 @@
-import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import { Delete, Example, Get, Patch, Path, Post, Query, Request, Response, Route, Security, Tags } from 'tsoa'
 import { provide } from 'inversify-binding-decorators'
 import type { Request as ExRequest } from 'express'
 
@@ -51,6 +51,40 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
   }
 
   /**
+   * @example action "read"
+   * @example resource "alarm"
+   * @example roleId "784bd959-08de-4b26-b575-92ded5aef872"
+   * @example effect "allow"
+   * @example selector "selector"
+   */
+  @Example(aclPrivilege)
+  @Post('')
+  async createAclV2Privilege(
+    @Query() action: string,
+    @Query() resource: string,
+    @Query() roleId: string,
+    @Query() effect?: string,
+    @Query() selector?: string,
+    @Query() force?: boolean
+  ): Promise<Unbrand<RestAnyPrivilege>> {
+    let options = {}
+    if (force !== undefined) {
+      options = { force }
+    }
+
+    return this.restApi.xoApp.createAclV2Privilege(
+      {
+        action: action as RestAnyPrivilege['action'],
+        selector: selector as RestAnyPrivilege['selector'],
+        effect: effect as RestAnyPrivilege['effect'],
+        resource: resource as RestAnyPrivilege['resource'],
+        roleId: roleId as RestAnyPrivilege['roleId'],
+      },
+      options
+    )
+  }
+
+  /**
    * @example id "c5d89d1a-df1e-4b72-98a0-c40adfdf49c1"
    */
   @Example(aclPrivilege)
@@ -58,5 +92,52 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
   @Response(notFoundResp.status, notFoundResp.description)
   getAclV2Privilege(@Path() id: string): Promise<Unbrand<RestAnyPrivilege>> {
     return this.getObject(id as RestAnyPrivilege['id'])
+  }
+
+  /**
+   * @example id "784bd959-08de-4b26-b575-92ded5aef872"
+   */
+  @Delete(':id')
+  async deleteAclV2Privilege(@Path() id: string, @Query() force?: boolean): Promise<void> {
+    let options = {}
+    if (force !== undefined) {
+      options = { force }
+    }
+
+    await this.restApi.xoApp.deleteAclV2Privilege(id as RestAnyPrivilege['id'], options)
+  }
+
+  /**
+   * @example id "784bd959-08de-4b26-b575-92ded5aef872"
+   * @example action "read"
+   * @example resource "alarm"
+   * @example effect "allow"
+   * @example selector "selector"
+   */
+  @Example(aclPrivilege)
+  @Patch(':id')
+  async updateAclV2Privilege(
+    @Path() id: string,
+    @Query() action?: string,
+    @Query() resource?: string,
+    @Query() effect?: string,
+    @Query() selector?: string,
+    @Query() force?: boolean
+  ): Promise<Unbrand<RestAnyPrivilege>> {
+    let options = {}
+    if (force !== undefined) {
+      options = { force }
+    }
+
+    return this.restApi.xoApp.updateAclV2Privilege(
+      id as RestAnyPrivilege['id'],
+      {
+        action: action as RestAnyPrivilege['action'],
+        selector: selector as RestAnyPrivilege['selector'],
+        effect: effect as RestAnyPrivilege['effect'],
+        resource: resource as RestAnyPrivilege['resource'],
+      },
+      options
+    )
   }
 }

--- a/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
@@ -33,7 +33,7 @@ import {
   type Unbrand,
 } from '../open-api/common/response.common.mjs'
 import type { RestAnyPrivilege } from './acl-privilege.type.mjs'
-import type { SendObjects } from '../helpers/helper.type.mjs'
+import type { SafeOmit, SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
 
 @Route('acl-privileges')
@@ -89,9 +89,9 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async createAclV2Privilege(
-    @Body() privilege: Omit<RestAnyPrivilege, 'id'>
+    @Body() privilege: Unbrand<SafeOmit<RestAnyPrivilege, 'id'>>
   ): Promise<{ id: Unbrand<RestAnyPrivilege['id']> }> {
-    const newPrivilege = await this.restApi.xoApp.createAclV2Privilege(privilege)
+    const newPrivilege = await this.restApi.xoApp.createAclV2Privilege(privilege as RestAnyPrivilege)
 
     return { id: newPrivilege.id }
   }
@@ -133,7 +133,7 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
   @Response(notFoundResp.status, notFoundResp.description)
   async updateAclV2Privilege(
     @Path() id: string,
-    @Body() privilege: Omit<RestAnyPrivilege, 'id' | 'roleId'>
+    @Body() privilege: Unbrand<SafeOmit<RestAnyPrivilege, 'id' | 'roleId'>>
   ): Promise<void> {
     await this.restApi.xoApp.updateAclV2Privilege(id as RestAnyPrivilege['id'], privilege)
   }

--- a/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
@@ -1,4 +1,18 @@
-import { Delete, Example, Get, Patch, Path, Post, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import {
+  Delete,
+  Example,
+  Get,
+  Patch,
+  Path,
+  Post,
+  Query,
+  Request,
+  Response,
+  Route,
+  Security,
+  SuccessResponse,
+  Tags,
+} from 'tsoa'
 import { provide } from 'inversify-binding-decorators'
 import type { Request as ExRequest } from 'express'
 
@@ -7,7 +21,14 @@ import {
   aclPrivilegeIds,
   partialAclPrivileges,
 } from '../open-api/oa-examples/acl-privilege.oa-example.mjs'
-import { badRequestResp, notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
+import {
+  badRequestResp,
+  createdResp,
+  noContentResp,
+  notFoundResp,
+  unauthorizedResp,
+  type Unbrand,
+} from '../open-api/common/response.common.mjs'
 import type { RestAnyPrivilege } from './acl-privilege.type.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
@@ -59,6 +80,8 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
    */
   @Example(aclPrivilege)
   @Post('')
+  @SuccessResponse(createdResp.status, createdResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
   async createAclV2Privilege(
     @Query() action: string,
     @Query() resource: string,
@@ -98,6 +121,8 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
    * @example id "784bd959-08de-4b26-b575-92ded5aef872"
    */
   @Delete(':id')
+  @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
   async deleteAclV2Privilege(@Path() id: string, @Query() force?: boolean): Promise<void> {
     let options = {}
     if (force !== undefined) {
@@ -116,6 +141,8 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
    */
   @Example(aclPrivilege)
   @Patch(':id')
+  @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
   async updateAclV2Privilege(
     @Path() id: string,
     @Query() action?: string,
@@ -123,13 +150,13 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
     @Query() effect?: string,
     @Query() selector?: string,
     @Query() force?: boolean
-  ): Promise<Unbrand<RestAnyPrivilege>> {
+  ): Promise<void> {
     let options = {}
     if (force !== undefined) {
       options = { force }
     }
 
-    return this.restApi.xoApp.updateAclV2Privilege(
+    await this.restApi.xoApp.updateAclV2Privilege(
       id as RestAnyPrivilege['id'],
       {
         action: action as RestAnyPrivilege['action'],

--- a/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
@@ -3,6 +3,7 @@ import {
   Delete,
   Example,
   Get,
+  Middlewares,
   Patch,
   Path,
   Post,
@@ -15,7 +16,7 @@ import {
   Tags,
 } from 'tsoa'
 import { provide } from 'inversify-binding-decorators'
-import type { Request as ExRequest } from 'express'
+import { json, type Request as ExRequest } from 'express'
 
 import {
   aclPrivilege,
@@ -84,6 +85,7 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
    */
   @Example(aclPrivilege)
   @Post('')
+  @Middlewares(json())
   @SuccessResponse(createdResp.status, createdResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
@@ -127,6 +129,7 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
    */
   @Example(aclPrivilege)
   @Patch('{id}')
+  @Middlewares(json())
   @SuccessResponse(noContentResp.status, noContentResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)

--- a/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
@@ -83,7 +83,6 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
    *  "selector": {"id": "784bd959-08de-4b26-b575-92ded5aef872"}
    * }
    */
-  @Example(aclPrivilege)
   @Post('')
   @Middlewares(json())
   @SuccessResponse(createdResp.status, createdResp.description)
@@ -91,10 +90,10 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
   @Response(notFoundResp.status, notFoundResp.description)
   async createAclV2Privilege(
     @Body() privilege: Omit<RestAnyPrivilege, 'id'>
-  ): Promise<Unbrand<RestAnyPrivilege['id']>> {
+  ): Promise<{ id: Unbrand<RestAnyPrivilege['id']> }> {
     const newPrivilege = await this.restApi.xoApp.createAclV2Privilege(privilege)
 
-    return newPrivilege.id
+    return { id: newPrivilege.id }
   }
 
   /**
@@ -127,7 +126,6 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
    *  "selector": {"id": "784bd959-08de-4b26-b575-92ded5aef872"}
    * }
    */
-  @Example(aclPrivilege)
   @Patch('{id}')
   @Middlewares(json())
   @SuccessResponse(noContentResp.status, noContentResp.description)

--- a/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
@@ -1,4 +1,5 @@
 import {
+  Body,
   Delete,
   Example,
   Get,
@@ -24,6 +25,7 @@ import {
 import {
   badRequestResp,
   createdResp,
+  forbiddenOperationResp,
   noContentResp,
   notFoundResp,
   unauthorizedResp,
@@ -72,39 +74,25 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
   }
 
   /**
-   * @example action "read"
-   * @example resource "alarm"
-   * @example roleId "784bd959-08de-4b26-b575-92ded5aef872"
-   * @example effect "allow"
-   * @example selector "selector"
+   * @example privilege {
+   *  "action": "read",
+   *  "resource": "alarm",
+   *  "roleId": "784bd959-08de-4b26-b575-92ded5aef872",
+   *  "effect": "allow",
+   *  "selector": {"id": "784bd959-08de-4b26-b575-92ded5aef872"}
+   * }
    */
   @Example(aclPrivilege)
   @Post('')
   @SuccessResponse(createdResp.status, createdResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async createAclV2Privilege(
-    @Query() action: string,
-    @Query() resource: string,
-    @Query() roleId: string,
-    @Query() effect?: string,
-    @Query() selector?: string,
-    @Query() force?: boolean
-  ): Promise<Unbrand<RestAnyPrivilege>> {
-    let options = {}
-    if (force !== undefined) {
-      options = { force }
-    }
+    @Body() privilege: Omit<RestAnyPrivilege, 'id'>
+  ): Promise<Unbrand<RestAnyPrivilege['id']>> {
+    const newPrivilege = await this.restApi.xoApp.createAclV2Privilege(privilege)
 
-    return this.restApi.xoApp.createAclV2Privilege(
-      {
-        action: action as RestAnyPrivilege['action'],
-        selector: selector as RestAnyPrivilege['selector'],
-        effect: effect as RestAnyPrivilege['effect'],
-        resource: resource as RestAnyPrivilege['resource'],
-        roleId: roleId as RestAnyPrivilege['roleId'],
-      },
-      options
-    )
+    return newPrivilege.id
   }
 
   /**
@@ -120,51 +108,32 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
   /**
    * @example id "784bd959-08de-4b26-b575-92ded5aef872"
    */
-  @Delete(':id')
+  @Delete('{id}')
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
-  async deleteAclV2Privilege(@Path() id: string, @Query() force?: boolean): Promise<void> {
-    let options = {}
-    if (force !== undefined) {
-      options = { force }
-    }
-
-    await this.restApi.xoApp.deleteAclV2Privilege(id as RestAnyPrivilege['id'], options)
+  async deleteAclV2Privilege(@Path() id: string): Promise<void> {
+    await this.restApi.xoApp.deleteAclV2Privilege(id as RestAnyPrivilege['id'])
   }
 
   /**
    * @example id "784bd959-08de-4b26-b575-92ded5aef872"
-   * @example action "read"
-   * @example resource "alarm"
-   * @example effect "allow"
-   * @example selector "selector"
+   * @example privilege {
+   *  "action": "read",
+   *  "resource": "alarm",
+   *  "effect": "allow",
+   *  "selector": {"id": "784bd959-08de-4b26-b575-92ded5aef872"}
+   * }
    */
   @Example(aclPrivilege)
-  @Patch(':id')
+  @Patch('{id}')
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async updateAclV2Privilege(
     @Path() id: string,
-    @Query() action?: string,
-    @Query() resource?: string,
-    @Query() effect?: string,
-    @Query() selector?: string,
-    @Query() force?: boolean
+    @Body() privilege: Omit<RestAnyPrivilege, 'id' | 'roleId'>
   ): Promise<void> {
-    let options = {}
-    if (force !== undefined) {
-      options = { force }
-    }
-
-    await this.restApi.xoApp.updateAclV2Privilege(
-      id as RestAnyPrivilege['id'],
-      {
-        action: action as RestAnyPrivilege['action'],
-        selector: selector as RestAnyPrivilege['selector'],
-        effect: effect as RestAnyPrivilege['effect'],
-        resource: resource as RestAnyPrivilege['resource'],
-      },
-      options
-    )
+    await this.restApi.xoApp.updateAclV2Privilege(id as RestAnyPrivilege['id'], privilege)
   }
 }

--- a/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-privileges/acl-privilege.controller.mts
@@ -83,6 +83,7 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
    *  "selector": {"id": "784bd959-08de-4b26-b575-92ded5aef872"}
    * }
    */
+  @Example({ id: 'c5d89d1a-df1e-4b72-98a0-c40adfdf49c1' })
   @Post('')
   @Middlewares(json())
   @SuccessResponse(createdResp.status, createdResp.description)
@@ -91,7 +92,7 @@ export class AclPrivilegeController extends XoController<RestAnyPrivilege> {
   async createAclV2Privilege(
     @Body() privilege: Unbrand<SafeOmit<RestAnyPrivilege, 'id'>>
   ): Promise<{ id: Unbrand<RestAnyPrivilege['id']> }> {
-    const newPrivilege = await this.restApi.xoApp.createAclV2Privilege(privilege as RestAnyPrivilege)
+    const newPrivilege = await this.restApi.xoApp.createAclV2Privilege(privilege as SafeOmit<RestAnyPrivilege, 'id'>)
 
     return { id: newPrivilege.id }
   }

--- a/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
@@ -139,35 +139,6 @@ export class AclRoleController extends XoController<XoAclRole> {
   }
 
   /**
-   * Returns all ACL privileges that match the following privilege:
-   * resource: acl-privilege, action: read
-   *
-   * @example id "426622cc-b2db-4545-a2f0-6ec47b3a6450"
-   * @example fields "id,action,resource"
-   * @example filter "action:create"
-   * @example limit 42
-   */
-  @Example(aclPrivilegeIds)
-  @Example(partialAclPrivileges)
-  @Get('{id}/privileges')
-  @Response(notFoundResp.status, notFoundResp.description)
-  async getAclV2RolePrivileges(
-    @Request() req: ExRequest,
-    @Path() id: string,
-    @Query() fields?: string,
-    @Query() ndjson?: boolean,
-    @Query() filter?: string,
-    @Query() limit?: number
-  ): SendObjects<Partial<Unbrand<RestAnyPrivilege>>> {
-    const privileges = (await this.restApi.xoApp.getAclV2RolePrivileges(id as XoAclRole['id'])) as RestAnyPrivilege[]
-    return this.sendObjects(limitAndFilterArray(privileges, { filter }), req, {
-      path: 'acl-privileges',
-      limit,
-      privilege: { resource: 'acl-privilege', action: 'read' },
-    })
-  }
-
-  /**
    * Copy a role with all its privileges. Possibility to modify the name and description of the copied role.
    *
    * @example id "784bd959-08de-4b26-b575-92ded5aef872"
@@ -203,6 +174,35 @@ export class AclRoleController extends XoController<XoAclRole> {
         name: 'copy role',
         objectId: roleId,
       },
+    })
+  }
+
+  /**
+   * Returns all ACL privileges that match the following privilege:
+   * resource: acl-privilege, action: read
+   *
+   * @example id "426622cc-b2db-4545-a2f0-6ec47b3a6450"
+   * @example fields "id,action,resource"
+   * @example filter "action:create"
+   * @example limit 42
+   */
+  @Example(aclPrivilegeIds)
+  @Example(partialAclPrivileges)
+  @Get('{id}/privileges')
+  @Response(notFoundResp.status, notFoundResp.description)
+  async getAclV2RolePrivileges(
+    @Request() req: ExRequest,
+    @Path() id: string,
+    @Query() fields?: string,
+    @Query() ndjson?: boolean,
+    @Query() filter?: string,
+    @Query() limit?: number
+  ): SendObjects<Partial<Unbrand<RestAnyPrivilege>>> {
+    const privileges = (await this.restApi.xoApp.getAclV2RolePrivileges(id as XoAclRole['id'])) as RestAnyPrivilege[]
+    return this.sendObjects(limitAndFilterArray(privileges, { filter }), req, {
+      path: 'acl-privileges',
+      limit,
+      privilege: { resource: 'acl-privilege', action: 'read' },
     })
   }
 }

--- a/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
@@ -26,6 +26,7 @@ import {
   badRequestResp,
   createdResp,
   forbiddenOperationResp,
+  invalidParameters,
   noContentResp,
   notFoundResp,
   unauthorizedResp,
@@ -87,9 +88,12 @@ export class AclRoleController extends XoController<XoAclRole> {
   @Post('')
   @Middlewares(json())
   @SuccessResponse(createdResp.status, createdResp.description)
-  async createAclV2Role(@Body() body: { name: string; description?: string }): Promise<Unbrand<XoAclRole['id']>> {
+  @Response(invalidParameters.status, invalidParameters.description)
+  async createAclV2Role(
+    @Body() body: { name: string; description?: string }
+  ): Promise<{ id: Unbrand<XoAclRole['id']> }> {
     const newRole = await this.restApi.xoApp.createAclV2Role(body)
-    return newRole.id
+    return { id: newRole.id }
   }
 
   /**
@@ -126,6 +130,7 @@ export class AclRoleController extends XoController<XoAclRole> {
   @SuccessResponse(noContentResp.status, noContentResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
+  @Response(invalidParameters.status, invalidParameters.description)
   async updateAclV2Role(
     @Path() id: string,
     @Body() body: { name?: string; description?: string | null }

--- a/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
@@ -25,6 +25,7 @@ import {
   asynchronousActionResp,
   badRequestResp,
   createdResp,
+  forbiddenOperationResp,
   noContentResp,
   notFoundResp,
   unauthorizedResp,
@@ -77,15 +78,17 @@ export class AclRoleController extends XoController<XoAclRole> {
   }
 
   /**
-   * @example name "staff"
-   * @example description "Vates staff"
+   * @example role {
+   *  "name": "VMs creator",
+   *  "description": "Allow to create VMs"
+   * }
    */
   @Example(aclRole)
   @Post('')
   @SuccessResponse(createdResp.status, createdResp.description)
-  @Response(notFoundResp.status, notFoundResp.description)
-  async createAclV2Role(@Query() name: string, @Query() description: string): Promise<Unbrand<XoAclRole>> {
-    return this.restApi.xoApp.createAclV2Role({ name, description })
+  async createAclV2Role(@Body() role: { name: string; description?: string }): Promise<Unbrand<XoAclRole['id']>> {
+    const newRole = await this.restApi.xoApp.createAclV2Role(role)
+    return newRole.id
   }
 
   /**
@@ -101,39 +104,31 @@ export class AclRoleController extends XoController<XoAclRole> {
   /**
    * @example id "784bd959-08de-4b26-b575-92ded5aef872"
    */
-  @Delete(':id')
+  @Delete('{id}')
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
-  async deleteAclV2Role(@Path() id: string, @Query() force?: boolean): Promise<void> {
-    let options = {}
-    if (force !== undefined) {
-      options = { force }
-    }
-
-    await this.restApi.xoApp.deleteAclV2Role(id as XoAclRole['id'], options)
+  async deleteAclV2Role(@Path() id: string): Promise<void> {
+    await this.restApi.xoApp.deleteAclV2Role(id as XoAclRole['id'])
   }
 
   /**
    * @example id "784bd959-08de-4b26-b575-92ded5aef872"
-   * @example name "staff"
-   * @example description "Vates staff"
+   * @example role {
+   *  "name": "VMs creator",
+   *  "description": "Allow to create VMs"
+   * }
    */
   @Example(aclRole)
-  @Patch(':id')
+  @Patch('{id}')
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async updateAclV2Role(
     @Path() id: string,
-    @Query() name?: string,
-    @Query() description?: string,
-    @Query() force?: boolean
+    @Body() role: { name?: string; description?: string | null }
   ): Promise<void> {
-    let options = {}
-    if (force !== undefined) {
-      options = { force }
-    }
-
-    await this.restApi.xoApp.updateAclV2Role(id as XoAclRole['id'], { name, description }, options)
+    await this.restApi.xoApp.updateAclV2Role(id as XoAclRole['id'], role)
   }
 
   /**

--- a/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
@@ -39,6 +39,7 @@ import type { RestAnyPrivilege } from '../acl-privileges/acl-privilege.type.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { taskLocation } from '../open-api/oa-examples/task.oa-example.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
+import { entityId } from '../open-api/oa-examples/common.oa-example.mjs'
 
 @Route('acl-roles')
 @Security('*')
@@ -84,14 +85,14 @@ export class AclRoleController extends XoController<XoAclRole> {
    *  "description": "Allow to create VMs"
    * }
    */
-  @Example({ id: '784bd959-08de-4b26-b575-92ded5aef872' })
+  @Example(entityId)
   @Post('')
   @Middlewares(json())
   @SuccessResponse(createdResp.status, createdResp.description)
   @Response(invalidParameters.status, invalidParameters.description)
   async createAclV2Role(
     @Body() body: { name: string; description?: string }
-  ): Promise<{ id: Unbrand<XoAclRole['id']> }> {
+  ): Promise<{ id: Unbrand<XoAclRole>['id'] }> {
     const newRole = await this.restApi.xoApp.createAclV2Role(body)
     return { id: newRole.id }
   }

--- a/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
@@ -78,16 +78,17 @@ export class AclRoleController extends XoController<XoAclRole> {
   }
 
   /**
-   * @example role {
+   * @example body {
    *  "name": "VMs creator",
    *  "description": "Allow to create VMs"
    * }
    */
-  @Example(aclRole)
+  @Example(aclRoleIds)
   @Post('')
+  @Middlewares(json())
   @SuccessResponse(createdResp.status, createdResp.description)
-  async createAclV2Role(@Body() role: { name: string; description?: string }): Promise<Unbrand<XoAclRole['id']>> {
-    const newRole = await this.restApi.xoApp.createAclV2Role(role)
+  async createAclV2Role(@Body() body: { name: string; description?: string }): Promise<Unbrand<XoAclRole['id']>> {
+    const newRole = await this.restApi.xoApp.createAclV2Role(body)
     return newRole.id
   }
 
@@ -114,21 +115,22 @@ export class AclRoleController extends XoController<XoAclRole> {
 
   /**
    * @example id "784bd959-08de-4b26-b575-92ded5aef872"
-   * @example role {
+   * @example body {
    *  "name": "VMs creator",
    *  "description": "Allow to create VMs"
    * }
    */
   @Example(aclRole)
   @Patch('{id}')
+  @Middlewares(json())
   @SuccessResponse(noContentResp.status, noContentResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async updateAclV2Role(
     @Path() id: string,
-    @Body() role: { name?: string; description?: string | null }
+    @Body() body: { name?: string; description?: string | null }
   ): Promise<void> {
-    await this.restApi.xoApp.updateAclV2Role(id as XoAclRole['id'], role)
+    await this.restApi.xoApp.updateAclV2Role(id as XoAclRole['id'], body)
   }
 
   /**

--- a/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
@@ -25,6 +25,7 @@ import {
   asynchronousActionResp,
   badRequestResp,
   createdResp,
+  noContentResp,
   notFoundResp,
   unauthorizedResp,
   Unbrand,
@@ -81,6 +82,8 @@ export class AclRoleController extends XoController<XoAclRole> {
    */
   @Example(aclRole)
   @Post('')
+  @SuccessResponse(createdResp.status, createdResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
   async createAclV2Role(@Query() name: string, @Query() description: string): Promise<Unbrand<XoAclRole>> {
     return this.restApi.xoApp.createAclV2Role({ name, description })
   }
@@ -99,6 +102,8 @@ export class AclRoleController extends XoController<XoAclRole> {
    * @example id "784bd959-08de-4b26-b575-92ded5aef872"
    */
   @Delete(':id')
+  @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
   async deleteAclV2Role(@Path() id: string, @Query() force?: boolean): Promise<void> {
     let options = {}
     if (force !== undefined) {
@@ -115,18 +120,20 @@ export class AclRoleController extends XoController<XoAclRole> {
    */
   @Example(aclRole)
   @Patch(':id')
+  @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
   async updateAclV2Role(
     @Path() id: string,
     @Query() name?: string,
     @Query() description?: string,
     @Query() force?: boolean
-  ): Promise<Unbrand<XoAclRole>> {
+  ): Promise<void> {
     let options = {}
     if (force !== undefined) {
       options = { force }
     }
 
-    return this.restApi.xoApp.updateAclV2Role(id as XoAclRole['id'], { name, description }, options)
+    await this.restApi.xoApp.updateAclV2Role(id as XoAclRole['id'], { name, description }, options)
   }
 
   /**

--- a/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
@@ -1,8 +1,10 @@
 import {
   Body,
+  Delete,
   Example,
   Get,
   Middlewares,
+  Patch,
   Path,
   Post,
   Query,
@@ -74,6 +76,16 @@ export class AclRoleController extends XoController<XoAclRole> {
   }
 
   /**
+   * @example name "staff"
+   * @example description "Vates staff"
+   */
+  @Example(aclRole)
+  @Post('')
+  async createAclV2Role(@Query() name: string, @Query() description: string): Promise<Unbrand<XoAclRole>> {
+    return this.restApi.xoApp.createAclV2Role({ name, description })
+  }
+
+  /**
    * @example id "784bd959-08de-4b26-b575-92ded5aef872"
    */
   @Example(aclRole)
@@ -81,6 +93,40 @@ export class AclRoleController extends XoController<XoAclRole> {
   @Response(notFoundResp.status, notFoundResp.description)
   getAclV2Role(@Path() id: string): Promise<Unbrand<XoAclRole>> {
     return this.getObject(id as XoAclRole['id'])
+  }
+
+  /**
+   * @example id "784bd959-08de-4b26-b575-92ded5aef872"
+   */
+  @Delete(':id')
+  async deleteAclV2Role(@Path() id: string, @Query() force?: boolean): Promise<void> {
+    let options = {}
+    if (force !== undefined) {
+      options = { force }
+    }
+
+    await this.restApi.xoApp.deleteAclV2Role(id as XoAclRole['id'], options)
+  }
+
+  /**
+   * @example id "784bd959-08de-4b26-b575-92ded5aef872"
+   * @example name "staff"
+   * @example description "Vates staff"
+   */
+  @Example(aclRole)
+  @Patch(':id')
+  async updateAclV2Role(
+    @Path() id: string,
+    @Query() name?: string,
+    @Query() description?: string,
+    @Query() force?: boolean
+  ): Promise<Unbrand<XoAclRole>> {
+    let options = {}
+    if (force !== undefined) {
+      options = { force }
+    }
+
+    return this.restApi.xoApp.updateAclV2Role(id as XoAclRole['id'], { name, description }, options)
   }
 
   /**

--- a/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
@@ -84,7 +84,7 @@ export class AclRoleController extends XoController<XoAclRole> {
    *  "description": "Allow to create VMs"
    * }
    */
-  @Example(aclRoleIds)
+  @Example({ id: '784bd959-08de-4b26-b575-92ded5aef872' })
   @Post('')
   @Middlewares(json())
   @SuccessResponse(createdResp.status, createdResp.description)
@@ -124,7 +124,6 @@ export class AclRoleController extends XoController<XoAclRole> {
    *  "description": "Allow to create VMs"
    * }
    */
-  @Example(aclRole)
   @Patch('{id}')
   @Middlewares(json())
   @SuccessResponse(noContentResp.status, noContentResp.description)

--- a/@xen-orchestra/rest-api/src/helpers/helper.type.mts
+++ b/@xen-orchestra/rest-api/src/helpers/helper.type.mts
@@ -29,3 +29,5 @@ export type AuthenticatedRequest = Request & {
     }
   }
 }
+
+export type SafeOmit<T, K extends keyof T> = T extends T ? Omit<T, K> : never

--- a/@xen-orchestra/rest-api/src/middlewares/tsoa-to-xo-error.middleware.mts
+++ b/@xen-orchestra/rest-api/src/middlewares/tsoa-to-xo-error.middleware.mts
@@ -1,11 +1,40 @@
 import { invalidParameters } from 'xo-common/api-errors.js'
 import { NextFunction, Request, Response } from 'express'
-import { ValidateError } from 'tsoa'
+import { FieldErrors, ValidateError } from 'tsoa'
 
 export default function tsoaToXoErrorHandler(error: unknown, _req: Request, _res: Response, next: NextFunction) {
   if (error instanceof ValidateError) {
-    throw invalidParameters(error.fields)
+    const fields = simplifyUnionValidationErrors(error.fields)
+    throw invalidParameters(fields)
   }
 
   return next(error)
+}
+
+function simplifyUnionValidationErrors(fields: Record<string, any>) {
+  const result: Record<string, any> = {}
+
+  for (const [key, field] of Object.entries(fields)) {
+    if (isUnionMismatchError(field)) {
+      result[key] = {
+        ...field,
+        message: 'Value does not match any allowed schema',
+      }
+      continue
+    }
+
+    result[key] = field
+  }
+
+  return result
+}
+
+function isUnionMismatchError(field: FieldErrors[string]) {
+  if (typeof field !== 'object' || field === null || !('message' in field)) {
+    return false
+  }
+
+  return (
+    typeof field.message === 'string' && field.message.startsWith('Could not match the union against any of the items')
+  )
 }

--- a/@xen-orchestra/rest-api/src/middlewares/tsoa-to-xo-error.middleware.mts
+++ b/@xen-orchestra/rest-api/src/middlewares/tsoa-to-xo-error.middleware.mts
@@ -11,8 +11,8 @@ export default function tsoaToXoErrorHandler(error: unknown, _req: Request, _res
   return next(error)
 }
 
-function simplifyUnionValidationErrors(fields: Record<string, any>) {
-  const result: Record<string, any> = {}
+function simplifyUnionValidationErrors(fields: FieldErrors): FieldErrors {
+  const result: FieldErrors = {}
 
   for (const [key, field] of Object.entries(fields)) {
     if (isUnionMismatchError(field)) {
@@ -29,12 +29,6 @@ function simplifyUnionValidationErrors(fields: Record<string, any>) {
   return result
 }
 
-function isUnionMismatchError(field: FieldErrors[string]) {
-  if (typeof field !== 'object' || field === null || !('message' in field)) {
-    return false
-  }
-
-  return (
-    typeof field.message === 'string' && field.message.startsWith('Could not match the union against any of the items')
-  )
+function isUnionMismatchError(field: FieldErrors[string]): boolean {
+  return field.message.startsWith('Could not match the union against any of the items')
 }

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/common.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/common.oa-example.mts
@@ -1,0 +1,3 @@
+export const entityId = {
+  id: '9cac02e2-f612-4b71-851e-d28b9c0cda88',
+}

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -133,7 +133,10 @@ export type XoApp = {
   checkFeatureAuthorization(featureCode: string): Promise<void>
   /* connect a server (XCP-ng/XenServer) */
   connectXenServer(id: XoServer['id']): Promise<void>
-  createAclV2Privilege<Resource extends SupportedResource, Privilege extends RestAnyPrivilege>(
+  createAclV2Privilege<
+    Resource extends SupportedResource,
+    Privilege extends RestAnyPrivilege = Extract<RestAnyPrivilege, { resource: Resource }>,
+  >(
     privilege: {
       action: Privilege['action']
       selector?: Privilege['selector']

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -263,7 +263,10 @@ export type XoApp = {
       preferences?: Record<string, string>
     }
   ): Promise<void>
-  updateAclV2Privilege<Resource extends SupportedResource, Privilege extends RestAnyPrivilege>(
+  updateAclV2Privilege<
+    Resource extends SupportedResource,
+    Privilege extends RestAnyPrivilege = Extract<RestAnyPrivilege, { resource: Resource }>,
+  >(
     privilegeId: Privilege['id'],
     privilege: {
       action?: Privilege['action']

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -267,9 +267,6 @@ export type XoApp = {
       selector?: Privilege['selector'] | null
       effect?: Privilege['effect']
       resource?: Resource
-    },
-    options?: {
-      force?: boolean
     }
   ): Promise<Privilege>
   updateAclV2Role(

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -46,6 +46,7 @@ import type {
 import type { XoAclRole } from '@vates/types/lib/xen-orchestra/acl'
 
 import type { InsertableXoServer } from '../servers/server.type.mjs'
+import { RestAnyPrivilege } from '../acl-privileges/acl-privilege.type.mjs'
 
 type XapiRecordByXapiXoRecord = {
   gpuGroup: XenApiGpuGroupWrapped
@@ -132,10 +133,23 @@ export type XoApp = {
   checkFeatureAuthorization(featureCode: string): Promise<void>
   /* connect a server (XCP-ng/XenServer) */
   connectXenServer(id: XoServer['id']): Promise<void>
+  createAclV2Privilege(
+    privilege: {
+      action: RestAnyPrivilege['action']
+      selector?: RestAnyPrivilege['selector']
+      effect?: RestAnyPrivilege['effect']
+      resource: RestAnyPrivilege['resource']
+      roleId: RestAnyPrivilege['roleId']
+    },
+    options?: {
+      force?: boolean
+    }
+  ): Promise<RestAnyPrivilege>
   copyAclV2Role(
     id: XoAclRole['id'],
     params?: { name?: XoAclRole['name']; description?: XoAclRole['description'] }
   ): Promise<XoAclRole['id']>
+  createAclV2Role(role: { name: XoAclRole['name']; description: XoAclRole['description'] }): Promise<XoAclRole>
   createAuthenticationToken(opts: {
     client?: {
       id?: string
@@ -146,6 +160,8 @@ export type XoApp = {
     userId: XoUser['id']
   }): Promise<XoAuthenticationToken>
   createUser(params: { name?: string; password?: string; [key: string]: unknown }): Promise<XoUser>
+  deleteAclV2Privilege(privilegeId: RestAnyPrivilege['id'], options?: { force?: boolean }): Promise<boolean>
+  deleteAclV2Role(roleId: XoAclRole['id'], options?: { force?: boolean }): Promise<boolean>
   deleteGroup(id: XoGroup['id']): Promise<void>
   deleteUser(id: XoUser['id']): Promise<void>
   /* disconnect a server (XCP-ng/XenServer) */
@@ -244,6 +260,28 @@ export type XoApp = {
       preferences?: Record<string, string>
     }
   ): Promise<void>
+  updateAclV2Privilege(
+    privilegeId: RestAnyPrivilege['id'],
+    privilege: {
+      action?: RestAnyPrivilege['action']
+      selector?: RestAnyPrivilege['selector']
+      effect?: RestAnyPrivilege['effect']
+      resource?: RestAnyPrivilege['resource']
+    },
+    options?: {
+      force?: boolean
+    }
+  ): Promise<RestAnyPrivilege>
+  updateAclV2Role(
+    roleId: XoAclRole['id'],
+    role: {
+      name?: XoAclRole['name']
+      description?: XoAclRole['description']
+    },
+    options?: {
+      force?: boolean
+    }
+  ): Promise<XoAclRole>
   updateGroup(
     id: XoGroup['id'],
     updates: {

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.type.mts
@@ -1,4 +1,4 @@
-import type { AnyPrivilege } from '@xen-orchestra/acl'
+import type { AnyPrivilege, SupportedResource } from '@xen-orchestra/acl'
 import type { EventEmitter } from 'node:events'
 import type { VatesTask } from '@vates/types/lib/vates/task'
 import type { Xapi } from '@vates/types/lib/xen-orchestra/xapi'
@@ -46,7 +46,7 @@ import type {
 import type { XoAclRole } from '@vates/types/lib/xen-orchestra/acl'
 
 import type { InsertableXoServer } from '../servers/server.type.mjs'
-import { RestAnyPrivilege } from '../acl-privileges/acl-privilege.type.mjs'
+import type { RestAnyPrivilege } from '../acl-privileges/acl-privilege.type.mjs'
 
 type XapiRecordByXapiXoRecord = {
   gpuGroup: XenApiGpuGroupWrapped
@@ -133,23 +133,23 @@ export type XoApp = {
   checkFeatureAuthorization(featureCode: string): Promise<void>
   /* connect a server (XCP-ng/XenServer) */
   connectXenServer(id: XoServer['id']): Promise<void>
-  createAclV2Privilege(
+  createAclV2Privilege<Resource extends SupportedResource, Privilege extends RestAnyPrivilege>(
     privilege: {
-      action: RestAnyPrivilege['action']
-      selector?: RestAnyPrivilege['selector']
-      effect?: RestAnyPrivilege['effect']
-      resource: RestAnyPrivilege['resource']
-      roleId: RestAnyPrivilege['roleId']
+      action: Privilege['action']
+      selector?: Privilege['selector']
+      effect?: Privilege['effect']
+      resource: Resource
+      roleId: Privilege['roleId']
     },
     options?: {
       force?: boolean
     }
-  ): Promise<RestAnyPrivilege>
+  ): Promise<Privilege>
   copyAclV2Role(
     id: XoAclRole['id'],
     params?: { name?: XoAclRole['name']; description?: XoAclRole['description'] }
   ): Promise<XoAclRole['id']>
-  createAclV2Role(role: { name: XoAclRole['name']; description: XoAclRole['description'] }): Promise<XoAclRole>
+  createAclV2Role(role: { name: XoAclRole['name']; description?: XoAclRole['description'] }): Promise<XoAclRole>
   createAuthenticationToken(opts: {
     client?: {
       id?: string
@@ -260,23 +260,23 @@ export type XoApp = {
       preferences?: Record<string, string>
     }
   ): Promise<void>
-  updateAclV2Privilege(
-    privilegeId: RestAnyPrivilege['id'],
+  updateAclV2Privilege<Resource extends SupportedResource, Privilege extends RestAnyPrivilege>(
+    privilegeId: Privilege['id'],
     privilege: {
-      action?: RestAnyPrivilege['action']
-      selector?: RestAnyPrivilege['selector']
-      effect?: RestAnyPrivilege['effect']
-      resource?: RestAnyPrivilege['resource']
+      action?: Privilege['action']
+      selector?: Privilege['selector'] | null
+      effect?: Privilege['effect']
+      resource?: Resource
     },
     options?: {
       force?: boolean
     }
-  ): Promise<RestAnyPrivilege>
+  ): Promise<Privilege>
   updateAclV2Role(
     roleId: XoAclRole['id'],
     role: {
       name?: XoAclRole['name']
-      description?: XoAclRole['description']
+      description?: XoAclRole['description'] | null
     },
     options?: {
       force?: boolean

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [REST API] Added CRUD rest routes for ACL roles and privileges (PR [#](https://github.com/vatesfr/xen-orchestra/pull/))
+- [REST API] Added CRUD rest routes for ACL roles and privileges (PR [#9502](https://github.com/vatesfr/xen-orchestra/pull/9502))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
+- [REST API] Added CRUD rest routes for ACL roles and privileges (PR [#](https://github.com/vatesfr/xen-orchestra/pull/))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -30,5 +32,8 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- @xen-orchestra/rest-api minor
+- xo-server minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,8 +11,6 @@
 
 > Users must be able to say: “Nice enhancement, I'm eager to test it”
 
-- [REST API] Added CRUD rest routes for ACL roles and privileges (PR [#9502](https://github.com/vatesfr/xen-orchestra/pull/9502))
-
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
@@ -32,8 +30,5 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
-
-- @xen-orchestra/rest-api minor
-- xo-server minor
 
 <!--packages-end-->

--- a/packages/xo-server/src/xo-mixins/acls-v2/index.mjs
+++ b/packages/xo-server/src/xo-mixins/acls-v2/index.mjs
@@ -312,7 +312,7 @@ export default class {
    * @param {object} privilege
    * @param {Privilege['action']} privilege.action
    * @param {Privilege['selector']} [privilege.selector]
-   * @param {Privilege['effect']} privilege.effect
+   * @param {Privilege['effect']} [privilege.effect]
    * @param {Privilege['resource']} privilege.resource
    * @param {Privilege['roleId']} privilege.roleId
    * @param {object} [opts]
@@ -345,6 +345,49 @@ export default class {
     }
 
     return this.#privilegeDb.remove(privilege.id)
+  }
+
+  /**
+   * @param {Privilege['id']} id
+   * @param {object} privilege
+   * @param {Privilege['action']} [privilege.action]
+   * @param {Privilege['selector'] | null} [privilege.selector]
+   * @param {Privilege['effect']} [privilege.effect]
+   * @param {Privilege['resource']} [privilege.resource]
+   * @param {object} [opts]
+   * @param {boolean} [opts.force]
+   *
+   * @returns {Promise<Privilege>}
+   */
+  async updateAclV2Privilege(id, { action, selector, effect, resource }, { force = false } = {}) {
+    const privilege = await this.getAclV2Privilege(id)
+    const role = await this.getAclV2Role(privilege.roleId)
+
+    if (!force && 'isTemplate' in role) {
+      throw forbiddenOperation('update ACL V2 privilege', 'role is a template')
+    }
+
+    if (action !== undefined) {
+      privilege.action = action
+    }
+
+    if (selector !== undefined) {
+      if (selector === null) {
+        delete privilege.selector
+      } else {
+        privilege.selector = selector
+      }
+    }
+
+    if (effect !== undefined) {
+      privilege.effect = effect
+    }
+
+    if (resource !== undefined) {
+      privilege.resource = resource
+    }
+
+    return this.#privilegeDb.update(privilege)
   }
 
   /**

--- a/packages/xo-server/src/xo-mixins/acls-v2/index.mjs
+++ b/packages/xo-server/src/xo-mixins/acls-v2/index.mjs
@@ -354,16 +354,14 @@ export default class {
    * @param {Privilege['selector'] | null} [privilege.selector]
    * @param {Privilege['effect']} [privilege.effect]
    * @param {Privilege['resource']} [privilege.resource]
-   * @param {object} [opts]
-   * @param {boolean} [opts.force]
    *
    * @returns {Promise<Privilege>}
    */
-  async updateAclV2Privilege(id, { action, selector, effect, resource }, { force = false } = {}) {
+  async updateAclV2Privilege(id, { action, selector, effect, resource }) {
     const privilege = await this.getAclV2Privilege(id)
     const role = await this.getAclV2Role(privilege.roleId)
 
-    if (!force && 'isTemplate' in role) {
+    if ('isTemplate' in role) {
       throw forbiddenOperation('update ACL V2 privilege', 'role is a template')
     }
 


### PR DESCRIPTION
### Description

([1814](https://project.vates.tech/vates-global/browse/XO-1814/))

Added create update and delete rest routes for ACL v2 roles and privileges

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
