### PR TITLE
docs(v2v migration guide): Highlight link to V2V troubleshooting doc

### DIFF
--- a/docs/docs/xo5/v2v-migration-guide.md
+++ b/docs/docs/xo5/v2v-migration-guide.md
@@ -254,7 +254,13 @@ Ensure stable network connectivity between the VMware environment, Xen Orchestra
 If warm migration fails, power off the VM, remove all snapshots, and try again.
 
 ## ❓ Need more help?
-For additional details and alternative methods, see the [XCP-ng migration guide](https://docs.xcp-ng.org/installation/migrate-to-xcp-ng/#ova).
+
+### Booting issues when importing VMs
+:::tip
+When migrating a VM from VMware, the system may fail to boot if the required Xen drivers are not pre-installed.
+
+To avoid this, use the `dracut` utility on the source VM prior to migration. For the specific driver injection procedure, refer to the [XCP-ng migration guide](https://docs.xcp-ng.org/installation/migrate-to-xcp-ng/#ova).
+:::
 
 ## 🚀 Boosting migration performance
 Migration speed depends on several factors. By identifying bottlenecks and optimizing your setup, you can significantly improve performance.


### PR DESCRIPTION
This pull request updates the [V2V migration guide](https://docs.xen-orchestra.com/v2v-migration-guide#-need-more-help) to address potential boot failures caused by missing Xen drivers. Some of our readers found that the link to the [relevant troubleshooting section on the XCP-ng doc](https://docs.xcp-ng.org/installation/migrate-to-xcp-ng/#ova) was too easy to miss, which prevented them from completing migrations successfully.

<img width="1462" height="827" alt="Capture d&#39;écran 2026-04-30 160241" src="https://github.com/user-attachments/assets/122586f9-7510-402d-a60e-566a45eaec4f" />

