### PR TITLE
feat(rest-api): add ACL middleware on GET /pgpus/{id}

### DIFF
--- a/@xen-orchestra/rest-api/src/pgpus/pgpu.controller.mts
+++ b/@xen-orchestra/rest-api/src/pgpus/pgpu.controller.mts
@@ -4,8 +4,15 @@ import type { Request as ExRequest } from 'express'
 
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
-import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
-import { badRequestResp, notFoundResp, unauthorizedResp, Unbrand } from '../open-api/common/response.common.mjs'
+import { Example, Get, Middlewares, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import { acl } from '../middlewares/acl.middleware.mjs'
+import {
+  badRequestResp,
+  forbiddenOperationResp,
+  notFoundResp,
+  unauthorizedResp,
+  Unbrand,
+} from '../open-api/common/response.common.mjs'
 import { provide } from 'inversify-binding-decorators'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { partialPgpus, pgpu, pgpuIds } from '../open-api/oa-examples/pgpu.oa-example.mjs'
@@ -46,10 +53,15 @@ export class PgpuController extends XapiXoController<XoPgpu> {
   }
 
   /**
+   * Required privilege:
+   * - resource: pgpu, action: read
+   *
    * @example id "838335fa-ee21-15e1-760a-a37a3a4ef1db"
    */
   @Example(pgpu)
   @Get('{id}')
+  @Middlewares(acl({ resource: 'pgpu', action: 'read', objectId: 'params.id' }))
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   getPgpu(@Path() id: string): Unbrand<XoPgpu> {
     return this.getObject(id as XoPgpu['id'])


### PR DESCRIPTION
### Description

Add ACL middleware on `GET /pgpus/{id}` endpoint to restrict access based on user privileges.

The `GET /pgpus` (list) endpoint already had ACL filtering via `sendObjects()` with `privilege: { action: 'read', resource: 'pgpu' }`, but the `GET /pgpus/{id}` (single resource) endpoint was missing the `@Middlewares(acl(...))` decorator that other controllers (VMs, VDIs, VBDs, VIFs) already have.

Changes:
- Add `@Middlewares(acl({ resource: 'pgpu', action: 'read', objectId: 'params.id' }))` on `getPgpu()`
- Add `@Response(forbiddenOperationResp)` for OpenAPI documentation
- Add JSDoc privilege documentation

Follows the exact same pattern as `vm.controller.mts`, `vdi.controller.mts`, `vbd.controller.mts`, `vif.controller.mts`.

See https://project.vates.tech/vates-global/browse/XO-2068/

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue (`See https://project.vates.tech/vates-global/browse/XO-2068/`)
  - [ ] If bug fix, add `Introduced by` — N/A (feature)
- Changelog
  - [ ] If visible by XOA users, add changelog entry
  - [ ] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [ ] If UI changes, add screenshots — N/A (API only)
  - [ ] If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
