### PR TITLE
fix(xo-lite/header): Fix menu button on large screen

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [VM/New] Added secureBoot support (PR [#9423](https://github.com/vatesfr/xen-orchestra/pull/9423))
 - [Dashboard] Fix reactivity of dashboard (PR [#9378](https://github.com/vatesfr/xen-orchestra/pull/9378))
+- [Header] Fix menu button on large screen (PR [#9558](https://github.com/vatesfr/xen-orchestra/pull/9558))
 
 ## **0.19.0** (2026-02-26)
 

--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - [VM/New] Added secureBoot support (PR [#9423](https://github.com/vatesfr/xen-orchestra/pull/9423))
 - [Dashboard] Fix reactivity of dashboard (PR [#9378](https://github.com/vatesfr/xen-orchestra/pull/9378))
-- [Header] Fix menu button on large screen (PR [#9558](https://github.com/vatesfr/xen-orchestra/pull/9558))
 
 ## **0.19.0** (2026-02-26)
 

--- a/@xen-orchestra/lite/src/components/AppHeader.vue
+++ b/@xen-orchestra/lite/src/components/AppHeader.vue
@@ -2,7 +2,6 @@
   <header class="app-header">
     <div class="left">
       <UiButtonIcon
-        v-if="!uiStore.isLarge"
         ref="navigationTrigger"
         :class="{ 'menu-to-right': !uiStore.isSmall }"
         accent="brand"


### PR DESCRIPTION
### Description

on large screen, the menu button was hidden.

_Introduced by #9488_ 

Before:

https://github.com/user-attachments/assets/3cc8c1b0-7e19-481e-a4ac-da16b68e7ebc

After:

https://github.com/user-attachments/assets/7f883ff1-3359-46a2-8bb3-b381366546ec

Introduced by #9488 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
