### PR TITLE
feat(rest-api): ACL middleware for schedule

### DIFF
--- a/@xen-orchestra/acl/src/actions/schedule.mts
+++ b/@xen-orchestra/acl/src/actions/schedule.mts
@@ -1,3 +1,4 @@
 export default {
   read: true,
+  run: true,
 }

--- a/@xen-orchestra/rest-api/src/schedules/schedule.controller.mts
+++ b/@xen-orchestra/rest-api/src/schedules/schedule.controller.mts
@@ -1,12 +1,27 @@
 import type { XoSchedule } from '@vates/types'
-import { Example, Get, Path, Post, Query, Request, Response, Route, Security, SuccessResponse, Tags } from 'tsoa'
+import {
+  Example,
+  Get,
+  Middlewares,
+  Path,
+  Post,
+  Query,
+  Request,
+  Response,
+  Route,
+  Security,
+  SuccessResponse,
+  Tags,
+} from 'tsoa'
 import { provide } from 'inversify-binding-decorators'
 import type { Request as ExRequest } from 'express'
 
+import { acl } from '../middlewares/acl.middleware.mjs'
 import {
   asynchronousActionResp,
   badRequestResp,
   featureUnauthorized,
+  forbiddenOperationResp,
   internalServerErrorResp,
   noContentResp,
   notFoundResp,
@@ -60,23 +75,55 @@ export class ScheduleController extends XoController<XoSchedule> {
   }
 
   /**
+   *
+   * Required privilege:
+   * - resource: schedule, action: read
+   *
    * @example id "cf7249f8-d20b-494f-97f4-b1f32f94e780"
    */
   @Example(schedule)
   @Get('{id}')
+  @Middlewares(
+    acl({
+      resource: 'schedule',
+      action: 'read',
+      objectId: 'params.id',
+      getObject:
+        ({ restApi }) =>
+        id =>
+          restApi.xoApp.getSchedule(id),
+    })
+  )
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   async getSchedule(@Path() id: string): Promise<Unbrand<XoSchedule>> {
     return this.getObject(id as XoSchedule['id'])
   }
 
   /**
+   *
+   * Required privilege:
+   * - resource: schedule, action: run
+   *
    * @example id "cf7249f8-d20b-494f-97f4-b1f32f94e780"
    */
   @Example(taskLocation)
   @Post('{id}/actions/run')
+  @Middlewares(
+    acl({
+      resource: 'schedule',
+      action: 'run',
+      objectId: 'params.id',
+      getObject:
+        ({ restApi }) =>
+        id =>
+          restApi.xoApp.getSchedule(id),
+    })
+  )
   @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(featureUnauthorized.status, featureUnauthorized.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
   async runSchedule(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {


### PR DESCRIPTION
### Description

Add ACL v2 enforcement on the `/schedules` REST endpoints, following the same pattern as the previous PRs in the ACL series (#9655 VM, #9712 SR, #9717 task, #9718 backup-repository, #9719 backup-log, #9737 backup-jobs, #9745 backup-archives).

Endpoints protected:

- `GET /schedules/{id}` — requires `schedule:read`
- `POST /schedules/{id}/actions/run` — requires `schedule:run`

To allow the granular separation between "see a schedule" and "trigger a schedule run", the `run` action is declared on the `schedule` ACL resource alongside the existing `read` action.

`GET /schedules` was already filtered via `sendObjects(..., { privilege: { action: 'read', resource: 'schedule' } })` and remains unchanged.

See XO-2073 (parent XO-835).

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
