### PR TITLE
fix: add chainPhysicalUsage property in vdi object

### DIFF
--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -721,6 +721,7 @@ type BaseXoVdi = BaseXapiXo & {
   other_config: Record<string, string>
   parent?: XoVdiUnmanaged['id']
   image_format?: string
+  parentChainPhysicalUsage: number
   size: number
   snapshots: XoVdiSnapshot['id'][]
   tags: string[]

--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -729,7 +729,7 @@ type BaseXoVdi = BaseXapiXo & {
 
 export type XoVdi = BaseXoVdi & {
   id: Branded<'VDI'>
-  parentChainPhysicalUsage: number
+  chainPhysicalUsage: number
   type: 'VDI'
 }
 

--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -721,7 +721,6 @@ type BaseXoVdi = BaseXapiXo & {
   other_config: Record<string, string>
   parent?: XoVdiUnmanaged['id']
   image_format?: string
-  parentChainPhysicalUsage: number
   size: number
   snapshots: XoVdiSnapshot['id'][]
   tags: string[]
@@ -730,6 +729,7 @@ type BaseXoVdi = BaseXapiXo & {
 
 export type XoVdi = BaseXoVdi & {
   id: Branded<'VDI'>
+  parentChainPhysicalUsage: number
   type: 'VDI'
 }
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -42,6 +42,7 @@
 - [VM] Add possibility to remove a VIF on network tab (PR [#9601](https://github.com/vatesfr/xen-orchestra/pull/9601))
 - [VM] Add possibility to remove a VDI on VDI tab (PR [#9689](https://github.com/vatesfr/xen-orchestra/pull/9689))
 - [VM] Add possibility to remove a VBD on VDI tab (PR [#9698](https://github.com/vatesfr/xen-orchestra/pull/9698))
+- [VDI] Add chainPhysicalUsage to have a proper usage linked to the complete chain (PR [#9708](https://github.com/vatesfr/xen-orchestra/pull/9708))
 - **XO 5**:
   - [Settings/Servers] Add info tip to remind users to only add pool masters
 

--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -770,12 +770,6 @@ const TRANSFORMS = {
       snapshots: link(obj, 'snapshots'),
       tags: obj.tags,
       usage: +obj.physical_utilisation,
-      parentChainPhysicalUsage:
-        +obj.physical_utilisation +
-        obj.snapshots.reduce((sum, snapshotRef) => {
-          const snapshot = obj.$xapi._objectsByRef[snapshotRef]
-          return sum + (snapshot !== undefined ? +snapshot.physical_utilisation : 0)
-        }, 0),
       VDI_type: obj.type,
       current_operations: obj.current_operations,
       other_config: obj.other_config,
@@ -790,6 +784,16 @@ const TRANSFORMS = {
       vdi.$snapshot_of = link(obj, 'snapshot_of')
     } else if (!obj.managed) {
       vdi.type += '-unmanaged'
+    } else {
+      let total = +obj.physical_utilisation
+      let parentUuid = obj.sm_config['vhd-parent']
+      while (parentUuid !== undefined) {
+        const parent = obj.$xapi.getObject(parentUuid, undefined)
+        if (parent === undefined) break
+        total += +parent.physical_utilisation
+        parentUuid = parent.sm_config?.['vhd-parent']
+      }
+      vdi.parentChainPhysicalUsage = total
     }
 
     return vdi

--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -770,6 +770,12 @@ const TRANSFORMS = {
       snapshots: link(obj, 'snapshots'),
       tags: obj.tags,
       usage: +obj.physical_utilisation,
+      parentChainPhysicalUsage:
+        +obj.physical_utilisation +
+        obj.snapshots.reduce((sum, snapshotRef) => {
+          const snapshot = obj.$xapi._objectsByRef[snapshotRef]
+          return sum + (snapshot !== undefined ? +snapshot.physical_utilisation : 0)
+        }, 0),
       VDI_type: obj.type,
       current_operations: obj.current_operations,
       other_config: obj.other_config,

--- a/packages/xo-server/src/xapi-object-to-xo.mjs
+++ b/packages/xo-server/src/xapi-object-to-xo.mjs
@@ -793,7 +793,7 @@ const TRANSFORMS = {
         total += +parent.physical_utilisation
         parentUuid = parent.sm_config?.['vhd-parent']
       }
-      vdi.parentChainPhysicalUsage = total
+      vdi.chainPhysicalUsage = total
     }
 
     return vdi


### PR DESCRIPTION
### Description

Right now, usage is not reflecting real memory usage of a given VDI. Here is an attempt to get the size by summing up all snapshots of the vdi chain. 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
