### PR TITLE
fix(backups): vhd directory have empty names

### DIFF
--- a/packages/vhd-lib/disk-consumer/DiskConsumerVhdDirectory.mjs
+++ b/packages/vhd-lib/disk-consumer/DiskConsumerVhdDirectory.mjs
@@ -11,7 +11,7 @@ import { asyncEach } from '@vates/async-each'
 import { VhdDirectory, VhdAbstract } from 'vhd-lib'
 import { unpackFooter, unpackHeader } from 'vhd-lib/Vhd/_utils.js'
 import { DEFAULT_BLOCK_SIZE } from '../_constants.js'
-import  assert  from 'node:assert'
+import assert from 'node:assert'
 
 /**
  * @typedef {Object} VhdRemoteTarget
@@ -47,7 +47,7 @@ export class DiskConsumerVhdDirectory extends BaseVhd {
     const { handler, path, compression, flags, validator, concurrency } = this.#target
     const SUFFIX = '.alias.vhd'
     assert.ok(path.endsWith(SUFFIX), `filename must be an alias , got ${path}`)
-    const base = basename(path).substring(0, -SUFFIX.length)
+    const base = basename(path).slice(0, -SUFFIX.length)
     const dataPath = `${dirname(path)}/data/${base}.vhd`
     const uid = 'to stream ' + Math.random()
     let generator


### PR DESCRIPTION
### Description

inroduced by https://github.com/vatesfr/xen-orchestra/pull/9548

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
