### PR TITLE
xo-server-sdn-controller: use new xcp-ng-xapi-plugins sdn-controller feature and some fixes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,7 +19,7 @@
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
 - [xo-server] Fix VM-template still visible after deletion (PR [#9760](https://github.com/vatesfr/xen-orchestra/pull/9760))
-
+- [xo-server-sdn-controller] Better traffic-rules synchronization related to VM lifecycle (PR [#9518](https://github.com/vatesfr/xen-orchestra/pull/9518))
 
 ### Packages to release
 
@@ -39,5 +39,6 @@
 
 - @xen-orchestra/web minor
 - xo-server patch
+- xo-server-sdn-controller minor
 
 <!--packages-end-->

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -720,6 +720,11 @@ class SDNController extends EventEmitter {
       } catch (error) {
         if (error.code === 'HOST_OFFLINE') {
           log.info('addNetworkRule: Ignoring HOST_OFFLINE', { network: networkId })
+        } else {
+          // continue on error: it could be normal to fail
+          // (if no port where to apply the rule for example)
+          // but log the error
+          log.warn('addNetworkRule: rule not added', error)
         }
       }
 
@@ -759,6 +764,8 @@ class SDNController extends EventEmitter {
             vif: vifId,
             host: vif.$VM.$resident_on?.uuid,
           })
+        } else {
+          throw (error)
         }
       }
 
@@ -835,6 +842,8 @@ class SDNController extends EventEmitter {
       } catch (error) {
         if (error.code === 'HOST_OFFLINE') {
           log.info('deleteNetworkOfRule: Ignoring HOST_OFFLINE', { network: networkId })
+        } else {
+          throw (error)
         }
       }
 
@@ -1284,6 +1293,9 @@ class SDNController extends EventEmitter {
         error,
         pool: xapi.pool.name_label,
       })
