### PR TITLE
feat(web-core): update default tab functionality

### DIFF
--- a/@xen-orchestra/web-core/lib/composables/default-tab.composable.md
+++ b/@xen-orchestra/web-core/lib/composables/default-tab.composable.md
@@ -7,7 +7,8 @@ This composable manages automatic navigation to default tabs and remembers the l
 The composable watches route changes and:
 
 - Automatically redirects to the remembered or default tab when navigating to the base dispatcher route
-- Stores the current tab in localStorage for future visits
+- Stores the last visited tab when switching between objects of the same type (e.g., VM → VM)
+- Resets to default tab when navigating to a different object type or any other page
 - Uses the naming convention `{dispatcherRouteName}/{tabName}` for tab route names
 
 ## Parameters
@@ -21,22 +22,27 @@ The composable watches route changes and:
 
 ```typescript
 // In the dispatcher page component (e.g., `pages/pool/[id].vue`)
-useDefaultTab('pool/[id]', 'dashboard')
+useDefaultTab('/pool/[id]', 'dashboard')
 
-// User first navigates to /pool/123
+// User navigates to /pool/123
 // → Automatic redirect to /pool/123/dashboard (default tab)
 
-// User then navigates to /pool/123/stats
-// → 'stats' is stored as the last visited tab for this route
+// User navigates to /pool/123/system
+// → 'system' is stored as the last visited tab
 
-// Finally, user navigates to /pool/456
-// → Automatic redirect to /pool/456/stats
+// User navigates to /pool/456 (same object type)
+// → Automatic redirect to /pool/456/system (tab remembered)
+
+// User navigates to /vm/789 (different object type)
+// → Automatic redirect to /vm/789/dashboard (Tab memory is reset)
+
+// User navigates back to /pool/456
+// → Automatic redirect to /pool/456/dashboard (default tab)
 ```
 
 ## Storage
 
-Tab preferences are stored in localStorage under the key `default-tabs` with the structure:
+Tab memory is stored in localStorage using two different keys:
 
-```typescript
-Map<string, string> // dispatcherRouteName -> lastVisitedTab
-```
+- `tab-memory.dispatcher` — the dispatcher route name of the last visited object type
+- `tab-memory.last` — the last visited tab name

--- a/@xen-orchestra/web-core/lib/composables/default-tab.composable.ts
+++ b/@xen-orchestra/web-core/lib/composables/default-tab.composable.ts
@@ -1,9 +1,10 @@
-import { useLocalStorage } from '@vueuse/core'
 import { watch } from 'vue'
 import { type RouteLocationRaw, type RouteRecordName, useRoute, useRouter } from 'vue-router'
 
+const TAB_MEMORY_DISPATCHER = 'tab-memory.dispatcher'
+const TAB_MEMORY_LAST = 'tab-memory.last'
+
 export function useDefaultTab(dispatcherRouteName: RouteRecordName & string, defaultTab: string) {
-  const storage = useLocalStorage('default-tabs', new Map<string, string>())
   const router = useRouter()
   const route = useRoute()
 
@@ -11,7 +12,8 @@ export function useDefaultTab(dispatcherRouteName: RouteRecordName & string, def
     () => route.name as string,
     name => {
       if (name === dispatcherRouteName) {
-        const tabName = storage.value.get(dispatcherRouteName) ?? defaultTab
+        const isSameDispatcher = localStorage.getItem(TAB_MEMORY_DISPATCHER) === dispatcherRouteName
+        const tabName = isSameDispatcher ? localStorage.getItem(TAB_MEMORY_LAST) : defaultTab
         void router.replace({ name: `${dispatcherRouteName}/${tabName}` } as RouteLocationRaw)
       } else if (!name.startsWith(dispatcherRouteName)) {
         return
@@ -19,7 +21,8 @@ export function useDefaultTab(dispatcherRouteName: RouteRecordName & string, def
 
       const tab = name.slice(dispatcherRouteName.length).split('/')[1] ?? defaultTab
 
-      storage.value.set(dispatcherRouteName, tab)
+      localStorage.setItem(TAB_MEMORY_DISPATCHER, dispatcherRouteName)
+      localStorage.setItem(TAB_MEMORY_LAST, tab)
     },
     { immediate: true }
   )

--- a/@xen-orchestra/web-core/lib/composables/default-tab.composable.ts
+++ b/@xen-orchestra/web-core/lib/composables/default-tab.composable.ts
@@ -8,12 +8,15 @@ export function useDefaultTab(dispatcherRouteName: RouteRecordName & string, def
   const router = useRouter()
   const route = useRoute()
 
+  // TODO: Delete after 2 to 3 months (once all users have cleared their local storage)
+  localStorage.removeItem('default-tabs')
+
   watch(
     () => route.name as string,
     name => {
       if (name === dispatcherRouteName) {
         const isSameDispatcher = localStorage.getItem(TAB_MEMORY_DISPATCHER) === dispatcherRouteName
-        const tabName = isSameDispatcher ? localStorage.getItem(TAB_MEMORY_LAST) : defaultTab
+        const tabName = (isSameDispatcher ? localStorage.getItem(TAB_MEMORY_LAST) : null) ?? defaultTab
         void router.replace({ name: `${dispatcherRouteName}/${tabName}` } as RouteLocationRaw)
       } else if (!name.startsWith(dispatcherRouteName)) {
         return


### PR DESCRIPTION
### Description

Updated the behavior of the `defaultTable` component to return the default tab only if the object changes.

:link: [XO-1848](https://project.vates.tech/vates-global/browse/XO-1848/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
