### PR TITLE
feat(rest-api): ACL middleware for restore-log

### DIFF
--- a/@xen-orchestra/rest-api/src/backup-logs/backup-log.service.mts
+++ b/@xen-orchestra/rest-api/src/backup-logs/backup-log.service.mts
@@ -1,4 +1,4 @@
-import type { AnyXoLog, XoBackupLog, XoVm } from '@vates/types'
+import type { AnyXoLog, XoBackupLog, XoRestoreLog, XoVm } from '@vates/types'
 import { noSuchObject } from 'xo-common/api-errors.js'
 import type { RestApi } from '../rest-api/rest-api.mjs'
 
@@ -17,6 +17,14 @@ export class BackupLogService {
     const log = await this.#restApi.xoApp.getBackupNgLogs(id)
     if (!this.isBackupLog(log)) {
       throw noSuchObject('backup-log')
+    }
+    return log
+  }
+
+  async getRestoreLog(id: AnyXoLog['id']): Promise<XoRestoreLog> {
+    const log = await this.#restApi.xoApp.getBackupNgLogs(id)
+    if (this.isBackupLog(log)) {
+      throw noSuchObject('restore-log')
     }
     return log
   }

--- a/@xen-orchestra/rest-api/src/restore-logs/restore-log.controller.mts
+++ b/@xen-orchestra/rest-api/src/restore-logs/restore-log.controller.mts
@@ -2,13 +2,19 @@ import { AnyXoLog, XoRestoreLog } from '@vates/types'
 import { createLogger } from '@xen-orchestra/log'
 import { Deprecated, Example, Get, Middlewares, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
 import { inject } from 'inversify'
-import { noSuchObject } from 'xo-common/api-errors.js'
 import { provide } from 'inversify-binding-decorators'
 import type { Request as ExRequest } from 'express'
 
+import { acl, autoBindService } from '../middlewares/acl.middleware.mjs'
 import { BackupLogService } from '../backup-logs/backup-log.service.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
-import { badRequestResp, unauthorizedResp, Unbrand } from '../open-api/common/response.common.mjs'
+import {
+  badRequestResp,
+  forbiddenOperationResp,
+  notFoundResp,
+  unauthorizedResp,
+  Unbrand,
+} from '../open-api/common/response.common.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
 import { SendObjects } from '../helpers/helper.type.mjs'
 import { partialRestoreLogs, restoreLog, restoreLogIds } from '../open-api/oa-examples/restore-log.oa-example.mjs'
@@ -34,12 +40,8 @@ export class RestoreLogController extends XoController<XoRestoreLog> {
     return this.restApi.xoApp.getBackupNgLogsSorted({ filter }) as Promise<XoRestoreLog[]>
   }
 
-  async getCollectionObject(id: AnyXoLog['id']): Promise<XoRestoreLog> {
-    const log = await this.restApi.xoApp.getBackupNgLogs(id)
-    if (this.#backupLogService.isBackupLog(log)) {
-      throw noSuchObject('restore-log')
-    }
-    return log
+  getCollectionObject(id: AnyXoLog['id']): Promise<XoRestoreLog> {
+    return this.#backupLogService.getRestoreLog(id)
   }
 
   /**
@@ -69,10 +71,23 @@ export class RestoreLogController extends XoController<XoRestoreLog> {
   }
 
   /**
-   * @example id "fo"
+   * Required privilege:
+   * - resource: restore-log, action: read
+   *
+   * @example id "1758180544428"
    */
   @Example(restoreLog)
   @Get('{id}')
+  @Middlewares(
+    acl({
+      resource: 'restore-log',
+      action: 'read',
+      objectId: 'params.id',
+      getObject: autoBindService(BackupLogService, 'getRestoreLog'),
+    })
+  )
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
   getRestoreLog(@Path() id: string): Promise<Unbrand<XoRestoreLog>> {
     return this.getObject(id as XoRestoreLog['id'])
   }
@@ -104,12 +119,8 @@ export class DeprecatedRestoreController extends XoController<XoRestoreLog> {
     return this.restApi.xoApp.getBackupNgLogsSorted({ filter }) as Promise<XoRestoreLog[]>
   }
 
-  async getCollectionObject(id: AnyXoLog['id']): Promise<XoRestoreLog> {
-    const log = await this.restApi.xoApp.getBackupNgLogs(id)
-    if (this.#backupLogService.isBackupLog(log)) {
-      throw noSuchObject('restore-log')
-    }
-    return log
+  getCollectionObject(id: AnyXoLog['id']): Promise<XoRestoreLog> {
+    return this.#backupLogService.getRestoreLog(id)
   }
 
   /**
@@ -141,11 +152,24 @@ export class DeprecatedRestoreController extends XoController<XoRestoreLog> {
   }
 
   /**
+   * Required privilege:
+   * - resource: restore-log, action: read
+   *
    * @example id "1758180544428"
    */
   @Example(restoreLog)
   @Deprecated()
   @Get('{id}')
+  @Middlewares(
+    acl({
+      resource: 'restore-log',
+      action: 'read',
+      objectId: 'params.id',
+      getObject: autoBindService(BackupLogService, 'getRestoreLog'),
+    })
+  )
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
   getDeprecatedRestoreLog(@Path() id: string): Promise<Unbrand<XoRestoreLog>> {
     return this.getObject(id as XoRestoreLog['id'])
   }

--- a/@xen-orchestra/rest-api/src/restore-logs/restore-log.controller.mts
+++ b/@xen-orchestra/rest-api/src/restore-logs/restore-log.controller.mts
@@ -135,7 +135,6 @@ export class DeprecatedRestoreController extends XoController<XoRestoreLog> {
   @Example(partialRestoreLogs)
   @Deprecated()
   @Get('')
-  @Security('*', ['acl'])
   async getDeprecatedRestoreLogs(
     @Request() req: ExRequest,
     @Query() fields?: string,
@@ -152,24 +151,11 @@ export class DeprecatedRestoreController extends XoController<XoRestoreLog> {
   }
 
   /**
-   * Required privilege:
-   * - resource: restore-log, action: read
-   *
    * @example id "1758180544428"
    */
   @Example(restoreLog)
   @Deprecated()
   @Get('{id}')
-  @Middlewares(
-    acl({
-      resource: 'restore-log',
-      action: 'read',
-      objectId: 'params.id',
-      getObject: autoBindService(BackupLogService, 'getRestoreLog'),
-    })
-  )
-  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
-  @Response(notFoundResp.status, notFoundResp.description)
   getDeprecatedRestoreLog(@Path() id: string): Promise<Unbrand<XoRestoreLog>> {
     return this.getObject(id as XoRestoreLog['id'])
   }


### PR DESCRIPTION
### Description

Add ACL v2 enforcement on the `/restore-logs` REST endpoints, following the same pattern as the previous PRs in the ACL series (#9655 VM, #9712 SR, #9717 task, #9718 backup-repository, #9719 backup-log, #9737 backup-jobs, #9745 backup-archives, #9748 schedule).

Endpoint protected:

- `GET /restore-logs/{id}` — requires `restore-log:read`
- `GET /restore/logs/{id}` (deprecated) — same protection, symmetrically applied

Before this change, any authenticated user could fetch any restore log by id, bypassing the ACL filter that was only applied on the collection. The fix reuses the shared `acl()` middleware with `autoBindService(BackupLogService, 'getRestoreLog')` to return `403` when the privilege is missing and `404` when the id doesn't exist or refers to a backup log.

`GET /restore-logs` and `GET /restore/logs` were already filtered via `sendObjects(..., { privilege: { action: 'read', resource: 'restore-log' } })` and remain unchanged.

Internal change: the pre-existing discriminator logic duplicated in both `RestoreLogController.getCollectionObject` and `DeprecatedRestoreController.getCollectionObject` is now centralized as `BackupLogService.getRestoreLog`, mirroring the existing `getBackupLog` on the same service (the service already served both log types via `isBackupLog`).

See XO-2072 (parent XO-835).

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
