### PR TITLE
feat(rest-api): ACL middleware for VM

### DIFF
--- a/@xen-orchestra/acl/src/actions/vm-controller.mts
+++ b/@xen-orchestra/acl/src/actions/vm-controller.mts
@@ -1,3 +1,4 @@
 export default {
+  'change-tags': true,
   read: true,
 }

--- a/@xen-orchestra/acl/src/actions/vm-controller.mts
+++ b/@xen-orchestra/acl/src/actions/vm-controller.mts
@@ -1,4 +1,6 @@
 export default {
-  'change-tags': true,
   read: true,
+  update: {
+    tags: true,
+  },
 }

--- a/@xen-orchestra/acl/src/actions/vm-snapshot.mts
+++ b/@xen-orchestra/acl/src/actions/vm-snapshot.mts
@@ -1,5 +1,7 @@
 export default {
-  'change-tags': true,
   delete: true,
   read: true,
+  update: {
+    tags: true,
+  },
 }

--- a/@xen-orchestra/acl/src/actions/vm-snapshot.mts
+++ b/@xen-orchestra/acl/src/actions/vm-snapshot.mts
@@ -1,5 +1,6 @@
 export default {
   delete: true,
+  export: true,
   read: true,
   update: {
     tags: true,

--- a/@xen-orchestra/acl/src/actions/vm-snapshot.mts
+++ b/@xen-orchestra/acl/src/actions/vm-snapshot.mts
@@ -1,3 +1,5 @@
 export default {
+  'change-tags': true,
+  delete: true,
   read: true,
 }

--- a/@xen-orchestra/acl/src/actions/vm-template.mts
+++ b/@xen-orchestra/acl/src/actions/vm-template.mts
@@ -1,4 +1,6 @@
 export default {
-  read: true,
+  'change-tags': true,
+  delete: true,
   instantiate: true,
+  read: true,
 }

--- a/@xen-orchestra/acl/src/actions/vm-template.mts
+++ b/@xen-orchestra/acl/src/actions/vm-template.mts
@@ -1,6 +1,8 @@
 export default {
-  'change-tags': true,
   delete: true,
   instantiate: true,
   read: true,
+  update: {
+    tags: true,
+  },
 }

--- a/@xen-orchestra/acl/src/actions/vm-template.mts
+++ b/@xen-orchestra/acl/src/actions/vm-template.mts
@@ -1,5 +1,6 @@
 export default {
   delete: true,
+  export: true,
   instantiate: true,
   read: true,
   update: {

--- a/@xen-orchestra/acl/src/actions/vm.mts
+++ b/@xen-orchestra/acl/src/actions/vm.mts
@@ -1,5 +1,6 @@
 export default {
   delete: true,
+  export: true,
   pause: true,
   read: true,
   reboot: {

--- a/@xen-orchestra/acl/src/actions/vm.mts
+++ b/@xen-orchestra/acl/src/actions/vm.mts
@@ -1,6 +1,4 @@
 export default {
-  'change-datasources': true,
-  'change-tags': true,
   delete: true,
   pause: true,
   read: true,
@@ -17,4 +15,8 @@ export default {
   start: true,
   suspend: true,
   unpause: true,
+  update: {
+    datasources: true,
+    tags: true,
+  },
 }

--- a/@xen-orchestra/acl/src/actions/vm.mts
+++ b/@xen-orchestra/acl/src/actions/vm.mts
@@ -1,16 +1,20 @@
 export default {
+  'change-datasources': true,
+  'change-tags': true,
+  delete: true,
+  pause: true,
   read: true,
-  start: true,
-  shutdown: {
-    clean: true,
-    hard: true,
-  },
   reboot: {
     clean: true,
     hard: true,
   },
-  pause: true,
-  suspend: true,
   resume: true,
+  shutdown: {
+    clean: true,
+    hard: true,
+  },
+  snapshot: true,
+  start: true,
+  suspend: true,
   unpause: true,
 }

--- a/@xen-orchestra/rest-api/src/vm-controller/vm-controller.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-controller/vm-controller.controller.mts
@@ -228,13 +228,13 @@ export class VmControllerController extends XapiXoController<XoVmController> {
 
   /**
    * Required privilege:
-   * - resource: vm-controller, action: change-tags
+   * - resource: vm-controller, action: update:tags
    *
    * @example id "9b4775bd-9493-490a-9afa-f786a44caa4f"
    * @example tag "from-rest-api"
    */
   @Put('{id}/tags/{tag}')
-  @Middlewares(acl({ resource: 'vm-controller', action: 'change-tags', objectId: 'params.id' }))
+  @Middlewares(acl({ resource: 'vm-controller', action: 'update:tags', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
@@ -245,13 +245,13 @@ export class VmControllerController extends XapiXoController<XoVmController> {
 
   /**
    * Required privilege:
-   * - resource: vm-controller, action: change-tags
+   * - resource: vm-controller, action: update:tags
    *
    * @example id "9b4775bd-9493-490a-9afa-f786a44caa4f"
    * @example tag "from-rest-api"
    */
   @Delete('{id}/tags/{tag}')
-  @Middlewares(acl({ resource: 'vm-controller', action: 'change-tags', objectId: 'params.id' }))
+  @Middlewares(acl({ resource: 'vm-controller', action: 'update:tags', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)

--- a/@xen-orchestra/rest-api/src/vm-controller/vm-controller.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-controller/vm-controller.controller.mts
@@ -2,14 +2,30 @@ import { inject } from 'inversify'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import type { XoAlarm, XoMessage, XoTask, XoVdi, XoVdiSnapshot, XoVmController } from '@vates/types'
-import { Delete, Example, Get, Path, Put, Query, Request, Response, Route, Security, SuccessResponse, Tags } from 'tsoa'
+import {
+  Delete,
+  Example,
+  Get,
+  Path,
+  Put,
+  Query,
+  Request,
+  Response,
+  Route,
+  Security,
+  SuccessResponse,
+  Tags,
+  Middlewares,
+} from 'tsoa'
 import { Request as ExRequest } from 'express'
 
 import { AlarmService } from '../alarms/alarm.service.mjs'
 import { escapeUnsafeComplexMatcher, limitAndFilterArray } from '../helpers/utils.helper.mjs'
+import { acl } from '../middlewares/acl.middleware.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
 import {
   badRequestResp,
+  forbiddenOperationResp,
   noContentResp,
   notFoundResp,
   unauthorizedResp,
@@ -72,11 +88,16 @@ export class VmControllerController extends XapiXoController<XoVmController> {
   }
 
   /**
+   * Required privilege:
+   * - resource: vm-controller, action: read
+   *
    * @example id "9b4775bd-9493-490a-9afa-f786a44caa4f"
    */
   @Example(vmController)
   @Get('{id}')
+  @Middlewares(acl({ resource: 'vm-controller', action: 'read', objectId: 'params.id' }))
   @Response(notFoundResp.status, notFoundResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   getVmController(@Path() id: string): Unbrand<XoVmController> {
     return this.getObject(id as XoVmController['id'])
   }
@@ -206,11 +227,16 @@ export class VmControllerController extends XapiXoController<XoVmController> {
   }
 
   /**
+   * Required privilege:
+   * - resource: vm-controller, action: change-tags
+   *
    * @example id "9b4775bd-9493-490a-9afa-f786a44caa4f"
    * @example tag "from-rest-api"
    */
   @Put('{id}/tags/{tag}')
+  @Middlewares(acl({ resource: 'vm-controller', action: 'change-tags', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async putVmControllerTag(@Path() id: string, @Path() tag: string): Promise<void> {
     const vmController = this.getXapiObject(id as XoVmController['id'])
@@ -218,11 +244,16 @@ export class VmControllerController extends XapiXoController<XoVmController> {
   }
 
   /**
+   * Required privilege:
+   * - resource: vm-controller, action: change-tags
+   *
    * @example id "9b4775bd-9493-490a-9afa-f786a44caa4f"
    * @example tag "from-rest-api"
    */
   @Delete('{id}/tags/{tag}')
+  @Middlewares(acl({ resource: 'vm-controller', action: 'change-tags', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async deleteVmControllerTag(@Path() id: string, @Path() tag: string): Promise<void> {
     const vmController = this.getXapiObject(id as XoVmController['id'])

--- a/@xen-orchestra/rest-api/src/vm-snapshots/vm-snapshot.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-snapshots/vm-snapshot.controller.mts
@@ -1,4 +1,18 @@
-import { Delete, Example, Get, Path, Put, Query, Request, Response, Route, Security, SuccessResponse, Tags } from 'tsoa'
+import {
+  Delete,
+  Example,
+  Get,
+  Path,
+  Put,
+  Query,
+  Request,
+  Response,
+  Route,
+  Security,
+  SuccessResponse,
+  Tags,
+  Middlewares,
+} from 'tsoa'
 import { Request as ExRequest } from 'express'
 import { inject } from 'inversify'
 import { Readable } from 'node:stream'
@@ -18,6 +32,7 @@ import {
 } from '../open-api/common/response.common.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
+import { acl } from '../middlewares/acl.middleware.mjs'
 import type { XoAlarm, XoMessage, XoVdiSnapshot, XoTask, XoVmSnapshot } from '@vates/types'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { provide } from 'inversify-binding-decorators'
@@ -78,10 +93,15 @@ export class VmSnapshotController extends XapiXoController<XoVmSnapshot> {
    *
    * Export VM-snapshot. Compress is only used for XVA format
    *
+   * Required privilege:
+   * - resource: vm-snapshot, action: read
+   *
    * @example id "d68fca2c-41e6-be87-d790-105c1642a090"
    */
   @Get('{id}.{format}')
+  @Middlewares(acl({ resource: 'vm-snapshot', action: 'read', objectId: 'params.id' }))
   @SuccessResponse(200, 'Download started', 'application/octet-stream')
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(422, 'Invalid format, Invalid compress')
   async exportVmSnapshot(
@@ -102,20 +122,30 @@ export class VmSnapshotController extends XapiXoController<XoVmSnapshot> {
   }
 
   /**
+   * Required privilege:
+   * - resource: vm-snapshot, action: read
+   *
    * @example id "d68fca2c-41e6-be87-d790-105c1642a090"
    */
   @Example(vmSnapshot)
   @Get('{id}')
+  @Middlewares(acl({ resource: 'vm-snapshot', action: 'read', objectId: 'params.id' }))
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   getVmSnapshot(@Path() id: string): Unbrand<XoVmSnapshot> {
     return this.getObject(id as XoVmSnapshot['id'])
   }
 
   /**
+   * Required privilege:
+   * - resource: vm-snapshot, action: delete
+   *
    * @example id "d68fca2c-41e6-be87-d790-105c1642a090"
    */
   @Delete('{id}')
+  @Middlewares(acl({ resource: 'vm-snapshot', action: 'delete', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(incorrectStateResp.status, incorrectStateResp.description)
@@ -249,11 +279,16 @@ export class VmSnapshotController extends XapiXoController<XoVmSnapshot> {
   }
 
   /**
+   * Required privilege:
+   * - resource: vm-snapshot, action: change-tags
+   *
    * @example id "d68fca2c-41e6-be87-d790-105c1642a090"
    * @example tag "from-rest-api"
    */
   @Put('{id}/tags/{tag}')
+  @Middlewares(acl({ resource: 'vm-snapshot', action: 'change-tags', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async putVmSnapshotTag(@Path() id: string, @Path() tag: string): Promise<void> {
     const vmSnapshot = this.getXapiObject(id as XoVmSnapshot['id'])
@@ -261,11 +296,16 @@ export class VmSnapshotController extends XapiXoController<XoVmSnapshot> {
   }
 
   /**
+   * Required privilege:
+   * - resource: vm-snapshot, action: change-tags
+   *
    * @example id "d68fca2c-41e6-be87-d790-105c1642a090"
    * @example tag "from-rest-api"
    */
   @Delete('{id}/tags/{tag}')
+  @Middlewares(acl({ resource: 'vm-snapshot', action: 'change-tags', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async deleteVmSnapshotTag(@Path() id: string, @Path() tag: string): Promise<void> {
     const vmSnapshot = this.getXapiObject(id as XoVmSnapshot['id'])

--- a/@xen-orchestra/rest-api/src/vm-snapshots/vm-snapshot.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-snapshots/vm-snapshot.controller.mts
@@ -145,7 +145,6 @@ export class VmSnapshotController extends XapiXoController<XoVmSnapshot> {
   @Delete('{id}')
   @Middlewares(acl({ resource: 'vm-snapshot', action: 'delete', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
-  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(incorrectStateResp.status, incorrectStateResp.description)

--- a/@xen-orchestra/rest-api/src/vm-snapshots/vm-snapshot.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-snapshots/vm-snapshot.controller.mts
@@ -279,13 +279,13 @@ export class VmSnapshotController extends XapiXoController<XoVmSnapshot> {
 
   /**
    * Required privilege:
-   * - resource: vm-snapshot, action: change-tags
+   * - resource: vm-snapshot, action: update:tags
    *
    * @example id "d68fca2c-41e6-be87-d790-105c1642a090"
    * @example tag "from-rest-api"
    */
   @Put('{id}/tags/{tag}')
-  @Middlewares(acl({ resource: 'vm-snapshot', action: 'change-tags', objectId: 'params.id' }))
+  @Middlewares(acl({ resource: 'vm-snapshot', action: 'update:tags', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
@@ -296,13 +296,13 @@ export class VmSnapshotController extends XapiXoController<XoVmSnapshot> {
 
   /**
    * Required privilege:
-   * - resource: vm-snapshot, action: change-tags
+   * - resource: vm-snapshot, action: update:tags
    *
    * @example id "d68fca2c-41e6-be87-d790-105c1642a090"
    * @example tag "from-rest-api"
    */
   @Delete('{id}/tags/{tag}')
-  @Middlewares(acl({ resource: 'vm-snapshot', action: 'change-tags', objectId: 'params.id' }))
+  @Middlewares(acl({ resource: 'vm-snapshot', action: 'update:tags', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)

--- a/@xen-orchestra/rest-api/src/vm-snapshots/vm-snapshot.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-snapshots/vm-snapshot.controller.mts
@@ -94,12 +94,12 @@ export class VmSnapshotController extends XapiXoController<XoVmSnapshot> {
    * Export VM-snapshot. Compress is only used for XVA format
    *
    * Required privilege:
-   * - resource: vm-snapshot, action: read
+   * - resource: vm-snapshot, action: export
    *
    * @example id "d68fca2c-41e6-be87-d790-105c1642a090"
    */
   @Get('{id}.{format}')
-  @Middlewares(acl({ resource: 'vm-snapshot', action: 'read', objectId: 'params.id' }))
+  @Middlewares(acl({ resource: 'vm-snapshot', action: 'export', objectId: 'params.id' }))
   @SuccessResponse(200, 'Download started', 'application/octet-stream')
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)

--- a/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
@@ -146,7 +146,6 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
   @Delete('{id}')
   @Middlewares(acl({ resource: 'vm-template', action: 'delete', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
-  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(incorrectStateResp.status, incorrectStateResp.description)

--- a/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
@@ -280,13 +280,13 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
 
   /**
    * Required privilege:
-   * - resource: vm-template, action: change-tags
+   * - resource: vm-template, action: update:tags
    *
    * @example id "613f541c-4bed-fc77-7ca8-2db6b68f079c"
    * @example tag "from-rest-api"
    */
   @Put('{id}/tags/{tag}')
-  @Middlewares(acl({ resource: 'vm-template', action: 'change-tags', objectId: 'params.id' }))
+  @Middlewares(acl({ resource: 'vm-template', action: 'update:tags', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
@@ -297,13 +297,13 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
 
   /**
    * Required privilege:
-   * - resource: vm-template, action: change-tags
+   * - resource: vm-template, action: update:tags
    *
    * @example id "613f541c-4bed-fc77-7ca8-2db6b68f079c"
    * @example tag "from-rest-api"
    */
   @Delete('{id}/tags/{tag}')
-  @Middlewares(acl({ resource: 'vm-template', action: 'change-tags', objectId: 'params.id' }))
+  @Middlewares(acl({ resource: 'vm-template', action: 'update:tags', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)

--- a/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
@@ -95,12 +95,12 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
    * Export VM-template. Compress is only used for XVA format
    *
    * Required privilege:
-   * - resource: vm-template, action: read
+   * - resource: vm-template, action: export
    *
    * @example id "b7569d99-30f8-178a-7d94-801de3e29b5b-f873abe0-b138-4995-8f6f-498b423d234d"
    */
   @Get('{id}.{format}')
-  @Middlewares(acl({ resource: 'vm-template', action: 'read', objectId: 'params.id' }))
+  @Middlewares(acl({ resource: 'vm-template', action: 'export', objectId: 'params.id' }))
   @SuccessResponse(200, 'Download started', 'application/octet-stream')
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)

--- a/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
@@ -1,4 +1,18 @@
-import { Example, Get, Security, Query, Request, Response, Route, Tags, Path, Delete, SuccessResponse, Put } from 'tsoa'
+import {
+  Example,
+  Get,
+  Security,
+  Query,
+  Request,
+  Response,
+  Route,
+  Tags,
+  Path,
+  Delete,
+  SuccessResponse,
+  Put,
+  Middlewares,
+} from 'tsoa'
 import { Request as ExRequest } from 'express'
 import { inject } from 'inversify'
 import { provide } from 'inversify-binding-decorators'
@@ -21,6 +35,7 @@ import { RestApi } from '../rest-api/rest-api.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
+import { acl } from '../middlewares/acl.middleware.mjs'
 import {
   partialVmTemplates,
   vmTemplate,
@@ -79,10 +94,15 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
    *
    * Export VM-template. Compress is only used for XVA format
    *
+   * Required privilege:
+   * - resource: vm-template, action: read
+   *
    * @example id "b7569d99-30f8-178a-7d94-801de3e29b5b-f873abe0-b138-4995-8f6f-498b423d234d"
    */
   @Get('{id}.{format}')
+  @Middlewares(acl({ resource: 'vm-template', action: 'read', objectId: 'params.id' }))
   @SuccessResponse(200, 'Download started', 'application/octet-stream')
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(422, 'Invalid format, Invalid compress')
   async exportVmTemplate(
@@ -103,20 +123,30 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
   }
 
   /**
+   * Required privilege:
+   * - resource: vm-template, action: read
+   *
    * @example id "b7569d99-30f8-178a-7d94-801de3e29b5b-f873abe0-b138-4995-8f6f-498b423d234d"
    * */
   @Example(vmTemplate)
   @Get('{id}')
+  @Middlewares(acl({ resource: 'vm-template', action: 'read', objectId: 'params.id' }))
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   getVmTemplate(@Path() id: string): Unbrand<XoVmTemplate> {
     return this.getObject(id as XoVmTemplate['id'])
   }
 
   /**
+   * Required privilege:
+   * - resource: vm-template, action: delete
+   *
    * @example id "6d50ba76-0f11-1ff1-4f6a-b502afc31b8e"
    */
   @Delete('{id}')
+  @Middlewares(acl({ resource: 'vm-template', action: 'delete', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(incorrectStateResp.status, incorrectStateResp.description)
@@ -250,11 +280,16 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
   }
 
   /**
+   * Required privilege:
+   * - resource: vm-template, action: change-tags
+   *
    * @example id "613f541c-4bed-fc77-7ca8-2db6b68f079c"
    * @example tag "from-rest-api"
    */
   @Put('{id}/tags/{tag}')
+  @Middlewares(acl({ resource: 'vm-template', action: 'change-tags', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async putVmTemplateTag(@Path() id: string, @Path() tag: string): Promise<void> {
     const vmTemplate = this.getXapiObject(id as XoVmTemplate['id'])
@@ -262,11 +297,16 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
   }
 
   /**
+   * Required privilege:
+   * - resource: vm-template, action: change-tags
+   *
    * @example id "613f541c-4bed-fc77-7ca8-2db6b68f079c"
    * @example tag "from-rest-api"
    */
   @Delete('{id}/tags/{tag}')
+  @Middlewares(acl({ resource: 'vm-template', action: 'change-tags', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async deleteVmTemplateTag(@Path() id: string, @Path() tag: string): Promise<void> {
     const vmTemplate = this.getXapiObject(id as XoVmTemplate['id'])

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -115,10 +115,15 @@ export class VmController extends XapiXoController<XoVm> {
    *
    * Export VM. Compress is only used for XVA format
    *
+   * Required privilege:
+   * - resource: vm, action: read
+   *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    */
   @Get('{id}.{format}')
+  @Middlewares(acl({ resource: 'vm', action: 'read', objectId: 'params.id' }))
   @SuccessResponse(200, 'Download started', 'application/octet-stream')
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(422, 'Invalid format, Invalid compress')
   async exportVm(
@@ -150,10 +155,15 @@ export class VmController extends XapiXoController<XoVm> {
   }
 
   /**
+   * Required privilege:
+   * - resource: vm, action: delete
+   *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    */
   @Delete('{id}')
+  @Middlewares(acl({ resource: 'vm', action: 'delete', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(incorrectStateResp.status, incorrectStateResp.description)
@@ -166,10 +176,15 @@ export class VmController extends XapiXoController<XoVm> {
    *
    *  VM must be running
    *
+   * Required privilege:
+   * - resource: vm, action: read
+   *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    */
   @Example(vmStatsExample)
   @Get('{id}/stats')
+  @Middlewares(acl({ resource: 'vm', action: 'read', objectId: 'params.id' }))
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(422, 'Invalid granularity, VM is halted or host could not be found')
   async getVmStats(@Path() id: string, @Query() granularity?: XapiStatsGranularity): Promise<XapiVmStats> {
@@ -216,13 +231,19 @@ export class VmController extends XapiXoController<XoVm> {
    * - **vif_#_tx** : Bytes per second transmitted on virtual interface vif. Enabled by default. *Condition*: VIF vif exists.
    * - **vif_#_rx_errors** : Receive errors per second on virtual interface vif. Enabled by default. *Condition*: VIF vif exists.
    * - **vif_#_tx_errors** : Transmit errors per second on virtual interface vif. Enabled by default. *Condition*: VIF vif exists.
+   *
+   * Required privilege:
+   * - resource: vm, action: change-datasources
+   *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    * @example dataSource "cpu0"
    */
+  @Put('{id}/stats/data_source/{data_source}')
+  @Middlewares(acl({ resource: 'vm', action: 'change-datasources', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
-  @Put('{id}/stats/data_source/{data_source}')
   async addDataSource(@Path() id: string, @Path('data_source') dataSource: string) {
     await this.getXapiObject(id as XoVm['id']).$call('record_data_source', dataSource)
   }
@@ -232,13 +253,18 @@ export class VmController extends XapiXoController<XoVm> {
    *
    * For a list of possible data sources, see the endpoint documentation: `GET {id}/stats/data_source/{data_source}`
    *
+   * Required privilege:
+   * - resource: vm, action: change-datasources
+   *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    * @example dataSource "cpu0"
    */
+  @Delete('{id}/stats/data_source/{data_source}')
+  @Middlewares(acl({ resource: 'vm', action: 'change-datasources', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
-  @Delete('{id}/stats/data_source/{data_source}')
   async deleteDataSource(@Path() id: string, @Path('data_source') dataSource: string) {
     await this.getXapiObject(id as XoVm['id']).$call('forget_data_source_archives', dataSource)
   }
@@ -352,11 +378,16 @@ export class VmController extends XapiXoController<XoVm> {
   }
 
   /**
+   * Required privilege:
+   * - resource: vm, action: shutdown:hard
+   *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    */
   @Example(taskLocation)
   @Post('{id}/actions/hard_shutdown')
+  @Middlewares(acl({ resource: 'vm', action: 'shutdown:hard', objectId: 'params.id' }))
   @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
@@ -377,11 +408,16 @@ export class VmController extends XapiXoController<XoVm> {
   }
 
   /**
+   * Required privilege:
+   * - resource: vm, action: reboot:hard
+   *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    */
   @Example(taskLocation)
   @Post('{id}/actions/hard_reboot')
+  @Middlewares(acl({ resource: 'vm', action: 'reboot:hard', objectId: 'params.id' }))
   @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
@@ -404,11 +440,16 @@ export class VmController extends XapiXoController<XoVm> {
   /**
    * The VM must be running
    *
+   * Required privilege:
+   * - resource: vm, action: pause
+   *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    */
   @Example(taskLocation)
   @Post('{id}/actions/pause')
+  @Middlewares(acl({ resource: 'vm', action: 'pause', objectId: 'params.id' }))
   @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
@@ -431,11 +472,16 @@ export class VmController extends XapiXoController<XoVm> {
   /**
    * The VM must be running
    *
+   * Required privilege:
+   * - resource: vm, action: suspend
+   *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    */
   @Example(taskLocation)
   @Post('{id}/actions/suspend')
+  @Middlewares(acl({ resource: 'vm', action: 'suspend', objectId: 'params.id' }))
   @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
@@ -458,11 +504,16 @@ export class VmController extends XapiXoController<XoVm> {
   /**
    * The VM must be suspended
    *
+   * Required privilege:
+   * - resource: vm, action: resume
+   *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    */
   @Example(taskLocation)
   @Post('{id}/actions/resume')
+  @Middlewares(acl({ resource: 'vm', action: 'resume', objectId: 'params.id' }))
   @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
@@ -485,11 +536,16 @@ export class VmController extends XapiXoController<XoVm> {
   /**
    * The VM must be paused
    *
+   * Required privilege:
+   * - resource: vm, action: unpause
+   *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    */
   @Example(taskLocation)
   @Post('{id}/actions/unpause')
+  @Middlewares(acl({ resource: 'vm', action: 'unpause', objectId: 'params.id' }))
   @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
@@ -510,13 +566,18 @@ export class VmController extends XapiXoController<XoVm> {
   }
 
   /**
+   * Required privilege:
+   * - resource: vm, action: snapshot
+   *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    * @example body { "name_label": "my_awesome_snapshot" }
    */
   @Example(taskLocation)
   @Post('{id}/actions/snapshot')
   @Middlewares(json())
+  @Middlewares(acl({ resource: 'vm', action: 'snapshot', objectId: 'params.id' }))
   @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(createdResp.status, 'Snapshot created')
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
@@ -708,11 +769,16 @@ export class VmController extends XapiXoController<XoVm> {
   }
 
   /**
+   * Required privilege:
+   * - resource: vm, action: change-tags
+   *
    * @example id "613f541c-4bed-fc77-7ca8-2db6b68f079c"
    * @example tag "from-rest-api"
    */
   @Put('{id}/tags/{tag}')
+  @Middlewares(acl({ resource: 'vm', action: 'change-tags', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async putVmTag(@Path() id: string, @Path() tag: string): Promise<void> {
     const vm = this.getXapiObject(id as XoVm['id'])
@@ -720,11 +786,16 @@ export class VmController extends XapiXoController<XoVm> {
   }
 
   /**
+   * Required privilege:
+   * - resource: vm, action: change-tags
+   *
    * @example id "613f541c-4bed-fc77-7ca8-2db6b68f079c"
    * @example tag "from-rest-api"
    */
   @Delete('{id}/tags/{tag}')
+  @Middlewares(acl({ resource: 'vm', action: 'change-tags', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async deleteVmTag(@Path() id: string, @Path() tag: string): Promise<void> {
     const vm = this.getXapiObject(id as XoVm['id'])
@@ -732,10 +803,15 @@ export class VmController extends XapiXoController<XoVm> {
   }
 
   /**
+   * Required privilege:
+   * - resource: vm, action: read
+   *
    * @example id "613f541c-4bed-fc77-7ca8-2db6b68f079c"
    */
   @Example(vmDashboard)
   @Get('{id}/dashboard')
+  @Middlewares(acl({ resource: 'vm', action: 'read', objectId: 'params.id' }))
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   async getVmDashboard(
     @Request() req: AuthenticatedRequest,
     @Path() id: string,

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -574,8 +574,7 @@ export class VmController extends XapiXoController<XoVm> {
    */
   @Example(taskLocation)
   @Post('{id}/actions/snapshot')
-  @Middlewares(json())
-  @Middlewares(acl({ resource: 'vm', action: 'snapshot', objectId: 'params.id' }))
+  @Middlewares([json(), acl({ resource: 'vm', action: 'snapshot', objectId: 'params.id' })])
   @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(createdResp.status, 'Snapshot created')

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -232,13 +232,13 @@ export class VmController extends XapiXoController<XoVm> {
    * - **vif_#_tx_errors** : Transmit errors per second on virtual interface vif. Enabled by default. *Condition*: VIF vif exists.
    *
    * Required privilege:
-   * - resource: vm, action: change-datasources
+   * - resource: vm, action: update:datasources
    *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    * @example dataSource "cpu0"
    */
   @Put('{id}/stats/data_source/{data_source}')
-  @Middlewares(acl({ resource: 'vm', action: 'change-datasources', objectId: 'params.id' }))
+  @Middlewares(acl({ resource: 'vm', action: 'update:datasources', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
@@ -253,13 +253,13 @@ export class VmController extends XapiXoController<XoVm> {
    * For a list of possible data sources, see the endpoint documentation: `GET {id}/stats/data_source/{data_source}`
    *
    * Required privilege:
-   * - resource: vm, action: change-datasources
+   * - resource: vm, action: update:datasources
    *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    * @example dataSource "cpu0"
    */
   @Delete('{id}/stats/data_source/{data_source}')
-  @Middlewares(acl({ resource: 'vm', action: 'change-datasources', objectId: 'params.id' }))
+  @Middlewares(acl({ resource: 'vm', action: 'update:datasources', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
@@ -768,13 +768,13 @@ export class VmController extends XapiXoController<XoVm> {
 
   /**
    * Required privilege:
-   * - resource: vm, action: change-tags
+   * - resource: vm, action: update:tags
    *
    * @example id "613f541c-4bed-fc77-7ca8-2db6b68f079c"
    * @example tag "from-rest-api"
    */
   @Put('{id}/tags/{tag}')
-  @Middlewares(acl({ resource: 'vm', action: 'change-tags', objectId: 'params.id' }))
+  @Middlewares(acl({ resource: 'vm', action: 'update:tags', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
@@ -785,13 +785,13 @@ export class VmController extends XapiXoController<XoVm> {
 
   /**
    * Required privilege:
-   * - resource: vm, action: change-tags
+   * - resource: vm, action: update:tags
    *
    * @example id "613f541c-4bed-fc77-7ca8-2db6b68f079c"
    * @example tag "from-rest-api"
    */
   @Delete('{id}/tags/{tag}')
-  @Middlewares(acl({ resource: 'vm', action: 'change-tags', objectId: 'params.id' }))
+  @Middlewares(acl({ resource: 'vm', action: 'update:tags', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -116,12 +116,12 @@ export class VmController extends XapiXoController<XoVm> {
    * Export VM. Compress is only used for XVA format
    *
    * Required privilege:
-   * - resource: vm, action: read
+   * - resource: vm, action: export
    *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    */
   @Get('{id}.{format}')
-  @Middlewares(acl({ resource: 'vm', action: 'read', objectId: 'params.id' }))
+  @Middlewares(acl({ resource: 'vm', action: 'export', objectId: 'params.id' }))
   @SuccessResponse(200, 'Download started', 'application/octet-stream')
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -163,7 +163,6 @@ export class VmController extends XapiXoController<XoVm> {
   @Delete('{id}')
   @Middlewares(acl({ resource: 'vm', action: 'delete', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
-  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(incorrectStateResp.status, incorrectStateResp.description)


### PR DESCRIPTION
### Description

Restrict VM endpoints with ACL middleware

Each route I modified was tested with and without ACL rights.

[XO-2054](https://project.vates.tech/vates-global/browse/XO-2054/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
