### PR TITLE
feat(rest-api/messages): restrict GET /messages/{id} with ACL

### DIFF
--- a/@xen-orchestra/rest-api/src/messages/message.controller.mts
+++ b/@xen-orchestra/rest-api/src/messages/message.controller.mts
@@ -1,14 +1,21 @@
-import { Example, Get, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import { Example, Get, Middlewares, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
 import type { Request as ExRequest } from 'express'
 import { inject } from 'inversify'
 import { noSuchObject } from 'xo-common/api-errors.js'
 import { provide } from 'inversify-binding-decorators'
 import type { XoMessage } from '@vates/types'
 
+import { acl } from '../middlewares/acl.middleware.mjs'
 import { alarmPredicate } from '../alarms/alarm.service.mjs'
 import { message, messageIds, partialMessages } from '../open-api/oa-examples/message.oa-example.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
-import { badRequestResp, notFoundResp, unauthorizedResp, type Unbrand } from '../open-api/common/response.common.mjs'
+import {
+  badRequestResp,
+  forbiddenOperationResp,
+  notFoundResp,
+  unauthorizedResp,
+  type Unbrand,
+} from '../open-api/common/response.common.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 import { safeParseComplexMatcher } from '../helpers/utils.helper.mjs'
@@ -81,10 +88,15 @@ export class MessageController extends XapiXoController<XoMessage> {
   }
 
   /**
+   * Required privilege:
+   * - resource: message, action: read
+   *
    * @example id "f775eaeb-abe5-94e0-9682-14c37c3a1dfe"
    */
   @Example(message)
   @Get('{id}')
+  @Middlewares(acl({ resource: 'message', action: 'read', objectId: 'params.id' }))
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   getMessage(@Path() id: string): UnbrandedXoMessage {
     return this.getObject(id as XoMessage['id'])

--- a/@xen-orchestra/rest-api/src/messages/message.controller.mts
+++ b/@xen-orchestra/rest-api/src/messages/message.controller.mts
@@ -22,6 +22,16 @@ import { safeParseComplexMatcher } from '../helpers/utils.helper.mjs'
 
 type UnbrandedXoMessage = Unbrand<XoMessage>
 
+function getMessage(restApi: RestApi, id: XoMessage['id']): XoMessage {
+  const message = restApi.getObject<XoMessage>(id, 'message')
+
+  if (alarmPredicate(message)) {
+    throw noSuchObject(id, 'message')
+  }
+
+  return message
+}
+
 @Route('messages')
 @Security('*')
 @Response(badRequestResp.status, badRequestResp.description)
@@ -53,13 +63,7 @@ export class MessageController extends XapiXoController<XoMessage> {
    * Override parent getObject in order to exclude`ALARM` message
    */
   getObject(id: XoMessage['id']): XoMessage {
-    const message = super.getObject(id)
-
-    if (alarmPredicate(message)) {
-      throw noSuchObject(id, 'message')
-    }
-
-    return message
+    return getMessage(this.restApi, id)
   }
 
   /**
@@ -95,7 +99,17 @@ export class MessageController extends XapiXoController<XoMessage> {
    */
   @Example(message)
   @Get('{id}')
-  @Middlewares(acl({ resource: 'message', action: 'read', objectId: 'params.id' }))
+  @Middlewares(
+    acl({
+      resource: 'message',
+      action: 'read',
+      objectId: 'params.id',
+      getObject:
+        ({ restApi }) =>
+        id =>
+          getMessage(restApi, id),
+    })
+  )
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   getMessage(@Path() id: string): UnbrandedXoMessage {


### PR DESCRIPTION
### Description

Restrict `GET /rest/v0/messages/{id}` with ACLs, in line with the broader XO-835 effort to homogenize ACL enforcement on the REST API.

Until now, the detail endpoint called `this.getObject(id)` directly, while the list endpoint already filtered messages via `sendObjects(..., { privilege: { action: 'read', resource: 'message' } })`. Any authenticated user could therefore retrieve a message by guessing its ID, bypassing the ACL policy enforced on the listing.

The fix applies the canonical `acl()` middleware pattern already used by `vms`, `hosts`, `pools`, `vdis`:

- `@Middlewares(acl({ resource: 'message', action: 'read', objectId: 'params.id' }))`
- `@Response(forbiddenOperationResp…)` to declare the 403 in the generated OpenAPI spec (404 was already declared).

Admin bypass is preserved natively by the middleware. When the requested object does not exist, `restApi.getObject` throws `noSuchObject`, which the middleware forwards via `next(error)` — clients still receive 404 (not 403), matching the behavior of the other controllers.

See XO-2064. Part of XO-835 (`[REST-API] ACLs`).

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
