### PR TITLE
docs(sdn_controller.md): openSSL 3 + sdn upgrade path: fix error in code sample

### DIFF
--- a/docs/docs/xo5/sdn_controller.md
+++ b/docs/docs/xo5/sdn_controller.md
@@ -197,7 +197,7 @@ We provide a script to run from a host that has access to your pool. To run the 
 Copy the file to where you want to run the script, then run this:
 
 ```
-$ bash -xe check-sdn-features.sh <pool-master-ip1> [pool-master-ip2] [pool-master-ip3] ...
+$ bash check-sdn-features.sh <pool-master-ip1> [pool-master-ip2] [pool-master-ip3] ...
 ```
 
 The script will connect to those masters and check:


### PR DESCRIPTION
As reported by @Danp2, the previous version of the code sample showed the script executing line by line. It works as expected after removing the `-xe`.
