### PR TITLE
feat(rest-api): add ACL v2 middleware on GET /pcis/{id}

### DIFF
--- a/@xen-orchestra/rest-api/src/pcis/pci.controller.mts
+++ b/@xen-orchestra/rest-api/src/pcis/pci.controller.mts
@@ -1,10 +1,17 @@
-import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import { Example, Get, Middlewares, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
 import { inject } from 'inversify'
 import { provide } from 'inversify-binding-decorators'
 import type { Request as ExRequest } from 'express'
 import type { XoPci } from '@vates/types'
 
-import { badRequestResp, notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
+import { acl } from '../middlewares/acl.middleware.mjs'
+import {
+  badRequestResp,
+  forbiddenOperationResp,
+  notFoundResp,
+  unauthorizedResp,
+  type Unbrand,
+} from '../open-api/common/response.common.mjs'
 import { partialPcis, pci, pciIds } from '../open-api/oa-examples/pci.oa-example.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
@@ -50,6 +57,8 @@ export class PciController extends XapiXoController<XoPci> {
    */
   @Example(pci)
   @Get('{id}')
+  @Middlewares(acl({ resource: 'pci', action: 'read', objectId: 'params.id' }))
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   getPci(@Path() id: string): Unbrand<XoPci> {
     return this.getObject(id as XoPci['id'])

--- a/@xen-orchestra/rest-api/src/pcis/pci.controller.mts
+++ b/@xen-orchestra/rest-api/src/pcis/pci.controller.mts
@@ -53,6 +53,9 @@ export class PciController extends XapiXoController<XoPci> {
   }
 
   /**
+   * Required privilege:
+   * - resource: pci, action: read
+   *
    * @example id "9377b642-cc71-8749-1e71-308898b652da"
    */
   @Example(pci)


### PR DESCRIPTION
### Description

Add ACL v2 middleware on `GET /pcis/{id}` endpoint to restrict access based on user privileges.

- The `GET /pcis` endpoint already filters results via `sendObjects` with `privilege: { action: 'read', resource: 'pci' }` (data filtering, does not block access)
- The `GET /pcis/{id}` endpoint now uses `@Middlewares(acl({ resource: 'pci', action: 'read', objectId: 'params.id' }))` to block unauthorized access with a 403

Follows the same pattern as `vbd`, `vif`, `vdi`, and `vm` controllers.

See https://project.vates.tech/vates-global/browse/XO-2067/

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue
- Changelog
  - [ ] If visible by XOA users, add changelog entry
  - [ ] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [x] No UI changes

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
