### PR TITLE
feat(xo6): topology view prototype

### DIFF
--- a/@xen-orchestra/web/package.json
+++ b/@xen-orchestra/web/package.json
@@ -29,6 +29,7 @@
     "@vates/types": "^1.19.0",
     "@vue-flow/controls": "^1.1.0",
     "@vue-flow/core": "^1.41.0",
+    "@vue-flow/minimap": "^1.5.4",
     "@vitejs/plugin-vue": "^5.2.1",
     "@vue/tsconfig": "^0.7.0",
     "@vueuse/core": "^13.0.0",

--- a/@xen-orchestra/web/package.json
+++ b/@xen-orchestra/web/package.json
@@ -12,6 +12,7 @@
     "prepublishOnly": "yarn run build-only"
   },
   "devDependencies": {
+    "@dagrejs/dagre": "^1.1.4",
     "@csstools/postcss-global-data": "^3.0.0",
     "@floating-ui/vue": "^1.1.6",
     "@fontsource/poppins": "^5.2.5",
@@ -26,6 +27,8 @@
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^18.19.80",
     "@vates/types": "^1.19.0",
+    "@vue-flow/controls": "^1.1.0",
+    "@vue-flow/core": "^1.41.0",
     "@vitejs/plugin-vue": "^5.2.1",
     "@vue/tsconfig": "^0.7.0",
     "@vueuse/core": "^13.0.0",

--- a/@xen-orchestra/web/src/modules/site/components/SiteHeader.vue
+++ b/@xen-orchestra/web/src/modules/site/components/SiteHeader.vue
@@ -32,6 +32,10 @@
     <RouterLink v-slot="{ isExactActive, href }" :to="{ name: '/(site)/vms' }" custom>
       <TabItem :active="isExactActive" :href tag="a">{{ t('vms') }}</TabItem>
     </RouterLink>
+    <RouterLink v-slot="{ isExactActive, href }" :to="{ name: '/(site)/topology' }" custom>
+      <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- prototype: i18n key to be added later -->
+      <TabItem :active="isExactActive" :href tag="a">Topology</TabItem>
+    </RouterLink>
   </TabList>
 </template>
 

--- a/@xen-orchestra/web/src/modules/topology/components/EmptyGroupNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/EmptyGroupNode.vue
@@ -1,0 +1,133 @@
+<!-- eslint-disable @intlify/vue-i18n/no-raw-text -- prototype: i18n keys to be added later -->
+<template>
+  <div class="topology-node empty-group-node" :class="isLR ? 'dir-lr' : 'dir-tb'">
+    <Handle type="target" :position="isLR ? Position.Left : Position.Top" />
+    <div class="group-header">
+      <span class="icon-circle">
+        <FontAwesomeIcon :icon="data.kind === 'network' ? faNetworkWired : faHardDrive" class="group-icon" />
+      </span>
+      <span class="group-label">
+        {{ data.items.length }} unused {{ data.kind === 'network' ? 'networks' : 'SRs' }}
+      </span>
+    </div>
+    <div v-if="data.isExpanded" class="item-list">
+      <div v-for="item in data.items" :key="item.id" class="item-row">
+        <span class="item-dot" />
+        <span class="item-name">{{ item.name }}</span>
+      </div>
+    </div>
+    <NodeExpandButton v-if="data.isExpandable" :expanded="data.isExpanded" @toggle="toggleExpand?.(id)" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import NodeExpandButton from '@/modules/topology/components/NodeExpandButton.vue'
+import { TOPOLOGY_DIRECTION, TOPOLOGY_TOGGLE_EXPAND } from '@/modules/topology/composables/use-topology-interaction.ts'
+import type { EmptyGroupNodeData } from '@/modules/topology/types/topology.types.ts'
+import { faHardDrive, faNetworkWired } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { Handle, Position } from '@vue-flow/core'
+import { inject } from 'vue'
+
+defineProps<{ data: EmptyGroupNodeData; id: string }>()
+
+const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
+const isLR = inject(TOPOLOGY_DIRECTION, 'TB') === 'LR'
+</script>
+
+<style scoped lang="postcss">
+.empty-group-node {
+  background: var(--color-neutral-background-secondary);
+  border: 0.1rem dashed var(--color-neutral-border);
+  border-radius: 0.6rem;
+  padding: 0.6rem 1rem;
+  min-width: 18rem;
+  max-width: 24rem;
+  overflow: visible;
+  position: relative;
+  opacity: 0.75;
+  box-shadow: var(--shadow-100);
+  transition:
+    box-shadow 0.2s ease,
+    opacity 0.2s ease;
+
+  &:hover {
+    opacity: 1;
+    box-shadow: var(--shadow-200);
+  }
+
+  &.dir-tb {
+    padding-bottom: 2rem;
+  }
+
+  &.dir-lr {
+    padding-right: 2.5rem;
+  }
+
+  .group-header {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+
+  .icon-circle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 50%;
+    background: var(--color-neutral-background-disabled);
+    flex-shrink: 0;
+
+    :root.dark & {
+      background: color-mix(in srgb, var(--color-neutral-txt-secondary) 15%, transparent);
+    }
+
+    .group-icon {
+      color: var(--color-neutral-txt-secondary);
+      font-size: 0.8rem;
+    }
+  }
+
+  .group-label {
+    font-size: 1.1rem;
+    font-weight: 500;
+    color: var(--color-neutral-txt-secondary);
+    white-space: nowrap;
+  }
+
+  .item-list {
+    margin-top: 0.4rem;
+    border-top: 0.1rem solid var(--color-neutral-border);
+    padding-top: 0.3rem;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .item-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.2rem 0;
+    min-width: 0;
+
+    .item-dot {
+      width: 0.5rem;
+      height: 0.5rem;
+      border-radius: 50%;
+      background: var(--color-neutral-txt-secondary);
+      flex-shrink: 0;
+      opacity: 0.5;
+    }
+
+    .item-name {
+      font-size: 1rem;
+      color: var(--color-neutral-txt-secondary);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+}
+</style>

--- a/@xen-orchestra/web/src/modules/topology/components/HostNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/HostNode.vue
@@ -1,0 +1,161 @@
+<!-- eslint-disable @intlify/vue-i18n/no-raw-text -- prototype: i18n keys to be added later -->
+<template>
+  <div class="topology-node host-node" :class="statusClass">
+    <Handle type="target" :position="Position.Top" />
+    <div class="node-header">
+      <span class="status-dot" />
+      <RouterLink :to="{ name: '/host/[id]', params: { id: data.host.id } }" class="node-title">
+        {{ data.host.name_label }}
+      </RouterLink>
+      <span class="vm-badge">{{ data.vmCount }} VMs</span>
+    </div>
+    <div class="resource-bars">
+      <div class="bar-row">
+        <span class="bar-label">CPU</span>
+        <div class="bar-track">
+          <div class="bar-fill cpu" :style="{ width: cpuPercent + '%' }" />
+        </div>
+        <span class="bar-value">{{ cpuPercent }}%</span>
+      </div>
+      <div class="bar-row">
+        <span class="bar-label">RAM</span>
+        <div class="bar-track">
+          <div class="bar-fill ram" :style="{ width: ramPercent + '%' }" />
+        </div>
+        <span class="bar-value">{{ ramPercent }}%</span>
+      </div>
+    </div>
+    <Handle type="source" :position="Position.Bottom" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import type { HostNodeData } from '@/modules/topology/types/topology.types.ts'
+import { HOST_POWER_STATE } from '@vates/types'
+import { Handle, Position } from '@vue-flow/core'
+import { computed } from 'vue'
+
+const props = defineProps<{ data: HostNodeData }>()
+
+const ramPercent = computed(() => {
+  if (props.data.memorySize === 0) return 0
+  return Math.round((props.data.memoryUsage / props.data.memorySize) * 100)
+})
+
+const cpuPercent = computed(() => {
+  const cpus = props.data.host.CPUs
+  if (!cpus || typeof cpus !== 'object') return 0
+  const values = Object.values(cpus).filter((v): v is number => typeof v === 'number')
+  if (values.length === 0) return 0
+  return Math.round((values.reduce((sum, v) => sum + v, 0) / values.length) * 100)
+})
+
+const statusClass = computed(() =>
+  props.data.host.power_state === HOST_POWER_STATE.RUNNING ? 'status-running' : 'status-halted'
+)
+</script>
+
+<style lang="postcss" scoped>
+.host-node {
+  background: var(--color-neutral-background-primary);
+  border: 0.1rem solid var(--color-neutral-border);
+  border-radius: 0.8rem;
+  padding: 1rem 1.4rem;
+  min-width: 22rem;
+
+  &.status-running {
+    border-left: 0.3rem solid var(--color-success-item-base);
+
+    .status-dot {
+      background: var(--color-success-item-base);
+    }
+  }
+
+  &.status-halted {
+    border-left: 0.3rem solid var(--color-danger-item-base);
+
+    .status-dot {
+      background: var(--color-danger-item-base);
+    }
+  }
+
+  .node-header {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+
+    .status-dot {
+      width: 0.8rem;
+      height: 0.8rem;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+
+    .node-title {
+      font-weight: 500;
+      font-size: 1.2rem;
+      color: var(--color-neutral-txt-primary);
+      text-decoration: none;
+      flex: 1;
+
+      &:hover {
+        color: var(--color-brand-item-hover);
+      }
+    }
+
+    .vm-badge {
+      font-size: 1rem;
+      color: var(--color-neutral-txt-secondary);
+      white-space: nowrap;
+    }
+  }
+
+  .resource-bars {
+    margin-top: 0.8rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+
+    .bar-row {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+
+      .bar-label {
+        font-size: 1rem;
+        color: var(--color-neutral-txt-secondary);
+        min-width: 2.8rem;
+      }
+
+      .bar-track {
+        flex: 1;
+        height: 0.6rem;
+        background: var(--color-neutral-background-disabled);
+        border-radius: 0.3rem;
+        overflow: hidden;
+      }
+
+      .bar-fill {
+        height: 100%;
+        border-radius: 0.3rem;
+        transition: width 0.3s ease;
+
+        &.cpu {
+          background: var(--color-info-item-base);
+        }
+
+        &.ram {
+          background: var(--color-warning-item-base);
+        }
+      }
+
+      .bar-value {
+        font-size: 1rem;
+        color: var(--color-neutral-txt-secondary);
+        min-width: 3rem;
+        text-align: right;
+      }
+    }
+  }
+}
+</style>

--- a/@xen-orchestra/web/src/modules/topology/components/HostNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/HostNode.vue
@@ -11,6 +11,13 @@
     </div>
     <div class="resource-bars">
       <div class="bar-row">
+        <span class="bar-label">CPU</span>
+        <div class="bar-track">
+          <div class="bar-fill cpu-fill" :style="{ width: (data.cpuPercent ?? 0) + '%' }" />
+        </div>
+        <span class="bar-value">{{ data.cpuPercent != null ? data.cpuPercent + '%' : '...' }}</span>
+      </div>
+      <div class="bar-row">
         <span class="bar-label">RAM</span>
         <div class="bar-track">
           <div class="bar-fill" :style="{ width: ramPercent + '%' }" />
@@ -108,6 +115,9 @@ const statusClass = computed(() =>
 
   .resource-bars {
     margin-top: 0.8rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
 
     .bar-row {
       display: flex;
@@ -133,6 +143,10 @@ const statusClass = computed(() =>
         border-radius: 0.3rem;
         background: var(--color-warning-item-base);
         transition: width 0.3s ease;
+
+        &.cpu-fill {
+          background: var(--color-brand-item-base);
+        }
       }
 
       .bar-value {

--- a/@xen-orchestra/web/src/modules/topology/components/HostNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/HostNode.vue
@@ -36,17 +36,17 @@ import { HOST_POWER_STATE } from '@vates/types'
 import { Handle, Position } from '@vue-flow/core'
 import { computed, inject } from 'vue'
 
-const props = defineProps<{ data: HostNodeData }>()
+const { data } = defineProps<{ data: HostNodeData }>()
 
 const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
 
 const statusClass = computed(() =>
-  props.data.host.power_state === HOST_POWER_STATE.RUNNING ? 'status-running' : 'status-halted'
+  data.host.power_state === HOST_POWER_STATE.RUNNING ? 'status-running' : 'status-halted'
 )
 
 const haloClass = computed(() => {
-  const cpu = props.data.cpuPercent
-  const mem = props.data.memorySize > 0 ? (props.data.memoryUsage / props.data.memorySize) * 100 : undefined
+  const cpu = data.cpuPercent
+  const mem = data.memorySize > 0 ? (data.memoryUsage / data.memorySize) * 100 : undefined
 
   const worst = Math.max(cpu ?? 0, mem ?? 0)
   if (cpu == null && mem == null) return undefined
@@ -56,7 +56,7 @@ const haloClass = computed(() => {
 })
 </script>
 
-<style lang="postcss" scoped>
+<style scoped lang="postcss">
 .host-node {
   background: var(--color-neutral-background-primary);
   border: 0.1rem solid var(--color-neutral-border);

--- a/@xen-orchestra/web/src/modules/topology/components/NetworkNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/NetworkNode.vue
@@ -1,0 +1,152 @@
+<!-- eslint-disable @intlify/vue-i18n/no-raw-text -- prototype: i18n keys to be added later -->
+<template>
+  <div class="topology-node network-node">
+    <Handle type="target" :position="Position.Left" />
+    <div class="node-header">
+      <span class="icon-circle">
+        <FontAwesomeIcon :icon="faNetworkWired" class="node-icon" />
+      </span>
+      <span class="node-title">{{ data.network.name_label }}</span>
+    </div>
+    <div class="node-info">
+      <span class="info-item">{{ data.vmCount }} {{ data.vmCount === 1 ? 'VM' : 'VMs' }}</span>
+      <span v-if="data.runningVmCount > 0" class="badge badge-running">{{ data.runningVmCount }} running</span>
+      <span class="info-item">on {{ data.pifHostCount }} {{ data.pifHostCount === 1 ? 'host' : 'hosts' }}</span>
+    </div>
+    <div class="node-meta">
+      <span class="info-item">MTU {{ data.mtu }}</span>
+      <span class="badge" :class="data.hasPhysicalPifs ? 'badge-physical' : 'badge-internal'">
+        {{ data.hasPhysicalPifs ? 'Physical' : 'Internal' }}
+      </span>
+    </div>
+    <NodeExpandButton
+      v-if="data.isExpandable"
+      :expanded="data.isExpanded"
+      @toggle="toggleExpand?.(`net-${data.network.id}`)"
+    />
+    <Handle v-else type="source" :position="Position.Right" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import NodeExpandButton from '@/modules/topology/components/NodeExpandButton.vue'
+import { TOPOLOGY_TOGGLE_EXPAND } from '@/modules/topology/composables/use-topology-interaction.ts'
+import type { NetworkNodeData } from '@/modules/topology/types/topology.types.ts'
+import { faNetworkWired } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { Handle, Position } from '@vue-flow/core'
+import { inject } from 'vue'
+
+defineProps<{ data: NetworkNodeData }>()
+
+const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
+</script>
+
+<style scoped lang="postcss">
+.network-node {
+  background: var(--color-neutral-background-primary);
+  border: 0.1rem solid var(--color-neutral-border);
+  border-left: 0.3rem solid #3b82f6;
+  border-radius: 0.8rem;
+  padding: 1rem 1.4rem;
+  padding-right: 2.5rem;
+  min-width: 24rem;
+  position: relative;
+  box-shadow: var(--shadow-200);
+  transition:
+    box-shadow 0.3s ease,
+    transform 0.2s ease;
+
+  &:hover {
+    box-shadow: var(--shadow-300);
+    transform: translateY(-0.2rem);
+  }
+
+  :root.dark & {
+    box-shadow: 0 0.2rem 0.8rem rgba(255, 255, 255, 0.06);
+
+    &:hover {
+      box-shadow: 0 0.4rem 1.4rem rgba(255, 255, 255, 0.1);
+    }
+  }
+
+  .node-header {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+
+    .icon-circle {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 2.4rem;
+      height: 2.4rem;
+      border-radius: 50%;
+      background: color-mix(in srgb, #3b82f6 15%, transparent);
+      color: #3b82f6;
+      flex-shrink: 0;
+
+      .node-icon {
+        font-size: 1rem;
+      }
+    }
+
+    .node-title {
+      font-weight: 500;
+      font-size: 1.2rem;
+      color: var(--color-neutral-txt-primary);
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
+  .node-info {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-top: 0.6rem;
+    flex-wrap: wrap;
+  }
+
+  .node-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-top: 0.4rem;
+    flex-wrap: wrap;
+  }
+
+  .info-item {
+    font-size: 1.1rem;
+    color: var(--color-neutral-txt-secondary);
+    white-space: nowrap;
+  }
+
+  .badge {
+    display: inline-block;
+    font-size: 1rem;
+    font-weight: 500;
+    padding: 0.1rem 0.6rem;
+    border-radius: 10rem;
+    white-space: nowrap;
+  }
+
+  .badge-running {
+    color: var(--color-success-item-base);
+    background: color-mix(in srgb, var(--color-success-item-base) 15%, transparent);
+  }
+
+  .badge-physical {
+    color: #3b82f6;
+    background: color-mix(in srgb, #3b82f6 15%, transparent);
+  }
+
+  .badge-internal {
+    color: var(--color-neutral-txt-secondary);
+    background: var(--color-neutral-background-secondary);
+  }
+}
+</style>

--- a/@xen-orchestra/web/src/modules/topology/components/NodeExpandButton.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/NodeExpandButton.vue
@@ -1,0 +1,65 @@
+<template>
+  <div class="expand-anchor">
+    <Handle type="source" :position="Position.Bottom" class="hidden-handle" />
+    <button type="button" class="expand-btn" :class="{ expanded }" @click.stop="$emit('toggle')">
+      <FontAwesomeIcon :icon="expanded ? faChevronUp : faChevronDown" />
+    </button>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { Handle, Position } from '@vue-flow/core'
+
+defineProps<{ expanded: boolean }>()
+defineEmits<{ toggle: [] }>()
+</script>
+
+<style lang="postcss" scoped>
+.expand-anchor {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translate(-50%, 50%);
+  z-index: 1;
+}
+
+.hidden-handle {
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.expand-btn {
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 50%;
+  border: 0.2rem solid var(--color-neutral-border);
+  background: var(--color-neutral-background-primary);
+  color: var(--color-neutral-txt-secondary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+
+  &:hover {
+    border-color: var(--color-brand-item-base);
+    color: var(--color-brand-item-base);
+    background: var(--color-brand-background-hover);
+  }
+
+  &.expanded {
+    border-color: var(--color-brand-item-base);
+    color: var(--color-brand-item-base);
+  }
+}
+</style>

--- a/@xen-orchestra/web/src/modules/topology/components/NodeExpandButton.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/NodeExpandButton.vue
@@ -1,19 +1,35 @@
 <template>
   <div class="expand-anchor">
     <Handle type="source" :position="Position.Bottom" class="hidden-handle" />
-    <button type="button" class="expand-btn" :class="{ expanded }" @click.stop="$emit('toggle')">
+    <button type="button" class="expand-btn" :class="{ expanded }" :style="scaleStyle" @click.stop="$emit('toggle')">
       <FontAwesomeIcon :icon="expanded ? faChevronUp : faChevronDown" />
     </button>
   </div>
 </template>
 
 <script lang="ts" setup>
+import { TOPOLOGY_ZOOM } from '@/modules/topology/composables/use-topology-interaction.ts'
 import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { Handle, Position } from '@vue-flow/core'
+import type { CSSProperties } from 'vue'
+import { computed, inject } from 'vue'
 
 defineProps<{ expanded: boolean }>()
 defineEmits<{ toggle: [] }>()
+
+const ZOOM_THRESHOLD = 0.6
+
+const zoom = inject(TOPOLOGY_ZOOM)
+
+const scaleStyle = computed<CSSProperties | undefined>(() => {
+  const z = zoom?.value ?? 1
+  if (z >= ZOOM_THRESHOLD) {
+    return undefined
+  }
+  const scale = ZOOM_THRESHOLD / z
+  return { transform: `scale(${scale})` }
+})
 </script>
 
 <style lang="postcss" scoped>
@@ -49,7 +65,8 @@ defineEmits<{ toggle: [] }>()
   transition:
     background-color 0.15s ease,
     border-color 0.15s ease,
-    color 0.15s ease;
+    color 0.15s ease,
+    transform 0.15s ease;
 
   &:hover {
     border-color: var(--color-brand-item-base);

--- a/@xen-orchestra/web/src/modules/topology/components/NodeExpandButton.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/NodeExpandButton.vue
@@ -1,26 +1,38 @@
 <template>
-  <div class="expand-anchor">
-    <Handle type="source" :position="Position.Bottom" class="hidden-handle" />
+  <div class="expand-anchor" :class="isLR ? 'anchor-lr' : 'anchor-tb'">
+    <Handle type="source" :position="sourcePosition" class="hidden-handle" />
     <button type="button" class="expand-btn" :class="{ expanded }" :style="scaleStyle" @click.stop="$emit('toggle')">
-      <FontAwesomeIcon :icon="expanded ? faChevronUp : faChevronDown" />
+      <FontAwesomeIcon :icon="expandIcon" />
     </button>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { TOPOLOGY_ZOOM } from '@/modules/topology/composables/use-topology-interaction.ts'
-import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons'
+import { TOPOLOGY_DIRECTION, TOPOLOGY_ZOOM } from '@/modules/topology/composables/use-topology-interaction.ts'
+import { faChevronDown, faChevronLeft, faChevronRight, faChevronUp } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { Handle, Position } from '@vue-flow/core'
 import type { CSSProperties } from 'vue'
 import { computed, inject } from 'vue'
 
-defineProps<{ expanded: boolean }>()
+const { expanded } = defineProps<{ expanded: boolean }>()
 defineEmits<{ toggle: [] }>()
 
 const ZOOM_THRESHOLD = 0.6
 
 const zoom = inject(TOPOLOGY_ZOOM)
+const direction = inject(TOPOLOGY_DIRECTION, 'TB')
+
+const isLR = direction === 'LR'
+
+const sourcePosition = computed(() => (isLR ? Position.Right : Position.Bottom))
+
+const expandIcon = computed(() => {
+  if (isLR) {
+    return expanded ? faChevronLeft : faChevronRight
+  }
+  return expanded ? faChevronUp : faChevronDown
+})
 
 const scaleStyle = computed<CSSProperties | undefined>(() => {
   const z = zoom?.value ?? 1
@@ -32,13 +44,22 @@ const scaleStyle = computed<CSSProperties | undefined>(() => {
 })
 </script>
 
-<style lang="postcss" scoped>
+<style scoped lang="postcss">
 .expand-anchor {
   position: absolute;
-  bottom: 0;
-  left: 50%;
-  transform: translate(-50%, 50%);
   z-index: 1;
+
+  &.anchor-tb {
+    bottom: 0;
+    left: 50%;
+    transform: translate(-50%, 50%);
+  }
+
+  &.anchor-lr {
+    right: 0;
+    top: 50%;
+    transform: translate(50%, -50%);
+  }
 }
 
 .hidden-handle {

--- a/@xen-orchestra/web/src/modules/topology/components/PoolNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/PoolNode.vue
@@ -14,17 +14,27 @@
     <div class="node-running">
       <span class="running-badge">{{ data.runningVmCount }} running</span>
     </div>
-    <Handle type="source" :position="Position.Bottom" />
+    <NodeExpandButton
+      v-if="data.isExpandable"
+      :expanded="data.isExpanded"
+      @toggle="toggleExpand?.(`pool-${data.pool.id}`)"
+    />
+    <Handle v-else type="source" :position="Position.Bottom" />
   </div>
 </template>
 
 <script lang="ts" setup>
+import NodeExpandButton from '@/modules/topology/components/NodeExpandButton.vue'
+import { TOPOLOGY_TOGGLE_EXPAND } from '@/modules/topology/composables/use-topology-interaction.ts'
 import type { PoolNodeData } from '@/modules/topology/types/topology.types.ts'
 import { faCity } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { Handle, Position } from '@vue-flow/core'
+import { inject } from 'vue'
 
 defineProps<{ data: PoolNodeData }>()
+
+const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
 </script>
 
 <style lang="postcss" scoped>
@@ -33,7 +43,9 @@ defineProps<{ data: PoolNodeData }>()
   border: 0.2rem solid var(--color-brand-item-base);
   border-radius: 0.8rem;
   padding: 1.2rem 1.6rem;
+  padding-bottom: 2rem;
   min-width: 24rem;
+  position: relative;
 
   .node-header {
     display: flex;

--- a/@xen-orchestra/web/src/modules/topology/components/PoolNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/PoolNode.vue
@@ -1,0 +1,75 @@
+<!-- eslint-disable @intlify/vue-i18n/no-raw-text -- prototype: i18n keys to be added later -->
+<template>
+  <div class="topology-node pool-node">
+    <Handle type="target" :position="Position.Top" />
+    <div class="node-header">
+      <FontAwesomeIcon :icon="faCity" class="node-icon" />
+      <RouterLink :to="{ name: '/pool/[id]', params: { id: data.pool.id } }" class="node-title">
+        {{ data.pool.name_label }}
+      </RouterLink>
+    </div>
+    <div class="node-info">
+      {{ data.hostCount }} {{ data.hostCount === 1 ? 'node' : 'nodes' }}, {{ data.vmCount }} VMs
+    </div>
+    <div class="node-running">
+      <span class="running-badge">{{ data.runningVmCount }} running</span>
+    </div>
+    <Handle type="source" :position="Position.Bottom" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import type { PoolNodeData } from '@/modules/topology/types/topology.types.ts'
+import { faCity } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { Handle, Position } from '@vue-flow/core'
+
+defineProps<{ data: PoolNodeData }>()
+</script>
+
+<style lang="postcss" scoped>
+.pool-node {
+  background: var(--color-neutral-background-primary);
+  border: 0.2rem solid var(--color-brand-item-base);
+  border-radius: 0.8rem;
+  padding: 1.2rem 1.6rem;
+  min-width: 24rem;
+
+  .node-header {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+
+    .node-icon {
+      color: var(--color-brand-item-base);
+    }
+
+    .node-title {
+      font-weight: 600;
+      font-size: 1.3rem;
+      color: var(--color-neutral-txt-primary);
+      text-decoration: none;
+
+      &:hover {
+        color: var(--color-brand-item-hover);
+      }
+    }
+  }
+
+  .node-info {
+    margin-top: 0.6rem;
+    font-size: 1.1rem;
+    color: var(--color-neutral-txt-secondary);
+  }
+
+  .node-running {
+    margin-top: 0.4rem;
+
+    .running-badge {
+      font-size: 1.1rem;
+      color: var(--color-success-item-base);
+      font-weight: 500;
+    }
+  }
+}
+</style>

--- a/@xen-orchestra/web/src/modules/topology/components/PoolNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/PoolNode.vue
@@ -96,6 +96,10 @@ const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
       font-size: 1.3rem;
       color: var(--color-neutral-txt-primary);
       text-decoration: none;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
 
       &:hover {
         color: var(--color-brand-item-hover);

--- a/@xen-orchestra/web/src/modules/topology/components/PoolNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/PoolNode.vue
@@ -3,7 +3,9 @@
   <div class="topology-node pool-node">
     <Handle type="target" :position="Position.Top" />
     <div class="node-header">
-      <FontAwesomeIcon :icon="faCity" class="node-icon" />
+      <span class="icon-circle">
+        <FontAwesomeIcon :icon="faCity" class="node-icon" />
+      </span>
       <RouterLink :to="{ name: '/pool/[id]', params: { id: data.pool.id } }" class="node-title">
         {{ data.pool.name_label }}
       </RouterLink>
@@ -12,7 +14,7 @@
       {{ data.hostCount }} {{ data.hostCount === 1 ? 'node' : 'nodes' }}, {{ data.vmCount }} VMs
     </div>
     <div class="node-running">
-      <span class="running-badge">{{ data.runningVmCount }} running</span>
+      <span class="running-pill">{{ data.runningVmCount }} running</span>
     </div>
     <NodeExpandButton
       v-if="data.isExpandable"
@@ -39,21 +41,54 @@ const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
 
 <style lang="postcss" scoped>
 .pool-node {
-  background: var(--color-neutral-background-primary);
+  background: var(--color-brand-background-selected);
   border: 0.2rem solid var(--color-brand-item-base);
   border-radius: 0.8rem;
   padding: 1.2rem 1.6rem;
   padding-bottom: 2rem;
   min-width: 24rem;
   position: relative;
+  box-shadow: var(--shadow-200);
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+
+  &:hover {
+    box-shadow: var(--shadow-300);
+    transform: translateY(-0.2rem);
+  }
+
+  :root.dark & {
+    box-shadow: 0 0.2rem 0.8rem rgba(255, 255, 255, 0.06);
+
+    &:hover {
+      box-shadow: 0 0.4rem 1.4rem rgba(255, 255, 255, 0.1);
+    }
+  }
 
   .node-header {
     display: flex;
     align-items: center;
     gap: 0.8rem;
 
-    .node-icon {
-      color: var(--color-brand-item-base);
+    .icon-circle {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 2.8rem;
+      height: 2.8rem;
+      border-radius: 50%;
+      background: var(--color-brand-background-selected);
+      flex-shrink: 0;
+
+      :root.dark & {
+        background: color-mix(in srgb, var(--color-brand-item-base) 20%, transparent);
+      }
+
+      .node-icon {
+        font-size: 1.2rem;
+        color: var(--color-brand-item-base);
+      }
     }
 
     .node-title {
@@ -77,10 +112,18 @@ const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
   .node-running {
     margin-top: 0.4rem;
 
-    .running-badge {
+    .running-pill {
+      display: inline-block;
       font-size: 1.1rem;
-      color: var(--color-success-item-base);
       font-weight: 500;
+      color: var(--color-success-item-base);
+      background: var(--color-success-background-selected);
+      padding: 0.1rem 0.8rem;
+      border-radius: 10rem;
+
+      :root.dark & {
+        background: color-mix(in srgb, var(--color-success-item-base) 20%, transparent);
+      }
     }
   }
 }

--- a/@xen-orchestra/web/src/modules/topology/components/PoolNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/PoolNode.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable @intlify/vue-i18n/no-raw-text -- prototype: i18n keys to be added later -->
 <template>
-  <div class="topology-node pool-node">
-    <Handle type="target" :position="Position.Top" />
+  <div class="topology-node pool-node" :class="isLR ? 'dir-lr' : 'dir-tb'">
+    <Handle type="target" :position="isLR ? Position.Left : Position.Top" />
     <div class="node-header">
       <span class="icon-circle">
         <FontAwesomeIcon :icon="faCity" class="node-icon" />
@@ -21,13 +21,13 @@
       :expanded="data.isExpanded"
       @toggle="toggleExpand?.(`pool-${data.pool.id}`)"
     />
-    <Handle v-else type="source" :position="Position.Bottom" />
+    <Handle v-else type="source" :position="isLR ? Position.Right : Position.Bottom" />
   </div>
 </template>
 
 <script lang="ts" setup>
 import NodeExpandButton from '@/modules/topology/components/NodeExpandButton.vue'
-import { TOPOLOGY_TOGGLE_EXPAND } from '@/modules/topology/composables/use-topology-interaction.ts'
+import { TOPOLOGY_DIRECTION, TOPOLOGY_TOGGLE_EXPAND } from '@/modules/topology/composables/use-topology-interaction.ts'
 import type { PoolNodeData } from '@/modules/topology/types/topology.types.ts'
 import { faCity } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
@@ -37,16 +37,24 @@ import { inject } from 'vue'
 defineProps<{ data: PoolNodeData }>()
 
 const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
+const isLR = inject(TOPOLOGY_DIRECTION, 'TB') === 'LR'
 </script>
 
-<style lang="postcss" scoped>
+<style scoped lang="postcss">
 .pool-node {
   background: var(--color-brand-background-selected);
   border: 0.2rem solid var(--color-brand-item-base);
   border-radius: 0.8rem;
   padding: 1.2rem 1.6rem;
-  padding-bottom: 2rem;
   min-width: 24rem;
+
+  &.dir-tb {
+    padding-bottom: 2rem;
+  }
+
+  &.dir-lr {
+    padding-right: 2.5rem;
+  }
   position: relative;
   box-shadow: var(--shadow-200);
   transition:

--- a/@xen-orchestra/web/src/modules/topology/components/SiteNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/SiteNode.vue
@@ -2,7 +2,9 @@
 <template>
   <div class="topology-node site-node">
     <div class="node-header">
-      <FontAwesomeIcon :icon="faSatellite" class="node-icon" />
+      <span class="icon-circle">
+        <FontAwesomeIcon :icon="faSatellite" class="node-icon" />
+      </span>
       <span class="node-title">{{ data.label }}</span>
     </div>
     <div class="node-stats">
@@ -10,11 +12,7 @@
       <span class="stat">{{ data.hostCount }} {{ data.hostCount === 1 ? 'host' : 'hosts' }}</span>
       <span class="stat">{{ data.vmCount }} VMs</span>
     </div>
-    <NodeExpandButton
-      v-if="data.isExpandable"
-      :expanded="data.isExpanded"
-      @toggle="toggleExpand?.(SITE_NODE_ID)"
-    />
+    <NodeExpandButton v-if="data.isExpandable" :expanded="data.isExpanded" @toggle="toggleExpand?.(SITE_NODE_ID)" />
     <Handle v-else type="source" :position="Position.Bottom" />
   </div>
 </template>
@@ -37,14 +35,42 @@ const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
 
 <style lang="postcss" scoped>
 .site-node {
-  background: var(--color-brand-item-base);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--color-brand-item-base) 85%, transparent),
+    color-mix(in srgb, var(--color-brand-item-hover) 75%, transparent)
+  );
+  backdrop-filter: blur(1.2rem);
   color: var(--color-brand-txt-item);
+  border: 0.1rem solid color-mix(in srgb, var(--color-brand-item-base) 40%, transparent);
   border-radius: 0.8rem;
   padding: 1.2rem 1.6rem;
   padding-bottom: 2rem;
   min-width: 26rem;
-  box-shadow: 0 0.4rem 1.2rem color-mix(in srgb, var(--color-brand-item-base) 30%, transparent);
+  box-shadow: var(--shadow-200);
   position: relative;
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+
+  &:hover {
+    box-shadow: var(--shadow-300);
+    transform: translateY(-0.2rem);
+  }
+
+  :root.dark & {
+    background: linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--color-brand-item-base) 60%, transparent),
+      color-mix(in srgb, var(--color-brand-item-base) 40%, transparent)
+    );
+    border-color: color-mix(in srgb, var(--color-brand-item-base) 30%, transparent);
+    box-shadow: 0 0.2rem 0.8rem rgba(255, 255, 255, 0.06);
+
+    &:hover {
+      box-shadow: 0 0.4rem 1.4rem rgba(255, 255, 255, 0.1);
+    }
+  }
 
   .node-header {
     display: flex;
@@ -52,6 +78,21 @@ const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
     gap: 0.8rem;
     font-weight: 600;
     font-size: 1.4rem;
+
+    .icon-circle {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 2.8rem;
+      height: 2.8rem;
+      border-radius: 50%;
+      background: rgba(255, 255, 255, 0.2);
+      flex-shrink: 0;
+
+      .node-icon {
+        font-size: 1.2rem;
+      }
+    }
   }
 
   .node-stats {

--- a/@xen-orchestra/web/src/modules/topology/components/SiteNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/SiteNode.vue
@@ -10,17 +10,29 @@
       <span class="stat">{{ data.hostCount }} {{ data.hostCount === 1 ? 'host' : 'hosts' }}</span>
       <span class="stat">{{ data.vmCount }} VMs</span>
     </div>
-    <Handle type="source" :position="Position.Bottom" />
+    <NodeExpandButton
+      v-if="data.isExpandable"
+      :expanded="data.isExpanded"
+      @toggle="toggleExpand?.(SITE_NODE_ID)"
+    />
+    <Handle v-else type="source" :position="Position.Bottom" />
   </div>
 </template>
 
 <script lang="ts" setup>
+import NodeExpandButton from '@/modules/topology/components/NodeExpandButton.vue'
+import { TOPOLOGY_TOGGLE_EXPAND } from '@/modules/topology/composables/use-topology-interaction.ts'
 import type { SiteNodeData } from '@/modules/topology/types/topology.types.ts'
 import { faSatellite } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { Handle, Position } from '@vue-flow/core'
+import { inject } from 'vue'
 
 defineProps<{ data: SiteNodeData }>()
+
+const SITE_NODE_ID = 'site-root'
+
+const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
 </script>
 
 <style lang="postcss" scoped>
@@ -29,8 +41,10 @@ defineProps<{ data: SiteNodeData }>()
   color: var(--color-brand-txt-item);
   border-radius: 0.8rem;
   padding: 1.2rem 1.6rem;
+  padding-bottom: 2rem;
   min-width: 26rem;
   box-shadow: 0 0.4rem 1.2rem color-mix(in srgb, var(--color-brand-item-base) 30%, transparent);
+  position: relative;
 
   .node-header {
     display: flex;

--- a/@xen-orchestra/web/src/modules/topology/components/SiteNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/SiteNode.vue
@@ -1,0 +1,55 @@
+<!-- eslint-disable @intlify/vue-i18n/no-raw-text -- prototype: i18n keys to be added later -->
+<template>
+  <div class="topology-node site-node">
+    <div class="node-header">
+      <FontAwesomeIcon :icon="faSatellite" class="node-icon" />
+      <span class="node-title">{{ data.label }}</span>
+    </div>
+    <div class="node-stats">
+      <span class="stat">{{ data.poolCount }} {{ data.poolCount === 1 ? 'pool' : 'pools' }}</span>
+      <span class="stat">{{ data.hostCount }} {{ data.hostCount === 1 ? 'host' : 'hosts' }}</span>
+      <span class="stat">{{ data.vmCount }} VMs</span>
+    </div>
+    <Handle type="source" :position="Position.Bottom" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import type { SiteNodeData } from '@/modules/topology/types/topology.types.ts'
+import { faSatellite } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { Handle, Position } from '@vue-flow/core'
+
+defineProps<{ data: SiteNodeData }>()
+</script>
+
+<style lang="postcss" scoped>
+.site-node {
+  background: var(--color-brand-item-base);
+  color: var(--color-brand-txt-item);
+  border-radius: 0.8rem;
+  padding: 1.2rem 1.6rem;
+  min-width: 26rem;
+  box-shadow: 0 0.4rem 1.2rem color-mix(in srgb, var(--color-brand-item-base) 30%, transparent);
+
+  .node-header {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    font-weight: 600;
+    font-size: 1.4rem;
+  }
+
+  .node-stats {
+    display: flex;
+    gap: 1.2rem;
+    margin-top: 0.8rem;
+    font-size: 1.2rem;
+    opacity: 0.85;
+
+    .stat {
+      white-space: nowrap;
+    }
+  }
+}
+</style>

--- a/@xen-orchestra/web/src/modules/topology/components/SiteNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/SiteNode.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable @intlify/vue-i18n/no-raw-text -- prototype: i18n keys to be added later -->
 <template>
-  <div class="topology-node site-node">
+  <div class="topology-node site-node" :class="isLR ? 'dir-lr' : 'dir-tb'">
     <div class="node-header">
       <span class="icon-circle">
         <FontAwesomeIcon :icon="faSatellite" class="node-icon" />
@@ -13,13 +13,13 @@
       <span class="stat">{{ data.vmCount }} VMs</span>
     </div>
     <NodeExpandButton v-if="data.isExpandable" :expanded="data.isExpanded" @toggle="toggleExpand?.(SITE_NODE_ID)" />
-    <Handle v-else type="source" :position="Position.Bottom" />
+    <Handle v-else type="source" :position="isLR ? Position.Right : Position.Bottom" />
   </div>
 </template>
 
 <script lang="ts" setup>
 import NodeExpandButton from '@/modules/topology/components/NodeExpandButton.vue'
-import { TOPOLOGY_TOGGLE_EXPAND } from '@/modules/topology/composables/use-topology-interaction.ts'
+import { TOPOLOGY_DIRECTION, TOPOLOGY_TOGGLE_EXPAND } from '@/modules/topology/composables/use-topology-interaction.ts'
 import type { SiteNodeData } from '@/modules/topology/types/topology.types.ts'
 import { faSatellite } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
@@ -31,9 +31,10 @@ defineProps<{ data: SiteNodeData }>()
 const SITE_NODE_ID = 'site-root'
 
 const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
+const isLR = inject(TOPOLOGY_DIRECTION, 'TB') === 'LR'
 </script>
 
-<style lang="postcss" scoped>
+<style scoped lang="postcss">
 .site-node {
   background: linear-gradient(
     135deg,
@@ -45,8 +46,15 @@ const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
   border: 0.1rem solid color-mix(in srgb, var(--color-brand-item-base) 40%, transparent);
   border-radius: 0.8rem;
   padding: 1.2rem 1.6rem;
-  padding-bottom: 2rem;
   min-width: 26rem;
+
+  &.dir-tb {
+    padding-bottom: 2rem;
+  }
+
+  &.dir-lr {
+    padding-right: 2.5rem;
+  }
   box-shadow: var(--shadow-200);
   position: relative;
   transition:

--- a/@xen-orchestra/web/src/modules/topology/components/SrNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/SrNode.vue
@@ -1,0 +1,184 @@
+<!-- eslint-disable @intlify/vue-i18n/no-raw-text -- prototype: i18n keys to be added later -->
+<template>
+  <div class="topology-node sr-node" :class="borderClass">
+    <Handle type="target" :position="Position.Left" />
+    <div class="node-header">
+      <span class="icon-circle">
+        <FontAwesomeIcon :icon="faHardDrive" class="node-icon" />
+      </span>
+      <span class="node-title">{{ data.sr.name_label }}</span>
+    </div>
+    <div class="node-info">
+      <span class="badge badge-type">{{ data.srType }}</span>
+      <span class="badge" :class="data.shared ? 'badge-shared' : 'badge-local'">
+        {{ data.shared ? 'Shared' : 'Local' }}
+      </span>
+      <span class="info-item">{{ data.pbdHostCount }} {{ data.pbdHostCount === 1 ? 'host' : 'hosts' }}</span>
+    </div>
+    <div class="node-vm-info">
+      <span class="info-item">{{ data.vmCount }} {{ data.vmCount === 1 ? 'VM' : 'VMs' }}</span>
+      <span v-if="data.runningVmCount > 0" class="badge badge-running">{{ data.runningVmCount }} running</span>
+    </div>
+    <div v-if="data.size > 0" class="usage-bar">
+      <VtsProgressBar :current="data.usage" :total="data.size" label="Usage" legend-type="percent" noruler />
+    </div>
+    <NodeExpandButton
+      v-if="data.isExpandable"
+      :expanded="data.isExpanded"
+      @toggle="toggleExpand?.(`sr-${data.sr.id}`)"
+    />
+    <Handle v-else type="source" :position="Position.Right" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import NodeExpandButton from '@/modules/topology/components/NodeExpandButton.vue'
+import { TOPOLOGY_TOGGLE_EXPAND } from '@/modules/topology/composables/use-topology-interaction.ts'
+import type { SrNodeData } from '@/modules/topology/types/topology.types.ts'
+import VtsProgressBar from '@core/components/progress-bar/VtsProgressBar.vue'
+import { faHardDrive } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { Handle, Position } from '@vue-flow/core'
+import { computed, inject } from 'vue'
+
+const { data } = defineProps<{ data: SrNodeData }>()
+
+const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
+
+const borderClass = computed(() => (data.allAttached ? 'border-ok' : 'border-danger'))
+</script>
+
+<style scoped lang="postcss">
+.sr-node {
+  background: var(--color-neutral-background-primary);
+  border: 0.1rem solid var(--color-neutral-border);
+  border-radius: 0.8rem;
+  padding: 1rem 1.4rem;
+  padding-right: 2.5rem;
+  min-width: 24rem;
+  position: relative;
+  box-shadow: var(--shadow-200);
+  transition:
+    box-shadow 0.3s ease,
+    transform 0.2s ease;
+
+  &:hover {
+    box-shadow: var(--shadow-300);
+    transform: translateY(-0.2rem);
+  }
+
+  :root.dark & {
+    box-shadow: 0 0.2rem 0.8rem rgba(255, 255, 255, 0.06);
+
+    &:hover {
+      box-shadow: 0 0.4rem 1.4rem rgba(255, 255, 255, 0.1);
+    }
+  }
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 0.3rem;
+    height: 100%;
+    border-radius: 0.8rem 0 0 0.8rem;
+  }
+
+  &.border-ok::before {
+    background: var(--color-success-item-base);
+  }
+
+  &.border-danger::before {
+    background: var(--color-danger-item-base);
+  }
+
+  .node-header {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+
+    .icon-circle {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 2.4rem;
+      height: 2.4rem;
+      border-radius: 50%;
+      background: color-mix(in srgb, #f59e0b 15%, transparent);
+      color: #f59e0b;
+      flex-shrink: 0;
+
+      .node-icon {
+        font-size: 1rem;
+      }
+    }
+
+    .node-title {
+      font-weight: 500;
+      font-size: 1.2rem;
+      color: var(--color-neutral-txt-primary);
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
+  .node-info {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-top: 0.6rem;
+    flex-wrap: wrap;
+  }
+
+  .node-vm-info {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-top: 0.4rem;
+    flex-wrap: wrap;
+  }
+
+  .info-item {
+    font-size: 1.1rem;
+    color: var(--color-neutral-txt-secondary);
+    white-space: nowrap;
+  }
+
+  .badge {
+    display: inline-block;
+    font-size: 1rem;
+    font-weight: 500;
+    padding: 0.1rem 0.6rem;
+    border-radius: 10rem;
+    white-space: nowrap;
+  }
+
+  .badge-type {
+    color: #f59e0b;
+    background: color-mix(in srgb, #f59e0b 15%, transparent);
+  }
+
+  .badge-shared {
+    color: #3b82f6;
+    background: color-mix(in srgb, #3b82f6 15%, transparent);
+  }
+
+  .badge-local {
+    color: var(--color-neutral-txt-secondary);
+    background: var(--color-neutral-background-secondary);
+  }
+
+  .badge-running {
+    color: var(--color-success-item-base);
+    background: color-mix(in srgb, var(--color-success-item-base) 15%, transparent);
+  }
+
+  .usage-bar {
+    margin-top: 0.6rem;
+  }
+}
+</style>

--- a/@xen-orchestra/web/src/modules/topology/components/TopologyCanvas.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/TopologyCanvas.vue
@@ -28,6 +28,13 @@
         <TopologyEdge v-bind="edgeProps" />
       </template>
       <Controls :show-interactive="false" />
+      <MiniMap
+        pannable
+        zoomable
+        :node-color="minimapNodeColor"
+        :node-border-radius="4"
+        mask-color="rgba(0, 0, 0, 0.15)"
+      />
     </VueFlow>
   </div>
 </template>
@@ -40,12 +47,15 @@ import TopologyEdge from '@/modules/topology/components/TopologyEdge.vue'
 import VmGroupNode from '@/modules/topology/components/VmGroupNode.vue'
 import type { TopologyEdge as TopologyEdgeType, TopologyNode } from '@/modules/topology/types/topology.types.ts'
 import { Controls } from '@vue-flow/controls'
+import type { GraphNode } from '@vue-flow/core'
 import { useVueFlow, VueFlow } from '@vue-flow/core'
+import { MiniMap } from '@vue-flow/minimap'
 import { markRaw, nextTick, watch } from 'vue'
 
 import '@vue-flow/core/dist/style.css'
 import '@vue-flow/core/dist/theme-default.css'
 import '@vue-flow/controls/dist/style.css'
+import '@vue-flow/minimap/dist/style.css'
 
 const props = defineProps<{
   nodes: TopologyNode[]
@@ -61,6 +71,21 @@ const nodeTypes: Record<string, any> = {
 
 const edgeTypes = {
   topology: markRaw(TopologyEdge),
+}
+
+const minimapNodeColor = (node: GraphNode) => {
+  switch (node.type) {
+    case 'site':
+      return '#8f84ff'
+    case 'pool':
+      return 'rgba(143, 132, 255, 0.4)'
+    case 'host':
+      return 'rgba(143, 132, 255, 0.25)'
+    case 'vm-group':
+      return 'rgba(143, 132, 255, 0.15)'
+    default:
+      return 'rgba(143, 132, 255, 0.2)'
+  }
 }
 
 const { fitView } = useVueFlow()
@@ -90,6 +115,17 @@ watch(
     transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
+  :deep(.vue-flow__minimap) {
+    background: var(--color-neutral-background-primary);
+    border: 0.1rem solid var(--color-neutral-border);
+    border-radius: 0.6rem;
+    overflow: hidden;
+
+    :root.dark & .vue-flow__minimap-mask {
+      fill: rgba(255, 255, 255, 0.08);
+    }
+  }
+
   :deep(.vue-flow__controls) {
     background: var(--color-neutral-background-primary);
     border: 0.1rem solid var(--color-neutral-border);
@@ -108,6 +144,12 @@ watch(
         fill: currentColor;
       }
     }
+  }
+}
+
+@keyframes edge-flow {
+  to {
+    stroke-dashoffset: -18;
   }
 }
 </style>

--- a/@xen-orchestra/web/src/modules/topology/components/TopologyCanvas.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/TopologyCanvas.vue
@@ -1,0 +1,96 @@
+<template>
+  <div class="topology-canvas">
+    <VueFlow
+      :nodes="nodes"
+      :edges="edges"
+      :node-types="nodeTypes"
+      :edge-types="edgeTypes"
+      :default-viewport="{ x: 0, y: 0, zoom: 0.85 }"
+      :min-zoom="0.2"
+      :max-zoom="2"
+      fit-view-on-init
+      :nodes-draggable="false"
+      :nodes-connectable="false"
+    >
+      <template #node-site="nodeProps">
+        <SiteNode :data="nodeProps.data" />
+      </template>
+      <template #node-pool="nodeProps">
+        <PoolNode :data="nodeProps.data" />
+      </template>
+      <template #node-host="nodeProps">
+        <HostNode :data="nodeProps.data" />
+      </template>
+      <template #node-vm-group="nodeProps">
+        <VmGroupNode :data="nodeProps.data" />
+      </template>
+      <template #edge-topology="edgeProps">
+        <TopologyEdge v-bind="edgeProps" />
+      </template>
+      <Controls :show-interactive="false" />
+    </VueFlow>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import HostNode from '@/modules/topology/components/HostNode.vue'
+import PoolNode from '@/modules/topology/components/PoolNode.vue'
+import SiteNode from '@/modules/topology/components/SiteNode.vue'
+import TopologyEdge from '@/modules/topology/components/TopologyEdge.vue'
+import VmGroupNode from '@/modules/topology/components/VmGroupNode.vue'
+import type { TopologyEdge as TopologyEdgeType, TopologyNode } from '@/modules/topology/types/topology.types.ts'
+import { Controls } from '@vue-flow/controls'
+import { VueFlow } from '@vue-flow/core'
+import { markRaw } from 'vue'
+
+import '@vue-flow/core/dist/style.css'
+import '@vue-flow/core/dist/theme-default.css'
+import '@vue-flow/controls/dist/style.css'
+
+defineProps<{
+  nodes: TopologyNode[]
+  edges: TopologyEdgeType[]
+}>()
+
+const nodeTypes = {
+  site: markRaw(SiteNode),
+  pool: markRaw(PoolNode),
+  host: markRaw(HostNode),
+  'vm-group': markRaw(VmGroupNode),
+}
+
+const edgeTypes = {
+  topology: markRaw(TopologyEdge),
+}
+</script>
+
+<style lang="postcss" scoped>
+.topology-canvas {
+  width: 100%;
+  height: 100%;
+
+  :deep(.vue-flow) {
+    background: var(--color-neutral-background-secondary);
+  }
+
+  :deep(.vue-flow__controls) {
+    background: var(--color-neutral-background-primary);
+    border: 0.1rem solid var(--color-neutral-border);
+    border-radius: 0.4rem;
+
+    button {
+      background: var(--color-neutral-background-primary);
+      color: var(--color-neutral-txt-primary);
+      border-bottom: 0.1rem solid var(--color-neutral-border);
+
+      &:hover {
+        background: var(--color-brand-background-hover);
+      }
+
+      svg {
+        fill: currentColor;
+      }
+    }
+  }
+}
+</style>

--- a/@xen-orchestra/web/src/modules/topology/components/TopologyCanvas.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/TopologyCanvas.vue
@@ -22,7 +22,7 @@
         <HostNode :data="nodeProps.data" />
       </template>
       <template #node-vm-group="nodeProps">
-        <VmGroupNode :data="nodeProps.data" />
+        <VmGroupNode :id="nodeProps.id" :data="nodeProps.data" />
       </template>
       <template #edge-topology="edgeProps">
         <TopologyEdge v-bind="edgeProps" />
@@ -40,19 +40,19 @@ import TopologyEdge from '@/modules/topology/components/TopologyEdge.vue'
 import VmGroupNode from '@/modules/topology/components/VmGroupNode.vue'
 import type { TopologyEdge as TopologyEdgeType, TopologyNode } from '@/modules/topology/types/topology.types.ts'
 import { Controls } from '@vue-flow/controls'
-import { VueFlow } from '@vue-flow/core'
-import { markRaw } from 'vue'
+import { useVueFlow, VueFlow } from '@vue-flow/core'
+import { markRaw, nextTick, watch } from 'vue'
 
 import '@vue-flow/core/dist/style.css'
 import '@vue-flow/core/dist/theme-default.css'
 import '@vue-flow/controls/dist/style.css'
 
-defineProps<{
+const props = defineProps<{
   nodes: TopologyNode[]
   edges: TopologyEdgeType[]
 }>()
 
-const nodeTypes = {
+const nodeTypes: Record<string, any> = {
   site: markRaw(SiteNode),
   pool: markRaw(PoolNode),
   host: markRaw(HostNode),
@@ -62,6 +62,19 @@ const nodeTypes = {
 const edgeTypes = {
   topology: markRaw(TopologyEdge),
 }
+
+const { fitView } = useVueFlow()
+
+watch(
+  () => props.nodes,
+  () => {
+    nextTick(() => {
+      setTimeout(() => {
+        fitView({ duration: 600 })
+      }, 50)
+    })
+  }
+)
 </script>
 
 <style lang="postcss" scoped>
@@ -71,6 +84,10 @@ const edgeTypes = {
 
   :deep(.vue-flow) {
     background: var(--color-neutral-background-secondary);
+  }
+
+  :deep(.vue-flow__node) {
+    transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   :deep(.vue-flow__controls) {

--- a/@xen-orchestra/web/src/modules/topology/components/TopologyCanvas.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/TopologyCanvas.vue
@@ -25,6 +25,15 @@
       <template #node-vm-group="nodeProps">
         <VmGroupNode :id="nodeProps.id" :data="nodeProps.data" />
       </template>
+      <template #node-network="nodeProps">
+        <NetworkNode :data="nodeProps.data" />
+      </template>
+      <template #node-sr="nodeProps">
+        <SrNode :data="nodeProps.data" />
+      </template>
+      <template #node-empty-group="nodeProps">
+        <EmptyGroupNode :id="nodeProps.id" :data="nodeProps.data" />
+      </template>
       <template #edge-topology="edgeProps">
         <TopologyEdge v-bind="edgeProps" />
       </template>
@@ -41,9 +50,12 @@
 </template>
 
 <script lang="ts" setup>
+import EmptyGroupNode from '@/modules/topology/components/EmptyGroupNode.vue'
 import HostNode from '@/modules/topology/components/HostNode.vue'
+import NetworkNode from '@/modules/topology/components/NetworkNode.vue'
 import PoolNode from '@/modules/topology/components/PoolNode.vue'
 import SiteNode from '@/modules/topology/components/SiteNode.vue'
+import SrNode from '@/modules/topology/components/SrNode.vue'
 import TopologyEdge from '@/modules/topology/components/TopologyEdge.vue'
 import VmGroupNode from '@/modules/topology/components/VmGroupNode.vue'
 import { TOPOLOGY_ZOOM } from '@/modules/topology/composables/use-topology-interaction.ts'
@@ -59,7 +71,7 @@ import '@vue-flow/core/dist/theme-default.css'
 import '@vue-flow/controls/dist/style.css'
 import '@vue-flow/minimap/dist/style.css'
 
-const props = defineProps<{
+const { nodes, edges } = defineProps<{
   nodes: TopologyNode[]
   edges: TopologyEdgeType[]
 }>()
@@ -69,6 +81,9 @@ const nodeTypes: Record<string, any> = {
   pool: markRaw(PoolNode),
   host: markRaw(HostNode),
   'vm-group': markRaw(VmGroupNode),
+  network: markRaw(NetworkNode),
+  sr: markRaw(SrNode),
+  'empty-group': markRaw(EmptyGroupNode),
 }
 
 const edgeTypes = {
@@ -85,6 +100,12 @@ const minimapNodeColor = (node: GraphNode) => {
       return 'rgba(143, 132, 255, 0.25)'
     case 'vm-group':
       return 'rgba(143, 132, 255, 0.15)'
+    case 'network':
+      return '#3b82f6'
+    case 'sr':
+      return '#f59e0b'
+    case 'empty-group':
+      return 'rgba(100, 100, 100, 0.2)'
     default:
       return 'rgba(143, 132, 255, 0.2)'
   }
@@ -101,7 +122,7 @@ function onViewportChange(viewport: { zoom: number }) {
 }
 
 watch(
-  () => props.nodes,
+  () => nodes.length,
   () => {
     nextTick(() => {
       setTimeout(() => {
@@ -112,7 +133,7 @@ watch(
 )
 </script>
 
-<style lang="postcss" scoped>
+<style scoped lang="postcss">
 .topology-canvas {
   width: 100%;
   height: 100%;

--- a/@xen-orchestra/web/src/modules/topology/components/TopologyCanvas.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/TopologyCanvas.vue
@@ -11,6 +11,7 @@
       fit-view-on-init
       :nodes-draggable="false"
       :nodes-connectable="false"
+      @viewport-change="onViewportChange"
     >
       <template #node-site="nodeProps">
         <SiteNode :data="nodeProps.data" />
@@ -45,12 +46,13 @@ import PoolNode from '@/modules/topology/components/PoolNode.vue'
 import SiteNode from '@/modules/topology/components/SiteNode.vue'
 import TopologyEdge from '@/modules/topology/components/TopologyEdge.vue'
 import VmGroupNode from '@/modules/topology/components/VmGroupNode.vue'
+import { TOPOLOGY_ZOOM } from '@/modules/topology/composables/use-topology-interaction.ts'
 import type { TopologyEdge as TopologyEdgeType, TopologyNode } from '@/modules/topology/types/topology.types.ts'
 import { Controls } from '@vue-flow/controls'
 import type { GraphNode } from '@vue-flow/core'
 import { useVueFlow, VueFlow } from '@vue-flow/core'
 import { MiniMap } from '@vue-flow/minimap'
-import { markRaw, nextTick, watch } from 'vue'
+import { markRaw, nextTick, provide, ref, watch } from 'vue'
 
 import '@vue-flow/core/dist/style.css'
 import '@vue-flow/core/dist/theme-default.css'
@@ -90,6 +92,14 @@ const minimapNodeColor = (node: GraphNode) => {
 
 const { fitView } = useVueFlow()
 
+const currentZoom = ref(0.85)
+
+provide(TOPOLOGY_ZOOM, currentZoom)
+
+function onViewportChange(viewport: { zoom: number }) {
+  currentZoom.value = viewport.zoom
+}
+
 watch(
   () => props.nodes,
   () => {
@@ -112,6 +122,7 @@ watch(
   }
 
   :deep(.vue-flow__node) {
+    overflow: visible;
     transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
   }
 

--- a/@xen-orchestra/web/src/modules/topology/components/TopologyEdge.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/TopologyEdge.vue
@@ -1,0 +1,28 @@
+<template>
+  <BaseEdge :path="edgePath" :style="edgeStyle" />
+</template>
+
+<script lang="ts" setup>
+import { BaseEdge, getSmoothStepPath, type EdgeProps } from '@vue-flow/core'
+import { computed } from 'vue'
+
+const props = defineProps<EdgeProps>()
+
+const edgePath = computed(() =>
+  getSmoothStepPath({
+    sourceX: props.sourceX,
+    sourceY: props.sourceY,
+    targetX: props.targetX,
+    targetY: props.targetY,
+    sourcePosition: props.sourcePosition,
+    targetPosition: props.targetPosition,
+    borderRadius: 8,
+  })[0]
+)
+
+const edgeStyle = {
+  stroke: 'var(--color-neutral-border)',
+  strokeWidth: 1.5,
+  strokeDasharray: '6 3',
+}
+</script>

--- a/@xen-orchestra/web/src/modules/topology/components/TopologyEdge.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/TopologyEdge.vue
@@ -6,17 +6,17 @@
 import { BaseEdge, getSmoothStepPath, type EdgeProps } from '@vue-flow/core'
 import { computed } from 'vue'
 
-const props = defineProps<EdgeProps>()
+const { sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition } = defineProps<EdgeProps>()
 
 const edgePath = computed(
   () =>
     getSmoothStepPath({
-      sourceX: props.sourceX,
-      sourceY: props.sourceY,
-      targetX: props.targetX,
-      targetY: props.targetY,
-      sourcePosition: props.sourcePosition,
-      targetPosition: props.targetPosition,
+      sourceX,
+      sourceY,
+      targetX,
+      targetY,
+      sourcePosition,
+      targetPosition,
       borderRadius: 8,
     })[0]
 )

--- a/@xen-orchestra/web/src/modules/topology/components/TopologyEdge.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/TopologyEdge.vue
@@ -8,21 +8,23 @@ import { computed } from 'vue'
 
 const props = defineProps<EdgeProps>()
 
-const edgePath = computed(() =>
-  getSmoothStepPath({
-    sourceX: props.sourceX,
-    sourceY: props.sourceY,
-    targetX: props.targetX,
-    targetY: props.targetY,
-    sourcePosition: props.sourcePosition,
-    targetPosition: props.targetPosition,
-    borderRadius: 8,
-  })[0]
+const edgePath = computed(
+  () =>
+    getSmoothStepPath({
+      sourceX: props.sourceX,
+      sourceY: props.sourceY,
+      targetX: props.targetX,
+      targetY: props.targetY,
+      sourcePosition: props.sourcePosition,
+      targetPosition: props.targetPosition,
+      borderRadius: 8,
+    })[0]
 )
 
 const edgeStyle = {
   stroke: 'var(--color-neutral-border)',
   strokeWidth: 1.5,
   strokeDasharray: '6 3',
+  animation: 'edge-flow 1.5s linear infinite',
 }
 </script>

--- a/@xen-orchestra/web/src/modules/topology/components/TopologyHeader.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/TopologyHeader.vue
@@ -1,0 +1,19 @@
+<!-- eslint-disable @intlify/vue-i18n/no-raw-text -- prototype: i18n keys to be added later -->
+<template>
+  <TabList>
+    <RouterLink v-slot="{ isActive, href }" :to="{ name: '/(site)/topology/infrastructure' }" custom>
+      <TabItem :active="isActive" :href tag="a">Infrastructure</TabItem>
+    </RouterLink>
+    <RouterLink v-slot="{ isActive, href }" :to="{ name: '/(site)/topology/networks' }" custom>
+      <TabItem :active="isActive" :href tag="a">Networks</TabItem>
+    </RouterLink>
+    <RouterLink v-slot="{ isActive, href }" :to="{ name: '/(site)/topology/storage' }" custom>
+      <TabItem :active="isActive" :href tag="a">Storage</TabItem>
+    </RouterLink>
+  </TabList>
+</template>
+
+<script lang="ts" setup>
+import TabItem from '@core/components/tab/TabItem.vue'
+import TabList from '@core/components/tab/TabList.vue'
+</script>

--- a/@xen-orchestra/web/src/modules/topology/components/VmGroupNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/VmGroupNode.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable @intlify/vue-i18n/no-raw-text -- prototype: i18n keys to be added later -->
 <template>
-  <div class="topology-node vm-group-node">
-    <Handle type="target" :position="Position.Top" />
+  <div class="topology-node vm-group-node" :class="isLR ? 'dir-lr' : 'dir-tb'">
+    <Handle type="target" :position="isLR ? Position.Left : Position.Top" />
     <div class="vm-header">
       <span class="icon-circle">
         <FontAwesomeIcon :icon="faDesktop" class="vm-icon" />
@@ -26,7 +26,7 @@
 
 <script lang="ts" setup>
 import NodeExpandButton from '@/modules/topology/components/NodeExpandButton.vue'
-import { TOPOLOGY_TOGGLE_EXPAND } from '@/modules/topology/composables/use-topology-interaction.ts'
+import { TOPOLOGY_DIRECTION, TOPOLOGY_TOGGLE_EXPAND } from '@/modules/topology/composables/use-topology-interaction.ts'
 import type { VmGroupNodeData } from '@/modules/topology/types/topology.types.ts'
 import { faDesktop } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
@@ -36,16 +36,24 @@ import { inject } from 'vue'
 defineProps<{ data: VmGroupNodeData; id: string }>()
 
 const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
+const isLR = inject(TOPOLOGY_DIRECTION, 'TB') === 'LR'
 </script>
 
-<style lang="postcss" scoped>
+<style scoped lang="postcss">
 .vm-group-node {
   background: var(--color-neutral-background-secondary);
   border: 0.1rem dashed var(--color-neutral-border);
   border-radius: 0.6rem;
   padding: 0.8rem 1.2rem;
-  padding-bottom: 2rem;
   min-width: 18rem;
+
+  &.dir-tb {
+    padding-bottom: 2rem;
+  }
+
+  &.dir-lr {
+    padding-right: 2.5rem;
+  }
   max-width: 26rem;
   overflow: visible;
   position: relative;

--- a/@xen-orchestra/web/src/modules/topology/components/VmGroupNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/VmGroupNode.vue
@@ -3,7 +3,9 @@
   <div class="topology-node vm-group-node">
     <Handle type="target" :position="Position.Top" />
     <div class="vm-header">
-      <FontAwesomeIcon :icon="faDesktop" class="vm-icon" />
+      <span class="icon-circle">
+        <FontAwesomeIcon :icon="faDesktop" class="vm-icon" />
+      </span>
       <div class="vm-summary">
         <span v-if="data.runningCount > 0" class="count running">{{ data.runningCount }} running</span>
         <span v-if="data.stoppedCount > 0" class="count stopped">{{ data.stoppedCount }} stopped</span>
@@ -18,11 +20,7 @@
         </RouterLink>
       </div>
     </div>
-    <NodeExpandButton
-      v-if="data.isExpandable"
-      :expanded="data.isExpanded"
-      @toggle="toggleExpand?.(id)"
-    />
+    <NodeExpandButton v-if="data.isExpandable" :expanded="data.isExpanded" @toggle="toggleExpand?.(id)" />
   </div>
 </template>
 
@@ -49,6 +47,23 @@ const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
   padding-bottom: 2rem;
   min-width: 18rem;
   position: relative;
+  box-shadow: var(--shadow-200);
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+
+  &:hover {
+    box-shadow: var(--shadow-300);
+    transform: translateY(-0.2rem);
+  }
+
+  :root.dark & {
+    box-shadow: 0 0.2rem 0.8rem rgba(255, 255, 255, 0.06);
+
+    &:hover {
+      box-shadow: 0 0.4rem 1.4rem rgba(255, 255, 255, 0.1);
+    }
+  }
 
   .vm-header {
     display: flex;
@@ -56,10 +71,24 @@ const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
     gap: 0.6rem;
   }
 
-  .vm-icon {
-    color: var(--color-neutral-txt-secondary);
-    font-size: 1.2rem;
+  .icon-circle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.4rem;
+    height: 2.4rem;
+    border-radius: 50%;
+    background: var(--color-neutral-background-disabled);
     flex-shrink: 0;
+
+    :root.dark & {
+      background: color-mix(in srgb, var(--color-neutral-txt-secondary) 15%, transparent);
+    }
+
+    .vm-icon {
+      color: var(--color-neutral-txt-secondary);
+      font-size: 1rem;
+    }
   }
 
   .vm-summary {

--- a/@xen-orchestra/web/src/modules/topology/components/VmGroupNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/VmGroupNode.vue
@@ -2,24 +2,42 @@
 <template>
   <div class="topology-node vm-group-node">
     <Handle type="target" :position="Position.Top" />
-    <div class="vm-icon">
-      <FontAwesomeIcon :icon="faDesktop" />
+    <div class="vm-header">
+      <FontAwesomeIcon :icon="faDesktop" class="vm-icon" />
+      <div class="vm-summary">
+        <span v-if="data.runningCount > 0" class="count running">{{ data.runningCount }} running</span>
+        <span v-if="data.stoppedCount > 0" class="count stopped">{{ data.stoppedCount }} stopped</span>
+        <span class="total">{{ data.vms.length }} VMs</span>
+      </div>
     </div>
-    <div class="vm-counts">
-      <span v-if="data.runningCount > 0" class="count running">{{ data.runningCount }} running</span>
-      <span v-if="data.stoppedCount > 0" class="count stopped">{{ data.stoppedCount }} stopped</span>
+    <div v-if="data.isExpanded" class="vm-list">
+      <div v-for="vm in data.vms" :key="vm.id" class="vm-row">
+        <span class="vm-dot" :class="vm.power_state === 'Running' ? 'running' : 'halted'" />
+        <RouterLink :to="{ name: '/vm/[id]', params: { id: vm.id } }" class="vm-name">
+          {{ vm.name_label }}
+        </RouterLink>
+      </div>
     </div>
-    <div class="vm-total">{{ data.vms.length }} VMs</div>
+    <NodeExpandButton
+      v-if="data.isExpandable"
+      :expanded="data.isExpanded"
+      @toggle="toggleExpand?.(id)"
+    />
   </div>
 </template>
 
 <script lang="ts" setup>
+import NodeExpandButton from '@/modules/topology/components/NodeExpandButton.vue'
+import { TOPOLOGY_TOGGLE_EXPAND } from '@/modules/topology/composables/use-topology-interaction.ts'
 import type { VmGroupNodeData } from '@/modules/topology/types/topology.types.ts'
 import { faDesktop } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { Handle, Position } from '@vue-flow/core'
+import { inject } from 'vue'
 
-defineProps<{ data: VmGroupNodeData }>()
+defineProps<{ data: VmGroupNodeData; id: string }>()
+
+const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
 </script>
 
 <style lang="postcss" scoped>
@@ -28,20 +46,27 @@ defineProps<{ data: VmGroupNodeData }>()
   border: 0.1rem dashed var(--color-neutral-border);
   border-radius: 0.6rem;
   padding: 0.8rem 1.2rem;
-  text-align: center;
-  min-width: 16rem;
+  padding-bottom: 2rem;
+  min-width: 18rem;
+  position: relative;
+
+  .vm-header {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
 
   .vm-icon {
     color: var(--color-neutral-txt-secondary);
-    font-size: 1.4rem;
-    margin-bottom: 0.4rem;
+    font-size: 1.2rem;
+    flex-shrink: 0;
   }
 
-  .vm-counts {
+  .vm-summary {
     display: flex;
-    justify-content: center;
-    gap: 0.8rem;
+    gap: 0.6rem;
     font-size: 1.1rem;
+    align-items: center;
 
     .count {
       font-weight: 600;
@@ -54,12 +79,53 @@ defineProps<{ data: VmGroupNodeData }>()
         color: var(--color-danger-txt-base);
       }
     }
+
+    .total {
+      color: var(--color-neutral-txt-secondary);
+    }
   }
 
-  .vm-total {
-    margin-top: 0.2rem;
-    font-size: 1rem;
-    color: var(--color-neutral-txt-secondary);
+  .vm-list {
+    margin-top: 0.6rem;
+    border-top: 0.1rem solid var(--color-neutral-border);
+    padding-top: 0.4rem;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .vm-row {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.3rem 0;
+
+    .vm-dot {
+      width: 0.6rem;
+      height: 0.6rem;
+      border-radius: 50%;
+      flex-shrink: 0;
+
+      &.running {
+        background: var(--color-success-item-base);
+      }
+
+      &.halted {
+        background: var(--color-danger-item-base);
+      }
+    }
+
+    .vm-name {
+      font-size: 1.1rem;
+      color: var(--color-neutral-txt-primary);
+      text-decoration: none;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+
+      &:hover {
+        color: var(--color-brand-item-hover);
+      }
+    }
   }
 }
 </style>

--- a/@xen-orchestra/web/src/modules/topology/components/VmGroupNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/VmGroupNode.vue
@@ -46,6 +46,8 @@ const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
   padding: 0.8rem 1.2rem;
   padding-bottom: 2rem;
   min-width: 18rem;
+  max-width: 26rem;
+  overflow: visible;
   position: relative;
   box-shadow: var(--shadow-200);
   transition:
@@ -127,6 +129,7 @@ const toggleExpand = inject(TOPOLOGY_TOGGLE_EXPAND, undefined)
     align-items: center;
     gap: 0.6rem;
     padding: 0.3rem 0;
+    min-width: 0;
 
     .vm-dot {
       width: 0.6rem;

--- a/@xen-orchestra/web/src/modules/topology/components/VmGroupNode.vue
+++ b/@xen-orchestra/web/src/modules/topology/components/VmGroupNode.vue
@@ -1,0 +1,65 @@
+<!-- eslint-disable @intlify/vue-i18n/no-raw-text -- prototype: i18n keys to be added later -->
+<template>
+  <div class="topology-node vm-group-node">
+    <Handle type="target" :position="Position.Top" />
+    <div class="vm-icon">
+      <FontAwesomeIcon :icon="faDesktop" />
+    </div>
+    <div class="vm-counts">
+      <span v-if="data.runningCount > 0" class="count running">{{ data.runningCount }} running</span>
+      <span v-if="data.stoppedCount > 0" class="count stopped">{{ data.stoppedCount }} stopped</span>
+    </div>
+    <div class="vm-total">{{ data.vms.length }} VMs</div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import type { VmGroupNodeData } from '@/modules/topology/types/topology.types.ts'
+import { faDesktop } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { Handle, Position } from '@vue-flow/core'
+
+defineProps<{ data: VmGroupNodeData }>()
+</script>
+
+<style lang="postcss" scoped>
+.vm-group-node {
+  background: var(--color-neutral-background-secondary);
+  border: 0.1rem dashed var(--color-neutral-border);
+  border-radius: 0.6rem;
+  padding: 0.8rem 1.2rem;
+  text-align: center;
+  min-width: 16rem;
+
+  .vm-icon {
+    color: var(--color-neutral-txt-secondary);
+    font-size: 1.4rem;
+    margin-bottom: 0.4rem;
+  }
+
+  .vm-counts {
+    display: flex;
+    justify-content: center;
+    gap: 0.8rem;
+    font-size: 1.1rem;
+
+    .count {
+      font-weight: 600;
+
+      &.running {
+        color: var(--color-success-item-base);
+      }
+
+      &.stopped {
+        color: var(--color-danger-txt-base);
+      }
+    }
+  }
+
+  .vm-total {
+    margin-top: 0.2rem;
+    font-size: 1rem;
+    color: var(--color-neutral-txt-secondary);
+  }
+}
+</style>

--- a/@xen-orchestra/web/src/modules/topology/composables/use-topology-graph.ts
+++ b/@xen-orchestra/web/src/modules/topology/composables/use-topology-graph.ts
@@ -1,0 +1,173 @@
+import { useXoHostCollection } from '@/modules/host/remote-resources/use-xo-host-collection.ts'
+import { useXoPoolCollection } from '@/modules/pool/remote-resources/use-xo-pool-collection.ts'
+import type {
+  HostNodeData,
+  PoolNodeData,
+  SiteNodeData,
+  TopologyEdge,
+  TopologyNode,
+  VmGroupNodeData,
+} from '@/modules/topology/types/topology.types.ts'
+import { useXoVmCollection } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
+import { XOA_NAME } from '@/shared/constants.ts'
+import { VM_POWER_STATE } from '@vates/types'
+import { logicAnd } from '@vueuse/math'
+import { computed } from 'vue'
+
+import { useTopologyLayout } from './use-topology-layout.ts'
+
+const SITE_NODE_ID = 'site-root'
+
+export function useTopologyGraph() {
+  const { pools, arePoolsReady } = useXoPoolCollection()
+  const { hostsByPool, hosts, areHostsReady } = useXoHostCollection()
+  const { vmsByHost, hostLessVmsByPool, vms, areVmsReady } = useXoVmCollection()
+
+  const isReady = logicAnd(arePoolsReady, areHostsReady, areVmsReady)
+
+  const rawNodes = computed<TopologyNode[]>(() => {
+    const nodes: TopologyNode[] = []
+    const poolList = pools.value
+
+    nodes.push({
+      id: SITE_NODE_ID,
+      type: 'site',
+      position: { x: 0, y: 0 },
+      data: {
+        type: 'site',
+        label: XOA_NAME,
+        poolCount: poolList.length,
+        hostCount: hosts.value.length,
+        vmCount: vms.value.length,
+      } satisfies SiteNodeData,
+    })
+
+    for (const pool of poolList) {
+      const poolHosts = hostsByPool.value.get(pool.id) ?? []
+      const poolVms = poolHosts.flatMap(h => vmsByHost.value.get(h.id) ?? [])
+      const hostLessVms = hostLessVmsByPool.value.get(pool.id) ?? []
+      const allPoolVms = [...poolVms, ...hostLessVms]
+
+      nodes.push({
+        id: `pool-${pool.id}`,
+        type: 'pool',
+        position: { x: 0, y: 0 },
+        data: {
+          type: 'pool',
+          pool,
+          hostCount: poolHosts.length,
+          vmCount: allPoolVms.length,
+          runningVmCount: allPoolVms.filter(vm => vm.power_state === VM_POWER_STATE.RUNNING).length,
+        } satisfies PoolNodeData,
+      })
+
+      for (const host of poolHosts) {
+        const hostVms = vmsByHost.value.get(host.id) ?? []
+        const runningCount = hostVms.filter(vm => vm.power_state === VM_POWER_STATE.RUNNING).length
+
+        nodes.push({
+          id: `host-${host.id}`,
+          type: 'host',
+          position: { x: 0, y: 0 },
+          data: {
+            type: 'host',
+            host,
+            vmCount: hostVms.length,
+            runningVmCount: runningCount,
+            memorySize: host.memory.size,
+            memoryUsage: host.memory.usage,
+          } satisfies HostNodeData,
+        })
+
+        if (hostVms.length > 0) {
+          nodes.push({
+            id: `vmgroup-host-${host.id}`,
+            type: 'vm-group',
+            position: { x: 0, y: 0 },
+            data: {
+              type: 'vm-group',
+              vms: hostVms,
+              runningCount,
+              stoppedCount: hostVms.length - runningCount,
+            } satisfies VmGroupNodeData,
+          })
+        }
+      }
+
+      if (hostLessVms.length > 0) {
+        const runningCount = hostLessVms.filter(vm => vm.power_state === VM_POWER_STATE.RUNNING).length
+
+        nodes.push({
+          id: `vmgroup-pool-${pool.id}`,
+          type: 'vm-group',
+          position: { x: 0, y: 0 },
+          data: {
+            type: 'vm-group',
+            vms: hostLessVms,
+            runningCount,
+            stoppedCount: hostLessVms.length - runningCount,
+          } satisfies VmGroupNodeData,
+        })
+      }
+    }
+
+    return nodes
+  })
+
+  const rawEdges = computed<TopologyEdge[]>(() => {
+    const edges: TopologyEdge[] = []
+    const poolList = pools.value
+
+    for (const pool of poolList) {
+      edges.push({
+        id: `e-site-pool-${pool.id}`,
+        source: SITE_NODE_ID,
+        target: `pool-${pool.id}`,
+        type: 'topology',
+      })
+
+      const poolHosts = hostsByPool.value.get(pool.id) ?? []
+
+      for (const host of poolHosts) {
+        edges.push({
+          id: `e-pool-host-${host.id}`,
+          source: `pool-${pool.id}`,
+          target: `host-${host.id}`,
+          type: 'topology',
+        })
+
+        const hostVms = vmsByHost.value.get(host.id) ?? []
+
+        if (hostVms.length > 0) {
+          edges.push({
+            id: `e-host-vmgroup-${host.id}`,
+            source: `host-${host.id}`,
+            target: `vmgroup-host-${host.id}`,
+            type: 'topology',
+          })
+        }
+      }
+
+      const hostLessVms = hostLessVmsByPool.value.get(pool.id) ?? []
+
+      if (hostLessVms.length > 0) {
+        edges.push({
+          id: `e-pool-vmgroup-${pool.id}`,
+          source: `pool-${pool.id}`,
+          target: `vmgroup-pool-${pool.id}`,
+          type: 'topology',
+        })
+      }
+    }
+
+    return edges
+  })
+
+  const layouted = useTopologyLayout(rawNodes, rawEdges)
+
+  return {
+    nodes: computed(() => layouted.value.nodes),
+    edges: computed(() => layouted.value.edges),
+    isReady,
+  }
+}

--- a/@xen-orchestra/web/src/modules/topology/composables/use-topology-graph.ts
+++ b/@xen-orchestra/web/src/modules/topology/composables/use-topology-graph.ts
@@ -251,7 +251,9 @@ export function useTopologyGraph() {
     return edges
   })
 
-  const layouted = useTopologyLayout(rawNodes, rawEdges)
+  const direction = 'TB' as const
+
+  const layouted = useTopologyLayout(rawNodes, rawEdges, direction)
 
   return {
     nodes: computed(() => layouted.value.nodes),
@@ -259,5 +261,6 @@ export function useTopologyGraph() {
     isReady,
     expandedNodes,
     toggleExpand,
+    direction,
   }
 }

--- a/@xen-orchestra/web/src/modules/topology/composables/use-topology-host-stats.ts
+++ b/@xen-orchestra/web/src/modules/topology/composables/use-topology-host-stats.ts
@@ -1,0 +1,130 @@
+import { GRANULARITY, RRD_STEP_FROM_STRING } from '@/shared/utils/rest-api-stats.ts'
+import type { XoHost } from '@vates/types'
+import type { XapiHostStats } from '@vates/types/common'
+import { computed, onScopeDispose, ref, watch, type Ref } from 'vue'
+
+/**
+ * Fetches CPU stats for hosts currently visible in the topology.
+ * Only polls hosts that are in the `visibleHostIds` set (i.e. their parent pool is expanded).
+ * Uses "minutes" granularity (1 request per host per 60s) to keep cost low on large infras.
+ */
+export function useTopologyHostStats(visibleHostIds: Ref<Set<XoHost['id']>>) {
+  const cpuByHost = ref<Map<XoHost['id'], number | undefined>>(new Map())
+  const activePollers = new Map<XoHost['id'], ReturnType<typeof setTimeout>>()
+  const abortControllers = new Map<XoHost['id'], AbortController>()
+
+  const granularity = GRANULARITY.Minutes
+  const pollInterval = RRD_STEP_FROM_STRING[granularity] * 1000
+
+  async function fetchHostCpu(hostId: XoHost['id']) {
+    const controller = new AbortController()
+    abortControllers.set(hostId, controller)
+
+    try {
+      const resp = await fetch(`/rest/v0/hosts/${hostId}/stats?granularity=${granularity}`, {
+        credentials: 'include',
+        signal: controller.signal,
+      })
+
+      if (!resp.ok) {
+        return
+      }
+
+      const data: XapiHostStats = await resp.json()
+      const cpus = data.stats.cpus
+
+      if (cpus == null) {
+        return
+      }
+
+      const cores = Object.values(cpus)
+
+      if (cores.length === 0) {
+        return
+      }
+
+      // Take the last (most recent) data point, average across all cores
+      let sum = 0
+      let count = 0
+
+      for (const core of cores) {
+        const last = core[core.length - 1]
+
+        if (last != null) {
+          sum += last
+          count++
+        }
+      }
+
+      if (count > 0) {
+        const next = new Map(cpuByHost.value)
+        next.set(hostId, Math.round(sum / count))
+        cpuByHost.value = next
+      }
+    } catch {
+      // Aborted or network error — ignore
+    } finally {
+      abortControllers.delete(hostId)
+    }
+  }
+
+  function startPolling(hostId: XoHost['id']) {
+    if (activePollers.has(hostId)) {
+      return
+    }
+
+    // Fetch immediately, then poll
+    fetchHostCpu(hostId)
+    const timer = setInterval(() => fetchHostCpu(hostId), pollInterval)
+    activePollers.set(hostId, timer)
+  }
+
+  function stopPolling(hostId: XoHost['id']) {
+    const timer = activePollers.get(hostId)
+
+    if (timer != null) {
+      clearInterval(timer)
+      activePollers.delete(hostId)
+    }
+
+    const controller = abortControllers.get(hostId)
+
+    if (controller != null) {
+      controller.abort()
+      abortControllers.delete(hostId)
+    }
+  }
+
+  watch(
+    visibleHostIds,
+    (current, previous) => {
+      const prev = previous ?? new Set<XoHost['id']>()
+
+      // Start polling for newly visible hosts
+      for (const id of current) {
+        if (!prev.has(id)) {
+          startPolling(id)
+        }
+      }
+
+      // Stop polling for hosts that are no longer visible
+      for (const id of prev) {
+        if (!current.has(id)) {
+          stopPolling(id)
+        }
+      }
+    },
+    { immediate: true }
+  )
+
+  onScopeDispose(() => {
+    for (const id of activePollers.keys()) {
+      stopPolling(id)
+    }
+    cpuByHost.value = new Map()
+  })
+
+  return {
+    cpuByHost: computed(() => cpuByHost.value),
+  }
+}

--- a/@xen-orchestra/web/src/modules/topology/composables/use-topology-interaction.ts
+++ b/@xen-orchestra/web/src/modules/topology/composables/use-topology-interaction.ts
@@ -1,5 +1,8 @@
 import type { InjectionKey, Ref } from 'vue'
 
+export type TopologyDirection = 'TB' | 'LR'
+
 export const TOPOLOGY_TOGGLE_EXPAND: InjectionKey<(nodeId: string) => void> = Symbol('topology-toggle-expand')
 export const TOPOLOGY_EXPANDED_NODES: InjectionKey<Ref<Set<string>>> = Symbol('topology-expanded-nodes')
 export const TOPOLOGY_ZOOM: InjectionKey<Ref<number>> = Symbol('topology-zoom')
+export const TOPOLOGY_DIRECTION: InjectionKey<TopologyDirection> = Symbol('topology-direction')

--- a/@xen-orchestra/web/src/modules/topology/composables/use-topology-interaction.ts
+++ b/@xen-orchestra/web/src/modules/topology/composables/use-topology-interaction.ts
@@ -1,0 +1,4 @@
+import type { InjectionKey, Ref } from 'vue'
+
+export const TOPOLOGY_TOGGLE_EXPAND: InjectionKey<(nodeId: string) => void> = Symbol('topology-toggle-expand')
+export const TOPOLOGY_EXPANDED_NODES: InjectionKey<Ref<Set<string>>> = Symbol('topology-expanded-nodes')

--- a/@xen-orchestra/web/src/modules/topology/composables/use-topology-interaction.ts
+++ b/@xen-orchestra/web/src/modules/topology/composables/use-topology-interaction.ts
@@ -2,3 +2,4 @@ import type { InjectionKey, Ref } from 'vue'
 
 export const TOPOLOGY_TOGGLE_EXPAND: InjectionKey<(nodeId: string) => void> = Symbol('topology-toggle-expand')
 export const TOPOLOGY_EXPANDED_NODES: InjectionKey<Ref<Set<string>>> = Symbol('topology-expanded-nodes')
+export const TOPOLOGY_ZOOM: InjectionKey<Ref<number>> = Symbol('topology-zoom')

--- a/@xen-orchestra/web/src/modules/topology/composables/use-topology-layout.ts
+++ b/@xen-orchestra/web/src/modules/topology/composables/use-topology-layout.ts
@@ -2,7 +2,21 @@ import dagre from '@dagrejs/dagre'
 import type { Ref } from 'vue'
 import { computed } from 'vue'
 
-import { NODE_DIMENSIONS, type TopologyEdge, type TopologyNode } from '../types/topology.types.ts'
+import {
+  NODE_DIMENSIONS,
+  VM_GROUP_EXPANDED_ROW_HEIGHT,
+  type TopologyEdge,
+  type TopologyNode,
+} from '../types/topology.types.ts'
+
+function getNodeDimensions(node: TopologyNode) {
+  const data = node.data!
+  if (data.type === 'vm-group' && data.isExpanded) {
+    const base = NODE_DIMENSIONS['vm-group']
+    return { width: base.width, height: base.height + data.vms.length * VM_GROUP_EXPANDED_ROW_HEIGHT }
+  }
+  return NODE_DIMENSIONS[data.type] ?? { width: 200, height: 100 }
+}
 
 export function useTopologyLayout(nodes: Ref<TopologyNode[]>, edges: Ref<TopologyEdge[]>) {
   return computed(() => {
@@ -17,7 +31,7 @@ export function useTopologyLayout(nodes: Ref<TopologyNode[]>, edges: Ref<Topolog
     })
 
     for (const node of nodes.value) {
-      const dims = NODE_DIMENSIONS[node.data.type] ?? { width: 200, height: 100 }
+      const dims = getNodeDimensions(node)
       g.setNode(node.id, { width: dims.width, height: dims.height })
     }
 
@@ -29,7 +43,7 @@ export function useTopologyLayout(nodes: Ref<TopologyNode[]>, edges: Ref<Topolog
 
     const layoutedNodes: TopologyNode[] = nodes.value.map(node => {
       const graphNode = g.node(node.id)
-      const dims = NODE_DIMENSIONS[node.data.type] ?? { width: 200, height: 100 }
+      const dims = getNodeDimensions(node)
       return {
         ...node,
         position: {

--- a/@xen-orchestra/web/src/modules/topology/composables/use-topology-layout.ts
+++ b/@xen-orchestra/web/src/modules/topology/composables/use-topology-layout.ts
@@ -1,8 +1,10 @@
+import type { TopologyDirection } from '@/modules/topology/composables/use-topology-interaction.ts'
 import dagre from '@dagrejs/dagre'
 import type { Ref } from 'vue'
 import { computed } from 'vue'
 
 import {
+  EMPTY_GROUP_EXPANDED_ROW_HEIGHT,
   NODE_DIMENSIONS,
   VM_GROUP_EXPANDED_ROW_HEIGHT,
   type TopologyEdge,
@@ -15,17 +17,25 @@ function getNodeDimensions(node: TopologyNode) {
     const base = NODE_DIMENSIONS['vm-group']
     return { width: base.width, height: base.height + data.vms.length * VM_GROUP_EXPANDED_ROW_HEIGHT }
   }
+  if (data.type === 'empty-group' && data.isExpanded) {
+    const base = NODE_DIMENSIONS['empty-group']
+    return { width: base.width, height: base.height + data.items.length * EMPTY_GROUP_EXPANDED_ROW_HEIGHT }
+  }
   return NODE_DIMENSIONS[data.type] ?? { width: 200, height: 100 }
 }
 
-export function useTopologyLayout(nodes: Ref<TopologyNode[]>, edges: Ref<TopologyEdge[]>) {
+export function useTopologyLayout(
+  nodes: Ref<TopologyNode[]>,
+  edges: Ref<TopologyEdge[]>,
+  direction: TopologyDirection = 'TB'
+) {
   return computed(() => {
     const g = new dagre.graphlib.Graph()
     g.setDefaultEdgeLabel(() => ({}))
     g.setGraph({
-      rankdir: 'TB',
-      nodesep: 60,
-      ranksep: 80,
+      rankdir: direction,
+      nodesep: direction === 'LR' ? 40 : 60,
+      ranksep: direction === 'LR' ? 100 : 80,
       marginx: 40,
       marginy: 40,
     })

--- a/@xen-orchestra/web/src/modules/topology/composables/use-topology-layout.ts
+++ b/@xen-orchestra/web/src/modules/topology/composables/use-topology-layout.ts
@@ -1,0 +1,44 @@
+import dagre from '@dagrejs/dagre'
+import type { Ref } from 'vue'
+import { computed } from 'vue'
+
+import { NODE_DIMENSIONS, type TopologyEdge, type TopologyNode } from '../types/topology.types.ts'
+
+export function useTopologyLayout(nodes: Ref<TopologyNode[]>, edges: Ref<TopologyEdge[]>) {
+  return computed(() => {
+    const g = new dagre.graphlib.Graph()
+    g.setDefaultEdgeLabel(() => ({}))
+    g.setGraph({
+      rankdir: 'TB',
+      nodesep: 60,
+      ranksep: 80,
+      marginx: 40,
+      marginy: 40,
+    })
+
+    for (const node of nodes.value) {
+      const dims = NODE_DIMENSIONS[node.data.type] ?? { width: 200, height: 100 }
+      g.setNode(node.id, { width: dims.width, height: dims.height })
+    }
+
+    for (const edge of edges.value) {
+      g.setEdge(edge.source, edge.target)
+    }
+
+    dagre.layout(g)
+
+    const layoutedNodes: TopologyNode[] = nodes.value.map(node => {
+      const graphNode = g.node(node.id)
+      const dims = NODE_DIMENSIONS[node.data.type] ?? { width: 200, height: 100 }
+      return {
+        ...node,
+        position: {
+          x: graphNode.x - dims.width / 2,
+          y: graphNode.y - dims.height / 2,
+        },
+      }
+    })
+
+    return { nodes: layoutedNodes, edges: edges.value }
+  })
+}

--- a/@xen-orchestra/web/src/modules/topology/composables/use-topology-network-graph.ts
+++ b/@xen-orchestra/web/src/modules/topology/composables/use-topology-network-graph.ts
@@ -1,0 +1,317 @@
+import { useXoHostCollection } from '@/modules/host/remote-resources/use-xo-host-collection.ts'
+import { useXoNetworkCollection } from '@/modules/network/remote-resources/use-xo-network-collection.ts'
+import { useXoPifCollection } from '@/modules/pif/remote-resources/use-xo-pif-collection.ts'
+import { useXoPoolCollection } from '@/modules/pool/remote-resources/use-xo-pool-collection.ts'
+import type {
+  EmptyGroupNodeData,
+  NetworkNodeData,
+  PoolNodeData,
+  SiteNodeData,
+  TopologyEdge,
+  TopologyNode,
+  VmGroupNodeData,
+} from '@/modules/topology/types/topology.types.ts'
+import { useXoVifCollection } from '@/modules/vif/remote-resources/use-xo-vif-collection.ts'
+import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
+import { useXoVmCollection } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
+import { XOA_NAME } from '@/shared/constants.ts'
+import { VM_POWER_STATE } from '@vates/types'
+import { logicAnd } from '@vueuse/math'
+import { computed, ref, watch } from 'vue'
+
+import { useTopologyLayout } from './use-topology-layout.ts'
+
+const SITE_NODE_ID = 'site-root'
+
+export function useTopologyNetworkGraph() {
+  const { pools, arePoolsReady } = useXoPoolCollection()
+  const { networks, areNetworksReady } = useXoNetworkCollection()
+  const { pifs, arePifsReady } = useXoPifCollection()
+  const { vifs, areVifsReady } = useXoVifCollection()
+  const { vms, areVmsReady, getVmById } = useXoVmCollection()
+  const { hosts, areHostsReady } = useXoHostCollection()
+
+  const isReady = logicAnd(arePoolsReady, areNetworksReady, arePifsReady, areVifsReady, areVmsReady, areHostsReady)
+
+  const expandedNodes = ref<Set<string>>(new Set([SITE_NODE_ID]))
+
+  // Auto-expand all pool nodes once data loads
+  watch(
+    () => pools.value,
+    poolList => {
+      for (const pool of poolList) {
+        expandedNodes.value.add(`pool-${pool.id}`)
+      }
+    },
+    { immediate: true }
+  )
+
+  function toggleExpand(nodeId: string) {
+    const next = new Set(expandedNodes.value)
+    if (next.has(nodeId)) {
+      next.delete(nodeId)
+    } else {
+      next.add(nodeId)
+    }
+    expandedNodes.value = next
+  }
+
+  // Group networks by pool
+  const networksByPool = computed(() => {
+    const map = new Map<string, typeof networks.value>()
+    for (const network of networks.value) {
+      const poolId = network.$pool
+      if (!map.has(poolId)) {
+        map.set(poolId, [])
+      }
+      map.get(poolId)!.push(network)
+    }
+    return map
+  })
+
+  // Group VIFs by network
+  const vifsByNetwork = computed(() => {
+    const map = new Map<string, typeof vifs.value>()
+    for (const vif of vifs.value) {
+      const netId = vif.$network
+      if (!map.has(netId)) {
+        map.set(netId, [])
+      }
+      map.get(netId)!.push(vif)
+    }
+    return map
+  })
+
+  // Resolve unique VMs per network from VIFs
+  const vmsByNetwork = computed(() => {
+    const map = new Map<string, FrontXoVm[]>()
+    for (const [netId, netVifs] of vifsByNetwork.value) {
+      const seen = new Set<string>()
+      const resolvedVms: FrontXoVm[] = []
+      for (const vif of netVifs) {
+        if (seen.has(vif.$VM)) {
+          continue
+        }
+        seen.add(vif.$VM)
+        const vm = getVmById(vif.$VM)
+        if (vm) {
+          resolvedVms.push(vm)
+        }
+      }
+      map.set(netId, resolvedVms)
+    }
+    return map
+  })
+
+  // Count PIFs per network (for host badge)
+  const pifCountByNetwork = computed(() => {
+    const map = new Map<string, number>()
+    for (const pif of pifs.value) {
+      map.set(pif.$network, (map.get(pif.$network) ?? 0) + 1)
+    }
+    return map
+  })
+
+  // Check for physical PIFs per network
+  const hasPhysicalPifsByNetwork = computed(() => {
+    const map = new Map<string, boolean>()
+    for (const pif of pifs.value) {
+      if (!map.get(pif.$network) && pif.vlan === -1 && !pif.isBondMaster) {
+        map.set(pif.$network, true)
+      }
+    }
+    return map
+  })
+
+  const rawNodes = computed<TopologyNode[]>(() => {
+    const nodes: TopologyNode[] = []
+    const poolList = pools.value
+    const expanded = expandedNodes.value
+
+    nodes.push({
+      id: SITE_NODE_ID,
+      type: 'site',
+      position: { x: 0, y: 0 },
+      data: {
+        type: 'site',
+        label: XOA_NAME,
+        poolCount: poolList.length,
+        hostCount: hosts.value.length,
+        vmCount: vms.value.length,
+        isExpanded: expanded.has(SITE_NODE_ID),
+        isExpandable: poolList.length > 0,
+      } satisfies SiteNodeData,
+    })
+
+    if (!expanded.has(SITE_NODE_ID)) {
+      return nodes
+    }
+
+    for (const pool of poolList) {
+      const poolId = `pool-${pool.id}`
+      const poolNetworks = networksByPool.value.get(pool.id) ?? []
+
+      // Partition into networks with VMs vs empty
+      const activeNetworks = poolNetworks.filter(n => (vmsByNetwork.value.get(n.id) ?? []).length > 0)
+      const emptyNetworks = poolNetworks.filter(n => (vmsByNetwork.value.get(n.id) ?? []).length === 0)
+
+      nodes.push({
+        id: poolId,
+        type: 'pool',
+        position: { x: 0, y: 0 },
+        data: {
+          type: 'pool',
+          pool,
+          hostCount: poolNetworks.length,
+          vmCount: 0,
+          runningVmCount: 0,
+          isExpanded: expanded.has(poolId),
+          isExpandable: activeNetworks.length > 0 || emptyNetworks.length > 0,
+        } satisfies PoolNodeData,
+      })
+
+      if (!expanded.has(poolId)) {
+        continue
+      }
+
+      for (const network of activeNetworks) {
+        const netId = `net-${network.id}`
+        const netVms = vmsByNetwork.value.get(network.id) ?? []
+        const runningVmCount = netVms.filter(vm => vm.power_state === VM_POWER_STATE.RUNNING).length
+
+        nodes.push({
+          id: netId,
+          type: 'network',
+          position: { x: 0, y: 0 },
+          data: {
+            type: 'network',
+            network,
+            vmCount: netVms.length,
+            runningVmCount,
+            pifHostCount: pifCountByNetwork.value.get(network.id) ?? 0,
+            hasPhysicalPifs: hasPhysicalPifsByNetwork.value.get(network.id) ?? false,
+            mtu: network.MTU,
+            isExpanded: expanded.has(netId),
+            isExpandable: netVms.length > 0,
+          } satisfies NetworkNodeData,
+        })
+
+        if (!expanded.has(netId)) {
+          continue
+        }
+
+        const vmGroupId = `vmgroup-net-${network.id}`
+        const stoppedCount = netVms.length - runningVmCount
+
+        nodes.push({
+          id: vmGroupId,
+          type: 'vm-group',
+          position: { x: 0, y: 0 },
+          data: {
+            type: 'vm-group',
+            vms: netVms,
+            runningCount: runningVmCount,
+            stoppedCount,
+            isExpanded: expanded.has(vmGroupId),
+            isExpandable: netVms.length > 0,
+          } satisfies VmGroupNodeData,
+        })
+      }
+
+      // Group empty networks into a single summary node
+      if (emptyNetworks.length > 0) {
+        const emptyGroupId = `empty-nets-pool-${pool.id}`
+
+        nodes.push({
+          id: emptyGroupId,
+          type: 'empty-group',
+          position: { x: 0, y: 0 },
+          data: {
+            type: 'empty-group',
+            kind: 'network',
+            items: emptyNetworks.map(n => ({ name: n.name_label, id: n.id })),
+            isExpanded: expanded.has(emptyGroupId),
+            isExpandable: emptyNetworks.length > 0,
+          } satisfies EmptyGroupNodeData,
+        })
+      }
+    }
+
+    return nodes
+  })
+
+  const rawEdges = computed<TopologyEdge[]>(() => {
+    const edges: TopologyEdge[] = []
+    const poolList = pools.value
+    const expanded = expandedNodes.value
+
+    if (!expanded.has(SITE_NODE_ID)) {
+      return edges
+    }
+
+    for (const pool of poolList) {
+      const poolId = `pool-${pool.id}`
+
+      edges.push({
+        id: `e-site-pool-${pool.id}`,
+        source: SITE_NODE_ID,
+        target: poolId,
+        type: 'topology',
+      })
+
+      if (!expanded.has(poolId)) {
+        continue
+      }
+
+      const poolNetworks = networksByPool.value.get(pool.id) ?? []
+      const activeNetworks = poolNetworks.filter(n => (vmsByNetwork.value.get(n.id) ?? []).length > 0)
+      const emptyNetworks = poolNetworks.filter(n => (vmsByNetwork.value.get(n.id) ?? []).length === 0)
+
+      for (const network of activeNetworks) {
+        const netId = `net-${network.id}`
+
+        edges.push({
+          id: `e-pool-net-${network.id}`,
+          source: poolId,
+          target: netId,
+          type: 'topology',
+        })
+
+        if (!expanded.has(netId)) {
+          continue
+        }
+
+        edges.push({
+          id: `e-net-vmgroup-${network.id}`,
+          source: netId,
+          target: `vmgroup-net-${network.id}`,
+          type: 'topology',
+        })
+      }
+
+      if (emptyNetworks.length > 0) {
+        edges.push({
+          id: `e-pool-empty-nets-${pool.id}`,
+          source: poolId,
+          target: `empty-nets-pool-${pool.id}`,
+          type: 'topology',
+        })
+      }
+    }
+
+    return edges
+  })
+
+  const direction = 'LR' as const
+
+  const layouted = useTopologyLayout(rawNodes, rawEdges, direction)
+
+  return {
+    nodes: computed(() => layouted.value.nodes),
+    edges: computed(() => layouted.value.edges),
+    isReady,
+    expandedNodes,
+    toggleExpand,
+    direction,
+  }
+}

--- a/@xen-orchestra/web/src/modules/topology/composables/use-topology-storage-graph.ts
+++ b/@xen-orchestra/web/src/modules/topology/composables/use-topology-storage-graph.ts
@@ -1,0 +1,318 @@
+import { useXoHostCollection } from '@/modules/host/remote-resources/use-xo-host-collection.ts'
+import { useXoPbdCollection } from '@/modules/pbd/remote-resources/use-xo-pbd-collection.ts'
+import { useXoPoolCollection } from '@/modules/pool/remote-resources/use-xo-pool-collection.ts'
+import { useXoSrCollection } from '@/modules/storage-repository/remote-resources/use-xo-sr-collection.ts'
+import type {
+  EmptyGroupNodeData,
+  PoolNodeData,
+  SiteNodeData,
+  SrNodeData,
+  TopologyEdge,
+  TopologyNode,
+  VmGroupNodeData,
+} from '@/modules/topology/types/topology.types.ts'
+import { useXoVbdCollection } from '@/modules/vbd/remote-resources/use-xo-vbd-collection.ts'
+import { useXoVdiCollection } from '@/modules/vdi/remote-resources/use-xo-vdi-collection.ts'
+import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
+import { useXoVmCollection } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
+import { XOA_NAME } from '@/shared/constants.ts'
+import { VM_POWER_STATE } from '@vates/types'
+import { logicAnd } from '@vueuse/math'
+import { computed, ref, watch } from 'vue'
+
+import { useTopologyLayout } from './use-topology-layout.ts'
+
+const SITE_NODE_ID = 'site-root'
+
+export function useTopologyStorageGraph() {
+  const { pools, arePoolsReady } = useXoPoolCollection()
+  const { areSrsReady, srsByPool } = useXoSrCollection()
+  const { pbdsBySr, arePbdsReady } = useXoPbdCollection()
+  const { vbds, areVbdsReady } = useXoVbdCollection()
+  const { vdis, areVdisReady } = useXoVdiCollection()
+  const { vms, areVmsReady, getVmById } = useXoVmCollection()
+  const { hosts, areHostsReady } = useXoHostCollection()
+
+  const isReady = logicAnd(
+    arePoolsReady,
+    areSrsReady,
+    arePbdsReady,
+    areVbdsReady,
+    areVdisReady,
+    areVmsReady,
+    areHostsReady
+  )
+
+  const expandedNodes = ref<Set<string>>(new Set([SITE_NODE_ID]))
+
+  // Auto-expand all pool nodes once data loads
+  watch(
+    () => pools.value,
+    poolList => {
+      for (const pool of poolList) {
+        expandedNodes.value.add(`pool-${pool.id}`)
+      }
+    },
+    { immediate: true }
+  )
+
+  function toggleExpand(nodeId: string) {
+    const next = new Set(expandedNodes.value)
+    if (next.has(nodeId)) {
+      next.delete(nodeId)
+    } else {
+      next.add(nodeId)
+    }
+    expandedNodes.value = next
+  }
+
+  // Group VDIs by SR
+  const vdisBySr = computed(() => {
+    const map = new Map<string, string[]>()
+    for (const vdi of vdis.value) {
+      const srId = vdi.$SR
+      if (!map.has(srId)) {
+        map.set(srId, [])
+      }
+      map.get(srId)!.push(vdi.id)
+    }
+    return map
+  })
+
+  // Group VBDs by VDI (excluding CD drives)
+  const vbdsByVdi = computed(() => {
+    const map = new Map<string, typeof vbds.value>()
+    for (const vbd of vbds.value) {
+      if (vbd.is_cd_drive) {
+        continue
+      }
+      const vdiId = vbd.VDI
+      if (!map.has(vdiId)) {
+        map.set(vdiId, [])
+      }
+      map.get(vdiId)!.push(vbd)
+    }
+    return map
+  })
+
+  // Resolve unique VMs per SR: SR → VDIs → VBDs → unique VMs
+  const vmsBySr = computed(() => {
+    const map = new Map<string, FrontXoVm[]>()
+    for (const [srId, vdiIds] of vdisBySr.value) {
+      const seen = new Set<string>()
+      const resolvedVms: FrontXoVm[] = []
+      for (const vdiId of vdiIds) {
+        const vdiVbds = vbdsByVdi.value.get(vdiId) ?? []
+        for (const vbd of vdiVbds) {
+          if (seen.has(vbd.VM)) {
+            continue
+          }
+          seen.add(vbd.VM)
+          const vm = getVmById(vbd.VM)
+          if (vm) {
+            resolvedVms.push(vm)
+          }
+        }
+      }
+      map.set(srId, resolvedVms)
+    }
+    return map
+  })
+
+  const rawNodes = computed<TopologyNode[]>(() => {
+    const nodes: TopologyNode[] = []
+    const poolList = pools.value
+    const expanded = expandedNodes.value
+
+    nodes.push({
+      id: SITE_NODE_ID,
+      type: 'site',
+      position: { x: 0, y: 0 },
+      data: {
+        type: 'site',
+        label: XOA_NAME,
+        poolCount: poolList.length,
+        hostCount: hosts.value.length,
+        vmCount: vms.value.length,
+        isExpanded: expanded.has(SITE_NODE_ID),
+        isExpandable: poolList.length > 0,
+      } satisfies SiteNodeData,
+    })
+
+    if (!expanded.has(SITE_NODE_ID)) {
+      return nodes
+    }
+
+    for (const pool of poolList) {
+      const poolId = `pool-${pool.id}`
+      const poolSrs = srsByPool.value.get(pool.id) ?? []
+
+      // Partition into SRs with VMs vs empty
+      const activeSrs = poolSrs.filter(sr => (vmsBySr.value.get(sr.id) ?? []).length > 0)
+      const emptySrs = poolSrs.filter(sr => (vmsBySr.value.get(sr.id) ?? []).length === 0)
+
+      nodes.push({
+        id: poolId,
+        type: 'pool',
+        position: { x: 0, y: 0 },
+        data: {
+          type: 'pool',
+          pool,
+          hostCount: poolSrs.length,
+          vmCount: 0,
+          runningVmCount: 0,
+          isExpanded: expanded.has(poolId),
+          isExpandable: activeSrs.length > 0 || emptySrs.length > 0,
+        } satisfies PoolNodeData,
+      })
+
+      if (!expanded.has(poolId)) {
+        continue
+      }
+
+      for (const sr of activeSrs) {
+        const srId = `sr-${sr.id}`
+        const srPbds = pbdsBySr.value.get(sr.id) ?? []
+        const allAttached = srPbds.length > 0 && srPbds.every(pbd => pbd.attached)
+        const srVms = vmsBySr.value.get(sr.id) ?? []
+        const runningVmCount = srVms.filter(vm => vm.power_state === VM_POWER_STATE.RUNNING).length
+
+        nodes.push({
+          id: srId,
+          type: 'sr',
+          position: { x: 0, y: 0 },
+          data: {
+            type: 'sr',
+            sr,
+            srType: sr.SR_type,
+            shared: sr.shared,
+            size: sr.size,
+            usage: sr.usage,
+            vmCount: srVms.length,
+            runningVmCount,
+            pbdHostCount: srPbds.length,
+            allAttached,
+            isExpanded: expanded.has(srId),
+            isExpandable: srVms.length > 0,
+          } satisfies SrNodeData,
+        })
+
+        if (!expanded.has(srId)) {
+          continue
+        }
+
+        const vmGroupId = `vmgroup-sr-${sr.id}`
+        const stoppedCount = srVms.length - runningVmCount
+
+        nodes.push({
+          id: vmGroupId,
+          type: 'vm-group',
+          position: { x: 0, y: 0 },
+          data: {
+            type: 'vm-group',
+            vms: srVms,
+            runningCount: runningVmCount,
+            stoppedCount,
+            isExpanded: expanded.has(vmGroupId),
+            isExpandable: srVms.length > 0,
+          } satisfies VmGroupNodeData,
+        })
+      }
+
+      // Group empty SRs into a single summary node
+      if (emptySrs.length > 0) {
+        const emptyGroupId = `empty-srs-pool-${pool.id}`
+
+        nodes.push({
+          id: emptyGroupId,
+          type: 'empty-group',
+          position: { x: 0, y: 0 },
+          data: {
+            type: 'empty-group',
+            kind: 'sr',
+            items: emptySrs.map(sr => ({ name: sr.name_label, id: sr.id })),
+            isExpanded: expanded.has(emptyGroupId),
+            isExpandable: emptySrs.length > 0,
+          } satisfies EmptyGroupNodeData,
+        })
+      }
+    }
+
+    return nodes
+  })
+
+  const rawEdges = computed<TopologyEdge[]>(() => {
+    const edges: TopologyEdge[] = []
+    const poolList = pools.value
+    const expanded = expandedNodes.value
+
+    if (!expanded.has(SITE_NODE_ID)) {
+      return edges
+    }
+
+    for (const pool of poolList) {
+      const poolId = `pool-${pool.id}`
+
+      edges.push({
+        id: `e-site-pool-${pool.id}`,
+        source: SITE_NODE_ID,
+        target: poolId,
+        type: 'topology',
+      })
+
+      if (!expanded.has(poolId)) {
+        continue
+      }
+
+      const poolSrs = srsByPool.value.get(pool.id) ?? []
+      const activeSrs = poolSrs.filter(sr => (vmsBySr.value.get(sr.id) ?? []).length > 0)
+      const emptySrs = poolSrs.filter(sr => (vmsBySr.value.get(sr.id) ?? []).length === 0)
+
+      for (const sr of activeSrs) {
+        const srId = `sr-${sr.id}`
+
+        edges.push({
+          id: `e-pool-sr-${sr.id}`,
+          source: poolId,
+          target: srId,
+          type: 'topology',
+        })
+
+        if (!expanded.has(srId)) {
+          continue
+        }
+
+        edges.push({
+          id: `e-sr-vmgroup-${sr.id}`,
+          source: srId,
+          target: `vmgroup-sr-${sr.id}`,
+          type: 'topology',
+        })
+      }
+
+      if (emptySrs.length > 0) {
+        edges.push({
+          id: `e-pool-empty-srs-${pool.id}`,
+          source: poolId,
+          target: `empty-srs-pool-${pool.id}`,
+          type: 'topology',
+        })
+      }
+    }
+
+    return edges
+  })
+
+  const direction = 'LR' as const
+
+  const layouted = useTopologyLayout(rawNodes, rawEdges, direction)
+
+  return {
+    nodes: computed(() => layouted.value.nodes),
+    edges: computed(() => layouted.value.edges),
+    isReady,
+    expandedNodes,
+    toggleExpand,
+    direction,
+  }
+}

--- a/@xen-orchestra/web/src/modules/topology/types/topology.types.ts
+++ b/@xen-orchestra/web/src/modules/topology/types/topology.types.ts
@@ -1,5 +1,7 @@
 import type { FrontXoHost } from '@/modules/host/remote-resources/use-xo-host-collection.ts'
+import type { FrontXoNetwork } from '@/modules/network/remote-resources/use-xo-network-collection.ts'
 import type { FrontXoPool } from '@/modules/pool/remote-resources/use-xo-pool-collection.ts'
+import type { FrontXoSr } from '@/modules/storage-repository/remote-resources/use-xo-sr-collection.ts'
 import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
 import type { Node, Edge } from '@vue-flow/core'
 
@@ -44,7 +46,49 @@ export type VmGroupNodeData = {
   isExpandable: boolean
 }
 
-export type TopologyNodeData = SiteNodeData | PoolNodeData | HostNodeData | VmGroupNodeData
+export type NetworkNodeData = {
+  type: 'network'
+  network: FrontXoNetwork
+  vmCount: number
+  runningVmCount: number
+  pifHostCount: number
+  hasPhysicalPifs: boolean
+  mtu: number
+  isExpanded: boolean
+  isExpandable: boolean
+}
+
+export type SrNodeData = {
+  type: 'sr'
+  sr: FrontXoSr
+  srType: string
+  shared: boolean
+  size: number
+  usage: number
+  vmCount: number
+  runningVmCount: number
+  pbdHostCount: number
+  allAttached: boolean
+  isExpanded: boolean
+  isExpandable: boolean
+}
+
+export type EmptyGroupNodeData = {
+  type: 'empty-group'
+  kind: 'network' | 'sr'
+  items: { name: string; id: string }[]
+  isExpanded: boolean
+  isExpandable: boolean
+}
+
+export type TopologyNodeData =
+  | SiteNodeData
+  | PoolNodeData
+  | HostNodeData
+  | VmGroupNodeData
+  | NetworkNodeData
+  | SrNodeData
+  | EmptyGroupNodeData
 
 export type TopologyNode = Node<TopologyNodeData>
 export type TopologyEdge = Edge
@@ -54,6 +98,10 @@ export const NODE_DIMENSIONS = {
   pool: { width: 260, height: 130 },
   host: { width: 240, height: 165 },
   'vm-group': { width: 260, height: 100 },
+  network: { width: 260, height: 120 },
+  sr: { width: 260, height: 140 },
+  'empty-group': { width: 240, height: 56 },
 } as const
 
 export const VM_GROUP_EXPANDED_ROW_HEIGHT = 24
+export const EMPTY_GROUP_EXPANDED_ROW_HEIGHT = 22

--- a/@xen-orchestra/web/src/modules/topology/types/topology.types.ts
+++ b/@xen-orchestra/web/src/modules/topology/types/topology.types.ts
@@ -9,6 +9,8 @@ export type SiteNodeData = {
   poolCount: number
   hostCount: number
   vmCount: number
+  isExpanded: boolean
+  isExpandable: boolean
 }
 
 export type PoolNodeData = {
@@ -17,6 +19,8 @@ export type PoolNodeData = {
   hostCount: number
   vmCount: number
   runningVmCount: number
+  isExpanded: boolean
+  isExpandable: boolean
 }
 
 export type HostNodeData = {
@@ -26,6 +30,8 @@ export type HostNodeData = {
   runningVmCount: number
   memorySize: number
   memoryUsage: number
+  isExpanded: boolean
+  isExpandable: boolean
 }
 
 export type VmGroupNodeData = {
@@ -33,6 +39,8 @@ export type VmGroupNodeData = {
   vms: FrontXoVm[]
   runningCount: number
   stoppedCount: number
+  isExpanded: boolean
+  isExpandable: boolean
 }
 
 export type TopologyNodeData = SiteNodeData | PoolNodeData | HostNodeData | VmGroupNodeData
@@ -41,8 +49,10 @@ export type TopologyNode = Node<TopologyNodeData>
 export type TopologyEdge = Edge
 
 export const NODE_DIMENSIONS = {
-  site: { width: 280, height: 100 },
-  pool: { width: 260, height: 110 },
-  host: { width: 240, height: 140 },
-  'vm-group': { width: 180, height: 80 },
+  site: { width: 280, height: 120 },
+  pool: { width: 260, height: 130 },
+  host: { width: 240, height: 130 },
+  'vm-group': { width: 200, height: 100 },
 } as const
+
+export const VM_GROUP_EXPANDED_ROW_HEIGHT = 24

--- a/@xen-orchestra/web/src/modules/topology/types/topology.types.ts
+++ b/@xen-orchestra/web/src/modules/topology/types/topology.types.ts
@@ -30,6 +30,7 @@ export type HostNodeData = {
   runningVmCount: number
   memorySize: number
   memoryUsage: number
+  cpuPercent: number | undefined
   isExpanded: boolean
   isExpandable: boolean
 }
@@ -51,7 +52,7 @@ export type TopologyEdge = Edge
 export const NODE_DIMENSIONS = {
   site: { width: 280, height: 120 },
   pool: { width: 260, height: 130 },
-  host: { width: 240, height: 130 },
+  host: { width: 240, height: 145 },
   'vm-group': { width: 200, height: 100 },
 } as const
 

--- a/@xen-orchestra/web/src/modules/topology/types/topology.types.ts
+++ b/@xen-orchestra/web/src/modules/topology/types/topology.types.ts
@@ -53,7 +53,7 @@ export const NODE_DIMENSIONS = {
   site: { width: 280, height: 120 },
   pool: { width: 260, height: 130 },
   host: { width: 240, height: 165 },
-  'vm-group': { width: 200, height: 100 },
+  'vm-group': { width: 260, height: 100 },
 } as const
 
 export const VM_GROUP_EXPANDED_ROW_HEIGHT = 24

--- a/@xen-orchestra/web/src/modules/topology/types/topology.types.ts
+++ b/@xen-orchestra/web/src/modules/topology/types/topology.types.ts
@@ -52,7 +52,7 @@ export type TopologyEdge = Edge
 export const NODE_DIMENSIONS = {
   site: { width: 280, height: 120 },
   pool: { width: 260, height: 130 },
-  host: { width: 240, height: 145 },
+  host: { width: 240, height: 165 },
   'vm-group': { width: 200, height: 100 },
 } as const
 

--- a/@xen-orchestra/web/src/modules/topology/types/topology.types.ts
+++ b/@xen-orchestra/web/src/modules/topology/types/topology.types.ts
@@ -1,0 +1,48 @@
+import type { FrontXoHost } from '@/modules/host/remote-resources/use-xo-host-collection.ts'
+import type { FrontXoPool } from '@/modules/pool/remote-resources/use-xo-pool-collection.ts'
+import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
+import type { Node, Edge } from '@vue-flow/core'
+
+export type SiteNodeData = {
+  type: 'site'
+  label: string
+  poolCount: number
+  hostCount: number
+  vmCount: number
+}
+
+export type PoolNodeData = {
+  type: 'pool'
+  pool: FrontXoPool
+  hostCount: number
+  vmCount: number
+  runningVmCount: number
+}
+
+export type HostNodeData = {
+  type: 'host'
+  host: FrontXoHost
+  vmCount: number
+  runningVmCount: number
+  memorySize: number
+  memoryUsage: number
+}
+
+export type VmGroupNodeData = {
+  type: 'vm-group'
+  vms: FrontXoVm[]
+  runningCount: number
+  stoppedCount: number
+}
+
+export type TopologyNodeData = SiteNodeData | PoolNodeData | HostNodeData | VmGroupNodeData
+
+export type TopologyNode = Node<TopologyNodeData>
+export type TopologyEdge = Edge
+
+export const NODE_DIMENSIONS = {
+  site: { width: 280, height: 100 },
+  pool: { width: 260, height: 110 },
+  host: { width: 240, height: 140 },
+  'vm-group': { width: 180, height: 80 },
+} as const

--- a/@xen-orchestra/web/src/pages/(site)/topology.vue
+++ b/@xen-orchestra/web/src/pages/(site)/topology.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="topology-page">
+    <VtsStateHero v-if="!isReady" format="page" type="busy" size="large" />
+    <TopologyCanvas v-else :nodes="nodes" :edges="edges" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import TopologyCanvas from '@/modules/topology/components/TopologyCanvas.vue'
+import { useTopologyGraph } from '@/modules/topology/composables/use-topology-graph.ts'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
+
+const { nodes, edges, isReady } = useTopologyGraph()
+</script>
+
+<style lang="postcss" scoped>
+.topology-page {
+  height: calc(100vh - 10rem);
+  width: 100%;
+}
+</style>

--- a/@xen-orchestra/web/src/pages/(site)/topology.vue
+++ b/@xen-orchestra/web/src/pages/(site)/topology.vue
@@ -8,9 +8,17 @@
 <script lang="ts" setup>
 import TopologyCanvas from '@/modules/topology/components/TopologyCanvas.vue'
 import { useTopologyGraph } from '@/modules/topology/composables/use-topology-graph.ts'
+import {
+  TOPOLOGY_TOGGLE_EXPAND,
+  TOPOLOGY_EXPANDED_NODES,
+} from '@/modules/topology/composables/use-topology-interaction.ts'
 import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
+import { provide } from 'vue'
 
-const { nodes, edges, isReady } = useTopologyGraph()
+const { nodes, edges, isReady, toggleExpand, expandedNodes } = useTopologyGraph()
+
+provide(TOPOLOGY_TOGGLE_EXPAND, toggleExpand)
+provide(TOPOLOGY_EXPANDED_NODES, expandedNodes)
 </script>
 
 <style lang="postcss" scoped>

--- a/@xen-orchestra/web/src/pages/(site)/topology/infrastructure.vue
+++ b/@xen-orchestra/web/src/pages/(site)/topology/infrastructure.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="topology-page">
+    <VtsStateHero v-if="!isReady" format="page" type="busy" size="large" />
+    <TopologyCanvas v-else :nodes="nodes" :edges="edges" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import TopologyCanvas from '@/modules/topology/components/TopologyCanvas.vue'
+import { useTopologyGraph } from '@/modules/topology/composables/use-topology-graph.ts'
+import {
+  TOPOLOGY_TOGGLE_EXPAND,
+  TOPOLOGY_EXPANDED_NODES,
+  TOPOLOGY_DIRECTION,
+} from '@/modules/topology/composables/use-topology-interaction.ts'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
+import { provide } from 'vue'
+
+const { nodes, edges, isReady, toggleExpand, expandedNodes, direction } = useTopologyGraph()
+
+provide(TOPOLOGY_TOGGLE_EXPAND, toggleExpand)
+provide(TOPOLOGY_EXPANDED_NODES, expandedNodes)
+provide(TOPOLOGY_DIRECTION, direction)
+</script>
+
+<style scoped lang="postcss">
+.topology-page {
+  height: calc(100vh - 10rem);
+  width: 100%;
+}
+</style>

--- a/@xen-orchestra/web/src/pages/(site)/topology/networks.vue
+++ b/@xen-orchestra/web/src/pages/(site)/topology/networks.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="topology-page">
+    <VtsStateHero v-if="!isReady" format="page" type="busy" size="large" />
+    <TopologyCanvas v-else :nodes="nodes" :edges="edges" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import TopologyCanvas from '@/modules/topology/components/TopologyCanvas.vue'
+import {
+  TOPOLOGY_DIRECTION,
+  TOPOLOGY_EXPANDED_NODES,
+  TOPOLOGY_TOGGLE_EXPAND,
+} from '@/modules/topology/composables/use-topology-interaction.ts'
+import { useTopologyNetworkGraph } from '@/modules/topology/composables/use-topology-network-graph.ts'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
+import { provide } from 'vue'
+
+const { nodes, edges, isReady, toggleExpand, expandedNodes, direction } = useTopologyNetworkGraph()
+
+provide(TOPOLOGY_TOGGLE_EXPAND, toggleExpand)
+provide(TOPOLOGY_EXPANDED_NODES, expandedNodes)
+provide(TOPOLOGY_DIRECTION, direction)
+</script>
+
+<style scoped lang="postcss">
+.topology-page {
+  height: calc(100vh - 10rem);
+  width: 100%;
+}
+</style>

--- a/@xen-orchestra/web/src/pages/(site)/topology/storage.vue
+++ b/@xen-orchestra/web/src/pages/(site)/topology/storage.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="topology-page">
+    <VtsStateHero v-if="!isReady" format="page" type="busy" size="large" />
+    <TopologyCanvas v-else :nodes="nodes" :edges="edges" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import TopologyCanvas from '@/modules/topology/components/TopologyCanvas.vue'
+import {
+  TOPOLOGY_DIRECTION,
+  TOPOLOGY_EXPANDED_NODES,
+  TOPOLOGY_TOGGLE_EXPAND,
+} from '@/modules/topology/composables/use-topology-interaction.ts'
+import { useTopologyStorageGraph } from '@/modules/topology/composables/use-topology-storage-graph.ts'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
+import { provide } from 'vue'
+
+const { nodes, edges, isReady, toggleExpand, expandedNodes, direction } = useTopologyStorageGraph()
+
+provide(TOPOLOGY_TOGGLE_EXPAND, toggleExpand)
+provide(TOPOLOGY_EXPANDED_NODES, expandedNodes)
+provide(TOPOLOGY_DIRECTION, direction)
+</script>
+
+<style scoped lang="postcss">
+.topology-page {
+  height: calc(100vh - 10rem);
+  width: 100%;
+}
+</style>

--- a/@xen-orchestra/web/typed-router.d.ts
+++ b/@xen-orchestra/web/typed-router.d.ts
@@ -24,6 +24,7 @@ declare module 'vue-router/auto-routes' {
     '/(site)/hosts': RouteRecordInfo<'/(site)/hosts', '/hosts', Record<never, never>, Record<never, never>>,
     '/(site)/pools': RouteRecordInfo<'/(site)/pools', '/pools', Record<never, never>, Record<never, never>>,
     '/(site)/tasks': RouteRecordInfo<'/(site)/tasks', '/tasks', Record<never, never>, Record<never, never>>,
+    '/(site)/topology': RouteRecordInfo<'/(site)/topology', '/topology', Record<never, never>, Record<never, never>>,
     '/(site)/vms': RouteRecordInfo<'/(site)/vms', '/vms', Record<never, never>, Record<never, never>>,
     '/[...path]': RouteRecordInfo<'/[...path]', '/:path(.*)', { path: ParamValue<true> }, { path: ParamValue<false> }>,
     '/backup/[id]': RouteRecordInfo<'/backup/[id]', '/backup/:id', { id: ParamValue<true> }, { id: ParamValue<false> }>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1906,6 +1906,18 @@
   resolved "https://registry.yarnpkg.com/@csstools/postcss-global-data/-/postcss-global-data-3.1.0.tgz#06b33f28b7cac6ad112deeef12b9f05c0a085497"
   integrity sha512-qfS0bUxBukuyxEyxTTZG+px2xwAQPf7Qk6B7lFdjWnovb/O6h0t3sxrVY81nJLh7z0KvEMhjxTURNtEmOrADpQ==
 
+"@dagrejs/dagre@^1.1.4":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@dagrejs/dagre/-/dagre-1.1.8.tgz#fcbee59344c7b4f48b711ba30783543b70029310"
+  integrity sha512-5SEDlndt4W/LaVzPYJW+bSmSEZc9EzTf8rJ20WCKvjS5EAZAN0b+x0Yww7VMT4R3Wootkg+X9bUfUxazYw6Blw==
+  dependencies:
+    "@dagrejs/graphlib" "2.2.4"
+
+"@dagrejs/graphlib@2.2.4":
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/@dagrejs/graphlib/-/graphlib-2.2.4.tgz#d77bfa9ff49e2307c0c6e6b8b26b5dd3c05816c4"
+  integrity sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==
+
 "@emnapi/core@^1.4.3":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.8.1.tgz#fd9efe721a616288345ffee17a1f26ac5dd01349"
@@ -4734,6 +4746,11 @@
   dependencies:
     uuid "*"
 
+"@types/web-bluetooth@^0.0.20":
+  version "0.0.20"
+  resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz#f066abfcd1cbe66267cdbbf0de010d8a41b41597"
+  integrity sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==
+
 "@types/web-bluetooth@^0.0.21":
   version "0.0.21"
   resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz#525433c784aed9b457aaa0ee3d92aeb71f346b63"
@@ -5158,6 +5175,22 @@
     path-browserify "^1.0.1"
     vscode-uri "^3.0.8"
 
+"@vue-flow/controls@^1.1.0":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@vue-flow/controls/-/controls-1.1.3.tgz#40866b553101fbef22d2b9a043965ed76fca4b2c"
+  integrity sha512-XCf+G+jCvaWURdFlZmOjifZGw3XMhN5hHlfMGkWh9xot+9nH9gdTZtn+ldIJKtarg3B21iyHU8JjKDhYcB6JMw==
+
+"@vue-flow/core@^1.41.0":
+  version "1.48.2"
+  resolved "https://registry.yarnpkg.com/@vue-flow/core/-/core-1.48.2.tgz#cef8641b17f6220c257d4208bdb2082cee882225"
+  integrity sha512-raxhgKWE+G/mcEvXJjGFUDYW9rAI3GOtiHR3ZkNpwBWuIaCC1EYiBmKGwJOoNzVFgwO7COgErnK7i08i287AFA==
+  dependencies:
+    "@vueuse/core" "^10.5.0"
+    d3-drag "^3.0.0"
+    d3-interpolate "^3.0.1"
+    d3-selection "^3.0.0"
+    d3-zoom "^3.0.0"
+
 "@vue-macros/common@^1.16.1":
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/@vue-macros/common/-/common-1.16.1.tgz#dac7ebc57ded4d6fb19d7f9a83d2973971d9fa65"
@@ -5335,6 +5368,16 @@
     "@vueuse/metadata" "13.9.0"
     "@vueuse/shared" "13.9.0"
 
+"@vueuse/core@^10.5.0":
+  version "10.11.1"
+  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-10.11.1.tgz#15d2c0b6448d2212235b23a7ba29c27173e0c2c6"
+  integrity sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==
+  dependencies:
+    "@types/web-bluetooth" "^0.0.20"
+    "@vueuse/metadata" "10.11.1"
+    "@vueuse/shared" "10.11.1"
+    vue-demi ">=0.14.8"
+
 "@vueuse/integrations@^13.0.0":
   version "13.9.0"
   resolved "https://registry.yarnpkg.com/@vueuse/integrations/-/integrations-13.9.0.tgz#1bd1d77093a327321cca00e2bbf5da7b18aa6b43"
@@ -5350,10 +5393,22 @@
   dependencies:
     "@vueuse/shared" "13.9.0"
 
+"@vueuse/metadata@10.11.1":
+  version "10.11.1"
+  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-10.11.1.tgz#209db7bb5915aa172a87510b6de2ca01cadbd2a7"
+  integrity sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==
+
 "@vueuse/metadata@13.9.0":
   version "13.9.0"
   resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-13.9.0.tgz#57c738d99661c33347080c0bc4cd11160e0d0881"
   integrity sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg==
+
+"@vueuse/shared@10.11.1":
+  version "10.11.1"
+  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-10.11.1.tgz#62b84e3118ae6e1f3ff38f4fbe71b0c5d0f10938"
+  integrity sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==
+  dependencies:
+    vue-demi ">=0.14.8"
 
 "@vueuse/shared@13.9.0", "@vueuse/shared@^13.0.0":
   version "13.9.0"
@@ -8154,6 +8209,11 @@ d3-color@1:
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
   integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
 
+"d3-color@1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
 d3-contour@1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-1.3.2.tgz#652aacd500d2264cb3423cee10db69f6f59bead3"
@@ -8166,6 +8226,11 @@ d3-dispatch@1:
   resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.6.tgz#00d37bcee4dd8cd97729dd893a0ac29caaba5d58"
   integrity sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==
 
+"d3-dispatch@1 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
+  integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
+
 d3-drag@1:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-1.2.5.tgz#2537f451acd39d31406677b7dc77c82f7d988f70"
@@ -8173,6 +8238,14 @@ d3-drag@1:
   dependencies:
     d3-dispatch "1"
     d3-selection "1"
+
+"d3-drag@2 - 3", d3-drag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-3.0.0.tgz#994aae9cd23c719f53b5e10e3a0a6108c69607ba"
+  integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-selection "3"
 
 d3-dsv@1:
   version "1.2.0"
@@ -8187,6 +8260,11 @@ d3-ease@1:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.7.tgz#9a834890ef8b8ae8c558b2fe55bd57f5993b85e2"
   integrity sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==
+
+"d3-ease@1 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
+  integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
 
 d3-fetch@1:
   version "1.2.0"
@@ -8228,6 +8306,13 @@ d3-interpolate@1:
   integrity sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==
   dependencies:
     d3-color "1"
+
+"d3-interpolate@1 - 3", d3-interpolate@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
 
 d3-path@1:
   version "1.0.9"
@@ -8273,6 +8358,11 @@ d3-selection@1, d3-selection@^1.1.0:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.2.tgz#dcaa49522c0dbf32d6c1858afc26b6094555bc5c"
   integrity sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==
+
+"d3-selection@2 - 3", d3-selection@3, d3-selection@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
+  integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
 
 d3-shape@1:
   version "1.3.7"
@@ -8326,6 +8416,11 @@ d3-timer@1:
   resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.10.tgz#dfe76b8a91748831b13b6d9c793ffbd508dd9de5"
   integrity sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==
 
+"d3-timer@1 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
+
 d3-transition@1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.3.2.tgz#a98ef2151be8d8600543434c1ca80140ae23b398"
@@ -8337,6 +8432,17 @@ d3-transition@1:
     d3-interpolate "1"
     d3-selection "^1.1.0"
     d3-timer "1"
+
+"d3-transition@2 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-3.0.1.tgz#6869fdde1448868077fdd5989200cb61b2a1645f"
+  integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
+  dependencies:
+    d3-color "1 - 3"
+    d3-dispatch "1 - 3"
+    d3-ease "1 - 3"
+    d3-interpolate "1 - 3"
+    d3-timer "1 - 3"
 
 d3-voronoi@1:
   version "1.1.4"
@@ -8353,6 +8459,17 @@ d3-zoom@1:
     d3-interpolate "1"
     d3-selection "1"
     d3-transition "1"
+
+d3-zoom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-3.0.0.tgz#d13f4165c73217ffeaa54295cd6969b3e7aee8f3"
+  integrity sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "2 - 3"
+    d3-transition "2 - 3"
 
 d3@^5.0.0:
   version "5.16.0"
@@ -18261,7 +18378,7 @@ string-length@^6.0.0:
   dependencies:
     strip-ansi "^7.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -18278,15 +18395,6 @@ string-width@^1.0.1, string-width@^1.0.2:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -18394,7 +18502,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -18421,13 +18529,6 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.2"
@@ -19829,7 +19930,7 @@ vscode-uri@^3.0.8:
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.1.0.tgz#dd09ec5a66a38b5c3fffc774015713496d14e09c"
   integrity sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==
 
-vue-demi@>=0.13.0:
+vue-demi@>=0.13.0, vue-demi@>=0.14.8:
   version "0.14.10"
   resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.10.tgz#afc78de3d6f9e11bf78c55e8510ee12814522f04"
   integrity sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==
@@ -20176,7 +20277,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -20197,15 +20298,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Summary

> **Draft / Prototype** — This is an experimental feature exploring a topology/map view for XO 6. It is not production-ready and is shared for visibility, feedback, and discussion. Not intended for merge as-is.

This PR adds a new **Topology** page to XO 6 that visualizes the infrastructure as an interactive node graph using [Vue Flow](https://vueflow.dev/). It provides three complementary views:

- **Infrastructure** — Site → Pools → Hosts → VMs (top-to-bottom)
- **Networks** — Site → Pools → Networks → VMs (left-to-right)
- **Storage** — Site → Pools → SRs → VMs (left-to-right)

### What it looks like

Each entity is a custom Vue Flow node with contextual data (status indicators, resource bars, running VM counts, badges). Nodes are connected with animated dashed edges and laid out automatically using [dagre](https://github.com/dagrejs/dagre).

## Design choices and rationale

### VM-centric hierarchy for Network and Storage views

The initial approach was host-centric: Network → PIF connections, SR → PBD connections. This spread too wide horizontally and didn't answer the most useful question: **which VMs are on which network/SR?**

The redesigned hierarchy resolves VMs through their actual data-plane connections:
- **Networks**: VIF collection → group VMs by network they're connected to
- **Storage**: VDI collection → VBD collection → resolve which VMs have disks on each SR

Host/PIF/PBD information is still surfaced as compact badges on the Network/SR nodes ("on 3 hosts", "2 PBDs attached").

### Left-to-right layout for Network and Storage

The infrastructure view uses top-to-bottom flow (natural hierarchy: site at top, VMs at bottom). Network and storage views switched to left-to-right because:
- These views have many sibling nodes at the same level (dozens of networks/SRs per pool)
- LR layout uses horizontal space much more efficiently
- Vertical scrolling is more natural than horizontal scrolling

The layout direction is injected via Vue's provide/inject (`TOPOLOGY_DIRECTION`) so all nodes adapt their handle positions and expand button placement automatically.

### Empty group nodes

Large infrastructures can have many networks or SRs with zero VMs attached. Instead of rendering each one as an individual node (which would dominate the view), networks/SRs with 0 VMs are grouped into a single compact "N unused networks/SRs" summary node per pool. This node can be expanded to see the list of names. This keeps the graph focused on what matters.

### Expand/collapse interaction

The graph starts collapsed (Site → Pools only) and progressively reveals detail on click:
- Pool → expands to show Hosts/Networks/SRs
- Host → expands to show VM group
- Network/SR → expands to show VM group
- VM group → expands to show individual VM list with status dots and links

Expanded state is tracked via a reactive `Set<string>` shared through provide/inject. This avoids prop drilling and keeps the interaction logic centralized.

### Zoom-adaptive expand buttons

The `NodeExpandButton` component scales based on the current zoom level (injected via `TOPOLOGY_ZOOM`). At low zoom levels, the buttons grow larger so they remain clickable even when the graph is zoomed out to show the full infrastructure.

### Host CPU stats polling

When a pool is expanded to show hosts, the `useTopologyHostStats` composable starts polling CPU stats for visible hosts only (using the REST API stats endpoint). Polling uses "minutes" granularity (one request per host per 60s) and automatically stops when hosts are collapsed/hidden. The CPU percentage is displayed as a progress bar on the host node alongside RAM usage.

### Dagre auto-layout

All positioning is automatic via dagre. Node dimensions are declared in a central `NODE_DIMENSIONS` map in `topology.types.ts`, with dynamic height adjustments for expanded VM groups and empty groups. This means no manual positioning — adding or removing nodes just works.

## Technical details

### New dependencies
- `@vue-flow/core` — graph rendering engine
- `@vue-flow/minimap` — minimap overlay
- `@vue-flow/controls` — zoom controls
- `@dagrejs/dagre` — automatic graph layout

### File structure
```
modules/topology/
├── components/
│   ├── TopologyCanvas.vue       # Shared canvas (VueFlow + minimap + controls)
│   ├── TopologyHeader.vue       # Tab navigation (Infrastructure/Networks/Storage)
│   ├── TopologyEdge.vue         # Animated dashed edge
│   ├── NodeExpandButton.vue     # Zoom-adaptive expand/collapse button
│   ├── SiteNode.vue             # Root site node
│   ├── PoolNode.vue             # Pool node with link
│   ├── HostNode.vue             # Host with CPU/RAM bars and status halo
│   ├── VmGroupNode.vue          # Grouped VMs with expandable list
│   ├── NetworkNode.vue          # Network with VM count and host badges
│   ├── SrNode.vue               # SR with usage bar and VM count
│   └── EmptyGroupNode.vue       # Compact group for unused networks/SRs
├── composables/
│   ├── use-topology-graph.ts         # Infrastructure graph builder
│   ├── use-topology-network-graph.ts # Network graph builder
│   ├── use-topology-storage-graph.ts # Storage graph builder
│   ├── use-topology-layout.ts        # Dagre layout engine
│   ├── use-topology-interaction.ts   # Injection keys for shared state
│   └── use-topology-host-stats.ts    # CPU polling for visible hosts
└── types/
    └── topology.types.ts              # Node data types and dimensions
```

### Data flow
Each view composable (`use-topology-*-graph.ts`) follows the same pattern:
1. Fetch collections from XO stores (pools, hosts, VMs, networks, VIFs, etc.)
2. Build computed maps grouping entities by parent (e.g., `vmsByNetwork`, `vmsBySr`)
3. Generate flat arrays of typed nodes and edges based on expand state
4. Pass to `useTopologyLayout` → dagre positions all nodes
5. Return positioned nodes/edges to `TopologyCanvas`

## Known limitations / TODO
- i18n: all user-facing text uses raw strings (eslint-disable comment present, keys to be added)
- No deep-linking to specific expanded state
- No filtering or search within the topology
- Performance not tested with very large infrastructures (100+ hosts)
- Host stats polling could be replaced by a WebSocket/subscription approach

## Test plan
- [ ] Infrastructure tab: verify Site → Pool → Host → VM hierarchy renders and expands correctly
- [ ] Networks tab: verify Pool → Network → VM hierarchy, LR layout
- [ ] Storage tab: verify Pool → SR → VM hierarchy with usage bars, LR layout
- [ ] Empty groups: networks/SRs with 0 VMs are grouped, expandable
- [ ] Zoom: scroll to zoom, minimap stays in sync, expand buttons scale
- [ ] Navigation: VM and pool names link to their detail pages
- [ ] Dark mode: all nodes render correctly in both themes
- [ ] No regressions on existing pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)