### PR TITLE
feat(openmetrics): add VM status and uptime metrics

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,6 +36,7 @@
 - [OpenMetrics] Add 9 missing host RRD metrics: `hostload`, `memory_reclaimed`, `memory_reclaimed_max`, `running_vcpus`, `pif_aggr_rx`, `pif_aggr_tx`, `iops_total`, `io_throughput_total`, `latency` per SR (PR [#9696](https://github.com/vatesfr/xen-orchestra/pull/9696))
 - [Netbox] Use platform hierarchy to assign versioned OS names (e.g. "Debian 12" instead of "Debian") when the major version is known (requires Netbox >= 4.4) [#7773](https://github.com/vatesfr/xen-orchestra/issues/7773) (PR [#9644](https://github.com/vatesfr/xen-orchestra/pull/9644))
 - [Backups] Backups no longer use their own task system, but instead use the same system as XO Task. This will help improve loading times in the future (PR [#9734](https://github.com/vatesfr/xen-orchestra/pull/9734))
+- [OpenMetrics] Add VM status (`xcp_vm_status`) and VM uptime (`xcp_vm_uptime_seconds`) metrics [#9684](https://github.com/vatesfr/xen-orchestra/pull/9684)
 
 ### Bug fixes
 

--- a/docs/docs/advanced.md
+++ b/docs/docs/advanced.md
@@ -468,37 +468,39 @@ Infrastructure metrics are prefixed with `xcp_` and XO management plane metrics 
 
 #### VM Metrics
 
-| Metric                                 | Type    | Description                        |
-| -------------------------------------- | ------- | ---------------------------------- |
-| `xcp_vm_memory_bytes`                  | gauge   | Memory usage in bytes              |
-| `xcp_vm_memory_internal_free_bytes`    | gauge   | Internal free memory               |
-| `xcp_vm_memory_target_bytes`           | gauge   | Memory target                      |
-| `xcp_vm_cpu_usage`                     | gauge   | CPU usage ratio                    |
-| `xcp_vm_cpu_core_usage`                | gauge   | Per-vCPU usage                     |
-| `xcp_vm_runstate_fullrun`              | gauge   | Runstate: full run ratio           |
-| `xcp_vm_runstate_full_contention`      | gauge   | Runstate: full contention ratio    |
-| `xcp_vm_runstate_partial_run`          | gauge   | Runstate: partial run ratio        |
-| `xcp_vm_runstate_partial_contention`   | gauge   | Runstate: partial contention ratio |
-| `xcp_vm_runstate_concurrency_hazard`   | gauge   | Runstate: concurrency hazard ratio |
-| `xcp_vm_runstate_blocked`              | gauge   | Runstate: blocked ratio            |
-| `xcp_vm_network_receive_bytes_total`   | counter | Network bytes received per VIF     |
-| `xcp_vm_network_transmit_bytes_total`  | counter | Network bytes transmitted per VIF  |
-| `xcp_vm_network_receive_errors_total`  | counter | Network receive errors             |
-| `xcp_vm_network_transmit_errors_total` | counter | Network transmit errors            |
-| `xcp_vm_disk_read_bytes_total`         | counter | Disk read bytes per device         |
-| `xcp_vm_disk_write_bytes_total`        | counter | Disk write bytes per device        |
-| `xcp_vm_disk_iops_read`                | gauge   | Disk read IOPS                     |
-| `xcp_vm_disk_iops_write`               | gauge   | Disk write IOPS                    |
-| `xcp_vm_disk_iops_total`               | gauge   | Disk total IOPS                    |
-| `xcp_vm_disk_read_latency_seconds`     | gauge   | Disk read latency                  |
-| `xcp_vm_disk_write_latency_seconds`    | gauge   | Disk write latency                 |
-| `xcp_vm_disk_throughput_read_bytes`    | gauge   | Disk read throughput (bytes/s)     |
-| `xcp_vm_disk_throughput_write_bytes`   | gauge   | Disk write throughput (bytes/s)    |
-| `xcp_vm_disk_throughput_total_bytes`   | gauge   | Disk total throughput (bytes/s)    |
-| `xcp_vm_disk_latency_seconds`          | gauge   | Disk average IO latency            |
-| `xcp_vm_disk_iowait`                   | gauge   | Disk IO wait ratio                 |
-| `xcp_vm_disk_inflight`                 | gauge   | In-flight disk operations          |
-| `xcp_vm_disk_queue_size`               | gauge   | Disk queue size                    |
+| Metric                                 | Type    | Description                                                                       |
+| -------------------------------------- | ------- | --------------------------------------------------------------------------------- |
+| `xcp_vm_memory_bytes`                  | gauge   | Memory usage in bytes                                                             |
+| `xcp_vm_memory_internal_free_bytes`    | gauge   | Internal free memory                                                              |
+| `xcp_vm_memory_target_bytes`           | gauge   | Memory target                                                                     |
+| `xcp_vm_cpu_usage`                     | gauge   | CPU usage ratio                                                                   |
+| `xcp_vm_cpu_core_usage`                | gauge   | Per-vCPU usage                                                                    |
+| `xcp_vm_runstate_fullrun`              | gauge   | Runstate: full run ratio                                                          |
+| `xcp_vm_runstate_full_contention`      | gauge   | Runstate: full contention ratio                                                   |
+| `xcp_vm_runstate_partial_run`          | gauge   | Runstate: partial run ratio                                                       |
+| `xcp_vm_runstate_partial_contention`   | gauge   | Runstate: partial contention ratio                                                |
+| `xcp_vm_runstate_concurrency_hazard`   | gauge   | Runstate: concurrency hazard ratio                                                |
+| `xcp_vm_runstate_blocked`              | gauge   | Runstate: blocked ratio                                                           |
+| `xcp_vm_network_receive_bytes_total`   | counter | Network bytes received per VIF                                                    |
+| `xcp_vm_network_transmit_bytes_total`  | counter | Network bytes transmitted per VIF                                                 |
+| `xcp_vm_network_receive_errors_total`  | counter | Network receive errors                                                            |
+| `xcp_vm_network_transmit_errors_total` | counter | Network transmit errors                                                           |
+| `xcp_vm_disk_read_bytes_total`         | counter | Disk read bytes per device                                                        |
+| `xcp_vm_disk_write_bytes_total`        | counter | Disk write bytes per device                                                       |
+| `xcp_vm_disk_iops_read`                | gauge   | Disk read IOPS                                                                    |
+| `xcp_vm_disk_iops_write`               | gauge   | Disk write IOPS                                                                   |
+| `xcp_vm_disk_iops_total`               | gauge   | Disk total IOPS                                                                   |
+| `xcp_vm_disk_read_latency_seconds`     | gauge   | Disk read latency                                                                 |
+| `xcp_vm_disk_write_latency_seconds`    | gauge   | Disk write latency                                                                |
+| `xcp_vm_disk_throughput_read_bytes`    | gauge   | Disk read throughput (bytes/s)                                                    |
+| `xcp_vm_disk_throughput_write_bytes`   | gauge   | Disk write throughput (bytes/s)                                                   |
+| `xcp_vm_disk_throughput_total_bytes`   | gauge   | Disk total throughput (bytes/s)                                                   |
+| `xcp_vm_disk_latency_seconds`          | gauge   | Disk average IO latency                                                           |
+| `xcp_vm_disk_iowait`                   | gauge   | Disk IO wait ratio                                                                |
+| `xcp_vm_disk_inflight`                 | gauge   | In-flight disk operations                                                         |
+| `xcp_vm_disk_queue_size`               | gauge   | Disk queue size                                                                   |
+| `xcp_vm_uptime_seconds`                | gauge   | VM uptime in seconds since boot (running VMs only)                                |
+| `xcp_vm_status`                        | gauge   | VM status (1 = current state, `power_state` in labels), including non-running VMs |
 
 #### SR Capacity Metrics
 
@@ -554,28 +556,28 @@ VDI metrics include labels `vdi_uuid`, `vdi_name`, `sr_uuid`, `sr_name`, `pool_i
 
 All metrics include these labels for filtering:
 
-| Label               | Description                                                              |
-| ------------------- | ------------------------------------------------------------------------ |
-| `pool_id`           | Pool UUID                                                                |
-| `pool_name`         | Pool name                                                                |
-| `uuid`              | Object UUID (host or VM)                                                 |
-| `type`              | Object type (`host` or `vm`)                                             |
-| `host_name`         | Host name (for host metrics)                                             |
-| `vm_name`           | VM name (for VM metrics)                                                 |
-| `sr_uuid`           | Storage Repository UUID (for SR metrics)                                 |
-| `sr_name`           | Storage Repository name (for disk metrics)                               |
-| `vdi_uuid`          | Virtual Disk UUID (for VDI metrics)                                      |
-| `vdi_name`          | Virtual Disk name (for VM disk and VDI metrics)                          |
-| `network_name`      | Network name (for network metrics)                                       |
-| `interface`         | Network interface name                                                   |
-| `device`            | Disk device (xvda, xvdb, etc.)                                           |
-| `core`              | CPU core number                                                          |
-| `vif`               | VIF index (for VM network metrics)                                       |
-| `sr`                | SR UUID suffix (for host disk metrics)                                   |
-| `host_id`           | Host UUID (for local SR capacity metrics)                                |
-| `is_control_domain` | Whether the VM is a control domain / dom0 (`true`/`false`)               |
-| `power_state`       | Host power state: `Running`, `Halted`, `Unknown` (for `xcp_host_status`) |
-| `enabled`           | Whether the host is enabled: `true`/`false` (for `xcp_host_status`)      |
+| Label               | Description                                                                                                                           |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `pool_id`           | Pool UUID                                                                                                                             |
+| `pool_name`         | Pool name                                                                                                                             |
+| `uuid`              | Object UUID (host or VM)                                                                                                              |
+| `type`              | Object type (`host` or `vm`)                                                                                                          |
+| `host_name`         | Host name (for host metrics)                                                                                                          |
+| `vm_name`           | VM name (for VM metrics)                                                                                                              |
+| `sr_uuid`           | Storage Repository UUID (for SR metrics)                                                                                              |
+| `sr_name`           | Storage Repository name (for disk metrics)                                                                                            |
+| `vdi_uuid`          | Virtual Disk UUID (for VDI metrics)                                                                                                   |
+| `vdi_name`          | Virtual Disk name (for VM disk and VDI metrics)                                                                                       |
+| `network_name`      | Network name (for network metrics)                                                                                                    |
+| `interface`         | Network interface name                                                                                                                |
+| `device`            | Disk device (xvda, xvdb, etc.)                                                                                                        |
+| `core`              | CPU core number                                                                                                                       |
+| `vif`               | VIF index (for VM network metrics)                                                                                                    |
+| `sr`                | SR UUID suffix (for host disk metrics)                                                                                                |
+| `host_id`           | Host UUID (for local SR capacity metrics)                                                                                             |
+| `is_control_domain` | Whether the VM is a control domain / dom0 (`true`/`false`)                                                                            |
+| `power_state`       | Power state: `Running`, `Halted`, `Unknown` (for `xcp_host_status`); `Running`, `Paused`, `Halted`, `Suspended` (for `xcp_vm_status`) |
+| `enabled`           | Whether the host is enabled: `true`/`false` (for `xcp_host_status`)                                                                   |
 
 ### PromQL Query Examples
 
@@ -625,6 +627,18 @@ xcp_host_status{power_state!="Running"}
 
 # Hosts in maintenance mode
 xcp_host_status{power_state="Running", enabled="false"}
+
+# Non-running VMs
+xcp_vm_status{power_state!="Running"}
+
+# Halted VMs
+xcp_vm_status{power_state="Halted"}
+
+# VM uptime in days (running VMs only)
+xcp_vm_uptime_seconds / 86400
+
+# VMs running for more than 30 days (may need a reboot)
+xcp_vm_uptime_seconds > 30 * 86400
 
 # VM CPU usage excluding dom0
 xcp_vm_cpu_usage{is_control_domain="false"} * 100
@@ -802,6 +816,24 @@ groups:
         annotations:
           summary: 'Host {{ $labels.host_name }} recently rebooted'
           description: 'Host {{ $labels.host_name }} has been up for less than 10 minutes.'
+
+      - alert: VMNotRunning
+        expr: xcp_vm_status{power_state!="Running"} == 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'VM {{ $labels.vm_name }} is {{ $labels.power_state }}'
+          description: 'VM {{ $labels.vm_name }} in pool {{ $labels.pool_name }} has power state {{ $labels.power_state }}.'
+
+      - alert: VMRecentlyRebooted
+        expr: xcp_vm_uptime_seconds < 600
+        for: 1m
+        labels:
+          severity: info
+        annotations:
+          summary: 'VM {{ $labels.vm_name }} recently rebooted'
+          description: 'VM {{ $labels.vm_name }} has been up for less than 10 minutes.'
 
       - alert: XOHighHeapUsage
         expr: (xo_nodejs_process_memory_bytes{type="heap_used"} / xo_nodejs_heap_size_limit_bytes) > 0.85

--- a/docs/docs/advanced.md
+++ b/docs/docs/advanced.md
@@ -826,13 +826,13 @@ groups:
           summary: 'VM {{ $labels.vm_name }} is {{ $labels.power_state }}'
           description: 'VM {{ $labels.vm_name }} in pool {{ $labels.pool_name }} has power state {{ $labels.power_state }}.'
 
-      - alert: VMRecentlyRebooted
+      - alert: VMRecentlyStarted
         expr: xcp_vm_uptime_seconds < 600
         for: 1m
         labels:
           severity: info
         annotations:
-          summary: 'VM {{ $labels.vm_name }} recently rebooted'
+          summary: 'VM {{ $labels.vm_name }} recently started'
           description: 'VM {{ $labels.vm_name }} has been up for less than 10 minutes.'
 
       - alert: XOHighHeapUsage

--- a/packages/xo-server-openmetrics/.USAGE.md
+++ b/packages/xo-server-openmetrics/.USAGE.md
@@ -11,6 +11,8 @@ This plugin creates an HTTP server that exposes a `/metrics` endpoint compatible
 - Host metrics: CPU, memory, network, disk IOPS/throughput/latency
 - Host uptime metric (`xcp_host_uptime_seconds`)
 - Host status metric (`xcp_host_status`) with `power_state` and `enabled` labels, including non-running hosts
+- VM status metric (`xcp_vm_status`) with `power_state` label, including non-running VMs
+- VM uptime metric (`xcp_vm_uptime_seconds`) for running VMs
 - VM metrics: CPU, memory, network, disk, runstate
 - `is_control_domain` label on all VM metrics to distinguish dom0 from user VMs
 - VDI disk size metrics: virtual size and physical usage per VDI (`xcp_vdi_virtual_size_bytes`, `xcp_vdi_physical_usage_bytes`)

--- a/packages/xo-server-openmetrics/README.md
+++ b/packages/xo-server-openmetrics/README.md
@@ -19,6 +19,8 @@ This plugin creates an HTTP server that exposes a `/metrics` endpoint compatible
 - Host metrics: CPU, memory, network, disk IOPS/throughput/latency
 - Host uptime metric (`xcp_host_uptime_seconds`)
 - Host status metric (`xcp_host_status`) with `power_state` and `enabled` labels, including non-running hosts
+- VM status metric (`xcp_vm_status`) with `power_state` label, including non-running VMs
+- VM uptime metric (`xcp_vm_uptime_seconds`) for running VMs
 - VM metrics: CPU, memory, network, disk, runstate
 - `is_control_domain` label on all VM metrics to distinguish dom0 from user VMs
 - VDI disk size metrics: virtual size and physical usage per VDI (`xcp_vdi_virtual_size_bytes`, `xcp_vdi_physical_usage_bytes`)

--- a/packages/xo-server-openmetrics/src/index.mts
+++ b/packages/xo-server-openmetrics/src/index.mts
@@ -70,6 +70,10 @@ export interface VmLabelInfo {
   vbdDeviceToVdiName: Record<string, string> // { "xvda": "System Disk" }
   vbdDeviceToVdiUuid: Record<string, XoVdi['uuid']> // { "xvda": "vdi-uuid-123" }
   vifIndexToNetworkName: Record<string, string> // { "0": "Pool-wide network" }
+  startTime: number | null // Unix timestamp of VM boot (from vm.startTime)
+  power_state: string // VM power state (Running, Paused, Halted, Suspended)
+  pool_id: string
+  pool_name: string
 }
 
 export interface HostLabelInfo {
@@ -162,6 +166,15 @@ export type HostStatusItem = Pick<XoHost, 'uuid' | 'name_label' | 'power_state' 
 
 interface HostStatusPayload {
   hosts: HostStatusItem[]
+}
+
+export type VmStatusItem = Pick<XoVm, 'uuid' | 'name_label' | 'power_state'> & {
+  pool_id: string
+  pool_name: string
+}
+
+interface VmStatusPayload {
+  vms: VmStatusItem[]
 }
 
 // Union type for all XO objects we handle
@@ -438,6 +451,16 @@ class OpenMetricsPlugin {
         break
       }
 
+      case 'GET_VM_STATUS': {
+        const vmStatus = this.#getVmStatusData()
+        this.#sendToChildNoWait({
+          type: 'VM_STATUS',
+          requestId: message.requestId,
+          payload: vmStatus,
+        })
+        break
+      }
+
       case 'GET_XO_METRICS': {
         this.#getXoMetrics()
           .then((xoMetrics: XoMetricsData) => {
@@ -710,6 +733,35 @@ class OpenMetricsPlugin {
   }
 
   /**
+   * Get VM status data for all VMs (excluding VM-controllers / dom0).
+   * Returns power_state for every VM.
+   */
+  #getVmStatusData(): VmStatusPayload {
+    const vms: VmStatusItem[] = []
+
+    const allPools = this.#xo.getObjects({ filter: { type: 'pool' } }) as Record<string, XoPool>
+    const poolLabelMap = new Map<string, string>()
+    for (const pool of Object.values(allPools)) {
+      poolLabelMap.set(pool.uuid, pool.name_label)
+    }
+
+    const allVms = this.#xo.getObjects({ filter: { type: 'VM' } }) as Record<string, XoVm>
+
+    for (const vm of Object.values(allVms)) {
+      vms.push({
+        uuid: vm.uuid,
+        name_label: vm.name_label,
+        power_state: vm.power_state,
+        pool_id: vm.$poolId,
+        pool_name: poolLabelMap.get(vm.$poolId) ?? '',
+      })
+    }
+
+    logger.debug('Returning VM status data', { vmCount: vms.length })
+    return { vms }
+  }
+
+  /**
    * Collect XO management plane metrics.
    * Gathers counts and stats from XO objects and XO APIs.
    */
@@ -865,6 +917,7 @@ class OpenMetricsPlugin {
 
     const vms: (XoVm | XoVmController)[] = []
     const hosts: XoHost[] = []
+    const pools: XoPool[] = []
     const srs: XoSr[] = []
     const vbds: XoVbd[] = []
     const vdis: XoVdi[] = []
@@ -880,6 +933,9 @@ class OpenMetricsPlugin {
           break
         case 'host':
           hosts.push(obj)
+          break
+        case 'pool':
+          pools.push(obj as XoPool)
           break
         case 'SR':
           srs.push(obj)
@@ -900,6 +956,12 @@ class OpenMetricsPlugin {
           networks.push(obj)
           break
       }
+    }
+
+    // Build pool label map (uuid -> name_label) for VM enrichment
+    const poolLabelMap = new Map<string, string>()
+    for (const pool of pools) {
+      poolLabelMap.set(pool.uuid, pool.name_label)
     }
 
     // Build network name map (id -> name_label)
@@ -1000,6 +1062,10 @@ class OpenMetricsPlugin {
         vbdDeviceToVdiName,
         vbdDeviceToVdiUuid,
         vifIndexToNetworkName,
+        startTime: vm.startTime ?? null,
+        power_state: vm.power_state,
+        pool_id: vm.$poolId,
+        pool_name: poolLabelMap.get(vm.$poolId) ?? '',
       }
     }
 

--- a/packages/xo-server-openmetrics/src/open-metric-server.mts
+++ b/packages/xo-server-openmetrics/src/open-metric-server.mts
@@ -172,27 +172,12 @@ function handleParentMessage(rawMessage: unknown): void {
       break
 
     case 'XAPI_CREDENTIALS':
-      handleCredentialsResponse(message)
-      break
-
     case 'SR_DATA':
-      handleSrDataResponse(message)
-      break
-
     case 'VDI_DATA':
-      handleVdiDataResponse(message)
-      break
-
     case 'HOST_STATUS':
-      handleHostStatusResponse(message)
-      break
-
     case 'VM_STATUS':
-      handleVmStatusResponse(message)
-      break
-
     case 'XO_METRICS':
-      handleXoMetricsResponse(message)
+      resolvePendingRequest(message)
       break
 
     default:
@@ -225,77 +210,7 @@ async function handleShutdown(): Promise<void> {
   await cleanup()
 }
 
-function handleCredentialsResponse(message: IpcMessage): void {
-  const requestId = message.requestId
-  if (requestId === undefined) {
-    return
-  }
-
-  const pending = pendingRequests.get(requestId)
-  if (pending !== undefined) {
-    clearTimeout(pending.timer)
-    pendingRequests.delete(requestId)
-    pending.resolve(message.payload)
-  }
-}
-
-function handleSrDataResponse(message: IpcMessage): void {
-  const requestId = message.requestId
-  if (requestId === undefined) {
-    return
-  }
-
-  const pending = pendingRequests.get(requestId)
-  if (pending !== undefined) {
-    clearTimeout(pending.timer)
-    pendingRequests.delete(requestId)
-    pending.resolve(message.payload)
-  }
-}
-
-function handleVdiDataResponse(message: IpcMessage): void {
-  const requestId = message.requestId
-  if (requestId === undefined) {
-    return
-  }
-
-  const pending = pendingRequests.get(requestId)
-  if (pending !== undefined) {
-    clearTimeout(pending.timer)
-    pendingRequests.delete(requestId)
-    pending.resolve(message.payload)
-  }
-}
-
-function handleHostStatusResponse(message: IpcMessage): void {
-  const requestId = message.requestId
-  if (requestId === undefined) {
-    return
-  }
-
-  const pending = pendingRequests.get(requestId)
-  if (pending !== undefined) {
-    clearTimeout(pending.timer)
-    pendingRequests.delete(requestId)
-    pending.resolve(message.payload)
-  }
-}
-
-function handleVmStatusResponse(message: IpcMessage): void {
-  const requestId = message.requestId
-  if (requestId === undefined) {
-    return
-  }
-
-  const pending = pendingRequests.get(requestId)
-  if (pending !== undefined) {
-    clearTimeout(pending.timer)
-    pendingRequests.delete(requestId)
-    pending.resolve(message.payload)
-  }
-}
-
-function handleXoMetricsResponse(message: IpcMessage): void {
+function resolvePendingRequest(message: IpcMessage): void {
   const requestId = message.requestId
   if (requestId === undefined) {
     return

--- a/packages/xo-server-openmetrics/src/open-metric-server.mts
+++ b/packages/xo-server-openmetrics/src/open-metric-server.mts
@@ -27,10 +27,13 @@ import {
   formatSrMetrics,
   formatToOpenMetrics,
   formatVdiMetrics,
+  formatVmStatusMetrics,
+  formatVmUptimeMetrics,
   formatXoMetrics,
   type HostStatusItem,
   type SrDataItem,
   type VdiDataItem,
+  type VmStatusItem,
   type XoMetricsData,
 } from './openmetric-formatter.mjs'
 
@@ -70,6 +73,10 @@ interface VmLabelInfo {
   vbdDeviceToVdiName: Record<string, string>
   vbdDeviceToVdiUuid: Record<string, string>
   vifIndexToNetworkName: Record<string, string>
+  startTime: number | null
+  power_state: string
+  pool_id: string
+  pool_name: string
 }
 
 interface HostLabelInfo {
@@ -105,6 +112,10 @@ interface VdiDataPayload {
 
 interface HostStatusPayload {
   hosts: HostStatusItem[]
+}
+
+interface VmStatusPayload {
+  vms: VmStatusItem[]
 }
 
 interface PendingRequest<T> {
@@ -174,6 +185,10 @@ function handleParentMessage(rawMessage: unknown): void {
 
     case 'HOST_STATUS':
       handleHostStatusResponse(message)
+      break
+
+    case 'VM_STATUS':
+      handleVmStatusResponse(message)
       break
 
     case 'XO_METRICS':
@@ -253,6 +268,20 @@ function handleVdiDataResponse(message: IpcMessage): void {
 }
 
 function handleHostStatusResponse(message: IpcMessage): void {
+  const requestId = message.requestId
+  if (requestId === undefined) {
+    return
+  }
+
+  const pending = pendingRequests.get(requestId)
+  if (pending !== undefined) {
+    clearTimeout(pending.timer)
+    pendingRequests.delete(requestId)
+    pending.resolve(message.payload)
+  }
+}
+
+function handleVmStatusResponse(message: IpcMessage): void {
   const requestId = message.requestId
   if (requestId === undefined) {
     return
@@ -383,6 +412,25 @@ async function requestHostStatusData(): Promise<HostStatusPayload> {
   })
 }
 
+async function requestVmStatusData(): Promise<VmStatusPayload> {
+  const requestId = `vm-status-${++requestIdCounter}`
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      pendingRequests.delete(requestId)
+      reject(new Error('Timeout waiting for VM status data from parent'))
+    }, IPC_REQUEST_TIMEOUT_MS)
+
+    pendingRequests.set(requestId, {
+      resolve: value => resolve(value as VmStatusPayload),
+      reject,
+      timer,
+    })
+
+    sendToParent({ type: 'GET_VM_STATUS', requestId })
+  })
+}
+
 async function requestXoMetrics(): Promise<XoMetricsData> {
   const requestId = `xo-metrics-${++requestIdCounter}`
 
@@ -480,11 +528,12 @@ async function fetchRrdFromHost(host: HostCredentials): Promise<ParsedRrdData | 
  * @returns OpenMetrics-formatted string
  */
 async function collectMetrics(): Promise<string> {
-  const [credentials, srData, vdiData, hostStatusData, xoMetricsData] = await Promise.all([
+  const [credentials, srData, vdiData, hostStatusData, vmStatusData, xoMetricsData] = await Promise.all([
     requestXapiCredentials(),
     requestSrData(),
     requestVdiData(),
     requestHostStatusData(),
+    requestVmStatusData(),
     requestXoMetrics(),
   ])
 
@@ -493,6 +542,7 @@ async function collectMetrics(): Promise<string> {
     srCount: srData.srs.length,
     vdiCount: vdiData.vdis.length,
     hostStatusCount: hostStatusData.hosts.length,
+    vmStatusCount: vmStatusData.vms.length,
   })
 
   if (credentials.hosts.length === 0) {
@@ -562,6 +612,16 @@ async function collectMetrics(): Promise<string> {
   const uptimeMetricsOutput = uptimeMetrics.length > 0 ? formatToOpenMetrics(uptimeMetrics) : ''
   logger.debug('Formatted host uptime metrics', { hostCount: uptimeMetrics.length })
 
+  // Format VM status metrics
+  const vmStatusMetrics = formatVmStatusMetrics(vmStatusData.vms)
+  const vmStatusOutput = vmStatusMetrics.length > 0 ? formatToOpenMetrics(vmStatusMetrics) : ''
+  logger.debug('Formatted VM status metrics', { vmCount: vmStatusMetrics.length })
+
+  // Format VM uptime metrics
+  const vmUptimeMetrics = formatVmUptimeMetrics(credentials)
+  const vmUptimeOutput = vmUptimeMetrics.length > 0 ? formatToOpenMetrics(vmUptimeMetrics) : ''
+  logger.debug('Formatted VM uptime metrics', { vmCount: vmUptimeMetrics.length })
+
   // Format XO management plane metrics
   const xoMetrics = formatXoMetrics(xoMetricsData)
   const xoMetricsOutput = xoMetrics.length > 0 ? formatToOpenMetrics(xoMetrics) : ''
@@ -591,6 +651,14 @@ async function collectMetrics(): Promise<string> {
 
   if (uptimeMetricsOutput !== '') {
     allMetricsSections.push(uptimeMetricsOutput)
+  }
+
+  if (vmStatusOutput !== '') {
+    allMetricsSections.push(vmStatusOutput)
+  }
+
+  if (vmUptimeOutput !== '') {
+    allMetricsSections.push(vmUptimeOutput)
   }
 
   if (xoMetricsOutput !== '') {

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.mts
@@ -7,10 +7,10 @@
 
 import { createLogger } from '@xen-orchestra/log'
 
-import type { HostStatusItem, LabelLookupData, SrDataItem, VdiDataItem, XoMetricsData } from './index.mjs'
+import type { HostStatusItem, LabelLookupData, SrDataItem, VdiDataItem, VmStatusItem, XoMetricsData } from './index.mjs'
 import type { ParsedMetric, ParsedRrdData } from './rrd-parser.mjs'
 
-export type { HostStatusItem, SrDataItem, VdiDataItem, XoMetricsData }
+export type { HostStatusItem, SrDataItem, VdiDataItem, VmStatusItem, XoMetricsData }
 
 const logger = createLogger('xo:xo-server-openmetrics:formatter')
 
@@ -1144,6 +1144,46 @@ export function formatHostStatusMetrics(hostStatusList: HostStatusItem[]): Forma
 }
 
 /**
+ * Format VM status metrics.
+ *
+ * Creates one FormattedMetric per VM with power_state label.
+ *
+ * @param vmStatusList - Array of VM status data
+ * @returns Array of FormattedMetric entries for VM status
+ */
+export function formatVmStatusMetrics(vmStatusList: VmStatusItem[]): FormattedMetric[] {
+  const metrics: FormattedMetric[] = []
+  const timestamp = Math.floor(Date.now() / 1000)
+
+  for (const vm of vmStatusList) {
+    const labels: Record<string, string> = {
+      pool_id: vm.pool_id,
+      uuid: vm.uuid,
+      power_state: vm.power_state,
+    }
+
+    if (vm.pool_name !== '') {
+      labels.pool_name = vm.pool_name
+    }
+
+    if (vm.name_label !== '') {
+      labels.vm_name = vm.name_label
+    }
+
+    metrics.push({
+      name: `${METRIC_PREFIX}_vm_status`,
+      help: 'VM status (1 = current state)',
+      type: 'gauge',
+      labels,
+      value: 1,
+      timestamp,
+    })
+  }
+
+  return metrics
+}
+
+/**
  * Format XO management plane metrics to OpenMetrics format.
  *
  * Produces counters/gauges for pools, hosts, VMs, SRs, users, groups,
@@ -1341,6 +1381,62 @@ export function formatHostUptimeMetrics(labelContext: LabelContext): FormattedMe
     metrics.push({
       name: `${METRIC_PREFIX}_host_uptime_seconds`,
       help: 'Host uptime in seconds since boot',
+      type: 'gauge',
+      labels,
+      value: uptimeSeconds,
+      timestamp: now,
+    })
+  }
+
+  return metrics
+}
+
+/**
+ * Format VM uptime metrics to OpenMetrics format.
+ *
+ * Creates a FormattedMetric entry for each VM's uptime, calculated as
+ * the difference between current time and vm.startTime (boot time).
+ * VM-controllers (dom0) are excluded.
+ *
+ * @param labelContext - Label context containing host credentials and label lookup data
+ * @returns Array of FormattedMetric entries for VM uptime
+ */
+export function formatVmUptimeMetrics(labelContext: LabelContext): FormattedMetric[] {
+  const metrics: FormattedMetric[] = []
+  const now = Math.floor(Date.now() / 1000)
+
+  for (const [vmUuid, vmInfo] of Object.entries(labelContext.labels.vms)) {
+    if (vmInfo.is_control_domain) {
+      continue
+    }
+
+    // Only emit uptime for running VMs — halted/suspended VMs retain stale startTime
+    if (vmInfo.power_state !== 'Running') {
+      continue
+    }
+
+    if (vmInfo.startTime === null || vmInfo.startTime === undefined) {
+      continue
+    }
+
+    const uptimeSeconds = Math.max(0, now - vmInfo.startTime)
+
+    const labels: Record<string, string> = {
+      pool_id: vmInfo.pool_id,
+      uuid: vmUuid,
+    }
+
+    if (vmInfo.pool_name !== '') {
+      labels.pool_name = vmInfo.pool_name
+    }
+
+    if (vmInfo.name_label !== '') {
+      labels.vm_name = vmInfo.name_label
+    }
+
+    metrics.push({
+      name: `${METRIC_PREFIX}_vm_uptime_seconds`,
+      help: 'VM uptime in seconds since boot',
       type: 'gauge',
       labels,
       value: uptimeSeconds,

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.mts
@@ -1172,7 +1172,7 @@ export function formatVmStatusMetrics(vmStatusList: VmStatusItem[]): FormattedMe
 
     metrics.push({
       name: `${METRIC_PREFIX}_vm_status`,
-      help: 'VM status (1 = current state)',
+      help: 'VM power state indicator (always 1; current state is carried by the power_state label)',
       type: 'gauge',
       labels,
       value: 1,

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
@@ -2040,14 +2040,20 @@ describe('formatVmStatusMetrics', () => {
     const metrics = formatVmStatusMetrics(vms)
     const output = formatToOpenMetrics(metrics)
 
-    assert.ok(output.includes('# HELP xcp_vm_status VM status (1 = current state)'))
+    assert.ok(
+      output.includes(
+        '# HELP xcp_vm_status VM power state indicator (always 1; current state is carried by the power_state label)'
+      )
+    )
     assert.ok(output.includes('# TYPE xcp_vm_status gauge'))
     assert.ok(output.includes('power_state="Running"'))
     assert.ok(output.includes('power_state="Halted"'))
 
     // HELP and TYPE should appear only once
     const helpCount = (output.match(/# HELP xcp_vm_status/g) || []).length
+    const typeCount = (output.match(/# TYPE xcp_vm_status/g) || []).length
     assert.equal(helpCount, 1)
+    assert.equal(typeCount, 1)
   })
 
   it('should escape special characters in VM names', () => {

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
@@ -15,11 +15,13 @@ import {
   formatHostStatusMetrics,
   formatHostUptimeMetrics,
   formatVdiMetrics,
+  formatVmStatusMetrics,
+  formatVmUptimeMetrics,
   type FormattedMetric,
   type LabelContext,
 } from './openmetric-formatter.mjs'
 
-import type { HostStatusItem, VdiDataItem } from './index.mjs'
+import type { HostStatusItem, VdiDataItem, VmStatusItem } from './index.mjs'
 
 import type { ParsedMetric, ParsedRrdData } from './rrd-parser.mjs'
 
@@ -735,6 +737,10 @@ describe('transformMetric with labelContext', () => {
           vbdDeviceToVdiName: { xvda: 'System Disk', xvdb: 'Data Disk' },
           vbdDeviceToVdiUuid: { xvda: 'vdi-uuid-system', xvdb: 'vdi-uuid-data' },
           vifIndexToNetworkName: { '0': 'Pool-wide network', '1': 'Storage network' },
+          startTime: null,
+          power_state: 'Running',
+          pool_id: 'pool-456',
+          pool_name: 'Production Pool',
         },
       },
       hosts: {
@@ -964,6 +970,10 @@ describe('transformMetric with labelContext', () => {
       vbdDeviceToVdiName: {},
       vbdDeviceToVdiUuid: {},
       vifIndexToNetworkName: {},
+      startTime: null,
+      power_state: 'Running',
+      pool_id: 'pool-456',
+      pool_name: 'Production Pool',
     }
 
     const metric: ParsedMetric = {
@@ -1047,6 +1057,10 @@ describe('formatAllPoolsToOpenMetrics with labelContext', () => {
           vbdDeviceToVdiName: { xvda: 'System Disk' },
           vbdDeviceToVdiUuid: { xvda: 'vdi-1' },
           vifIndexToNetworkName: { '0': 'Management' },
+          startTime: null,
+          power_state: 'Running',
+          pool_id: 'pool-1',
+          pool_name: 'Production',
         },
       },
       hosts: {
@@ -1314,6 +1328,10 @@ describe('CPU usage fallback', () => {
             vbdDeviceToVdiName: {},
             vbdDeviceToVdiUuid: {},
             vifIndexToNetworkName: {},
+            startTime: null,
+            power_state: 'Running',
+            pool_id: 'pool-1',
+            pool_name: 'Production',
           },
         },
         hosts: {},
@@ -1898,5 +1916,361 @@ describe('formatVdiMetrics', () => {
     const output = formatToOpenMetrics(metrics)
 
     assert.ok(output.includes('vdi_name="Disk \\"with quotes\\""'))
+  })
+})
+
+// ============================================================================
+// formatVmStatusMetrics Tests
+// ============================================================================
+
+describe('formatVmStatusMetrics', () => {
+  it('should return empty array for empty input', () => {
+    const result = formatVmStatusMetrics([])
+    assert.deepEqual(result, [])
+  })
+
+  it('should create one metric per VM with value 1', () => {
+    const vms: VmStatusItem[] = [
+      {
+        uuid: 'vm-1',
+        name_label: 'VM 1',
+        power_state: 'Running',
+        pool_id: 'pool-1',
+        pool_name: 'Pool',
+      },
+      {
+        uuid: 'vm-2',
+        name_label: 'VM 2',
+        power_state: 'Halted',
+        pool_id: 'pool-1',
+        pool_name: 'Pool',
+      },
+    ]
+
+    const result = formatVmStatusMetrics(vms)
+
+    assert.equal(result.length, 2)
+    assert.equal(result[0]!.value, 1)
+    assert.equal(result[1]!.value, 1)
+  })
+
+  it('should set correct metric name and type', () => {
+    const vms: VmStatusItem[] = [
+      {
+        uuid: 'vm-1',
+        name_label: 'VM 1',
+        power_state: 'Running',
+        pool_id: 'pool-1',
+        pool_name: 'Pool',
+      },
+    ]
+
+    const result = formatVmStatusMetrics(vms)
+
+    assert.equal(result[0]!.name, 'xcp_vm_status')
+    assert.equal(result[0]!.type, 'gauge')
+  })
+
+  it('should include all expected labels', () => {
+    const vms: VmStatusItem[] = [
+      {
+        uuid: 'vm-1',
+        name_label: 'VM 1',
+        power_state: 'Running',
+        pool_id: 'pool-1',
+        pool_name: 'Production',
+      },
+    ]
+
+    const result = formatVmStatusMetrics(vms)
+    const labels = result[0]!.labels
+
+    assert.equal(labels.pool_id, 'pool-1')
+    assert.equal(labels.pool_name, 'Production')
+    assert.equal(labels.uuid, 'vm-1')
+    assert.equal(labels.vm_name, 'VM 1')
+    assert.equal(labels.power_state, 'Running')
+  })
+
+  it('should omit pool_name when empty', () => {
+    const vms: VmStatusItem[] = [
+      { uuid: 'vm-1', name_label: 'VM 1', power_state: 'Running', pool_id: 'pool-1', pool_name: '' },
+    ]
+
+    const result = formatVmStatusMetrics(vms)
+
+    assert.equal(result[0]!.labels.pool_name, undefined)
+  })
+
+  it('should handle all VM power_state values', () => {
+    const vms: VmStatusItem[] = [
+      { uuid: 'vm-0', name_label: 'VM 0', power_state: 'Running', pool_id: 'pool-1', pool_name: 'Pool' },
+      { uuid: 'vm-1', name_label: 'VM 1', power_state: 'Paused', pool_id: 'pool-1', pool_name: 'Pool' },
+      { uuid: 'vm-2', name_label: 'VM 2', power_state: 'Halted', pool_id: 'pool-1', pool_name: 'Pool' },
+      { uuid: 'vm-3', name_label: 'VM 3', power_state: 'Suspended', pool_id: 'pool-1', pool_name: 'Pool' },
+    ]
+
+    const result = formatVmStatusMetrics(vms)
+
+    assert.equal(result.length, 4)
+    assert.equal(result[0]!.labels.power_state, 'Running')
+    assert.equal(result[1]!.labels.power_state, 'Paused')
+    assert.equal(result[2]!.labels.power_state, 'Halted')
+    assert.equal(result[3]!.labels.power_state, 'Suspended')
+  })
+
+  it('should produce valid OpenMetrics output', () => {
+    const vms: VmStatusItem[] = [
+      {
+        uuid: 'vm-1',
+        name_label: 'VM 1',
+        power_state: 'Running',
+        pool_id: 'pool-1',
+        pool_name: 'Pool',
+      },
+      {
+        uuid: 'vm-2',
+        name_label: 'VM 2',
+        power_state: 'Halted',
+        pool_id: 'pool-1',
+        pool_name: 'Pool',
+      },
+    ]
+
+    const metrics = formatVmStatusMetrics(vms)
+    const output = formatToOpenMetrics(metrics)
+
+    assert.ok(output.includes('# HELP xcp_vm_status VM status (1 = current state)'))
+    assert.ok(output.includes('# TYPE xcp_vm_status gauge'))
+    assert.ok(output.includes('power_state="Running"'))
+    assert.ok(output.includes('power_state="Halted"'))
+
+    // HELP and TYPE should appear only once
+    const helpCount = (output.match(/# HELP xcp_vm_status/g) || []).length
+    assert.equal(helpCount, 1)
+  })
+
+  it('should escape special characters in VM names', () => {
+    const vms: VmStatusItem[] = [
+      {
+        uuid: 'vm-1',
+        name_label: 'VM "with quotes"',
+        power_state: 'Running',
+        pool_id: 'pool-1',
+        pool_name: 'Pool',
+      },
+    ]
+
+    const metrics = formatVmStatusMetrics(vms)
+    const output = formatToOpenMetrics(metrics)
+
+    assert.ok(output.includes('vm_name="VM \\"with quotes\\""'))
+  })
+
+  it('should omit vm_name when empty', () => {
+    const vms: VmStatusItem[] = [
+      { uuid: 'vm-1', name_label: '', power_state: 'Running', pool_id: 'pool-1', pool_name: 'Pool' },
+    ]
+
+    const result = formatVmStatusMetrics(vms)
+
+    assert.equal(result[0]!.labels.vm_name, undefined)
+  })
+})
+
+// ============================================================================
+// formatVmUptimeMetrics Tests
+// ============================================================================
+
+describe('formatVmUptimeMetrics', () => {
+  const createVmLabelContext = (
+    overrides: Partial<{
+      startTime: number | null
+      is_control_domain: boolean
+      name_label: string
+      pool_name: string
+      power_state: string
+    }> = {}
+  ): LabelContext => ({
+    hosts: [
+      {
+        hostId: 'host-1',
+        hostAddress: '192.168.1.1',
+        hostLabel: 'Host 1',
+        poolId: 'pool-456',
+        poolLabel: 'Production Pool',
+        sessionId: 'session-123',
+        protocol: 'https:',
+      },
+    ],
+    labels: {
+      vms: {
+        'vm-uuid-123': {
+          name_label: overrides.name_label ?? 'Test VM',
+          is_control_domain: overrides.is_control_domain ?? false,
+          vbdDeviceToVdiName: {},
+          vbdDeviceToVdiUuid: {},
+          vifIndexToNetworkName: {},
+          startTime: overrides.startTime !== undefined ? overrides.startTime : Math.floor(Date.now() / 1000) - 3600,
+          power_state: overrides.power_state ?? 'Running',
+          pool_id: 'pool-456',
+          pool_name: overrides.pool_name ?? 'Production Pool',
+        },
+      },
+      hosts: {
+        'host-1': {
+          name_label: 'Host 1',
+          pifDeviceToNetworkName: {},
+          startTime: Math.floor(Date.now() / 1000) - 7200,
+        },
+      },
+      srs: {},
+      srSuffixToUuid: {},
+      vdiUuidToSrUuid: {},
+    },
+  })
+
+  it('should generate uptime metric for VM with valid startTime', () => {
+    const now = Math.floor(Date.now() / 1000)
+    const bootTime = now - 3600 // 1 hour ago
+    const labelContext = createVmLabelContext({ startTime: bootTime })
+
+    const metrics = formatVmUptimeMetrics(labelContext)
+
+    assert.equal(metrics.length, 1)
+    const metric = metrics[0]!
+    assert.equal(metric.name, 'xcp_vm_uptime_seconds')
+    assert.equal(metric.type, 'gauge')
+    assert.equal(metric.help, 'VM uptime in seconds since boot')
+    assert.equal(metric.labels.pool_id, 'pool-456')
+    assert.equal(metric.labels.pool_name, 'Production Pool')
+    assert.equal(metric.labels.uuid, 'vm-uuid-123')
+    assert.equal(metric.labels.vm_name, 'Test VM')
+    // Value should be approximately 3600 (1 hour)
+    assert.ok(metric.value >= 3599 && metric.value <= 3601)
+  })
+
+  it('should skip VM with null startTime', () => {
+    const labelContext = createVmLabelContext({ startTime: null })
+
+    const metrics = formatVmUptimeMetrics(labelContext)
+
+    assert.equal(metrics.length, 0)
+  })
+
+  it('should skip VM-controller (is_control_domain)', () => {
+    const labelContext = createVmLabelContext({ is_control_domain: true })
+
+    const metrics = formatVmUptimeMetrics(labelContext)
+
+    assert.equal(metrics.length, 0)
+  })
+
+  it('should generate metrics for multiple VMs', () => {
+    const now = Math.floor(Date.now() / 1000)
+    const labelContext: LabelContext = {
+      hosts: [
+        {
+          hostId: 'host-1',
+          hostAddress: '192.168.1.1',
+          hostLabel: 'Host 1',
+          poolId: 'pool-1',
+          poolLabel: 'Pool A',
+          sessionId: 'session-1',
+          protocol: 'https:',
+        },
+      ],
+      labels: {
+        vms: {
+          'vm-1': {
+            name_label: 'VM 1',
+            is_control_domain: false,
+            vbdDeviceToVdiName: {},
+            vbdDeviceToVdiUuid: {},
+            vifIndexToNetworkName: {},
+            startTime: now - 7200, // 2 hours
+            power_state: 'Running',
+            pool_id: 'pool-1',
+            pool_name: 'Pool A',
+          },
+          'vm-2': {
+            name_label: 'VM 2',
+            is_control_domain: false,
+            vbdDeviceToVdiName: {},
+            vbdDeviceToVdiUuid: {},
+            vifIndexToNetworkName: {},
+            startTime: now - 1800, // 30 minutes
+            power_state: 'Running',
+            pool_id: 'pool-1',
+            pool_name: 'Pool A',
+          },
+        },
+        hosts: {
+          'host-1': {
+            name_label: 'Host 1',
+            pifDeviceToNetworkName: {},
+            startTime: now - 86400,
+          },
+        },
+        srs: {},
+        srSuffixToUuid: {},
+        vdiUuidToSrUuid: {},
+      },
+    }
+
+    const metrics = formatVmUptimeMetrics(labelContext)
+
+    assert.equal(metrics.length, 2)
+    const vm1Metric = metrics.find(m => m.labels.uuid === 'vm-1')
+    const vm2Metric = metrics.find(m => m.labels.uuid === 'vm-2')
+    assert.ok(vm1Metric)
+    assert.ok(vm2Metric)
+    assert.ok(vm1Metric.value >= 7199 && vm1Metric.value <= 7201)
+    assert.ok(vm2Metric.value >= 1799 && vm2Metric.value <= 1801)
+  })
+
+  it('should omit pool_name when empty', () => {
+    const labelContext = createVmLabelContext({ pool_name: '' })
+
+    const metrics = formatVmUptimeMetrics(labelContext)
+
+    assert.equal(metrics.length, 1)
+    assert.equal(metrics[0]!.labels.pool_name, undefined)
+  })
+
+  it('should omit vm_name when empty', () => {
+    const labelContext = createVmLabelContext({ name_label: '' })
+
+    const metrics = formatVmUptimeMetrics(labelContext)
+
+    assert.equal(metrics.length, 1)
+    assert.equal(metrics[0]!.labels.vm_name, undefined)
+  })
+
+  it('should skip halted VM with stale startTime', () => {
+    const now = Math.floor(Date.now() / 1000)
+    const labelContext = createVmLabelContext({ startTime: now - 86400, power_state: 'Halted' })
+
+    const metrics = formatVmUptimeMetrics(labelContext)
+
+    assert.equal(metrics.length, 0)
+  })
+
+  it('should skip suspended VM', () => {
+    const now = Math.floor(Date.now() / 1000)
+    const labelContext = createVmLabelContext({ startTime: now - 3600, power_state: 'Suspended' })
+
+    const metrics = formatVmUptimeMetrics(labelContext)
+
+    assert.equal(metrics.length, 0)
+  })
+
+  it('should skip paused VM', () => {
+    const now = Math.floor(Date.now() / 1000)
+    const labelContext = createVmLabelContext({ startTime: now - 3600, power_state: 'Paused' })
+
+    const metrics = formatVmUptimeMetrics(labelContext)
+
+    assert.equal(metrics.length, 0)
   })
 })


### PR DESCRIPTION
### Description

Add VM status and uptime metrics to the OpenMetrics/Prometheus endpoint.

Two new gauge metrics are exposed:

| Metric | Description |
|--------|-------------|
| `xcp_vm_status` | VM power state (1 = current state), with `power_state` label (`Running`, `Paused`, `Halted`, `Suspended`) |
| `xcp_vm_uptime_seconds` | VM uptime in seconds since boot (running VMs only) |

**Labels for `xcp_vm_status`:** `pool_id`, `uuid`, `power_state`, and optionally `pool_name`, `vm_name`.
**Labels for `xcp_vm_uptime_seconds`:** `pool_id`, `uuid`, and optionally `pool_name`, `vm_name`.

The implementation follows the existing host status/uptime patterns:
- **Status**: dedicated IPC payload (`VmStatusItem` via `GET_VM_STATUS`/`VM_STATUS`), ensuring all VMs are included regardless of RRD data availability
- **Uptime**: `LabelContext` enrichment (`VmLabelInfo` with `startTime`, `power_state`, `pool_id`, `pool_name`), only emitted for running VMs to avoid stale `startTime` on halted/suspended VMs

VM-controllers (dom0) are excluded from both metrics.

Tested on XOA with real infrastructure — both metrics correctly exposed on `/metrics` endpoint.

<img width="845" height="855" alt="Capture d'écran du 2026-04-08 12-43-19" src="https://github.com/user-attachments/assets/b300d3b8-85db-42df-83d8-540a0a9a35f2" />
<img width="851" height="738" alt="Capture d'écran du 2026-04-08 12-42-43" src="https://github.com/user-attachments/assets/382d0b64-6c64-432d-8194-db32e20eaf37" />


Fixes [XO-1993](https://project.vates.tech/vates-global/browse/XO-1993/)

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue (`Fixes XO-1993`)
  - [ ] If bug fix, add `Introduced by`
- Changelog
  - [x] If visible by XOA users, add changelog entry
  - [x] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [ ] If UI changes, add screenshots
  - [ ] If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.