### PR TITLE
fix(XO6): update watch to avoid reset template select in new VM

### DIFF
--- a/@xen-orchestra/web/src/pages/vm/new.vue
+++ b/@xen-orchestra/web/src/pages/vm/new.vue
@@ -920,11 +920,11 @@ watch(
 watch(
   pools,
   newPools => {
-    const targetPool = newPools.find(pool => pool.id === poolId.value)
-
-    if (targetPool?.id !== vmState.pool?.id) {
-      vmState.pool = targetPool
+    if (!poolId.value || vmState.pool !== undefined) {
+      return
     }
+
+    vmState.pool = newPools.find(pool => pool.id === poolId.value)
   },
   { immediate: true }
 )

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,6 +36,7 @@
 - [S3] Check provider compatibility before using batch deletion (PR [#9598](https://github.com/vatesfr/xen-orchestra/pull/9598))
 - [REST API] Exclude ISO SRs from the `/dashboard` endpoint in the `resourcesOverview.srSize` and `storageRepositories.size.*` properties (PR [#9608](https://github.com/vatesfr/xen-orchestra/pull/9608))
 - [VM] Fixed duplicated ip addresses in the network tab [Forum#101359](https://xcp-ng.org/forum/topic/11604/xo-6-dedicated-thread-for-all-your-feedback/110) (PR [#9547](https://github.com/vatesfr/xen-orchestra/pull/9547))
+- [VM/New] Fix template that was resetting (PR [#9603] (https://github.com/vatesfr/xen-orchestra/pull/9603))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

Update watch to avoid reset template select in new VM

:link: [XO-1663
](https://project.vates.tech/vates-global/browse/XO-1663/)

**Issue :**
The server was refreshing the pools, which triggered a watch that was only meant to initialize the pool from the URL. Since no pool ID was in the URL (the user had chosen the pool manually), the watch was setting the pool back to undefined, which in turn reset the selected template.

**Solution :**
`watch` should only run once at initialization to pre-select the pool from the URL. After that, `useFormSelect` takes over to keep `vmState.pool` up to date.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
