### PR TITLE
feat(host): add transient option to host.disable

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: "Nice enhancement, I'm eager to test it"
 
+- [Host] Add persistent option to `host.disable` to persist across host reboots (PR [#9503](https://github.com/vatesfr/xen-orchestra/pull/9503))
+
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”

--- a/packages/xo-server/src/api/host.mjs
+++ b/packages/xo-server/src/api/host.mjs
@@ -377,14 +377,15 @@ enable.resolve = {
 
 // -------------------------------------------------------------------
 
-export function disable({ host }) {
-  return this.getXapi(host).disableHost(host._xapiId)
+export function disable({ host, transient }) {
+  return this.getXapi(host).disableHost(host._xapiId, { transient })
 }
 
-disable.description = 'disable to create VM on the hsot'
+disable.description = 'disable to create VM on the host'
 
 disable.params = {
   id: { type: 'string' },
+  transient: { type: 'boolean', optional: true },
 }
 
 disable.resolve = {

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -252,8 +252,10 @@ export default class Xapi extends XapiBase {
     }
   }
 
-  async disableHost(hostId) {
-    await this.call('host.disable', this.getObject(hostId).$ref)
+  // The XAPI second parameter is `transient`, only supported since 25.31.0.
+  async disableHost(hostId, { transient = true } = {}) {
+    const ref = this.getObject(hostId).$ref
+    await this.call('host.disable', ref, ...(transient ? [] : [false]))
   }
 
   async forgetHost(hostId) {


### PR DESCRIPTION
### Description

Add optional `transient` parameter (boolean) to `host.disable` API endpoint.

When `transient=true`, passes `auto_enable=false` to XAPI, keeping the host disabled across reboots and toolstack restarts (requires XAPI >= 25.31.0). Default behavior unchanged (backward compatible).

XAPI 25.31.0 introduced a new `auto_enable` parameter to `Host.disable` ([xen-api#6652](https://github.com/xapi-project/xen-api/pull/6652)). When set to `false`, the host stays disabled regardless of toolstack restarts, host reboots, or `consider_enabling_host` calls. Only an explicit `Host.enable` can re-activate it.

See [XO-1841](https://project.vates.tech/vates-global/browse/XO-1841/)

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue (`See XO-1841`)
- Changelog
  - [x] If visible by XOA users, add changelog entry
  - [x] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [x] No UI changes
  - [x] Tested manually

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
