### PR TITLE
docs(intro_backup.md): fix broken youtube embed

### DIFF
--- a/docs/docs/intro_backup.md
+++ b/docs/docs/intro_backup.md
@@ -8,7 +8,7 @@ Xen Orchestra is currently the most capable and advanced solution to backup your
 
 Alternatively, here is a video recap on different backup capabilities:
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/FfUqIwT8KzI?si=kTvxIFhPjv-8Iwri" title="Administer and backup your VM infrastructure the easiest way" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="stricn-when-crt-origioss-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/FfUqIwT8KzI?si=kTvxIFhPjv-8Iwri" title="Administer and backup your VM infrastructure the easiest way" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 - [Rolling Snapshots](rolling_snapshots.md)
 - [Full Backups](full_backups.md)

--- a/docs/docs/intro_backup.md
+++ b/docs/docs/intro_backup.md
@@ -8,7 +8,7 @@ Xen Orchestra is currently the most capable and advanced solution to backup your
 
 Alternatively, here is a video recap on different backup capabilities:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/FfUqIwT8KzI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/FfUqIwT8KzI?si=kTvxIFhPjv-8Iwri" title="Administer and backup your VM infrastructure the easiest way" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="stricn-when-crt-origioss-origin" allowfullscreen></iframe>
 
 - [Rolling Snapshots](rolling_snapshots.md)
 - [Full Backups](full_backups.md)


### PR DESCRIPTION
The YouTube video "[Administer and backup your VM infrastructure the easiest way](https://www.youtube.com/watch?v=FfUqIwT8KzI)" is currently broken on the "[Introduction to backups](https://docs.xen-orchestra.com/backups)" page. Instead of playing as an embedded video, it requires users to click through to YouTube.

<img width="1537" height="958" alt="Capture d&#39;écran 2026-04-13 094314" src="https://github.com/user-attachments/assets/60533939-c85a-4cf3-ad5c-097f7cfe8005" />

This pull request fixes the iframe configuration and allows the video to be played directly from the Xen Orchestra documentation.