### PR TITLE
fix(backups): fix RemoteVhdDisk & DiskChain parent and directory issue

### DIFF
--- a/@xen-orchestra/backups/disks/RemoteDisk.mjs
+++ b/@xen-orchestra/backups/disks/RemoteDisk.mjs
@@ -89,11 +89,21 @@ export class RemoteDisk extends RandomAccessDisk {
   }
 
   /**
+   * Abstract
    * Gets the indexes of all blocks in the VHD.
    * @returns {Array<number>}
    */
   getBlockIndexes() {
     throw new Error(`getBlockIndexes must be implemented`)
+  }
+
+  /**
+   * Abstract
+   * Returns the parent non inizialized instance
+   * @returns {RemoteDisk}
+   */
+  instantiateParent() {
+    throw new Error(`instantiateParent must be implemented`)
   }
 
   /**

--- a/@xen-orchestra/backups/disks/RemoteDisk.test.mjs
+++ b/@xen-orchestra/backups/disks/RemoteDisk.test.mjs
@@ -202,17 +202,25 @@ describe('tests RemoteVhdDiskChain', { concurrency: 1 }, () => {
   test('RemoteVhdDiskChain should read block', async () => {
     // Create parent and child VHDs
     const chainParent = await generateVhd(`${basePath}/parent.vhd`, { blocks: [0] })
-    await generateVhd(`${basePath}/child.vhd`, {
+    const chainChild = await generateVhd(`${basePath}/child.vhd`, {
       header: {
         parentUnicodeName: 'parent.vhd',
         parentUuid: chainParent.footer.uuid,
       },
       blocks: [1],
     })
+    await generateVhd(`${basePath}/child_2.vhd`, {
+      header: {
+        parentUnicodeName: 'child.vhd',
+        parentUuid: chainChild.footer.uuid,
+      },
+      blocks: [1],
+    })
 
     const parent = new RemoteVhdDisk({ handler, path: `${basePath}/parent.vhd` })
     const child = new RemoteVhdDisk({ handler, path: `${basePath}/child.vhd` })
-    const diskChain = new RemoteVhdDiskChain({ disks: [parent, child] })
+    const child_2 = new RemoteVhdDisk({ handler, path: `${basePath}/child_2.vhd` })
+    const diskChain = new RemoteVhdDiskChain({ disks: [parent, child, child_2] })
 
     await diskChain.init({ force: false })
 
@@ -362,18 +370,18 @@ describe('tests MergeVhdChain', { concurrency: 1 }, () => {
 
     // Create ancestor and children VHDs
     await generateVhd(`${basePath}/ancestor.vhd`, { blocks: [0, 1] })
-    const chainParent = await generateVhd(`${basePath}/child_1.vhd`, { blocks: [2] })
-    await generateVhd(`${basePath}/child_2.vhd`, {
+    const chainChild1 = await generateVhd(`${basePath}/child_1.vhd`, { blocks: [2] })
+    const chainChild2 = await generateVhd(`${basePath}/child_2.vhd`, {
       header: {
         parentUnicodeName: 'child_1.vhd',
-        parentUuid: chainParent.footer.uuid,
+        parentUuid: chainChild1.footer.uuid,
       },
       blocks: [3],
     })
     await generateVhd(`${basePath}/child_3.vhd`, {
       header: {
         parentUnicodeName: 'child_1.vhd',
-        parentUuid: chainParent.footer.uuid,
+        parentUuid: chainChild2.footer.uuid,
       },
       blocks: [4],
     })

--- a/@xen-orchestra/backups/disks/RemoteDisk.test.mjs
+++ b/@xen-orchestra/backups/disks/RemoteDisk.test.mjs
@@ -380,7 +380,7 @@ describe('tests MergeVhdChain', { concurrency: 1 }, () => {
     })
     await generateVhd(`${basePath}/child_3.vhd`, {
       header: {
-        parentUnicodeName: 'child_1.vhd',
+        parentUnicodeName: 'child_2.vhd',
         parentUuid: chainChild2.footer.uuid,
       },
       blocks: [4],

--- a/@xen-orchestra/backups/disks/RemoteVhdDiskChain.mjs
+++ b/@xen-orchestra/backups/disks/RemoteVhdDiskChain.mjs
@@ -56,9 +56,7 @@ export class RemoteVhdDiskChain extends RemoteDisk {
       await Promise.all(this.#disks.map(disk => disk.init(options)))
       let parentUuid = ''
       for (const [index, disk] of this.#disks.entries()) {
-        if (index === 0) {
-          parentUuid = disk.getUuid()
-        } else {
+        if (index !== 0) {
           if (!disk.isDifferencing()) {
             throw Object.assign(new Error("Can't init vhd directory with non differencing child disks"), {
               code: 'NOT_SUPPORTED',
@@ -70,6 +68,8 @@ export class RemoteVhdDiskChain extends RemoteDisk {
             })
           }
         }
+
+        parentUuid = disk.getUuid()
       }
     } catch (error) {
       await this.close()
@@ -176,6 +176,14 @@ export class RemoteVhdDiskChain extends RemoteDisk {
       }
     }
     return [...indexes]
+  }
+
+  /**
+   * Returns the parent non inizialized instance
+   * @returns {RemoteDisk}
+   */
+  instantiateParent() {
+    return this.#disks[0].instantiateParent()
   }
 
   /**

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,11 +32,12 @@
 ### Bug fixes
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
-> 
+
 - [HUB Recipe] A bug in the Pyrgos recipe requires to remove the DHCP option of the recipe form (PR [#9454](https://github.com/vatesfr/xen-orchestra/pull/9454))
 - [OpenMetrics] Fix ECONNREFUSED on IPv6-only systems by binding to `localhost` instead of `127.0.0.1` (PR [#9489](https://github.com/vatesfr/xen-orchestra/pull/9489))
 - [REST API] Exclude removable and ISO storage from top 5 SRs usage (PR [#9495](https://github.com/vatesfr/xen-orchestra/pull/9495))
 - [xo-server-sdn-controller] traffic rules robustness (PR [#9442](https://github.com/vatesfr/xen-orchestra/pull/9442))
+- [Backup] Fix error during backup and health check (PR [#9508](https://github.com/vatesfr/xen-orchestra/pull/9508))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

Fix issue introduced by [#9300](https://github.com/vatesfr/xen-orchestra/pull/9300/)

- Some RemoteVhdDisk where not initializing due to isDirectory function to functioning properly.
- RemoteVhdDiskChain where not initializing due to wrong handling of parentUuid during check.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
