### PR TITLE
feat(fs): make part size configurable for s3

### DIFF
--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -40,6 +40,9 @@ export default class S3Handler extends RemoteHandlerAbstract {
   #dir
   #s3
   #immutable = false
+  #maxPartSize
+  #maxPartNumber
+  #minPartSize
 
   constructor(remote, _opts) {
     super(remote, _opts)
@@ -51,7 +54,14 @@ export default class S3Handler extends RemoteHandlerAbstract {
       password,
       protocol,
       region = guessAwsRegion(host),
+      maxPartSize = MAX_PART_SIZE,
+      maxPartNumber = MAX_PART_NUMBER,
+      minPartSize = MIN_PART_SIZE,
     } = parse(remote.url)
+
+    this.#maxPartSize = maxPartSize
+    this.#maxPartNumber = maxPartNumber
+    this.#minPartSize = minPartSize
 
     this.#s3 = new S3Client({
       apiVersion: '2006-03-01',
@@ -122,12 +132,12 @@ export default class S3Handler extends RemoteHandlerAbstract {
           new UploadPartCopyCommand({
             ...multipartParams,
             CopySource,
-            CopySourceRange: `bytes=${start}-${Math.min(start + MAX_PART_SIZE, size) - 1}`,
+            CopySourceRange: `bytes=${start}-${Math.min(start + this.#maxPartSize, size) - 1}`,
             PartNumber: partNumber,
           })
         )
         parts.push({ ETag: upload.CopyPartResult.ETag, PartNumber: partNumber })
-        start += MAX_PART_SIZE
+        start += this.#maxPartSize
       }
       await this.#s3.send(
         new CompleteMultipartUploadCommand({
@@ -203,14 +213,17 @@ export default class S3Handler extends RemoteHandlerAbstract {
     let partSize
     if (maxStreamLength === undefined) {
       warn(`Writing ${path} to a S3 remote without a max size set will cut it to 50GB`, { path })
-      partSize = MIN_PART_SIZE // min size for S3
+      partSize = this.#minPartSize // min size for S3
     } else {
-      partSize = Math.min(Math.max(Math.ceil(maxStreamLength / MAX_PART_NUMBER), MIN_PART_SIZE), MAX_PART_SIZE)
+      partSize = Math.min(
+        Math.max(Math.ceil(maxStreamLength / this.#maxPartNumber), this.#minPartSize),
+        this.#maxPartSize
+      )
     }
 
     // ensure we don't try to upload a stream to big for this partSize
     let readCounter = 0
-    const MAX_SIZE = MAX_PART_NUMBER * partSize
+    const MAX_SIZE = this.#maxPartNumber * partSize
     const streamCutter = new Transform({
       transform(chunk, encoding, callback) {
         readCounter += chunk.length

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,8 +11,9 @@
 
 > Users must be able to say: "Nice enhancement, I'm eager to test it"
 
+- [S3] add configuration for max/minPartSize and maxPartNumber in the API (PR [#9561](https://github.com/vatesfr/xen-orchestra/pull/9561))
+
 ### Bug fixes
-- [S3] add configuration for max/minPartSize and maxPartNumber in the API (PR [#9535](https://github.com/vatesfr/xen-orchestra/pull/9535))
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: "Nice enhancement, I'm eager to test it"
 
 ### Bug fixes
+- [S3] add configuration for max/minPartSize and maxPartNumber in the API (PR [#9535](https://github.com/vatesfr/xen-orchestra/pull/9535))
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
@@ -35,6 +36,7 @@
 
 - @vates/generator-toolbox patch
 - @xen-orchestra/disk-transform patch
+- @xen-orchestra/fs minor
 - xo-server minor
 
 <!--packages-end-->


### PR DESCRIPTION
add the &minPartSize=124&maxPartSize=345&maxPartNumber=34654 to your remote url

from  https://xcp-ng.org/forum/topic/10587/s3-backup-maximum-number-of-parts/
### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
