### PR TITLE
fix(rest-api): fix double slash in the href property

### DIFF
--- a/@xen-orchestra/rest-api/src/helpers/object-wrapper.helper.mts
+++ b/@xen-orchestra/rest-api/src/helpers/object-wrapper.helper.mts
@@ -7,15 +7,21 @@ import type { WithHref } from './helper.type.mjs'
 
 export function makeObjectMapper<T extends XoRecord>(req: Request, path?: string | ((obj: T) => string)) {
   const makeUrl = (obj: T) => {
-    let _path = path === undefined ? req.path : typeof path === 'string' ? path : path(obj)
-    if (_path.startsWith('/')) {
-      _path = _path.slice(1)
+    let _path: string
+    if (path === undefined) {
+      _path = req.path
+    } else {
+      let tmpPath = typeof path === 'string' ? path : path(obj)
+      if (tmpPath.startsWith('/')) {
+        tmpPath = tmpPath.slice(1)
+      }
+      _path = `${BASE_URL}/${tmpPath}`
     }
+
     if (_path.endsWith('/')) {
       _path = _path.slice(0, -1)
     }
-
-    return `${BASE_URL}/${_path}/${String(obj.id)}`
+    return `${_path}/${String(obj.id)}`
   }
   let objectMapper: (object: T) => string | WithHref<Partial<T>> | WithHref<T>
 

--- a/@xen-orchestra/rest-api/src/helpers/object-wrapper.helper.mts
+++ b/@xen-orchestra/rest-api/src/helpers/object-wrapper.helper.mts
@@ -7,21 +7,15 @@ import type { WithHref } from './helper.type.mjs'
 
 export function makeObjectMapper<T extends XoRecord>(req: Request, path?: string | ((obj: T) => string)) {
   const makeUrl = (obj: T) => {
-    let _path: string
-    if (path === undefined) {
-      _path = req.path
-    } else {
-      let tmpPath = typeof path === 'string' ? path : path(obj)
-      if (tmpPath.startsWith('/')) {
-        tmpPath = tmpPath.slice(1)
-      }
-      if (tmpPath.endsWith('/')) {
-        tmpPath = tmpPath.slice(0, -1)
-      }
-      _path = `${BASE_URL}/${tmpPath}`
+    let _path = path === undefined ? req.path : typeof path === 'string' ? path : path(obj)
+    if (_path.startsWith('/')) {
+      _path = _path.slice(1)
+    }
+    if (_path.endsWith('/')) {
+      _path = _path.slice(0, -1)
     }
 
-    return `${_path}/${String(obj.id)}`
+    return `${BASE_URL}/${_path}/${String(obj.id)}`
   }
   let objectMapper: (object: T) => string | WithHref<Partial<T>> | WithHref<T>
 

--- a/@xen-orchestra/rest-api/src/helpers/object-wrapper.helper.test.mts
+++ b/@xen-orchestra/rest-api/src/helpers/object-wrapper.helper.test.mts
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import type { Request } from 'express'
+
+import { makeObjectMapper } from './object-wrapper.helper.mjs'
+import type { XoRecord } from '@vates/types'
+
+const BASE_URL = '/rest/v0'
+
+function makeRequest(path: string, fields?: string | string[]): Request {
+  return {
+    path,
+    query: fields !== undefined ? { fields } : {},
+  } as unknown as Request
+}
+
+const obj = { id: 'abc-123', name: 'test-vm', type: 'VM', power_state: 'Running' } as unknown as XoRecord
+
+describe('makeObjectMapper()', () => {
+  describe('no fields query param — returns URL string', () => {
+    it('uses req.path when no path argument is given', () => {
+      const mapper = makeObjectMapper(makeRequest('/rest/v0/vms'))
+      assert.equal(mapper(obj), '/rest/v0/vms/abc-123')
+    })
+
+    it('uses BASE_URL + string path when path argument is a string', () => {
+      const mapper = makeObjectMapper(makeRequest('/rest/v0/vms'), 'hosts')
+      assert.equal(mapper(obj), `${BASE_URL}/hosts/abc-123`)
+    })
+
+    it('strips leading slash from string path argument', () => {
+      const mapper = makeObjectMapper(makeRequest('/rest/v0/vms'), '/hosts')
+      assert.equal(mapper(obj), `${BASE_URL}/hosts/abc-123`)
+    })
+
+    it('strips trailing slash from req.path', () => {
+      const mapper = makeObjectMapper(makeRequest('/rest/v0/vms/'))
+      assert.equal(mapper(obj), '/rest/v0/vms/abc-123')
+    })
+
+    it('strips trailing slash from string path argument', () => {
+      const mapper = makeObjectMapper(makeRequest('/rest/v0/vms'), 'hosts/')
+      assert.equal(mapper(obj), `${BASE_URL}/hosts/abc-123`)
+    })
+
+    it('uses the return value of the path function', () => {
+      const mapper = makeObjectMapper(makeRequest('/rest/v0/vms'), () => 'hosts')
+      assert.equal(mapper(obj), `${BASE_URL}/hosts/abc-123`)
+    })
+
+    it('passes the mapped object to the path function', () => {
+      let received: unknown
+      const mapper = makeObjectMapper(makeRequest('/rest/v0/vms'), object => {
+        received = object
+        return 'hosts'
+      })
+      mapper(obj)
+      assert.equal(received, obj)
+    })
+
+    it('strips leading slash from path function return value', () => {
+      const mapper = makeObjectMapper(makeRequest('/rest/v0/vms'), () => '/hosts')
+      assert.equal(mapper(obj), `${BASE_URL}/hosts/abc-123`)
+    })
+
+    it('falls back to URL string when fields is an array', () => {
+      const mapper = makeObjectMapper(makeRequest('/rest/v0/vms', ['name', 'type']))
+      assert.equal(mapper(obj), '/rest/v0/vms/abc-123')
+    })
+
+    it('coerces a numeric id to string in the URL', () => {
+      const numObj = { id: 42, name: 'test' }
+      const mapper = makeObjectMapper(makeRequest('/rest/v0/vms'))
+      assert.equal(mapper(numObj as unknown as XoRecord), '/rest/v0/vms/42')
+    })
+  })
+
+  describe('fields === "*" — returns full object with href', () => {
+    it('spreads all object properties and adds href', () => {
+      const mapper = makeObjectMapper(makeRequest('/rest/v0/vms', '*'))
+      assert.deepEqual(mapper(obj), { ...obj, href: '/rest/v0/vms/abc-123' })
+    })
+
+    it('href uses BASE_URL + string path when path argument is given', () => {
+      const mapper = makeObjectMapper(makeRequest('/rest/v0/vms', '*'), 'hosts')
+      assert.deepEqual(mapper(obj), { ...obj, href: `${BASE_URL}/hosts/abc-123` })
+    })
+  })
+
+  describe('fields is a comma-separated string — returns picked fields with href', () => {
+    it('returns only the requested fields alongside href', () => {
+      const mapper = makeObjectMapper(makeRequest('/rest/v0/vms', 'name,type'))
+      assert.deepEqual(mapper(obj), { name: 'test-vm', type: 'VM', href: '/rest/v0/vms/abc-123' })
+    })
+
+    it('omits fields not present on the object', () => {
+      const mapper = makeObjectMapper(makeRequest('/rest/v0/vms', 'name,nonexistent'))
+      assert.deepEqual(mapper(obj), { name: 'test-vm', href: '/rest/v0/vms/abc-123' })
+    })
+
+    it('returns only href when fields is an empty string', () => {
+      const mapper = makeObjectMapper(makeRequest('/rest/v0/vms', ''))
+      assert.deepEqual(mapper(obj), { href: '/rest/v0/vms/abc-123' })
+    })
+  })
+})

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,7 +37,7 @@
 - [Netbox] Use platform hierarchy to assign versioned OS names (e.g. "Debian 12" instead of "Debian") when the major version is known (requires Netbox >= 4.4) [#7773](https://github.com/vatesfr/xen-orchestra/issues/7773) (PR [#9644](https://github.com/vatesfr/xen-orchestra/pull/9644))
 - [Backups] Backups no longer use their own task system, but instead use the same system as XO Task. This will help improve loading times in the future (PR [#9734](https://github.com/vatesfr/xen-orchestra/pull/9734))
 - [OpenMetrics] Add VM status (`xcp_vm_status`) and VM uptime (`xcp_vm_uptime_seconds`) metrics [#9684](https://github.com/vatesfr/xen-orchestra/pull/9684)
-- [REST API] Fix the `href` property collections when executing a query with a trailing slash. (PR [#9741](https://github.com/vatesfr/xen-orchestra/pull/9741))
+- [REST API] Fix the `href` property in collection responses when the request URL has a trailing slash. (PR [#9741](https://github.com/vatesfr/xen-orchestra/pull/9741))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,6 +37,7 @@
 - [Netbox] Use platform hierarchy to assign versioned OS names (e.g. "Debian 12" instead of "Debian") when the major version is known (requires Netbox >= 4.4) [#7773](https://github.com/vatesfr/xen-orchestra/issues/7773) (PR [#9644](https://github.com/vatesfr/xen-orchestra/pull/9644))
 - [Backups] Backups no longer use their own task system, but instead use the same system as XO Task. This will help improve loading times in the future (PR [#9734](https://github.com/vatesfr/xen-orchestra/pull/9734))
 - [OpenMetrics] Add VM status (`xcp_vm_status`) and VM uptime (`xcp_vm_uptime_seconds`) metrics [#9684](https://github.com/vatesfr/xen-orchestra/pull/9684)
+- [REST API] Fix the `href` property collections when executing a query with a trailing slash.
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,7 +37,7 @@
 - [Netbox] Use platform hierarchy to assign versioned OS names (e.g. "Debian 12" instead of "Debian") when the major version is known (requires Netbox >= 4.4) [#7773](https://github.com/vatesfr/xen-orchestra/issues/7773) (PR [#9644](https://github.com/vatesfr/xen-orchestra/pull/9644))
 - [Backups] Backups no longer use their own task system, but instead use the same system as XO Task. This will help improve loading times in the future (PR [#9734](https://github.com/vatesfr/xen-orchestra/pull/9734))
 - [OpenMetrics] Add VM status (`xcp_vm_status`) and VM uptime (`xcp_vm_uptime_seconds`) metrics [#9684](https://github.com/vatesfr/xen-orchestra/pull/9684)
-- [REST API] Fix the `href` property collections when executing a query with a trailing slash.
+- [REST API] Fix the `href` property collections when executing a query with a trailing slash. (PR [#9741](https://github.com/vatesfr/xen-orchestra/pull/9741))
 
 ### Bug fixes
 


### PR DESCRIPTION
### Description

Introduced by dd5f0cdaa9993fae25469bd1cb1d01d4f2123f44

To reproduce, simply perform a REST API request on a collection (E.g. /vms) with a trailing slash. `/rest/v0/vms/`
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
