### PR TITLE
feat(xo-server): add DNS-01 challenge support

### DIFF
--- a/@xen-orchestra/mixins/SslCertificate.mjs
+++ b/@xen-orchestra/mixins/SslCertificate.mjs
@@ -27,31 +27,19 @@ async function outputFile(path, content) {
   await fs.writeFile(path, content, { flag: 'wx', mode: 0o400 })
 }
 
-// https://datatracker.ietf.org/doc/html/rfc8555#section-8.4
-export async function dnsChallengeCreate(filePath, authz, keyAuthorization) {
-  const dnsRecord = `_acme-challenge.${authz.identifier.value}`
-  await fs.writeFile(filePath, JSON.stringify({ domain: dnsRecord, value: keyAuthorization }))
-  info('DNS-01 challenge: please create a TXT record', { dnsRecord, challengeFile: filePath })
-}
-
-export async function dnsChallengeRemove(filePath) {
-  try {
-    await fs.unlink(filePath)
-  } catch (error) {
-    if (error.code !== 'ENOENT') {
-      throw error
-    }
-  }
-}
-
 // from https://github.com/publishlab/node-acme-client/blob/master/examples/auto.js
 class SslCertificate {
   #cert
+  #challengeCreateFn
+  #challengeRemoveFn
   #delayBeforeRenewal = 30 * 24 * 60 * 60 * 1000 // 30 days
   #secureContext
   #updateSslCertificatePromise
 
-  constructor(cert, key) {
+  constructor({ challengeCreateFn, challengeRemoveFn }, cert, key) {
+    this.#challengeCreateFn = challengeCreateFn
+    this.#challengeRemoveFn = challengeRemoveFn
+
     this.#set(cert, key)
   }
 
@@ -103,12 +91,6 @@ class SslCertificate {
   async #updateSslCertificate(config) {
     const { cert: certPath, key: keyPath, acmeEmail, acmeDomain, acmeDnsChallengeFile } = config
     try {
-      if (acmeDnsChallengeFile === undefined) {
-        throw new Error(
-          'acmeDnsChallengeFile must be set in the configuration to use automatic certificate management. See the documentation for details.'
-        )
-      }
-
       let { acmeCa = 'letsencrypt/production' } = config
       if (!(acmeCa.startsWith('http:') || acmeCa.startsWith('https:'))) {
         acmeCa = get(acme.directory, acmeCa.split('/'))
@@ -128,12 +110,37 @@ class SslCertificate {
       key = key.toString()
       debug('Successfully generated key and csr')
 
+      let challengeCreateFn, challengeRemoveFn, challengePriority
+      if (acmeDnsChallengeFile !== undefined) {
+        challengePriority = ['dns-01']
+        challengeCreateFn = async (authz, _challenge, keyAuthorization) => {
+          const domain = `_acme-challenge.${authz.identifier.value}`
+          await outputFile(acmeDnsChallengeFile, JSON.stringify({ domain, value: keyAuthorization }))
+          info('DNS challenge file written, create the TXT record then trigger validation', {
+            domain,
+            file: acmeDnsChallengeFile,
+          })
+        }
+        challengeRemoveFn = async () => {
+          try {
+            await fs.unlink(acmeDnsChallengeFile)
+          } catch (error) {
+            if (error.code !== 'ENOENT') {
+              throw error
+            }
+          }
+        }
+      } else {
+        challengePriority = ['http-01']
+        challengeCreateFn = this.#challengeCreateFn
+        challengeRemoveFn = this.#challengeRemoveFn
+      }
+
       /* Certificate */
       const cert = await client.auto({
-        challengeCreateFn: (authz, _challenge, keyAuthorization) =>
-          dnsChallengeCreate(acmeDnsChallengeFile, authz, keyAuthorization),
-        challengePriority: ['dns-01'],
-        challengeRemoveFn: () => dnsChallengeRemove(acmeDnsChallengeFile),
+        challengeCreateFn,
+        challengePriority,
+        challengeRemoveFn,
         csr,
         email: acmeEmail,
         skipChallengeVerification: true,
@@ -157,6 +164,15 @@ class SslCertificate {
 
 export default class SslCertificates {
   #app
+  #challenges = new Map()
+  #challengeHandlers = {
+    challengeCreateFn: (authz, challenge, keyAuthorization) => {
+      this.#challenges.set(challenge.token, keyAuthorization)
+    },
+    challengeRemoveFn: (authz, challenge, keyAuthorization) => {
+      this.#challenges.delete(challenge.token)
+    },
+  }
   #handlers = new Map()
 
   constructor(app, { httpServer }) {
@@ -166,6 +182,14 @@ export default class SslCertificates {
     if (httpServer === undefined) {
       return
     }
+    const prefix = '/.well-known/acme-challenge/'
+    httpServer.on('request', (req, res) => {
+      const { url } = req
+      if (url.startsWith(prefix)) {
+        const token = url.slice(prefix.length)
+        this.#acmeChallengeMiddleware(req, res, token)
+      }
+    })
 
     this.#app = app
 
@@ -192,9 +216,25 @@ export default class SslCertificates {
     let handler = handlers.get(configKey)
     if (handler === undefined) {
       // register the handler for this domain
-      handler = new SslCertificate(initialCert, initialKey)
+      handler = new SslCertificate(this.#challengeHandlers, initialCert, initialKey)
       handlers.set(configKey, handler)
     }
     return handler.getSecureContext(config)
+  }
+
+  // middleware that will serve the http challenge to let's encrypt servers
+  #acmeChallengeMiddleware(req, res, token) {
+    debug('fetching challenge for token ', token)
+    const challenge = this.#challenges.get(token)
+    debug('challenge content is ', challenge)
+    if (challenge === undefined) {
+      res.statusCode = 404
+      res.end()
+      return
+    }
+
+    res.write(challenge)
+    res.end()
+    debug('successfully answered challenge ')
   }
 }

--- a/@xen-orchestra/mixins/SslCertificate.mjs
+++ b/@xen-orchestra/mixins/SslCertificate.mjs
@@ -27,19 +27,31 @@ async function outputFile(path, content) {
   await fs.writeFile(path, content, { flag: 'wx', mode: 0o400 })
 }
 
+// https://datatracker.ietf.org/doc/html/rfc8555#section-8.4
+export async function dnsChallengeCreate(filePath, authz, keyAuthorization) {
+  const dnsRecord = `_acme-challenge.${authz.identifier.value}`
+  await fs.writeFile(filePath, JSON.stringify({ domain: dnsRecord, value: keyAuthorization }))
+  info('DNS-01 challenge: please create a TXT record', { dnsRecord, challengeFile: filePath })
+}
+
+export async function dnsChallengeRemove(filePath) {
+  try {
+    await fs.unlink(filePath)
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error
+    }
+  }
+}
+
 // from https://github.com/publishlab/node-acme-client/blob/master/examples/auto.js
 class SslCertificate {
   #cert
-  #challengeCreateFn
-  #challengeRemoveFn
   #delayBeforeRenewal = 30 * 24 * 60 * 60 * 1000 // 30 days
   #secureContext
   #updateSslCertificatePromise
 
-  constructor({ challengeCreateFn, challengeRemoveFn }, cert, key) {
-    this.#challengeCreateFn = challengeCreateFn
-    this.#challengeRemoveFn = challengeRemoveFn
-
+  constructor(cert, key) {
     this.#set(cert, key)
   }
 
@@ -89,8 +101,14 @@ class SslCertificate {
   }
 
   async #updateSslCertificate(config) {
-    const { cert: certPath, key: keyPath, acmeEmail, acmeDomain } = config
+    const { cert: certPath, key: keyPath, acmeEmail, acmeDomain, acmeDnsChallengeFile } = config
     try {
+      if (acmeDnsChallengeFile === undefined) {
+        throw new Error(
+          'acmeDnsChallengeFile must be set in the configuration to use automatic certificate management. See the documentation for details.'
+        )
+      }
+
       let { acmeCa = 'letsencrypt/production' } = config
       if (!(acmeCa.startsWith('http:') || acmeCa.startsWith('https:'))) {
         acmeCa = get(acme.directory, acmeCa.split('/'))
@@ -112,9 +130,10 @@ class SslCertificate {
 
       /* Certificate */
       const cert = await client.auto({
-        challengeCreateFn: this.#challengeCreateFn,
-        challengePriority: ['http-01'],
-        challengeRemoveFn: this.#challengeRemoveFn,
+        challengeCreateFn: (authz, _challenge, keyAuthorization) =>
+          dnsChallengeCreate(acmeDnsChallengeFile, authz, keyAuthorization),
+        challengePriority: ['dns-01'],
+        challengeRemoveFn: () => dnsChallengeRemove(acmeDnsChallengeFile),
         csr,
         email: acmeEmail,
         skipChallengeVerification: true,
@@ -138,15 +157,6 @@ class SslCertificate {
 
 export default class SslCertificates {
   #app
-  #challenges = new Map()
-  #challengeHandlers = {
-    challengeCreateFn: (authz, challenge, keyAuthorization) => {
-      this.#challenges.set(challenge.token, keyAuthorization)
-    },
-    challengeRemoveFn: (authz, challenge, keyAuthorization) => {
-      this.#challenges.delete(challenge.token)
-    },
-  }
   #handlers = new Map()
 
   constructor(app, { httpServer }) {
@@ -156,14 +166,6 @@ export default class SslCertificates {
     if (httpServer === undefined) {
       return
     }
-    const prefix = '/.well-known/acme-challenge/'
-    httpServer.on('request', (req, res) => {
-      const { url } = req
-      if (url.startsWith(prefix)) {
-        const token = url.slice(prefix.length)
-        this.#acmeChallengeMiddleware(req, res, token)
-      }
-    })
 
     this.#app = app
 
@@ -190,25 +192,9 @@ export default class SslCertificates {
     let handler = handlers.get(configKey)
     if (handler === undefined) {
       // register the handler for this domain
-      handler = new SslCertificate(this.#challengeHandlers, initialCert, initialKey)
+      handler = new SslCertificate(initialCert, initialKey)
       handlers.set(configKey, handler)
     }
     return handler.getSecureContext(config)
-  }
-
-  // middleware that will serve the http challenge to let's encrypt servers
-  #acmeChallengeMiddleware(req, res, token) {
-    debug('fetching challenge for token ', token)
-    const challenge = this.#challenges.get(token)
-    debug('challenge content is ', challenge)
-    if (challenge === undefined) {
-      res.statusCode = 404
-      res.end()
-      return
-    }
-
-    res.write(challenge)
-    res.end()
-    debug('successfully answered challenge ')
   }
 }

--- a/@xen-orchestra/mixins/SslCertificate.mjs
+++ b/@xen-orchestra/mixins/SslCertificate.mjs
@@ -14,8 +14,8 @@ acme.setLogger(message => {
 
 // - create any missing parent directories
 // - replace existing files
-// - secure permissions (read-only for the owner)
-async function outputFile(path, content) {
+// - secure permissions (read-only for the owner by default, pass mode to override for scripts that need to be able to read the file)
+async function outputFile(path, content, mode = 0o400) {
   await fs.mkdir(dirname(path), { recursive: true })
   try {
     await fs.unlink(path)
@@ -24,7 +24,27 @@ async function outputFile(path, content) {
       throw error
     }
   }
-  await fs.writeFile(path, content, { flag: 'wx', mode: 0o400 })
+  await fs.writeFile(path, content, { flag: 'wx', mode })
+}
+
+const DNS_CHALLENGE_POLL_INTERVAL = 10000
+const DNS_CHALLENGE_DEFAULT_TIMEOUT = 30 * 60 * 1000
+
+async function waitForDoneFile(doneFile, timeout) {
+  const deadline = Date.now() + timeout
+  while (Date.now() < deadline) {
+    try {
+      await fs.access(doneFile)
+      return
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        throw error
+      }
+    }
+    await new Promise(resolve => setTimeout(resolve, DNS_CHALLENGE_POLL_INTERVAL))
+  }
+  warn('DNS challenge timed out waiting for done file', { doneFile, timeoutMs: timeout })
+  throw new Error(`DNS challenge validation timed out after ${timeout}ms — done file never appeared: ${doneFile}`)
 }
 
 // from https://github.com/publishlab/node-acme-client/blob/master/examples/auto.js
@@ -112,14 +132,27 @@ class SslCertificate {
 
       let challengeCreateFn, challengeRemoveFn, challengePriority
       if (acmeDnsChallengeFile !== undefined) {
+        const { acmeDnsChallengeTimeout = DNS_CHALLENGE_DEFAULT_TIMEOUT } = config
         challengePriority = ['dns-01']
         challengeCreateFn = async (authz, _challenge, keyAuthorization) => {
           const domain = `_acme-challenge.${authz.identifier.value}`
-          await outputFile(acmeDnsChallengeFile, JSON.stringify({ domain, value: keyAuthorization }))
-          info('DNS challenge file written, create the TXT record then trigger validation', {
+          const doneFile = acmeDnsChallengeFile + '.done'
+          // remove any stale done file from an eventual previous failed attempt
+          try {
+            await fs.unlink(doneFile)
+          } catch (error) {
+            if (error.code !== 'ENOENT') {
+              throw error
+            }
+          }
+          await outputFile(acmeDnsChallengeFile, JSON.stringify({ domain, value: keyAuthorization }), 0o640)
+          info('DNS challenge file written, create the TXT record then create the done file to proceed', {
             domain,
             file: acmeDnsChallengeFile,
+            doneFile,
           })
+          await waitForDoneFile(doneFile, acmeDnsChallengeTimeout)
+          await fs.unlink(doneFile)
         }
         challengeRemoveFn = async () => {
           try {

--- a/@xen-orchestra/mixins/SslCertificate.mjs
+++ b/@xen-orchestra/mixins/SslCertificate.mjs
@@ -53,6 +53,7 @@ class SslCertificate {
   #challengeCreateFn
   #challengeRemoveFn
   #delayBeforeRenewal = 30 * 24 * 60 * 60 * 1000 // 30 days
+  #retryAfter = 0
   #secureContext
   #updateSslCertificatePromise
 
@@ -82,7 +83,7 @@ class SslCertificate {
       return this.#secureContext
     }
 
-    if (this.#updateSslCertificatePromise === undefined) {
+    if (this.#updateSslCertificatePromise === undefined && Date.now() >= this.#retryAfter) {
       // not currently updating certificate
       //
       // ensure we only refresh certificate once at a time
@@ -96,7 +97,12 @@ class SslCertificate {
       return this.#secureContext
     }
 
-    return this.#updateSslCertificatePromise
+    if (this.#updateSslCertificatePromise === undefined) {
+      return undefined
+    }
+
+    const timeout = new Promise(resolve => setTimeout(() => resolve(undefined), 2 * 60 * 1000))
+    return Promise.race([this.#updateSslCertificatePromise, timeout])
   }
 
   async #save(certPath, cert, keyPath, key) {
@@ -189,6 +195,7 @@ class SslCertificate {
       return this.#secureContext
     } catch (error) {
       warn(`couldn't renew ssl certificate`, { acmeDomain, error })
+      this.#retryAfter = Date.now() + 5 * 60 * 1000
     } finally {
       this.#updateSslCertificatePromise = undefined
     }

--- a/@xen-orchestra/mixins/docs/SslCertificate.md
+++ b/@xen-orchestra/mixins/docs/SslCertificate.md
@@ -1,18 +1,21 @@
-> This module provides [Let's Encrypt](https://letsencrypt.org/) integration to `xo-proxy` and `xo-server` using DNS-01 ACME challenges.
+> This module provides [Let's Encrypt](https://letsencrypt.org/) integration to `xo-proxy` and `xo-server`.
 
-When a certificate needs to be issued or renewed, XO writes a JSON file at a configured path containing the DNS record to create:
+Two challenge types are supported: **HTTP-01** (default) and **DNS-01**.
 
-```json
-{ "domain": "_acme-challenge.my.domain.net", "value": "..." }
+## HTTP-01 challenge (default)
+
+First of all, make sure your server is listening on HTTP on port 80 and on HTTPS 443.
+
+In `xo-server`, to avoid HTTP access, enable the redirection to HTTPs:
+
+```toml
+[http]
+redirectToHttps = true
 ```
 
-An `info` log is also emitted indicating the file path. You (or your own automation) are responsible for creating the corresponding `TXT` record in your DNS before Let's Encrypt attempts to verify it. XO deletes the file automatically once verification succeeds.
+Your server must be reachable with the configured domain to the certificate provider (e.g. Let's Encrypt), it usually means publicly reachable.
 
-This approach does not require XO to be publicly reachable on the internet.
-
-## Configuration
-
-Add the following entries to your HTTPS configuration:
+Finally, add the following entries to your HTTPS configuration.
 
 ```toml
 # Must be set to true for this feature
@@ -47,21 +50,38 @@ acmeDomain = 'my.domain.net'
 #
 # It will be notified of any issues.
 acmeEmail = 'admin@my.domain.net'
+```
 
-# Path to a file where XO will write the DNS-01 challenge value.
+## DNS-01 challenge
+
+Use this method when your XO server is **not publicly reachable** on port 80. Validation is done via a DNS TXT record instead.
+
+Add `acmeDnsChallengeFile` to your HTTPS configuration block:
+
+```toml
+autoCert = true
+
+cert = 'path/to/cert.pem'
+key = 'path/to/key.pem'
+
+acmeDomain = 'my.domain.net'
+acmeEmail = 'admin@my.domain.net'
+
+# Path to a file where XO will write the DNS challenge.
 #
-# The path must be writable by the xo-server process.
-# XO will create the file when a certificate needs to be issued or renewed,
-# and delete it once Let's Encrypt verifies the challenge.
-#
-# The file will contain a JSON object with the DNS TXT record to create:
-#   { "domain": "_acme-challenge.my.domain.net", "value": "..." }
-#
-# You are responsible for creating that TXT record before Let's Encrypt
-# verifies it. See docs/dns-challenge-hook.example.sh for a starting point.
+# When set, DNS-01 is used instead of HTTP-01.
+# XO does not need to be publicly reachable on port 80.
 acmeDnsChallengeFile = '/etc/xo-server/dns-challenge.json'
 ```
 
-## Hook script
+When a certificate needs to be issued or renewed, XO will:
 
-You need a process watching `acmeDnsChallengeFile` and creating the DNS TXT record when it appears. An example hook script is provided at [`docs/dns-challenge-hook.example.sh`](dns-challenge-hook.example.sh). Copy and adapt it for your DNS provider.
+1. Write a JSON file at the configured path:
+   ```json
+   { "domain": "_acme-challenge.my.domain.net", "value": "<token>" }
+   ```
+2. Log an `info` message indicating the file path and the domain to configure.
+3. Wait for your script or automation to create the corresponding DNS TXT record.
+4. Delete the file automatically once validation succeeds.
+
+You are responsible for monitoring the file and creating the DNS TXT record. A simple approach is to watch the file with a script and call your DNS provider's API when it appears.

--- a/@xen-orchestra/mixins/docs/SslCertificate.md
+++ b/@xen-orchestra/mixins/docs/SslCertificate.md
@@ -72,7 +72,15 @@ acmeEmail = 'admin@my.domain.net'
 # When set, DNS-01 is used instead of HTTP-01.
 # XO does not need to be publicly reachable on port 80.
 acmeDnsChallengeFile = '/etc/xo-server/dns-challenge.json'
+
+# How long XO will wait for the DNS record to be validated before giving up.
+#
+# Expressed in milliseconds. Default is 1800000 (30 minutes).
+# Increase this value if your DNS provider has slow propagation.
+# acmeDnsChallengeTimeout = 1800000
 ```
+
+### How it works
 
 When a certificate needs to be issued or renewed, XO will:
 
@@ -80,8 +88,43 @@ When a certificate needs to be issued or renewed, XO will:
    ```json
    { "domain": "_acme-challenge.my.domain.net", "value": "<token>" }
    ```
-2. Log an `info` message indicating the file path and the domain to configure.
-3. Wait for your script or automation to create the corresponding DNS TXT record.
-4. Delete the file automatically once validation succeeds.
+2. Log an `info` message with the file path and the name of the done file to create.
+3. **Wait** — XO is now blocked until you signal that the DNS record is ready (see below).
+4. Ask Let's Encrypt to validate the DNS TXT record.
+5. Delete the challenge file automatically once validation succeeds.
 
-You are responsible for monitoring the file and creating the DNS TXT record. A simple approach is to watch the file with a script and call your DNS provider's API when it appears.
+### Your responsibilities
+
+XO cannot create DNS records on your behalf — it has no knowledge of your DNS provider or credentials. You are responsible for:
+
+1. **Watching** `acmeDnsChallengeFile` for changes (e.g. with `inotifywait` or a cron polling script)
+2. **Creating** the DNS TXT record via your provider's API or interface, with the `domain` and `value` from the JSON file
+3. **Waiting** for the record to propagate — this can take anywhere from a few seconds to several hours depending on your DNS provider and TTL settings
+4. **Signalling** XO that the record is ready by creating a done file at `<acmeDnsChallengeFile>.done` (e.g. `/etc/xo-server/dns-challenge.json.done`)
+
+Once XO detects the done file, it deletes it and immediately asks Let's Encrypt to validate.
+
+> **DNS propagation time varies greatly between providers.** Some propagate within seconds, others can take up to 24 hours. Make sure the TXT record is fully propagated before creating the done file, otherwise Let's Encrypt validation will fail.
+
+### Timeout
+
+XO will wait up to 30 minutes by default for the done file to appear. If the timeout is reached, XO logs a warning and aborts the certificate renewal — it will retry on the next restart or incoming HTTPS request.
+
+If your setup requires more time, increase `acmeDnsChallengeTimeout` in your configuration.
+
+### Example automation scripts
+
+Template scripts are available alongside this document:
+
+- **Shell** (Linux/macOS, requires `inotify-tools` and `jq`): [`dns-challenge.example.sh`](./dns-challenge.example.sh)
+- **PowerShell** (Windows): [`dns-challenge.example.ps1`](./dns-challenge.example.ps1)
+
+To use them:
+
+1. Copy the file for your platform and remove the `.example` extension:
+   ```sh
+   cp dns-challenge.example.sh dns-challenge.sh
+   chmod +x dns-challenge.sh
+   ```
+2. Edit the `# TODO` section to call your DNS provider's API.
+3. Run the script before or alongside `xo-server`.

--- a/@xen-orchestra/mixins/docs/SslCertificate.md
+++ b/@xen-orchestra/mixins/docs/SslCertificate.md
@@ -1,17 +1,18 @@
-> This module provides [Let's Encrypt](https://letsencrypt.org/) integration to `xo-proxy` and `xo-server`.
+> This module provides [Let's Encrypt](https://letsencrypt.org/) integration to `xo-proxy` and `xo-server` using DNS-01 ACME challenges.
 
-First of all, make sure your server is listening on HTTP on port 80 and on HTTPS 443.
+When a certificate needs to be issued or renewed, XO writes a JSON file at a configured path containing the DNS record to create:
 
-In `xo-server`, to avoid HTTP access, enable the redirection to HTTPs:
-
-```toml
-[http]
-redirectToHttps = true
+```json
+{ "domain": "_acme-challenge.my.domain.net", "value": "..." }
 ```
 
-Your server must be reachable with the configured domain to the certificate provider (e.g. Let's Encrypt), it usually means publicly reachable.
+An `info` log is also emitted indicating the file path. You (or your own automation) are responsible for creating the corresponding `TXT` record in your DNS before Let's Encrypt attempts to verify it. XO deletes the file automatically once verification succeeds.
 
-Finally, add the following entries to your HTTPS configuration.
+This approach does not require XO to be publicly reachable on the internet.
+
+## Configuration
+
+Add the following entries to your HTTPS configuration:
 
 ```toml
 # Must be set to true for this feature
@@ -26,7 +27,7 @@ key = 'path/to/key.pem'
 #
 # Specifies the URL to the ACME CA's directory.
 #
-# A identifier `provider/directory` can be passed instead of a URL, see the
+# An identifier `provider/directory` can be passed instead of a URL, see the
 # list of supported directories here: https://www.npmjs.com/package/acme-client#directory-urls
 #
 # Note that the application cannot detect that this value has changed.
@@ -46,4 +47,21 @@ acmeDomain = 'my.domain.net'
 #
 # It will be notified of any issues.
 acmeEmail = 'admin@my.domain.net'
+
+# Path to a file where XO will write the DNS-01 challenge value.
+#
+# The path must be writable by the xo-server process.
+# XO will create the file when a certificate needs to be issued or renewed,
+# and delete it once Let's Encrypt verifies the challenge.
+#
+# The file will contain a JSON object with the DNS TXT record to create:
+#   { "domain": "_acme-challenge.my.domain.net", "value": "..." }
+#
+# You are responsible for creating that TXT record before Let's Encrypt
+# verifies it. See docs/dns-challenge-hook.example.sh for a starting point.
+acmeDnsChallengeFile = '/etc/xo-server/dns-challenge.json'
 ```
+
+## Hook script
+
+You need a process watching `acmeDnsChallengeFile` and creating the DNS TXT record when it appears. An example hook script is provided at [`docs/dns-challenge-hook.example.sh`](dns-challenge-hook.example.sh). Copy and adapt it for your DNS provider.

--- a/@xen-orchestra/mixins/docs/dns-challenge.example.ps1
+++ b/@xen-orchestra/mixins/docs/dns-challenge.example.ps1
@@ -1,0 +1,51 @@
+# Example script for DNS-01 challenge automation with xo-server.
+#
+# Usage:
+#   1. Copy this file: Copy-Item dns-challenge.example.ps1 dns-challenge.ps1
+#   2. Edit the "TODO" section below to call your DNS provider's API
+#   3. Run it before or alongside xo-server
+#
+# Requirements: PowerShell 5+
+
+$ChallengeFile = 'C:\xo-server\dns-challenge.json'
+$DoneFile = "$ChallengeFile.done"
+$ChallengeDir = Split-Path $ChallengeFile
+$ChallengeBasename = Split-Path -Leaf $ChallengeFile
+
+# Wait for the challenge file to appear.
+# Uses a polling loop so the script works even if xo-server writes the file
+# before this script's watcher is established.
+while (-not (Test-Path $ChallengeFile)) {
+    $watcher = New-Object System.IO.FileSystemWatcher $ChallengeDir
+    $watcher.Filter = $ChallengeBasename
+    $watcher.EnableRaisingEvents = $true
+    # WaitForChanged returns after the event or after the timeout (ms)
+    $null = $watcher.WaitForChanged('Created,Changed', 2000)
+    $watcher.Dispose()
+}
+
+$challenge = Get-Content $ChallengeFile | ConvertFrom-Json
+$domain = $challenge.domain
+$value = $challenge.value
+
+# TODO: call your DNS provider's API to create the TXT record.
+#
+# The record to create:
+#   Type:  TXT
+#   Name:  $domain  (e.g. _acme-challenge.my.domain.net)
+#   Value: $value   (the ACME key authorization token)
+#
+# Example with a fictional provider:
+#   Invoke-RestMethod -Method Post `
+#     -Headers @{ Authorization = "Bearer YOUR_API_TOKEN" } `
+#     -Body (@{ name = $domain; value = $value } | ConvertTo-Json) `
+#     -Uri "https://api.your-dns-provider.com/v1/txt-records"
+
+Write-Host "TXT record created for $domain — waiting for propagation if needed"
+
+# TODO (optional): sleep here if your DNS provider has slow propagation.
+# Let's Encrypt may fail validation if the record hasn't propagated yet.
+# Start-Sleep -Seconds 60
+
+# Signal xo-server that the DNS record is ready.
+New-Item -ItemType File $DoneFile | Out-Null

--- a/@xen-orchestra/mixins/docs/dns-challenge.example.sh
+++ b/@xen-orchestra/mixins/docs/dns-challenge.example.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Example script for DNS-01 challenge automation with xo-server.
+#
+# Usage:
+#   1. Copy this file: cp dns-challenge.example.sh dns-challenge.sh
+#   2. Make it executable: chmod +x dns-challenge.sh
+#   3. Edit the "TODO" section below to call your DNS provider's API
+#   4. Run it before or alongside xo-server (it handles the case where
+#      xo-server starts before the script)
+#
+# Requirements: inotify-tools, jq
+
+CHALLENGE_FILE=/etc/xo-server/dns-challenge.json
+DONE_FILE="${CHALLENGE_FILE}.done"
+CHALLENGE_DIR="$(dirname "$CHALLENGE_FILE")"
+CHALLENGE_BASENAME="^$(basename "$CHALLENGE_FILE")$"
+
+# Wait for the challenge file to appear.
+# Uses a polling loop so the script works even if xo-server writes the file
+# before this script's watches are established.
+until [ -f "$CHALLENGE_FILE" ]; do
+  inotifywait -t 2 -e create,close_write --include "$CHALLENGE_BASENAME" "$CHALLENGE_DIR" 2>/dev/null || true
+done
+
+DOMAIN=$(jq -r '.domain' "$CHALLENGE_FILE")
+VALUE=$(jq -r '.value' "$CHALLENGE_FILE")
+
+# TODO: call your DNS provider's API to create the TXT record.
+#
+# The record to create:
+#   Type:  TXT
+#   Name:  $DOMAIN  (e.g. _acme-challenge.my.domain.net)
+#   Value: $VALUE   (the ACME key authorization token)
+#
+# Example with a fictional provider:
+#   curl --silent --fail --request POST \
+#     --header "Authorization: Bearer YOUR_API_TOKEN" \
+#     --data "{\"name\":\"${DOMAIN}\",\"value\":\"${VALUE}\"}" \
+#     https://api.your-dns-provider.com/v1/txt-records
+
+echo "TXT record created for ${DOMAIN} — waiting for propagation if needed"
+
+# TODO (optional): sleep here if your DNS provider has slow propagation.
+# Let's Encrypt may fail validation if the record hasn't propagated yet.
+# sleep 60
+
+# Signal xo-server that the DNS record is ready.
+touch "$DONE_FILE"

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@
 - [i18n] Update Chinese (Simplified Han script), Czech, Dutch, German, Persian, Polish, Portuguese, Portuguese (Brasil), Slovak, Spanish and Swedish translations (PR [#9729](https://github.com/vatesfr/xen-orchestra/pull/9729))
 - [REST API] Add `POST rest/v0/plugins/sdn-controller/networks/:id/actions/add_traffic_rule` and `POST rest/v0/plugins/sdn-controller/networks/:id/actions/delete_traffic_rule` endpoints ([#9418](https://github.com/vatesfr/xen-orchestra/pull/9418))
 - [Pool/Network] Add Network deletion (PR [#9714](https://github.com/vatesfr/xen-orchestra/pull/9714))
+- [DNS] add Let's Encrypt DNS-01 challenge support (PR [#9592](https://github.com/vatesfr/xen-orchestra/pull/9592))
 
 ### Bug fixes
 
@@ -54,6 +55,7 @@
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+- @xen-orchestra/mixins minor
 - xo-server minor
 - xo-server-sdn-controller minor
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -52,10 +52,10 @@
 - @vates/types minor
 - @xen-orchestra/acl major
 - @xen-orchestra/backups patch
+- @xen-orchestra/mixins minor
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
-- @xen-orchestra/mixins minor
 - xo-server minor
 - xo-server-sdn-controller minor
 


### PR DESCRIPTION
### Description

This is an integration test, I couldn't find any way to test this E2E without a real domain and DNS provider.
To test this PR you'll need docker, inotify-tools, jq, and curl installed.

* Add a temporary config in packages/xo-server/config.toml after [http.listen.0] :
```
  [http.listen.1]
  autoCert = true
  acmeCa = 'https://localhost:14000/dir'
  acmeDomain = 'ton.domaine.test'
  acmeDnsChallengeFile = '/tmp/dns-challenge.json'
  cert = '/tmp/xo-cert.pem'
  key = '/tmp/xo-key.pem'
  port = 9000
```

* Create a `pebble` subfolder at @xen-orchestra/mixins/docs and add 2 files :
- docker-compose.yml containing 
```
version: '3'
services:
  pebble:
    image: ghcr.io/letsencrypt/pebble:latest
    command: -config /test/config/pebble-config.json -strict -dnsserver 10.30.50.3:8053
    ports:
      - 14000:14000 # HTTPS ACME API
      - 15000:15000 # HTTPS Management API
    networks:
      acmenet:
        ipv4_address: 10.30.50.2

  challtestsrv:
    image: ghcr.io/letsencrypt/pebble-challtestsrv:latest
    command: -defaultIPv6 "" -defaultIPv4 10.30.50.3
    ports:
      - 8055:8055 # HTTP Management API
    networks:
      acmenet:
        ipv4_address: 10.30.50.3

networks:
  acmenet:
    driver: bridge
    ipam:
      driver: default
      config:
        - subnet: 10.30.50.0/24
```

- and the test script dns-challenge-test.sh :
```
#!/bin/sh
# Test script for DNS-01 challenge with Pebble + challtestsrv.
#
# Replaces the real DNS provider API call with challtestsrv's /set-txt endpoint.
#
# Usage:
#   1. Start Pebble: docker-compose up
#   2. Configure xo-server with:
#        acmeCa = 'https://localhost:14000/dir'
#        acmeDnsChallengeFile = '/tmp/dns-challenge.json'
#   3. Run this script and leave it running in the background
#
# Requirements: inotify-tools, jq, curl

CHALLENGE_FILE=/tmp/dns-challenge.json
DONE_FILE="${CHALLENGE_FILE}.done"
CHALLTESTSRV=http://localhost:8055
CHALLENGE_BASENAME="^$(basename "$CHALLENGE_FILE")$"
CHALLENGE_DIR="$(dirname "$CHALLENGE_FILE")"

# ACME may retry the challenge multiple times; loop to handle each attempt
while true; do
  # Wait for the challenge file to appear.
  # Use a poll loop with a short inotifywait timeout to avoid missing events
  # that occur before watches are established (race condition at startup).
  until [ -f "$CHALLENGE_FILE" ]; do
    inotifywait -t 2 -e create,close_write --include "$CHALLENGE_BASENAME" "$CHALLENGE_DIR" 2>/dev/null || true
  done

  DOMAIN=$(jq -r '.domain' "$CHALLENGE_FILE")
  VALUE=$(jq -r '.value' "$CHALLENGE_FILE")

  # Register the TXT record in challtestsrv (trailing dot required)
  curl --silent --fail --request POST \
    --data "{\"host\":\"${DOMAIN}.\", \"value\":\"${VALUE}\"}" \
    "${CHALLTESTSRV}/set-txt"

  echo "TXT record set for ${DOMAIN}"

  # Signal XO that the record is ready
  touch "$DONE_FILE"

  # Wait for XO to delete the challenge file (after validation completes or fails)
  until [ ! -f "$CHALLENGE_FILE" ]; do
    inotifywait -t 2 -e delete --include "$CHALLENGE_BASENAME" "$CHALLENGE_DIR" 2>/dev/null || true
  done

  # Cleanup: remove the TXT record
  curl --silent --request POST \
    --data "{\"host\":\"${DOMAIN}.\"}" \
    "${CHALLTESTSRV}/clear-txt"

  echo "TXT record cleared for ${DOMAIN}"
done
```

* Start Pebble (a fake local ACME server) from @xen-orchestra/mixins/docs/pebble/ :

```
docker-compose -f docker-compose.yml up
```
Wait for:
  ACME directory available at: https://0.0.0.0:14000/dir

* From packages/xo-server/:
```
  sudo rm -f /tmp/xo-cert.pem /tmp/xo-key.pem /tmp/dns-challenge.json
  /tmp/dns-challenge.json.done
  sudo env NODE_TLS_REJECT_UNAUTHORIZED=0 yarn start
```
  Wait for:
  Web server listening on https://[::]:9000

* From the root of the repo:
```
  sudo @xen-orchestra/mixins/docs/pebble/dns-challenge-test.sh
```
The script handles startup race conditions on its own — no need to wait for a specific message before moving on.

* Trigger the challenge
```
  curl -k https://ton.domaine.test:9000 --resolve ton.domaine.test:9000:127.0.0.1
  --max-time 120
```

**Expected output**

- script :
```
  TXT record set for _acme-challenge.ton.domaine.test
  TXT record cleared for _acme-challenge.ton.domaine.test
```

- xo-server logs :
```
DNS challenge file written, create the TXT record then create the done file to proceed
  new certificate generated { cert: '/tmp/xo-cert.pem', key: '/tmp/xo-key.pem' }
```

- Pebble :
```
  authz ... set VALID by completed challenge ...
  Issued certificate serial ... for order ...
```

- curl :
```
  Found. Redirecting to /signin
```

 * Cleanup

  Revert the [http.listen.1] block added to config.toml, then:
```
  sudo rm -f /tmp/xo-cert.pem /tmp/xo-key.pem /tmp/dns-challenge.json
  /tmp/dns-challenge.json.done
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
4. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   5. The _junior reviewer_ assigns the _senior reviewer_.
   6. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
