### PR TITLE
fix(backups): fix out_of_range -4 merge error

### DIFF
--- a/@xen-orchestra/backup-archive/src/disks/MergeRemoteDisk.mjs
+++ b/@xen-orchestra/backup-archive/src/disks/MergeRemoteDisk.mjs
@@ -142,10 +142,10 @@ export class MergeRemoteDisk {
       const mergeStateContent = await this.#handler.readFile(this.#statePath)
       this.#state = JSON.parse(mergeStateContent)
 
-      // work-around to bugs introduce in 97d94b795 and 4e50858
+      // work-around to bugs introduced in 97d94b795 and 4e50858
       //
       // currentBlock could be `null` due to the JSON.stringify of a `NaN` value
-      // it would also be -1 due to being set as Math.min(...merging) - 1 if merging contains 0
+      // could also be -1 due to being set as Math.min(...merging) - 1 if merging contains 0
       if (this.#state?.currentBlock === null || this.#state.currentBlock < 0) this.#state.currentBlock = 0
       this.#isResuming = true
     } catch (error) {

--- a/@xen-orchestra/backup-archive/src/disks/MergeRemoteDisk.mjs
+++ b/@xen-orchestra/backup-archive/src/disks/MergeRemoteDisk.mjs
@@ -146,7 +146,7 @@ export class MergeRemoteDisk {
       //
       // currentBlock could be `null` due to the JSON.stringify of a `NaN` value
       // could also be -1 due to being set as Math.min(...merging) - 1 if merging contains 0
-      if (this.#state?.currentBlock === null || this.#state.currentBlock < 0) this.#state.currentBlock = 0
+      if (this.#state?.currentBlock === null || this.#state?.currentBlock < 0) this.#state.currentBlock = 0
       this.#isResuming = true
     } catch (error) {
       // @ts-ignore

--- a/@xen-orchestra/backup-archive/src/disks/MergeRemoteDisk.mjs
+++ b/@xen-orchestra/backup-archive/src/disks/MergeRemoteDisk.mjs
@@ -142,10 +142,11 @@ export class MergeRemoteDisk {
       const mergeStateContent = await this.#handler.readFile(this.#statePath)
       this.#state = JSON.parse(mergeStateContent)
 
-      // work-around a bug introduce in 97d94b795
+      // work-around to bugs introduce in 97d94b795 and 4e50858
       //
       // currentBlock could be `null` due to the JSON.stringify of a `NaN` value
-      if (this.#state?.currentBlock === null) this.#state.currentBlock = 0
+      // it would also be -1 due to being set as Math.min(...merging) - 1 if merging contains 0
+      if (this.#state?.currentBlock === null || this.#state.currentBlock < 0) this.#state.currentBlock = 0
       this.#isResuming = true
     } catch (error) {
       // @ts-ignore
@@ -255,7 +256,7 @@ export class MergeRemoteDisk {
         const blockSize = await parentDisk.mergeBlock(childDisk, blockId, this.#isResuming)
         this.#state.mergedDataSize += blockSize
 
-        this.#state.currentBlock = Math.min(...merging) - 1
+        this.#state.currentBlock = Math.max(0, Math.min(...merging) - 1)
         merging.delete(blockId)
 
         this.#onProgress({ total: nBlocks, done: counter + 1 })

--- a/@xen-orchestra/backup-archive/src/disks/RemoteDisk.test.mjs
+++ b/@xen-orchestra/backup-archive/src/disks/RemoteDisk.test.mjs
@@ -972,6 +972,53 @@ describe('tests MergeRemoteDisk', { concurrency: 1 }, () => {
     assert.deepEqual(parent2.getBlockIndexes(), [0, 1, 2, 3], 'all blocks from the chain should be merged')
   })
 
+  test('mergeRemoteDisk resumes when state has currentBlock = -1', async () => {
+    // If the merge fails it will try to resume the merge at the lowest merging block - 1,
+    // if block 0 was being merged at this time, the state file currentBlock will be set to -1
+    // which is not a valid block id.
+
+    const parentVhdPath = `${basePath}/parent.vhd`
+    await generateVhd(parentVhdPath, { blocks: [1] })
+    const parent = new RemoteVhdDisk({ handler, path: parentVhdPath })
+    await parent.init({ force: false })
+
+    const childVhdPath = `${basePath}/child.vhd`
+    await generateVhd(childVhdPath, { blocks: [0] })
+    const child = new RemoteVhdDisk({ handler, path: childVhdPath })
+    await child.init({ force: false })
+
+    // Fail after asyncEach completes
+    parent.flushMetadata = async () => {
+      throw new Error('simulated interruption')
+    }
+
+    const mergeRemoteDisk = new MergeRemoteDisk(handler, { writeStateDelay: 0 })
+    let threw = false
+    try {
+      await mergeRemoteDisk.merge(parent, child)
+    } catch (err) {
+      threw = true
+      assert.equal(err.message, 'simulated interruption')
+    }
+    assert.ok(threw, 'first merge attempt should throw on simulated interruption')
+
+    const stateFileName = `.parent.vhd.merge.json`
+    assert.ok((await handler.list(basePath)).includes(stateFileName), 'state file should exist after failure')
+
+    // Resume with fresh instances
+    const parent2 = new RemoteVhdDisk({ handler, path: parentVhdPath })
+    await parent2.init({ force: true })
+    const child2 = new RemoteVhdDisk({ handler, path: childVhdPath })
+    await child2.init({ force: true })
+
+    const mergeRemoteDisk2 = new MergeRemoteDisk(handler, { removeUnused: false })
+    await mergeRemoteDisk2.merge(parent2, child2)
+
+    const indexes = parent2.getBlockIndexes()
+    assert.ok(indexes.includes(0), 'block 0 from child should be merged into parent')
+    assert.ok(indexes.includes(1), 'block 1 from parent should remain')
+  })
+
   test('mergeRemoteDisk merge a bigger child into a parent', async () => {
     const parentVhdPath = `${basePath}/parent.vhd`
     await generateVhd(parentVhdPath, { blocks: [0, 1] })

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
 - [xo-server] Fix network being put first in boot order when HVM template has VDIs (PR [#9867](https://github.com/vatesfr/xen-orchestra/pull/9867))
+- [Backup] Fix OUT_OF_RANGE error when resuming failed merge (PR [#9782](https://github.com/vatesfr/xen-orchestra/pull/9782))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

Introduced by #9300 

Ticket #57310

Fix OUT_OF_RANGE error occurring when resuming failed merge.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
