### PR TITLE
fix(backups): fix vhd directory merge speed regression

### DIFF
--- a/@xen-orchestra/backups/disks/RemoteDisk.test.mjs
+++ b/@xen-orchestra/backups/disks/RemoteDisk.test.mjs
@@ -921,3 +921,119 @@ describe('tests MergeVhdChain', { concurrency: 1 }, () => {
     assert.deepEqual(parentIndexes, expectedIndexes, 'all child blocks should be merged into parent')
   })
 })
+
+/**
+ * Benchmarks
+ *
+ * These tests always pass. They log merge throughput so regressions are visible.
+ * Warning emitted when throughput drops below threshold.
+ *
+ * Block count can be overriden via BENCH_MERGE_BLOCKS env var (1 block = 2 MB):
+ * BENCH_MERGE_BLOCKS=2560 node --test RemoteDisk.test.mjs
+ */
+describe('benchmark MergeRemoteDisk', { concurrency: 1 }, () => {
+  // Block size as written by generateVhd: 2 MB of data + 512 B bitmap
+  const BLOCK_DATA_BYTES = 2 * 1024 * 1024
+  const BENCH_BLOCKS = process.env.BENCH_MERGE_BLOCKS ?? 500
+  const WARN_THRESHOLD_FILE_MB_S = 500
+  const WARN_THRESHOLD_DIRECTORY_MB_S = 5000
+
+  test('mergeRemoteDisk throughput - VHD file mode', async t => {
+    const childBlocks = Array.from({ length: BENCH_BLOCKS }, (_, i) => i + 2)
+
+    await generateVhd(`${basePath}/ancestor.vhd`, { blocks: [0, 1] })
+    await generateVhd(`${basePath}/child.vhd`, { blocks: childBlocks })
+
+    const parent = new RemoteVhdDisk({ handler, path: `${basePath}/ancestor.vhd` })
+    const child = new RemoteVhdDisk({ handler, path: `${basePath}/child.vhd` })
+
+    const mergeRemoteDisk = new MergeRemoteDisk(handler, { removeUnused: true })
+    const isResumingMerge = await mergeRemoteDisk.isResuming(parent)
+    await parent.init({ force: isResumingMerge })
+    await child.init({ force: isResumingMerge })
+
+    const start = performance.now()
+    await mergeRemoteDisk.merge(parent, child)
+    const elapsedMs = performance.now() - start
+
+    const totalMB = (BENCH_BLOCKS * BLOCK_DATA_BYTES) / (1024 * 1024)
+    const throughputMBs = totalMB / (elapsedMs / 1000)
+
+    t.diagnostic(
+      `VHD file merge: ${BENCH_BLOCKS} blocks (${totalMB.toFixed(0)} MB) in ${(elapsedMs / 1000).toFixed(2)}s: ${throughputMBs.toFixed(1)} MB/s`
+    )
+
+    if (throughputMBs < WARN_THRESHOLD_FILE_MB_S) {
+      t.diagnostic(
+        `WARNING: throughput ${throughputMBs.toFixed(1)} MB/s is below the ${WARN_THRESHOLD_FILE_MB_S} MB/s threshold`
+      )
+    }
+  })
+
+  test('mergeRemoteDisk throughput - VHD directory mode (direct disk, reference)', async t => {
+    const childBlocks = Array.from({ length: BENCH_BLOCKS }, (_, i) => i + 2)
+
+    await generateVhd(`${basePath}/ancestor.vhd`, { blocks: [0, 1], mode: 'directory', useAlias: true })
+    await generateVhd(`${basePath}/child.vhd`, { blocks: childBlocks, mode: 'directory', useAlias: true })
+
+    const parent = new RemoteVhdDisk({ handler, path: `${basePath}/ancestor.vhd.alias.vhd` })
+    const child = new RemoteVhdDisk({ handler, path: `${basePath}/child.vhd.alias.vhd` })
+
+    const mergeRemoteDisk = new MergeRemoteDisk(handler, { removeUnused: true })
+    const isResumingMerge = await mergeRemoteDisk.isResuming(parent)
+    await parent.init({ force: isResumingMerge })
+    await child.init({ force: isResumingMerge })
+
+    const start = performance.now()
+    await mergeRemoteDisk.merge(parent, child)
+    const elapsedMs = performance.now() - start
+
+    const totalMB = (BENCH_BLOCKS * BLOCK_DATA_BYTES) / (1024 * 1024)
+    const throughputMBs = totalMB / (elapsedMs / 1000)
+
+    t.diagnostic(
+      `VHD directory merge (direct disk): ${BENCH_BLOCKS} blocks (${totalMB.toFixed(0)} MB) in ${(elapsedMs / 1000).toFixed(2)}s: ${throughputMBs.toFixed(1)} MB/s`
+    )
+
+    if (throughputMBs < WARN_THRESHOLD_DIRECTORY_MB_S) {
+      t.diagnostic(
+        `WARNING: chain merge throughput ${throughputMBs.toFixed(1)} MB/s is below the ${WARN_THRESHOLD_DIRECTORY_MB_S} MB/s threshold`
+      )
+    }
+  })
+
+  test('mergeRemoteDisk throughput - VHD directory mode (chain, cleanVm path)', async t => {
+    const childBlocks = Array.from({ length: BENCH_BLOCKS }, (_, i) => i + 2)
+
+    await generateVhd(`${basePath}/ancestor.vhd`, { blocks: [0, 1], mode: 'directory', useAlias: true })
+    await generateVhd(`${basePath}/child.vhd`, { blocks: childBlocks, mode: 'directory', useAlias: true })
+
+    const parent = new RemoteVhdDisk({ handler, path: `${basePath}/ancestor.vhd.alias.vhd` })
+    // Replicate _mergeVhdChain exactly: child disks are wrapped in a RemoteVhdDiskChain
+    const childDisk = new RemoteVhdDisk({ handler, path: `${basePath}/child.vhd.alias.vhd` })
+    const childChain = new RemoteVhdDiskChain({ disks: [childDisk] })
+
+    const mergeRemoteDisk = new MergeRemoteDisk(handler, { removeUnused: true })
+    // init pattern matches _mergeVhdChain: parent individually, chain for all children
+    const isResumingMerge = await mergeRemoteDisk.isResuming(parent)
+    await parent.init({ force: isResumingMerge })
+    await childChain.init({ force: isResumingMerge })
+
+    const start = performance.now()
+    await mergeRemoteDisk.merge(parent, childChain)
+    const elapsedMs = performance.now() - start
+
+    const totalMB = (BENCH_BLOCKS * BLOCK_DATA_BYTES) / (1024 * 1024)
+    const throughputMBs = totalMB / (elapsedMs / 1000)
+
+    t.diagnostic(
+      `VHD directory merge (chain / cleanVm path): ${BENCH_BLOCKS} blocks (${totalMB.toFixed(0)} MB) in ${(elapsedMs / 1000).toFixed(2)}s: ${throughputMBs.toFixed(1)} MB/s`
+    )
+
+    if (throughputMBs < WARN_THRESHOLD_DIRECTORY_MB_S) {
+      t.diagnostic(
+        `WARNING: chain merge throughput ${throughputMBs.toFixed(1)} MB/s is below the ${WARN_THRESHOLD_DIRECTORY_MB_S} MB/s threshold`
+      )
+    }
+  })
+})

