### PR TITLE
fix(bakups): fix merge resume issue when child is disk chain

### DIFF
--- a/@xen-orchestra/backups/_cleanVm.integ.mjs
+++ b/@xen-orchestra/backups/_cleanVm.integ.mjs
@@ -286,6 +286,54 @@ test('it finish unterminated merge ', async () => {
   assert.equal(remainingVhds.includes('child.vhd'), true)
 })
 
+test('it finishes unterminated merge when child is a disk chain', async () => {
+  // This test covers the case where a merge was interrupted and the child disk is a disk chain.
+
+  await handler.writeFile(
+    `${rootPath}/metadata.json`,
+    JSON.stringify({
+      mode: 'delta',
+      size: 209920,
+      vhds: [`${relativePath}/child.vhd`],
+    })
+  )
+
+  const ancestor = await generateVhd(`${basePath}/ancestor.vhd`)
+  const intermediate = await generateVhd(`${basePath}/intermediate.vhd`, {
+    header: {
+      parentUnicodeName: 'ancestor.vhd',
+      parentUuid: ancestor.footer.uuid,
+    },
+  })
+  await generateVhd(`${basePath}/child.vhd`, {
+    header: {
+      parentUnicodeName: 'intermediate.vhd',
+      parentUuid: intermediate.footer.uuid,
+    },
+  })
+
+  // merge state file with chain field
+  await handler.writeFile(
+    `${basePath}/.ancestor.vhd.merge.json`,
+    JSON.stringify({
+      parent: { uuid: '0' },
+      child: { uuid: '0' },
+      chain: ['ancestor.vhd', 'intermediate.vhd', 'child.vhd'],
+      currentBlock: 0,
+      mergedDataSize: 0,
+      step: 'mergeBlocks',
+      diskSize: 0,
+    })
+  )
+
+  await adapter.cleanVm(rootPath, { remove: true, merge: true, logWarn: () => {}, lock: false })
+
+  // ancestor should be renamed to child.vhd (replacing it), intermediate.vhd should be deleted
+  const remainingVhds = await handler.list(basePath)
+  assert.equal(remainingVhds.length, 1)
+  assert.equal(remainingVhds[0], 'child.vhd')
+})
+
 // each of the vhd can be a file, a directory, an alias to a file or an alias to a directory
 // the message and resulting files should be identical to the output with vhd files which is tested independently
 describe('tests multiple combination ', { concurrency: 1 }, () => {

--- a/@xen-orchestra/backups/disks/MergeRemoteDisk.mjs
+++ b/@xen-orchestra/backups/disks/MergeRemoteDisk.mjs
@@ -208,11 +208,9 @@ export class MergeRemoteDisk {
     } else {
       this.#state.child = { uuid: childDisk.getUuid() ?? undefined }
       this.#state.parent = { uuid: parentDisk.getUuid() ?? undefined }
-      const childPaths = childDisk.getPaths()
-      this.#state.chain =
-        childPaths !== undefined
-          ? [parentDisk.getPath(), ...childPaths].map(p => relativeFromFile(this.#statePath, p))
-          : undefined
+      this.#state.chain = [parentDisk.getPath(), ...childDisk.getPaths()].map(path =>
+        relativeFromFile(this.#statePath, path)
+      )
 
       // Finds first allocated block for the 2 following loops
       while (this.#state.currentBlock < getMaxBlockCount && !childDisk.hasBlock(this.#state.currentBlock)) {

--- a/@xen-orchestra/backups/disks/MergeRemoteDisk.mjs
+++ b/@xen-orchestra/backups/disks/MergeRemoteDisk.mjs
@@ -10,6 +10,7 @@ import { createLogger } from '@xen-orchestra/log'
 
 import { basename, dirname } from 'path'
 import { asyncEach } from '@vates/async-each'
+import { relativeFromFile } from '@xen-orchestra/fs/path'
 
 // @ts-ignore
 const { warn } = createLogger('remote-disk:merge')
@@ -18,6 +19,7 @@ const { warn } = createLogger('remote-disk:merge')
  * @typedef {Object} MergeState
  * @property {{ uuid: string }} child
  * @property {{ uuid: string }} parent
+ * @property { string[]  | undefined} chain
  * @property {number} currentBlock
  * @property {number} mergedDataSize
  * @property {'mergeBlocks' | 'cleanup'} step
@@ -32,6 +34,7 @@ export class MergeRemoteDisk {
   #state = {
     child: { uuid: '0' },
     parent: { uuid: '0' },
+    chain: undefined,
     currentBlock: 0,
     mergedDataSize: 0,
     step: 'mergeBlocks',
@@ -205,6 +208,11 @@ export class MergeRemoteDisk {
     } else {
       this.#state.child = { uuid: childDisk.getUuid() ?? undefined }
       this.#state.parent = { uuid: parentDisk.getUuid() ?? undefined }
+      const childPaths = childDisk.getPaths()
+      this.#state.chain =
+        childPaths !== undefined
+          ? [parentDisk.getPath(), ...childPaths].map(p => relativeFromFile(this.#statePath, p))
+          : undefined
 
       // Finds first allocated block for the 2 following loops
       while (this.#state.currentBlock < getMaxBlockCount && !childDisk.hasBlock(this.#state.currentBlock)) {

--- a/@xen-orchestra/backups/disks/RemoteDisk.mjs
+++ b/@xen-orchestra/backups/disks/RemoteDisk.mjs
@@ -57,6 +57,16 @@ export class RemoteDisk extends RandomAccessDisk {
 
   /**
    * Abstract
+   * Either returns an array of disk paths for disk chains or undefined for simple disks.
+   *
+   * @returns {string[] | undefined}
+   */
+  getPaths() {
+    throw new Error(`getPaths must be implemented`)
+  }
+
+  /**
+   * Abstract
    * @returns {string}
    */
   getUuid() {

--- a/@xen-orchestra/backups/disks/RemoteDisk.mjs
+++ b/@xen-orchestra/backups/disks/RemoteDisk.mjs
@@ -57,9 +57,9 @@ export class RemoteDisk extends RandomAccessDisk {
 
   /**
    * Abstract
-   * Either returns an array of disk paths for disk chains or undefined for simple disks.
+   * Returns an array of disk paths.
    *
-   * @returns {string[] | undefined}
+   * @returns {string[]}
    */
   getPaths() {
     throw new Error(`getPaths must be implemented`)

--- a/@xen-orchestra/backups/disks/RemoteDisk.test.mjs
+++ b/@xen-orchestra/backups/disks/RemoteDisk.test.mjs
@@ -910,13 +910,12 @@ describe('tests MergeRemoteDisk', { concurrency: 1 }, () => {
 
     const mergeRemoteDisk = new MergeRemoteDisk(handler, { removeUnused: true, writeStateDelay: 0 })
 
-    const isResumingMerge = await mergeRemoteDisk.isResuming(parent)
-    assert.ok(!isResumingMerge, 'merge is not resuming')
+    assert.ok(!(await mergeRemoteDisk.isResuming(parent)), 'merge is not resuming')
 
-    await parent.init({ force: isResumingMerge })
-    await child1.init({ force: isResumingMerge })
-    await child2.init({ force: isResumingMerge })
-    await childDiskChain.init({ force: isResumingMerge })
+    await parent.init({ force: false })
+    await child1.init({ force: false })
+    await child2.init({ force: false })
+    await childDiskChain.init({ force: false })
 
     // Make writeBlock fail, the state file is already written
     parent.writeBlock = async () => {
@@ -949,13 +948,12 @@ describe('tests MergeRemoteDisk', { concurrency: 1 }, () => {
     const child2b = new RemoteVhdDisk({ handler, path: `${basePath}/child_2.vhd` })
     const childDiskChain2 = new RemoteVhdDiskChain({ disks: [child1b, child2b] })
 
-    const isResumingMerge2 = await mergeRemoteDisk.isResuming(parent2)
-    assert.ok(isResumingMerge2, 'merge should be resuming')
+    assert.ok(await mergeRemoteDisk.isResuming(parent2), 'merge should be resuming')
 
-    await parent2.init({ force: isResumingMerge2 })
-    await child1b.init({ force: isResumingMerge2 })
-    await child2b.init({ force: isResumingMerge2 })
-    await childDiskChain2.init({ force: isResumingMerge2 })
+    await parent2.init({ force: true })
+    await child1b.init({ force: true })
+    await child2b.init({ force: true })
+    await childDiskChain2.init({ force: true })
 
     const result = await mergeRemoteDisk.merge(parent2, childDiskChain2)
 

--- a/@xen-orchestra/backups/disks/RemoteDisk.test.mjs
+++ b/@xen-orchestra/backups/disks/RemoteDisk.test.mjs
@@ -321,10 +321,10 @@ describe('tests RemoteVhdDiskChain', { concurrency: 1 }, () => {
 })
 
 /**
- * MergeVhdChain
+ * MergeRemoteDisk
  */
-describe('tests MergeVhdChain', { concurrency: 1 }, () => {
-  test('mergeVhdChain merges a simple ancestor VHD + child VHD', async () => {
+describe('tests MergeRemoteDisk', { concurrency: 1 }, () => {
+  test('MergeRemoteDisk merges a simple ancestor VHD + child VHD', async () => {
     let progressCalls = 0
     const onProgress = () => {
       progressCalls++
@@ -362,7 +362,7 @@ describe('tests MergeVhdChain', { concurrency: 1 }, () => {
     assert.deepEqual(parentIndexes, expectedIndexes, 'all child blocks should be merged into parent')
   })
 
-  test('mergeVhdChain merges a simple ancestor VHD + child VHD chain', async () => {
+  test('MergeRemoteDisk merges a simple ancestor VHD + child VHD chain', async () => {
     let progressCalls = 0
     const onProgress = () => {
       progressCalls++
@@ -424,7 +424,7 @@ describe('tests MergeVhdChain', { concurrency: 1 }, () => {
     assert.deepEqual(parentIndexes, expectedIndexes, 'all child blocks should be merged into parent')
   })
 
-  test('mergeVhdChain merges an alias ancestor VHD + alias child VHD', async () => {
+  test('MergeRemoteDisk merges an alias ancestor VHD + alias child VHD', async () => {
     let progressCalls = 0
     const onProgress = () => {
       progressCalls++
@@ -465,7 +465,7 @@ describe('tests MergeVhdChain', { concurrency: 1 }, () => {
     assert.deepEqual(parentIndexes, expectedIndexes, 'all child blocks should be merged into parent')
   })
 
-  test('mergeVhdChain merges an alias ancestor VHD + alias child VHD chain', async () => {
+  test('MergeRemoteDisk merges an alias ancestor VHD + alias child VHD chain', async () => {
     let progressCalls = 0
     const onProgress = () => {
       progressCalls++
@@ -520,7 +520,7 @@ describe('tests MergeVhdChain', { concurrency: 1 }, () => {
     assert.deepEqual(parentIndexes, expectedIndexes, 'all child blocks should be merged into parent')
   })
 
-  test('mergeVhdChain merges an alias ancestor VHD + child VHD', async () => {
+  test('MergeRemoteDisk merges an alias ancestor VHD + child VHD', async () => {
     let progressCalls = 0
     const onProgress = () => {
       progressCalls++
@@ -561,7 +561,7 @@ describe('tests MergeVhdChain', { concurrency: 1 }, () => {
     assert.deepEqual(parentIndexes, expectedIndexes, 'all child blocks should be merged into parent')
   })
 
-  test('mergeVhdChain merges an ancestor VHD + alias child VHD', async () => {
+  test('MergeRemoteDisk merges an ancestor VHD + alias child VHD', async () => {
     let progressCalls = 0
     const onProgress = () => {
       progressCalls++
@@ -602,7 +602,7 @@ describe('tests MergeVhdChain', { concurrency: 1 }, () => {
     assert.deepEqual(parentIndexes, expectedIndexes, 'all child blocks should be merged into parent')
   })
 
-  test('mergeVhdChain merges a alias ancestor VHD directory + alias child VHD directory', async () => {
+  test('MergeRemoteDisk merges a alias ancestor VHD directory + alias child VHD directory', async () => {
     let progressCalls = 0
     const onProgress = () => {
       progressCalls++
@@ -646,7 +646,7 @@ describe('tests MergeVhdChain', { concurrency: 1 }, () => {
     assert.ok(ancestorData.length > 0, 'ancestor.vhd directory should contain blocks')
   })
 
-  test('mergeVhdChain closes disks on error', async () => {
+  test('MergeRemoteDisk closes disks on error', async () => {
     // Create parent and child VHDs
     await generateVhd(`${basePath}/ancestor.vhd`, { blocks: [0] })
     await generateVhd(`${basePath}/child.vhd`, { blocks: [1] })
@@ -890,6 +890,88 @@ describe('tests MergeVhdChain', { concurrency: 1 }, () => {
 
       assert.ok(size >= parent2.getBlockSize(), `block ${index} complete`)
     }
+  })
+
+  test('mergeRemoteDisk writes chain to state file and resumes when child is a disk chain', async () => {
+    const ancestorVhd = await generateVhd(`${basePath}/ancestor.vhd`, { blocks: [0, 1] })
+    const child1Vhd = await generateVhd(`${basePath}/child_1.vhd`, {
+      header: { parentUnicodeName: 'ancestor.vhd', parentUuid: ancestorVhd.footer.uuid },
+      blocks: [2],
+    })
+    await generateVhd(`${basePath}/child_2.vhd`, {
+      header: { parentUnicodeName: 'child_1.vhd', parentUuid: child1Vhd.footer.uuid },
+      blocks: [3],
+    })
+
+    const parent = new RemoteVhdDisk({ handler, path: `${basePath}/ancestor.vhd` })
+    const child1 = new RemoteVhdDisk({ handler, path: `${basePath}/child_1.vhd` })
+    const child2 = new RemoteVhdDisk({ handler, path: `${basePath}/child_2.vhd` })
+    const childDiskChain = new RemoteVhdDiskChain({ disks: [child1, child2] })
+
+    const mergeRemoteDisk = new MergeRemoteDisk(handler, { removeUnused: true, writeStateDelay: 0 })
+
+    const isResumingMerge = await mergeRemoteDisk.isResuming(parent)
+    assert.ok(!isResumingMerge, 'merge is not resuming')
+
+    await parent.init({ force: isResumingMerge })
+    await child1.init({ force: isResumingMerge })
+    await child2.init({ force: isResumingMerge })
+    await childDiskChain.init({ force: isResumingMerge })
+
+    // Make writeBlock fail, the state file is already written
+    parent.writeBlock = async () => {
+      throw new Error('simulated interruption')
+    }
+
+    let threw = false
+    try {
+      await mergeRemoteDisk.merge(parent, childDiskChain)
+    } catch (err) {
+      threw = true
+      assert.equal(err.message, 'simulated interruption')
+    }
+    assert.equal(threw, true, 'merge should throw on simulated interruption')
+
+    // State file must exist with full chain: parent first, then children, all as relative paths
+    const stateFileName = `.ancestor.vhd.merge.json`
+    assert.ok((await handler.list(basePath)).includes(stateFileName), 'merge state file should exist after failure')
+
+    const stateContent = JSON.parse(await handler.readFile(`${basePath}/${stateFileName}`))
+    assert.deepEqual(
+      stateContent.chain,
+      ['ancestor.vhd', 'child_1.vhd', 'child_2.vhd'],
+      'state file must contain the full chain'
+    )
+
+    // Recreate new remoteDisks to simulate a new operation
+    const parent2 = new RemoteVhdDisk({ handler, path: `${basePath}/ancestor.vhd` })
+    const child1b = new RemoteVhdDisk({ handler, path: `${basePath}/child_1.vhd` })
+    const child2b = new RemoteVhdDisk({ handler, path: `${basePath}/child_2.vhd` })
+    const childDiskChain2 = new RemoteVhdDiskChain({ disks: [child1b, child2b] })
+
+    const isResumingMerge2 = await mergeRemoteDisk.isResuming(parent2)
+    assert.ok(isResumingMerge2, 'merge should be resuming')
+
+    await parent2.init({ force: isResumingMerge2 })
+    await child1b.init({ force: isResumingMerge2 })
+    await child2b.init({ force: isResumingMerge2 })
+    await childDiskChain2.init({ force: isResumingMerge2 })
+
+    const result = await mergeRemoteDisk.merge(parent2, childDiskChain2)
+
+    assert.ok(result.finalDiskSize > 0, 'final disk size should be > 0')
+
+    assert.equal(
+      (await handler.list(basePath)).includes(stateFileName),
+      false,
+      'merge state file should be removed after successful resume'
+    )
+
+    // ancestor renamed to child_2.vhd (replacing it), child_1.vhd deleted
+    assert.deepEqual(await handler.list(basePath), ['child_2.vhd'])
+
+    // All blocks from the full chain must be present in the result
+    assert.deepEqual(parent2.getBlockIndexes(), [0, 1, 2, 3], 'all blocks from the chain should be merged')
   })
 
   test('mergeRemoteDisk merge a bigger child into a parent', async () => {

--- a/@xen-orchestra/backups/disks/RemoteVhdDisk.mjs
+++ b/@xen-orchestra/backups/disks/RemoteVhdDisk.mjs
@@ -142,6 +142,15 @@ export class RemoteVhdDisk extends RemoteDisk {
   }
 
   /**
+   * Simple disks don't have a list of path to return.
+   *
+   * @returns {undefined}
+   */
+  getPaths() {
+    return undefined
+  }
+
+  /**
    * @returns {string}
    */
   getUuid() {

--- a/@xen-orchestra/backups/disks/RemoteVhdDisk.mjs
+++ b/@xen-orchestra/backups/disks/RemoteVhdDisk.mjs
@@ -142,12 +142,12 @@ export class RemoteVhdDisk extends RemoteDisk {
   }
 
   /**
-   * Simple disks don't have a list of path to return.
+   * Returns the disk path in an array.
    *
-   * @returns {undefined}
+   * @returns {string[]}
    */
   getPaths() {
-    return undefined
+    return [this.getPath()]
   }
 
   /**

--- a/@xen-orchestra/backups/disks/RemoteVhdDiskChain.mjs
+++ b/@xen-orchestra/backups/disks/RemoteVhdDiskChain.mjs
@@ -124,6 +124,15 @@ export class RemoteVhdDiskChain extends RemoteDisk {
   }
 
   /**
+   * Disk chains return an array of disk paths.
+   *
+   * @returns {string[]}
+   */
+  getPaths() {
+    return this.#disks.map(disk => disk.getPath())
+  }
+
+  /**
    * @returns {string}
    */
   getUuid() {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 
 - [Header]: Fix `Unable to connect to XO server` falshing every 30 secondes (PR [#9681](https://github.com/vatesfr/xen-orchestra/pull/9681))
 - [Backups]: Fix regression on cleanVM speed (PR [#9692](https://github.com/vatesfr/xen-orchestra/pull/9692))
+- [Backups]: Fix merge resume when child is disk chain (PR [#9692](https://github.com/vatesfr/xen-orchestra/pull/9668))
 - [Incremental Replication]: Fix "Storage_error ([S(Illegal_transition);[[S(Activated);S(RO)];[S(Activated);S(RW)]]])" [Forum#12059](https://xcp-ng.org/forum/topic/12059/xen-orchestra-6.3.2-random-replication-failure) (PR [#9702](https://github.com/vatesfr/xen-orchestra/pull/9702))
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”


### PR DESCRIPTION
### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
