### PR TITLE
fix(backups): fix double close on merge

### DIFF
--- a/@xen-orchestra/backups/disks/RemoteVhdDisk.mjs
+++ b/@xen-orchestra/backups/disks/RemoteVhdDisk.mjs
@@ -101,7 +101,7 @@ export class RemoteVhdDisk extends RemoteDisk {
    */
   async close() {
     const dispose = this.#dispose
-    this.#dispose = () => {}
+    this.#dispose = () => Promise.resolve()
     await dispose()
   }
 

--- a/@xen-orchestra/backups/disks/RemoteVhdDisk.mjs
+++ b/@xen-orchestra/backups/disks/RemoteVhdDisk.mjs
@@ -95,10 +95,14 @@ export class RemoteVhdDisk extends RemoteDisk {
 
   /**
    * Closes the VHD.
+   * We replace the dispose function call so the disk can only be closed once.
+   *
    * @returns {Promise<void>}
    */
   async close() {
-    await this.#dispose()
+    const dispose = this.#dispose
+    this.#dispose = () => {}
+    await dispose()
   }
 
   /**

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@
 - [i18n] Fix English grammar issues on Site Dashboard, contribution by [@DustyArmstrong](https://github.com/DustyArmstrong) (PR [#9647](https://github.com/vatesfr/xen-orchestra/pull/https://github.com/vatesfr/xen-orchestra/pull/9647))
 - [Incremental Replication] fix the disk target and cleanup to ensure replications and backups can be chained (PR [#9635](https://github.com/vatesfr/xen-orchestra/pull/9635))
 - [REST-API/VM/Dashboard] Fix _cannot read properties of undefined, (reading vms)_ [Forum#12031](https://xcp-ng.org/forum/topic/12031/backup-info-under-vm-tab-in-v6-never-loads...) (PR [#9650](https://github.com/vatesfr/xen-orchestra/pull/9650))
+- [Backups] Fix double close when merging disks (PR [#9636](https://github.com/vatesfr/xen-orchestra/pull/9636))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

([XO-2085](https://project.vates.tech/vates-global/browse/XO-2085/))

Fix double close INFO when merging remote disks

Introduced by #9300

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
