### PR TITLE
doc(users.md): recommend against using local users in prod environments

### DIFF
--- a/docs/docs/users.md
+++ b/docs/docs/users.md
@@ -9,6 +9,10 @@ There are 2 types of XO users:
 - **admins**, with all rights on all connected resources
 - **users**, with no rights by default
 
+:::note
+Local user accounts should be avoided in production environments. LDAP authentication is strongly recommended for centralized credential management.
+:::
+
 ## Authentication
 
 Xen Orchestra supports various types of user authentication, internal or even external thanks to the usage of the [Passport library](http://passportjs.org/).


### PR DESCRIPTION
For compliance reasons (cf. the NGC report), we now advice XO users not to use local user accounts in production environments, and to use LDAP instead.