### PR TITLE
fix(XO6): 'please wait' page not displayed  on dev pages

### DIFF
--- a/@xen-orchestra/web/src/layouts/AppLayout.vue
+++ b/@xen-orchestra/web/src/layouts/AppLayout.vue
@@ -15,7 +15,7 @@
       <SidebarSearch v-model="filter" />
     </template>
     <template #sidebar-content>
-      <VtsStateHero v-if="!isConnected" format="card" type="busy" size="medium" class="loader" />
+      <VtsStateHero v-if="!isConnected && !isDevPage" format="card" type="busy" size="medium" class="loader" />
       <VtsTreeList v-else-if="!isReady">
         <VtsTreeLoadingItem v-for="i in 5" :key="i" icon="object:pool" />
       </VtsTreeList>
@@ -26,7 +26,7 @@
       <SiteTreeList v-else :branches="sites" />
     </template>
     <template #content>
-      <VtsStateHero v-if="!isConnected" format="page" type="busy" size="large">
+      <VtsStateHero v-if="!isConnected && !isDevPage" format="page" type="busy" size="large">
         <div class="state-content">
           <span class="typo-caption">{{ t('loading') }}</span>
           <span class="title typo-h1">{{ t('please-wait') }}</span>
@@ -79,6 +79,8 @@ const route = useRoute<'/pool/[id]' | '/host/[id]' | '/vm/[id]'>()
 
 const { buildXo5Route } = useXoRoutes()
 const xo5Route = computed(() => buildXo5Route('/'))
+
+const isDevPage = computed(() => route.path.startsWith('/dev'))
 
 async function scrollToRouteParamId() {
   const paramId = route.params.id

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,4 +31,6 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/web patch
+
 <!--packages-end-->


### PR DESCRIPTION
### Description

Don't display the “Please wait” page for dev pages 

Card : [XO-2273](https://project.vates.tech/vates-global/browse/XO-2273/)

Introduced by : [PR 9568](https://github.com/vatesfr/xen-orchestra/pull/9568)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
