### PR TITLE
fix(complex-matcher): avoid array allocation in isRawString

### DIFF
--- a/packages/complex-matcher/index.js
+++ b/packages/complex-matcher/index.js
@@ -17,7 +17,12 @@ const RAW_STRING_SYMBOLS = {
 const isRawStringChar = c =>
   (c >= '0' && c <= '9') || c in RAW_STRING_SYMBOLS || !(c === c.toUpperCase() && c === c.toLowerCase())
 
-const isRawString = string => [...string].every(isRawStringChar)
+const isRawString = string => {
+  for (const c of string) {
+    if (!isRawStringChar(c)) return false
+  }
+  return true
+}
 
 // -------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Replaces `[...string].every(isRawStringChar)` with a `for...of` loop in `isRawString`
- The spread `[...string]` allocated a temporary heap array on every call; the `for...of` loop iterates the string directly, avoiding the allocation

## Test plan

- [ ] Existing tests in `packages/complex-matcher` pass