### PR TITLE
fix(fs/s3): add check before using DeleteObjectsCommand

### DIFF
--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -395,6 +395,7 @@ export default class S3Handler extends RemoteHandlerAbstract {
   // @todo : use parallel processing for unlink
   async _rmtree(path) {
     let NextContinuationToken
+    let supportsDeleteObjects = true
     const Prefix = this.#makePrefix(path)
     do {
       const result = await this.#s3.send(
@@ -404,24 +405,39 @@ export default class S3Handler extends RemoteHandlerAbstract {
           ContinuationToken: NextContinuationToken,
         })
       )
-
       NextContinuationToken = result.IsTruncated ? result.NextContinuationToken : undefined
-      try {
-        await this.#s3.send(
-          new DeleteObjectsCommand({
-            Bucket: this.#bucket,
-            Delete: {
-              Objects: result.Contents ?? [],
+      if (supportsDeleteObjects) {
+        try {
+          await this.#s3.send(
+            new DeleteObjectsCommand({
+              Bucket: this.#bucket,
+              Delete: {
+                Objects: result.Contents ?? [],
+              },
+            })
+          )
+        } catch (error) {
+          warn('Unsupported DeleteObjects, fallback to DeleteObject.', { error, $response: error.$response ?? '' })
+          supportsDeleteObjects = false
+          await asyncEach(
+            result.Contents ?? [],
+            async ({ Key }) => {
+              await this.#s3.send(
+                new DeleteObjectCommand({
+                  Bucket: this.#bucket,
+                  Key,
+                })
+              )
             },
-          })
-        )
-      } catch (error) {
-        warn('Unsupported DeleteObjects, fallback to DeleteObject.', { error, $response: error.$response ?? '' })
+            {
+              concurrency: 16,
+            }
+          )
+        }
+      } else {
         await asyncEach(
           result.Contents ?? [],
           async ({ Key }) => {
-            // _unlink will add the prefix, but Key contains everything
-            // also we don't need to check if we delete a directory, since the list only return files
             await this.#s3.send(
               new DeleteObjectCommand({
                 Bucket: this.#bucket,

--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -391,6 +391,25 @@ export default class S3Handler extends RemoteHandlerAbstract {
     // nothing to do, directories do not exist, they are part of the files' path
   }
 
+  async #legacyBatchDeleteCommand(result) {
+    await asyncEach(
+      result.Contents ?? [],
+      async ({ Key }) => {
+        // _unlink will add the prefix, but Key contains everything
+        // also we don't need to check if we delete a directory, since the list only return files
+        await this.#s3.send(
+          new DeleteObjectCommand({
+            Bucket: this.#bucket,
+            Key,
+          })
+        )
+      },
+      {
+        concurrency: 16,
+      }
+    )
+  }
+
   // reimplement _rmtree to handle efficiently path with more than 1000 entries in trees
   // @todo : use parallel processing for unlink
   async _rmtree(path) {
@@ -419,40 +438,10 @@ export default class S3Handler extends RemoteHandlerAbstract {
         } catch (error) {
           warn('Unsupported DeleteObjects, fallback to DeleteObject.', { error, $response: error.$response ?? '' })
           supportsDeleteObjects = false
-          await asyncEach(
-            result.Contents ?? [],
-            async ({ Key }) => {
-              // _unlink will add the prefix, but Key contains everything
-              // also we don't need to check if we delete a directory, since the list only return files
-              await this.#s3.send(
-                new DeleteObjectCommand({
-                  Bucket: this.#bucket,
-                  Key,
-                })
-              )
-            },
-            {
-              concurrency: 16,
-            }
-          )
+          await this.#legacyBatchDeleteCommand(result)
         }
       } else {
-        await asyncEach(
-          result.Contents ?? [],
-          async ({ Key }) => {
-            // _unlink will add the prefix, but Key contains everything
-            // also we don't need to check if we delete a directory, since the list only return files
-            await this.#s3.send(
-              new DeleteObjectCommand({
-                Bucket: this.#bucket,
-                Key,
-              })
-            )
-          },
-          {
-            concurrency: 16,
-          }
-        )
+        await this.#legacyBatchDeleteCommand(result)
       }
     } while (NextContinuationToken !== undefined)
   }

--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -422,6 +422,8 @@ export default class S3Handler extends RemoteHandlerAbstract {
           await asyncEach(
             result.Contents ?? [],
             async ({ Key }) => {
+              // _unlink will add the prefix, but Key contains everything
+              // also we don't need to check if we delete a directory, since the list only return files
               await this.#s3.send(
                 new DeleteObjectCommand({
                   Bucket: this.#bucket,
@@ -438,6 +440,8 @@ export default class S3Handler extends RemoteHandlerAbstract {
         await asyncEach(
           result.Contents ?? [],
           async ({ Key }) => {
+            // _unlink will add the prefix, but Key contains everything
+            // also we don't need to check if we delete a directory, since the list only return files
             await this.#s3.send(
               new DeleteObjectCommand({
                 Bucket: this.#bucket,

--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -435,6 +435,9 @@ export default class S3Handler extends RemoteHandlerAbstract {
               },
             })
           )
+          // we catch any error because some providers don't return "NotImplemented" errors when they don't
+          // support DeleteObjectsCommand. As we catch any error, we don't store supportsDeleteObjects param
+          // because it can be due to network issues
         } catch (error) {
           warn('Unsupported DeleteObjects, fallback to DeleteObject.', { error, $response: error.$response ?? '' })
           supportsDeleteObjects = false

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@
 - [Backup] Reduce backup memory consumption (PR [#9557](https://github.com/vatesfr/xen-orchestra/pull/9557))
 - [VM/New] VCPU was ignored [Forum#11954](https://xcp-ng.org/forum/topic/11954/unable-to-define-count-of-cpus-during-vm-create) (PR [#9591](https://github.com/vatesfr/xen-orchestra/pull/9591))
 - [Backups/Runs] Fix transfer size calculation (PR [#9496](https://github.com/vatesfr/xen-orchestra/pull/9496))
+- [S3] Check provider compatibility before using batch deletion (PR [#9598](https://github.com/vatesfr/xen-orchestra/pull/9598))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

Solve timeout issue when remote not compatible with DeleteObjectsCommand. Before it was trying to use it at every request. Now, it will only try to use this command once then go back to DeleteObjectCommand

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
