### PR TITLE
fix(backups): use the snapshot of the source

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
@@ -242,11 +242,13 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
     const xapi = this._xapi
 
     const vdiCandidates = {}
-
+    const vdiUuids = this._vm.$VBDs.map(({ VDI }) => VDI)
     Object.values(xapi.objects.indexes.type.VDI)
       .filter(_ => !!_) // filter nullish
-      .filter(({ other_config, $snapshot_of }) => {
-        return $snapshot_of !== undefined && other_config[JOB_ID] === jobId && other_config[VM_UUID] === this._vm.uuid
+      .filter(({ other_config, snapshot_of }) => {
+        return (
+          vdiUuids.includes(snapshot_of) && other_config[JOB_ID] === jobId && other_config[VM_UUID] === this._vm.uuid
+        )
       })
       .forEach(vdi => {
         vdiCandidates[vdi.uuid] = vdi

--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
@@ -11,6 +11,7 @@ import { getOldEntries } from '../../_getOldEntries.mjs'
 import { Task } from '../../Task.mjs'
 import { Abstract } from './_Abstract.mjs'
 import {
+  COPY_OF,
   DATETIME,
   JOB_ID,
   SCHEDULE_ID,
@@ -247,7 +248,10 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
       .filter(_ => !!_) // filter nullish
       .filter(({ other_config, snapshot_of }) => {
         return (
-          vdiUuids.includes(snapshot_of) && other_config[JOB_ID] === jobId && other_config[VM_UUID] === this._vm.uuid
+          vdiUuids.includes(snapshot_of) &&
+          other_config[JOB_ID] === jobId &&
+          other_config[VM_UUID] === this._vm.uuid &&
+          other_config[COPY_OF] === undefined
         )
       })
       .forEach(vdi => {

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
@@ -30,13 +30,23 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
       return
     }
 
-    // @todo : this seems similar to decorateVmMetadata
-    // Only match live (non-snapshot) VDIs: a replication target is a single
-    // live VM and we need the active disk for in-place update.  This must
-    // stay consistent with the filter in #decorateVmMetadata.
+    // Only match live (non-snapshot) VDIs attached to exactly one
+    // non-control-domain VM that is a valid replication target for this job.
+    // This must stay consistent with the filter in #decorateVmMetadata.
     const replicatedVdis = sr.$VDIs.filter(vdi => {
-      // REPLICATED_TO_SR_UUID is not used here since we are already filtering from sr.$VDIs
-      return vdi?.managed && !vdi?.is_a_snapshot && baseUuidToSrcVdi.has(vdi?.other_config[COPY_OF])
+      if (!vdi?.managed || vdi?.is_a_snapshot || !baseUuidToSrcVdi.has(vdi?.other_config[COPY_OF])) {
+        return false
+      }
+      const userVbds = vdi.$VBDs?.filter(vbd => vbd.$VM && !vbd.$VM.is_control_domain) ?? []
+      if (userVbds.length !== 1) {
+        return false
+      }
+      const vm = userVbds[0].$VM
+      return (
+        vm.other_config[JOB_ID] === this._job.id &&
+        vm.other_config[VM_UUID] === this._vmUuid &&
+        'start' in vm.blocked_operations
+      )
     })
 
     const replicatedCopyOfUuids = replicatedVdis.map(({ other_config }) => other_config?.[COPY_OF]).filter(_ => !!_)
@@ -49,18 +59,8 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
 
     // Track the target VM (the replicated VM to update on the next transfer).
     if (replicatedVdis.length > 0) {
-      for (const vdi of replicatedVdis) {
-        const vbd = vdi.$VBDs?.find(vbd => !vbd.$VM.is_control_domain)
-        if (!vbd || !vbd.$VM) {
-          continue
-        }
-        const vm = vbd.$VM
-
-        if (vm.blocked_operations.start !== undefined) {
-          this._targetVmRef = vm.$ref
-          break
-        }
-      }
+      const vbd = replicatedVdis[0].$VBDs.find(vbd => vbd.$VM && !vbd.$VM.is_control_domain)
+      this._targetVmRef = vbd.$VM.$ref
     }
   }
   updateUuidAndChain() {

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
@@ -30,13 +30,13 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
       return
     }
 
-    // @todo use an index if possible
     // @todo : this seems similar to decorateVmMetadata
+    // Only match live (non-snapshot) VDIs: a replication target is a single
+    // live VM and we need the active disk for in-place update.  This must
+    // stay consistent with the filter in #decorateVmMetadata.
     const replicatedVdis = sr.$VDIs.filter(vdi => {
       // REPLICATED_TO_SR_UUID is not used here since we are already filtering from sr.$VDIs
-      // Also search snapshot VDIs to support the single-VM replication flow where
-      // base VDIs live on snapshots of the replicated VM.
-      return vdi?.managed && baseUuidToSrcVdi.has(vdi?.other_config[COPY_OF])
+      return vdi?.managed && !vdi?.is_a_snapshot && baseUuidToSrcVdi.has(vdi?.other_config[COPY_OF])
     })
 
     const replicatedCopyOfUuids = replicatedVdis.map(({ other_config }) => other_config?.[COPY_OF]).filter(_ => !!_)
@@ -48,17 +48,13 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
     }
 
     // Track the target VM (the replicated VM to update on the next transfer).
-    // For snapshot VDIs, traverse snapshot VM → snapshot_of to reach the replicated VM.
     if (replicatedVdis.length > 0) {
       for (const vdi of replicatedVdis) {
         const vbd = vdi.$VBDs?.find(vbd => !vbd.$VM.is_control_domain)
         if (!vbd || !vbd.$VM) {
           continue
         }
-        let vm = vbd.$VM
-        if (vm.is_a_snapshot) {
-          vm = vm.$snapshot_of
-        }
+        const vm = vbd.$VM
 
         if (vm.blocked_operations.start !== undefined) {
           this._targetVmRef = vm.$ref

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,7 +22,7 @@
 - [REST API] Add `POST /hosts/{id}/actions/disable` and `POST /hosts/{id}/actions/enable` endpoints (PR [#9532](https://github.com/vatesfr/xen-orchestra/pull/9532))
 - [OpenMetrics] Add missing VBD throughput, VBD average latency, and DCMI power consumption metrics (PR [#9563](https://github.com/vatesfr/xen-orchestra/pull/9563))
 - [MCP] Add `list_networks` and `get_network_details` tools to query network resources (PR [#9595](https://github.com/vatesfr/xen-orchestra/pull/9595))
-- [Backup] Fix incremental replication always doing a full hen source and target are in the same pool (PR [#9598](https://github.com/vatesfr/xen-orchestra/pull/9598))
+- [Backup] Fix incremental replication always doing a full when source and target are in the same pool (PR [#9612](https://github.com/vatesfr/xen-orchestra/pull/9612))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@
 - [REST API] Add `POST /hosts/{id}/actions/disable` and `POST /hosts/{id}/actions/enable` endpoints (PR [#9532](https://github.com/vatesfr/xen-orchestra/pull/9532))
 - [OpenMetrics] Add missing VBD throughput, VBD average latency, and DCMI power consumption metrics (PR [#9563](https://github.com/vatesfr/xen-orchestra/pull/9563))
 - [MCP] Add `list_networks` and `get_network_details` tools to query network resources (PR [#9595](https://github.com/vatesfr/xen-orchestra/pull/9595))
+- [Backup] Fix incremental replication always doing a full hen source and target are in the same pool (PR [#9598](https://github.com/vatesfr/xen-orchestra/pull/9598))
 
 ### Bug fixes
 


### PR DESCRIPTION
introduced by 9524

use only the vdi from the source VM as the source on backup this bug could only occurs if the replication was intra pool, if not the different xapi was filtering the results

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
