### PR TITLE
fix(immutable-backups): omnibus fixes

### DIFF
--- a/@xen-orchestra/immutable-backups/package.json
+++ b/@xen-orchestra/immutable-backups/package.json
@@ -38,6 +38,7 @@
     "build": "tsc",
     "clean": "rimraf dist/",
     "postversion": "npm publish --access public",
+    "test": "tsc && node --test dist/*.test.mjs",
     "test-integration": "tsc && node --test dist/*.integ.mjs",
     "prebuild": "npm run clean",
     "prepublishOnly": "npm run build"

--- a/@xen-orchestra/immutable-backups/src/_datetime.mts
+++ b/@xen-orchestra/immutable-backups/src/_datetime.mts
@@ -1,0 +1,27 @@
+/**
+ * Matches the datetime prefix shared by all files/directories belonging to a
+ * single backup run.
+ *
+ * Examples:
+ *   "20231215T142030.json"        → "20231215T142030"
+ *   "20231215T142030Z.alias.vhd"  → "20231215T142030Z"
+ *   "cache.json.gz"               → undefined  (not a backup file)
+ */
+export const DATETIME_RE = /^(\d{8}T\d{6}Z?)\./
+
+export function extractDatetime(filename: string): string | undefined {
+  return DATETIME_RE.exec(filename)?.[1]
+}
+
+// Parse a datetime string like "20231215T142030Z" or "20231215T142030" into a
+// Unix timestamp (ms).  Returns undefined when the format does not match.
+// Using the filename-encoded datetime as the expiry reference is intentional:
+// XO rewrites backup metadata json files after creation (reconciliation, cache
+// refresh), which updates mtime and would indefinitely defer the expiry window.
+export function parseDatetime(datetime: string): number | undefined {
+  const m = /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})(Z?)$/.exec(datetime)
+  if (m === null) return undefined
+  const [, year, month, day, hour, min, sec, z] = m
+  const ts = Date.parse(`${year}-${month}-${day}T${hour}:${min}:${sec}${z || 'Z'}`)
+  return isNaN(ts) ? undefined : ts
+}

--- a/@xen-orchestra/immutable-backups/src/_datetime.test.mts
+++ b/@xen-orchestra/immutable-backups/src/_datetime.test.mts
@@ -1,0 +1,63 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { extractDatetime, parseDatetime } from './_datetime.mjs'
+
+describe('extractDatetime', () => {
+  it('extracts datetime with Z suffix from a .json filename', () => {
+    assert.strictEqual(extractDatetime('20231215T142030Z.json'), '20231215T142030Z')
+  })
+
+  it('extracts datetime without Z suffix', () => {
+    assert.strictEqual(extractDatetime('20231215T142030.json'), '20231215T142030')
+  })
+
+  it('extracts datetime from a .alias.vhd filename', () => {
+    assert.strictEqual(extractDatetime('20231215T142030Z.alias.vhd'), '20231215T142030Z')
+  })
+
+  it('returns undefined for cache.json.gz (no datetime prefix)', () => {
+    assert.strictEqual(extractDatetime('cache.json.gz'), undefined)
+  })
+
+  it('returns undefined for plain metadata.json', () => {
+    assert.strictEqual(extractDatetime('metadata.json'), undefined)
+  })
+})
+
+describe('parseDatetime', () => {
+  it('parses a UTC datetime (Z suffix) correctly', () => {
+    const ts = parseDatetime('20231215T142030Z')
+    assert.ok(ts !== undefined)
+    const d = new Date(ts)
+    assert.strictEqual(d.getUTCFullYear(), 2023)
+    assert.strictEqual(d.getUTCMonth(), 11) // December = 11
+    assert.strictEqual(d.getUTCDate(), 15)
+    assert.strictEqual(d.getUTCHours(), 14)
+    assert.strictEqual(d.getUTCMinutes(), 20)
+    assert.strictEqual(d.getUTCSeconds(), 30)
+  })
+
+  it('treats a datetime without Z suffix as UTC', () => {
+    const withZ = parseDatetime('20231215T142030Z')
+    const withoutZ = parseDatetime('20231215T142030')
+    assert.strictEqual(withZ, withoutZ)
+  })
+
+  it('returns undefined for an empty string', () => {
+    assert.strictEqual(parseDatetime(''), undefined)
+  })
+
+  it('returns undefined for a plain date (no time part)', () => {
+    assert.strictEqual(parseDatetime('20231215'), undefined)
+  })
+
+  it('returns undefined for a random string', () => {
+    assert.strictEqual(parseDatetime('cache.json.gz'), undefined)
+  })
+
+  it('returns a timestamp in the past for an old date', () => {
+    const ts = parseDatetime('20200101T000000Z')
+    assert.ok(ts !== undefined)
+    assert.ok(ts < Date.now(), 'Jan 2020 must be in the past')
+  })
+})

