### PR TITLE
fix(complex-matcher): update engines to reflect actual Node.js requirement

### DIFF
--- a/packages/complex-matcher/package.json
+++ b/packages/complex-matcher/package.json
@@ -21,7 +21,7 @@
     ">2%"
   ],
   "engines": {
-    "node": ">=6"
+    "node": ">=18"
   },
   "dependencies": {
     "lodash": "^4.18.0"


### PR DESCRIPTION
## Summary

- Updates `engines.node` from `>=6` to `>=18`

The code uses ES2015+ features (classes, arrow functions, spread operator, `for...of`) that are unavailable in Node 6. `>=18` better reflects the actual minimum requirement and aligns with current active LTS.

## Test plan

- [ ] Verify `npm test` still passes on Node 18+