--- a/@xen-orchestra/backups/disks/RemoteVhdDisk.mjs
+++ b/@xen-orchestra/backups/disks/RemoteVhdDisk.mjs
@@ -16,6 +16,7 @@ import { DISK_TYPES } from 'vhd-lib/_constants.js'
 import { isVhdAlias, resolveVhdAlias } from 'vhd-lib/aliases.js'
 import { stringify } from 'uuid'
 import { dirname, join } from 'node:path'
+import { RemoteVhdDiskChain } from './RemoteVhdDiskChain.mjs'
 
 export class RemoteVhdDisk extends RemoteDisk {
   /**
@@ -259,7 +260,11 @@ export class RemoteVhdDisk extends RemoteDisk {
    * @returns {Promise<number>} blockSize
    */
   async mergeBlock(childDisk, index, isResumingMerge) {
-    if ((await this.isDirectory()) && childDisk instanceof RemoteVhdDisk && (await childDisk.isDirectory())) {
+    if (
+      (childDisk instanceof RemoteVhdDisk || childDisk instanceof RemoteVhdDiskChain) &&
+      (await this.isDirectory()) &&
+      (await childDisk.isDirectory())
+    ) {
       try {
         await this.#handler.rename(childDisk.getBlockPath(index), this.getBlockPath(index))
 

--- a/@xen-orchestra/backups/disks/RemoteVhdDiskChain.mjs
+++ b/@xen-orchestra/backups/disks/RemoteVhdDiskChain.mjs
@@ -134,12 +134,7 @@ export class RemoteVhdDiskChain extends RemoteDisk {
    * @returns {Promise<boolean>} canMergeConcurently
    */
   async canMergeConcurently() {
-    for (const disk of this.#disks) {
-      if (!(await disk.isDirectory())) {
-        return true
-      }
-    }
-    return false
+    return this.isDirectory()
   }
 
   /**
@@ -222,6 +217,21 @@ export class RemoteVhdDiskChain extends RemoteDisk {
   }
 
   /**
+   * Gets a specific block path from the VHD directory disk.
+   * @param {number} index
+   * @returns {string} blockPath
+   */
+  getBlockPath(index) {
+    for (const disk of [...this.#disks].reverse()) {
+      if (disk.hasBlock(index)) {
+        return disk.getBlockPath(index)
+      }
+    }
+
+    throw new Error(`Block ${index} not found in chain`)
+  }
+
+  /**
    * @returns {VhdFooter}
    */
   getMetadata() {
@@ -268,5 +278,18 @@ export class RemoteVhdDiskChain extends RemoteDisk {
     for (const disk of this.#disks) {
       await disk.unlink()
     }
+  }
+
+  /**
+   * Check if all the disks in the chain are VHD directories.
+   * @returns {Promise<boolean>}
+   */
+  async isDirectory() {
+    for (const disk of this.#disks) {
+      if (!(await disk.isDirectory())) {
+        return false
+      }
+    }
+    return true
   }
 }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@
 ### Bug fixes
 
 - [Header]: Fix `Unable to connect to XO server` falshing every 30 secondes (PR [#9681](https://github.com/vatesfr/xen-orchestra/pull/9681))
+- [Backups]: Fix regression on cleanVM speed (PR [#9692](https://github.com/vatesfr/xen-orchestra/pull/9692))
 
 > Users must be able to say: “I had this issue, happy to know it's fixed”
 
@@ -33,6 +34,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
 - @xen-orchestra/immutable-backups patch
 - @xen-orchestra/web patch
 - @xen-orchestra/web-core patch


### PR DESCRIPTION
### Description

Fix issue with merge concurrency and block rename on VHD directory merge to fix cleanVm speed regression.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
