### PR TITLE
feat(rest-api): add POST and DELETE /plugins/snd-controller/vif/rules/:id routes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@
 - [OpenMetrics] Add per-VDI disk size metrics: `xcp_vdi_virtual_size_bytes` and `xcp_vdi_physical_usage_bytes` [#9680](https://github.com/vatesfr/xen-orchestra/pull/9680)
 - [i18n] Update Chinese (Simplified Han script), Czech, Dutch, German, Persian, Polish, Portuguese, Portuguese (Brasil), Slovak, Spanish and Swedish translations (PR [#9729](https://github.com/vatesfr/xen-orchestra/pull/9729))
 - [REST API] Add `POST rest/v0/plugins/sdn-controller/networks/:id/actions/add_traffic_rule` and `POST rest/v0/plugins/sdn-controller/networks/:id/actions/delete_traffic_rule` endpoints ([#9418](https://github.com/vatesfr/xen-orchestra/pull/9418))
+- [REST API] Add `POST rest/v0/plugins/sdn-controller/vifs/:id/actions/add_traffic_rule` and `POST rest/v0/plugins/sdn-controller/vifs/:id/actions/delete_traffic_rule` endpoints ([#9759](https://github.com/vatesfr/xen-orchestra/pull/9759))
 - [Pool/Network] Add Network deletion (PR [#9714](https://github.com/vatesfr/xen-orchestra/pull/9714))
 
 ### Bug fixes

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -459,7 +459,7 @@ class SDNController extends EventEmitter {
         res.status(statusCode)
         return result ?? {}
       } else {
-        pResult.catch(() => { })
+        pResult.catch(() => {})
         res.status(202).set('Location', `/rest/v0/tasks/${task.id}`).json({ taskId: task.id })
         return undefined
       }
@@ -798,7 +798,6 @@ class SDNController extends EventEmitter {
       for (const pool of pools) {
         pool.update_other_config('xo:sdn-controller:of-method', of_method)
       }
-
     } catch (error) {
       log.error('Error while handling xapi connection', {
         id: xapi.pool.uuid,
@@ -887,9 +886,7 @@ class SDNController extends EventEmitter {
       const network = this._xo.getXapiObject(this._xo.getObject(networkId, 'network'))
       assert(network.$PIFs.length > 0, 'Network needs to be plugged to add a rule')
 
-      const networkRules = JSON.parse(
-        network.other_config['xo:sdn-controller:of-rules'] || '[]'
-      ).map(JSON.parse)
+      const networkRules = JSON.parse(network.other_config['xo:sdn-controller:of-rules'] || '[]').map(JSON.parse)
 
       // filter matching rule (don't compare allow and cookie)
       const matchRules = networkRules.filter(rule => {
@@ -902,15 +899,18 @@ class SDNController extends EventEmitter {
       let cookie
       if (matchRules.length !== 0) {
         // use the one in rule if matching rule is present
-        cookie = matchRules.map(rule => { return rule.cookie })[0]
-
+        cookie = matchRules.map(rule => {
+          return rule.cookie
+        })[0]
       } else {
         // generate a new cookie not in use (OpenVSwitch cookie range: 0x1 to 0xFFFF_FFFF_FFFF_FFFF)
         do {
           cookie = '0x' + randomBytes(8).toString('hex')
         } while (
           cookie === '0x0000000000000000' ||
-          networkRules.filter(rule => { return rule.cookie === cookie }).length > 0
+          networkRules.filter(rule => {
+            return rule.cookie === cookie
+          }).length > 0
         )
       }
 
@@ -984,7 +984,7 @@ class SDNController extends EventEmitter {
             host: vif.$VM.$resident_on?.uuid,
           })
         } else {
-          throw (error)
+          throw error
         }
       }
 
@@ -1032,9 +1032,7 @@ class SDNController extends EventEmitter {
       let network = this._xo.getXapiObject(this._xo.getObject(networkId, 'network'))
       assert(network.$PIFs.length > 0, 'Network needs to be plugged to delete a rule')
 
-      const networkRules = JSON.parse(
-        network.other_config['xo:sdn-controller:of-rules'] || '[]'
-      ).map(JSON.parse)
+      const networkRules = JSON.parse(network.other_config['xo:sdn-controller:of-rules'] || '[]').map(JSON.parse)
 
       // filter matching rule (don't compare allow and cookie)
       const matchRules = networkRules.filter(rule => {
@@ -1045,12 +1043,14 @@ class SDNController extends EventEmitter {
 
       // ignore processing if rule not present here
       if (matchRules.length === 0) {
-        log.info("_deleteNetworkOfRule: rule not present, ignoring", {})
+        log.info('_deleteNetworkOfRule: rule not present, ignoring', {})
         return
       }
 
       // extract the (first) matching cookie
-      const cookie = matchRules.map(rule => { return rule.cookie })[0]
+      const cookie = matchRules.map(rule => {
+        return rule.cookie
+      })[0]
 
       try {
         const host = this._xo.getXapiObject(this._xo.getObject(network.$PIFs[0].host, 'host'))
@@ -1062,7 +1062,7 @@ class SDNController extends EventEmitter {
         if (error.code === 'HOST_OFFLINE') {
           log.info('deleteNetworkOfRule: Ignoring HOST_OFFLINE', { network: networkId })
         } else {
-          throw (error)
+          throw error
         }
       }
 
@@ -1072,7 +1072,11 @@ class SDNController extends EventEmitter {
 
       const newNetworkRules = networkRules.filter(rule => {
         return (
-          rule.protocol !== protocol || rule.port !== port || rule.ipRange !== ipRange || rule.direction !== direction || rule.cookie !== cookie
+          rule.protocol !== protocol ||
+          rule.port !== port ||
+          rule.ipRange !== ipRange ||
+          rule.direction !== direction ||
+          rule.cookie !== cookie
         )
       })
       await network.update_other_config(

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -459,7 +459,7 @@ class SDNController extends EventEmitter {
         res.status(statusCode)
         return result ?? {}
       } else {
-        pResult.catch(() => {})
+        pResult.catch(() => { })
         res.status(202).set('Location', `/rest/v0/tasks/${task.id}`).json({ taskId: task.id })
         return undefined
       }
@@ -551,6 +551,102 @@ class SDNController extends EventEmitter {
                 taskProperties: {
                   name: 'delete network traffic rule',
                   objectId: rule.networkId,
+                },
+              })
+            },
+          },
+        },
+        vifs: {
+          ':id/actions/add_traffic_rule': {
+            _post: async (req, res, next) => {
+              const validationErrors = []
+              if (!req.body) {
+                validationErrors.push('body is required')
+                throw invalidParameters(validationErrors)
+              }
+
+              if (!req.body.allow || typeof req.body.allow !== 'boolean') {
+                validationErrors.push('allow is required and must be a boolean')
+              }
+
+              if (!req.body.direction || typeof req.body.direction !== 'string') {
+                validationErrors.push('direction is required and must be a string')
+              }
+
+              if (!req.body.ipRange || typeof req.body.ipRange !== 'string') {
+                validationErrors.push('ipRange is required and must be a string')
+              }
+
+              if (!req.body.protocol || typeof req.body.protocol !== 'string') {
+                validationErrors.push('protocol is required and must be a string')
+              }
+              if (req.body.port && isNaN(parseInt(req.body.port))) {
+                validationErrors.push('port must be an integer')
+              }
+
+              if (validationErrors.length > 0) {
+                throw invalidParameters(validationErrors)
+              }
+
+              const rule = {
+                allow: req.body.allow,
+                direction: req.body.direction,
+                ipRange: req.body.ipRange,
+                protocol: req.body.protocol,
+                vifId: req.params.id,
+              }
+
+              if (req.body.port != null) {
+                rule.port = req.body.port
+              }
+
+              return createAction(res, () => this._addRule(rule), {
+                sync: req.query.sync ?? false,
+                statusCode: 204,
+                taskProperties: {
+                  name: 'add vif traffic rule',
+                  objectId: rule.vifId,
+                },
+              })
+            },
+          },
+          ':id/actions/delete_traffic_rule': {
+            _post: async (req, res, next) => {
+              const validationErrors = []
+
+              if (!req.body.direction || typeof req.body.direction !== 'string') {
+                validationErrors.push('direction is required and must be a string')
+              }
+
+              if (!req.body.ipRange || typeof req.body.ipRange !== 'string') {
+                validationErrors.push('ipRange is required and must be a string')
+              }
+
+              if (!req.body.protocol || typeof req.body.protocol !== 'string') {
+                validationErrors.push('protocol is required and must be a string')
+              }
+
+              if (validationErrors.length > 0) {
+                throw invalidParameters(validationErrors)
+              }
+
+              const rule = {
+                direction: req.body.direction,
+                ipRange: req.body.ipRange,
+                protocol: req.body.protocol,
+                vifId: req.params.id,
+              }
+
+              if (req.body.port != null) {
+                rule.port = req.body.port
+              }
+
+              return createAction(res, () => this._deleteRule(rule), {
+                sync: req.query.sync ?? false,
+                statusCode: 204,
+                taskProperties: {
+                  name: 'delete vif traffic rule',
+                  objectId: rule.vifId,
                 },
               })
             },

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -798,6 +798,7 @@ class SDNController extends EventEmitter {
       for (const pool of pools) {
         pool.update_other_config('xo:sdn-controller:of-method', of_method)
       }
+      
     } catch (error) {
       log.error('Error while handling xapi connection', {
         id: xapi.pool.uuid,
@@ -886,7 +887,9 @@ class SDNController extends EventEmitter {
       const network = this._xo.getXapiObject(this._xo.getObject(networkId, 'network'))
       assert(network.$PIFs.length > 0, 'Network needs to be plugged to add a rule')
 
-      const networkRules = JSON.parse(network.other_config['xo:sdn-controller:of-rules'] || '[]').map(JSON.parse)
+      const networkRules = JSON.parse(
+        network.other_config['xo:sdn-controller:of-rules'] || '[]'
+      ).map(JSON.parse)
 
       // filter matching rule (don't compare allow and cookie)
       const matchRules = networkRules.filter(rule => {
@@ -899,18 +902,15 @@ class SDNController extends EventEmitter {
       let cookie
       if (matchRules.length !== 0) {
         // use the one in rule if matching rule is present
-        cookie = matchRules.map(rule => {
-          return rule.cookie
-        })[0]
+         cookie = matchRules.map(rule => { return rule.cookie })[0]
+
       } else {
         // generate a new cookie not in use (OpenVSwitch cookie range: 0x1 to 0xFFFF_FFFF_FFFF_FFFF)
         do {
           cookie = '0x' + randomBytes(8).toString('hex')
         } while (
           cookie === '0x0000000000000000' ||
-          networkRules.filter(rule => {
-            return rule.cookie === cookie
-          }).length > 0
+          networkRules.filter(rule => { return rule.cookie === cookie }).length > 0
         )
       }
 
@@ -1032,7 +1032,9 @@ class SDNController extends EventEmitter {
       let network = this._xo.getXapiObject(this._xo.getObject(networkId, 'network'))
       assert(network.$PIFs.length > 0, 'Network needs to be plugged to delete a rule')
 
-      const networkRules = JSON.parse(network.other_config['xo:sdn-controller:of-rules'] || '[]').map(JSON.parse)
+      const networkRules = JSON.parse(
+        network.other_config['xo:sdn-controller:of-rules'] || '[]'
+      ).map(JSON.parse)
 
       // filter matching rule (don't compare allow and cookie)
       const matchRules = networkRules.filter(rule => {
@@ -1043,14 +1045,12 @@ class SDNController extends EventEmitter {
 
       // ignore processing if rule not present here
       if (matchRules.length === 0) {
-        log.info('_deleteNetworkOfRule: rule not present, ignoring', {})
+        log.info("_deleteNetworkOfRule: rule not present, ignoring", {})
         return
       }
 
       // extract the (first) matching cookie
-      const cookie = matchRules.map(rule => {
-        return rule.cookie
-      })[0]
+      const cookie = matchRules.map(rule => { return rule.cookie })[0]
 
       try {
         const host = this._xo.getXapiObject(this._xo.getObject(network.$PIFs[0].host, 'host'))
@@ -1072,11 +1072,7 @@ class SDNController extends EventEmitter {
 
       const newNetworkRules = networkRules.filter(rule => {
         return (
-          rule.protocol !== protocol ||
-          rule.port !== port ||
-          rule.ipRange !== ipRange ||
-          rule.direction !== direction ||
-          rule.cookie !== cookie
+          rule.protocol !== protocol || rule.port !== port || rule.ipRange !== ipRange || rule.direction !== direction || rule.cookie !== cookie
         )
       })
       await network.update_other_config(

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -798,7 +798,7 @@ class SDNController extends EventEmitter {
       for (const pool of pools) {
         pool.update_other_config('xo:sdn-controller:of-method', of_method)
       }
-      
+
     } catch (error) {
       log.error('Error while handling xapi connection', {
         id: xapi.pool.uuid,
@@ -902,7 +902,7 @@ class SDNController extends EventEmitter {
       let cookie
       if (matchRules.length !== 0) {
         // use the one in rule if matching rule is present
-         cookie = matchRules.map(rule => { return rule.cookie })[0]
+        cookie = matchRules.map(rule => { return rule.cookie })[0]
 
       } else {
         // generate a new cookie not in use (OpenVSwitch cookie range: 0x1 to 0xFFFF_FFFF_FFFF_FFFF)
@@ -984,7 +984,7 @@ class SDNController extends EventEmitter {
             host: vif.$VM.$resident_on?.uuid,
           })
         } else {
-          throw error
+          throw (error)
         }
       }
 
@@ -1062,7 +1062,7 @@ class SDNController extends EventEmitter {
         if (error.code === 'HOST_OFFLINE') {
           log.info('deleteNetworkOfRule: Ignoring HOST_OFFLINE', { network: networkId })
         } else {
-          throw error
+          throw (error)
         }
       }
 


### PR DESCRIPTION
### Description

[XO-1682](https://project.vates.tech/vates-global/browse/XO-1682/)

Adds the POST and DELETE /plugin/snd-controller/rules/:id rest routes, not documented in the swagger

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
