### PR TITLE
fix(rest-api): early return for admin user in acl check

### DIFF
--- a/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
@@ -60,7 +60,9 @@ export abstract class BaseController<T extends RestXoRecord, IsSync extends bool
 
     const user = this.restApi.getCurrentUser()
     const userPrivileges = (
-      opts?.privilege !== undefined ? await this.restApi.xoApp.getAclV2UserPrivileges(user.id) : []
+      opts?.privilege !== undefined && user.permission !== 'admin'
+        ? await this.restApi.xoApp.getAclV2UserPrivileges(user.id)
+        : []
     ) as AnyPrivilege[]
 
     let limit = opts?.limit ?? Infinity

--- a/@xen-orchestra/rest-api/src/middlewares/acl.middleware.mts
+++ b/@xen-orchestra/rest-api/src/middlewares/acl.middleware.mts
@@ -275,6 +275,11 @@ export function acl(acls: AclEntry | AclEntry[]) {
       return next(new ValidateError(invalidFields, 'invalid parameters'))
     }
 
+    if (user.permission === 'admin') {
+      // Administrator users do not need to go further
+      return next()
+    }
+
     let userPrivileges: AnyPrivilege[]
     try {
       userPrivileges = (await restApi.xoApp.getAclV2UserPrivileges(user.id)) as AnyPrivilege[]

--- a/@xen-orchestra/rest-api/src/tasks/task.controller.mts
+++ b/@xen-orchestra/rest-api/src/tasks/task.controller.mts
@@ -113,7 +113,10 @@ export class TaskController extends XoController<XoTask> {
       const userId = this.restApi.getCurrentUser().id
       const update = async (task: XoTask) => {
         const user = await this.restApi.xoApp.getUser(userId)
-        const userPrivileges = (await this.restApi.xoApp.getAclV2UserPrivileges(user.id)) as AnyPrivilege[]
+        const userPrivileges =
+          user.permission === 'admin'
+            ? []
+            : ((await this.restApi.xoApp.getAclV2UserPrivileges(user.id)) as AnyPrivilege[])
 
         if (
           hasPrivilegeOn({ user, userPrivileges, action: 'read', resource: 'task', objects: task }) &&
@@ -124,7 +127,10 @@ export class TaskController extends XoController<XoTask> {
       }
       const remove = async (task: XoTask) => {
         const user = await this.restApi.xoApp.getUser(userId)
-        const userPrivileges = (await this.restApi.xoApp.getAclV2UserPrivileges(user.id)) as AnyPrivilege[]
+        const userPrivileges =
+          user.permission === 'admin'
+            ? []
+            : ((await this.restApi.xoApp.getAclV2UserPrivileges(user.id)) as AnyPrivilege[])
 
         if (
           hasPrivilegeOn({ user, userPrivileges, action: 'read', resource: 'task', objects: task }) &&
@@ -190,7 +196,8 @@ export class TaskController extends XoController<XoTask> {
   @SuccessResponse(noContentResp.status, noContentResp.description)
   async deleteTasks(): Promise<void> {
     const user = this.restApi.getCurrentUser()
-    const userPrivileges = (await this.restApi.xoApp.getAclV2UserPrivileges(user.id)) as AnyPrivilege[]
+    const userPrivileges =
+      user.permission === 'admin' ? [] : ((await this.restApi.xoApp.getAclV2UserPrivileges(user.id)) as AnyPrivilege[])
 
     const deletePromises: Promise<void>[] = []
     for await (const task of this.restApi.tasks.list()) {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,8 @@
 
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
+- [REST API] Fix REST API not available for clients with plan < Entreprise (PR [#9798](https://github.com/vatesfr/xen-orchestra/pull/9798))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -33,6 +35,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/rest-api patch
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@
 
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
-- [REST API] Fix REST API not available for clients with plan < Entreprise (PR [#9798](https://github.com/vatesfr/xen-orchestra/pull/9798))
+- [REST API] Fix REST API not available for clients with plan < Enterprise (PR [#9798](https://github.com/vatesfr/xen-orchestra/pull/9798))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

Voluntary keep the `for (const acl of _acls) {...}` to standardize HTTP responses between non-admin and admin users. (E.g., 404 instead of 202 for actions, and so on)

For users with plan < Enterprise, it throw because `getAclV2UserPrivileges` call `checkFeatureAuthorization`.
For user admin, this don't need to be called

See https://xcp-ng.org/forum/post/104896

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
