### PR TITLE
fix(backups): file level restore : omnibus fixes

### DIFF
--- a/@vates/fuse-vhd/index.mjs
+++ b/@vates/fuse-vhd/index.mjs
@@ -4,7 +4,7 @@ import { createLogger } from '@xen-orchestra/log'
 import { VhdSynthetic } from 'vhd-lib'
 import { Disposable, fromCallback } from 'promise-toolbox'
 
-const { warn, debug } = createLogger('vates:fuse-vhd')
+const { warn } = createLogger('vates:fuse-vhd')
 
 // build a stat object from https://github.com/fuse-friends/fuse-native/blob/master/test/fixtures/stat.js
 const stat = st => ({
@@ -49,42 +49,15 @@ export const mount = Disposable.factory(async function* mount(handler, diskPath,
   const readQueue = [] // { blockId, resolve, reject }[]
   let queueRunning = false
 
-  let statFuseReads = 0 // total FUSE read() calls
-  let statBlockReads = 0 // actual vhd.readBlock() calls issued
-  let statCoalesced = 0 // FUSE reads that hit an in-flight block (coalescing)
-  let statCacheHits = 0 // FUSE reads served from the in-memory cache
-  let statFuseBytes = 0 // bytes actually requested by FUSE
-  let statDiskBytes = 0 // bytes actually read from backing store (blockReads × blockSize)
-  const start = Date.now()
-  const toMiBs = n => (n / (1024 * 1024)).toFixed(1) + ' MiB/s'
-
   // log stats every 10 s while there is activity
-  const statsInterval = setInterval(() => {
-    if (statFuseReads === 0) return
-    const duration = Math.round((Date.now() - start) / 1000)
-    debug('read stats', {
-      duration,
-      fuseReadsPerSec: Math.round(statFuseReads / duration),
-      blockReadsPerSec: Math.round(statBlockReads / duration),
-      cacheHitsPerSec: Math.round(statCacheHits / duration),
-      coalescedPerSec: Math.round(statCoalesced / duration),
-      fuseBytesPerSec: toMiBs(Math.round(statFuseBytes / duration)),
-      diskBytesPerSec: toMiBs(Math.round(statDiskBytes / duration)),
-      // how many times more data we read from disk than FUSE actually needed
-      amplification: statFuseBytes > 0 ? (statDiskBytes / statFuseBytes).toFixed(1) + 'x' : 'n/a',
-    })
-  }, 60e3)
-  statsInterval.unref()
 
   function enqueueBlock(blockId) {
     // 1. serve from cache if available
     if (blockCache.has(blockId)) {
-      statCacheHits++
       return Promise.resolve(blockCache.get(blockId))
     }
     // 2. coalesce: join an existing in-flight read for this block
     if (pendingBlocks.has(blockId)) {
-      statCoalesced++
       return pendingBlocks.get(blockId)
     }
     const p = new Promise((resolve, reject) => {
@@ -111,8 +84,6 @@ export const mount = Disposable.factory(async function* mount(handler, diskPath,
       while (readQueue.length > 0) {
         const { blockId, resolve, reject } = readQueue.shift()
         try {
-          statBlockReads++
-          statDiskBytes += blockSize
           resolve((await vhd.readBlock(blockId)).data)
         } catch (err) {
           reject(err)
@@ -151,8 +122,6 @@ export const mount = Disposable.factory(async function* mount(handler, diskPath,
     },
     read(path, fd, buf, len, pos, cb) {
       if (path === '/vhd0') {
-        statFuseReads++
-        statFuseBytes += len
         return readData(buf, len, pos).then(cb, error => {
           warn('read error', { path, len, pos, error })
           cb(Fuse.EIO)
@@ -163,7 +132,6 @@ export const mount = Disposable.factory(async function* mount(handler, diskPath,
   })
   return new Disposable(
     () => {
-      clearInterval(statsInterval)
       return fromCallback(cb => fuse.unmount(cb))
     },
     fromCallback(cb => fuse.mount(cb))

--- a/@vates/fuse-vhd/index.mjs
+++ b/@vates/fuse-vhd/index.mjs
@@ -1,12 +1,12 @@
-import LRU from 'lru-cache'
 import Fuse from 'fuse-native'
+import LRU from 'lru-cache'
 import { createLogger } from '@xen-orchestra/log'
 import { VhdSynthetic } from 'vhd-lib'
 import { Disposable, fromCallback } from 'promise-toolbox'
 
-const { warn } = createLogger('vates:fuse-vhd')
+const { warn, debug } = createLogger('vates:fuse-vhd')
 
-// build a s stat object from https://github.com/fuse-friends/fuse-native/blob/master/test/fixtures/stat.js
+// build a stat object from https://github.com/fuse-friends/fuse-native/blob/master/test/fixtures/stat.js
 const stat = st => ({
   mtime: st.mtime || new Date(),
   atime: st.atime || new Date(),
@@ -20,42 +20,140 @@ const stat = st => ({
 export const mount = Disposable.factory(async function* mount(handler, diskPath, mountDir) {
   const vhd = yield VhdSynthetic.fromVhdChain(handler, diskPath)
 
-  const cache = new LRU({
-    max: 16, // each cached block is 2MB in size
-  })
   await vhd.readBlockAllocationTable()
+  const { blockSize } = vhd.header
+
+  // A zeroed buffer returned for VHD blocks that are not present in the chain.
+  // Never mutated — safe to share across all reads.
+  const EMPTY_BLOCK = Buffer.alloc(blockSize, 0)
+
+  // --- coalescing block read queue ---
+  //
+  // FUSE read requests from NTFS-3g arrive in small chunks (typically 4 KiB)
+  // while VHD blocks are 2 MiB. Reading blocks one at a time from the backing
+  // store (CIFS/NFS/…) bounds libuv threadpool usage to 1 concurrent I/O call.
+  //
+  // Coalescing: all pending requests for the same blockId share a single
+  // readBlock() call. When the block resolves, every waiter is fulfilled at once.
+  //
+  // Together these two properties prevent the FUSE-on-FUSE threadpool deadlock:
+  // concurrent NTFS-3g reads no longer starve the VHD block reads they depend on.
+  // In-memory block cache. Each VHD block is 2 MiB; 16 blocks = 32 MiB.
+  // This is the primary tool against the 300× CIFS amplification: NTFS-3g
+  // reads a 2 MiB block in ~512 sequential 4 KiB FUSE requests. Without a
+  // cache, each request causes a full 2 MiB CIFS read. With the cache, only
+  // the first request reads from CIFS; the rest are served from RAM.
+  const blockCache = new LRU({ max: 64 })
+
+  const pendingBlocks = new Map() // blockId → Promise<Buffer>
+  const readQueue = [] // { blockId, resolve, reject }[]
+  let queueRunning = false
+
+  let statFuseReads = 0 // total FUSE read() calls
+  let statBlockReads = 0 // actual vhd.readBlock() calls issued
+  let statCoalesced = 0 // FUSE reads that hit an in-flight block (coalescing)
+  let statCacheHits = 0 // FUSE reads served from the in-memory cache
+  let statFuseBytes = 0 // bytes actually requested by FUSE
+  let statDiskBytes = 0 // bytes actually read from backing store (blockReads × blockSize)
+  const start = Date.now()
+  const toMiBs = n => (n / (1024 * 1024)).toFixed(1) + ' MiB/s'
+
+  // log stats every 10 s while there is activity
+  const statsInterval = setInterval(() => {
+    if (statFuseReads === 0) return
+    const duration = Math.round((Date.now() - start) / 1000)
+    debug('read stats', {
+      duration,
+      fuseReadsPerSec: Math.round(statFuseReads / duration),
+      blockReadsPerSec: Math.round(statBlockReads / duration),
+      cacheHitsPerSec: Math.round(statCacheHits / duration),
+      coalescedPerSec: Math.round(statCoalesced / duration),
+      fuseBytesPerSec: toMiBs(Math.round(statFuseBytes / duration)),
+      diskBytesPerSec: toMiBs(Math.round(statDiskBytes / duration)),
+      // how many times more data we read from disk than FUSE actually needed
+      amplification: statFuseBytes > 0 ? (statDiskBytes / statFuseBytes).toFixed(1) + 'x' : 'n/a',
+    })
+  }, 60e3)
+  statsInterval.unref()
+
+  function enqueueBlock(blockId) {
+    // 1. serve from cache if available
+    if (blockCache.has(blockId)) {
+      statCacheHits++
+      return Promise.resolve(blockCache.get(blockId))
+    }
+    // 2. coalesce: join an existing in-flight read for this block
+    if (pendingBlocks.has(blockId)) {
+      statCoalesced++
+      return pendingBlocks.get(blockId)
+    }
+    const p = new Promise((resolve, reject) => {
+      readQueue.push({ blockId, resolve, reject })
+    })
+    pendingBlocks.set(blockId, p)
+    p.then(
+      data => {
+        pendingBlocks.delete(blockId)
+        blockCache.set(blockId, data)
+      },
+      () => pendingBlocks.delete(blockId)
+    )
+    drainQueue()
+    return p
+  }
+
+  function drainQueue() {
+    if (queueRunning) return
+    queueRunning = true
+    // async IIFE — errors are forwarded to individual reject() callbacks,
+    // so the outer floating promise is always fulfilled
+    ;(async () => {
+      while (readQueue.length > 0) {
+        const { blockId, resolve, reject } = readQueue.shift()
+        try {
+          statBlockReads++
+          statDiskBytes += blockSize
+          resolve((await vhd.readBlock(blockId)).data)
+        } catch (err) {
+          reject(err)
+        }
+      }
+      queueRunning = false
+    })()
+  }
+
+  async function readData(buf, len, pos) {
+    if (len === 0) return 0
+    const startBlockId = Math.floor(pos / blockSize)
+    // use (pos + len - 1) so an exact block boundary doesn't include the next block
+    const endBlockId = Math.floor((pos + len - 1) / blockSize)
+
+    let copied = 0
+    for (let blockId = startBlockId; blockId <= endBlockId; blockId++) {
+      const data = vhd.containsBlock(blockId) ? await enqueueBlock(blockId) : EMPTY_BLOCK
+      const offsetStart = blockId === startBlockId ? pos % blockSize : 0
+      const offsetEnd = blockId === endBlockId ? ((pos + len - 1) % blockSize) + 1 : blockSize
+      data.copy(buf, copied, offsetStart, offsetEnd)
+      copied += offsetEnd - offsetStart
+    }
+    return copied
+  }
+
   const fuse = new Fuse(mountDir, {
     async readdir(path, cb) {
-      if (path === '/') {
-        return cb(null, ['vhd0'])
-      }
+      if (path === '/') return cb(null, ['vhd0'])
       cb(Fuse.ENOENT)
     },
     async getattr(path, cb) {
-      if (path === '/') {
-        return cb(
-          null,
-          stat({
-            mode: 'dir',
-            size: 4096,
-          })
-        )
-      }
-      if (path === '/vhd0') {
-        return cb(
-          null,
-          stat({
-            mode: 'file',
-            size: vhd.footer.currentSize,
-          })
-        )
-      }
-
+      if (path === '/') return cb(null, stat({ mode: 'dir', size: 4096 }))
+      if (path === '/vhd0') return cb(null, stat({ mode: 'file', size: vhd.footer.currentSize }))
       cb(Fuse.ENOENT)
     },
     read(path, fd, buf, len, pos, cb) {
       if (path === '/vhd0') {
-        return vhd.readRawData(pos, len, cache, buf).then(cb, error => {
+        statFuseReads++
+        statFuseBytes += len
+        return readData(buf, len, pos).then(cb, error => {
           warn('read error', { path, len, pos, error })
           cb(Fuse.EIO)
         })
@@ -64,7 +162,10 @@ export const mount = Disposable.factory(async function* mount(handler, diskPath,
     },
   })
   return new Disposable(
-    () => fromCallback(cb => fuse.unmount(cb)),
+    () => {
+      clearInterval(statsInterval)
+      return fromCallback(cb => fuse.unmount(cb))
+    },
     fromCallback(cb => fuse.mount(cb))
   )
 })

--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -537,11 +537,27 @@ export class RemoteAdapter {
       }
 
       const results = []
-      await asyncMapSettled(partitions, partition =>
-        partition.type === LVM_PARTITION_TYPE_MBR || partition.type === LVM_PARTITION_TYPE_GPT
-          ? this._listLvmLogicalVolumes(devicePath, partition, results)
-          : results.push(partition)
-      )
+      await asyncMapSettled(partitions, async partition => {
+        if (partition.type === LVM_PARTITION_TYPE_MBR || partition.type === LVM_PARTITION_TYPE_GPT) {
+          return this._listLvmLogicalVolumes(devicePath, partition, results)
+        }
+
+        // Some Linux installers (e.g. Ubuntu subiquity) mark LVM PV partitions with a
+        // generic Linux filesystem type instead of the standard LVM type. Probe the
+        // partition: if pvs finds logical volumes, expose them; otherwise treat it as a
+        // regular mountable partition.
+        const lvResults = []
+        try {
+          await this._listLvmLogicalVolumes(devicePath, partition, lvResults)
+        } catch (_) {
+          // not an LVM PV — fall through to regular partition handling
+        }
+        if (lvResults.length > 0) {
+          results.push(...lvResults)
+        } else {
+          results.push(partition)
+        }
+      })
       return results
     })
   }

--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -5,10 +5,12 @@ import { createLogger } from '@xen-orchestra/log'
 import { VhdDirectory, VhdSynthetic } from 'vhd-lib'
 import { decorateMethodsWith } from '@vates/decorate-with'
 import { deduped } from '@vates/disposable/deduped.js'
+import { createHash, randomBytes } from 'node:crypto'
 import { dirname, join, resolve } from 'node:path'
 import { execFile } from 'child_process'
+import { lstat, open, readdir, unlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { mount } from '@vates/fuse-vhd'
-import { readdir, lstat } from 'node:fs/promises'
 import { synchronized } from 'decorator-synchronized'
 import { ZipFile } from 'yazl'
 import Disposable from 'promise-toolbox/Disposable'
@@ -122,36 +124,109 @@ export class RemoteAdapter {
   }
 
   async *_getLvmPhysicalVolume(devicePath, partition) {
-    const args = []
+    const loopArgs = []
     if (partition !== undefined) {
-      args.push('-o', partition.start * 512, '--sizelimit', partition.size)
+      loopArgs.push('-o', partition.start * 512, '--sizelimit', partition.size)
     }
-    args.push('--show', '-f', devicePath)
+    loopArgs.push('--show', '-f', devicePath)
 
     debug('attach loop device', { devicePath, partition })
-    const path = (await fromCallback(execFile, 'losetup', args)).trim()
-    try {
-      debug('list LVM physical volume', { path })
-      await fromCallback(execFile, 'pvscan', ['--cache', path])
+    const loopDevice = (await fromCallback(execFile, 'losetup', loopArgs)).trim()
 
-      yield path
+    let cowPath, cowLoop, mapperName, effectivePath
+    try {
+      try {
+        // Create a sparse COW file (~4 MB is enough to hold LVM metadata rewrites)
+        mapperName = `xo-pv-${randomBytes(4).toString('hex')}`
+        cowPath = join(tmpdir(), `${mapperName}.cow`)
+        const fh = await open(cowPath, 'w')
+        await fh.truncate(4 * 1024 * 1024)
+        await fh.close()
+
+        cowLoop = (await fromCallback(execFile, 'losetup', ['--show', '-f', cowPath])).trim()
+
+        const sectors = (await fromCallback(execFile, 'blockdev', ['--getsz', loopDevice])).trim()
+        await fromCallback(execFile, 'dmsetup', [
+          'create',
+          mapperName,
+          '--table',
+          `0 ${sectors} snapshot ${loopDevice} ${cowLoop} P 8`,
+        ])
+
+        // pvscan must run before vgimportclone so LVM registers the snapshot device
+        // and can locate the Physical Volume ID on it
+        await fromCallback(execFile, 'pvscan', ['--cache', `/dev/mapper/${mapperName}`])
+
+        // Deterministic VG name: same hash for the same disk+partition across list and mount calls,
+        // but unique across different disks — avoids duplicate VG name conflicts without state.
+        const vgBase =
+          'xo' +
+          createHash('sha256')
+            .update(devicePath)
+            .update(String(partition?.id ?? ''))
+            .digest('hex')
+            .slice(0, 10)
+        debug('import LVM volume group with unique name via dm-snapshot', { vgBase })
+        await fromCallback(execFile, 'vgimportclone', ['--basevgname', vgBase, `/dev/mapper/${mapperName}`])
+
+        effectivePath = `/dev/mapper/${mapperName}`
+      } catch (error) {
+        // dm-snapshot or vgimportclone unavailable — fall back to direct loop device.
+        // Duplicate VG names across disks may still cause activation failures.
+        // Exit code 5 = "device is partitioned": expected when whole-disk detection runs on a
+        // partitioned disk that partx failed to parse — not a real failure, no need to warn.
+        if (error.code === 5) {
+          debug('device is partitioned, skipping vgimportclone', { devicePath, partition })
+        } else {
+          warn('dm-snapshot overlay failed, falling back to direct loop device', { error })
+        }
+        if (mapperName !== undefined) {
+          await fromCallback(execFile, 'dmsetup', ['remove', mapperName]).catch(noop)
+          mapperName = undefined
+        }
+        if (cowLoop !== undefined) {
+          await fromCallback(execFile, 'losetup', ['-d', cowLoop]).catch(noop)
+          cowLoop = undefined
+        }
+        if (cowPath !== undefined) {
+          await unlink(cowPath).catch(noop)
+          cowPath = undefined
+        }
+        effectivePath = loopDevice
+      }
+
+      debug('scan LVM physical volumes', { path: effectivePath })
+      await fromCallback(execFile, 'pvscan', ['--cache', effectivePath])
+
+      yield effectivePath
     } finally {
       try {
-        const vgNames = await pvs('vg_name', path)
-
-        debug('deactivate LVM volume groups', { vgNames })
-        await fromCallback(execFile, 'vgchange', ['-an', ...vgNames])
+        const vgNames = (await pvs('vg_name', effectivePath).catch(() => [])).filter(Boolean)
+        if (vgNames.length > 0) {
+          debug('deactivate LVM volume groups', { vgNames })
+          await fromCallback(execFile, 'vgchange', ['-an', ...vgNames])
+        }
       } finally {
-        debug('detach loop device', { path })
-        await fromCallback(execFile, 'losetup', ['-d', path])
+        if (mapperName !== undefined) {
+          debug('remove dm-snapshot', { mapperName })
+          await fromCallback(execFile, 'dmsetup', ['remove', mapperName]).catch(err =>
+            warn('failed to remove dm-snapshot', { mapperName, error: err })
+          )
+        }
+        if (cowLoop !== undefined) {
+          await fromCallback(execFile, 'losetup', ['-d', cowLoop]).catch(noop)
+        }
+        if (cowPath !== undefined) {
+          await unlink(cowPath).catch(noop)
+        }
+        debug('detach loop device', { loopDevice })
+        await fromCallback(execFile, 'losetup', ['-d', loopDevice])
       }
     }
   }
 
   async *_getPartition(devicePath, partition) {
-    // the norecovery option is necessary because if the partition is dirty,
-    // mount will try to fix it which is impossible if because the device is read-only
-    const options = ['loop', 'ro', 'norecovery']
+    const options = ['loop', 'ro']
 
     if (partition !== undefined) {
       const { size, start } = partition
@@ -171,8 +246,8 @@ export class RemoteAdapter {
       ])
     }
 
-    // `norecovery` option is used for ext3/ext4/xfs, if it fails it might be
-    // another fs, try without
+    // norecovery prevents mount from attempting journal replay on a read-only device (ext3/ext4/xfs).
+    // Other filesystems don't support it, so fall back without it on failure.
     try {
       await mount([...options, 'norecovery'])
     } catch (error) {
@@ -443,6 +518,9 @@ export class RemoteAdapter {
   async *getPartition(diskId, partitionId) {
     const devicePath = yield this.getDisk(diskId)
     if (partitionId === undefined) {
+      debug(
+        'no partition specified, attempting raw disk mount — call listPartitions first if disk has partitions or LVM'
+      )
       return yield this._getPartition(devicePath)
     }
 
@@ -525,7 +603,22 @@ export class RemoteAdapter {
 
   listPartitions(diskId) {
     return Disposable.use(this.getDisk(diskId), async devicePath => {
-      const partitions = await listPartitions(devicePath)
+      // partx may return empty on FUSE-backed files (vhd0); a loop device
+      // presents proper block-device semantics that partx reads reliably.
+      // losetup may itself fail if the FUSE mount isn't fully ready yet —
+      // fall back to the direct path so listPartitions returns [] instead of throwing.
+      let loopForParts, partitions
+      try {
+        loopForParts = (await fromCallback(execFile, 'losetup', ['--show', '-f', devicePath])).trim()
+        partitions = await listPartitions(loopForParts)
+      } catch (error) {
+        debug('partition probe via loop device failed, falling back to direct path', { error })
+        partitions = await listPartitions(devicePath)
+      } finally {
+        if (loopForParts !== undefined) {
+          await fromCallback(execFile, 'losetup', ['-d', loopForParts]).catch(noop)
+        }
+      }
 
       if (partitions.length === 0) {
         try {

--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -110,16 +110,24 @@ export class RemoteAdapter {
   }
 
   async *_getLvmLogicalVolumes(devicePath, pvId, vgName) {
-    yield this._getLvmPhysicalVolume(devicePath, pvId && (await this._findPartition(devicePath, pvId)))
+    const { path: pvPath } = yield this._getLvmPhysicalVolume(
+      devicePath,
+      pvId && (await this._findPartition(devicePath, pvId))
+    )
 
-    debug('activate LVM volume group', { vgName })
-    await fromCallback(execFile, 'vgchange', ['-ay', vgName])
+    // vgimportclone may have renamed the VG (e.g. ubuntu-vg → xo<hash>); query the
+    // actual name from the PV rather than trusting the partitionId-embedded name.
+    const [actualVgName] = (await pvs('vg_name', pvPath).catch(() => [])).filter(Boolean)
+    const effectiveVgName = actualVgName ?? vgName
+
+    debug('activate LVM volume group', { effectiveVgName, requestedVgName: vgName })
+    await fromCallback(execFile, 'vgchange', ['-ay', effectiveVgName])
     try {
-      debug('get LVM volume group name and path', { vgName })
-      yield lvs(['lv_name', 'lv_path'], vgName)
+      debug('get LVM logical volumes', { effectiveVgName })
+      yield lvs(['lv_name', 'lv_path'], effectiveVgName)
     } finally {
-      debug('deactivate LVM volume group', { vgName })
-      await fromCallback(execFile, 'vgchange', ['-an', vgName])
+      debug('deactivate LVM volume group', { effectiveVgName })
+      await fromCallback(execFile, 'vgchange', ['-an', effectiveVgName])
     }
   }
 
@@ -259,7 +267,12 @@ export class RemoteAdapter {
         `--options=${options.join(',')}`,
         `--source=${devicePath}`,
         `--target=${path}`,
-      ])
+      ]).catch(error => {
+        if (error.stderr) {
+          error.message = `${error.message}: ${error.stderr.trim()}`
+        }
+        throw error
+      })
     }
 
     // norecovery prevents mount from attempting journal replay on a read-only device (ext3/ext4/xfs).
@@ -696,8 +709,11 @@ export class RemoteAdapter {
         const lvResults = []
         try {
           await this._listLvmLogicalVolumes(devicePath, partition, lvResults)
-        } catch (_) {
-          // not an LVM PV — fall through to regular partition handling
+        } catch (error) {
+          debug('LVM probe failed for non-standard-type partition, treating as regular partition', {
+            partition,
+            error,
+          })
         }
         if (lvResults.length > 0) {
           results.push(...lvResults)

--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -1,42 +1,23 @@
 import { asyncEach } from '@vates/async-each'
 import { asyncMap, asyncMapSettled } from '@xen-orchestra/async-map'
-import { compose } from '@vates/compose'
 import { createLogger } from '@xen-orchestra/log'
 import { VhdDirectory, VhdSynthetic } from 'vhd-lib'
 import { decorateMethodsWith } from '@vates/decorate-with'
-import { deduped } from '@vates/disposable/deduped.js'
-import { createHash, randomBytes } from 'node:crypto'
 import { dirname, join, resolve } from 'node:path'
-import { execFile } from 'child_process'
-import { finished } from 'node:stream/promises'
-import { lstat, open, readdir, unlink } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { mount } from '@vates/fuse-vhd'
 import { synchronized } from 'decorator-synchronized'
-import { ZipFile } from 'yazl'
 import Disposable from 'promise-toolbox/Disposable'
 import fromCallback from 'promise-toolbox/fromCallback'
 import groupBy from 'lodash/groupBy.js'
-import pDefer from 'promise-toolbox/defer'
 import pickBy from 'lodash/pickBy.js'
 import reduce from 'lodash/reduce.js'
-import * as tar from 'tar'
 import zlib from 'zlib'
 
 import { BACKUP_DIR } from './_getVmBackupDir.mjs'
 import { VmBackupDirectory } from '@xen-orchestra/backup-archive'
+import { fileRestoreDecorators, fileRestoreMethods } from './_fileRestore.mjs'
 import { formatFilenameDate } from './_filenameDate.mjs'
-import { getTmpDir } from './_getTmpDir.mjs'
 import { isMetadataFile } from './_backupType.mjs'
 import { isValidXva } from './_isValidXva.mjs'
-import {
-  listPartitions,
-  LINUX_DATA_PARTITION_TYPE_GPT,
-  LINUX_DATA_PARTITION_TYPE_MBR,
-  LVM_PARTITION_TYPE_GPT,
-  LVM_PARTITION_TYPE_MBR,
-} from './_listPartitions.mjs'
-import { lvs, pvs } from './_lvm.mjs'
 import { watchStreamSize } from './_watchStreamSize.mjs'
 
 import { RemoteVhdDisk, openDiskChain } from '@xen-orchestra/backup-archive/disks'
@@ -49,39 +30,13 @@ export const DIR_XO_POOL_METADATA_BACKUPS = 'xo-pool-metadata-backups'
 
 const IMMUTABILITY_METADATA_FILENAME = '/immutability.json'
 
-const { debug, info, warn } = createLogger('xo:backups:RemoteAdapter')
+const { debug, warn } = createLogger('xo:backups:RemoteAdapter')
 
 export const compareTimestamp = (a, b) => a.timestamp - b.timestamp
 
 const noop = Function.prototype
 
-// Restrict LVM scanning to a single device. Backup PVs are clones: the very same PVID
-// appears at once on the raw loop device, the dm-snapshot overlaid on it, and every
-// other restored copy of the same VM. An unscoped pvs/pvscan/vgimportclone/vgchange then
-// aborts with "duplicate PV ... for PVID ..." and the VG can neither be renamed nor
-// activated. Accepting only the device in hand removes every duplicate from LVM's view.
-const lvmOnlyDevice = devicePath => `devices { global_filter=[ "a|^${devicePath}$|", "r|.*|" ] }`
-
 const resolveRelativeFromFile = (file, path) => resolve('/', dirname(file), path).slice(1)
-const makeRelative = path => resolve('/', path).slice(1)
-const resolveSubpath = (root, path) => resolve(root, makeRelative(path))
-
-async function addZipEntries(zip, realBasePath, virtualBasePath, relativePaths) {
-  for (const relativePath of relativePaths) {
-    const realPath = join(realBasePath, relativePath)
-    const virtualPath = join(virtualBasePath, relativePath)
-
-    const stats = await lstat(realPath)
-    const { mode, mtime } = stats
-    const opts = { mode, mtime }
-    if (stats.isDirectory()) {
-      zip.addEmptyDirectory(virtualPath, opts)
-      await addZipEntries(zip, realPath, virtualPath, await readdir(realPath))
-    } else if (stats.isFile()) {
-      zip.addFile(realPath, virtualPath, opts)
-    }
-  }
-}
 
 const createSafeReaddir = (handler, methodName) => (path, options) =>
   handler.list(path, options).catch(error => {
@@ -90,11 +45,6 @@ const createSafeReaddir = (handler, methodName) => (path, options) =>
     }
     return []
   })
-
-const debounceResourceFactory = factory =>
-  function () {
-    return this._debounceResource(factory.apply(this, arguments))
-  }
 
 export class RemoteAdapter {
   constructor(
@@ -113,232 +63,6 @@ export class RemoteAdapter {
     return this._handler
   }
 
-  async _findPartition(devicePath, partitionId) {
-    const partitions = await listPartitions(devicePath)
-    const partition = partitions.find(_ => _.id === partitionId)
-    if (partition === undefined) {
-      throw new Error(`partition ${partitionId} not found`)
-    }
-    return partition
-  }
-
-  async *_getLvmLogicalVolumes(devicePath, pvId, vgName) {
-    const { path: pvPath, lvmConfig } = yield this._getLvmPhysicalVolume(
-      devicePath,
-      pvId && (await this._findPartition(devicePath, pvId))
-    )
-
-    // vgimportclone may have renamed the VG (e.g. ubuntu-vg → xo<hash>); query the
-    // actual name from the PV rather than trusting the partitionId-embedded name.
-    // lvmConfig scopes every command to this PV so a colliding/duplicate VG on the host
-    // or another restored copy can't shadow it.
-    const [actualVgName] = (await pvs('vg_name', '--config', lvmConfig, pvPath).catch(() => [])).filter(Boolean)
-    const effectiveVgName = actualVgName ?? vgName
-
-    debug('activate LVM volume group', { effectiveVgName, requestedVgName: vgName })
-    await fromCallback(execFile, 'vgchange', ['--config', lvmConfig, '-ay', effectiveVgName])
-    try {
-      debug('get LVM logical volumes', { effectiveVgName })
-      yield lvs(['lv_name', 'lv_path'], '--config', lvmConfig, effectiveVgName)
-    } finally {
-      debug('deactivate LVM volume group', { effectiveVgName })
-      await fromCallback(execFile, 'vgchange', ['--config', lvmConfig, '-an', effectiveVgName])
-    }
-  }
-
-  async *_getLvmPhysicalVolume(devicePath, partition) {
-    const loopArgs = []
-    if (partition !== undefined) {
-      loopArgs.push('-o', partition.start * 512, '--sizelimit', partition.size)
-    }
-    loopArgs.push('--show', '-f', devicePath)
-
-    debug('attach loop device', { devicePath, partition })
-    const loopDevice = (await fromCallback(execFile, 'losetup', loopArgs)).trim()
-
-    let cowPath, cowLoop, mapperName, effectivePath, originalVgName, lvmConfig
-    try {
-      try {
-        // Create a sparse COW file (~4 MB is enough to hold LVM metadata rewrites)
-        mapperName = `xo-pv-${randomBytes(4).toString('hex')}`
-        const mapperPath = `/dev/mapper/${mapperName}`
-        // Scope LVM to the snapshot only: the raw loop device carries the same PVID and
-        // would otherwise be flagged as a duplicate, breaking pvscan and vgimportclone.
-        const mapperConfig = lvmOnlyDevice(mapperPath)
-        cowPath = join(tmpdir(), `${mapperName}.cow`)
-        const fh = await open(cowPath, 'w')
-        await fh.truncate(4 * 1024 * 1024)
-        await fh.close()
-
-        cowLoop = (await fromCallback(execFile, 'losetup', ['--show', '-f', cowPath])).trim()
-
-        const sectors = (await fromCallback(execFile, 'blockdev', ['--getsz', loopDevice])).trim()
-        await fromCallback(execFile, 'dmsetup', [
-          'create',
-          mapperName,
-          '--table',
-          `0 ${sectors} snapshot ${loopDevice} ${cowLoop} P 8`,
-        ])
-
-        // Capture the original VG name before vgimportclone renames it so callers can display a
-        // human-readable name. We deliberately do NOT `pvscan --cache` first: with a duplicate
-        // PVID present (concurrent restore of the same VM) it fails, and vgimportclone reads the
-        // device directly (scoped by mapperConfig) without needing the online cache anyway.
-        ;[originalVgName] = (await pvs('vg_name', '--config', mapperConfig, mapperPath).catch(() => [])).filter(Boolean)
-
-        // Deterministic VG name: same hash for the same disk+partition across list and mount calls,
-        // but unique across different disks — avoids duplicate VG name conflicts without state.
-        const vgBase =
-          'xo' +
-          createHash('sha256')
-            .update(devicePath)
-            .update(String(partition?.id ?? ''))
-            .digest('hex')
-            .slice(0, 10)
-        debug('import LVM volume group with unique name via dm-snapshot', { vgBase, originalVgName })
-        await fromCallback(execFile, 'vgimportclone', ['--config', mapperConfig, '--basevgname', vgBase, mapperPath])
-
-        effectivePath = mapperPath
-      } catch (error) {
-        // dm-snapshot or vgimportclone unavailable — fall back to direct loop device.
-        // Duplicate VG names across disks may still cause activation failures.
-        const message = String(error.message ?? '')
-        if (error.code === 5 && message.includes('device is partitioned')) {
-          debug('device is partitioned, skipping vgimportclone', { devicePath, partition })
-        } else if (error.code === 5) {
-          // Other LVM exit-5 errors (e.g. "No physical volume found", "Failed to find PVID")
-          debug('vgimportclone failed, falling back to direct loop device', {
-            devicePath,
-            partition,
-            message,
-          })
-        } else {
-          warn('dm-snapshot overlay failed, falling back to direct loop device', { error })
-        }
-        if (mapperName !== undefined) {
-          await fromCallback(execFile, 'dmsetup', ['remove', mapperName]).catch(noop)
-          mapperName = undefined
-        }
-        if (cowLoop !== undefined) {
-          await fromCallback(execFile, 'losetup', ['-d', cowLoop]).catch(noop)
-          cowLoop = undefined
-        }
-        if (cowPath !== undefined) {
-          await unlink(cowPath).catch(noop)
-          cowPath = undefined
-        }
-        originalVgName = undefined
-        effectivePath = loopDevice
-      }
-
-      // Whether we ended up on the snapshot or fell back to the raw loop, scope every
-      // remaining command to that one device so duplicate PVIDs from other copies (or a
-      // same-named VG on the host) can't shadow it.
-      lvmConfig = lvmOnlyDevice(effectivePath)
-
-      // Best-effort: activation/listing below scans the device directly via lvmConfig, so a
-      // duplicate-PVID failure here (concurrent restore of the same VM) must not abort.
-      debug('scan LVM physical volumes', { path: effectivePath })
-      await fromCallback(execFile, 'pvscan', ['--config', lvmConfig, '--cache', effectivePath]).catch(error =>
-        debug('pvscan --cache failed (continuing)', { path: effectivePath, error })
-      )
-
-      // In the fallback path the VG is unmodified, so query the original name now.
-      if (originalVgName === undefined) {
-        ;[originalVgName] = (await pvs('vg_name', '--config', lvmConfig, effectivePath).catch(() => [])).filter(Boolean)
-      }
-
-      yield { path: effectivePath, originalVgName, lvmConfig }
-    } finally {
-      try {
-        const vgNames = (await pvs('vg_name', '--config', lvmConfig, effectivePath).catch(() => [])).filter(Boolean)
-        if (vgNames.length > 0) {
-          debug('deactivate LVM volume groups', { vgNames })
-          await fromCallback(execFile, 'vgchange', ['--config', lvmConfig, '-an', ...vgNames])
-        }
-      } finally {
-        if (mapperName !== undefined) {
-          debug('remove dm-snapshot', { mapperName })
-          await fromCallback(execFile, 'dmsetup', ['remove', mapperName]).catch(err =>
-            warn('failed to remove dm-snapshot', { mapperName, error: err })
-          )
-        }
-        if (cowLoop !== undefined) {
-          await fromCallback(execFile, 'losetup', ['-d', cowLoop]).catch(noop)
-        }
-        if (cowPath !== undefined) {
-          await unlink(cowPath).catch(noop)
-        }
-        debug('detach loop device', { loopDevice })
-        await fromCallback(execFile, 'losetup', ['-d', loopDevice])
-      }
-    }
-  }
-
-  async *_getPartition(devicePath, partition) {
-    const options = ['loop', 'ro']
-
-    if (partition !== undefined) {
-      const { size, start } = partition
-      options.push(`sizelimit=${size}`)
-      if (start !== undefined) {
-        options.push(`offset=${start * 512}`)
-      }
-    }
-
-    const path = yield getTmpDir()
-    const mount = options => {
-      debug('mount device', { devicePath, mountPath: path })
-      return fromCallback(execFile, 'mount', [
-        `--options=${options.join(',')}`,
-        `--source=${devicePath}`,
-        `--target=${path}`,
-      ]).catch(error => {
-        if (error.stderr) {
-          error.message = `${error.message}: ${error.stderr.trim()}`
-        }
-        throw error
-      })
-    }
-
-    // norecovery prevents mount from attempting journal replay on a read-only device (ext3/ext4/xfs).
-    // Other filesystems don't support it, so fall back without it on failure.
-    try {
-      await mount([...options, 'norecovery'])
-    } catch (error) {
-      await mount(options)
-    }
-
-    try {
-      yield path
-    } finally {
-      debug('umount device', { devicePath, mountPath: path })
-      await fromCallback(execFile, 'umount', ['--lazy', path])
-    }
-  }
-
-  _listLvmLogicalVolumes(devicePath, partition, results = []) {
-    return Disposable.use(
-      this._getLvmPhysicalVolume(devicePath, partition),
-      async ({ path, originalVgName, lvmConfig }) => {
-        const lvItems = await pvs(['lv_name', 'lv_path', 'lv_size', 'vg_name'], '--config', lvmConfig, path)
-        const partitionId = partition !== undefined ? partition.id : ''
-        lvItems.forEach(lv => {
-          const lvName = lv.lv_name
-          if (lvName !== '') {
-            results.push({
-              id: `${partitionId}/${lv.vg_name}/${lvName}`,
-              // show "ubuntu-vg/ubuntu-lv" so users can identify the volume group
-              name: originalVgName !== undefined ? `${originalVgName}/${lvName}` : lvName,
-              size: lv.lv_size,
-            })
-          }
-        })
-        return results
-      }
-    )
-  }
-
   // check if we will be allowed to merge a vhd created in this adapter
   // with the vhd at path `path`
   async isMergeableParent(packedParentUid, path) {
@@ -354,70 +78,6 @@ export class RemoteAdapter {
         ? this.useVhdDirectory() && this.#getCompressionType() === vhd.compressionType
         : !this.useVhdDirectory()
     })
-  }
-
-  fetchPartitionFiles(diskId, partitionId, paths, format) {
-    const { promise, reject, resolve } = pDefer()
-    Disposable.use(
-      async function* () {
-        const path = yield this.getPartition(diskId, partitionId)
-        let outputStream
-
-        // debug: bytes actually transmitted to the client (compressed wire bytes).
-        // Unlike fuse-vhd's fuseBytes (skewed by kernel_cache), this is comparable
-        // across configs. Logged every 5s so it can be read at any cut-off point.
-        const transmitted = { size: 0 }
-        const startedAt = Date.now()
-        const report = setInterval(() => {
-          const seconds = (Date.now() - startedAt) / 1000
-          info('partition files transmitted', {
-            format,
-            transmittedMiB: +(transmitted.size / 1048576).toFixed(1),
-            seconds: +seconds.toFixed(1),
-            mibPerSec: +(transmitted.size / 1048576 / seconds).toFixed(1),
-          })
-        }, 60e3)
-        report.unref()
-
-        try {
-          if (format === 'tgz') {
-            // jobs: 1 — process one entry at a time. node-tar defaults to 4
-            // concurrent jobs, which on a FUSE-backed restore mount means up to 4
-            // simultaneous reads; those saturate the libuv threadpool and starve
-            // the underlying vhd/CIFS reads NTFS-3g depends on (FUSE-on-FUSE
-            // threadpool deadlock). Serializing keeps a worker free for them.
-            outputStream = tar.c({ cwd: path, gzip: true, jobs: 1 }, paths.map(makeRelative))
-            watchStreamSize(outputStream, transmitted)
-            resolve(outputStream)
-          } else if (format === 'zip') {
-            const zip = new ZipFile()
-            // Resolve with the stream before enumeration so the client can start
-            // receiving data immediately — addZipEntries over FUSE/S3 can take
-            // minutes for large trees (e.g. node_modules) and would otherwise
-            // appear as a freeze with no response sent.
-            outputStream = zip.outputStream
-            watchStreamSize(outputStream, transmitted)
-            resolve(zip.outputStream)
-            await addZipEntries(zip, path, '', paths.map(makeRelative))
-            zip.end()
-          } else {
-            throw new Error('unsupported format ' + format)
-          }
-
-          // Wait for the stream to finish before releasing the mounted partition.
-          // finished() correctly handles 'end', 'close', and 'error' — unlike
-          // fromEvent('end') which hangs forever if the stream errors (client
-          // disconnect, FUSE read failure), leaking the mount and loop devices.
-          await finished(outputStream).catch(noop)
-        } finally {
-          clearInterval(report)
-        }
-      }.bind(this)
-    ).catch(error => {
-      warn(error)
-      reject(error)
-    })
-    return promise
   }
 
   async #removeVmBackupsFromCache(backups) {
@@ -557,79 +217,6 @@ export class RemoteAdapter {
     return this.useVhdDirectory()
   }
 
-  async *#getDiskLegacy(diskId) {
-    const RE_VHDI = /^vhdi(\d+)$/
-    const handler = this._handler
-
-    const diskPath = handler.getFilePath('/' + diskId)
-    const mountDir = yield getTmpDir()
-
-    debug('mount VHD (vhdimount)', { diskPath, mountPath: mountDir })
-    await fromCallback(execFile, 'vhdimount', [diskPath, mountDir])
-    try {
-      let max = 0
-      let maxEntry
-      const entries = await readdir(mountDir)
-      entries.forEach(entry => {
-        const matches = RE_VHDI.exec(entry)
-        if (matches !== null) {
-          const value = +matches[1]
-          if (value > max) {
-            max = value
-            maxEntry = entry
-          }
-        }
-      })
-      if (max === 0) {
-        throw new Error('no disks found')
-      }
-
-      yield `${mountDir}/${maxEntry}`
-    } finally {
-      debug('umount VHD (fusermount)', { diskPath, mountPath: mountDir })
-      await fromCallback(execFile, 'fusermount', ['-uz', mountDir])
-    }
-  }
-
-  async *getDisk(diskId) {
-    if (this._useGetDiskLegacy) {
-      yield* this.#getDiskLegacy(diskId)
-      return
-    }
-    const handler = this._handler
-    // this is a disposable
-    const mountDir = yield getTmpDir()
-    // this is also a disposable
-    yield mount(handler, diskId, mountDir)
-    // this will yield disk path to caller
-    yield `${mountDir}/vhd0`
-  }
-
-  // partitionId values:
-  //
-  // - undefined: raw disk
-  // - `<partitionId>`: partitioned disk
-  // - `<pvId>/<vgName>/<lvName>`: LVM on a partitioned disk
-  // - `/<vgName>/lvName>`: LVM on a raw disk
-  async *getPartition(diskId, partitionId) {
-    const devicePath = yield this.getDisk(diskId)
-    if (partitionId === undefined) {
-      debug(
-        'no partition specified, attempting raw disk mount — call listPartitions first if disk has partitions or LVM'
-      )
-      return yield this._getPartition(devicePath)
-    }
-
-    const isLvmPartition = partitionId.includes('/')
-    if (isLvmPartition) {
-      const [pvId, vgName, lvName] = partitionId.split('/')
-      const lvs = yield this._getLvmLogicalVolumes(devicePath, pvId !== '' ? pvId : undefined, vgName)
-      return yield this._getPartition(lvs.find(_ => _.lv_name === lvName).lv_path)
-    }
-
-    return yield this._getPartition(devicePath, await this._findPartition(devicePath, partitionId))
-  }
-
   // if we use alias on this remote, we have to name the file alias.vhd
   getVhdFileName(baseName) {
     if (this.#useAlias()) {
@@ -668,97 +255,6 @@ export class RemoteAdapter {
       }
     })
     return backups
-  }
-
-  listPartitionFiles(diskId, partitionId, path) {
-    return Disposable.use(this.getPartition(diskId, partitionId), async rootPath => {
-      path = resolveSubpath(rootPath, path)
-      const entriesMap = {}
-      await asyncEach(
-        await readdir(path),
-        async name => {
-          try {
-            const stats = await lstat(`${path}/${name}`)
-            if (stats.isDirectory()) {
-              entriesMap[name + '/'] = {}
-            } else if (stats.isFile()) {
-              entriesMap[name] = {}
-            }
-          } catch (error) {
-            if (error == null || error.code !== 'ENOENT') {
-              throw error
-            }
-          }
-        },
-        { concurrency: 1 }
-      )
-
-      return entriesMap
-    })
-  }
-
-  listPartitions(diskId) {
-    return Disposable.use(this.getDisk(diskId), async devicePath => {
-      // partx may return empty on FUSE-backed files (vhd0); a loop device
-      // presents proper block-device semantics that partx reads reliably.
-      // losetup may itself fail if the FUSE mount isn't fully ready yet —
-      // fall back to the direct path so listPartitions returns [] instead of throwing.
-      let loopForParts, partitions
-      try {
-        loopForParts = (await fromCallback(execFile, 'losetup', ['--show', '-f', devicePath])).trim()
-        partitions = await listPartitions(loopForParts)
-      } catch (error) {
-        debug('partition probe via loop device failed, falling back to direct path', { error })
-        partitions = await listPartitions(devicePath)
-      } finally {
-        if (loopForParts !== undefined) {
-          await fromCallback(execFile, 'losetup', ['-d', loopForParts]).catch(noop)
-        }
-      }
-
-      if (partitions.length === 0) {
-        try {
-          // handle potential raw LVM physical volume
-          return await this._listLvmLogicalVolumes(devicePath, undefined, partitions)
-        } catch (error) {
-          return []
-        }
-      }
-
-      const results = []
-      await asyncMapSettled(partitions, async partition => {
-        if (partition.type === LVM_PARTITION_TYPE_MBR || partition.type === LVM_PARTITION_TYPE_GPT) {
-          return this._listLvmLogicalVolumes(devicePath, partition, results)
-        }
-
-        // Some Linux installers (e.g. Ubuntu subiquity) mark LVM PV partitions with a
-        // generic Linux-data type instead of the standard LVM type. Only those need the
-        // (expensive) loop + dm-snapshot + vgimportclone probe; other types — BIOS boot,
-        // EFI, swap, … — are never LVM PVs, so mount them directly as regular partitions.
-        const isProbeableForLvm =
-          partition.type === LINUX_DATA_PARTITION_TYPE_MBR || partition.type === LINUX_DATA_PARTITION_TYPE_GPT
-        if (!isProbeableForLvm) {
-          results.push(partition)
-          return
-        }
-
-        const lvResults = []
-        try {
-          await this._listLvmLogicalVolumes(devicePath, partition, lvResults)
-        } catch (error) {
-          debug('LVM probe failed for Linux-data partition, treating as regular partition', {
-            partition,
-            error,
-          })
-        }
-        if (lvResults.length > 0) {
-          results.push(...lvResults)
-        } else {
-          results.push(partition)
-        }
-      })
-      return results
-    })
   }
 
   async listPoolMetadataBackups() {
@@ -1147,26 +643,8 @@ Object.assign(RemoteAdapter.prototype, {
   isValidXva,
 })
 
-decorateMethodsWith(RemoteAdapter, {
-  _getLvmLogicalVolumes: compose([
-    Disposable.factory,
-    [deduped, (devicePath, pvId, vgName) => [devicePath, pvId, vgName]],
-    debounceResourceFactory,
-  ]),
+// File-level-restore methods live in ./_fileRestore.mjs; mix them onto the prototype
+// before decorating so decorateMethodsWith can wrap them.
+Object.assign(RemoteAdapter.prototype, fileRestoreMethods)
 
-  _getLvmPhysicalVolume: compose([
-    Disposable.factory,
-    [deduped, (devicePath, partition) => [devicePath, partition?.id]],
-    debounceResourceFactory,
-  ]),
-
-  _getPartition: compose([
-    Disposable.factory,
-    [deduped, (devicePath, partition) => [devicePath, partition?.id]],
-    debounceResourceFactory,
-  ]),
-
-  getDisk: compose([Disposable.factory, [deduped, diskId => [diskId]], debounceResourceFactory]),
-
-  getPartition: Disposable.factory,
-})
+decorateMethodsWith(RemoteAdapter, fileRestoreDecorators)

--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -29,7 +29,13 @@ import { formatFilenameDate } from './_filenameDate.mjs'
 import { getTmpDir } from './_getTmpDir.mjs'
 import { isMetadataFile } from './_backupType.mjs'
 import { isValidXva } from './_isValidXva.mjs'
-import { listPartitions, LVM_PARTITION_TYPE_MBR, LVM_PARTITION_TYPE_GPT } from './_listPartitions.mjs'
+import {
+  listPartitions,
+  LINUX_DATA_PARTITION_TYPE_GPT,
+  LINUX_DATA_PARTITION_TYPE_MBR,
+  LVM_PARTITION_TYPE_GPT,
+  LVM_PARTITION_TYPE_MBR,
+} from './_listPartitions.mjs'
 import { lvs, pvs } from './_lvm.mjs'
 import { watchStreamSize } from './_watchStreamSize.mjs'
 
@@ -703,14 +709,21 @@ export class RemoteAdapter {
         }
 
         // Some Linux installers (e.g. Ubuntu subiquity) mark LVM PV partitions with a
-        // generic Linux filesystem type instead of the standard LVM type. Probe the
-        // partition: if pvs finds logical volumes, expose them; otherwise treat it as a
-        // regular mountable partition.
+        // generic Linux-data type instead of the standard LVM type. Only those need the
+        // (expensive) loop + dm-snapshot + vgimportclone probe; other types — BIOS boot,
+        // EFI, swap, … — are never LVM PVs, so mount them directly as regular partitions.
+        const isProbeableForLvm =
+          partition.type === LINUX_DATA_PARTITION_TYPE_MBR || partition.type === LINUX_DATA_PARTITION_TYPE_GPT
+        if (!isProbeableForLvm) {
+          results.push(partition)
+          return
+        }
+
         const lvResults = []
         try {
           await this._listLvmLogicalVolumes(devicePath, partition, lvResults)
         } catch (error) {
-          debug('LVM probe failed for non-standard-type partition, treating as regular partition', {
+          debug('LVM probe failed for Linux-data partition, treating as regular partition', {
             partition,
             error,
           })

--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -10,7 +10,6 @@ import { dirname, join, resolve } from 'node:path'
 import { execFile } from 'child_process'
 import { finished } from 'node:stream/promises'
 import { lstat, open, readdir, unlink } from 'node:fs/promises'
-import { Readable } from 'node:stream'
 import { tmpdir } from 'node:os'
 import { mount } from '@vates/fuse-vhd'
 import { synchronized } from 'decorator-synchronized'
@@ -44,7 +43,7 @@ export const DIR_XO_POOL_METADATA_BACKUPS = 'xo-pool-metadata-backups'
 
 const IMMUTABILITY_METADATA_FILENAME = '/immutability.json'
 
-const { debug, warn } = createLogger('xo:backups:RemoteAdapter')
+const { debug, info, warn } = createLogger('xo:backups:RemoteAdapter')
 
 export const compareTimestamp = (a, b) => a.timestamp - b.timestamp
 
@@ -54,34 +53,7 @@ const resolveRelativeFromFile = (file, path) => resolve('/', dirname(file), path
 const makeRelative = path => resolve('/', path).slice(1)
 const resolveSubpath = (root, path) => resolve(root, makeRelative(path))
 
-// Open the file only when yazl actually pumps this entry, so the source is read
-// strictly one file at a time. yazl's addFile() instead eagerly fs.stat()s every
-// added file at add-time; on a FUSE-backed restore mount that floods the libuv
-// threadpool and can deadlock the restore (the upper-layer reads starve the
-// lower-level vhd/CIFS reads that NTFS-3g depends on — a FUSE-on-FUSE deadlock).
-function createLazyReadStream(realPath) {
-  return Readable.from(
-    (async function* () {
-      const fh = await open(realPath, 'r')
-      try {
-        yield* fh.createReadStream()
-      } finally {
-        await fh.close()
-      }
-    })()
-  )
-}
-
 async function addZipEntries(zip, realBasePath, virtualBasePath, relativePaths) {
-  // Walk the source tree strictly sequentially to bound concurrency on the
-  // FUSE-backed mount: list this directory, add its files, then descend into
-  // each sub-directory one at a time. Files are added via lazy read streams
-  // (one open file at a time) rather than zip.addFile to avoid yazl's eager
-  // per-file fs.stat. Together this keeps the libuv threadpool from being
-  // saturated by the restore. See createLazyReadStream above.
-  const subDirs = []
-
-  // 1. listing: stat each entry once, classify into files / sub-directories
   for (const relativePath of relativePaths) {
     const realPath = join(realBasePath, relativePath)
     const virtualPath = join(virtualBasePath, relativePath)
@@ -91,16 +63,10 @@ async function addZipEntries(zip, realBasePath, virtualBasePath, relativePaths) 
     const opts = { mode, mtime }
     if (stats.isDirectory()) {
       zip.addEmptyDirectory(virtualPath, opts)
-      subDirs.push({ realPath, virtualPath })
+      await addZipEntries(zip, realPath, virtualPath, await readdir(realPath))
     } else if (stats.isFile()) {
-      // 2. files of this directory (read lazily, one at a time, when pumped)
-      zip.addReadStream(createLazyReadStream(realPath), virtualPath, opts)
+      zip.addFile(realPath, virtualPath, opts)
     }
-  }
-
-  // 3. sub-directories, one at a time
-  for (const { realPath, virtualPath } of subDirs) {
-    await addZipEntries(zip, realPath, virtualPath, await readdir(realPath))
   }
 }
 
@@ -303,6 +269,7 @@ export class RemoteAdapter {
     } catch (error) {
       await mount(options)
     }
+
     try {
       yield path
     } finally {
@@ -354,33 +321,55 @@ export class RemoteAdapter {
         const path = yield this.getPartition(diskId, partitionId)
         let outputStream
 
-        if (format === 'tgz') {
-          // jobs: 1 — process one entry at a time. node-tar defaults to 4
-          // concurrent jobs, which on a FUSE-backed restore mount means up to 4
-          // simultaneous reads; those saturate the libuv threadpool and starve
-          // the underlying vhd/CIFS reads NTFS-3g depends on (FUSE-on-FUSE
-          // threadpool deadlock). Serializing keeps a worker free for them.
-          outputStream = tar.c({ cwd: path, gzip: true, jobs: 1 }, paths.map(makeRelative))
-          resolve(outputStream)
-        } else if (format === 'zip') {
-          const zip = new ZipFile()
-          // Resolve with the stream before enumeration so the client can start
-          // receiving data immediately — addZipEntries over FUSE/S3 can take
-          // minutes for large trees (e.g. node_modules) and would otherwise
-          // appear as a freeze with no response sent.
-          resolve(zip.outputStream)
-          outputStream = zip.outputStream
-          await addZipEntries(zip, path, '', paths.map(makeRelative))
-          zip.end()
-        } else {
-          throw new Error('unsupported format ' + format)
-        }
+        // debug: bytes actually transmitted to the client (compressed wire bytes).
+        // Unlike fuse-vhd's fuseBytes (skewed by kernel_cache), this is comparable
+        // across configs. Logged every 5s so it can be read at any cut-off point.
+        const transmitted = { size: 0 }
+        const startedAt = Date.now()
+        const report = setInterval(() => {
+          const seconds = (Date.now() - startedAt) / 1000
+          info('partition files transmitted', {
+            format,
+            transmittedMiB: +(transmitted.size / 1048576).toFixed(1),
+            seconds: +seconds.toFixed(1),
+            mibPerSec: +(transmitted.size / 1048576 / seconds).toFixed(1),
+          })
+        }, 60e3)
+        report.unref()
 
-        // Wait for the stream to finish before releasing the mounted partition.
-        // finished() correctly handles 'end', 'close', and 'error' — unlike
-        // fromEvent('end') which hangs forever if the stream errors (client
-        // disconnect, FUSE read failure), leaking the mount and loop devices.
-        await finished(outputStream).catch(noop)
+        try {
+          if (format === 'tgz') {
+            // jobs: 1 — process one entry at a time. node-tar defaults to 4
+            // concurrent jobs, which on a FUSE-backed restore mount means up to 4
+            // simultaneous reads; those saturate the libuv threadpool and starve
+            // the underlying vhd/CIFS reads NTFS-3g depends on (FUSE-on-FUSE
+            // threadpool deadlock). Serializing keeps a worker free for them.
+            outputStream = tar.c({ cwd: path, gzip: true, jobs: 1 }, paths.map(makeRelative))
+            watchStreamSize(outputStream, transmitted)
+            resolve(outputStream)
+          } else if (format === 'zip') {
+            const zip = new ZipFile()
+            // Resolve with the stream before enumeration so the client can start
+            // receiving data immediately — addZipEntries over FUSE/S3 can take
+            // minutes for large trees (e.g. node_modules) and would otherwise
+            // appear as a freeze with no response sent.
+            outputStream = zip.outputStream
+            watchStreamSize(outputStream, transmitted)
+            resolve(zip.outputStream)
+            await addZipEntries(zip, path, '', paths.map(makeRelative))
+            zip.end()
+          } else {
+            throw new Error('unsupported format ' + format)
+          }
+
+          // Wait for the stream to finish before releasing the mounted partition.
+          // finished() correctly handles 'end', 'close', and 'error' — unlike
+          // fromEvent('end') which hangs forever if the stream errors (client
+          // disconnect, FUSE read failure), leaking the mount and loop devices.
+          await finished(outputStream).catch(noop)
+        } finally {
+          clearInterval(report)
+        }
       }.bind(this)
     ).catch(error => {
       warn(error)

--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -133,7 +133,7 @@ export class RemoteAdapter {
     debug('attach loop device', { devicePath, partition })
     const loopDevice = (await fromCallback(execFile, 'losetup', loopArgs)).trim()
 
-    let cowPath, cowLoop, mapperName, effectivePath
+    let cowPath, cowLoop, mapperName, effectivePath, originalVgName
     try {
       try {
         // Create a sparse COW file (~4 MB is enough to hold LVM metadata rewrites)
@@ -157,6 +157,10 @@ export class RemoteAdapter {
         // and can locate the Physical Volume ID on it
         await fromCallback(execFile, 'pvscan', ['--cache', `/dev/mapper/${mapperName}`])
 
+        // Capture the original VG name before vgimportclone renames it so callers
+        // can display a human-readable name even after the VG is renamed.
+        ;[originalVgName] = (await pvs('vg_name', `/dev/mapper/${mapperName}`).catch(() => [])).filter(Boolean)
+
         // Deterministic VG name: same hash for the same disk+partition across list and mount calls,
         // but unique across different disks — avoids duplicate VG name conflicts without state.
         const vgBase =
@@ -166,17 +170,23 @@ export class RemoteAdapter {
             .update(String(partition?.id ?? ''))
             .digest('hex')
             .slice(0, 10)
-        debug('import LVM volume group with unique name via dm-snapshot', { vgBase })
+        debug('import LVM volume group with unique name via dm-snapshot', { vgBase, originalVgName })
         await fromCallback(execFile, 'vgimportclone', ['--basevgname', vgBase, `/dev/mapper/${mapperName}`])
 
         effectivePath = `/dev/mapper/${mapperName}`
       } catch (error) {
         // dm-snapshot or vgimportclone unavailable — fall back to direct loop device.
         // Duplicate VG names across disks may still cause activation failures.
-        // Exit code 5 = "device is partitioned": expected when whole-disk detection runs on a
-        // partitioned disk that partx failed to parse — not a real failure, no need to warn.
-        if (error.code === 5) {
+        const message = String(error.message ?? '')
+        if (error.code === 5 && message.includes('device is partitioned')) {
           debug('device is partitioned, skipping vgimportclone', { devicePath, partition })
+        } else if (error.code === 5) {
+          // Other LVM exit-5 errors (e.g. "No physical volume found", "Failed to find PVID")
+          debug('vgimportclone failed, falling back to direct loop device', {
+            devicePath,
+            partition,
+            message,
+          })
         } else {
           warn('dm-snapshot overlay failed, falling back to direct loop device', { error })
         }
@@ -192,13 +202,19 @@ export class RemoteAdapter {
           await unlink(cowPath).catch(noop)
           cowPath = undefined
         }
+        originalVgName = undefined
         effectivePath = loopDevice
       }
 
       debug('scan LVM physical volumes', { path: effectivePath })
       await fromCallback(execFile, 'pvscan', ['--cache', effectivePath])
 
-      yield effectivePath
+      // In the fallback path the VG is unmodified, so query the original name now.
+      if (originalVgName === undefined) {
+        ;[originalVgName] = (await pvs('vg_name', effectivePath).catch(() => [])).filter(Boolean)
+      }
+
+      yield { path: effectivePath, originalVgName }
     } finally {
       try {
         const vgNames = (await pvs('vg_name', effectivePath).catch(() => [])).filter(Boolean)
@@ -262,15 +278,16 @@ export class RemoteAdapter {
   }
 
   _listLvmLogicalVolumes(devicePath, partition, results = []) {
-    return Disposable.use(this._getLvmPhysicalVolume(devicePath, partition), async path => {
-      const lvs = await pvs(['lv_name', 'lv_path', 'lv_size', 'vg_name'], path)
+    return Disposable.use(this._getLvmPhysicalVolume(devicePath, partition), async ({ path, originalVgName }) => {
+      const lvItems = await pvs(['lv_name', 'lv_path', 'lv_size', 'vg_name'], path)
       const partitionId = partition !== undefined ? partition.id : ''
-      lvs.forEach((lv, i) => {
-        const name = lv.lv_name
-        if (name !== '') {
+      lvItems.forEach(lv => {
+        const lvName = lv.lv_name
+        if (lvName !== '') {
           results.push({
-            id: `${partitionId}/${lv.vg_name}/${name}`,
-            name,
+            id: `${partitionId}/${lv.vg_name}/${lvName}`,
+            // show "ubuntu-vg/ubuntu-lv" so users can identify the volume group
+            name: originalVgName !== undefined ? `${originalVgName}/${lvName}` : lvName,
             size: lv.lv_size,
           })
         }

--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -10,6 +10,7 @@ import { dirname, join, resolve } from 'node:path'
 import { execFile } from 'child_process'
 import { finished } from 'node:stream/promises'
 import { lstat, open, readdir, unlink } from 'node:fs/promises'
+import { Readable } from 'node:stream'
 import { tmpdir } from 'node:os'
 import { mount } from '@vates/fuse-vhd'
 import { synchronized } from 'decorator-synchronized'
@@ -53,7 +54,34 @@ const resolveRelativeFromFile = (file, path) => resolve('/', dirname(file), path
 const makeRelative = path => resolve('/', path).slice(1)
 const resolveSubpath = (root, path) => resolve(root, makeRelative(path))
 
+// Open the file only when yazl actually pumps this entry, so the source is read
+// strictly one file at a time. yazl's addFile() instead eagerly fs.stat()s every
+// added file at add-time; on a FUSE-backed restore mount that floods the libuv
+// threadpool and can deadlock the restore (the upper-layer reads starve the
+// lower-level vhd/CIFS reads that NTFS-3g depends on — a FUSE-on-FUSE deadlock).
+function createLazyReadStream(realPath) {
+  return Readable.from(
+    (async function* () {
+      const fh = await open(realPath, 'r')
+      try {
+        yield* fh.createReadStream()
+      } finally {
+        await fh.close()
+      }
+    })()
+  )
+}
+
 async function addZipEntries(zip, realBasePath, virtualBasePath, relativePaths) {
+  // Walk the source tree strictly sequentially to bound concurrency on the
+  // FUSE-backed mount: list this directory, add its files, then descend into
+  // each sub-directory one at a time. Files are added via lazy read streams
+  // (one open file at a time) rather than zip.addFile to avoid yazl's eager
+  // per-file fs.stat. Together this keeps the libuv threadpool from being
+  // saturated by the restore. See createLazyReadStream above.
+  const subDirs = []
+
+  // 1. listing: stat each entry once, classify into files / sub-directories
   for (const relativePath of relativePaths) {
     const realPath = join(realBasePath, relativePath)
     const virtualPath = join(virtualBasePath, relativePath)
@@ -63,10 +91,16 @@ async function addZipEntries(zip, realBasePath, virtualBasePath, relativePaths) 
     const opts = { mode, mtime }
     if (stats.isDirectory()) {
       zip.addEmptyDirectory(virtualPath, opts)
-      await addZipEntries(zip, realPath, virtualPath, await readdir(realPath))
+      subDirs.push({ realPath, virtualPath })
     } else if (stats.isFile()) {
-      zip.addFile(realPath, virtualPath, opts)
+      // 2. files of this directory (read lazily, one at a time, when pumped)
+      zip.addReadStream(createLazyReadStream(realPath), virtualPath, opts)
     }
+  }
+
+  // 3. sub-directories, one at a time
+  for (const { realPath, virtualPath } of subDirs) {
+    await addZipEntries(zip, realPath, virtualPath, await readdir(realPath))
   }
 }
 
@@ -321,7 +355,12 @@ export class RemoteAdapter {
         let outputStream
 
         if (format === 'tgz') {
-          outputStream = tar.c({ cwd: path, gzip: true }, paths.map(makeRelative))
+          // jobs: 1 — process one entry at a time. node-tar defaults to 4
+          // concurrent jobs, which on a FUSE-backed restore mount means up to 4
+          // simultaneous reads; those saturate the libuv threadpool and starve
+          // the underlying vhd/CIFS reads NTFS-3g depends on (FUSE-on-FUSE
+          // threadpool deadlock). Serializing keeps a worker free for them.
+          outputStream = tar.c({ cwd: path, gzip: true, jobs: 1 }, paths.map(makeRelative))
           resolve(outputStream)
         } else if (format === 'zip') {
           const zip = new ZipFile()

--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -55,6 +55,13 @@ export const compareTimestamp = (a, b) => a.timestamp - b.timestamp
 
 const noop = Function.prototype
 
+// Restrict LVM scanning to a single device. Backup PVs are clones: the very same PVID
+// appears at once on the raw loop device, the dm-snapshot overlaid on it, and every
+// other restored copy of the same VM. An unscoped pvs/pvscan/vgimportclone/vgchange then
+// aborts with "duplicate PV ... for PVID ..." and the VG can neither be renamed nor
+// activated. Accepting only the device in hand removes every duplicate from LVM's view.
+const lvmOnlyDevice = devicePath => `devices { global_filter=[ "a|^${devicePath}$|", "r|.*|" ] }`
+
 const resolveRelativeFromFile = (file, path) => resolve('/', dirname(file), path).slice(1)
 const makeRelative = path => resolve('/', path).slice(1)
 const resolveSubpath = (root, path) => resolve(root, makeRelative(path))
@@ -116,24 +123,26 @@ export class RemoteAdapter {
   }
 
   async *_getLvmLogicalVolumes(devicePath, pvId, vgName) {
-    const { path: pvPath } = yield this._getLvmPhysicalVolume(
+    const { path: pvPath, lvmConfig } = yield this._getLvmPhysicalVolume(
       devicePath,
       pvId && (await this._findPartition(devicePath, pvId))
     )
 
     // vgimportclone may have renamed the VG (e.g. ubuntu-vg → xo<hash>); query the
     // actual name from the PV rather than trusting the partitionId-embedded name.
-    const [actualVgName] = (await pvs('vg_name', pvPath).catch(() => [])).filter(Boolean)
+    // lvmConfig scopes every command to this PV so a colliding/duplicate VG on the host
+    // or another restored copy can't shadow it.
+    const [actualVgName] = (await pvs('vg_name', '--config', lvmConfig, pvPath).catch(() => [])).filter(Boolean)
     const effectiveVgName = actualVgName ?? vgName
 
     debug('activate LVM volume group', { effectiveVgName, requestedVgName: vgName })
-    await fromCallback(execFile, 'vgchange', ['-ay', effectiveVgName])
+    await fromCallback(execFile, 'vgchange', ['--config', lvmConfig, '-ay', effectiveVgName])
     try {
       debug('get LVM logical volumes', { effectiveVgName })
-      yield lvs(['lv_name', 'lv_path'], effectiveVgName)
+      yield lvs(['lv_name', 'lv_path'], '--config', lvmConfig, effectiveVgName)
     } finally {
       debug('deactivate LVM volume group', { effectiveVgName })
-      await fromCallback(execFile, 'vgchange', ['-an', effectiveVgName])
+      await fromCallback(execFile, 'vgchange', ['--config', lvmConfig, '-an', effectiveVgName])
     }
   }
 
@@ -147,11 +156,15 @@ export class RemoteAdapter {
     debug('attach loop device', { devicePath, partition })
     const loopDevice = (await fromCallback(execFile, 'losetup', loopArgs)).trim()
 
-    let cowPath, cowLoop, mapperName, effectivePath, originalVgName
+    let cowPath, cowLoop, mapperName, effectivePath, originalVgName, lvmConfig
     try {
       try {
         // Create a sparse COW file (~4 MB is enough to hold LVM metadata rewrites)
         mapperName = `xo-pv-${randomBytes(4).toString('hex')}`
+        const mapperPath = `/dev/mapper/${mapperName}`
+        // Scope LVM to the snapshot only: the raw loop device carries the same PVID and
+        // would otherwise be flagged as a duplicate, breaking pvscan and vgimportclone.
+        const mapperConfig = lvmOnlyDevice(mapperPath)
         cowPath = join(tmpdir(), `${mapperName}.cow`)
         const fh = await open(cowPath, 'w')
         await fh.truncate(4 * 1024 * 1024)
@@ -167,13 +180,11 @@ export class RemoteAdapter {
           `0 ${sectors} snapshot ${loopDevice} ${cowLoop} P 8`,
         ])
 
-        // pvscan must run before vgimportclone so LVM registers the snapshot device
-        // and can locate the Physical Volume ID on it
-        await fromCallback(execFile, 'pvscan', ['--cache', `/dev/mapper/${mapperName}`])
-
-        // Capture the original VG name before vgimportclone renames it so callers
-        // can display a human-readable name even after the VG is renamed.
-        ;[originalVgName] = (await pvs('vg_name', `/dev/mapper/${mapperName}`).catch(() => [])).filter(Boolean)
+        // Capture the original VG name before vgimportclone renames it so callers can display a
+        // human-readable name. We deliberately do NOT `pvscan --cache` first: with a duplicate
+        // PVID present (concurrent restore of the same VM) it fails, and vgimportclone reads the
+        // device directly (scoped by mapperConfig) without needing the online cache anyway.
+        ;[originalVgName] = (await pvs('vg_name', '--config', mapperConfig, mapperPath).catch(() => [])).filter(Boolean)
 
         // Deterministic VG name: same hash for the same disk+partition across list and mount calls,
         // but unique across different disks — avoids duplicate VG name conflicts without state.
@@ -185,9 +196,9 @@ export class RemoteAdapter {
             .digest('hex')
             .slice(0, 10)
         debug('import LVM volume group with unique name via dm-snapshot', { vgBase, originalVgName })
-        await fromCallback(execFile, 'vgimportclone', ['--basevgname', vgBase, `/dev/mapper/${mapperName}`])
+        await fromCallback(execFile, 'vgimportclone', ['--config', mapperConfig, '--basevgname', vgBase, mapperPath])
 
-        effectivePath = `/dev/mapper/${mapperName}`
+        effectivePath = mapperPath
       } catch (error) {
         // dm-snapshot or vgimportclone unavailable — fall back to direct loop device.
         // Duplicate VG names across disks may still cause activation failures.
@@ -220,21 +231,30 @@ export class RemoteAdapter {
         effectivePath = loopDevice
       }
 
+      // Whether we ended up on the snapshot or fell back to the raw loop, scope every
+      // remaining command to that one device so duplicate PVIDs from other copies (or a
+      // same-named VG on the host) can't shadow it.
+      lvmConfig = lvmOnlyDevice(effectivePath)
+
+      // Best-effort: activation/listing below scans the device directly via lvmConfig, so a
+      // duplicate-PVID failure here (concurrent restore of the same VM) must not abort.
       debug('scan LVM physical volumes', { path: effectivePath })
-      await fromCallback(execFile, 'pvscan', ['--cache', effectivePath])
+      await fromCallback(execFile, 'pvscan', ['--config', lvmConfig, '--cache', effectivePath]).catch(error =>
+        debug('pvscan --cache failed (continuing)', { path: effectivePath, error })
+      )
 
       // In the fallback path the VG is unmodified, so query the original name now.
       if (originalVgName === undefined) {
-        ;[originalVgName] = (await pvs('vg_name', effectivePath).catch(() => [])).filter(Boolean)
+        ;[originalVgName] = (await pvs('vg_name', '--config', lvmConfig, effectivePath).catch(() => [])).filter(Boolean)
       }
 
-      yield { path: effectivePath, originalVgName }
+      yield { path: effectivePath, originalVgName, lvmConfig }
     } finally {
       try {
-        const vgNames = (await pvs('vg_name', effectivePath).catch(() => [])).filter(Boolean)
+        const vgNames = (await pvs('vg_name', '--config', lvmConfig, effectivePath).catch(() => [])).filter(Boolean)
         if (vgNames.length > 0) {
           debug('deactivate LVM volume groups', { vgNames })
-          await fromCallback(execFile, 'vgchange', ['-an', ...vgNames])
+          await fromCallback(execFile, 'vgchange', ['--config', lvmConfig, '-an', ...vgNames])
         }
       } finally {
         if (mapperName !== undefined) {
@@ -298,22 +318,25 @@ export class RemoteAdapter {
   }
 
   _listLvmLogicalVolumes(devicePath, partition, results = []) {
-    return Disposable.use(this._getLvmPhysicalVolume(devicePath, partition), async ({ path, originalVgName }) => {
-      const lvItems = await pvs(['lv_name', 'lv_path', 'lv_size', 'vg_name'], path)
-      const partitionId = partition !== undefined ? partition.id : ''
-      lvItems.forEach(lv => {
-        const lvName = lv.lv_name
-        if (lvName !== '') {
-          results.push({
-            id: `${partitionId}/${lv.vg_name}/${lvName}`,
-            // show "ubuntu-vg/ubuntu-lv" so users can identify the volume group
-            name: originalVgName !== undefined ? `${originalVgName}/${lvName}` : lvName,
-            size: lv.lv_size,
-          })
-        }
-      })
-      return results
-    })
+    return Disposable.use(
+      this._getLvmPhysicalVolume(devicePath, partition),
+      async ({ path, originalVgName, lvmConfig }) => {
+        const lvItems = await pvs(['lv_name', 'lv_path', 'lv_size', 'vg_name'], '--config', lvmConfig, path)
+        const partitionId = partition !== undefined ? partition.id : ''
+        lvItems.forEach(lv => {
+          const lvName = lv.lv_name
+          if (lvName !== '') {
+            results.push({
+              id: `${partitionId}/${lv.vg_name}/${lvName}`,
+              // show "ubuntu-vg/ubuntu-lv" so users can identify the volume group
+              name: originalVgName !== undefined ? `${originalVgName}/${lvName}` : lvName,
+              size: lv.lv_size,
+            })
+          }
+        })
+        return results
+      }
+    )
   }
 
   // check if we will be allowed to merge a vhd created in this adapter

--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -8,6 +8,7 @@ import { deduped } from '@vates/disposable/deduped.js'
 import { createHash, randomBytes } from 'node:crypto'
 import { dirname, join, resolve } from 'node:path'
 import { execFile } from 'child_process'
+import { finished } from 'node:stream/promises'
 import { lstat, open, readdir, unlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { mount } from '@vates/fuse-vhd'
@@ -15,7 +16,6 @@ import { synchronized } from 'decorator-synchronized'
 import { ZipFile } from 'yazl'
 import Disposable from 'promise-toolbox/Disposable'
 import fromCallback from 'promise-toolbox/fromCallback'
-import fromEvent from 'promise-toolbox/fromEvent'
 import groupBy from 'lodash/groupBy.js'
 import pDefer from 'promise-toolbox/defer'
 import pickBy from 'lodash/pickBy.js'
@@ -322,17 +322,26 @@ export class RemoteAdapter {
 
         if (format === 'tgz') {
           outputStream = tar.c({ cwd: path, gzip: true }, paths.map(makeRelative))
+          resolve(outputStream)
         } else if (format === 'zip') {
           const zip = new ZipFile()
+          // Resolve with the stream before enumeration so the client can start
+          // receiving data immediately — addZipEntries over FUSE/S3 can take
+          // minutes for large trees (e.g. node_modules) and would otherwise
+          // appear as a freeze with no response sent.
+          resolve(zip.outputStream)
+          outputStream = zip.outputStream
           await addZipEntries(zip, path, '', paths.map(makeRelative))
           zip.end()
-          ;({ outputStream } = zip)
         } else {
           throw new Error('unsupported format ' + format)
         }
 
-        resolve(outputStream)
-        await fromEvent(outputStream, 'end')
+        // Wait for the stream to finish before releasing the mounted partition.
+        // finished() correctly handles 'end', 'close', and 'error' — unlike
+        // fromEvent('end') which hangs forever if the stream errors (client
+        // disconnect, FUSE read failure), leaking the mount and loop devices.
+        await finished(outputStream).catch(noop)
       }.bind(this)
     ).catch(error => {
       warn(error)

--- a/@xen-orchestra/backups/_fileRestore.integ.mjs
+++ b/@xen-orchestra/backups/_fileRestore.integ.mjs
@@ -1,0 +1,94 @@
+import { strict as assert } from 'node:assert'
+import test from 'node:test'
+import { execFile } from 'node:child_process'
+import { copyFile, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import { randomBytes } from 'node:crypto'
+
+import Disposable from 'promise-toolbox/Disposable'
+
+import { RemoteAdapter } from './RemoteAdapter.mjs'
+
+// losetup/dmsetup/pvcreate/vgcreate/lvcreate/mkfs all require root (CAP_SYS_ADMIN).
+const skip =
+  typeof process.getuid !== 'function' || process.getuid() !== 0 ? 'requires root (losetup/dmsetup/lvm)' : false
+
+const pExec = promisify(execFile)
+const uniqueName = () => `xotest${randomBytes(6).toString('hex')}`
+
+async function withLoop(imagePath, fn) {
+  const loop = (await pExec('losetup', ['--show', '-f', imagePath])).stdout.trim()
+  try {
+    return await fn(loop)
+  } finally {
+    await pExec('losetup', ['-d', loop]).catch(() => {})
+  }
+}
+
+// Build a self-contained LVM image: a 64 MiB file holding one PV / VG / ext4 LV.
+async function createLvmImage(imagePath, vgName, lvName) {
+  await pExec('truncate', ['-s', '64M', imagePath])
+  await withLoop(imagePath, async loop => {
+    await pExec('pvcreate', ['-f', '-y', loop])
+    await pExec('vgcreate', [vgName, loop])
+    await pExec('lvcreate', ['-y', '-l', '100%FREE', '-n', lvName, vgName])
+    await pExec('mkfs.ext4', ['-q', `/dev/${vgName}/${lvName}`])
+    await pExec('vgchange', ['-an', vgName])
+  })
+}
+
+test('LVM file-restore against real losetup/dmsetup/lvm', { skip }, async t => {
+  const tmp = await mkdtemp(join(tmpdir(), 'xo-flr-'))
+  const adapter = new RemoteAdapter({})
+  const vg = uniqueName()
+  const lv = 'root_lv'
+  const image = join(tmp, 'disk.raw')
+  const clone = join(tmp, 'clone.raw')
+  const plain = join(tmp, 'plain.raw')
+
+  t.after(async () => {
+    await rm(tmp, { recursive: true, force: true })
+    // drop any stale online-cache entries pointing at the now-deleted images
+    await pExec('pvscan', ['--cache']).catch(() => {})
+  })
+
+  await createLvmImage(image, vg, lv)
+
+  await t.test('detects the PV and renames the VG to a unique name', async () => {
+    await Disposable.use(adapter._getLvmPhysicalVolume(image, undefined), async ({ originalVgName, vgName }) => {
+      assert.equal(originalVgName, vg)
+      assert.match(vgName, /^xo[0-9a-f]{16}$/)
+      assert.notEqual(vgName, vg)
+    })
+  })
+
+  await t.test('two clones of the same VM (shared PVID) list concurrently without collision', async () => {
+    await copyFile(image, clone) // exact clone → identical PVID + VG name + VG UUID
+    const [a, b] = await Promise.all([
+      adapter._listLvmLogicalVolumes(image, undefined, []),
+      adapter._listLvmLogicalVolumes(clone, undefined, []),
+    ])
+    assert.equal(a.length, 1)
+    assert.equal(b.length, 1)
+    // the human-readable name is the (shared) original; the id carries the unique renamed VG
+    assert.equal(a[0].name, `${vg}/${lv}`)
+    assert.equal(b[0].name, `${vg}/${lv}`)
+    assert.notEqual(a[0].id, b[0].id)
+  })
+
+  await t.test('a non-LVM partition is rejected without building a snapshot', async () => {
+    await pExec('truncate', ['-s', '16M', plain])
+    await pExec('mkfs.ext4', ['-q', plain])
+    await assert.rejects(
+      Disposable.use(adapter._getLvmPhysicalVolume(plain, undefined), async () => {}),
+      /no LVM physical volume/
+    )
+  })
+
+  await t.test('leaves no dangling xo-pv-* dm-snapshots behind', async () => {
+    const { stdout } = await pExec('dmsetup', ['ls']).catch(() => ({ stdout: '' }))
+    assert.equal(/xo-pv-/.test(stdout), false, `leftover snapshots:\n${stdout}`)
+  })
+})

--- a/@xen-orchestra/backups/_fileRestore.mjs
+++ b/@xen-orchestra/backups/_fileRestore.mjs
@@ -11,7 +11,7 @@ import { asyncMapSettled } from '@xen-orchestra/async-map'
 import { compose } from '@vates/compose'
 import { createLogger } from '@xen-orchestra/log'
 import { deduped } from '@vates/disposable/deduped.js'
-import { createHash, randomBytes } from 'node:crypto'
+import { randomBytes } from 'node:crypto'
 import { join, resolve } from 'node:path'
 import { execFile } from 'child_process'
 import { finished } from 'node:stream/promises'
@@ -44,7 +44,26 @@ const noop = Function.prototype
 // other restored copy of the same VM. An unscoped pvs/pvscan/vgimportclone/vgchange then
 // aborts with "duplicate PV ... for PVID ..." and the VG can neither be renamed nor
 // activated. Accepting only the device in hand removes every duplicate from LVM's view.
-const lvmOnlyDevice = devicePath => `devices { global_filter=[ "a|^${devicePath}$|", "r|.*|" ] }`
+export const lvmOnlyDevice = devicePath => `devices { global_filter=[ "a|^${devicePath}$|", "r|.*|" ] }`
+
+// Partition-type predicates (exported for unit tests).
+export const isLvmPartitionType = type => type === LVM_PARTITION_TYPE_MBR || type === LVM_PARTITION_TYPE_GPT
+
+// Some installers (e.g. Ubuntu subiquity) place an LVM PV on a generic Linux-data partition
+// instead of the LVM type, so those are the only non-LVM types worth the (expensive) probe.
+export const isProbeableForLvm = type =>
+  type === LINUX_DATA_PARTITION_TYPE_MBR || type === LINUX_DATA_PARTITION_TYPE_GPT
+
+// Build the partition entries for a PV's logical volumes (exported for unit tests).
+// Shows "ubuntu-vg/ubuntu-lv" for readability; skips unnamed LVs.
+export const toLvPartitions = (partitionId, originalVgName, lvItems) =>
+  lvItems
+    .filter(lv => lv.lv_name !== '')
+    .map(lv => ({
+      id: `${partitionId}/${lv.vg_name}/${lv.lv_name}`,
+      name: originalVgName !== undefined ? `${originalVgName}/${lv.lv_name}` : lv.lv_name,
+      size: lv.lv_size,
+    }))
 
 const makeRelative = path => resolve('/', path).slice(1)
 const resolveSubpath = (root, path) => resolve(root, makeRelative(path))
@@ -117,20 +136,18 @@ export const fileRestoreMethods = {
     return partition
   },
 
-  async *_getLvmLogicalVolumes(devicePath, pvId, vgName) {
-    const { path: pvPath, lvmConfig } = yield this._getLvmPhysicalVolume(
+  async *_getLvmLogicalVolumes(devicePath, pvId, requestedVgName) {
+    const { vgName, lvmConfig } = yield this._getLvmPhysicalVolume(
       devicePath,
       pvId && (await this._findPartition(devicePath, pvId))
     )
 
-    // vgimportclone may have renamed the VG (e.g. ubuntu-vg → xo<hash>); query the
-    // actual name from the PV rather than trusting the partitionId-embedded name.
-    // lvmConfig scopes every command to this PV so a colliding/duplicate VG on the host
-    // or another restored copy can't shadow it.
-    const [actualVgName] = (await pvs('vg_name', '--config', lvmConfig, pvPath).catch(() => [])).filter(Boolean)
-    const effectiveVgName = actualVgName ?? vgName
+    // vgName is the unique name vgimportclone just assigned to this PV; prefer it over the
+    // (possibly stale) name embedded in the partitionId. lvmConfig scopes every command to
+    // this device so a colliding/duplicate VG on the host or another copy can't shadow it.
+    const effectiveVgName = vgName ?? requestedVgName
 
-    debug('activate LVM volume group', { effectiveVgName, requestedVgName: vgName })
+    debug('activate LVM volume group', { effectiveVgName, requestedVgName })
     await fromCallback(execFile, 'vgchange', ['--config', lvmConfig, '-ay', effectiveVgName])
     try {
       debug('get LVM logical volumes', { effectiveVgName })
@@ -151,122 +168,66 @@ export const fileRestoreMethods = {
     debug('attach loop device', { devicePath, partition })
     const loopDevice = (await fromCallback(execFile, 'losetup', loopArgs)).trim()
 
-    let cowPath, cowLoop, mapperName, effectivePath, originalVgName, lvmConfig
+    let cowPath, cowLoop, mapperName, vgName, lvmConfig
     try {
-      try {
-        // Create a sparse COW file (~4 MB is enough to hold LVM metadata rewrites)
-        mapperName = `xo-pv-${randomBytes(4).toString('hex')}`
-        const mapperPath = `/dev/mapper/${mapperName}`
-        // Scope LVM to the snapshot only: the raw loop device carries the same PVID and
-        // would otherwise be flagged as a duplicate, breaking pvscan and vgimportclone.
-        const mapperConfig = lvmOnlyDevice(mapperPath)
-        cowPath = join(tmpdir(), `${mapperName}.cow`)
-        const fh = await open(cowPath, 'w')
-        await fh.truncate(4 * 1024 * 1024)
-        await fh.close()
-
-        cowLoop = (await fromCallback(execFile, 'losetup', ['--show', '-f', cowPath])).trim()
-
-        const sectors = (await fromCallback(execFile, 'blockdev', ['--getsz', loopDevice])).trim()
-        await fromCallback(execFile, 'dmsetup', [
-          'create',
-          mapperName,
-          '--table',
-          `0 ${sectors} snapshot ${loopDevice} ${cowLoop} P 8`,
-        ])
-
-        // Capture the original VG name before vgimportclone renames it so callers can display a
-        // human-readable name. We deliberately do NOT `pvscan --cache` first: with a duplicate
-        // PVID present (concurrent restore of the same VM) it fails, and vgimportclone reads the
-        // device directly (scoped by mapperConfig) without needing the online cache anyway.
-        ;[originalVgName] = (await pvs('vg_name', '--config', mapperConfig, mapperPath).catch(() => [])).filter(Boolean)
-
-        // Deterministic VG name: same hash for the same disk+partition across list and mount calls,
-        // but unique across different disks — avoids duplicate VG name conflicts without state.
-        const vgBase =
-          'xo' +
-          createHash('sha256')
-            .update(devicePath)
-            .update(String(partition?.id ?? ''))
-            .digest('hex')
-            .slice(0, 10)
-        debug('import LVM volume group with unique name via dm-snapshot', { vgBase, originalVgName })
-        await fromCallback(execFile, 'vgimportclone', ['--config', mapperConfig, '--basevgname', vgBase, mapperPath])
-
-        effectivePath = mapperPath
-      } catch (error) {
-        // dm-snapshot or vgimportclone unavailable — fall back to direct loop device.
-        // Duplicate VG names across disks may still cause activation failures.
-        const message = String(error.message ?? '')
-        if (error.code === 5 && message.includes('device is partitioned')) {
-          debug('device is partitioned, skipping vgimportclone', { devicePath, partition })
-        } else if (error.code === 5) {
-          // Other LVM exit-5 errors (e.g. "No physical volume found", "Failed to find PVID")
-          debug('vgimportclone failed, falling back to direct loop device', {
-            devicePath,
-            partition,
-            message,
-          })
-        } else {
-          warn('dm-snapshot overlay failed, falling back to direct loop device', { error })
-        }
-        if (mapperName !== undefined) {
-          await fromCallback(execFile, 'dmsetup', ['remove', mapperName]).catch(noop)
-          mapperName = undefined
-        }
-        if (cowLoop !== undefined) {
-          await fromCallback(execFile, 'losetup', ['-d', cowLoop]).catch(noop)
-          cowLoop = undefined
-        }
-        if (cowPath !== undefined) {
-          await unlink(cowPath).catch(noop)
-          cowPath = undefined
-        }
-        originalVgName = undefined
-        effectivePath = loopDevice
-      }
-
-      // Whether we ended up on the snapshot or fell back to the raw loop, scope every
-      // remaining command to that one device so duplicate PVIDs from other copies (or a
-      // same-named VG on the host) can't shadow it.
-      lvmConfig = lvmOnlyDevice(effectivePath)
-
-      // Best-effort: activation/listing below scans the device directly via lvmConfig, so a
-      // duplicate-PVID failure here (concurrent restore of the same VM) must not abort.
-      debug('scan LVM physical volumes', { path: effectivePath })
-      await fromCallback(execFile, 'pvscan', ['--config', lvmConfig, '--cache', effectivePath]).catch(error =>
-        debug('pvscan --cache failed (continuing)', { path: effectivePath, error })
-      )
-
-      // In the fallback path the VG is unmodified, so query the original name now.
+      // Cheap pre-check, scoped to this loop so a duplicate PVID (another copy of the same
+      // VM restored concurrently) can't make it fail: is there an LVM PV here at all?
+      // Non-PV partitions (/boot, EFI, raw disks) skip the whole dm-snapshot machinery.
+      const [originalVgName] = (
+        await pvs('vg_name', '--config', lvmOnlyDevice(loopDevice), loopDevice).catch(() => [])
+      ).filter(Boolean)
       if (originalVgName === undefined) {
-        ;[originalVgName] = (await pvs('vg_name', '--config', lvmConfig, effectivePath).catch(() => [])).filter(Boolean)
+        const where = partition !== undefined ? ` partition ${partition.id}` : ''
+        throw new Error(`no LVM physical volume on ${devicePath}${where}`)
       }
 
-      yield { path: effectivePath, originalVgName, lvmConfig }
+      // The backup is read-only, so overlay a writable dm-snapshot to let vgimportclone
+      // rewrite metadata, and rename the VG to a unique name so concurrent clones (identical
+      // PVID and VG name) don't collide on device-mapper node names. Every LVM command is
+      // scoped to the snapshot device (lvmConfig) to keep duplicate PVIDs out of LVM's view.
+      mapperName = `xo-pv-${randomBytes(4).toString('hex')}`
+      const mapperPath = `/dev/mapper/${mapperName}`
+      lvmConfig = lvmOnlyDevice(mapperPath)
+
+      // ~4 MB sparse COW is enough to hold the LVM metadata rewrites
+      cowPath = join(tmpdir(), `${mapperName}.cow`)
+      const fh = await open(cowPath, 'w')
+      await fh.truncate(4 * 1024 * 1024)
+      await fh.close()
+      cowLoop = (await fromCallback(execFile, 'losetup', ['--show', '-f', cowPath])).trim()
+
+      const sectors = (await fromCallback(execFile, 'blockdev', ['--getsz', loopDevice])).trim()
+      await fromCallback(execFile, 'dmsetup', [
+        'create',
+        mapperName,
+        '--table',
+        `0 ${sectors} snapshot ${loopDevice} ${cowLoop} P 8`,
+      ])
+
+      // Unique random VG name: list and mount each query/yield the name from the device, so
+      // it need not be deterministic — only collision-free across concurrent clones.
+      vgName = `xo${randomBytes(8).toString('hex')}`
+      debug('import LVM volume group with unique name via dm-snapshot', { vgName, originalVgName })
+      await fromCallback(execFile, 'vgimportclone', ['--config', lvmConfig, '--basevgname', vgName, mapperPath])
+
+      yield { path: mapperPath, originalVgName, vgName, lvmConfig }
     } finally {
-      try {
-        const vgNames = (await pvs('vg_name', '--config', lvmConfig, effectivePath).catch(() => [])).filter(Boolean)
-        if (vgNames.length > 0) {
-          debug('deactivate LVM volume groups', { vgNames })
-          await fromCallback(execFile, 'vgchange', ['--config', lvmConfig, '-an', ...vgNames])
-        }
-      } finally {
-        if (mapperName !== undefined) {
-          debug('remove dm-snapshot', { mapperName })
-          await fromCallback(execFile, 'dmsetup', ['remove', mapperName]).catch(err =>
-            warn('failed to remove dm-snapshot', { mapperName, error: err })
-          )
-        }
-        if (cowLoop !== undefined) {
-          await fromCallback(execFile, 'losetup', ['-d', cowLoop]).catch(noop)
-        }
-        if (cowPath !== undefined) {
-          await unlink(cowPath).catch(noop)
-        }
-        debug('detach loop device', { loopDevice })
-        await fromCallback(execFile, 'losetup', ['-d', loopDevice])
+      if (mapperName !== undefined) {
+        // best-effort deactivate (a no-op if it was never activated) before removing the snapshot
+        await fromCallback(execFile, 'vgchange', ['--config', lvmConfig, '-an', vgName]).catch(noop)
+        debug('remove dm-snapshot', { mapperName })
+        await fromCallback(execFile, 'dmsetup', ['remove', mapperName]).catch(err =>
+          warn('failed to remove dm-snapshot', { mapperName, error: err })
+        )
       }
+      if (cowLoop !== undefined) {
+        await fromCallback(execFile, 'losetup', ['-d', cowLoop]).catch(noop)
+      }
+      if (cowPath !== undefined) {
+        await unlink(cowPath).catch(noop)
+      }
+      debug('detach loop device', { loopDevice })
+      await fromCallback(execFile, 'losetup', ['-d', loopDevice])
     }
   },
 
@@ -318,17 +279,7 @@ export const fileRestoreMethods = {
       async ({ path, originalVgName, lvmConfig }) => {
         const lvItems = await pvs(['lv_name', 'lv_path', 'lv_size', 'vg_name'], '--config', lvmConfig, path)
         const partitionId = partition !== undefined ? partition.id : ''
-        lvItems.forEach(lv => {
-          const lvName = lv.lv_name
-          if (lvName !== '') {
-            results.push({
-              id: `${partitionId}/${lv.vg_name}/${lvName}`,
-              // show "ubuntu-vg/ubuntu-lv" so users can identify the volume group
-              name: originalVgName !== undefined ? `${originalVgName}/${lvName}` : lvName,
-              size: lv.lv_size,
-            })
-          }
-        })
+        results.push(...toLvPartitions(partitionId, originalVgName, lvItems))
         return results
       }
     )
@@ -494,17 +445,14 @@ export const fileRestoreMethods = {
 
       const results = []
       await asyncMapSettled(partitions, async partition => {
-        if (partition.type === LVM_PARTITION_TYPE_MBR || partition.type === LVM_PARTITION_TYPE_GPT) {
+        if (isLvmPartitionType(partition.type)) {
           return this._listLvmLogicalVolumes(devicePath, partition, results)
         }
 
-        // Some Linux installers (e.g. Ubuntu subiquity) mark LVM PV partitions with a
-        // generic Linux-data type instead of the standard LVM type. Only those need the
-        // (expensive) loop + dm-snapshot + vgimportclone probe; other types — BIOS boot,
-        // EFI, swap, … — are never LVM PVs, so mount them directly as regular partitions.
-        const isProbeableForLvm =
-          partition.type === LINUX_DATA_PARTITION_TYPE_MBR || partition.type === LINUX_DATA_PARTITION_TYPE_GPT
-        if (!isProbeableForLvm) {
+        // Only generic Linux-data partitions can hide an LVM PV (subiquity-style); other
+        // types — BIOS boot, EFI, swap, … — are never PVs, so list them directly without
+        // the (expensive) loop + dm-snapshot + vgimportclone probe.
+        if (!isProbeableForLvm(partition.type)) {
           results.push(partition)
           return
         }

--- a/@xen-orchestra/backups/_fileRestore.mjs
+++ b/@xen-orchestra/backups/_fileRestore.mjs
@@ -1,0 +1,556 @@
+// File-level-restore (FLR) methods for RemoteAdapter.
+//
+// These were extracted from RemoteAdapter.mjs to keep that file focused on backup
+// CRUD/cache/metadata. They are mixed back onto `RemoteAdapter.prototype` via
+// `Object.assign` and decorated via `decorateMethodsWith` in RemoteAdapter.mjs, so `this`
+// is the RemoteAdapter instance at call time (`this._handler`, `this._debounceResource`,
+// `this._useGetDiskLegacy` keep working unchanged). The logger keeps the original
+// `xo:backups:RemoteAdapter` namespace so existing debug filters are unaffected.
+import { asyncEach } from '@vates/async-each'
+import { asyncMapSettled } from '@xen-orchestra/async-map'
+import { compose } from '@vates/compose'
+import { createLogger } from '@xen-orchestra/log'
+import { deduped } from '@vates/disposable/deduped.js'
+import { createHash, randomBytes } from 'node:crypto'
+import { join, resolve } from 'node:path'
+import { execFile } from 'child_process'
+import { finished } from 'node:stream/promises'
+import { lstat, open, readdir, unlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { mount } from '@vates/fuse-vhd'
+import { ZipFile } from 'yazl'
+import Disposable from 'promise-toolbox/Disposable'
+import fromCallback from 'promise-toolbox/fromCallback'
+import pDefer from 'promise-toolbox/defer'
+import * as tar from 'tar'
+
+import { getTmpDir } from './_getTmpDir.mjs'
+import {
+  listPartitions,
+  LINUX_DATA_PARTITION_TYPE_GPT,
+  LINUX_DATA_PARTITION_TYPE_MBR,
+  LVM_PARTITION_TYPE_GPT,
+  LVM_PARTITION_TYPE_MBR,
+} from './_listPartitions.mjs'
+import { lvs, pvs } from './_lvm.mjs'
+import { watchStreamSize } from './_watchStreamSize.mjs'
+
+const { debug, info, warn } = createLogger('xo:backups:RemoteAdapter')
+
+const noop = Function.prototype
+
+// Restrict LVM scanning to a single device. Backup PVs are clones: the very same PVID
+// appears at once on the raw loop device, the dm-snapshot overlaid on it, and every
+// other restored copy of the same VM. An unscoped pvs/pvscan/vgimportclone/vgchange then
+// aborts with "duplicate PV ... for PVID ..." and the VG can neither be renamed nor
+// activated. Accepting only the device in hand removes every duplicate from LVM's view.
+const lvmOnlyDevice = devicePath => `devices { global_filter=[ "a|^${devicePath}$|", "r|.*|" ] }`
+
+const makeRelative = path => resolve('/', path).slice(1)
+const resolveSubpath = (root, path) => resolve(root, makeRelative(path))
+
+async function addZipEntries(zip, realBasePath, virtualBasePath, relativePaths) {
+  for (const relativePath of relativePaths) {
+    const realPath = join(realBasePath, relativePath)
+    const virtualPath = join(virtualBasePath, relativePath)
+
+    const stats = await lstat(realPath)
+    const { mode, mtime } = stats
+    const opts = { mode, mtime }
+    if (stats.isDirectory()) {
+      zip.addEmptyDirectory(virtualPath, opts)
+      await addZipEntries(zip, realPath, virtualPath, await readdir(realPath))
+    } else if (stats.isFile()) {
+      zip.addFile(realPath, virtualPath, opts)
+    }
+  }
+}
+
+const debounceResourceFactory = factory =>
+  function () {
+    return this._debounceResource(factory.apply(this, arguments))
+  }
+
+// legacy disk mount via vhdimount; extracted from a private method so it can live in this
+// module (mixin methods cannot reference class-private members).
+async function* getDiskLegacy(handler, diskId) {
+  const RE_VHDI = /^vhdi(\d+)$/
+
+  const diskPath = handler.getFilePath('/' + diskId)
+  const mountDir = yield getTmpDir()
+
+  debug('mount VHD (vhdimount)', { diskPath, mountPath: mountDir })
+  await fromCallback(execFile, 'vhdimount', [diskPath, mountDir])
+  try {
+    let max = 0
+    let maxEntry
+    const entries = await readdir(mountDir)
+    entries.forEach(entry => {
+      const matches = RE_VHDI.exec(entry)
+      if (matches !== null) {
+        const value = +matches[1]
+        if (value > max) {
+          max = value
+          maxEntry = entry
+        }
+      }
+    })
+    if (max === 0) {
+      throw new Error('no disks found')
+    }
+
+    yield `${mountDir}/${maxEntry}`
+  } finally {
+    debug('umount VHD (fusermount)', { diskPath, mountPath: mountDir })
+    await fromCallback(execFile, 'fusermount', ['-uz', mountDir])
+  }
+}
+
+// Mixed onto RemoteAdapter.prototype — `this` is the RemoteAdapter instance.
+export const fileRestoreMethods = {
+  async _findPartition(devicePath, partitionId) {
+    const partitions = await listPartitions(devicePath)
+    const partition = partitions.find(_ => _.id === partitionId)
+    if (partition === undefined) {
+      throw new Error(`partition ${partitionId} not found`)
+    }
+    return partition
+  },
+
+  async *_getLvmLogicalVolumes(devicePath, pvId, vgName) {
+    const { path: pvPath, lvmConfig } = yield this._getLvmPhysicalVolume(
+      devicePath,
+      pvId && (await this._findPartition(devicePath, pvId))
+    )
+
+    // vgimportclone may have renamed the VG (e.g. ubuntu-vg → xo<hash>); query the
+    // actual name from the PV rather than trusting the partitionId-embedded name.
+    // lvmConfig scopes every command to this PV so a colliding/duplicate VG on the host
+    // or another restored copy can't shadow it.
+    const [actualVgName] = (await pvs('vg_name', '--config', lvmConfig, pvPath).catch(() => [])).filter(Boolean)
+    const effectiveVgName = actualVgName ?? vgName
+
+    debug('activate LVM volume group', { effectiveVgName, requestedVgName: vgName })
+    await fromCallback(execFile, 'vgchange', ['--config', lvmConfig, '-ay', effectiveVgName])
+    try {
+      debug('get LVM logical volumes', { effectiveVgName })
+      yield lvs(['lv_name', 'lv_path'], '--config', lvmConfig, effectiveVgName)
+    } finally {
+      debug('deactivate LVM volume group', { effectiveVgName })
+      await fromCallback(execFile, 'vgchange', ['--config', lvmConfig, '-an', effectiveVgName])
+    }
+  },
+
+  async *_getLvmPhysicalVolume(devicePath, partition) {
+    const loopArgs = []
+    if (partition !== undefined) {
+      loopArgs.push('-o', partition.start * 512, '--sizelimit', partition.size)
+    }
+    loopArgs.push('--show', '-f', devicePath)
+
+    debug('attach loop device', { devicePath, partition })
+    const loopDevice = (await fromCallback(execFile, 'losetup', loopArgs)).trim()
+
+    let cowPath, cowLoop, mapperName, effectivePath, originalVgName, lvmConfig
+    try {
+      try {
+        // Create a sparse COW file (~4 MB is enough to hold LVM metadata rewrites)
+        mapperName = `xo-pv-${randomBytes(4).toString('hex')}`
+        const mapperPath = `/dev/mapper/${mapperName}`
+        // Scope LVM to the snapshot only: the raw loop device carries the same PVID and
+        // would otherwise be flagged as a duplicate, breaking pvscan and vgimportclone.
+        const mapperConfig = lvmOnlyDevice(mapperPath)
+        cowPath = join(tmpdir(), `${mapperName}.cow`)
+        const fh = await open(cowPath, 'w')
+        await fh.truncate(4 * 1024 * 1024)
+        await fh.close()
+
+        cowLoop = (await fromCallback(execFile, 'losetup', ['--show', '-f', cowPath])).trim()
+
+        const sectors = (await fromCallback(execFile, 'blockdev', ['--getsz', loopDevice])).trim()
+        await fromCallback(execFile, 'dmsetup', [
+          'create',
+          mapperName,
+          '--table',
+          `0 ${sectors} snapshot ${loopDevice} ${cowLoop} P 8`,
+        ])
+
+        // Capture the original VG name before vgimportclone renames it so callers can display a
+        // human-readable name. We deliberately do NOT `pvscan --cache` first: with a duplicate
+        // PVID present (concurrent restore of the same VM) it fails, and vgimportclone reads the
+        // device directly (scoped by mapperConfig) without needing the online cache anyway.
+        ;[originalVgName] = (await pvs('vg_name', '--config', mapperConfig, mapperPath).catch(() => [])).filter(Boolean)
+
+        // Deterministic VG name: same hash for the same disk+partition across list and mount calls,
+        // but unique across different disks — avoids duplicate VG name conflicts without state.
+        const vgBase =
+          'xo' +
+          createHash('sha256')
+            .update(devicePath)
+            .update(String(partition?.id ?? ''))
+            .digest('hex')
+            .slice(0, 10)
+        debug('import LVM volume group with unique name via dm-snapshot', { vgBase, originalVgName })
+        await fromCallback(execFile, 'vgimportclone', ['--config', mapperConfig, '--basevgname', vgBase, mapperPath])
+
+        effectivePath = mapperPath
+      } catch (error) {
+        // dm-snapshot or vgimportclone unavailable — fall back to direct loop device.
+        // Duplicate VG names across disks may still cause activation failures.
+        const message = String(error.message ?? '')
+        if (error.code === 5 && message.includes('device is partitioned')) {
+          debug('device is partitioned, skipping vgimportclone', { devicePath, partition })
+        } else if (error.code === 5) {
+          // Other LVM exit-5 errors (e.g. "No physical volume found", "Failed to find PVID")
+          debug('vgimportclone failed, falling back to direct loop device', {
+            devicePath,
+            partition,
+            message,
+          })
+        } else {
+          warn('dm-snapshot overlay failed, falling back to direct loop device', { error })
+        }
+        if (mapperName !== undefined) {
+          await fromCallback(execFile, 'dmsetup', ['remove', mapperName]).catch(noop)
+          mapperName = undefined
+        }
+        if (cowLoop !== undefined) {
+          await fromCallback(execFile, 'losetup', ['-d', cowLoop]).catch(noop)
+          cowLoop = undefined
+        }
+        if (cowPath !== undefined) {
+          await unlink(cowPath).catch(noop)
+          cowPath = undefined
+        }
+        originalVgName = undefined
+        effectivePath = loopDevice
+      }
+
+      // Whether we ended up on the snapshot or fell back to the raw loop, scope every
+      // remaining command to that one device so duplicate PVIDs from other copies (or a
+      // same-named VG on the host) can't shadow it.
+      lvmConfig = lvmOnlyDevice(effectivePath)
+
+      // Best-effort: activation/listing below scans the device directly via lvmConfig, so a
+      // duplicate-PVID failure here (concurrent restore of the same VM) must not abort.
+      debug('scan LVM physical volumes', { path: effectivePath })
+      await fromCallback(execFile, 'pvscan', ['--config', lvmConfig, '--cache', effectivePath]).catch(error =>
+        debug('pvscan --cache failed (continuing)', { path: effectivePath, error })
+      )
+
+      // In the fallback path the VG is unmodified, so query the original name now.
+      if (originalVgName === undefined) {
+        ;[originalVgName] = (await pvs('vg_name', '--config', lvmConfig, effectivePath).catch(() => [])).filter(Boolean)
+      }
+
+      yield { path: effectivePath, originalVgName, lvmConfig }
+    } finally {
+      try {
+        const vgNames = (await pvs('vg_name', '--config', lvmConfig, effectivePath).catch(() => [])).filter(Boolean)
+        if (vgNames.length > 0) {
+          debug('deactivate LVM volume groups', { vgNames })
+          await fromCallback(execFile, 'vgchange', ['--config', lvmConfig, '-an', ...vgNames])
+        }
+      } finally {
+        if (mapperName !== undefined) {
+          debug('remove dm-snapshot', { mapperName })
+          await fromCallback(execFile, 'dmsetup', ['remove', mapperName]).catch(err =>
+            warn('failed to remove dm-snapshot', { mapperName, error: err })
+          )
+        }
+        if (cowLoop !== undefined) {
+          await fromCallback(execFile, 'losetup', ['-d', cowLoop]).catch(noop)
+        }
+        if (cowPath !== undefined) {
+          await unlink(cowPath).catch(noop)
+        }
+        debug('detach loop device', { loopDevice })
+        await fromCallback(execFile, 'losetup', ['-d', loopDevice])
+      }
+    }
+  },
+
+  async *_getPartition(devicePath, partition) {
+    const options = ['loop', 'ro']
+
+    if (partition !== undefined) {
+      const { size, start } = partition
+      options.push(`sizelimit=${size}`)
+      if (start !== undefined) {
+        options.push(`offset=${start * 512}`)
+      }
+    }
+
+    const path = yield getTmpDir()
+    const mount = options => {
+      debug('mount device', { devicePath, mountPath: path })
+      return fromCallback(execFile, 'mount', [
+        `--options=${options.join(',')}`,
+        `--source=${devicePath}`,
+        `--target=${path}`,
+      ]).catch(error => {
+        if (error.stderr) {
+          error.message = `${error.message}: ${error.stderr.trim()}`
+        }
+        throw error
+      })
+    }
+
+    // norecovery prevents mount from attempting journal replay on a read-only device (ext3/ext4/xfs).
+    // Other filesystems don't support it, so fall back without it on failure.
+    try {
+      await mount([...options, 'norecovery'])
+    } catch (error) {
+      await mount(options)
+    }
+
+    try {
+      yield path
+    } finally {
+      debug('umount device', { devicePath, mountPath: path })
+      await fromCallback(execFile, 'umount', ['--lazy', path])
+    }
+  },
+
+  _listLvmLogicalVolumes(devicePath, partition, results = []) {
+    return Disposable.use(
+      this._getLvmPhysicalVolume(devicePath, partition),
+      async ({ path, originalVgName, lvmConfig }) => {
+        const lvItems = await pvs(['lv_name', 'lv_path', 'lv_size', 'vg_name'], '--config', lvmConfig, path)
+        const partitionId = partition !== undefined ? partition.id : ''
+        lvItems.forEach(lv => {
+          const lvName = lv.lv_name
+          if (lvName !== '') {
+            results.push({
+              id: `${partitionId}/${lv.vg_name}/${lvName}`,
+              // show "ubuntu-vg/ubuntu-lv" so users can identify the volume group
+              name: originalVgName !== undefined ? `${originalVgName}/${lvName}` : lvName,
+              size: lv.lv_size,
+            })
+          }
+        })
+        return results
+      }
+    )
+  },
+
+  fetchPartitionFiles(diskId, partitionId, paths, format) {
+    const { promise, reject, resolve } = pDefer()
+    Disposable.use(
+      async function* () {
+        const path = yield this.getPartition(diskId, partitionId)
+        let outputStream
+
+        // debug: bytes actually transmitted to the client (compressed wire bytes).
+        // Unlike fuse-vhd's fuseBytes (skewed by kernel_cache), this is comparable
+        // across configs. Logged every 5s so it can be read at any cut-off point.
+        const transmitted = { size: 0 }
+        const startedAt = Date.now()
+        const report = setInterval(() => {
+          const seconds = (Date.now() - startedAt) / 1000
+          info('partition files transmitted', {
+            format,
+            transmittedMiB: +(transmitted.size / 1048576).toFixed(1),
+            seconds: +seconds.toFixed(1),
+            mibPerSec: +(transmitted.size / 1048576 / seconds).toFixed(1),
+          })
+        }, 60e3)
+        report.unref()
+
+        try {
+          if (format === 'tgz') {
+            // jobs: 1 — process one entry at a time. node-tar defaults to 4
+            // concurrent jobs, which on a FUSE-backed restore mount means up to 4
+            // simultaneous reads; those saturate the libuv threadpool and starve
+            // the underlying vhd/CIFS reads NTFS-3g depends on (FUSE-on-FUSE
+            // threadpool deadlock). Serializing keeps a worker free for them.
+            outputStream = tar.c({ cwd: path, gzip: true, jobs: 1 }, paths.map(makeRelative))
+            watchStreamSize(outputStream, transmitted)
+            resolve(outputStream)
+          } else if (format === 'zip') {
+            const zip = new ZipFile()
+            // Resolve with the stream before enumeration so the client can start
+            // receiving data immediately — addZipEntries over FUSE/S3 can take
+            // minutes for large trees (e.g. node_modules) and would otherwise
+            // appear as a freeze with no response sent.
+            outputStream = zip.outputStream
+            watchStreamSize(outputStream, transmitted)
+            resolve(zip.outputStream)
+            await addZipEntries(zip, path, '', paths.map(makeRelative))
+            zip.end()
+          } else {
+            throw new Error('unsupported format ' + format)
+          }
+
+          // Wait for the stream to finish before releasing the mounted partition.
+          // finished() correctly handles 'end', 'close', and 'error' — unlike
+          // fromEvent('end') which hangs forever if the stream errors (client
+          // disconnect, FUSE read failure), leaking the mount and loop devices.
+          await finished(outputStream).catch(noop)
+        } finally {
+          clearInterval(report)
+        }
+      }.bind(this)
+    ).catch(error => {
+      warn(error)
+      reject(error)
+    })
+    return promise
+  },
+
+  async *getDisk(diskId) {
+    if (this._useGetDiskLegacy) {
+      yield* getDiskLegacy(this._handler, diskId)
+      return
+    }
+    const handler = this._handler
+    // this is a disposable
+    const mountDir = yield getTmpDir()
+    // this is also a disposable
+    yield mount(handler, diskId, mountDir)
+    // this will yield disk path to caller
+    yield `${mountDir}/vhd0`
+  },
+
+  // partitionId values:
+  //
+  // - undefined: raw disk
+  // - `<partitionId>`: partitioned disk
+  // - `<pvId>/<vgName>/<lvName>`: LVM on a partitioned disk
+  // - `/<vgName>/lvName>`: LVM on a raw disk
+  async *getPartition(diskId, partitionId) {
+    const devicePath = yield this.getDisk(diskId)
+    if (partitionId === undefined) {
+      debug(
+        'no partition specified, attempting raw disk mount — call listPartitions first if disk has partitions or LVM'
+      )
+      return yield this._getPartition(devicePath)
+    }
+
+    const isLvmPartition = partitionId.includes('/')
+    if (isLvmPartition) {
+      const [pvId, vgName, lvName] = partitionId.split('/')
+      const lvs = yield this._getLvmLogicalVolumes(devicePath, pvId !== '' ? pvId : undefined, vgName)
+      return yield this._getPartition(lvs.find(_ => _.lv_name === lvName).lv_path)
+    }
+
+    return yield this._getPartition(devicePath, await this._findPartition(devicePath, partitionId))
+  },
+
+  listPartitionFiles(diskId, partitionId, path) {
+    return Disposable.use(this.getPartition(diskId, partitionId), async rootPath => {
+      path = resolveSubpath(rootPath, path)
+      const entriesMap = {}
+      await asyncEach(
+        await readdir(path),
+        async name => {
+          try {
+            const stats = await lstat(`${path}/${name}`)
+            if (stats.isDirectory()) {
+              entriesMap[name + '/'] = {}
+            } else if (stats.isFile()) {
+              entriesMap[name] = {}
+            }
+          } catch (error) {
+            if (error == null || error.code !== 'ENOENT') {
+              throw error
+            }
+          }
+        },
+        { concurrency: 1 }
+      )
+
+      return entriesMap
+    })
+  },
+
+  listPartitions(diskId) {
+    return Disposable.use(this.getDisk(diskId), async devicePath => {
+      // partx may return empty on FUSE-backed files (vhd0); a loop device
+      // presents proper block-device semantics that partx reads reliably.
+      // losetup may itself fail if the FUSE mount isn't fully ready yet —
+      // fall back to the direct path so listPartitions returns [] instead of throwing.
+      let loopForParts, partitions
+      try {
+        loopForParts = (await fromCallback(execFile, 'losetup', ['--show', '-f', devicePath])).trim()
+        partitions = await listPartitions(loopForParts)
+      } catch (error) {
+        debug('partition probe via loop device failed, falling back to direct path', { error })
+        partitions = await listPartitions(devicePath)
+      } finally {
+        if (loopForParts !== undefined) {
+          await fromCallback(execFile, 'losetup', ['-d', loopForParts]).catch(noop)
+        }
+      }
+
+      if (partitions.length === 0) {
+        try {
+          // handle potential raw LVM physical volume
+          return await this._listLvmLogicalVolumes(devicePath, undefined, partitions)
+        } catch (error) {
+          return []
+        }
+      }
+
+      const results = []
+      await asyncMapSettled(partitions, async partition => {
+        if (partition.type === LVM_PARTITION_TYPE_MBR || partition.type === LVM_PARTITION_TYPE_GPT) {
+          return this._listLvmLogicalVolumes(devicePath, partition, results)
+        }
+
+        // Some Linux installers (e.g. Ubuntu subiquity) mark LVM PV partitions with a
+        // generic Linux-data type instead of the standard LVM type. Only those need the
+        // (expensive) loop + dm-snapshot + vgimportclone probe; other types — BIOS boot,
+        // EFI, swap, … — are never LVM PVs, so mount them directly as regular partitions.
+        const isProbeableForLvm =
+          partition.type === LINUX_DATA_PARTITION_TYPE_MBR || partition.type === LINUX_DATA_PARTITION_TYPE_GPT
+        if (!isProbeableForLvm) {
+          results.push(partition)
+          return
+        }
+
+        const lvResults = []
+        try {
+          await this._listLvmLogicalVolumes(devicePath, partition, lvResults)
+        } catch (error) {
+          debug('LVM probe failed for Linux-data partition, treating as regular partition', {
+            partition,
+            error,
+          })
+        }
+        if (lvResults.length > 0) {
+          results.push(...lvResults)
+        } else {
+          results.push(partition)
+        }
+      })
+      return results
+    })
+  },
+}
+
+// Applied by RemoteAdapter.mjs via decorateMethodsWith(RemoteAdapter, fileRestoreDecorators).
+// debounceResourceFactory/deduped reference `this._debounceResource` at call time.
+export const fileRestoreDecorators = {
+  _getLvmLogicalVolumes: compose([
+    Disposable.factory,
+    [deduped, (devicePath, pvId, vgName) => [devicePath, pvId, vgName]],
+    debounceResourceFactory,
+  ]),
+
+  _getLvmPhysicalVolume: compose([
+    Disposable.factory,
+    [deduped, (devicePath, partition) => [devicePath, partition?.id]],
+    debounceResourceFactory,
+  ]),
+
+  _getPartition: compose([
+    Disposable.factory,
+    [deduped, (devicePath, partition) => [devicePath, partition?.id]],
+    debounceResourceFactory,
+  ]),
+
+  getDisk: compose([Disposable.factory, [deduped, diskId => [diskId]], debounceResourceFactory]),
+
+  getPartition: Disposable.factory,
+}

--- a/@xen-orchestra/backups/_fileRestore.mjs
+++ b/@xen-orchestra/backups/_fileRestore.mjs
@@ -292,9 +292,9 @@ export const fileRestoreMethods = {
       let outputStream
 
       if (format === 'tgz') {
-        // jobs: 1 — process one entry at a time. node-tar defaults to 4
+        // process one entry at a time with { job: 1}. node-tar defaults to 4
         // concurrent jobs, which on a FUSE-backed restore mount means up to 4
-        // simultaneous reads; those saturate the libuv threadpool and starve
+        // simultaneous reads. Those saturate the libuv threadpool and starve
         // the underlying vhd/CIFS reads NTFS-3g depends on (FUSE-on-FUSE
         // threadpool deadlock). Serializing keeps a worker free for them.
         outputStream = tar.c({ cwd: path, gzip: true, jobs: 1 }, paths.map(makeRelative))
@@ -313,10 +313,6 @@ export const fileRestoreMethods = {
         throw new Error('unsupported format ' + format)
       }
 
-      // Wait for the stream to finish before releasing the mounted partition.
-      // finished() correctly handles 'end', 'close', and 'error' — unlike
-      // fromEvent('end') which hangs forever if the stream errors (client
-      // disconnect, FUSE read failure), leaking the mount and loop devices.
       await finished(outputStream).catch(noop)
     }).catch(error => {
       warn(error)

--- a/@xen-orchestra/backups/_fileRestore.mjs
+++ b/@xen-orchestra/backups/_fileRestore.mjs
@@ -33,9 +33,8 @@ import {
   LVM_PARTITION_TYPE_MBR,
 } from './_listPartitions.mjs'
 import { lvs, pvs } from './_lvm.mjs'
-import { watchStreamSize } from './_watchStreamSize.mjs'
 
-const { debug, info, warn } = createLogger('xo:backups:RemoteAdapter')
+const { debug, warn } = createLogger('xo:backups:RemoteAdapter')
 
 const noop = Function.prototype
 
@@ -287,62 +286,39 @@ export const fileRestoreMethods = {
 
   fetchPartitionFiles(diskId, partitionId, paths, format) {
     const { promise, reject, resolve } = pDefer()
-    Disposable.use(
-      async function* () {
-        const path = yield this.getPartition(diskId, partitionId)
-        let outputStream
+    const self = this
+    Disposable.use(async function* () {
+      const path = yield self.getPartition(diskId, partitionId)
+      let outputStream
 
-        // debug: bytes actually transmitted to the client (compressed wire bytes).
-        // Unlike fuse-vhd's fuseBytes (skewed by kernel_cache), this is comparable
-        // across configs. Logged every 5s so it can be read at any cut-off point.
-        const transmitted = { size: 0 }
-        const startedAt = Date.now()
-        const report = setInterval(() => {
-          const seconds = (Date.now() - startedAt) / 1000
-          info('partition files transmitted', {
-            format,
-            transmittedMiB: +(transmitted.size / 1048576).toFixed(1),
-            seconds: +seconds.toFixed(1),
-            mibPerSec: +(transmitted.size / 1048576 / seconds).toFixed(1),
-          })
-        }, 60e3)
-        report.unref()
+      if (format === 'tgz') {
+        // jobs: 1 — process one entry at a time. node-tar defaults to 4
+        // concurrent jobs, which on a FUSE-backed restore mount means up to 4
+        // simultaneous reads; those saturate the libuv threadpool and starve
+        // the underlying vhd/CIFS reads NTFS-3g depends on (FUSE-on-FUSE
+        // threadpool deadlock). Serializing keeps a worker free for them.
+        outputStream = tar.c({ cwd: path, gzip: true, jobs: 1 }, paths.map(makeRelative))
+        resolve(outputStream)
+      } else if (format === 'zip') {
+        const zip = new ZipFile()
+        // Resolve with the stream before enumeration so the client can start
+        // receiving data immediately — addZipEntries over FUSE/S3 can take
+        // minutes for large trees (e.g. node_modules) and would otherwise
+        // appear as a freeze with no response sent.
+        outputStream = zip.outputStream
+        resolve(zip.outputStream)
+        await addZipEntries(zip, path, '', paths.map(makeRelative))
+        zip.end()
+      } else {
+        throw new Error('unsupported format ' + format)
+      }
 
-        try {
-          if (format === 'tgz') {
-            // jobs: 1 — process one entry at a time. node-tar defaults to 4
-            // concurrent jobs, which on a FUSE-backed restore mount means up to 4
-            // simultaneous reads; those saturate the libuv threadpool and starve
-            // the underlying vhd/CIFS reads NTFS-3g depends on (FUSE-on-FUSE
-            // threadpool deadlock). Serializing keeps a worker free for them.
-            outputStream = tar.c({ cwd: path, gzip: true, jobs: 1 }, paths.map(makeRelative))
-            watchStreamSize(outputStream, transmitted)
-            resolve(outputStream)
-          } else if (format === 'zip') {
-            const zip = new ZipFile()
-            // Resolve with the stream before enumeration so the client can start
-            // receiving data immediately — addZipEntries over FUSE/S3 can take
-            // minutes for large trees (e.g. node_modules) and would otherwise
-            // appear as a freeze with no response sent.
-            outputStream = zip.outputStream
-            watchStreamSize(outputStream, transmitted)
-            resolve(zip.outputStream)
-            await addZipEntries(zip, path, '', paths.map(makeRelative))
-            zip.end()
-          } else {
-            throw new Error('unsupported format ' + format)
-          }
-
-          // Wait for the stream to finish before releasing the mounted partition.
-          // finished() correctly handles 'end', 'close', and 'error' — unlike
-          // fromEvent('end') which hangs forever if the stream errors (client
-          // disconnect, FUSE read failure), leaking the mount and loop devices.
-          await finished(outputStream).catch(noop)
-        } finally {
-          clearInterval(report)
-        }
-      }.bind(this)
-    ).catch(error => {
+      // Wait for the stream to finish before releasing the mounted partition.
+      // finished() correctly handles 'end', 'close', and 'error' — unlike
+      // fromEvent('end') which hangs forever if the stream errors (client
+      // disconnect, FUSE read failure), leaking the mount and loop devices.
+      await finished(outputStream).catch(noop)
+    }).catch(error => {
       warn(error)
       reject(error)
     })

--- a/@xen-orchestra/backups/_fileRestore.test.mjs
+++ b/@xen-orchestra/backups/_fileRestore.test.mjs
@@ -1,0 +1,61 @@
+import { strict as assert } from 'node:assert'
+import test from 'node:test'
+
+import { isLvmPartitionType, isProbeableForLvm, lvmOnlyDevice, toLvPartitions } from './_fileRestore.mjs'
+import {
+  LINUX_DATA_PARTITION_TYPE_GPT,
+  LINUX_DATA_PARTITION_TYPE_MBR,
+  LVM_PARTITION_TYPE_GPT,
+  LVM_PARTITION_TYPE_MBR,
+} from './_listPartitions.mjs'
+
+// well-known GPT type GUIDs that must NOT be probed/treated as LVM
+const EFI = 'c12a7328-f81f-11d2-ba4b-00a0c93ec93b'
+const BIOS_BOOT = '21686148-6449-6e6f-744e-656564454649'
+const SWAP = '0657fd6d-a4ab-43c4-84e5-0933c84b4f4f'
+
+test('lvmOnlyDevice builds an accept-only global_filter for the device', () => {
+  assert.equal(
+    lvmOnlyDevice('/dev/mapper/xo-pv-abcd1234'),
+    'devices { global_filter=[ "a|^/dev/mapper/xo-pv-abcd1234$|", "r|.*|" ] }'
+  )
+  assert.equal(lvmOnlyDevice('/dev/loop7'), 'devices { global_filter=[ "a|^/dev/loop7$|", "r|.*|" ] }')
+})
+
+test('isLvmPartitionType matches only the LVM partition types', () => {
+  assert.equal(isLvmPartitionType(LVM_PARTITION_TYPE_MBR), true)
+  assert.equal(isLvmPartitionType(LVM_PARTITION_TYPE_GPT), true)
+  assert.equal(isLvmPartitionType(LINUX_DATA_PARTITION_TYPE_GPT), false)
+  assert.equal(isLvmPartitionType(EFI), false)
+  assert.equal(isLvmPartitionType(undefined), false)
+})
+
+test('isProbeableForLvm matches only generic Linux-data types', () => {
+  assert.equal(isProbeableForLvm(LINUX_DATA_PARTITION_TYPE_MBR), true)
+  assert.equal(isProbeableForLvm(LINUX_DATA_PARTITION_TYPE_GPT), true)
+  // never probe these
+  assert.equal(isProbeableForLvm(LVM_PARTITION_TYPE_GPT), false)
+  assert.equal(isProbeableForLvm(BIOS_BOOT), false)
+  assert.equal(isProbeableForLvm(EFI), false)
+  assert.equal(isProbeableForLvm(SWAP), false)
+  assert.equal(isProbeableForLvm(undefined), false)
+})
+
+test('toLvPartitions builds entries, skips unnamed LVs, shows the original VG name', () => {
+  const lvItems = [
+    { lv_name: 'ubuntu-lv', lv_path: '/dev/xohash/ubuntu-lv', lv_size: '1000', vg_name: 'xohash' },
+    // a PV with no LV yields a row with an empty lv_name → must be skipped
+    { lv_name: '', lv_path: '', lv_size: '0', vg_name: 'xohash' },
+    { lv_name: 'swap_1', lv_path: '/dev/xohash/swap_1', lv_size: '500', vg_name: 'xohash' },
+  ]
+  assert.deepEqual(toLvPartitions('part3', 'ubuntu-vg', lvItems), [
+    { id: 'part3/xohash/ubuntu-lv', name: 'ubuntu-vg/ubuntu-lv', size: '1000' },
+    { id: 'part3/xohash/swap_1', name: 'ubuntu-vg/swap_1', size: '500' },
+  ])
+})
+
+test('toLvPartitions falls back to the bare LV name when the original VG name is unknown', () => {
+  const lvItems = [{ lv_name: 'data', lv_path: '/dev/xohash/data', lv_size: '42', vg_name: 'xohash' }]
+  // raw-disk PV → empty partitionId
+  assert.deepEqual(toLvPartitions('', undefined, lvItems), [{ id: '/xohash/data', name: 'data', size: '42' }])
+})

--- a/@xen-orchestra/backups/_listPartitions.mjs
+++ b/@xen-orchestra/backups/_listPartitions.mjs
@@ -29,6 +29,15 @@ export const LVM_PARTITION_TYPE_MBR = 0x8e
 // GPT LVM type
 export const LVM_PARTITION_TYPE_GPT = 'e6d6d379-f507-44c2-a23c-238f2a3df928'
 
+// Generic "Linux filesystem data" types. These are the only non-LVM-typed
+// partitions worth probing for a hidden LVM PV, because some installers (e.g.
+// Ubuntu subiquity) place a PV on a partition left with this generic type.
+// Other types (BIOS boot, EFI, swap, …) are never LVM PVs.
+// MBR Linux native
+export const LINUX_DATA_PARTITION_TYPE_MBR = 0x83
+// GPT Linux filesystem data
+export const LINUX_DATA_PARTITION_TYPE_GPT = '0fc63daf-8483-4772-8e79-3d69d8477de4'
+
 const parsePartxLine = createParser({
   keyTransform: key => (key === 'UUID' ? 'id' : key.toLowerCase()),
   valueTransform: (value, key) => {

--- a/@xen-orchestra/qa-test/package.json
+++ b/@xen-orchestra/qa-test/package.json
@@ -43,6 +43,7 @@
     "qa:backup:metadata": "node --env-file-if-exists=.env --test tests/metadata-backup.test.js",
     "demo": "node --env-file-if-exists=.env index.js",
     "report": "node --env-file-if-exists=.env scripts/run-and-report.mjs",
-    "report:smtp-test": "node --env-file-if-exists=.env scripts/run-and-report.mjs --smtp-test"
+    "report:smtp-test": "node --env-file-if-exists=.env scripts/run-and-report.mjs --smtp-test",
+    "qa:backup:file-restore": "node --env-file-if-exists=.env --test tests/backup.file-restore.test.js"
   }
 }

--- a/@xen-orchestra/qa-test/tests/backup.file-restore.test.js
+++ b/@xen-orchestra/qa-test/tests/backup.file-restore.test.js
@@ -1,0 +1,181 @@
+import assert from 'node:assert'
+import { after, before, describe, it } from 'node:test'
+import { createLogger } from '@xen-orchestra/log'
+
+import { backupConfig } from '../backup.config.js'
+import { generateBackupJobName, getDefaultSchedule, getScheduleKey } from '../utils/index.js'
+import { assertBackupSuccess } from '../utils/backupUtils.js'
+import { setup, teardown } from './setup.js'
+
+const log = createLogger('qa:backup:file-restore')
+
+// Magic bytes used to validate archive format integrity
+const TGZ_MAGIC = [0x1f, 0x8b]
+const ZIP_MAGIC = [0x50, 0x4b]
+
+describe('Incremental backup file restore', () => {
+  let dispatchClient
+  let tracker
+  let vm
+  let backupRepository
+
+  // The second (delta) backup to run file restore on
+  let incrementalBackup
+
+  before(async () => {
+    ;({ dispatchClient, tracker, vm, backupRepository } = await setup())
+
+    const name = generateBackupJobName()
+    const schedule = getDefaultSchedule()
+    const config = backupConfig(name, schedule, vm, backupRepository)
+    config.mode = 'delta'
+
+    const backupJobId = await dispatchClient.backup.createBackupJob(config)
+    const backupJob = await dispatchClient.backup.details(backupJobId)
+
+    tracker.trackResource('backupJob', backupJobId, { name, mode: 'delta' })
+    const scheduleKey = getScheduleKey(backupJob)
+    if (scheduleKey) {
+      tracker.trackResource('schedule', scheduleKey, { name, backupJobId })
+    }
+
+    assert(scheduleKey, 'Schedule key is required for file restore tests')
+
+    // First run → full backup (base), second run → delta (incremental)
+    for (let i = 0; i < 2; i++) {
+      const result = await dispatchClient.backup.runJobAndGetLog(backupJobId, scheduleKey)
+      assertBackupSuccess(result, `Backup run ${i + 1}/2`)
+      log.debug(`Completed backup run ${i + 1}/2`, { status: result.status })
+    }
+
+    // Pick the most recent delta backup for file restore testing
+    const backupsByRemoteAndVm = await dispatchClient.xoClient.call('backupNg.listVmBackups', {
+      remotes: [backupRepository.id],
+    })
+
+    const vmBackups = backupsByRemoteAndVm[backupRepository.id]?.[vm.uuid]
+    assert(Array.isArray(vmBackups) && vmBackups.length >= 2, 'Expected at least 2 backups after two runs')
+
+    const sorted = [...vmBackups].sort((a, b) => a.timestamp - b.timestamp)
+    incrementalBackup = sorted[sorted.length - 1]
+
+    assert.strictEqual(incrementalBackup.mode, 'delta', 'Latest backup should be a delta (incremental) backup')
+    assert(incrementalBackup.disks.length > 0, 'Incremental backup should contain at least one disk')
+
+    log.debug('Selected incremental backup for file restore', {
+      backupId: incrementalBackup.id,
+      diskCount: incrementalBackup.disks.length,
+      timestamp: new Date(incrementalBackup.timestamp).toISOString(),
+    })
+  })
+
+  after(async () => {
+    await teardown(dispatchClient, tracker)
+  })
+
+  it('should list partitions, list files, and restore first 2 files in tgz and zip for each disk', async () => {
+    const remoteId = backupRepository.id
+
+    for (const disk of incrementalBackup.disks) {
+      log.debug('Processing disk', { diskId: disk.id, diskName: disk.name })
+
+      const partitions = await dispatchClient.xoClient.call('backupNg.listPartitions', {
+        remote: remoteId,
+        disk: disk.id,
+      })
+
+      assert(Array.isArray(partitions), `listPartitions should return an array for disk ${disk.id}`)
+      log.debug('Found partitions', { diskId: disk.id, count: partitions.length })
+
+      // When listPartitions returns empty, treat the disk as a single raw (unpartitioned) volume.
+      // The API accepts partition: undefined for this case.
+      const partitionTargets = partitions.length > 0 ? partitions : [{ id: undefined }]
+
+      for (const partition of partitionTargets) {
+        const partitionId = partition.id
+        log.debug('Processing partition', { diskId: disk.id, partitionId })
+
+        let fileEntries
+        try {
+          fileEntries = await dispatchClient.xoClient.call('backupNg.listFiles', {
+            remote: remoteId,
+            disk: disk.id,
+            ...(partitionId !== undefined && { partition: partitionId }),
+            path: '/',
+          })
+        } catch (error) {
+          // Some partitions (swap, EFI system) cannot be mounted — skip gracefully
+          log.warn('Could not list files for partition, skipping', {
+            diskId: disk.id,
+            partitionId,
+            error: error.message,
+          })
+          continue
+        }
+
+        assert(
+          fileEntries !== null && typeof fileEntries === 'object',
+          `listFiles should return an object for disk ${disk.id} partition ${partitionId}`
+        )
+
+        // Directories are suffixed with '/', files are not
+        const fileNames = Object.keys(fileEntries).filter(name => !name.endsWith('/'))
+
+        if (fileNames.length === 0) {
+          log.debug('No files at partition root, skipping', { diskId: disk.id, partitionId })
+          continue
+        }
+
+        // Restore at most 2 files — paths must be absolute for fetchFiles
+        const paths = fileNames.slice(0, 2).map(name => `/${name}`)
+
+        log.debug('Restoring files', { diskId: disk.id, partitionId, paths })
+
+        for (const format of ['tgz', 'zip']) {
+          await assertFetchFiles(dispatchClient, { remote: remoteId, disk: disk.id, partitionId, paths, format })
+        }
+      }
+    }
+  })
+})
+
+/**
+ * Calls backupNg.fetchFiles, downloads the resulting archive, and validates
+ * that the response is a non-empty, correctly-formatted archive.
+ *
+ * @param {import('../client/dispatchClient.js').DispatchClient} dispatchClient
+ * @param {{ remote: string, disk: string, partitionId: string|undefined, paths: string[], format: 'tgz'|'zip' }} opts
+ */
+async function assertFetchFiles(dispatchClient, { remote, disk, partitionId, paths, format }) {
+  const params = {
+    remote,
+    disk,
+    paths,
+    format,
+    ...(partitionId !== undefined && { partition: partitionId }),
+  }
+
+  const result = await dispatchClient.xoClient.call('backupNg.fetchFiles', params)
+  const downloadPath = result.$getFrom
+  assert(
+    typeof downloadPath === 'string' && downloadPath.length > 0,
+    `fetchFiles (${format}) should return a non-empty $getFrom URL`
+  )
+
+  const response = await fetch(`${dispatchClient.restApiClient.baseUrl}${downloadPath}`, {
+    method: 'GET',
+    headers: dispatchClient.restApiClient.headers,
+    signal: AbortSignal.timeout(120_000),
+  })
+
+  assert(response.ok, `Download failed for ${format}: HTTP ${response.status} ${response.statusText}`)
+
+  const bytes = Buffer.from(await response.arrayBuffer())
+  assert(bytes.length > 0, `Downloaded ${format} archive should not be empty`)
+
+  const magic = format === 'tgz' ? TGZ_MAGIC : ZIP_MAGIC
+  assert.strictEqual(bytes[0], magic[0], `${format} archive should start with correct magic byte[0]`)
+  assert.strictEqual(bytes[1], magic[1], `${format} archive should start with correct magic byte[1]`)
+
+  log.debug('File restore validated', { format, size: bytes.length, paths, partitionId })
+}

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -86,8 +86,8 @@
 - @vates/fuse-vhd patch
 - @vates/types minor
 - @xen-orchestra/acl minor
-- @xen-orchestra/backups patch
 - @xen-orchestra/backup-archive patch
+- @xen-orchestra/backups patch
 - @xen-orchestra/disk-transform patch
 - @xen-orchestra/qa-test minor
 - @xen-orchestra/qcow2 patch

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -64,6 +64,8 @@
 - [Rest Api] Fix `possibly unhandled rejection invalid crendentials` (PR [#9938](https://github.com/vatesfr/xen-orchestra/pull/9938))
 - [Backups] Fixed "Cannot read properties of undefined" issues (PR [#9944](https://github.com/vatesfr/xen-orchestra/pull/9944))
 - [REST API] `GET /vms/:id.:format`, `GET /vm-templates/:id.:format`, `GET /vm-snapshots/:id.:format` now correctly support explicit compress query param (`zstd` | `gzip`). Still support `true` | `false` as deprecated value (PR [#9960](https://github.com/vatesfr/xen-orchestra/pull/9960))
+- [Backup/Restore] Fix file-level restore of VMs whose disks use LVM (e.g. the default Ubuntu install layout): logical volumes are now listed and can be restored, including when restoring several copies of the same VM at once — previously failed with `unknown filesystem type 'LVM2_member'` (PR [#9776](https://github.com/vatesfr/xen-orchestra/pull/9776))
+- [Backup/Restore] Fix file-level restore hanging when downloading large folders, and high memory use when downloading a folder as a zip (PR [#9776](https://github.com/vatesfr/xen-orchestra/pull/9776))
 
 ### Packages to release
 
@@ -81,11 +83,13 @@
 
 <!--packages-start-->
 
+- @vates/fuse-vhd patch
 - @vates/types minor
 - @xen-orchestra/acl minor
+- @xen-orchestra/backups patch
 - @xen-orchestra/backup-archive patch
 - @xen-orchestra/disk-transform patch
-- @xen-orchestra/qa-test patch
+- @xen-orchestra/qa-test minor
 - @xen-orchestra/qcow2 patch
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor

--- a/packages/xo-web/src/xo-app/backup/file-restore/restore-file-modal.js
+++ b/packages/xo-web/src/xo-app/backup/file-restore/restore-file-modal.js
@@ -18,9 +18,23 @@ import { listPartitions, listFiles } from 'xo'
 // -----------------------------------------------------------------------------
 
 const PARTITION_TYPE_NAMES = {
+  // MBR types
+  0x05: 'Extended',
   0x07: 'NTFS',
-  0x0c: 'FAT',
-  0x83: 'LINUX',
+  0x0b: 'FAT32',
+  0x0c: 'FAT32',
+  0x0e: 'FAT16',
+  0x82: 'Linux swap',
+  0x83: 'Linux',
+  0x8e: 'LVM',
+  0xfd: 'Linux RAID',
+  // GPT types
+  '0657fd6d-a4ab-43c4-84e5-0933c84b4f4f': 'Linux swap',
+  '0fc63daf-8483-4772-8e79-3d69d8477de4': 'Linux',
+  '21686148-6449-6e6f-744e-656564454649': 'BIOS boot',
+  'c12a7328-f81f-11d2-ba4b-00a0c93ec93b': 'EFI System',
+  'e6d6d379-f507-44c2-a23c-238f2a3df928': 'LVM',
+  'ebd0a0a2-b9e5-4433-87c0-68b6b72699c7': 'Windows',
 }
 
 const BACKUP_RENDERER = getRenderXoItemOfType('backup')
@@ -31,12 +45,16 @@ const diskOptionRenderer = disk => (
   </span>
 )
 
-const partitionOptionRenderer = partition => (
-  <span>
-    {partition.name} {defined(PARTITION_TYPE_NAMES[partition.type], partition.type)}{' '}
-    {partition.size && `(${formatSize(+partition.size)})`}
-  </span>
-)
+const partitionOptionRenderer = partition => {
+  const typeName = defined(PARTITION_TYPE_NAMES[partition.type], partition.type)
+  const label = [partition.name, typeName].filter(Boolean).join(' ')
+  return (
+    <span>
+      {label}
+      {partition.size && ` (${formatSize(+partition.size)})`}
+    </span>
+  )
+}
 
 const fileOptionRenderer = ({ isFile, name }) => (
   <span>


### PR DESCRIPTION
### Description

LVM VG name collision: dm-snapshot overlay + vgimportclone with a deterministic unique VG name (SHA-256 of path+partition). Multiple disks sharing the same ubuntu-vg no longer conflict. Original VG name preserved for display (ubuntu-vg/ubuntu-lv).

norecovery fallback never worked: option was in the base array and added again on first attempt, so the fallback never dropped it. Fixed so non-ext/xfs filesystems (btrfs, vfat, ntfs…) are actually retried without it.

NTFS support: when generic mount fails, also tries -t ntfs3 (in-kernel, Debian 12) and -t ntfs-3g explicitly — helps on setups where ntfs-3g is not installed. (edge case for xo from source)

Resource leak in fetchPartitionFiles: fromEvent(stream, 'end') hangs on stream error (client disconnect, FUSE failure), keeping mounts and loop devices open forever. Replaced with finished(stream).catch(noop).

Zip freeze on large trees: resolved stream before addZipEntries so the client starts receiving immediately while file enumeration runs concurrently.

Partition labels in UI: PARTITION_TYPE_NAMES extended with common GPT UUIDs. Renderer no longer emits a leading space when partition name is empty.

create archive from file sequentially to not starve libuv . Current state : able to restore the Windows folder of a VM.
  
note that the performance of file restore is typically between 10 and 30 time slower than the speed of your remote. If the user need to restore more than 10% of a disk, it can be faster to restore the VM / disk 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
