### PR TITLE
fix(rest-api/dashboard): exlude ISO SRs from dashboard

### DIFF
--- a/@xen-orchestra/rest-api/src/xoa/xoa.service.mts
+++ b/@xen-orchestra/rest-api/src/xoa/xoa.service.mts
@@ -22,7 +22,7 @@ import { Writable } from 'node:stream'
 
 import { type AsyncCacheEntry, getFromAsyncCache } from '../helpers/cache.helper.mjs'
 import { DashboardBackupRepositoriesSizeInfo, DashboardBackupsInfo, SrSizeInfo, XoaDashboard } from './xoa.type.mjs'
-import { isReplicaVm, isSrWritableOrIso, promiseWriteInStream, vmContainsNoBakTag } from '../helpers/utils.helper.mjs'
+import { isReplicaVm, isSrWritable, promiseWriteInStream, vmContainsNoBakTag } from '../helpers/utils.helper.mjs'
 import type { IsEmptyData, IsMaybeExpired, MaybePromise } from '../helpers/helper.type.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { HostService } from '../hosts/host.service.mjs'
@@ -174,7 +174,7 @@ export class XoaService {
     const hosts = Object.values(this.#restApi.getObjectsByType<XoHost>('host'))
     const srs = Object.values(
       this.#restApi.getObjectsByType<XoSr>('SR', {
-        filter: isSrWritableOrIso,
+        filter: isSrWritable,
       })
     )
 
@@ -330,7 +330,7 @@ export class XoaService {
 
   #getStorageRepositoriesSizeInfo(): SrSizeInfo | IsEmptyData {
     const writableSrs = this.#restApi.getObjectsByType<XoSr>('SR', {
-      filter: isSrWritableOrIso,
+      filter: isSrWritable,
     })
 
     const srs = Object.values(writableSrs)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,6 +28,7 @@
 - [VM/New] VCPU was ignored [Forum#11954](https://xcp-ng.org/forum/topic/11954/unable-to-define-count-of-cpus-during-vm-create) (PR [#9591](https://github.com/vatesfr/xen-orchestra/pull/9591))
 - [Backups/Runs] Fix transfer size calculation (PR [#9496](https://github.com/vatesfr/xen-orchestra/pull/9496))
 - [S3] Check provider compatibility before using batch deletion (PR [#9598](https://github.com/vatesfr/xen-orchestra/pull/9598))
+- [REST API] Exclude ISO SRs from the `/dashboard` endpoint in the `resourcesOverview.srSize` and `storageRepositories.size.*` properties (PR [#9608](https://github.com/vatesfr/xen-orchestra/pull/9608))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

See [matrix](https://chat.vates.tech/#/room/!pKYPrNVmluSqqhZMjd:vates.tech/$X5w7puy_D6zbOMOT4t3QzU4jrcf5VynY8CsHiG2IUII?via=vates.tech)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
