### PR TITLE
feat(rest-api): add route to see user privileges

### DIFF
--- a/@xen-orchestra/rest-api/src/users/user.controller.mts
+++ b/@xen-orchestra/rest-api/src/users/user.controller.mts
@@ -54,6 +54,7 @@ import { groupIds, partialGroups } from '../open-api/oa-examples/group.oa-exampl
 import { partialTasks, taskIds } from '../open-api/oa-examples/task.oa-example.mjs'
 import { redirectMeAlias } from './user.middleware.mjs'
 import { aclPrivilegeIds, partialAclPrivileges } from '../open-api/oa-examples/acl-privilege.oa-example.mjs'
+import type { AnyPrivilege } from '@xen-orchestra/acl'
 
 const log = createLogger('xo:rest-api:user-controller')
 
@@ -392,7 +393,7 @@ export class UserController extends XoController<XoUser> {
 
   /**
    * Returns all ACL privileges that match the following privilege:
-   * - resource: acl-privilege, action: read
+   * - resource: acl-privilege, action: read (if not self)
    *
    * @example id "me"
    * @example fields "id,action,resource"
@@ -412,7 +413,7 @@ export class UserController extends XoController<XoUser> {
     @Query() ndjson?: boolean,
     @Query() filter?: string,
     @Query() limit?: number
-  ) {
+  ): SendObjects<Partial<Unbrand<AnyPrivilege>>> {
     const user = await this.getObject(id as XoUser['id'])
     const currentUser = this.restApi.getCurrentUser()
 

--- a/@xen-orchestra/rest-api/src/users/user.controller.mts
+++ b/@xen-orchestra/rest-api/src/users/user.controller.mts
@@ -53,6 +53,7 @@ import { XoController } from '../abstract-classes/xo-controller.mjs'
 import { groupIds, partialGroups } from '../open-api/oa-examples/group.oa-example.mjs'
 import { partialTasks, taskIds } from '../open-api/oa-examples/task.oa-example.mjs'
 import { redirectMeAlias } from './user.middleware.mjs'
+import { aclPrivilegeIds, partialAclPrivileges } from '../open-api/oa-examples/acl-privilege.oa-example.mjs'
 
 const log = createLogger('xo:rest-api:user-controller')
 
@@ -387,5 +388,40 @@ export class UserController extends XoController<XoUser> {
     })
 
     return { token }
+  }
+
+  /**
+   * Returns all ACL privileges that match the following privilege:
+   * - resource: acl-privilege, action: read
+   *
+   * @example id "me"
+   * @example fields "id,action,resource"
+   * @example filter "action:create"
+   * @example limit 42
+   */
+  @Example(aclPrivilegeIds)
+  @Example(partialAclPrivileges)
+  @Get('{id}/acl-privileges')
+  @Security('*', ['acl'])
+  @Tags('acls')
+  @Response(notFoundResp.status, notFoundResp.description)
+  async getUserPrivileges(
+    @Request() req: ExRequest,
+    @Path() id: string,
+    @Query() fields?: string,
+    @Query() ndjson?: boolean,
+    @Query() filter?: string,
+    @Query() limit?: number
+  ) {
+    const user = await this.getObject(id as XoUser['id'])
+    const currentUser = this.restApi.getCurrentUser()
+
+    const userPrivileges = await this.restApi.xoApp.getAclV2UserPrivileges(user.id)
+
+    return this.sendObjects(limitAndFilterArray(userPrivileges, { filter }), req, {
+      path: 'acl-privileges',
+      limit,
+      privilege: currentUser.id === user.id ? undefined : { action: 'read', resource: 'acl-privilege' },
+    })
   }
 }


### PR DESCRIPTION
### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
