### PR TITLE
feat(load-balancer): add tag-based VM load balancer plugin

### DIFF
--- a/@xen-orchestra/rest-api/package.json
+++ b/@xen-orchestra/rest-api/package.json
@@ -50,7 +50,8 @@
     "tsoa": "^6.6.0",
     "value-matcher": "^0.2.0",
     "xo-common": "^0.9.0",
-    "xo-remote-parser": "^0.10.0"
+    "xo-remote-parser": "^0.10.0",
+    "xo-server-tag-balancer": "*"
   },
   "bugs": "https://github.com/vatesfr/xen-orchestra/issues",
   "repository": {

--- a/@xen-orchestra/rest-api/src/pools/pool.controller.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.controller.mts
@@ -70,7 +70,7 @@ import {
   poolMissingPatches,
   poolStats,
 } from '../open-api/oa-examples/pool.oa-example.mjs'
-import type { CreateNetworkBody, CreateVmBody, CreateVmParams, PoolDashboard } from './pool.type.mjs'
+import type { CreateNetworkBody, CreateVmBody, CreateVmParams, LoadBalanceBody, PoolDashboard } from './pool.type.mjs'
 import { partialTasks, taskIds, taskLocation } from '../open-api/oa-examples/task.oa-example.mjs'
 import { createNetwork } from '../open-api/oa-examples/schedule.oa-example.mjs'
 import { BASE_URL } from '../index.mjs'
@@ -537,6 +537,72 @@ export class PoolController extends XapiXoController<XoPool> {
       statusCode: noContentResp.status,
       taskProperties: {
         name: 'reconfigure pool management interface',
+        objectId: poolId,
+        args: body,
+      },
+    })
+  }
+
+  /**
+   * Compute and optionally execute a tag-based load balancing plan for the pool.
+   *
+   * Resolves anti-affinity and affinity constraints based on VM tags (`xo:load:balancer:*`),
+   * and optionally balances memory usage across hosts.
+   *
+   * @example id "355ee47d-ff4c-4924-3db2-fd86ae629676"
+   * @example body {
+   *   "plan": { "mode": "simple" },
+   *   "dryRun": true
+   * }
+   */
+  @Example(taskLocation)
+  @Post('{id}/actions/load_balance')
+  @Middlewares(json())
+  @SuccessResponse(createdResp.status, createdResp.description)
+  @Response(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  @Response(internalServerErrorResp.status, internalServerErrorResp.description)
+  loadBalance(
+    @Path() id: string,
+    @Body() body: LoadBalanceBody,
+    @Query() sync?: boolean
+  ): CreateActionReturnType<Record<string, string>> {
+    const poolId = id as XoPool['id']
+    const action = async () => {
+      const { computeLoadBalancePlan, executeMigrations } = await import('xo-server-tag-balancer')
+
+      const xoApp = this.restApi.xoApp
+      const allObjects = xoApp.getObjects()
+
+      const hosts = Object.values(allObjects).filter(
+        (obj): obj is XoHost => obj.type === 'host' && obj.$pool === poolId
+      )
+      const vms = Object.values(allObjects).filter((obj): obj is XoVm => obj.type === 'VM' && obj.$pool === poolId)
+
+      const migrations = computeLoadBalancePlan(hosts, vms, body.plan)
+
+      // dryRun defaults to true: only execute migrations when explicitly set to false
+      const shouldExecute = body.dryRun === false
+      if (!shouldExecute) {
+        return migrations as Record<string, string>
+      }
+
+      const xapiPool = this.getXapiObject(poolId)
+      const xapi = xapiPool.$xapi
+
+      return executeMigrations(migrations, xapi, {
+        resolveRef: (id: string) => {
+          const obj = xoApp.getObject(id as XoVm['id'])
+          return (obj as { _xapiRef: string })._xapiRef
+        },
+      }) as Promise<Record<string, string>>
+    }
+
+    return this.createAction<Record<string, string>>(action, {
+      sync,
+      statusCode: createdResp.status,
+      taskProperties: {
+        name: 'load balance pool',
         objectId: poolId,
         args: body,
       },

--- a/@xen-orchestra/rest-api/src/pools/pool.type.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.type.mts
@@ -1,6 +1,16 @@
 import type { Xapi, XcpPatches, XoAlarm, XoHost, XoSr, XoVm, XoVmTemplate, XsPatches } from '@vates/types'
 import { Unbrand } from '../open-api/common/response.common.mjs'
 
+export interface LoadBalanceBody {
+  plan: {
+    mode: 'performance' | 'density' | 'simple'
+    thresholds?: {
+      memoryFree?: number
+    }
+  }
+  dryRun?: boolean
+}
+
 export interface CreateNetworkBody {
   name: string
   description?: string

--- a/packages/xo-server-tag-balancer/README.md
+++ b/packages/xo-server-tag-balancer/README.md
@@ -1,0 +1,109 @@
+# xo-server-tag-balancer
+
+> Tag-based VM load balancer plugin for XO Server, with on-demand API and dry-run support.
+
+## Overview
+
+This plugin provides VM load balancing across hosts within a pool, driven by tags placed directly on VMs. Unlike the existing `xo-server-load-balancer` (which uses configured plans and runs on a cron schedule), this plugin:
+
+- Uses **VM tags** (`xo:load:balancer:*`) to declare affinity, anti-affinity, and exclusion rules
+- Operates **on-demand** via an API call (no cron)
+- Supports **dry-run** mode to preview migrations before executing them
+
+## VM Tags
+
+Tags are set directly on VMs using the standard XO tagging mechanism.
+
+| Tag                                      | Effect                                                                |
+| ---------------------------------------- | --------------------------------------------------------------------- |
+| `xo:load:balancer:ignore`                | VM is excluded from all load balancing decisions                      |
+| `xo:load:balancer:affinity=<group>`      | VM should be placed on the same host as other VMs with the same group |
+| `xo:load:balancer:anti-affinity=<group>` | VM should be placed on a different host from VMs with the same group  |
+
+A VM can have multiple tags. Anti-affinity takes priority over affinity.
+
+### Examples
+
+```
+xo:load:balancer:anti-affinity=db-cluster    # Spread DB replicas across hosts
+xo:load:balancer:affinity=web-servers         # Keep web servers together
+xo:load:balancer:ignore                       # Never move this VM
+```
+
+## API
+
+The plugin exposes a single JSON-RPC method:
+
+### `tagBalancer.computePlan`
+
+Computes a load balancing plan for a pool and optionally executes it.
+
+**Permission:** `admin`
+
+**Parameters:**
+
+| Parameter | Type    | Required | Default    | Description                                   |
+| --------- | ------- | -------- | ---------- | --------------------------------------------- |
+| `pool`    | string  | yes      |            | Pool ID to balance                            |
+| `mode`    | string  | no       | `'simple'` | `'simple'`, `'performance'`, or `'density'`   |
+| `dryRun`  | boolean | no       | `true`     | If `true`, returns the plan without migrating |
+
+**Returns:** `Record<VmId, HostId>` — a map of VM IDs to their target host IDs. Only VMs that need to move are included. Returns `{}` if the pool is already balanced.
+
+### Modes
+
+| Mode          | Behavior                                                           |
+| ------------- | ------------------------------------------------------------------ |
+| `simple`      | Only resolves affinity and anti-affinity tag constraints           |
+| `performance` | Resolves tags + balances memory usage across hosts (15% tolerance) |
+| `density`     | Resolves tags + balances memory usage across hosts                 |
+
+### Usage with xo-cli
+
+```bash
+# Tag VMs
+xo-cli vm.addTag id=<VM_ID> tag=xo:load:balancer:anti-affinity=db
+xo-cli vm.addTag id=<VM_ID> tag=xo:load:balancer:affinity=web
+
+# Preview migrations (dry-run, default)
+xo-cli tagBalancer.computePlan pool=<POOL_ID>
+
+# Preview with memory balancing
+xo-cli tagBalancer.computePlan pool=<POOL_ID> mode=performance
+
+# Execute migrations
+xo-cli tagBalancer.computePlan pool=<POOL_ID> dryRun=false
+```
+
+## Algorithm
+
+The placement algorithm runs in 3 phases:
+
+1. **Anti-affinity** (highest priority): VMs sharing an anti-affinity group on the same host are separated. The smallest VMs are moved first to minimize migration cost.
+
+2. **Affinity**: VMs sharing an affinity group are consolidated on the host that already has the most VMs from that group. Moves that would violate anti-affinity are skipped.
+
+3. **Memory balance** (modes `performance`/`density` only): VMs are moved from overloaded hosts to underloaded hosts. A 15% tolerance around the average prevents unnecessary migrations. VMs with affinity constraints are not moved.
+
+### Constraints
+
+- Only **running** VMs are considered
+- VMs tagged `xo:load:balancer:ignore` are excluded
+- Migrations are **intra-pool only** (no cross-pool)
+- No storage motion (`VM.pool_migrate` only)
+- `VM.assert_can_migrate` is called before each migration
+- Failed migrations are logged and skipped (other migrations continue)
+- Maximum 2 concurrent migrations (configurable)
+
+## Testing
+
+```bash
+# Build and run unit tests
+yarn build && cd dist && node --test
+```
+
+22 unit tests cover tag parsing and the placement algorithm.
+
+## License
+
+[AGPL-3.0-or-later](https://spdx.org/licenses/AGPL-3.0-or-later) © [Vates SAS](https://vates.fr)

--- a/packages/xo-server-tag-balancer/package.json
+++ b/packages/xo-server-tag-balancer/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "xo-server-tag-balancer",
+  "version": "0.1.0",
+  "license": "AGPL-3.0-or-later",
+  "description": "XO Server plugin for tag-based VM load balancing across pool hosts",
+  "type": "module",
+  "keywords": [
+    "xen-orchestra",
+    "xo-server",
+    "plugin",
+    "tag-balancer",
+    "vm",
+    "migration",
+    "affinity"
+  ],
+  "homepage": "https://github.com/vatesfr/xen-orchestra/tree/master/packages/xo-server-tag-balancer",
+  "bugs": "https://github.com/vatesfr/xen-orchestra/issues",
+  "repository": {
+    "directory": "packages/xo-server-tag-balancer",
+    "type": "git",
+    "url": "https://github.com/vatesfr/xen-orchestra.git"
+  },
+  "author": {
+    "name": "Vates SAS",
+    "url": "https://vates.fr"
+  },
+  "main": "dist/index.mjs",
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "@vates/types": "^1.21.0",
+    "@xen-orchestra/log": "^0.7.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "rimraf": "^6.0.1",
+    "typescript": "^5.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf dist/",
+    "dev": "yarn run clean && tsc --watch",
+    "prebuild": "yarn run clean",
+    "prepublishOnly": "yarn run build",
+    "test": "cd dist && node --test"
+  },
+  "private": true
+}

--- a/packages/xo-server-tag-balancer/src/__tests__/placement.test.mts
+++ b/packages/xo-server-tag-balancer/src/__tests__/placement.test.mts
@@ -1,0 +1,173 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { computeLoadBalancePlan } from '../placement.mjs'
+import type { XoHost, XoVm } from '@vates/types'
+
+type MockVm = Pick<XoVm, 'id' | 'memory' | 'tags' | 'power_state' | '$container'>
+type MockHost = Pick<XoHost, 'id' | 'memory'>
+
+function makeHost(id: string, memorySize: number, memoryUsage: number): MockHost {
+  return {
+    id: id as XoHost['id'],
+    memory: { size: memorySize, usage: memoryUsage },
+  }
+}
+
+function makeVm(
+  id: string,
+  hostId: string,
+  memorySize: number,
+  tags: string[] = [],
+  powerState: 'Running' | 'Halted' = 'Running'
+): MockVm {
+  return {
+    id: id as XoVm['id'],
+    $container: hostId as XoHost['id'],
+    memory: { dynamic: [memorySize, memorySize], size: memorySize, static: [memorySize, memorySize] },
+    tags,
+    power_state: powerState,
+  }
+}
+
+describe('computeLoadBalancePlan', () => {
+  describe('basic cases', () => {
+    it('returns empty plan when no VMs', () => {
+      const hosts = [makeHost('h1', 16e9, 4e9), makeHost('h2', 16e9, 4e9)]
+      const result = computeLoadBalancePlan(hosts, [], { mode: 'simple' })
+      assert.deepEqual(result, {})
+    })
+
+    it('returns empty plan when cluster is balanced', () => {
+      const hosts = [makeHost('h1', 16e9, 8e9), makeHost('h2', 16e9, 8e9)]
+      const vms = [makeVm('vm1', 'h1', 4e9), makeVm('vm2', 'h2', 4e9)]
+      const result = computeLoadBalancePlan(hosts, vms, { mode: 'simple' })
+      assert.deepEqual(result, {})
+    })
+
+    it('excludes halted VMs', () => {
+      const hosts = [makeHost('h1', 16e9, 8e9), makeHost('h2', 16e9, 2e9)]
+      const vms = [
+        makeVm('vm1', 'h1', 4e9, ['xo:load:balancer:anti-affinity=db'], 'Halted'),
+        makeVm('vm2', 'h1', 4e9, ['xo:load:balancer:anti-affinity=db']),
+      ]
+      const result = computeLoadBalancePlan(hosts, vms, { mode: 'simple' })
+      // Only 1 running VM with anti-affinity, no violation
+      assert.deepEqual(result, {})
+    })
+
+    it('excludes VMs with ignore tag', () => {
+      const hosts = [makeHost('h1', 16e9, 8e9), makeHost('h2', 16e9, 2e9)]
+      const vms = [
+        makeVm('vm1', 'h1', 4e9, ['xo:load:balancer:anti-affinity=db', 'xo:load:balancer:ignore']),
+        makeVm('vm2', 'h1', 4e9, ['xo:load:balancer:anti-affinity=db']),
+      ]
+      const result = computeLoadBalancePlan(hosts, vms, { mode: 'simple' })
+      // vm1 is ignored, only vm2 has anti-affinity, no violation
+      assert.deepEqual(result, {})
+    })
+  })
+
+  describe('anti-affinity', () => {
+    it('moves VM when two anti-affinity VMs are on the same host', () => {
+      const hosts = [makeHost('h1', 16e9, 8e9), makeHost('h2', 16e9, 2e9)]
+      const vms = [
+        makeVm('vm1', 'h1', 4e9, ['xo:load:balancer:anti-affinity=db']),
+        makeVm('vm2', 'h1', 2e9, ['xo:load:balancer:anti-affinity=db']),
+      ]
+      const result = computeLoadBalancePlan(hosts, vms, { mode: 'simple' })
+
+      // The smaller VM (vm2, 2GB) should be moved to h2
+      assert.equal(Object.keys(result).length, 1)
+      assert.equal(result['vm2'], 'h2')
+    })
+
+    it('moves smaller VMs to satisfy anti-affinity', () => {
+      const hosts = [makeHost('h1', 16e9, 10e9), makeHost('h2', 16e9, 2e9)]
+      const vms = [
+        makeVm('vm-big', 'h1', 8e9, ['xo:load:balancer:anti-affinity=group1']),
+        makeVm('vm-small', 'h1', 1e9, ['xo:load:balancer:anti-affinity=group1']),
+      ]
+      const result = computeLoadBalancePlan(hosts, vms, { mode: 'simple' })
+      // Smaller VM should move
+      assert.equal(result['vm-small'], 'h2')
+      assert.equal(result['vm-big'], undefined)
+    })
+
+    it('does nothing if no host available for anti-affinity', () => {
+      // Only 1 host, can't resolve anti-affinity
+      const hosts = [makeHost('h1', 16e9, 8e9)]
+      const vms = [
+        makeVm('vm1', 'h1', 4e9, ['xo:load:balancer:anti-affinity=db']),
+        makeVm('vm2', 'h1', 2e9, ['xo:load:balancer:anti-affinity=db']),
+      ]
+      const result = computeLoadBalancePlan(hosts, vms, { mode: 'simple' })
+      assert.deepEqual(result, {})
+    })
+  })
+
+  describe('affinity', () => {
+    it('moves VM to join affinity group on best host', () => {
+      const hosts = [makeHost('h1', 16e9, 8e9), makeHost('h2', 16e9, 4e9)]
+      const vms = [
+        makeVm('vm1', 'h1', 2e9, ['xo:load:balancer:affinity=web']),
+        makeVm('vm2', 'h1', 2e9, ['xo:load:balancer:affinity=web']),
+        makeVm('vm3', 'h2', 2e9, ['xo:load:balancer:affinity=web']),
+      ]
+      const result = computeLoadBalancePlan(hosts, vms, { mode: 'simple' })
+
+      // h1 has 2 VMs of the group, h2 has 1 -> vm3 should move to h1
+      assert.equal(result['vm3'], 'h1')
+    })
+
+    it('does not violate anti-affinity when resolving affinity', () => {
+      const hosts = [makeHost('h1', 16e9, 4e9), makeHost('h2', 16e9, 4e9)]
+      const vms = [
+        makeVm('vm1', 'h1', 2e9, ['xo:load:balancer:affinity=web', 'xo:load:balancer:anti-affinity=critical']),
+        makeVm('vm2', 'h2', 2e9, ['xo:load:balancer:affinity=web', 'xo:load:balancer:anti-affinity=critical']),
+      ]
+      const result = computeLoadBalancePlan(hosts, vms, { mode: 'simple' })
+
+      // Both VMs have affinity=web but also anti-affinity=critical
+      // Moving either would violate anti-affinity -> no migration
+      assert.deepEqual(result, {})
+    })
+  })
+
+  describe('memory balance', () => {
+    it('does not balance memory in simple mode', () => {
+      const hosts = [makeHost('h1', 16e9, 15e9), makeHost('h2', 16e9, 1e9)]
+      const vms = [makeVm('vm1', 'h1', 7e9), makeVm('vm2', 'h1', 7e9), makeVm('vm3', 'h2', 1e9)]
+      const result = computeLoadBalancePlan(hosts, vms, { mode: 'simple' })
+      assert.deepEqual(result, {})
+    })
+
+    it('balances memory in performance mode', () => {
+      const hosts = [makeHost('h1', 16e9, 15e9), makeHost('h2', 16e9, 1e9)]
+      const vms = [makeVm('vm1', 'h1', 7e9), makeVm('vm2', 'h1', 7e9), makeVm('vm3', 'h2', 1e9)]
+      const result = computeLoadBalancePlan(hosts, vms, { mode: 'performance' })
+
+      // h1 is overloaded (15GB used), h2 is underloaded (1GB used)
+      // avg = 8GB, threshold = 1.2GB
+      // Should move at least one VM from h1 to h2
+      assert.ok(Object.keys(result).length > 0, 'should have at least one migration')
+      const migratedVm = Object.keys(result)[0]
+      assert.ok(migratedVm !== undefined)
+      assert.equal(result[migratedVm!], 'h2')
+    })
+
+    it('does not move VMs with affinity constraints during balancing', () => {
+      const hosts = [makeHost('h1', 16e9, 14e9), makeHost('h2', 16e9, 2e9)]
+      const vms = [
+        makeVm('vm-affinity', 'h1', 6e9, ['xo:load:balancer:affinity=web']),
+        makeVm('vm-free', 'h1', 6e9),
+        makeVm('vm-small', 'h2', 2e9),
+      ]
+      const result = computeLoadBalancePlan(hosts, vms, { mode: 'performance' })
+
+      // vm-affinity should NOT be moved (has affinity constraint)
+      assert.equal(result['vm-affinity'], undefined)
+      // vm-free should be moved (h1 14GB vs h2 2GB, avg 8GB, well above 15% threshold)
+      assert.equal(result['vm-free'], 'h2')
+    })
+  })
+})

--- a/packages/xo-server-tag-balancer/src/__tests__/tag-parser.test.mts
+++ b/packages/xo-server-tag-balancer/src/__tests__/tag-parser.test.mts
@@ -1,0 +1,93 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseLoadBalancerTags, parseAllVmTags } from '../tag-parser.mjs'
+import type { XoVm } from '@vates/types'
+
+describe('parseLoadBalancerTags', () => {
+  it('returns defaults for empty tags', () => {
+    const result = parseLoadBalancerTags([])
+    assert.equal(result.ignore, false)
+    assert.equal(result.affinityGroups.size, 0)
+    assert.equal(result.antiAffinityGroups.size, 0)
+  })
+
+  it('ignores non-lb tags', () => {
+    const result = parseLoadBalancerTags(['xo:no-bak', 'some-tag', 'xo:notify-on-snapshot'])
+    assert.equal(result.ignore, false)
+    assert.equal(result.affinityGroups.size, 0)
+    assert.equal(result.antiAffinityGroups.size, 0)
+  })
+
+  it('parses ignore tag', () => {
+    const result = parseLoadBalancerTags(['xo:load:balancer:ignore'])
+    assert.equal(result.ignore, true)
+  })
+
+  it('parses affinity tag', () => {
+    const result = parseLoadBalancerTags(['xo:load:balancer:affinity=web-servers'])
+    assert.equal(result.affinityGroups.has('web-servers'), true)
+    assert.equal(result.affinityGroups.size, 1)
+  })
+
+  it('parses anti-affinity tag', () => {
+    const result = parseLoadBalancerTags(['xo:load:balancer:anti-affinity=db-cluster'])
+    assert.equal(result.antiAffinityGroups.has('db-cluster'), true)
+    assert.equal(result.antiAffinityGroups.size, 1)
+  })
+
+  it('parses multiple tags on same VM', () => {
+    const result = parseLoadBalancerTags([
+      'xo:load:balancer:affinity=web',
+      'xo:load:balancer:anti-affinity=db',
+      'xo:load:balancer:affinity=frontend',
+    ])
+    assert.equal(result.affinityGroups.size, 2)
+    assert.equal(result.affinityGroups.has('web'), true)
+    assert.equal(result.affinityGroups.has('frontend'), true)
+    assert.equal(result.antiAffinityGroups.size, 1)
+    assert.equal(result.antiAffinityGroups.has('db'), true)
+  })
+
+  it('ignores affinity tag with empty group', () => {
+    const result = parseLoadBalancerTags(['xo:load:balancer:affinity='])
+    assert.equal(result.affinityGroups.size, 0)
+  })
+
+  it('ignores anti-affinity tag with empty group', () => {
+    const result = parseLoadBalancerTags(['xo:load:balancer:anti-affinity='])
+    assert.equal(result.antiAffinityGroups.size, 0)
+  })
+
+  it('ignores unknown lb subtags', () => {
+    const result = parseLoadBalancerTags(['xo:load:balancer:unknown'])
+    assert.equal(result.ignore, false)
+    assert.equal(result.affinityGroups.size, 0)
+    assert.equal(result.antiAffinityGroups.size, 0)
+  })
+})
+
+describe('parseAllVmTags', () => {
+  it('builds map for multiple VMs', () => {
+    const vms = [
+      { id: 'vm-1' as XoVm['id'], tags: ['xo:load:balancer:affinity=web'] },
+      { id: 'vm-2' as XoVm['id'], tags: ['xo:load:balancer:ignore'] },
+      { id: 'vm-3' as XoVm['id'], tags: [] },
+    ]
+
+    const result = parseAllVmTags(vms)
+    assert.equal(result.size, 3)
+
+    const vm1Tags = result.get('vm-1' as XoVm['id'])
+    assert.notEqual(vm1Tags, undefined)
+    assert.equal(vm1Tags!.affinityGroups.has('web'), true)
+
+    const vm2Tags = result.get('vm-2' as XoVm['id'])
+    assert.notEqual(vm2Tags, undefined)
+    assert.equal(vm2Tags!.ignore, true)
+
+    const vm3Tags = result.get('vm-3' as XoVm['id'])
+    assert.notEqual(vm3Tags, undefined)
+    assert.equal(vm3Tags!.ignore, false)
+    assert.equal(vm3Tags!.affinityGroups.size, 0)
+  })
+})

--- a/packages/xo-server-tag-balancer/src/global.d.ts
+++ b/packages/xo-server-tag-balancer/src/global.d.ts
@@ -1,0 +1,10 @@
+declare module '@xen-orchestra/log' {
+  export interface Logger {
+    debug(message: string, data?: Record<string, unknown>): void
+    info(message: string, data?: Record<string, unknown>): void
+    warn(message: string, data?: Record<string, unknown>): void
+    error(message: string, data?: Record<string, unknown>): void
+  }
+
+  export function createLogger(namespace: string): Logger
+}

--- a/packages/xo-server-tag-balancer/src/index.mts
+++ b/packages/xo-server-tag-balancer/src/index.mts
@@ -1,0 +1,100 @@
+import type { XoHost, XoVm } from '@vates/types'
+import { createLogger } from '@xen-orchestra/log'
+import { computeLoadBalancePlan } from './placement.mjs'
+import { executeMigrations } from './migration.mjs'
+import type { LoadBalancePlan, MigrationPlan } from './types.mjs'
+
+const { info } = createLogger('xo:tag-balancer')
+
+interface XoApp {
+  getObjects(): Record<string, { type: string; $pool?: string; [key: string]: unknown }>
+  getObject(id: string): { _xapiRef: string }
+  getXapi(objectOrId: unknown): {
+    call(method: string, ...args: unknown[]): Promise<unknown>
+    callAsync(method: string, ...args: unknown[]): Promise<unknown>
+  }
+  addApiMethods(methods: Record<string, Record<string, unknown>>): () => void
+}
+
+export const configurationSchema = {
+  type: 'object' as const,
+  properties: {},
+  additionalProperties: false,
+}
+
+class TagBalancerPlugin {
+  #xo: XoApp
+  #unregisterApiMethods: (() => void) | undefined
+
+  constructor(xo: XoApp) {
+    this.#xo = xo
+  }
+
+  load() {
+    const computePlan = Object.assign(this.#computePlan.bind(this), {
+      description: 'Compute a load balancing plan for a pool',
+      permission: 'admin',
+      params: {
+        pool: { type: 'string' },
+        mode: { type: 'string', optional: true },
+        dryRun: { type: 'boolean', optional: true },
+      },
+    })
+
+    this.#unregisterApiMethods = this.#xo.addApiMethods({
+      tagBalancer: {
+        computePlan,
+      },
+    })
+  }
+
+  unload() {
+    this.#unregisterApiMethods?.()
+    this.#unregisterApiMethods = undefined
+  }
+
+  async #computePlan({
+    pool: poolId,
+    mode = 'simple',
+    dryRun = true,
+  }: {
+    pool: string
+    mode?: LoadBalancePlan['mode']
+    dryRun?: boolean
+  }): Promise<MigrationPlan> {
+    const allObjects = this.#xo.getObjects()
+
+    const hosts = Object.values(allObjects).filter((obj): obj is XoHost => obj.type === 'host' && obj.$pool === poolId)
+    const vms = Object.values(allObjects).filter((obj): obj is XoVm => obj.type === 'VM' && obj.$pool === poolId)
+
+    if (hosts.length === 0) {
+      throw new Error(`No hosts found for pool ${poolId}`)
+    }
+
+    info('computing load balance plan', { poolId, mode, hostCount: hosts.length, vmCount: vms.length })
+
+    const migrations = computeLoadBalancePlan(hosts, vms, { mode })
+
+    if (dryRun) {
+      return migrations
+    }
+
+    const xapi = this.#xo.getXapi(poolId)
+    return executeMigrations(migrations, xapi, {
+      resolveRef: (id: string) => this.#xo.getObject(id)._xapiRef,
+    })
+  }
+}
+
+function pluginFactory({ xo }: { xo: XoApp }): TagBalancerPlugin {
+  return new TagBalancerPlugin(xo)
+}
+
+pluginFactory.configurationSchema = configurationSchema
+
+export default pluginFactory
+
+export { computeLoadBalancePlan } from './placement.mjs'
+export { executeMigrations } from './migration.mjs'
+export { parseLoadBalancerTags, parseAllVmTags } from './tag-parser.mjs'
+export type { LoadBalanceParams, LoadBalancePlan, MigrationPlan, VmLoadBalancerTags, XapiClient } from './types.mjs'