+      if (error.code === 'CERTIFICATE_DOES_NOT_EXIST') {
+        needInstall = true
+      }
     }
     if (!needInstall) {
       return

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -13,6 +13,7 @@ import { OvsdbClient } from './protocol/ovsdb-client'
 import { PrivateNetwork } from './private-network/private-network'
 import { TlsHelper } from './utils/tls-helper'
 import { instantiateController } from './openflow-controller'
+import { randomBytes } from 'crypto'
 
 // =============================================================================
 
@@ -667,11 +668,54 @@ class SDNController extends EventEmitter {
       const network = this._xo.getXapiObject(this._xo.getObject(networkId, 'network'))
       assert(network.$PIFs.length > 0, 'Network needs to be plugged to add a rule')
 
+      const networkRules = JSON.parse(
+        network.other_config['xo:sdn-controller:of-rules'] || '[]'
+      ).map(JSON.parse)
+
+      // filter matching rule (don't compare allow and cookie)
+      const matchRules = networkRules.filter(rule => {
+        return (
+          rule.direction === direction && rule.ipRange === ipRange && rule.port === port && rule.protocol === protocol
+        )
+      })
+
+      // compute a cookie
+      let cookie
+      if (matchRules.length !== 0) {
+        // use the one in rule if matching rule is present
+        cookie = matchRules.map(rule => { return rule.cookie })[0]
+
+      } else {
+        // generate a new cookie not in use (OpenVSwitch cookie range: 0x1 to 0xFFFF_FFFF_FFFF_FFFF)
+        do {
+          cookie = '0x' + randomBytes(8).toString('hex')
+        } while (
+          cookie === '0x0000000000000000' ||
+          networkRules.filter(rule => { return rule.cookie === cookie }).length > 0
+        )
+      }
+
+      // update the rule if already here (don't compare allow and cookie) to behave like OpenVSwitch
+      const newNetworkRules = networkRules.filter(rule => {
+        return (
+          rule.protocol !== protocol || rule.port !== port || rule.ipRange !== ipRange || rule.direction !== direction
+        )
+      })
+      const newRule = {
+        allow,
+        protocol,
+        port,
+        ipRange,
+        direction,
+        cookie,
+      }
+      newNetworkRules.push(newRule)
+
       try {
         const host = this._xo.getXapiObject(this._xo.getObject(network.$PIFs[0].host, 'host'))
         const channel = await this._getOrCreateOfChannel(host)
         if (channel !== undefined) {
-          await channel.addNetworkRule({ network, allow, protocol, port, ipRange, direction })
+          await channel.addNetworkRule({ network, allow, protocol, port, ipRange, direction, cookie })
         }
       } catch (error) {
         if (error.code === 'HOST_OFFLINE') {
@@ -679,19 +723,11 @@ class SDNController extends EventEmitter {
         }
       }
 
-      const networkRules = network.other_config['xo:sdn-controller:of-rules']
-      const newNetworkRules = networkRules !== undefined ? JSON.parse(networkRules) : []
-      const stringRule = JSON.stringify({
-        allow,
-        protocol,
-        port,
-        ipRange,
-        direction,
-      })
-      if (!newNetworkRules.includes(stringRule)) {
-        newNetworkRules.push(stringRule)
-        await network.update_other_config('xo:sdn-controller:of-rules', JSON.stringify(newNetworkRules))
-      }
+      // update XAPI once done
+      await network.update_other_config(
+        'xo:sdn-controller:of-rules',
+        JSON.stringify(newNetworkRules.map(JSON.stringify))
+      )
     } catch (error) {
       log.error('Error while adding Network OF rule', {
         error,
@@ -770,11 +806,31 @@ class SDNController extends EventEmitter {
       let network = this._xo.getXapiObject(this._xo.getObject(networkId, 'network'))
       assert(network.$PIFs.length > 0, 'Network needs to be plugged to delete a rule')
 
+      const networkRules = JSON.parse(
+        network.other_config['xo:sdn-controller:of-rules'] || '[]'
+      ).map(JSON.parse)
+
+      // filter matching rule (don't compare allow and cookie)
+      const matchRules = networkRules.filter(rule => {
+        return (
+          rule.direction === direction && rule.ipRange === ipRange && rule.port === port && rule.protocol === protocol
+        )
+      })
+
+      // ignore processing if rule not present here
+      if (matchRules.length === 0) {
+        log.info("_deleteNetworkOfRule: rule not present, ignoring", {})
+        return
+      }
+
+      // extract the (first) matching cookie
+      const cookie = matchRules.map(rule => { return rule.cookie })[0]
+
       try {
         const host = this._xo.getXapiObject(this._xo.getObject(network.$PIFs[0].host, 'host'))
         const channel = await this._getOrCreateOfChannel(host)
         if (channel !== undefined) {
-          await channel.deleteNetworkRule({ network, protocol, port, ipRange, direction })
+          await channel.deleteNetworkRule({ network, protocol, port, ipRange, direction, cookie })
         }
       } catch (error) {
         if (error.code === 'HOST_OFFLINE') {
@@ -786,24 +842,15 @@ class SDNController extends EventEmitter {
         return
       }
 
-      const networkRules = network.other_config['xo:sdn-controller:of-rules']
-      if (networkRules === undefined) {
-        // Nothing to do
-        return
-      }
-
-      const newNetworkRules = JSON.parse(networkRules).filter(networkRule => {
-        const rule = JSON.parse(networkRule)
+      const newNetworkRules = networkRules.filter(rule => {
         return (
-          rule.protocol !== protocol || rule.port !== port || rule.ipRange !== ipRange || rule.direction !== direction
+          rule.protocol !== protocol || rule.port !== port || rule.ipRange !== ipRange || rule.direction !== direction || rule.cookie !== cookie
         )
       })
-
       await network.update_other_config(
         'xo:sdn-controller:of-rules',
-        Object.keys(newNetworkRules).length === 0 ? null : JSON.stringify(newNetworkRules)
+        Object.keys(newNetworkRules).length === 0 ? null : JSON.stringify(newNetworkRules.map(JSON.stringify))
       )
-
       network = await network.$xapi.barrier(network.$ref)
 
       // Put back rules that could have been wrongfully deleted because delete rule too general

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -1439,8 +1439,20 @@ class SDNController extends EventEmitter {
     }
   }
 
+  async _cleanNetworkOfRules(network) {
+    const networkRules = network.other_config['xo:sdn-controller:of-rules']
+    const parsedRules = networkRules !== undefined ? JSON.parse(networkRules) : []
+    for (const stringRule of parsedRules) {
+      const rule = JSON.parse(stringRule)
+      await this._deleteNetworkOfRule({ ...rule, networkId: network.$id }, false)
+    }
+  }
+
   async _cleanOfVmRules(vm) {
     for (const vif of vm.$VIFs) {
+      // refresh NetworkOfRules by cleaning/applying
+      await this._cleanNetworkOfRules(vif.$network)
+      await this._applyNetworkOfRules(vif.$network)
       await this._cleanVifOfRules(vif)
     }
   }
@@ -1448,6 +1460,7 @@ class SDNController extends EventEmitter {
   async _applyOfRules(vm) {
     for (const vif of vm.$VIFs) {
       await this._applyVifOfRules(vif)
+      await this._applyNetworkOfRules(vif.$network)
     }
   }
 

--- a/packages/xo-server-sdn-controller/src/openflow-plugin.js
+++ b/packages/xo-server-sdn-controller/src/openflow-plugin.js
@@ -49,30 +49,32 @@ export class OpenFlowPlugin {
     })
   }
 
-  async addNetworkRule({ network, allow, protocol, ipRange, direction, port }) {
+  async addNetworkRule({ network, allow, protocol, ipRange, direction, port, cookie }) {
     if (port) {
       port = String(port)
     }
-    log.debug('addNetworkRule', { network, allow, protocol, ipRange, direction, port })
+    log.debug('addNetworkRule', { network, allow, protocol, ipRange, direction, port, cookie })
     return this.#callPluginOnAllNetwork(network, 'add-rule', {
       allow: allow ? 'true' : 'false',
       protocol,
       ipRange,
       direction,
       port,
+      cookie,
     })
   }
-  async deleteNetworkRule({ network, allow, protocol, ipRange, direction, port }) {
+  async deleteNetworkRule({ network, allow, protocol, ipRange, direction, port, cookie }) {
     if (port) {
       port = String(port)
     }
-    log.debug('deleteNetworkRule', { network, allow, protocol, ipRange, direction, port })
+    log.debug('deleteNetworkRule', { network, allow, protocol, ipRange, direction, port, cookie })
     return this.#callPluginOnAllNetwork(network, 'del-rule', {
       allow: allow ? 'true' : 'false',
       protocol,
       ipRange,
       direction,
       port,
+      cookie,
     })
   }
 

--- a/packages/xo-server-sdn-controller/src/private-network/private-network.js
+++ b/packages/xo-server-sdn-controller/src/private-network/private-network.js
@@ -1,6 +1,7 @@
 import assert from 'assert'
 import { createLogger } from '@xen-orchestra/log'
-import { filter, forOwn, sample } from 'lodash'
+import { filter, forOwn } from 'lodash'
+import { randomBytes } from 'crypto'
 
 // =============================================================================
 
@@ -8,8 +9,21 @@ const log = createLogger('xo:xo-server:sdn-controller:private-network')
 
 // =============================================================================
 
-const CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789?!'
-const createPassword = () => Array.from({ length: 16 }, _ => sample(CHARS)).join('')
+const createPassword = () => {
+  const CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789?!'
+  const length = 16
+
+  const buffer = randomBytes(length)
+  let password = ''
+
+  for (let i = 0; i < length; i++) {
+    // no modular bias as length=16 CHARS.length=64
+    const randomIndex = buffer[i] % CHARS.length
+    password += CHARS[randomIndex]
+  }
+
+  return password
+}
 
 // =============================================================================
 

--- a/packages/xo-server-sdn-controller/src/protocol/openflow-channel.js
+++ b/packages/xo-server-sdn-controller/src/protocol/openflow-channel.js
@@ -200,7 +200,7 @@ export class OpenFlowChannel extends EventEmitter {
     try {
       await this._coalesceConnect()
     } catch (error) {
-      log.error("addRule: _coalesceConnect", {
+      log.error("deleteRule: _coalesceConnect", {
         error
       })
       return


### PR DESCRIPTION
work on xo-server-sdn-controller reliability fixes for Network Rules:
- use new xcp-ng-xapi-plugins sdn-controller feature [cookie usage](https://github.com/xcp-ng/xcp-ng-xapi-plugins/pull/58)
- fixes some missed events processing to update Network Rules
- while here, use proper csPRNG for generating psk
