### PR TITLE
fix(xo-server-auth-oidc): handle missing profile fields in username resolution

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
 - [XO5/XO6/Stats] Return `null` instead of `0` when no stats available (PR [#9634](https://github.com/vatesfr/xen-orchestra/pull/9634))
+- [Auth/OIDC] Handle missing profile fields in username resolution (PR [#9648](https://github.com/vatesfr/xen-orchestra/pull/9648))
 
 ### Packages to release
 
@@ -38,5 +39,6 @@
 
 - @xen-orchestra/web-core minor
 - xo-server patch
+- xo-server-auth-oidc patch
 
 <!--packages-end-->

--- a/packages/xo-server-auth-oidc/index.js
+++ b/packages/xo-server-auth-oidc/index.js
@@ -135,12 +135,10 @@ class AuthOidc {
           // See https://github.com/jaredhanson/passport-openidconnect/blob/master/lib/profile.js
           const { id } = profile
 
-          let name
-          if (usernameField === 'email') {
-            name = profile.emails?.[0]?.value ?? profile._json?.email
-          } else {
-            name = profile[usernameField] ?? profile._json?.[usernameField]
-          }
+          const name =
+            usernameField === 'email'
+              ? (profile.emails?.[0]?.value ?? claims.email)
+              : (profile[usernameField] ?? claims[usernameField])
 
           if (name === undefined) {
             throw new Error(

--- a/packages/xo-server-auth-oidc/index.js
+++ b/packages/xo-server-auth-oidc/index.js
@@ -134,8 +134,22 @@ class AuthOidc {
 
           // See https://github.com/jaredhanson/passport-openidconnect/blob/master/lib/profile.js
           const { id } = profile
+
+          let name
+          if (usernameField === 'email') {
+            name = profile.emails?.[0]?.value ?? profile._json?.email
+          } else {
+            name = profile[usernameField] ?? profile._json?.[usernameField]
+          }
+
+          if (name === undefined) {
+            throw new Error(
+              `Could not find username: field "${usernameField}" is missing from the OIDC profile. Ensure the required scopes are configured and granted by your identity provider.`
+            )
+          }
+
           const user = await xo.registerUser2('oidc:' + issuer, {
-            user: { id, name: usernameField === 'email' ? profile.emails[0].value : profile[usernameField] },
+            user: { id, name },
           })
 
           await this._synchronizeGroups(user, groups)

--- a/packages/xo-server-auth-oidc/package.json
+++ b/packages/xo-server-auth-oidc/package.json
@@ -30,7 +30,7 @@
   "license": "AGPL-3.0-or-later",
   "version": "0.4.2",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "dependencies": {
     "passport-openidconnect": "^0.1.2"


### PR DESCRIPTION
## Summary

- Fix crash when OIDC provider doesn't return the expected profile fields (e.g. SURF/SRAM which only provides `openid` scope by default)
- Fall back to raw OIDC claims (`profile._json`) when passport's parsed profile doesn't contain the configured `usernameField`
- Replace cryptic TypeError / assertion failure with an actionable error message

## Context

Reported at https://xcp-ng.org/forum/topic/12011/oidc-login-internal-server-error/

Two distinct crashes:
1. `usernameField: "email"` → `Cannot read properties of undefined (reading '0')` because `profile.emails` is undefined
2. `usernameField: "uid"` → `Expected values to be strictly equal: 'undefined' vs 'string'` because `profile['uid']` is undefined (passport-openidconnect only maps standard fields)

## Test plan

- [ ] Configure OIDC with a provider that returns email in claims → should work via `profile._json.email` fallback
- [ ] Configure OIDC with a custom `usernameField` (e.g. `uid`) → should work via `profile._json` fallback
- [ ] Configure OIDC with a provider that genuinely doesn't return the field → should show clear error message
- [ ] Existing working OIDC setups should not be affected (standard fields still resolved from profile first)