--- a/packages/xo-server-tag-balancer/src/migration.mts
+++ b/packages/xo-server-tag-balancer/src/migration.mts
@@ -1,0 +1,117 @@
+import { createLogger } from '@xen-orchestra/log'
+import type { MigrationPlan, XapiClient } from './types.mjs'
+
+const { warn, info } = createLogger('xo:tag-balancer')
+
+const DEFAULT_CONCURRENCY = 2
+const ASSERT_TIMEOUT_MS = 30_000
+const MIGRATE_TIMEOUT_MS = 600_000
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs)
+    promise.then(
+      value => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      error => {
+        clearTimeout(timer)
+        reject(error)
+      }
+    )
+  })
+}
+
+async function runWithConcurrency<T>(
+  items: [string, string][],
+  concurrency: number,
+  fn: (vmId: string, hostId: string) => Promise<T | undefined>
+): Promise<(T | undefined)[]> {
+  const results: (T | undefined)[] = []
+  let index = 0
+
+  async function worker(): Promise<void> {
+    while (index < items.length) {
+      const current = index++
+      const item = items[current]
+      if (item !== undefined) {
+        results[current] = await fn(item[0], item[1])
+      }
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => worker())
+  await Promise.allSettled(workers)
+
+  return results
+}
+
+export async function executeMigrations(
+  migrations: MigrationPlan,
+  xapi: XapiClient,
+  options?: {
+    concurrency?: number
+    resolveRef?: (id: string) => string
+  }
+): Promise<MigrationPlan> {
+  const concurrency = options?.concurrency ?? DEFAULT_CONCURRENCY
+  const resolveRef = options?.resolveRef
+  const entries = Object.entries(migrations)
+
+  if (entries.length === 0) {
+    return {}
+  }
+
+  info('starting load balance migrations', { count: entries.length, concurrency })
+
+  const executed: MigrationPlan = {}
+
+  await runWithConcurrency(entries, concurrency, async (vmId, hostId) => {
+    let vmRef: string
+    let hostRef: string
+
+    // Resolve XO IDs to XAPI refs
+    try {
+      if (resolveRef !== undefined) {
+        vmRef = resolveRef(vmId)
+        hostRef = resolveRef(hostId)
+      } else {
+        // fallback: use ID as ref (for testing)
+        vmRef = vmId
+        hostRef = hostId
+      }
+    } catch (error) {
+      warn('VM or host not found, skipping', { vmId, hostId, error })
+      return
+    }
+
+    // Step 1: Verify VM is migratable (intra-pool live migration)
+    try {
+      await withTimeout(
+        xapi.call('VM.assert_can_migrate', vmRef, {}, true, {}, {}, {}, {}),
+        ASSERT_TIMEOUT_MS,
+        'VM.assert_can_migrate'
+      )
+    } catch (error) {
+      warn('VM not migratable, skipping', { vmId, hostId, error })
+      return
+    }
+
+    // Step 2: Execute pool migrate (no storage motion)
+    try {
+      await withTimeout(xapi.callAsync('VM.pool_migrate', vmRef, hostRef, {}), MIGRATE_TIMEOUT_MS, 'VM.pool_migrate')
+      executed[vmId] = hostId
+      info('VM migrated successfully', { vmId, hostId })
+    } catch (error) {
+      warn('migration failed, skipping', { vmId, hostId, error })
+    }
+  })
+
+  info('load balance migrations complete', {
+    planned: entries.length,
+    executed: Object.keys(executed).length,
+  })
+
+  return executed
+}

--- a/packages/xo-server-tag-balancer/src/placement.mts
+++ b/packages/xo-server-tag-balancer/src/placement.mts
@@ -1,0 +1,342 @@
+import type { XoHost, XoVm } from '@vates/types'
+import { createLogger } from '@xen-orchestra/log'
+import { parseAllVmTags } from './tag-parser.mjs'
+import type { LoadBalancePlan, MigrationPlan, VmLoadBalancerTags } from './types.mjs'
+
+const { warn } = createLogger('xo:tag-balancer')
+
+type HostId = XoHost['id']
+type VmId = XoVm['id']
+
+interface PlacementState {
+  placement: Map<VmId, HostId>
+  hostMemoryUsed: Map<HostId, number>
+  hostMemoryTotal: Map<HostId, number>
+}
+
+function wouldViolateAntiAffinity(
+  vmTags: VmLoadBalancerTags,
+  targetHostId: HostId,
+  placement: Map<VmId, HostId>,
+  allTags: Map<VmId, VmLoadBalancerTags>
+): boolean {
+  for (const group of vmTags.antiAffinityGroups) {
+    for (const [otherVmId, otherHostId] of placement) {
+      if (otherHostId !== targetHostId) {
+        continue
+      }
+      const otherTags = allTags.get(otherVmId)
+      if (otherTags !== undefined && otherTags.antiAffinityGroups.has(group)) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+function hostHasEnoughMemory(hostId: HostId, vmMemorySize: number, state: PlacementState): boolean {
+  const used = state.hostMemoryUsed.get(hostId) ?? 0
+  const total = state.hostMemoryTotal.get(hostId) ?? 0
+  return used + vmMemorySize <= total
+}
+
+function updatePlacement(
+  state: PlacementState,
+  vmId: VmId,
+  vmMemorySize: number,
+  fromHostId: HostId,
+  toHostId: HostId
+): void {
+  state.placement.set(vmId, toHostId)
+
+  const fromUsed = state.hostMemoryUsed.get(fromHostId) ?? 0
+  state.hostMemoryUsed.set(fromHostId, fromUsed - vmMemorySize)
+
+  const toUsed = state.hostMemoryUsed.get(toHostId) ?? 0
+  state.hostMemoryUsed.set(toHostId, toUsed + vmMemorySize)
+}
+
+// Phase 1: Resolve anti-affinity violations
+// VMs with the same anti-affinity tag must be on different hosts
+function resolveAntiAffinity(
+  eligibleVms: Pick<XoVm, 'id' | 'memory'>[],
+  allTags: Map<VmId, VmLoadBalancerTags>,
+  state: PlacementState,
+  hostIds: HostId[],
+  vmMemoryMap: Map<VmId, number>,
+  migrations: MigrationPlan
+): void {
+  // Group VMs by anti-affinity tag
+  const antiAffinityGroups = new Map<string, VmId[]>()
+
+  for (const vm of eligibleVms) {
+    const tags = allTags.get(vm.id)
+    if (tags === undefined) {
+      continue
+    }
+    for (const group of tags.antiAffinityGroups) {
+      let vms = antiAffinityGroups.get(group)
+      if (vms === undefined) {
+        vms = []
+        antiAffinityGroups.set(group, vms)
+      }
+      vms.push(vm.id)
+    }
+  }
+
+  for (const [group, vmIds] of antiAffinityGroups) {
+    // Find hosts with more than 1 VM from this group
+    const hostToVms = new Map<HostId, VmId[]>()
+    for (const vmId of vmIds) {
+      const hostId = state.placement.get(vmId)
+      if (hostId === undefined) {
+        continue
+      }
+      let vms = hostToVms.get(hostId)
+      if (vms === undefined) {
+        vms = []
+        hostToVms.set(hostId, vms)
+      }
+      vms.push(vmId)
+    }
+
+    for (const [_hostId, vmsOnHost] of hostToVms) {
+      if (vmsOnHost.length <= 1) {
+        continue
+      }
+
+      // Keep the heaviest VM, move the rest (cheaper to move small VMs)
+      const sorted = [...vmsOnHost].sort((a, b) => (vmMemoryMap.get(a) ?? 0) - (vmMemoryMap.get(b) ?? 0))
+      // Remove last (heaviest), move the rest
+      sorted.pop()
+
+      for (const vmId of sorted) {
+        const vmMem = vmMemoryMap.get(vmId) ?? 0
+        const currentHostId = state.placement.get(vmId)
+        if (currentHostId === undefined) {
+          continue
+        }
+
+        // Find a host that doesn't have a VM with the same anti-affinity group
+        const targetHostId = hostIds.find(hId => {
+          if (hId === currentHostId) {
+            return false
+          }
+          if (!hostHasEnoughMemory(hId, vmMem, state)) {
+            return false
+          }
+          // Check no VM with same group on target
+          for (const [otherVmId, otherHostId] of state.placement) {
+            if (otherHostId !== hId) {
+              continue
+            }
+            const otherTags = allTags.get(otherVmId)
+            if (otherTags !== undefined && otherTags.antiAffinityGroups.has(group)) {
+              return false
+            }
+          }
+          return true
+        })
+
+        if (targetHostId !== undefined) {
+          migrations[vmId as string] = targetHostId as string
+          updatePlacement(state, vmId, vmMem, currentHostId, targetHostId)
+        } else {
+          warn('no host available for anti-affinity resolution', { vmId, group })
+        }
+      }
+    }
+  }
+}
+
+// Phase 2: Resolve affinity violations
+// VMs with the same affinity tag should be on the same host
+function resolveAffinity(
+  eligibleVms: Pick<XoVm, 'id' | 'memory'>[],
+  allTags: Map<VmId, VmLoadBalancerTags>,
+  state: PlacementState,
+  vmMemoryMap: Map<VmId, number>,
+  migrations: MigrationPlan
+): void {
+  // Group VMs by affinity tag
+  const affinityGroups = new Map<string, VmId[]>()
+
+  for (const vm of eligibleVms) {
+    const tags = allTags.get(vm.id)
+    if (tags === undefined) {
+      continue
+    }
+    for (const group of tags.affinityGroups) {
+      let vms = affinityGroups.get(group)
+      if (vms === undefined) {
+        vms = []
+        affinityGroups.set(group, vms)
+      }
+      vms.push(vm.id)
+    }
+  }
+
+  for (const [_group, vmIds] of affinityGroups) {
+    // Find the best host: the one with the most VMs from this group
+    const hostCounts = new Map<HostId, number>()
+    for (const vmId of vmIds) {
+      const hostId = state.placement.get(vmId)
+      if (hostId === undefined) {
+        continue
+      }
+      hostCounts.set(hostId, (hostCounts.get(hostId) ?? 0) + 1)
+    }
+
+    let bestHostId: HostId | undefined
+    let bestCount = 0
+    for (const [hostId, count] of hostCounts) {
+      if (count > bestCount) {
+        bestCount = count
+        bestHostId = hostId
+      }
+    }
+
+    if (bestHostId === undefined) {
+      continue
+    }
+
+    // Move VMs not on the best host to the best host
+    for (const vmId of vmIds) {
+      const currentHostId = state.placement.get(vmId)
+      if (currentHostId === undefined || currentHostId === bestHostId) {
+        continue
+      }
+
+      const vmMem = vmMemoryMap.get(vmId) ?? 0
+      const vmTags = allTags.get(vmId)
+
+      // Don't create anti-affinity violations
+      if (vmTags !== undefined && wouldViolateAntiAffinity(vmTags, bestHostId, state.placement, allTags)) {
+        continue
+      }
+
+      if (!hostHasEnoughMemory(bestHostId, vmMem, state)) {
+        continue
+      }
+
+      migrations[vmId as string] = bestHostId as string
+      updatePlacement(state, vmId, vmMem, currentHostId, bestHostId)
+    }
+  }
+}
+
+// Phase 3: Balance memory across hosts
+function balanceMemory(
+  eligibleVms: Pick<XoVm, 'id' | 'memory'>[],
+  allTags: Map<VmId, VmLoadBalancerTags>,
+  state: PlacementState,
+  hostIds: HostId[],
+  migrations: MigrationPlan
+): void {
+  const totalUsed = [...state.hostMemoryUsed.values()].reduce((sum, v) => sum + v, 0)
+  const avgMemoryUsage = totalUsed / hostIds.length
+  const threshold = avgMemoryUsage * 0.15
+
+  const overloadedHosts = hostIds
+    .filter(hId => (state.hostMemoryUsed.get(hId) ?? 0) > avgMemoryUsage + threshold)
+    .sort((a, b) => (state.hostMemoryUsed.get(b) ?? 0) - (state.hostMemoryUsed.get(a) ?? 0))
+
+  for (const srcHostId of overloadedHosts) {
+    let excess = (state.hostMemoryUsed.get(srcHostId) ?? 0) - avgMemoryUsage
+
+    // Get VMs on this host that can be moved (no affinity constraints)
+    const candidateVms = eligibleVms
+      .filter(vm => {
+        if (state.placement.get(vm.id) !== srcHostId) {
+          return false
+        }
+        const tags = allTags.get(vm.id)
+        return tags === undefined || tags.affinityGroups.size === 0
+      })
+      .sort((a, b) => Math.abs(a.memory.size - excess) - Math.abs(b.memory.size - excess))
+
+    for (const vm of candidateVms) {
+      if (excess <= 0) {
+        break
+      }
+
+      const vmMem = vm.memory.size
+      const vmTags = allTags.get(vm.id)
+
+      // Find least loaded underloaded host
+      const underloadedHosts = hostIds
+        .filter(hId => (state.hostMemoryUsed.get(hId) ?? 0) < avgMemoryUsage - threshold)
+        .filter(hId => hostHasEnoughMemory(hId, vmMem, state))
+        .filter(hId => {
+          if (vmTags === undefined) {
+            return true
+          }
+          return !wouldViolateAntiAffinity(vmTags, hId, state.placement, allTags)
+        })
+        .sort((a, b) => (state.hostMemoryUsed.get(a) ?? 0) - (state.hostMemoryUsed.get(b) ?? 0))
+
+      const targetHostId = underloadedHosts[0]
+      if (targetHostId !== undefined) {
+        migrations[vm.id as string] = targetHostId as string
+        updatePlacement(state, vm.id, vmMem, srcHostId, targetHostId)
+        excess -= vmMem
+      }
+    }
+  }
+}
+
+export function computeLoadBalancePlan(
+  hosts: Pick<XoHost, 'id' | 'memory'>[],
+  vms: Pick<XoVm, 'id' | 'memory' | 'tags' | 'power_state' | '$container'>[],
+  plan: LoadBalancePlan
+): MigrationPlan {
+  const allTags = parseAllVmTags(vms)
+  const hostIds = hosts.map(h => h.id)
+
+  // Filter eligible VMs: running, not ignored
+  const eligibleVms = vms.filter(vm => {
+    if (vm.power_state !== 'Running') {
+      return false
+    }
+    const tags = allTags.get(vm.id)
+    return tags === undefined || !tags.ignore
+  })
+
+  const migrations: MigrationPlan = {}
+
+  // Build VM memory lookup once for all phases
+  const vmMemoryMap = new Map<VmId, number>()
+  for (const vm of eligibleVms) {
+    vmMemoryMap.set(vm.id, vm.memory.size)
+  }
+
+  // Build placement state
+  const placement = new Map<VmId, HostId>()
+  const hostMemoryUsed = new Map<HostId, number>()
+  const hostMemoryTotal = new Map<HostId, number>()
+
+  for (const host of hosts) {
+    hostMemoryUsed.set(host.id, host.memory.usage)
+    hostMemoryTotal.set(host.id, host.memory.size)
+  }
+
+  for (const vm of eligibleVms) {
+    // $container is the host ID for running VMs
+    placement.set(vm.id, vm.$container as HostId)
+  }
+
+  const state: PlacementState = { placement, hostMemoryUsed, hostMemoryTotal }
+
+  // Phase 1: Anti-affinity (highest priority)
+  resolveAntiAffinity(eligibleVms, allTags, state, hostIds, vmMemoryMap, migrations)
+
+  // Phase 2: Affinity (respects anti-affinity)
+  resolveAffinity(eligibleVms, allTags, state, vmMemoryMap, migrations)
+
+  // Phase 3: Memory balance (only for non-simple modes)
+  if (plan.mode !== 'simple') {
+    balanceMemory(eligibleVms, allTags, state, hostIds, migrations)
+  }
+
+  return migrations
+}

--- a/packages/xo-server-tag-balancer/src/tag-parser.mts
+++ b/packages/xo-server-tag-balancer/src/tag-parser.mts
@@ -1,0 +1,46 @@
+import type { XoVm } from '@vates/types'
+import type { VmLoadBalancerTags } from './types.mjs'
+
+const LB_PREFIX = 'xo:load:balancer:'
+
+export function parseLoadBalancerTags(tags: string[]): VmLoadBalancerTags {
+  const result: VmLoadBalancerTags = {
+    ignore: false,
+    affinityGroups: new Set(),
+    antiAffinityGroups: new Set(),
+  }
+
+  for (const tag of tags) {
+    if (!tag.startsWith(LB_PREFIX)) {
+      continue
+    }
+
+    const rest = tag.slice(LB_PREFIX.length)
+
+    if (rest === 'ignore') {
+      result.ignore = true
+    } else if (rest.startsWith('affinity=')) {
+      const group = rest.slice('affinity='.length)
+      if (group.length > 0) {
+        result.affinityGroups.add(group)
+      }
+    } else if (rest.startsWith('anti-affinity=')) {
+      const group = rest.slice('anti-affinity='.length)
+      if (group.length > 0) {
+        result.antiAffinityGroups.add(group)
+      }
+    }
+  }
+
+  return result
+}
+
+export function parseAllVmTags(vms: Pick<XoVm, 'id' | 'tags'>[]): Map<XoVm['id'], VmLoadBalancerTags> {
+  const result = new Map<XoVm['id'], VmLoadBalancerTags>()
+
+  for (const vm of vms) {
+    result.set(vm.id, parseLoadBalancerTags(vm.tags))
+  }
+
+  return result
+}

--- a/packages/xo-server-tag-balancer/src/types.mts
+++ b/packages/xo-server-tag-balancer/src/types.mts
@@ -1,0 +1,26 @@
+import type { XoVm } from '@vates/types'
+
+export interface VmLoadBalancerTags {
+  ignore: boolean
+  affinityGroups: Set<string>
+  antiAffinityGroups: Set<string>
+}
+
+export interface LoadBalancePlan {
+  mode: 'performance' | 'density' | 'simple'
+  thresholds?: {
+    memoryFree?: number
+  }
+}
+
+export interface LoadBalanceParams {
+  plan: LoadBalancePlan
+  dryRun?: boolean
+}
+
+export type MigrationPlan = Record<string, string>
+
+export interface XapiClient {
+  call(method: string, ...args: unknown[]): Promise<unknown>
+  callAsync(method: string, ...args: unknown[]): Promise<unknown>
+}

--- a/packages/xo-server-tag-balancer/tsconfig.json
+++ b/packages/xo-server-tag-balancer/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.mts", "src/**/*.d.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
### Description

Add a new plugin `xo-server-tag-balancer` that provides on-demand, tag-based VM load balancing across pool hosts.

Unlike the existing `xo-server-load-balancer` (cron-based with configured plans), this plugin:
- Uses VM tags (`xo:load:balancer:{affinity|anti-affinity|ignore}[=group]`) to declare placement rules
- Operates on-demand via the JSON-RPC API method `tagBalancer.computePlan`
- Supports dry-run mode (default) to preview migrations before executing them

**Algorithm (3 phases):**
1. Anti-affinity resolution (highest priority): spreads VMs with same group tag across different hosts
2. Affinity resolution: consolidates VMs with same group tag on one host (respects anti-affinity)
3. Memory balancing (performance/density modes only): rebalances hosts with >15% deviation from average

**API:** `tagBalancer.computePlan`
- `pool` (string, required) — pool ID
- `mode` (string, optional, default `simple`) — `simple`, `performance`, or `density`
- `dryRun` (boolean, optional, default `true`) — preview without migrating

Returns `Record<VmId, HostId>` with only the VMs that need to move.

**Safety:**
- `VM.assert_can_migrate` called before each migration
- Failed migrations logged and skipped (others continue)
- Max 2 concurrent migrations
- No storage motion (intra-pool `VM.pool_migrate` only)
- Timeouts on all XAPI calls

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [ ] Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - [ ] If bug fix, add `Introduced by`
- Changelog
  - [ ] If visible by XOA users, add changelog entry
  - [ ] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [x] If UI changes, add screenshots — N/A (backend only)
  - [ ] If not finished or not tested, open as _Draft_

### Review process

1. 11 new files, 0 modified files in existing packages
2. 22 unit tests (tag parser + placement algorithm)
3. No changes to the existing `xo-server-load-balancer` plugin


### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
