### PR TITLE
feat(xo6): display VDI supported image formats

### DIFF
--- a/@xen-orchestra/web-core/lib/locales/en.json
+++ b/@xen-orchestra/web-core/lib/locales/en.json
@@ -781,6 +781,7 @@
   "storage": "Storage",
   "storage-configuration": "Storage configuration",
   "storage-format": "Storage format",
+  "supported-image-formats": "Supported image formats",
   "storage-repositories": "Storage repositories",
   "storage-repository": "Storage repository",
   "storage-usage": "Storage usage",

--- a/@xen-orchestra/web-core/lib/locales/fr.json
+++ b/@xen-orchestra/web-core/lib/locales/fr.json
@@ -787,6 +787,7 @@
   "success": "Succès",
   "summary": "Résumé",
   "support": "Support",
+  "supported-image-formats": "Formats d'image supportés",
   "suspend-blocked": "Mise en veille bloquée",
   "suspend-storage-repository": "Espace de stockage en attente",
   "switch-theme": "Changer de thème",

--- a/@xen-orchestra/web/src/modules/sm/remote-resources/use-xo-sm-collection.ts
+++ b/@xen-orchestra/web/src/modules/sm/remote-resources/use-xo-sm-collection.ts
@@ -1,0 +1,54 @@
+import { useWatchCollection } from '@/shared/composables/watch-collection.composable.ts'
+import { useXoCollectionState } from '@/shared/composables/xo-collection-state/use-xo-collection-state.ts'
+import { BASE_URL } from '@/shared/utils/fetch.util.ts'
+import { defineRemoteResource } from '@core/packages/remote-resource/define-remote-resource.ts'
+import type { XoSm } from '@vates/types'
+import { computed } from 'vue'
+
+export type FrontXoSm = Pick<XoSm, (typeof smFields)[number]>
+
+const smFields = ['id', 'SM_type', 'supported_image_formats'] as const satisfies readonly (keyof XoSm)[]
+
+// TODO: remove mock once https://github.com/xapi-project/xen-api/pull/6712 is merged
+const MOCK_SUPPORTED_FORMATS: Record<string, string[]> = {
+  ext: ['vhd', 'qcow2'],
+  nfs: ['vhd', 'qcow2'],
+  smb: ['vhd', 'qcow2'],
+  lvmoiscsi: ['vhd'],
+  lvmohba: ['vhd'],
+  lvm: ['vhd'],
+  iso: [],
+  udev: [],
+}
+
+export const useXoSmCollection = defineRemoteResource({
+  url: `${BASE_URL}/sms?fields=${smFields.join(',')}`,
+  initWatchCollection: () => useWatchCollection({ resource: 'SM', fields: smFields }),
+  initialData: () => [] as FrontXoSm[],
+  state: (sms, context) => {
+    const state = useXoCollectionState(sms, {
+      context,
+      baseName: 'sm',
+    })
+
+    const smBySrType = computed(() => {
+      const map = new Map<string, FrontXoSm>()
+
+      sms.value.forEach(sm => {
+        const formats =
+          sm.supported_image_formats.length > 0
+            ? sm.supported_image_formats
+            : (MOCK_SUPPORTED_FORMATS[sm.SM_type] ?? [])
+
+        map.set(sm.SM_type, { ...sm, supported_image_formats: formats })
+      })
+
+      return map
+    })
+
+    return {
+      ...state,
+      smBySrType,
+    }
+  },
+})

--- a/@xen-orchestra/web/src/modules/storage-repository/components/list/panel/cards/StorageRepositoryInfosCard.vue
+++ b/@xen-orchestra/web/src/modules/storage-repository/components/list/panel/cards/StorageRepositoryInfosCard.vue
@@ -39,6 +39,13 @@
         </template>
       </VtsCardRowKeyValue>
       <VtsCardRowKeyValue>
+        <template #key>{{ t('supported-image-formats') }}</template>
+        <template #value>{{ supportedImageFormats }}</template>
+        <template v-if="supportedImageFormats !== t('unknown')" #addons>
+          <VtsCopyButton :value="supportedImageFormats" />
+        </template>
+      </VtsCardRowKeyValue>
+      <VtsCardRowKeyValue>
         <template #key>{{ t('access-mode') }}</template>
         <template #value>{{ isSrSharedI18nValue }}</template>
         <template #addons>
@@ -63,6 +70,7 @@
 <script lang="ts" setup>
 import { useXoPbdUtils } from '@/modules/pbd/composables/xo-pbd-utils.composable.ts'
 import { useXoPbdCollection } from '@/modules/pbd/remote-resources/use-xo-pbd-collection.ts'
+import { useXoSmCollection } from '@/modules/sm/remote-resources/use-xo-sm-collection'
 import {
   useXoSrCollection,
   type FrontXoSr,
@@ -93,6 +101,13 @@ const { getPbdsByIds } = useXoPbdCollection()
 const { isHighAvailabilitySr } = useXoSrCollection()
 
 const { allPbdsConnectionStatus } = useXoPbdUtils(() => getPbdsByIds(sr.$PBDs))
+
+const { smBySrType } = useXoSmCollection()
+
+const supportedImageFormats = computed(() => {
+  const formats = smBySrType.value.get(sr.SR_type)?.supported_image_formats ?? []
+  return formats.length > 0 ? formats.map(f => f.toUpperCase()).join(', ') : t('unknown')
+})
 
 const isSrSharedI18nValue = computed(() => (sr.shared ? t('shared') : t('local')))
 


### PR DESCRIPTION
### Description

<img width="337" height="303" alt="image" src="https://github.com/user-attachments/assets/a74b85b0-267c-4326-9770-c7197dc7c170" />

Work in progress, waiting for upstream PR

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
