### PR TITLE
fix(openmetrics): convert latency from µs to seconds instead of ms

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [Dashboard] Fix reactivity of dashboard (PR [#9378](https://github.com/vatesfr/xen-orchestra/pull/9378))
+- [OpenMetrics] Fix latency metrics (`xcp_host_disk_read_latency_seconds`, `xcp_host_disk_write_latency_seconds`, `xcp_vm_disk_read_latency_seconds`, `xcp_vm_disk_write_latency_seconds`) reporting milliseconds instead of seconds (PR [#9550](https://github.com/vatesfr/xen-orchestra/pull/9550))
 
 ### Packages to release
 
@@ -38,5 +39,6 @@
 
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+- xo-server-openmetrics patch
 
 <!--packages-end-->

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.mts
@@ -153,7 +153,7 @@ export const HOST_METRICS: MetricDefinition[] = [
     openMetricName: 'host_disk_throughput_read_bytes',
     type: 'gauge',
     help: 'Host disk read throughput in bytes per second',
-    transformValue: v => v * Math.pow(2, 20), // MB to bytes
+    transformValue: v => v * Math.pow(2, 20), // MiB to bytes
     extractLabels: matches => ({ sr: matches[1]! }),
   },
   {
@@ -161,7 +161,7 @@ export const HOST_METRICS: MetricDefinition[] = [
     openMetricName: 'host_disk_throughput_write_bytes',
     type: 'gauge',
     help: 'Host disk write throughput in bytes per second',
-    transformValue: v => v * Math.pow(2, 20), // MB to bytes
+    transformValue: v => v * Math.pow(2, 20), // MiB to bytes
     extractLabels: matches => ({ sr: matches[1]! }),
   },
 
@@ -171,7 +171,7 @@ export const HOST_METRICS: MetricDefinition[] = [
     openMetricName: 'host_disk_read_latency_seconds',
     type: 'gauge',
     help: 'Host disk read latency in seconds',
-    transformValue: v => v / 1000, // ms to seconds
+    transformValue: v => v / 1e6, // µs to seconds
     extractLabels: matches => ({ sr: matches[1]! }),
   },
   {
@@ -179,7 +179,7 @@ export const HOST_METRICS: MetricDefinition[] = [
     openMetricName: 'host_disk_write_latency_seconds',
     type: 'gauge',
     help: 'Host disk write latency in seconds',
-    transformValue: v => v / 1000, // ms to seconds
+    transformValue: v => v / 1e6, // µs to seconds
     extractLabels: matches => ({ sr: matches[1]! }),
   },
 
@@ -348,7 +348,7 @@ export const VM_METRICS: MetricDefinition[] = [
     openMetricName: 'vm_disk_read_latency_seconds',
     type: 'gauge',
     help: 'VM disk read latency in seconds',
-    transformValue: v => v / 1000, // ms to seconds
+    transformValue: v => v / 1e6, // µs to seconds
     extractLabels: matches => ({ device: `xvd${matches[1]!}` }),
   },
   {
@@ -356,7 +356,7 @@ export const VM_METRICS: MetricDefinition[] = [
     openMetricName: 'vm_disk_write_latency_seconds',
     type: 'gauge',
     help: 'VM disk write latency in seconds',
-    transformValue: v => v / 1000, // ms to seconds
+    transformValue: v => v / 1e6, // µs to seconds
     extractLabels: matches => ({ device: `xvd${matches[1]!}` }),
   },
 

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
@@ -71,12 +71,12 @@ describe('HOST_METRICS', () => {
     assert.equal(throughput.transformValue!(1), Math.pow(2, 20))
   })
 
-  it('should include latency metrics with ms to seconds transformation', () => {
+  it('should include latency metrics with µs to seconds transformation', () => {
     const latency = HOST_METRICS.find(m => m.openMetricName === 'host_disk_read_latency_seconds')
     assert.ok(latency)
     assert.ok(latency.transformValue)
-    // 1000 ms = 1 second
-    assert.equal(latency.transformValue!(1000), 1)
+    // 1000000 µs = 1 second
+    assert.equal(latency.transformValue!(1000000), 1)
   })
 })
 


### PR DESCRIPTION
### Description

Fix latency metrics (`xcp_host_disk_read_latency_seconds`, `xcp_host_disk_write_latency_seconds`, `xcp_vm_disk_read_latency_seconds`, `xcp_vm_disk_write_latency_seconds`) reporting values 1000x too large.

The XAPI RRD raw values for `read_latency` / `write_latency` are in **microseconds (µs)** (confirmed by [xcp-rrdd source code](https://github.com/xapi-project/xcp-rrdd/blob/master/bin/rrdp-iostat/rrdp_iostat.ml) with `~units:"μs"`). The formatter was dividing by `1000` (µs → ms) instead of `1e6` (µs → s), producing millisecond values with a `_seconds` suffix.

Users setting Prometheus alert thresholds based on the `_seconds` suffix would get values **1000x larger** than expected (e.g., `2.638` instead of `0.002638` for a 2.6ms latency).

Fixes https://project.vates.tech/vates-global/browse/XO-2086/

Introduced by 980e4b588 (#9323)

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue (`Fixes XO-2086`)
  - [x] If bug fix, add `Introduced by`
- Changelog
  - [x] If visible by XOA users, add changelog entry
  - [x] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [x] No UI changes


### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
