### PR TITLE
Style(xo6): update color for status paused VM icon

### DIFF
--- a/@xen-orchestra/web-core/lib/icons/status-icons.ts
+++ b/@xen-orchestra/web-core/lib/icons/status-icons.ts
@@ -1,7 +1,7 @@
 import { defineIconPack, type IconSingleConfig } from '@core/packages/icon'
 import {
-  faSquare as checkboxEmpty,
   faCircle as circleEmpty,
+  faSquare as checkboxEmpty,
   type IconDefinition,
 } from '@fortawesome/free-regular-svg-icons'
 import {
@@ -51,11 +51,11 @@ export const statusIcons = defineIconPack({
   'paused-circle': [
     {
       icon: faCircle,
-      color: 'var(--color-brand-item-base)',
+      color: 'var(--color-info-item-base)',
     },
     {
       icon: faPause,
-      color: 'var(--color-brand-txt-item)',
+      color: 'var(--color-info-txt-item)',
       size: 8,
     },
   ],


### PR DESCRIPTION
### Description

Change color for icon "status paused" VM to avoid readability issues with custom themes

**Screenshots :** 

With Monokai theme : 

<img width="1890" height="656" alt="image" src="https://github.com/user-attachments/assets/5a3cd2db-7dab-4b3f-b91d-445b017035cf" />


With Default theme : 

<img width="1890" height="656" alt="image" src="https://github.com/user-attachments/assets/cc418967-59ca-41ba-a8b1-2c8184cf6438" />



### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
