### PR TITLE
feat(rest-api): ACL middleware for several endpoints

### DIFF
--- a/@vates/types/src/lib/xen-orchestra-xapi.mts
+++ b/@vates/types/src/lib/xen-orchestra-xapi.mts
@@ -62,6 +62,11 @@ export interface Xapi {
     ref: T['$ref'],
     field: K
   ): Promise<T[K]>
+  getObject: <T extends XenApiRecord>(
+    // id is either uuid or ref
+    idOrUuidOrRef: T[Extract<'uuid', keyof T>] | T['$ref'],
+    defaultValue?: T
+  ) => T
   createNetwork(
     params:
       | {

--- a/@vates/types/src/lib/xen-orchestra-xapi.mts
+++ b/@vates/types/src/lib/xen-orchestra-xapi.mts
@@ -23,6 +23,7 @@ import type {
   XoVmTemplate,
 } from '../xo.mjs'
 import type { SUPPORTED_VDI_FORMAT } from '../common.mjs'
+import type { XapiXoRecord } from '../xo.mjs'
 
 export type XcpPatches = {
   changelog?: {
@@ -62,11 +63,13 @@ export interface Xapi {
     ref: T['$ref'],
     field: K
   ): Promise<T[K]>
-  getObject: <T extends XenApiRecord>(
-    // id is either uuid or ref
-    idOrUuidOrRef: T[Extract<'uuid', keyof T>] | T['$ref'],
-    defaultValue?: T
-  ) => T
+  getObject: <
+    XoRecord extends XapiXoRecord,
+    WrappedRecord extends WrappedXenApiRecord = Extract<WrappedXenApiRecord, { $type: XoRecord['type'] }>,
+  >(
+    idOrUuidOrRef: XoRecord['id'] | WrappedRecord['$ref'] | WrappedRecord['uuid'],
+    defaultValue?: WrappedRecord
+  ) => WrappedRecord
   createNetwork(
     params:
       | {

--- a/@xen-orchestra/acl/src/actions/network.mts
+++ b/@xen-orchestra/acl/src/actions/network.mts
@@ -1,3 +1,4 @@
 export default {
+  create: true,
   read: true,
 }

--- a/@xen-orchestra/acl/src/actions/pool.mts
+++ b/@xen-orchestra/acl/src/actions/pool.mts
@@ -1,3 +1,9 @@
 export default {
+  'emergency-shutdown': true,
   read: true,
+  'rolling-reboot': true,
+  'rolling-update': true,
+  update: {
+    tags: true,
+  },
 }

--- a/@xen-orchestra/acl/src/actions/pool.mts
+++ b/@xen-orchestra/acl/src/actions/pool.mts
@@ -1,4 +1,8 @@
 export default {
+  create: {
+    network: true,
+    vm: true,
+  },
   'emergency-shutdown': true,
   read: true,
   'rolling-reboot': true,

--- a/@xen-orchestra/acl/src/actions/sr.mts
+++ b/@xen-orchestra/acl/src/actions/sr.mts
@@ -1,3 +1,6 @@
 export default {
+  import: {
+    vm: true,
+  },
   read: true,
 }

--- a/@xen-orchestra/acl/src/actions/vm.mts
+++ b/@xen-orchestra/acl/src/actions/vm.mts
@@ -1,5 +1,4 @@
 export default {
-  create: true,
   read: true,
   start: true,
   shutdown: {

--- a/@xen-orchestra/acl/src/actions/vm.mts
+++ b/@xen-orchestra/acl/src/actions/vm.mts
@@ -1,4 +1,5 @@
 export default {
+  create: true,
   read: true,
   start: true,
   shutdown: {

--- a/@xen-orchestra/rest-api/src/middlewares/acl.middleware.mts
+++ b/@xen-orchestra/rest-api/src/middlewares/acl.middleware.mts
@@ -65,13 +65,13 @@ type AclEntry = {
   ) &
     (
       | {
-          objectIds: string[] | ((opts: { req: AuthenticatedRequest }) => XoRecord['id'][])
+          objectIds: string[] | ((opts: { req: AuthenticatedRequest; restApi: RestApi }) => XoRecord['id'][])
           getObject?:
             | ((opts: { restApi: RestApi }) => (id: Branded<any>) => Promise<NonXapiXoRecord>)
             | ((opts: { restApi: RestApi }) => (id: Branded<any>) => XapiXoRecord)
         }
       | {
-          objectId: string | ((opts: { req: AuthenticatedRequest }) => XoRecord['id'])
+          objectId: string | ((opts: { req: AuthenticatedRequest; restApi: RestApi }) => XoRecord['id'])
           getObject?:
             | ((opts: { restApi: RestApi }) => (id: Branded<any>) => Promise<NonXapiXoRecord>)
             | ((opts: { restApi: RestApi }) => (id: Branded<any>) => XapiXoRecord)
@@ -80,7 +80,7 @@ type AclEntry = {
           objectIds?: never
           objectId?: never
           getObject?: never
-          objects: object[] | ((opts: { req: AuthenticatedRequest }) => object[])
+          objects: object[] | ((opts: { req: AuthenticatedRequest }) => object[] | undefined)
           object?: never
         }
       | {
@@ -88,7 +88,7 @@ type AclEntry = {
           objectId?: never
           getObject?: never
           objects?: never
-          object: object | ((opts: { req: AuthenticatedRequest }) => object)
+          object: object | ((opts: { req: AuthenticatedRequest }) => object | undefined)
         }
     )
 }[SupportedResource]
@@ -140,7 +140,7 @@ function normalizeAclEntry(acl: AclEntry) {
   }
 
   if ('object' in acl && acl.object !== undefined) {
-    let objects: object[] | ((opts: { req: AuthenticatedRequest }) => object[])
+    let objects: object[] | ((opts: { req: AuthenticatedRequest }) => object[] | undefined)
     if (typeof acl.object === 'function') {
       const fn = acl.object
       objects = (opts: { req: AuthenticatedRequest }) => [fn(opts)]
@@ -155,10 +155,10 @@ function normalizeAclEntry(acl: AclEntry) {
   }
 
   if ('objectId' in acl && acl.objectId !== undefined) {
-    let objectIds: string[] | ((opts: { req: AuthenticatedRequest }) => string[])
+    let objectIds: string[] | ((opts: { req: AuthenticatedRequest; restApi: RestApi }) => string[])
     if (typeof acl.objectId === 'function') {
       const fn = acl.objectId
-      objectIds = (opts: { req: AuthenticatedRequest }) => [fn(opts)]
+      objectIds = (opts: { req: AuthenticatedRequest; restApi: RestApi }) => [fn(opts)]
     } else {
       objectIds = [acl.objectId]
     }
@@ -184,10 +184,10 @@ export function acl(acls: AclEntry | AclEntry[]) {
       if ('objectIds' in acl) {
         let ids: { id: unknown; path?: string }[] = []
         if (typeof acl.objectIds === 'function') {
-          ids = acl.objectIds({ req }).map(id => ({ id }))
+          ids = acl.objectIds({ req, restApi }).map(id => ({ id }))
         } else {
           for (const path of acl.objectIds) {
-            const id: unknown = path.split('.').reduce((obj, part) => obj[part], req)
+            const id: unknown = path.split('.').reduce((obj, part) => obj?.[part], req)
             ids.push({ id, path })
           }
         }
@@ -220,7 +220,10 @@ export function acl(acls: AclEntry | AclEntry[]) {
       }
       if ('objects' in acl) {
         if (typeof acl.objects === 'function') {
-          objects = acl.objects({ req })
+          const _objects = acl.objects({ req })
+          if (_objects !== undefined) {
+            objects = _objects
+          }
         } else {
           objects = acl.objects
         }

--- a/@xen-orchestra/rest-api/src/pifs/pif.controller.mts
+++ b/@xen-orchestra/rest-api/src/pifs/pif.controller.mts
@@ -1,4 +1,4 @@
-import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import { Example, Get, Middlewares, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
 import { inject } from 'inversify'
 import { provide } from 'inversify-binding-decorators'
 import type { Request as ExRequest } from 'express'
@@ -6,8 +6,15 @@ import type { XoAlarm, XoMessage, XoPif, XoTask } from '@vates/types'
 
 import { AlarmService } from '../alarms/alarm.service.mjs'
 import { escapeUnsafeComplexMatcher } from '../helpers/utils.helper.mjs'
+import { acl } from '../middlewares/acl.middleware.mjs'
 import { genericAlarmsExample } from '../open-api/oa-examples/alarm.oa-example.mjs'
-import { badRequestResp, notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
+import {
+  badRequestResp,
+  forbiddenOperationResp,
+  notFoundResp,
+  unauthorizedResp,
+  type Unbrand,
+} from '../open-api/common/response.common.mjs'
 import { partialPifs, pif, pifIds } from '../open-api/oa-examples/pif.oa-example.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
@@ -56,10 +63,15 @@ export class PifController extends XapiXoController<XoPif> {
   }
 
   /**
+   * Required privilege:
+   * - resource: pif, action: read
+   *
    * @example id "d9e42451-3794-089f-de81-4ee0e6137bee"
    */
   @Example(pif)
   @Get('{id}')
+  @Middlewares(acl({ resource: 'pif', action: 'read', objectId: 'params.id' }))
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   getPif(@Path() id: string): UnbrandedXoPif {
     return this.getObject(id as XoPif['id'])

--- a/@xen-orchestra/rest-api/src/pools/pool.controller.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.controller.mts
@@ -378,7 +378,7 @@ export class PoolController extends XapiXoController<XoPool> {
         action: 'instantiate',
         objectId: ({ req, restApi }) => {
           const pool = restApi.getXapiObject<XoPool>(req.params.id as XoPool['id'], 'pool')
-          const template = pool.$xapi.getObject<XenApiVm>(req.body.template)
+          const template = pool.$xapi.getObject<XoVm>(req.body.template)
 
           if (template.is_default_template) {
             return `${pool.uuid}-${template.uuid}`

--- a/@xen-orchestra/rest-api/src/pools/pool.controller.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.controller.mts
@@ -146,6 +146,7 @@ export class PoolController extends XapiXoController<XoPool> {
 
   /**
    * Required privilege:
+   * - resource: pool, action: create:network
    * - resource: network, action: create
    *
    * @example id "355ee47d-ff4c-4924-3db2-fd86ae629676"
@@ -159,7 +160,14 @@ export class PoolController extends XapiXoController<XoPool> {
   @Example(taskLocation)
   @Example(createNetwork)
   @Post('{id}/actions/create_network')
-  @Middlewares([json(), acl({ resource: 'network', action: 'create', object: ({ req }) => req.body })])
+  @Middlewares([
+    json(),
+    acl([
+      // these two rights are a bit redundant, but for now this is the only way to restrict network creation on a given pool
+      { resource: 'pool', action: 'create:network', objectId: 'params.id' },
+      { resource: 'network', action: 'create', object: ({ req }) => req.body },
+    ]),
+  ])
   @Tags('networks')
   @SuccessResponse(createdResp.status, createdResp.description)
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
@@ -292,8 +300,7 @@ export class PoolController extends XapiXoController<XoPool> {
    *  Import an XVA VM into a pool
    *
    * Required privilege:
-   * - resource: sr, action: read
-   * - resource: vm, action: create
+   * - resource: sr, action: import:vm
    *
    * @example id "355ee47d-ff4c-4924-3db2-fd86ae629677"
    * @example sr "c787b75c-3e0d-70fa-d0c3-cbfd382d7e33"
@@ -303,8 +310,18 @@ export class PoolController extends XapiXoController<XoPool> {
   @Post('{id}/vms')
   @Middlewares(
     acl([
-      { resource: 'vm', action: 'create', object: ({ req }) => req.body },
-      { resource: 'sr', action: 'read', objectId: 'query.sr' },
+      {
+        resource: 'sr',
+        action: 'import:vm',
+        objectId: ({ req, restApi }) => {
+          if (req.query.sr) {
+            return req.query.sr as XoSr['id']
+          } else {
+            const pool = restApi.getObject(req.params.id as XoPool['id'], 'pool') as XoPool
+            return pool.default_SR as XoSr['id']
+          }
+        },
+      },
     ])
   )
   @Tags('vms')
@@ -335,8 +352,12 @@ export class PoolController extends XapiXoController<XoPool> {
 
   /**
    * Required privilege:
-   * - resource: vm, action: create
-   * - resource: vm-template, action: read
+   * - resource: pool, action: create:vm
+   * - resource: vm-template, action: instantiate
+   * - resource: vdi, action: create (if vdis is passed)
+   * - resource: vdi, action: boot (if install.repository is passed)
+   * - resource: vif, action: create (if vifs is passed)
+   * - resource: host, action: allow-vm (if affinity is passed)
    *
    * @example id "355ee47d-ff4c-4924-3db2-fd86ae629677"
    * @example body {
@@ -351,8 +372,34 @@ export class PoolController extends XapiXoController<XoPool> {
   @Middlewares([
     json(),
     acl([
-      { resource: 'vm', action: 'create', object: ({ req }) => req.body },
-      { resource: 'vm-template', action: 'read', objectId: 'body.template' },
+      { resource: 'pool', action: 'create:vm', objectId: 'params.id' },
+      {
+        resource: 'vm-template',
+        action: 'instantiate',
+        objectId: ({ req, restApi }) => {
+          const pool = restApi.getXapiObject<XoPool>(req.params.id as XoPool['id'], 'pool')
+          const template = pool.$xapi.getObject<XenApiVm>(req.body.template)
+
+          if (template.is_default_template) {
+            return `${pool.uuid}-${template.uuid}`
+          }
+
+          return req.body.template
+        },
+      },
+      {
+        resource: 'vdi',
+        action: 'boot',
+        objectId: ({ req }) => {
+          const repository = req.body.install?.repository
+          if (repository !== '') {
+            return repository
+          }
+        },
+      },
+      { resource: 'vdi', action: 'create', objects: ({ req }) => req.body.vdis },
+      { resource: 'vif', action: 'create', objects: ({ req }) => req.body.vifs },
+      { resource: 'host', action: 'allow-vm', objectId: 'body.affinity' },
     ]),
   ])
   @Tags('vms')

--- a/@xen-orchestra/rest-api/src/pools/pool.controller.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.controller.mts
@@ -21,12 +21,14 @@ import { provide } from 'inversify-binding-decorators'
 import { json, type Request as ExRequest, type Response as ExResponse } from 'express'
 import type { VatesTask } from '@vates/types/lib/vates/task'
 
+import { acl } from '../middlewares/acl.middleware.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import {
   asynchronousActionResp,
   badRequestResp,
   createdResp,
   featureUnauthorized,
+  forbiddenOperationResp,
   internalServerErrorResp,
   noContentResp,
   notFoundResp,
@@ -128,16 +130,24 @@ export class PoolController extends XapiXoController<XoPool> {
   }
 
   /**
+   * Required privilege:
+   * - resource: pool, action: read
+   *
    * @example id "355ee47d-ff4c-4924-3db2-fd86ae629676"
    */
   @Example(pool)
   @Get('{id}')
+  @Middlewares(acl({ resource: 'pool', action: 'read', objectId: 'params.id' }))
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   getPool(@Path() id: string): Unbrand<XoPool> {
     return this.getObject(id as XoPool['id'])
   }
 
   /**
+   * Required privilege:
+   * - resource: network, action: create
+   *
    * @example id "355ee47d-ff4c-4924-3db2-fd86ae629676"
    * @example body {
    *    "name": "awes0me_network",
@@ -149,9 +159,10 @@ export class PoolController extends XapiXoController<XoPool> {
   @Example(taskLocation)
   @Example(createNetwork)
   @Post('{id}/actions/create_network')
-  @Middlewares(json())
+  @Middlewares([json(), acl({ resource: 'network', action: 'create', object: ({ req }) => req.body })])
   @Tags('networks')
   @SuccessResponse(createdResp.status, createdResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
@@ -182,11 +193,16 @@ export class PoolController extends XapiXoController<XoPool> {
   }
 
   /**
+   * Required privilege:
+   * - resource: pool, action: emergency-shutdown
+   *
    * @example id "355ee47d-ff4c-4924-3db2-fd86ae629677"
    */
   @Example(taskLocation)
   @Post('{id}/actions/emergency_shutdown')
+  @Middlewares(acl({ resource: 'pool', action: 'emergency-shutdown', objectId: 'params.id' }))
   @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(featureUnauthorized.status, featureUnauthorized.description)
   @Response(notFoundResp.status, notFoundResp.description)
@@ -208,11 +224,16 @@ export class PoolController extends XapiXoController<XoPool> {
   }
 
   /**
+   * Required privilege:
+   * - resource: pool, action: rolling-reboot
+   *
    * @example id "355ee47d-ff4c-4924-3db2-fd86ae629677"
    */
   @Example(taskLocation)
   @Post('{id}/actions/rolling_reboot')
+  @Middlewares(acl({ resource: 'pool', action: 'rolling-reboot', objectId: 'params.id' }))
   @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(featureUnauthorized.status, featureUnauthorized.description)
   @Response(notFoundResp.status, notFoundResp.description)
@@ -235,11 +256,16 @@ export class PoolController extends XapiXoController<XoPool> {
   }
 
   /**
+   * Required privilege:
+   * - resource: pool, action: rolling-update
+   *
    * @example id "355ee47d-ff4c-4924-3db2-fd86ae629677"
    */
   @Example(taskLocation)
   @Post('{id}/actions/rolling_update')
+  @Middlewares(acl({ resource: 'pool', action: 'rolling-update', objectId: 'params.id' }))
   @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(featureUnauthorized.status, featureUnauthorized.description)
   @Response(notFoundResp.status, notFoundResp.description)
@@ -265,14 +291,25 @@ export class PoolController extends XapiXoController<XoPool> {
   /**
    *  Import an XVA VM into a pool
    *
+   * Required privilege:
+   * - resource: sr, action: read
+   * - resource: vm, action: create
+   *
    * @example id "355ee47d-ff4c-4924-3db2-fd86ae629677"
    * @example sr "c787b75c-3e0d-70fa-d0c3-cbfd382d7e33"
    *
    */
   @Example(importVm)
   @Post('{id}/vms')
+  @Middlewares(
+    acl([
+      { resource: 'vm', action: 'create', object: ({ req }) => req.body },
+      { resource: 'sr', action: 'read', objectId: 'query.sr' },
+    ])
+  )
   @Tags('vms')
   @SuccessResponse(createdResp.status, 'VM imported')
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
   async importVm(
@@ -297,6 +334,10 @@ export class PoolController extends XapiXoController<XoPool> {
   }
 
   /**
+   * Required privilege:
+   * - resource: vm, action: create
+   * - resource: vm-template, action: read
+   *
    * @example id "355ee47d-ff4c-4924-3db2-fd86ae629677"
    * @example body {
    * "name_label": "new VM from REST API",
@@ -307,9 +348,16 @@ export class PoolController extends XapiXoController<XoPool> {
   @Example(taskLocation)
   @Example(createVm)
   @Post('{id}/actions/create_vm')
-  @Middlewares(json())
+  @Middlewares([
+    json(),
+    acl([
+      { resource: 'vm', action: 'create', object: ({ req }) => req.body },
+      { resource: 'vm-template', action: 'read', objectId: 'body.template' },
+    ]),
+  ])
   @Tags('vms')
   @SuccessResponse(createdResp.status, createdResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
@@ -339,10 +387,15 @@ export class PoolController extends XapiXoController<XoPool> {
   }
 
   /**
+   * Required privilege:
+   * - resource: pool, action: read
+   *
    * @example id "355ee47d-ff4c-4924-3db2-fd86ae629677"
    */
   @Example(poolStats)
   @Get('{id}/stats')
+  @Middlewares(acl({ resource: 'pool', action: 'read', objectId: 'params.id' }))
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(422, 'Invalid granularity')
   getStats(@Path() id: string, @Query() granularity?: XapiStatsGranularity): Promise<XapiPoolStats> {
@@ -350,10 +403,15 @@ export class PoolController extends XapiXoController<XoPool> {
   }
 
   /**
+   * Required privilege:
+   * - resource: pool, action: read
+   *
    * @example id "355ee47d-ff4c-4924-3db2-fd86ae629677"
    */
   @Example(poolDashboard)
   @Get('{id}/dashboard')
+  @Middlewares(acl({ resource: 'pool', action: 'read', objectId: 'params.id' }))
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async getPoolDashboard(
     @Request() req: ExRequest,
@@ -416,10 +474,15 @@ export class PoolController extends XapiXoController<XoPool> {
   }
 
   /**
+   * Required privilege:
+   * - resource: pool, action: read
+   *
    * @example id "355ee47d-ff4c-4924-3db2-fd86ae629676"
    */
   @Example(poolMissingPatches)
   @Get('{id}/missing_patches')
+  @Middlewares(acl({ resource: 'pool', action: 'read', objectId: 'params.id' }))
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(featureUnauthorized.status, featureUnauthorized.description)
   async getPoolMissingPatches(@Path() id: string): Promise<XcpPatches[] | XsPatches[]> {
@@ -462,11 +525,16 @@ export class PoolController extends XapiXoController<XoPool> {
   }
 
   /**
+   * Required privilege:
+   * - resource: pool, action: update:tags
+   *
    * @example id "355ee47d-ff4c-4924-3db2-fd86ae629676"
    * @example tag "from-rest-api"
    */
   @Put('{id}/tags/{tag}')
+  @Middlewares(acl({ resource: 'pool', action: 'update:tags', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async putPoolTag(@Path() id: string, @Path() tag: string): Promise<void> {
     const pool = this.getXapiObject(id as XoPool['id'])
@@ -474,11 +542,16 @@ export class PoolController extends XapiXoController<XoPool> {
   }
 
   /**
+   * Required privilege:
+   * - resource: pool, action: update:tags
+   *
    * @example id "355ee47d-ff4c-4924-3db2-fd86ae629676"
    * @example tag "from-rest-api"
    */
   @Delete('{id}/tags/{tag}')
+  @Middlewares(acl({ resource: 'pool', action: 'update:tags', objectId: 'params.id' }))
   @SuccessResponse(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async deletePoolTag(@Path() id: string, @Path() tag: string): Promise<void> {
     const pool = this.getXapiObject(id as XoPool['id'])

--- a/@xen-orchestra/rest-api/src/proxies/proxy.controller.mts
+++ b/@xen-orchestra/rest-api/src/proxies/proxy.controller.mts
@@ -1,9 +1,16 @@
-import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import { Example, Get, Middlewares, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
 import { provide } from 'inversify-binding-decorators'
 import type { Request as ExRequest } from 'express'
 import type { XoProxy } from '@vates/types'
 
-import { badRequestResp, notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
+import { acl } from '../middlewares/acl.middleware.mjs'
+import {
+  badRequestResp,
+  forbiddenOperationResp,
+  notFoundResp,
+  unauthorizedResp,
+  type Unbrand,
+} from '../open-api/common/response.common.mjs'
 import { partialProxies, proxy, proxyIds } from '../open-api/oa-examples/proxy.oa-example.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
@@ -49,10 +56,22 @@ export class ProxyController extends XoController<XoProxy> {
   }
 
   /**
+   * Required privilege:
+   * - resource: proxy, action: read
+   *
    * @example id "e625ea0c-a876-405a-b838-109d762efe88"
    */
   @Example(proxy)
   @Get('{id}')
+  @Middlewares(
+    acl({
+      resource: 'proxy',
+      action: 'read',
+      objectId: 'params.id',
+      getObject: ({ restApi }) => restApi.xoApp.getProxy,
+    })
+  )
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   getProxy(@Path() id: string): Promise<Unbrand<XoProxy>> {
     return this.getObject(id as XoProxy['id'])

--- a/@xen-orchestra/rest-api/src/srs/sr.controller.mts
+++ b/@xen-orchestra/rest-api/src/srs/sr.controller.mts
@@ -133,7 +133,7 @@ export class SrController extends XapiXoController<XoSr> {
    * Import an exported VDI
    *
    * Required privilege:
-   * - resource: sr, action: import-vdi
+   * - resource: sr, action: import:vdi
    *
    * @example id "c4284e12-37c9-7967-b9e8-83ef229c3e03"
    * @example name_label "VDI_foo_import"
@@ -142,7 +142,7 @@ export class SrController extends XapiXoController<XoSr> {
    */
   @Example(vdiId)
   @Post('{id}/vdis')
-  @Middlewares(acl({ resource: 'sr', action: 'import-vdi', objectId: 'params.id' }))
+  @Middlewares(acl({ resource: 'sr', action: 'import:vdi', objectId: 'params.id' }))
   @Tags('vdis')
   @SuccessResponse(createdResp.status, 'VDI imported')
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)

--- a/packages/xo-server/src/xo-mixins/acls-v2/template-roles.mjs
+++ b/packages/xo-server/src/xo-mixins/acls-v2/template-roles.mjs
@@ -66,6 +66,7 @@ export const VMS_CREATOR = {
   name: 'VMs creator',
   description: 'Allow to create VMs',
   privileges: [
+    { action: 'create:vm', resource: 'pool', effect: 'allow' },
     { action: 'instantiate', resource: 'vm-template', effect: 'allow' },
     { action: 'create', resource: 'vdi', effect: 'allow' },
     { action: 'create', resource: 'vif', effect: 'allow' },


### PR DESCRIPTION
### Description

**Review by commit**

ACL middleware for :
- pif ([XO-2069](https://project.vates.tech/vates-global/browse/XO-2069/))
- proxy ([XO-2071](https://project.vates.tech/vates-global/browse/XO-2071/))
- pool ([XO-2070](https://project.vates.tech/vates-global/browse/XO-2070/))

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
