### PR TITLE
feat(@vates/task): change default id creation

### DIFF
--- a/@vates/task/index.js
+++ b/@vates/task/index.js
@@ -93,7 +93,11 @@ class Task {
   _onProgress
 
   get id() {
-    return (this.id = Math.random().toString(36).slice(2))
+    // Use a compact, sortable, string representation of the creation date,
+    // and add a random part to differenciate tasks created at the same time
+    //
+    // Due to the padding, dates are sortable up to 5188-04-22T11:04:28.415Z
+    return (this.id = Date.now().toString(36).padStart(9, '0') + '-' + Math.random().toString(36).slice(2))
   }
   set id(value) {
     define(this, 'id', value)

--- a/@xen-orchestra/mixins/Tasks.mjs
+++ b/@xen-orchestra/mixins/Tasks.mjs
@@ -10,8 +10,6 @@ export { Task }
 
 const { warn } = createLogger('xo:mixins:Tasks')
 
-const formatId = timestamp => timestamp.toString(36).padStart(9, '0')
-
 const noop = Function.prototype
 
 // Create a serializable object from an error.
@@ -190,20 +188,9 @@ export default class Tasks extends EventEmitter {
 
     const task = new Task({ properties: { ...props, name, objectId, userId, type }, onProgress: this.#onProgress })
 
-    // Use a compact, sortable, string representation of the creation date
-    //
-    // Due to the padding, dates are sortable up to 5188-04-22T11:04:28.415Z
-    let now = Date.now()
-    let id
-    while (tasks.has((id = formatId(now)))) {
-      // if the current id is already taken, use the next millisecond
-      ++now
-    }
-    task.id = id
-
-    tasks.set(id, task)
+    tasks.set(task.id, task)
     if (clearLogOnSuccess) {
-      this.#logsToClearOnSuccess.add(id)
+      this.#logsToClearOnSuccess.add(task.id)
     }
 
     return task

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -45,6 +45,7 @@
 - @vates/task minor
 - @vates/types minor
 - @xen-orchestra/backups minor
+- @xen-orchestra/mixins minor
 - @xen-orchestra/proxy minor
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor


### PR DESCRIPTION
### Description

**This PR is not directed to master**

**review by commit**

With the current code of branch _backup-XO-Tasks_, tasks with two different systems of IDs exist in the same table, one for backup tasks (that use the [default id from the Task class](https://github.com/vatesfr/xen-orchestra/blob/109e37695c0104df60d9bc02655b1527c66f8b93/%40vates/task/index.js#L75)), and the other for tasks created with the [Tasks mixin](https://github.com/vatesfr/xen-orchestra/blob/109e37695c0104df60d9bc02655b1527c66f8b93/%40xen-orchestra/mixins/Tasks.mjs#L13). This is not ideal, especially because this table's IDs used to be sorted by timestamp, which is no longer the case with the code of this branch.

This PR aims to have a common ID generation, with the constraint that it must be lexicographically sortable with previous task IDs so the previous logs get deleted when they get too ancient.

- Previous default ID from the Task class: _{random data, base 36}_
- Previous ID from the tasks mixin: _{timestamp converted to base 36}_
- New common ID I suggest: _{timestamp converted to base 36}-{random data, base 36}_

We could also choose to adopt this ID generation for the Task class and keep the current ID generation of the tasks mixin, they could be in the same table and still be sorted properly.

(CI is still failing due to a problem on master)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