--- a/@xen-orchestra/immutable-backups/src/_watcher.integ.mts
+++ b/@xen-orchestra/immutable-backups/src/_watcher.integ.mts
@@ -235,6 +235,29 @@ describe('watchVmDirectory', () => {
     }
   })
 
+  it('does not re-lock a backup whose datetime is past the immutability window', async () => {
+    const dir = await mkTmp()
+    const vmDir = path.join(dir, 'vm')
+    await fs.mkdir(vmDir, { recursive: true })
+
+    const errors: unknown[] = []
+    // BACKUP_DATE (Jan 2024) is over a year ago — well past ONE_DAY_MS
+    const close = watchVmDirectory(vmDir, err => errors.push(err), {
+      delayBetweenSizeCheck: 100,
+      immutabilityDuration: ONE_DAY_MS,
+    })
+    try {
+      const jsonFile = path.join(vmDir, `${BACKUP_DATE}.json`)
+      await fs.writeFile(jsonFile, '{}')
+      await new Promise(r => setTimeout(r, 500))
+      assert.strictEqual(await File.isImmutable(jsonFile), false, 'expired backup must not be re-locked')
+      assert.strictEqual(errors.length, 0)
+    } finally {
+      close()
+      await cleanupRoot(dir)
+    }
+  })
+
   it('locks a flat VHD file when .json is written', async () => {
     const dir = await mkTmp()
     const vmDir = path.join(dir, 'vm')

--- a/@xen-orchestra/immutable-backups/src/_watcher.integ.mts
+++ b/@xen-orchestra/immutable-backups/src/_watcher.integ.mts
@@ -89,6 +89,47 @@ describe('waitForWriteDone', () => {
     }
   })
 
+  it('rejects fast with code=ENOENT when file never appears', async () => {
+    const dir = await mkTmp()
+    try {
+      const file = path.join(dir, 'nonexistent.bin')
+      const start = Date.now()
+      await assert.rejects(waitForWriteDone(file, 30_000, 100), (err: NodeJS.ErrnoException) => {
+        assert.strictEqual(err.code, 'ENOENT', 'error must carry code ENOENT')
+        return true
+      })
+      const elapsed = Date.now() - start
+      assert.ok(elapsed < 5000, `should fail within 5 s (took ${elapsed} ms)`)
+    } finally {
+      await rimraf(dir)
+    }
+  })
+
+  it('rejects with no ENOENT code when file appears but never stabilises', async () => {
+    const dir = await mkTmp()
+    try {
+      const file = path.join(dir, 'growing2.bin')
+      let stop = false
+      const writer = (async () => {
+        let i = 0
+        while (!stop) {
+          await fs.appendFile(file, `chunk-${i++}\n`)
+          await new Promise(r => setTimeout(r, 80))
+        }
+      })()
+
+      await assert.rejects(waitForWriteDone(file, 500, 100), (err: NodeJS.ErrnoException) => {
+        assert.ok(/Timeout/.test(err.message), 'error must say Timeout')
+        assert.strictEqual(err.code, undefined, 'must not carry ENOENT code')
+        return true
+      })
+      stop = true
+      await writer
+    } finally {
+      await rimraf(dir)
+    }
+  })
+
   it('resolves once a growing file stops changing', async () => {
     const dir = await mkTmp()
     try {

--- a/@xen-orchestra/immutable-backups/src/_watcher.mts
+++ b/@xen-orchestra/immutable-backups/src/_watcher.mts
@@ -1,8 +1,9 @@
 import fs from 'node:fs'
 import fsp from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, basename } from 'node:path'
 import * as Directory from './directory.mjs'
 import { createLogger } from '@xen-orchestra/log'
+import { extractDatetime, parseDatetime } from './_datetime.mjs'
 
 const { debug } = createLogger('xen-orchestra:immutable-backups:watcher')
 
@@ -11,20 +12,8 @@ export interface WatchOptions {
   lockTimeout?: number
   /** Milliseconds to wait between consecutive size checks when polling for write completion. */
   delayBetweenSizeCheck: number
-}
-
-/**
- * Matches the datetime prefix shared by all files belonging to a single backup run.
- *
- * Examples:
- *   "20231215T142030.json"        → "20231215T142030"
- *   "20231215T142030.alias.vhd"   → "20231215T142030"
- *   "cache.json.gz"               → undefined  (not a backup file)
- */
-const DATETIME_RE = /^(\d{8}T\d{6}Z?)\./
-
-function extractDatetime(filename: string): string | undefined {
-  return DATETIME_RE.exec(filename)?.[1]
+  /** When set, backups whose filename-encoded datetime is already past the immutability window are not re-locked. */
+  immutabilityDuration?: number
 }
 
 // Poll `path` with `fs.stat` until the file size stops changing, indicating the
@@ -125,7 +114,7 @@ async function lockBackup(vmDir: string, datetime: string): Promise<void> {
 export function watchVmDirectory(
   vmDir: string,
   onError: (err: unknown) => void,
-  { lockTimeout = 10 * 60 * 1000, delayBetweenSizeCheck }: WatchOptions
+  { lockTimeout = 10 * 60 * 1000, delayBetweenSizeCheck, immutabilityDuration }: WatchOptions
 ): () => void {
   const watcher = fs.watch(vmDir)
 
@@ -145,9 +134,20 @@ export function watchVmDirectory(
     const datetime = extractDatetime(name)
     debug(`[watcher] watchVmDirectory: extractDatetime("${name}") → ${datetime}`)
     if (datetime === undefined) {
-      debug(`[watcher] watchVmDirectory: ignoring "${name}" — does not match DATETIME_RE ${DATETIME_RE}`)
+      debug(`[watcher] watchVmDirectory: ignoring "${name}" — does not match datetime pattern`)
       return // e.g. cache.json.gz
     }
+    // Skip re-locking files whose backup datetime is already past the immutability
+    // window — XO rewrites metadata json files periodically (cache refresh, reconciliation)
+    // which would otherwise cause the watcher to re-lock an already-expired backup.
+    if (immutabilityDuration !== undefined) {
+      const backupTimestamp = parseDatetime(datetime)
+      if (backupTimestamp !== undefined && Date.now() - backupTimestamp > immutabilityDuration) {
+        debug(`[watcher] watchVmDirectory: "${name}" is past immutability window — skip lock`)
+        return
+      }
+    }
+
     // ensure we handle event once per file
     // clear up the remaingin data after a reasonnable tie
     if (lockedDatetimes.has(datetime)) {
@@ -194,7 +194,7 @@ export function watchVmDirectory(
 function watchBackupDateDirectory(
   dateDir: string,
   onError: (err: unknown) => void,
-  { lockTimeout = 10 * 60 * 1000, delayBetweenSizeCheck }: WatchOptions
+  { lockTimeout = 10 * 60 * 1000, delayBetweenSizeCheck, immutabilityDuration }: WatchOptions
 ): () => void {
   const watcher = fs.watch(dateDir)
   let locked = false
@@ -210,6 +210,13 @@ function watchBackupDateDirectory(
     }
     if (locked) {
       return
+    }
+    if (immutabilityDuration !== undefined) {
+      const backupTimestamp = parseDatetime(basename(dateDir))
+      if (backupTimestamp !== undefined && Date.now() - backupTimestamp > immutabilityDuration) {
+        debug(`[watcher] watchBackupDateDirectory: "${dateDir}" is past immutability window — skip lock`)
+        return
+      }
     }
     const metadataPath = join(dateDir, 'metadata.json')
     waitForWriteDone(metadataPath, lockTimeout, delayBetweenSizeCheck)

--- a/@xen-orchestra/immutable-backups/src/_watcher.mts
+++ b/@xen-orchestra/immutable-backups/src/_watcher.mts
@@ -30,29 +30,40 @@ function extractDatetime(filename: string): string | undefined {
 // Poll `path` with `fs.stat` until the file size stops changing, indicating the
 // write is complete regardless of file format (plain or encrypted).
 // The first stat is issued immediately; resolution requires a stable non-zero
-// size across two consecutive polls spaced 100 ms apart.
-// Rejects with an error if `timeout` ms elapse before stability is reached.
+// size across two consecutive polls spaced delayBetweenSizeCheck ms apart.
+// Fails fast with code='ENOENT' if the file never appears within 2 s — this
+// handles spurious or deletion-triggered fs events where the file won't arrive.
+// Rejects with a plain Timeout error if the file appeared but never stabilised.
 export async function waitForWriteDone(path: string, timeout: number, delayBetweenSizeCheck: number): Promise<void> {
   const deadline = Date.now() + timeout
+  const firstSeenDeadline = Date.now() + Math.min(timeout, 2000)
   let prevSize = -1
+  let everSeen = false
 
   while (Date.now() < deadline) {
     try {
       const { size } = await fsp.stat(path)
+      everSeen = true
       if (size > 0 && size === prevSize) {
-        return // non-empty and size stable — write done
+        return // non-zero and size stable — write done
       }
       prevSize = size
     } catch (err) {
-      if (err.code !== 'ENOENT') {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
         throw err
       }
-      // file not yet visible — keep waiting
+      if (!everSeen && Date.now() >= firstSeenDeadline) {
+        throw Object.assign(new Error(`File never appeared: ${path}`), { code: 'ENOENT' })
+      }
     }
     await new Promise<void>(resolve => setTimeout(resolve, delayBetweenSizeCheck))
   }
 
-  throw new Error(`Timeout waiting for write to complete on ${path}`)
+  const error = new Error(`Timeout waiting for write to complete on ${path}`)
+  if (!everSeen) {
+    ;(error as NodeJS.ErrnoException).code = 'ENOENT'
+  }
+  throw error
 }
 
 // Lock every file belonging to the backup run identified by `datetime` inside `vmDir`.

--- a/@xen-orchestra/immutable-backups/src/directory.mts
+++ b/@xen-orchestra/immutable-backups/src/directory.mts
@@ -6,17 +6,18 @@ export async function makeImmutable(dirPath: string): Promise<void> {
 }
 
 // chattr processes all paths even when some are missing (it does not abort on the first
-// error), so every existing path is correctly lifted.  Per-path "No such file or
-// directory while trying to stat" messages are silently ignored; any other error
+// error), so every existing path is correctly lifted.  Per-path "while trying to stat"
+// messages (ENOENT) are silently ignored regardless of locale; any other error
 // (e.g. permission denied) causes the error to be re-thrown.
+// Note: chattr localizes the ENOENT description ("No such file or directory" becomes
+// e.g. "Aucun fichier ou dossier de ce nom" in French) but "while trying to stat" is
+// always emitted in English, so we match on that suffix only.
 async function execChattrWithMissingFiles(args: string[]) {
   try {
     await execa('chattr', args)
   } catch (err) {
     const stderr: string = 'stderr' in err ? err.stderr : ''
-    const hasUnexpected = stderr
-      .split('\n')
-      .some(line => line.trim() !== '' && !line.includes('No such file or directory while trying to stat'))
+    const hasUnexpected = stderr.split('\n').some(line => line.trim() !== '' && !line.includes('while trying to stat'))
     if (hasUnexpected) {
       throw err
     }

--- a/@xen-orchestra/immutable-backups/src/directory.mts
+++ b/@xen-orchestra/immutable-backups/src/directory.mts
@@ -1,4 +1,4 @@
-import execa from 'execa'
+import execa, { type ExecaError } from 'execa'
 
 // Recursively set the immutable (`+i`) attribute on a directory and all its contents.
 export async function makeImmutable(dirPath: string): Promise<void> {
@@ -16,7 +16,7 @@ async function execChattrWithMissingFiles(args: string[]) {
   try {
     await execa('chattr', args)
   } catch (err) {
-    const stderr: string = 'stderr' in err ? err.stderr : ''
+    const stderr = (err as ExecaError).stderr ?? ''
     const hasUnexpected = stderr.split('\n').some(line => line.trim() !== '' && !line.includes('while trying to stat'))
     if (hasUnexpected) {
       throw err

--- a/@xen-orchestra/immutable-backups/src/directory.mts
+++ b/@xen-orchestra/immutable-backups/src/directory.mts
@@ -6,19 +6,34 @@ export async function makeImmutable(dirPath: string): Promise<void> {
 }
 
 // chattr processes all paths even when some are missing (it does not abort on the first
-// error), so every existing path is correctly lifted.  Per-path "while trying to stat"
-// messages (ENOENT) are silently ignored regardless of locale; any other error
-// (e.g. permission denied) causes the error to be re-thrown.
-// Note: chattr localizes the ENOENT description ("No such file or directory" becomes
-// e.g. "Aucun fichier ou dossier de ce nom" in French) but "while trying to stat" is
-// always emitted in English, so we match on that suffix only.
-async function execChattrWithMissingFiles(args: string[]) {
-  try {
-    await execa('chattr', args)
-  } catch (err) {
-    const stderr = (err as ExecaError).stderr ?? ''
-    const hasUnexpected = stderr.split('\n').some(line => line.trim() !== '' && !line.includes('while trying to stat'))
-    if (hasUnexpected) {
+// error), so every existing path is correctly lifted.
+//
+// Per-path "while trying to stat" messages (ENOENT) are silently ignored regardless of
+// locale — these are always expected for optional paths (.xva, .alias.vhd, …) that are
+// absent in delta backups.  chattr localises the error description but "while trying to
+// stat" is always emitted in English, so we match on that suffix only.
+//
+// Any other error (e.g. EAGAIN on NFS when the file is still open, permission denied) is
+// retried up to 3 times with a 1 s delay before being re-thrown.
+async function execChattrWithMissingFiles(args: string[]): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await execa('chattr', args)
+      return
+    } catch (err) {
+      const stderr = (err as ExecaError).stderr ?? ''
+      const lines = stderr.split('\n').filter(line => line.trim() !== '')
+
+      // All errors are ENOENT for optional missing paths — silently accept, no retry.
+      if (lines.every(line => line.includes('while trying to stat'))) {
+        return
+      }
+
+      // At least one non-ENOENT error — retry up to 3 times, then re-throw.
+      if (attempt < 3) {
+        await new Promise<void>(resolve => setTimeout(resolve, 1000))
+        continue
+      }
       throw err
     }
   }

--- a/@xen-orchestra/immutable-backups/src/directory.mts
+++ b/@xen-orchestra/immutable-backups/src/directory.mts
@@ -30,7 +30,7 @@ async function execChattrWithMissingFiles(args: string[]): Promise<void> {
       }
 
       // At least one non-ENOENT error — retry up to 3 times, then re-throw.
-      if (attempt < 3) {
+      if (attempt <= 3) {
         await new Promise<void>(resolve => setTimeout(resolve, 1000))
         continue
       }

--- a/@xen-orchestra/immutable-backups/src/directory.mts
+++ b/@xen-orchestra/immutable-backups/src/directory.mts
@@ -30,7 +30,7 @@ async function execChattrWithMissingFiles(args: string[]): Promise<void> {
       }
 
       // At least one non-ENOENT error — retry up to 3 times, then re-throw.
-      if (attempt <= 3) {
+      if (attempt < 3) {
         await new Promise<void>(resolve => setTimeout(resolve, 1000))
         continue
       }

--- a/@xen-orchestra/immutable-backups/src/liftProtection.mts
+++ b/@xen-orchestra/immutable-backups/src/liftProtection.mts
@@ -1,5 +1,5 @@
 import fsp from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, basename } from 'node:path'
 import * as Directory from './directory.mjs'
 import * as File from './file.mjs'
 import { createLogger } from '@xen-orchestra/log'
@@ -7,26 +7,14 @@ import { asyncEach } from '@vates/async-each'
 import cleanXoCache from './_cleanXoCache.mjs'
 import { RemoteConfig } from './_loadConfig.mjs'
 
+import { extractDatetime, parseDatetime } from './_datetime.mjs'
+
 const { debug, warn } = createLogger('xen-orchestra:immutable-backups:liftProtection')
 
 // On the very first lift run after startup, skip the isImmutable fast-path so
 // that orphaned immutable VHDs/XVAs left by a previous partial or buggy lock
 // are caught and released even when the .json sentinel is already mutable.
 let isFirstLift = true
-
-/**
- * Matches the datetime prefix shared by all files belonging to a single VM backup run.
- *
- * Examples:
- *   "20231215T142030.json"        → "20231215T142030"
- *   "20231215T142030Z.alias.vhd"  → "20231215T142030Z"
- *   "cache.json.gz"               → undefined  (not a backup file)
- */
-const DATETIME_RE = /^(\d{8}T\d{6}Z?)\./
-
-function extractDatetime(filename: string): string | undefined {
-  return DATETIME_RE.exec(filename)?.[1]
-}
 
 // Returns the absolute paths of all immediate subdirectories of `dir`.
 // Returns [] if `dir` does not exist.
@@ -66,11 +54,11 @@ async function liftExpiredVmBackups(root: string, immutabilityDuration: number, 
       if (!entry.isFile() || !entry.name.endsWith('.json')) continue
       const datetime = extractDatetime(entry.name)
       if (datetime === undefined) continue // e.g. cache.json.gz
+      const backupTimestamp = parseDatetime(datetime)
+      if (backupTimestamp === undefined || backupTimestamp > threshold) continue
       const jsonPath = join(vmDir, entry.name)
       try {
         if (!fullScan && !(await File.isImmutable(jsonPath))) continue
-        const { mtimeMs } = await fsp.stat(jsonPath)
-        if (mtimeMs > threshold) continue
         debug('VM backup expired, scheduling lift', { jsonPath })
         expiredDatetimes.push(datetime)
         firstExpiredJsonPath ??= jsonPath
@@ -138,11 +126,11 @@ async function liftExpiredConfigBackups(root: string, immutabilityDuration: numb
   debug('scanning config backup directories', { count: scheduleDirs.length, fullScan })
   await asyncEach(scheduleDirs, async scheduleDir => {
     for (const dateDir of await listDirs(scheduleDir)) {
+      const backupTimestamp = parseDatetime(basename(dateDir))
+      if (backupTimestamp === undefined || backupTimestamp > threshold) continue
       const metadataPath = join(dateDir, 'metadata.json')
       try {
         if (!fullScan && !(await File.isImmutable(metadataPath))) continue
-        const { mtimeMs } = await fsp.stat(metadataPath)
-        if (mtimeMs > threshold) continue
         debug('config backup expired, scheduling lift', { metadataPath })
         await liftDirBackup(dateDir)
         debug('config backup lifted', { dateDir })
@@ -163,11 +151,11 @@ async function liftExpiredPoolBackups(root: string, immutabilityDuration: number
   await asyncEach(scheduleDirs, async scheduleDir => {
     for (const poolDir of await listDirs(scheduleDir)) {
       for (const dateDir of await listDirs(poolDir)) {
+        const backupTimestamp = parseDatetime(basename(dateDir))
+        if (backupTimestamp === undefined || backupTimestamp > threshold) continue
         const metadataPath = join(dateDir, 'metadata.json')
         try {
           if (!fullScan && !(await File.isImmutable(metadataPath))) continue
-          const { mtimeMs } = await fsp.stat(metadataPath)
-          if (mtimeMs > threshold) continue
           debug('pool metadata backup expired, scheduling lift', { metadataPath })
           await liftDirBackup(dateDir)
           debug('pool metadata backup lifted', { dateDir })

--- a/@xen-orchestra/immutable-backups/src/liftProtection.mts
+++ b/@xen-orchestra/immutable-backups/src/liftProtection.mts
@@ -9,6 +9,11 @@ import { RemoteConfig } from './_loadConfig.mjs'
 
 const { warn } = createLogger('xen-orchestra:immutable-backups:liftProtection')
 
+// On the very first lift run after startup, skip the isImmutable fast-path so
+// that orphaned immutable VHDs/XVAs left by a previous partial or buggy lock
+// are caught and released even when the .json sentinel is already mutable.
+let isFirstLift = true
+
 /**
  * Matches the datetime prefix shared by all files belonging to a single VM backup run.
  *
@@ -47,7 +52,7 @@ async function liftDirBackup(dateDir: string): Promise<void> {
 // any VM backup run whose metadata mtime is older than `immutabilityDuration`.
 // Per vmDir: vdis is read once, all expired datetimes are batched into a single
 // liftImmutabilityBatch call, and cleanXoCache is called once.
-async function liftExpiredVmBackups(root: string, immutabilityDuration: number): Promise<void> {
+async function liftExpiredVmBackups(root: string, immutabilityDuration: number, fullScan: boolean): Promise<void> {
   const threshold = Date.now() - immutabilityDuration
   await asyncEach(await listDirs(join(root, 'xo-vm-backups')), async vmDir => {
     // 1. Find all expired datetimes in this vmDir.
@@ -61,7 +66,7 @@ async function liftExpiredVmBackups(root: string, immutabilityDuration: number):
       if (datetime === undefined) continue // e.g. cache.json.gz
       const jsonPath = join(vmDir, entry.name)
       try {
-        if (!(await File.isImmutable(jsonPath))) continue
+        if (!fullScan && !(await File.isImmutable(jsonPath))) continue
         const { mtimeMs } = await fsp.stat(jsonPath)
         if (mtimeMs > threshold) continue
         expiredDatetimes.push(datetime)
@@ -123,13 +128,13 @@ async function liftExpiredVmBackups(root: string, immutabilityDuration: number):
 
 // Walk `xo-config-backups/<scheduleId>/<datetime>/metadata.json` files and
 // lift immutability on any backup directory whose metadata mtime is expired.
-async function liftExpiredConfigBackups(root: string, immutabilityDuration: number): Promise<void> {
+async function liftExpiredConfigBackups(root: string, immutabilityDuration: number, fullScan: boolean): Promise<void> {
   const threshold = Date.now() - immutabilityDuration
   await asyncEach(await listDirs(join(root, 'xo-config-backups')), async scheduleDir => {
     for (const dateDir of await listDirs(scheduleDir)) {
       const metadataPath = join(dateDir, 'metadata.json')
       try {
-        if (!(await File.isImmutable(metadataPath))) continue
+        if (!fullScan && !(await File.isImmutable(metadataPath))) continue
         const { mtimeMs } = await fsp.stat(metadataPath)
         if (mtimeMs > threshold) continue
         await liftDirBackup(dateDir)
@@ -143,14 +148,14 @@ async function liftExpiredConfigBackups(root: string, immutabilityDuration: numb
 
 // Walk `xo-pool-metadata-backups/<scheduleId>/<poolUUID>/<datetime>/metadata.json`
 // files and lift immutability on any backup directory whose metadata mtime is expired.
-async function liftExpiredPoolBackups(root: string, immutabilityDuration: number): Promise<void> {
+async function liftExpiredPoolBackups(root: string, immutabilityDuration: number, fullScan: boolean): Promise<void> {
   const threshold = Date.now() - immutabilityDuration
   await asyncEach(await listDirs(join(root, 'xo-pool-metadata-backups')), async scheduleDir => {
     for (const poolDir of await listDirs(scheduleDir)) {
       for (const dateDir of await listDirs(poolDir)) {
         const metadataPath = join(dateDir, 'metadata.json')
         try {
-          if (!(await File.isImmutable(metadataPath))) continue
+          if (!fullScan && !(await File.isImmutable(metadataPath))) continue
           const { mtimeMs } = await fsp.stat(metadataPath)
           if (mtimeMs > threshold) continue
           await liftDirBackup(dateDir)
@@ -165,18 +170,24 @@ async function liftExpiredPoolBackups(root: string, immutabilityDuration: number
 
 // Scan the filesystem for expired immutable backups under `root` and lift their
 // immutability.  No index is required — the backup tree is walked directly.
-export async function liftRemoteImmutability(root: string, immutabilityDuration: number): Promise<void> {
+export async function liftRemoteImmutability(
+  root: string,
+  immutabilityDuration: number,
+  fullScan: boolean
+): Promise<void> {
   await Promise.all([
-    liftExpiredVmBackups(root, immutabilityDuration),
-    liftExpiredConfigBackups(root, immutabilityDuration),
-    liftExpiredPoolBackups(root, immutabilityDuration),
+    liftExpiredVmBackups(root, immutabilityDuration, fullScan),
+    liftExpiredConfigBackups(root, immutabilityDuration, fullScan),
+    liftExpiredPoolBackups(root, immutabilityDuration, fullScan),
   ])
 }
 
 // Lift immutability on all expired backups across every configured remote.
 export async function liftImmutability(remotes: Record<string, RemoteConfig>): Promise<void> {
+  const fullScan = isFirstLift
+  isFirstLift = false
   for (const [remoteId, { root, immutabilityDuration }] of Object.entries(remotes)) {
-    await liftRemoteImmutability(root, immutabilityDuration).catch(err =>
+    await liftRemoteImmutability(root, immutabilityDuration, fullScan).catch(err =>
       warn('error during liftRemoteImmutability', { err, remoteId, root, immutabilityDuration })
     )
   }

--- a/@xen-orchestra/immutable-backups/src/liftProtection.mts
+++ b/@xen-orchestra/immutable-backups/src/liftProtection.mts
@@ -7,7 +7,7 @@ import { asyncEach } from '@vates/async-each'
 import cleanXoCache from './_cleanXoCache.mjs'
 import { RemoteConfig } from './_loadConfig.mjs'
 
-const { warn } = createLogger('xen-orchestra:immutable-backups:liftProtection')
+const { debug, warn } = createLogger('xen-orchestra:immutable-backups:liftProtection')
 
 // On the very first lift run after startup, skip the isImmutable fast-path so
 // that orphaned immutable VHDs/XVAs left by a previous partial or buggy lock
@@ -54,7 +54,9 @@ async function liftDirBackup(dateDir: string): Promise<void> {
 // liftImmutabilityBatch call, and cleanXoCache is called once.
 async function liftExpiredVmBackups(root: string, immutabilityDuration: number, fullScan: boolean): Promise<void> {
   const threshold = Date.now() - immutabilityDuration
-  await asyncEach(await listDirs(join(root, 'xo-vm-backups')), async vmDir => {
+  const vmDirs = await listDirs(join(root, 'xo-vm-backups'))
+  debug('scanning VM backup directories', { count: vmDirs.length, fullScan })
+  await asyncEach(vmDirs, async vmDir => {
     // 1. Find all expired datetimes in this vmDir.
     const entries = await fsp.readdir(vmDir, { withFileTypes: true }).catch(() => [])
     const expiredDatetimes: string[] = []
@@ -69,6 +71,7 @@ async function liftExpiredVmBackups(root: string, immutabilityDuration: number, 
         if (!fullScan && !(await File.isImmutable(jsonPath))) continue
         const { mtimeMs } = await fsp.stat(jsonPath)
         if (mtimeMs > threshold) continue
+        debug('VM backup expired, scheduling lift', { jsonPath })
         expiredDatetimes.push(datetime)
         firstExpiredJsonPath ??= jsonPath
       } catch (err) {
@@ -120,6 +123,7 @@ async function liftExpiredVmBackups(root: string, immutabilityDuration: number, 
     try {
       await Directory.liftImmutabilityBatch(candidates)
       await cleanXoCache(firstExpiredJsonPath!)
+      debug('VM backups lifted', { vmDir, count: expiredDatetimes.length })
     } catch (err) {
       warn('error lifting VM backup immutability', { err, vmDir })
     }
@@ -130,14 +134,18 @@ async function liftExpiredVmBackups(root: string, immutabilityDuration: number, 
 // lift immutability on any backup directory whose metadata mtime is expired.
 async function liftExpiredConfigBackups(root: string, immutabilityDuration: number, fullScan: boolean): Promise<void> {
   const threshold = Date.now() - immutabilityDuration
-  await asyncEach(await listDirs(join(root, 'xo-config-backups')), async scheduleDir => {
+  const scheduleDirs = await listDirs(join(root, 'xo-config-backups'))
+  debug('scanning config backup directories', { count: scheduleDirs.length, fullScan })
+  await asyncEach(scheduleDirs, async scheduleDir => {
     for (const dateDir of await listDirs(scheduleDir)) {
       const metadataPath = join(dateDir, 'metadata.json')
       try {
         if (!fullScan && !(await File.isImmutable(metadataPath))) continue
         const { mtimeMs } = await fsp.stat(metadataPath)
         if (mtimeMs > threshold) continue
+        debug('config backup expired, scheduling lift', { metadataPath })
         await liftDirBackup(dateDir)
+        debug('config backup lifted', { dateDir })
       } catch (err) {
         const code = err.code
         if (code !== 'ENOENT') warn('error lifting config backup immutability', { err, metadataPath })
@@ -150,7 +158,9 @@ async function liftExpiredConfigBackups(root: string, immutabilityDuration: numb
 // files and lift immutability on any backup directory whose metadata mtime is expired.
 async function liftExpiredPoolBackups(root: string, immutabilityDuration: number, fullScan: boolean): Promise<void> {
   const threshold = Date.now() - immutabilityDuration
-  await asyncEach(await listDirs(join(root, 'xo-pool-metadata-backups')), async scheduleDir => {
+  const scheduleDirs = await listDirs(join(root, 'xo-pool-metadata-backups'))
+  debug('scanning pool metadata backup directories', { count: scheduleDirs.length, fullScan })
+  await asyncEach(scheduleDirs, async scheduleDir => {
     for (const poolDir of await listDirs(scheduleDir)) {
       for (const dateDir of await listDirs(poolDir)) {
         const metadataPath = join(dateDir, 'metadata.json')
@@ -158,7 +168,9 @@ async function liftExpiredPoolBackups(root: string, immutabilityDuration: number
           if (!fullScan && !(await File.isImmutable(metadataPath))) continue
           const { mtimeMs } = await fsp.stat(metadataPath)
           if (mtimeMs > threshold) continue
+          debug('pool metadata backup expired, scheduling lift', { metadataPath })
           await liftDirBackup(dateDir)
+          debug('pool metadata backup lifted', { dateDir })
         } catch (err) {
           const code = err.code
           if (code !== 'ENOENT') warn('error lifting pool metadata backup immutability', { err, metadataPath })

--- a/@xen-orchestra/immutable-backups/src/remote.integ.mts
+++ b/@xen-orchestra/immutable-backups/src/remote.integ.mts
@@ -21,7 +21,9 @@ const VM_UUID = 'aaaaaaaa-0000-0000-0000-000000000001'
 const JOB_UUID = 'bbbbbbbb-0000-0000-0000-000000000001'
 const VDI_UUID = 'cccccccc-0000-0000-0000-000000000001'
 const SCHEDULE_UUID = 'dddddddd-0000-0000-0000-000000000001'
-const BACKUP_DATE = '20240115T120000Z'
+// Generate a current datetime so it falls within any reasonable immutabilityDuration window.
+// A hardcoded past date would be rejected by the datetime-based expiry check added in the watcher.
+const BACKUP_DATE = new Date().toISOString().replace(/[-:.]/g, '').slice(0, 15) + 'Z'
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/@xen-orchestra/immutable-backups/src/remote.load.mts
+++ b/@xen-orchestra/immutable-backups/src/remote.load.mts
@@ -419,7 +419,7 @@ async function main(): Promise<void> {
     }
   }, 1000)
 
-  await liftRemoteImmutability(root, 0)
+  await liftRemoteImmutability(root, 0, false)
 
   clearInterval(liftSampler)
   sampleMemory()

--- a/@xen-orchestra/immutable-backups/src/remote.mts
+++ b/@xen-orchestra/immutable-backups/src/remote.mts
@@ -69,7 +69,10 @@ export async function watchRemote(
   )
   await File.makeImmutable(settingPath)
 
-  const close = await startRemoteWatcher(root, err => warn('watcher error', { err }), { delayBetweenSizeCheck })
+  const close = await startRemoteWatcher(root, err => warn('watcher error', { err }), {
+    delayBetweenSizeCheck,
+    immutabilityDuration,
+  })
 
   return { close }
 }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,8 @@
 
 ### Packages to release
 
+- [immutable backups] Fix error while locking vhd files (PR [#9767](https://github.com/vatesfr/xen-orchestra/pull/9767))
+
 > When modifying a package, add it here with its release type.
 >
 > The format is the following: `- $packageName $releaseType`
@@ -33,7 +35,9 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/immutable-backups patch
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

- fix typing
- fix error message mishandling on non english server 
- fix too little delay to apply immutabtility 
- better handling of event deleting objects that was throwing a ETIMOUT instead of a ENOENT
- force a complete check on first immutability lift to harvest anything that could have gone wrong before
- and more debug 
- **MAIN CHANGE** we were using mtime  (last modified) as a reference date a merged file was then marked immutable again, with race condition between lift/ protect and merge. New code use the date time of the file as the reference for immutability
- 
from 51952 and 56240
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
