### PR TITLE
feat : Make "allow = false " accepted in the traffic rules Rest API

### DIFF
--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -472,7 +472,7 @@ class SDNController extends EventEmitter {
             _post: async (req, res, next) => {
               const validationErrors = []
 
-              if (!req.body.allow || typeof req.body.allow !== 'boolean') {
+              if (req.body.allow === undefined || typeof req.body.allow !== 'boolean') {
                 validationErrors.push('allow is required and must be a boolean')
               }
 
@@ -487,7 +487,9 @@ class SDNController extends EventEmitter {
               if (!req.body.protocol || typeof req.body.protocol !== 'string') {
                 validationErrors.push('protocol is required and must be a string')
               }
-
+              if (req.body.port && Number.isInteger(req.body.port) === false) {
+                validationErrors.push('port must be an integer')
+              }
               if (validationErrors.length > 0) {
                 throw invalidParameters(validationErrors)
               }
@@ -529,6 +531,9 @@ class SDNController extends EventEmitter {
               if (!req.body.protocol || typeof req.body.protocol !== 'string') {
                 validationErrors.push('protocol is required and must be a string')
               }
+              if (req.body.port && Number.isInteger(req.body.port) === false) {
+                validationErrors.push('port must be an integer')
+              }
 
               if (validationErrors.length > 0) {
                 throw invalidParameters(validationErrors)
@@ -565,7 +570,7 @@ class SDNController extends EventEmitter {
                 throw invalidParameters(validationErrors)
               }
 
-              if (!req.body.allow || typeof req.body.allow !== 'boolean') {
+              if (req.body.allow === undefined || typeof req.body.allow !== 'boolean') {
                 validationErrors.push('allow is required and must be a boolean')
               }
 
@@ -580,7 +585,7 @@ class SDNController extends EventEmitter {
               if (!req.body.protocol || typeof req.body.protocol !== 'string') {
                 validationErrors.push('protocol is required and must be a string')
               }
-              if (req.body.port && isNaN(parseInt(req.body.port))) {
+              if (req.body.port && Number.isInteger(req.body.port) === false) {
                 validationErrors.push('port must be an integer')
               }
 
@@ -624,6 +629,9 @@ class SDNController extends EventEmitter {
 
               if (!req.body.protocol || typeof req.body.protocol !== 'string') {
                 validationErrors.push('protocol is required and must be a string')
+              }
+              if (req.body.port && Number.isInteger(req.body.port) === false) {
+                validationErrors.push('port must be an integer')
               }
 
               if (validationErrors.length > 0) {
@@ -798,7 +806,6 @@ class SDNController extends EventEmitter {
       for (const pool of pools) {
         pool.update_other_config('xo:sdn-controller:of-method', of_method)
       }
-
     } catch (error) {
       log.error('Error while handling xapi connection', {
         id: xapi.pool.uuid,
@@ -887,9 +894,7 @@ class SDNController extends EventEmitter {
       const network = this._xo.getXapiObject(this._xo.getObject(networkId, 'network'))
       assert(network.$PIFs.length > 0, 'Network needs to be plugged to add a rule')
 
-      const networkRules = JSON.parse(
-        network.other_config['xo:sdn-controller:of-rules'] || '[]'
-      ).map(JSON.parse)
+      const networkRules = JSON.parse(network.other_config['xo:sdn-controller:of-rules'] || '[]').map(JSON.parse)
 
       // filter matching rule (don't compare allow and cookie)
       const matchRules = networkRules.filter(rule => {
@@ -902,15 +907,18 @@ class SDNController extends EventEmitter {
       let cookie
       if (matchRules.length !== 0) {
         // use the one in rule if matching rule is present
-        cookie = matchRules.map(rule => { return rule.cookie })[0]
-
+        cookie = matchRules.map(rule => {
+          return rule.cookie
+        })[0]
       } else {
         // generate a new cookie not in use (OpenVSwitch cookie range: 0x1 to 0xFFFF_FFFF_FFFF_FFFF)
         do {
           cookie = '0x' + randomBytes(8).toString('hex')
         } while (
           cookie === '0x0000000000000000' ||
-          networkRules.filter(rule => { return rule.cookie === cookie }).length > 0
+          networkRules.filter(rule => {
+            return rule.cookie === cookie
+          }).length > 0
         )
       }
 
@@ -984,7 +992,7 @@ class SDNController extends EventEmitter {
             host: vif.$VM.$resident_on?.uuid,
           })
         } else {
-          throw (error)
+          throw error
         }
       }
 
@@ -1032,9 +1040,7 @@ class SDNController extends EventEmitter {
       let network = this._xo.getXapiObject(this._xo.getObject(networkId, 'network'))
       assert(network.$PIFs.length > 0, 'Network needs to be plugged to delete a rule')
 
-      const networkRules = JSON.parse(
-        network.other_config['xo:sdn-controller:of-rules'] || '[]'
-      ).map(JSON.parse)
+      const networkRules = JSON.parse(network.other_config['xo:sdn-controller:of-rules'] || '[]').map(JSON.parse)
 
       // filter matching rule (don't compare allow and cookie)
       const matchRules = networkRules.filter(rule => {
@@ -1045,12 +1051,14 @@ class SDNController extends EventEmitter {
 
       // ignore processing if rule not present here
       if (matchRules.length === 0) {
-        log.info("_deleteNetworkOfRule: rule not present, ignoring", {})
+        log.info('_deleteNetworkOfRule: rule not present, ignoring', {})
         return
       }
 
       // extract the (first) matching cookie
-      const cookie = matchRules.map(rule => { return rule.cookie })[0]
+      const cookie = matchRules.map(rule => {
+        return rule.cookie
+      })[0]
 
       try {
         const host = this._xo.getXapiObject(this._xo.getObject(network.$PIFs[0].host, 'host'))
@@ -1062,7 +1070,7 @@ class SDNController extends EventEmitter {
         if (error.code === 'HOST_OFFLINE') {
           log.info('deleteNetworkOfRule: Ignoring HOST_OFFLINE', { network: networkId })
         } else {
-          throw (error)
+          throw error
         }
       }
 
@@ -1072,7 +1080,11 @@ class SDNController extends EventEmitter {
 
       const newNetworkRules = networkRules.filter(rule => {
         return (
-          rule.protocol !== protocol || rule.port !== port || rule.ipRange !== ipRange || rule.direction !== direction || rule.cookie !== cookie
+          rule.protocol !== protocol ||
+          rule.port !== port ||
+          rule.ipRange !== ipRange ||
+          rule.direction !== direction ||
+          rule.cookie !== cookie
         )
       })
       await network.update_other_config(


### PR DESCRIPTION
### Description

Fixes an allow bug that disallowed allow=false in traffic rules

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
