### PR TITLE
feat(rest): add revert snapshot route

### DIFF
--- a/@vates/types/src/lib/xen-orchestra-xapi.mts
+++ b/@vates/types/src/lib/xen-orchestra-xapi.mts
@@ -37,6 +37,7 @@ import type {
   XoVm,
   XoVmTemplate,
   XoVif,
+  XoVmSnapshot,
 } from '../xo.mjs'
 
 export type XcpPatches = {
@@ -129,6 +130,7 @@ export interface Xapi {
   listMissingPatches(host: XoHost['id']): Promise<XcpPatches[] | XsPatches[]>
   pool_emergencyShutdown(): Promise<void>
   resumeVm(id: XoVm['id']): Promise<void>
+  revertVm(snapshotId: XoVmSnapshot['id']): Promise<void>
   unpauseVm(id: XoVm['id']): Promise<void>
   cloneVm(
     vmId: XoVm['id'],

--- a/@xen-orchestra/acl/src/actions/vm.mts
+++ b/@xen-orchestra/acl/src/actions/vm.mts
@@ -8,6 +8,7 @@ export default {
     hard: true,
   },
   resume: true,
+  'revert-snapshot': true,
   shutdown: {
     clean: true,
     hard: true,

--- a/@xen-orchestra/rest-api/src/groups/group.controller.mts
+++ b/@xen-orchestra/rest-api/src/groups/group.controller.mts
@@ -129,7 +129,7 @@ export class GroupController extends XoController<XoGroup> {
     json(),
     acl({
       resource: 'group',
-      action: actionFromBody('update:name'),
+      action: actionFromBody<'group'>('update:name'),
       objectId: 'params.id',
       getObject: ({ restApi }) => restApi.xoApp.getGroup,
     }),

--- a/@xen-orchestra/rest-api/src/middlewares/acl.middleware.mts
+++ b/@xen-orchestra/rest-api/src/middlewares/acl.middleware.mts
@@ -72,7 +72,7 @@ export type AclEntry = {
     | {
         action:
           | SupportedActions<Resource>
-          | ((opts: { req: AuthenticatedRequest; restApi: RestApi }) => SupportedActions<Resource>)
+          | ((opts: { req: AuthenticatedRequest; restApi: RestApi }) => SupportedActions<Resource> | undefined)
         actions?: never
       }
     | {

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -582,8 +582,10 @@ export class VmController extends XapiXoController<XoVm> {
   @Post('{id}/actions/revert_snapshot')
   @Middlewares([json(), acl({ resource: 'vm', action: 'revert-snapshot', objectId: 'params.id' })])
   @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
+  @Response(invalidParametersResp.status, invalidParametersResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
   async revertSnapshotVm(
     @Path() id: string,
@@ -592,11 +594,19 @@ export class VmController extends XapiXoController<XoVm> {
   ): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
+      const snapshotId = body.snapshot as XoVmSnapshot['id']
+
+      // Ensure the snapshot belongs to this VM
+      const vm = this.getObject(vmId)
+      if (!vm.snapshots.includes(snapshotId)) {
+        throw invalidParameters(`snapshot ${snapshotId} does not belong to VM ${vmId}`)
+      }
+
       if (body.snapshotBefore) {
         await this.getXapiObject(vmId).$snapshot({ ignoredVdisTag: IGNORED_VDIS_TAG })
       }
 
-      await this.getXapi(vmId).revertVm(body.snapshot as XoVmSnapshot['id'])
+      await this.getXapi(vmId).revertVm(snapshotId)
     }
 
     return this.createAction<void>(action, {

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -67,6 +67,7 @@ import { partialVmBackupJobs, vmBackupJobIds } from '../open-api/oa-examples/bac
 import { messageIds, partialMessages } from '../open-api/oa-examples/message.oa-example.mjs'
 import type { UnbrandedVmDashboard } from './vm.type.mjs'
 import type { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
+import { Task } from '@vates/task'
 
 const IGNORED_VDIS_TAG = '[NOSNAP]'
 
@@ -574,27 +575,38 @@ export class VmController extends XapiXoController<XoVm> {
   /**
    * Required privilege:
    * - resource: vm, action: revert-snapshot
+   * - resource: vm, action: snapshot
    *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
-   * @example body { "snapshot": "f07ab729-c0e8-721c-45ec-f11276377030", "snapshotBefore": true }
+   * @example body { "snapshotId": "f07ab729-c0e8-721c-45ec-f11276377030", "snapshotBefore": true }
    */
   @Example(taskLocation)
   @Post('{id}/actions/revert_snapshot')
-  @Middlewares([json(), acl({ resource: 'vm', action: 'revert-snapshot', objectId: 'params.id' })])
+  @Middlewares([
+    json(),
+    acl([
+      { resource: 'vm', action: 'revert-snapshot', objectId: 'params.id' },
+      {
+        resource: 'vm',
+        actions: ({ req }) => (req.body.snapshotBefore ? ['snapshot'] : []),
+        objectId: 'params.id',
+      },
+    ]),
+  ])
   @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
-  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
   @Response(invalidParametersResp.status, invalidParametersResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
   async revertSnapshotVm(
     @Path() id: string,
-    @Body() body: { snapshot: string; snapshotBefore?: boolean },
+    @Body() body: { snapshotId: string; snapshotBefore?: boolean },
     @Query() sync?: boolean
   ): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
-      const snapshotId = body.snapshot as XoVmSnapshot['id']
+      const snapshotId = body.snapshotId as XoVmSnapshot['id']
 
       // Ensure the snapshot belongs to this VM
       const vm = this.getObject(vmId)
@@ -603,10 +615,14 @@ export class VmController extends XapiXoController<XoVm> {
       }
 
       if (body.snapshotBefore) {
-        await this.getXapiObject(vmId).$snapshot({ ignoredVdisTag: IGNORED_VDIS_TAG })
-      }
+        await Task.run({ properties: { name: 'snapshot VM' } }, () =>
+          this.getXapiObject(vmId).$snapshot({ ignoredVdisTag: IGNORED_VDIS_TAG })
+        )
 
-      await this.getXapi(vmId).revertVm(snapshotId)
+        await Task.run({ properties: { name: 'revert snapshot' } }, () => this.getXapi(vmId).revertVm(snapshotId))
+      } else {
+        await this.getXapi(vmId).revertVm(snapshotId)
+      }
     }
 
     return this.createAction<void>(action, {

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -573,14 +573,14 @@ export class VmController extends XapiXoController<XoVm> {
 
   /**
    * Required privilege:
-   * - resource: vm, action: snapshot
+   * - resource: vm, action: revert-snapshot
    *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    * @example body { "snapshot": "f07ab729-c0e8-721c-45ec-f11276377030", "snapshotBefore": true }
    */
   @Example(taskLocation)
   @Post('{id}/actions/revert_snapshot')
-  @Middlewares(json())
+  @Middlewares([json(), acl({ resource: 'vm', action: 'revert-snapshot', objectId: 'params.id' })])
   @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(noContentResp.status, noContentResp.description)
   @Response(notFoundResp.status, notFoundResp.description)
@@ -610,6 +610,9 @@ export class VmController extends XapiXoController<XoVm> {
   }
 
   /**
+   * Required privilege:
+   * - resource: vm, action: snapshot
+   *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    * @example body { "name_label": "my_awesome_snapshot" }
    */

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -575,7 +575,7 @@ export class VmController extends XapiXoController<XoVm> {
   /**
    * Required privilege:
    * - resource: vm, action: revert-snapshot
-   * - resource: vm, action: snapshot
+   * - resource: vm, action: snapshot (if `snapshotBefore: true`)
    *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    * @example body { "snapshotId": "f07ab729-c0e8-721c-45ec-f11276377030", "snapshotBefore": true }
@@ -615,11 +615,13 @@ export class VmController extends XapiXoController<XoVm> {
       }
 
       if (body.snapshotBefore) {
-        await Task.run({ properties: { name: 'snapshot VM' } }, () =>
+        await Task.run({ properties: { name: 'snapshot VM', objectId: vmId, objectType: 'VM' } }, () =>
           this.getXapiObject(vmId).$snapshot({ ignoredVdisTag: IGNORED_VDIS_TAG })
         )
 
-        await Task.run({ properties: { name: 'revert snapshot' } }, () => this.getXapi(vmId).revertVm(snapshotId))
+        await Task.run({ properties: { name: 'revert snapshot', objectId: vmId, objectType: 'VM' } }, () =>
+          this.getXapi(vmId).revertVm(snapshotId)
+        )
       } else {
         await this.getXapi(vmId).revertVm(snapshotId)
       }

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -576,6 +576,41 @@ export class VmController extends XapiXoController<XoVm> {
    * - resource: vm, action: snapshot
    *
    * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
+   * @example body { "snapshot": "f07ab729-c0e8-721c-45ec-f11276377030", "snapshotBefore": true }
+   */
+  @Example(taskLocation)
+  @Post('{id}/actions/revert_snapshot')
+  @Middlewares(json())
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  @Response(internalServerErrorResp.status, internalServerErrorResp.description)
+  async revertSnapshotVm(
+    @Path() id: string,
+    @Body() body: { snapshot: string; snapshotBefore?: boolean },
+    @Query() sync?: boolean
+  ): CreateActionReturnType<void> {
+    const vmId = id as XoVm['id']
+    const action = async () => {
+      if (body.snapshotBefore) {
+        await this.getXapiObject(vmId).$snapshot({ ignoredVdisTag: IGNORED_VDIS_TAG })
+      }
+
+      await this.getXapi(vmId).revertVm(body.snapshot as XoVmSnapshot['id'])
+    }
+
+    return this.createAction<void>(action, {
+      sync,
+      statusCode: noContentResp.status,
+      taskProperties: {
+        name: 'revert VM snapshot',
+        objectId: vmId,
+      },
+    })
+  }
+
+  /**
+   * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
    * @example body { "name_label": "my_awesome_snapshot" }
    */
   @Example(taskLocation)
@@ -609,40 +644,6 @@ export class VmController extends XapiXoController<XoVm> {
       statusCode: createdResp.status,
       taskProperties: {
         name: 'snapshot VM',
-        objectId: vmId,
-      },
-    })
-  }
-
-  /**
-   * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
-   * @example body { "snapshot": "f07ab729-c0e8-721c-45ec-f11276377030", "snapshotBefore": true }
-   */
-  @Example(taskLocation)
-  @Post('{id}/actions/revert_snapshot')
-  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
-  @Response(noContentResp.status, noContentResp.description)
-  @Response(notFoundResp.status, notFoundResp.description)
-  @Response(internalServerErrorResp.status, internalServerErrorResp.description)
-  async revertSnapshotVm(
-    @Path() id: string,
-    @Body() body: { snapshot: XoVmSnapshot['id']; snapshotBefore?: boolean },
-    @Query() sync?: boolean
-  ): CreateActionReturnType<void> {
-    const vmId = id as XoVm['id']
-    const action = async () => {
-      if (body.snapshotBefore) {
-        await this.getXapiObject(vmId).$snapshot({ ignoredVdisTag: IGNORED_VDIS_TAG })
-      }
-
-      await this.getXapi(vmId).revertVm(body.snapshot)
-    }
-
-    return this.createAction<void>(action, {
-      sync,
-      statusCode: noContentResp.status,
-      taskProperties: {
-        name: 'revert VM snapshot',
         objectId: vmId,
       },
     })

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -588,7 +588,7 @@ export class VmController extends XapiXoController<XoVm> {
       { resource: 'vm', action: 'revert-snapshot', objectId: 'params.id' },
       {
         resource: 'vm',
-        actions: ({ req }) => (req.body.snapshotBefore ? ['snapshot'] : []),
+        action: ({ req }) => (req.body.snapshotBefore ? 'snapshot' : undefined),
         objectId: 'params.id',
       },
     ]),

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -615,6 +615,40 @@ export class VmController extends XapiXoController<XoVm> {
   }
 
   /**
+   * @example id "f07ab729-c0e8-721c-45ec-f11276377030"
+   * @example body { "snapshot": "f07ab729-c0e8-721c-45ec-f11276377030", "snapshotBefore": true }
+   */
+  @Example(taskLocation)
+  @Post('{id}/actions/revert_snapshot')
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(noContentResp.status, noContentResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  @Response(internalServerErrorResp.status, internalServerErrorResp.description)
+  async revertSnapshotVm(
+    @Path() id: string,
+    @Body() body: { snapshot: XoVmSnapshot['id']; snapshotBefore?: boolean },
+    @Query() sync?: boolean
+  ): CreateActionReturnType<void> {
+    const vmId = id as XoVm['id']
+    const action = async () => {
+      if (body.snapshotBefore) {
+        await this.getXapiObject(vmId).$snapshot({ ignoredVdisTag: IGNORED_VDIS_TAG })
+      }
+
+      await this.getXapi(vmId).revertVm(body.snapshot)
+    }
+
+    return this.createAction<void>(action, {
+      sync,
+      statusCode: noContentResp.status,
+      taskProperties: {
+        name: 'revert VM snapshot',
+        objectId: vmId,
+      },
+    })
+  }
+
+  /**
    *
    * - For fast clone on the same SR, omit `srId` and set `fast` to `true`.
    * - For full copy on the same SR, omit `srId` and set `fast` to `false`.

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@
 - [xo-server] support qcow2 format in `disk.importContent` and `disk.import` jsonRPC api (PR [#9817](https://github.com/vatesfr/xen-orchestra/pull/9817))
 - [web-core] Update `UiTag` and parse tag for detecting tags with `=` (PR [#9811](https://github.com/vatesfr/xen-orchestra/pull/9811))
 - [Encryption] Implement encryption and decryption feature for redis (PR [#9735](https://github.com/vatesfr/xen-orchestra/pull/9735))
+- [REST API] Add `vms/:id/actions/revert_snapshot` REST route (PR [#9788](https://github.com/vatesfr/xen-orchestra/pull/9788))
 - **XO 5**:
   - [Export config] Hide passphrase by default (PR [#9824](https://github.com/vatesfr/xen-orchestra/pull/9824))
 - [Backups] Refactor clean phase for incremental and full backups ([#9765](https://github.com/vatesfr/xen-orchestra/pull/9765))
@@ -50,11 +51,6 @@
 
 - @vates/types minor
 - @xen-orchestra/acl minor
-- @xen-orchestra/backup-archive major
-- @xen-orchestra/backups minor
-- @xen-orchestra/backups-cli patch
-- @xen-orchestra/disk-cli minor
-- @xen-orchestra/disk-transform minor
 - @xen-orchestra/fs minor
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -51,6 +51,11 @@
 
 - @vates/types minor
 - @xen-orchestra/acl minor
+- @xen-orchestra/backup-archive major
+- @xen-orchestra/backups minor
+- @xen-orchestra/backups-cli patch
+- @xen-orchestra/disk-cli minor
+- @xen-orchestra/disk-transform minor
 - @xen-orchestra/fs minor
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor

--- a/docs/docs/xo6/acl-v2.md
+++ b/docs/docs/xo6/acl-v2.md
@@ -105,7 +105,7 @@ Actions are written using the exact string you pass in a privilege. A parent act
 
 | Resource        | Available actions                                                                                                                                                                               |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `vm`            | `read`, `delete`, `export`, `pause`, `start`, `resume`, `snapshot`, `suspend`, `unpause`, `reboot:clean`, `reboot:hard`, `shutdown:clean`, `shutdown:hard`, `update:datasources`, `update:tags` |
+| `vm`            | `read`, `delete`, `export`, `pause`, `start`, `resume`, `revert-snapshot`, `snapshot`, `suspend`, `unpause`, `reboot:clean`, `reboot:hard`, `shutdown:clean`, `shutdown:hard`, `update:datasources`, `update:tags` |
 | `vm-snapshot`   | `read`, `delete`, `export`, `update:tags`                                                                                                                                                       |
 | `vm-template`   | `read`, `delete`, `export`, `instantiate`, `update:tags`                                                                                                                                        |
 | `vm-controller` | `read`, `update:tags`                                                                                                                                                                           |


### PR DESCRIPTION
### Description

Added `vms/:id/actions/revert_snapshot` REST route protected by new `resource:vm` `action:revert-snapshot` and `resource:vm` `action:snapshot` acl privileges.

Route tested and working, acl tested.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
