### PR TITLE
fix(complex-matcher): use !== undefined instead of truthiness check in setPropertyClause

### DIFF
--- a/packages/complex-matcher/index.js
+++ b/packages/complex-matcher/index.js
@@ -618,7 +618,8 @@ exports.getPropertyClausesStrings = function getPropertyClausesStrings(node) {
 // -------------------------------------------------------------------
 
 exports.setPropertyClause = function setPropertyClause(node, name, child) {
-  const property = child && new Property(name, typeof child === 'string' ? new StringNode(child) : child)
+  const property =
+    child !== undefined ? new Property(name, typeof child === 'string' ? new StringNode(child) : child) : undefined
 
   if (node === undefined) {
     return property

--- a/packages/complex-matcher/index.test.js
+++ b/packages/complex-matcher/index.test.js
@@ -118,10 +118,14 @@ describe('setPropertyClause', () => {
     assert.equal(setPropertyClause(parse('foo:|(baz plop)'), 'foo', 'bar').toString(), 'foo:bar')
   })
 
-  it('removes the property clause if no chid is passed', () => {
+  it('removes the property clause if undefined is passed', () => {
     assert.equal(setPropertyClause(parse('foo bar:baz qux'), 'bar', undefined).toString(), 'foo qux')
 
     assert.equal(setPropertyClause(parse('foo bar:baz qux'), 'baz', undefined).toString(), 'foo bar:baz qux')
+  })
+
+  it('keeps the property clause for empty string or other falsy values', () => {
+    assert.equal(setPropertyClause(parse('foo bar:baz qux'), 'bar', '').toString(), 'foo qux bar:""')
   })
 })
 


### PR DESCRIPTION
## Summary

In `setPropertyClause`, the previous code used a truthiness check (`child &&`) to decide whether to create a `Property` node. This meant any falsy value (`null`, `0`, `''`, `false`) passed as `child` would silently skip creating the property clause instead of matching that value. Only `undefined` should be treated as "remove the clause".

Changed to `child !== undefined ?` so that falsy-but-present values correctly produce a `Property` node, while only `undefined` results in removal of the clause.