### PR TITLE
fix(backups): full when going from 6.2 to 6.3

### DIFF
--- a/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
@@ -56,62 +56,77 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
     })
     debug('checkBaseVdis, got snapshot candidates,', snapshotCandidates.length)
 
-    // ensure no data have been written since this snapshot
-    // but there may be have some other snapshot for another job
-    let targetVmRef
-    let canChainToTargetVm = true
-    await asyncEach(
-      snapshotCandidates,
-      async snapshot => {
-        let diffDisk
-        try {
-          const activeVdi = sr.$xapi.getObject(snapshot.$snapshot_of)
-          const userVbds = activeVdi.$VBDs?.filter(vbd => vbd.$VM && !vbd.$VM.is_control_domain) ?? []
-          if (userVbds.length !== 1) {
-            debug('checkBaseVdis, share vbd ', { ref: snapshot.$ref, userVbds })
-            // shared vdi ignore
-            return
-          }
-          const vm = userVbds[0].$VM
-          if (!('start' in vm.blocked_operations)) {
-            debug('checkBaseVdis, vm not blocked', { vmRef: vm.$ref })
-            // vm start unlocked
-            // not really an issue since we have check the delta
-            // but it indicates the users played with the blocked operations
-            return
-          }
-          diffDisk = new XapiDiskSource({ xapi: sr.$xapi, vdiRef: activeVdi.$ref, baseRef: snapshot.$ref })
-          await diffDisk.init()
-          if (diffDisk.getBlockIndexes().length === 0) {
-            const sourceUuid = snapshot.other_config?.[COPY_OF]
-            if (sourceUuid) {
-              this.#baseVdisBySourceUuid.set(sourceUuid, activeVdi)
+    if (snapshotCandidates.length > 0) {
+      // New snapshot-based flow (6.3+): verify no data was written between
+      // the target snapshot and its active VDI.
+      let targetVmRef
+      let canChainToTargetVm = true
+      await asyncEach(
+        snapshotCandidates,
+        async snapshot => {
+          let diffDisk
+          try {
+            const activeVdi = sr.$xapi.getObject(snapshot.$snapshot_of)
+            const userVbds = activeVdi.$VBDs?.filter(vbd => vbd.$VM && !vbd.$VM.is_control_domain) ?? []
+            if (userVbds.length !== 1) {
+              debug('checkBaseVdis, share vbd ', { ref: snapshot.$ref, userVbds })
+              // shared vdi ignore
+              return
             }
-            // Track the target VM (the replicated VM to update on the next transfer).
-            targetVmRef = vm.$ref
-          } else {
-            // not empty, we will create a new VM
-            canChainToTargetVm = false
-            debug('checkBaseVdis, data between snapshot and active disk', {
-              vdiRef: snapshot.$ref,
-              nbBlocks: diffDisk.getBlockIndexes().length,
-            })
+            const vm = userVbds[0].$VM
+            if (!('start' in vm.blocked_operations)) {
+              debug('checkBaseVdis, vm not blocked', { vmRef: vm.$ref })
+              // vm start unlocked
+              // not really an issue since we have check the delta
+              // but it indicates the users played with the blocked operations
+              return
+            }
+            diffDisk = new XapiDiskSource({ xapi: sr.$xapi, vdiRef: activeVdi.$ref, baseRef: snapshot.$ref })
+            await diffDisk.init()
+            if (diffDisk.getBlockIndexes().length === 0) {
+              const sourceUuid = snapshot.other_config?.[COPY_OF]
+              if (sourceUuid) {
+                this.#baseVdisBySourceUuid.set(sourceUuid, activeVdi)
+              }
+              // Track the target VM (the replicated VM to update on the next transfer).
+              targetVmRef = vm.$ref
+            } else {
+              // not empty, we will create a new VM
+              canChainToTargetVm = false
+              debug('checkBaseVdis, data between snapshot and active disk', {
+                vdiRef: snapshot.$ref,
+                nbBlocks: diffDisk.getBlockIndexes().length,
+              })
+            }
+          } catch (error) {
+            debug('checkBaseVdis, skipping snapshot', { ref: snapshot.$ref, error })
+            return
+          } finally {
+            await diffDisk?.close().catch(error => debug('checkBaseVdis, error closing', error))
           }
-        } catch (error) {
-          debug('checkBaseVdis, skipping snapshot', { ref: snapshot.$ref, error })
-          return
-        } finally {
-          await diffDisk?.close().catch(error => debug('checkBaseVdis, error closing', error))
+        },
+        {
+          concurrency: 4,
         }
-      },
-      {
-        concurrency: 4,
-      }
-    )
+      )
 
-    if (canChainToTargetVm && targetVmRef !== undefined) {
-      debug('checkBaseVdis,got a valid vm target', targetVmRef)
-      this._targetVmRef = targetVmRef
+      if (canChainToTargetVm && targetVmRef !== undefined) {
+        debug('checkBaseVdis,got a valid vm target', targetVmRef)
+        this._targetVmRef = targetVmRef
+      }
+    } else {
+      // Legacy fallback (upgrade from pre-6.3): no target snapshots exist yet,
+      // look for active (non-snapshot) VDIs with matching COPY_OF, like the old code did.
+      debug('checkBaseVdis, no snapshot candidates, falling back to legacy active VDI lookup')
+      const legacyVdis = sr.$VDIs.filter(vdi => {
+        return vdi?.managed && !vdi?.is_a_snapshot && baseUuidToSrcVdi.has(vdi?.other_config[COPY_OF])
+      })
+      for (const vdi of legacyVdis) {
+        const sourceUuid = vdi.other_config[COPY_OF]
+        if (sourceUuid) {
+          this.#baseVdisBySourceUuid.set(sourceUuid, vdi)
+        }
+      }
     }
 
     for (const uuid of baseUuidToSrcVdi.keys()) {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,8 @@
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
+- [Replication] fix the fall back to full when going 6.2.->6.3 (PR [#9660](https://github.com/vatesfr/xen-orchestra/pull/9660))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -31,4 +33,5 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
 <!--packages-end-->


### PR DESCRIPTION
### Description

when migrating incremental replication from 6.2.2 to 6.3 , the first run is a full

This PR use a mechanism to fallback to the old target  detection to ensure this is always delat when possible 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
