### PR TITLE
feat(web-core): updated UiModal to v3

### DIFF
--- a/@xen-orchestra/lite/src/components/modals/JsonEditorModal.vue
+++ b/@xen-orchestra/lite/src/components/modals/JsonEditorModal.vue
@@ -1,6 +1,6 @@
 <template>
   <VtsModal
-    :accent="isJsonValid ? 'success' : 'danger'"
+    :accent="isJsonValid ? 'info' : 'danger'"
     class="json-editor-modal"
     icon="fa:code"
     @confirm="handleSubmit()"

--- a/@xen-orchestra/lite/src/route-map.d.ts
+++ b/@xen-orchestra/lite/src/route-map.d.ts
@@ -323,6 +323,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/story/web-core/drawer/vts-drawer': RouteRecordInfo<
+      '/story/web-core/drawer/vts-drawer',
+      '/story/web-core/drawer/vts-drawer',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/story/web-core/dropdown-title/vts-dropdown-title': RouteRecordInfo<
       '/story/web-core/dropdown-title/vts-dropdown-title',
       '/story/web-core/dropdown-title/vts-dropdown-title',
@@ -361,6 +368,13 @@ declare module 'vue-router/auto-routes' {
     '/story/web-core/legend-group/vts-legend-group': RouteRecordInfo<
       '/story/web-core/legend-group/vts-legend-group',
       '/story/web-core/legend-group/vts-legend-group',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
+    '/story/web-core/modal/vts-modal': RouteRecordInfo<
+      '/story/web-core/modal/vts-modal',
+      '/story/web-core/modal/vts-modal',
       Record<never, never>,
       Record<never, never>,
       | never
@@ -624,6 +638,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/story/web-core/ui/drawer/ui-drawer': RouteRecordInfo<
+      '/story/web-core/ui/drawer/ui-drawer',
+      '/story/web-core/ui/drawer/ui-drawer',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/story/web-core/ui/dropdown/ui-dropdown': RouteRecordInfo<
       '/story/web-core/ui/dropdown/ui-dropdown',
       '/story/web-core/ui/dropdown/ui-dropdown',
@@ -711,6 +732,13 @@ declare module 'vue-router/auto-routes' {
     '/story/web-core/ui/logo-text/ui-logo-text': RouteRecordInfo<
       '/story/web-core/ui/logo-text/ui-logo-text',
       '/story/web-core/ui/logo-text/ui-logo-text',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
+    '/story/web-core/ui/modal/ui-modal': RouteRecordInfo<
+      '/story/web-core/ui/modal/ui-modal',
+      '/story/web-core/ui/modal/ui-modal',
       Record<never, never>,
       Record<never, never>,
       | never
@@ -1235,6 +1263,12 @@ declare module 'vue-router/auto-routes' {
       views:
         | never
     }
+    'src/stories/web-core/drawer/vts-drawer.story.vue': {
+      routes:
+        | '/story/web-core/drawer/vts-drawer'
+      views:
+        | never
+    }
     'src/stories/web-core/dropdown-title/vts-dropdown-title.story.vue': {
       routes:
         | '/story/web-core/dropdown-title/vts-dropdown-title'
@@ -1268,6 +1302,12 @@ declare module 'vue-router/auto-routes' {
     'src/stories/web-core/legend-group/vts-legend-group.story.vue': {
       routes:
         | '/story/web-core/legend-group/vts-legend-group'
+      views:
+        | never
+    }
+    'src/stories/web-core/modal/vts-modal.story.vue': {
+      routes:
+        | '/story/web-core/modal/vts-modal'
       views:
         | never
     }
@@ -1493,6 +1533,12 @@ declare module 'vue-router/auto-routes' {
       views:
         | never
     }
+    'src/stories/web-core/ui/drawer/ui-drawer.story.vue': {
+      routes:
+        | '/story/web-core/ui/drawer/ui-drawer'
+      views:
+        | never
+    }
     'src/stories/web-core/ui/dropdown/ui-dropdown.story.vue': {
       routes:
         | '/story/web-core/ui/dropdown/ui-dropdown'
@@ -1568,6 +1614,12 @@ declare module 'vue-router/auto-routes' {
     'src/stories/web-core/ui/logo-text/ui-logo-text.story.vue': {
       routes:
         | '/story/web-core/ui/logo-text/ui-logo-text'
+      views:
+        | never
+    }
+    'src/stories/web-core/ui/modal/ui-modal.story.vue': {
+      routes:
+        | '/story/web-core/ui/modal/ui-modal'
       views:
         | never
     }

--- a/@xen-orchestra/lite/src/stories/web-core/modal/vts-modal.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/modal/vts-modal.story.vue
@@ -24,7 +24,7 @@
       setting('showDemoButtons').widget(boolean()),
     ]"
   >
-    <VtsModal :accent="properties.accent" :dismissible="properties.dismissible" class="story" v-bind="properties">
+    <VtsModal class="story" v-bind="properties">
       <template #title>{{ settings.titleSlotContent }}</template>
       <template #content>{{ settings.contentSlotContent }}</template>
       <template v-if="settings.showDemoButtons" #buttons>
@@ -43,3 +43,10 @@ import VtsModal from '@core/components/modal/VtsModal.vue'
 import VtsModalCancelButton from '@core/components/modal/VtsModalCancelButton.vue'
 import VtsModalConfirmButton from '@core/components/modal/VtsModalConfirmButton.vue'
 </script>
+
+<style lang="postcss" scoped>
+.story {
+  position: relative;
+  height: 100%;
+}
+</style>

--- a/@xen-orchestra/lite/src/stories/web-core/modal/vts-modal.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/modal/vts-modal.story.vue
@@ -1,0 +1,45 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties, settings }"
+    :params="[
+      prop('accent').required().enum('info', 'warning', 'danger').preset('info').widget(),
+      iconProp(),
+      prop('dismissible').bool().widget(),
+      prop('onDismiss').type('function').widget(),
+      prop('onConfirm').type('function').widget(),
+      prop('current').bool().widget(),
+      event('confirm'),
+      event('dismiss'),
+      slot('title'),
+      slot('content'),
+      slot('buttons'),
+      setting('titleSlotContent')
+        .preset('Example content for title slot')
+        .widget(text())
+        .help('Content for title slot'),
+      setting('contentSlotContent')
+        .preset('Example content for content slot')
+        .widget(text())
+        .help('Content for content slot'),
+      setting('showDemoButtons').widget(boolean()),
+    ]"
+  >
+    <VtsModal :accent="properties.accent" :dismissible="properties.dismissible" class="story" v-bind="properties">
+      <template #title>{{ settings.titleSlotContent }}</template>
+      <template #content>{{ settings.contentSlotContent }}</template>
+      <template v-if="settings.showDemoButtons" #buttons>
+        <VtsModalCancelButton>Cancel</VtsModalCancelButton>
+        <VtsModalConfirmButton> Confirm </VtsModalConfirmButton>
+      </template>
+    </VtsModal>
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import { iconProp, prop, event, slot, setting } from '@/libs/story/story-param'
+import { text, boolean } from '@/libs/story/story-widget'
+import VtsModal from '@core/components/modal/VtsModal.vue'
+import VtsModalCancelButton from '@core/components/modal/VtsModalCancelButton.vue'
+import VtsModalConfirmButton from '@core/components/modal/VtsModalConfirmButton.vue'
+</script>

--- a/@xen-orchestra/lite/src/stories/web-core/ui/modal/ui-modal.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/modal/ui-modal.story.vue
@@ -1,0 +1,42 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties, settings }"
+    :params="[
+      prop('accent').required().enum('info', 'warning', 'danger').preset('info').widget(),
+      iconProp(),
+      prop('dismissible').bool().widget(),
+      prop('onDismiss').type('function').widget(),
+      event('dismiss'),
+      slot('title'),
+      slot('content'),
+      slot('buttons'),
+      setting('titleSlotContent')
+        .preset('Example content for title slot')
+        .widget(text())
+        .help('Content for title slot'),
+      setting('contentSlotContent')
+        .preset('Example content for content slot')
+        .widget(text())
+        .help('Content for content slot'),
+      setting('showDemoButton').widget(boolean()).preset(true),
+    ]"
+  >
+    <UiModal :accent="properties.accent" :dismissible="properties.dismissible" class="story" v-bind="properties">
+      <template #title>{{ settings.titleSlotContent }}</template>
+      <template #content>{{ settings.contentSlotContent }}</template>
+      <template v-if="settings.showDemoButton" #buttons>
+        <UiButton :accent="properties.accent == 'info' ? 'brand' : properties.accent" variant="primary" size="medium">
+          Confirm
+        </UiButton>
+      </template>
+    </UiModal>
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import { iconProp, prop, event, slot, setting } from '@/libs/story/story-param'
+import { text, boolean } from '@/libs/story/story-widget'
+import UiButton from '@core/components/ui/button/UiButton.vue'
+import UiModal from '@core/components/ui/modal/UiModal.vue'
+</script>

--- a/@xen-orchestra/lite/src/stories/web-core/ui/modal/ui-modal.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/modal/ui-modal.story.vue
@@ -21,11 +21,11 @@
       setting('showDemoButton').widget(boolean()).preset(true),
     ]"
   >
-    <UiModal :accent="properties.accent" :dismissible="properties.dismissible" class="story" v-bind="properties">
+    <UiModal class="story" v-bind="properties">
       <template #title>{{ settings.titleSlotContent }}</template>
       <template #content>{{ settings.contentSlotContent }}</template>
       <template v-if="settings.showDemoButton" #buttons>
-        <UiButton :accent="properties.accent == 'info' ? 'brand' : properties.accent" variant="primary" size="medium">
+        <UiButton :accent="properties.accent === 'info' ? 'brand' : properties.accent" variant="primary" size="medium">
           Confirm
         </UiButton>
       </template>
@@ -40,3 +40,10 @@ import { text, boolean } from '@/libs/story/story-widget'
 import UiButton from '@core/components/ui/button/UiButton.vue'
 import UiModal from '@core/components/ui/modal/UiModal.vue'
 </script>
+
+<style lang="postcss" scoped>
+.story {
+  position: relative;
+  height: 100%;
+}
+</style>

--- a/@xen-orchestra/web-core/lib/components/modal/VtsModalButton.vue
+++ b/@xen-orchestra/web-core/lib/components/modal/VtsModalButton.vue
@@ -26,7 +26,6 @@ const modalAccent = inject(IK_MODAL_ACCENT)
 const buttonAccent = useMapper(
   () => modalAccent?.value,
   {
-    success: 'brand',
     info: 'brand',
     warning: 'warning',
     danger: 'danger',

--- a/@xen-orchestra/web-core/lib/components/query-builder/VtsQueryBuilderModal.vue
+++ b/@xen-orchestra/web-core/lib/components/query-builder/VtsQueryBuilderModal.vue
@@ -44,7 +44,6 @@ const uiStore = useUiStore()
   }
 
   &:deep(.modal) {
-    background-color: var(--color-neutral-background-primary) !important;
     padding: 0;
     gap: 0;
 

--- a/@xen-orchestra/web-core/lib/components/ui/modal/UiModal.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/modal/UiModal.vue
@@ -1,4 +1,4 @@
-<!-- v3 -->
+<!-- v4 -->
 <template>
   <form :class="className" class="ui-modal" @click.self="emit('dismiss')">
     <div class="modal">
@@ -36,7 +36,7 @@ import { useMapper } from '@core/packages/mapper'
 import { toVariants } from '@core/utils/to-variants.util.ts'
 import { computed } from 'vue'
 
-export type ModalAccent = 'info' | 'success' | 'warning' | 'danger'
+export type ModalAccent = 'info' | 'warning' | 'danger'
 
 const { accent } = defineProps<{
   accent: ModalAccent
@@ -58,7 +58,6 @@ const closeIconAccent = useMapper(
   () => accent,
   {
     info: 'brand',
-    success: 'brand',
     warning: 'warning',
     danger: 'danger',
   },
@@ -76,6 +75,11 @@ const className = computed(() => toVariants({ accent }))
   justify-content: center;
   align-items: center;
 
+  &.story {
+    position: relative;
+    height: 100%;
+  }
+
   .modal {
     display: flex;
     flex-direction: column;
@@ -84,7 +88,7 @@ const className = computed(() => toVariants({ accent }))
     max-height: min(90vh, 80rem);
     padding: 3.2rem 2.4rem 2.4rem;
     gap: 2.4rem;
-    background-color: var(--color-neutral-background-primary);
+    background-color: var(--color-neutral-background-secondary);
     border-radius: 1rem;
     border-width: 0.1rem;
     border-style: solid;
@@ -130,16 +134,6 @@ const className = computed(() => toVariants({ accent }))
 
     .main .icon {
       color: var(--color-info-txt-base);
-    }
-  }
-
-  &.accent--success {
-    .modal {
-      border-color: var(--color-success-item-base);
-    }
-
-    .main .icon {
-      color: var(--color-success-txt-base);
     }
   }
 

--- a/@xen-orchestra/web-core/lib/components/ui/modal/UiModal.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/modal/UiModal.vue
@@ -75,11 +75,6 @@ const className = computed(() => toVariants({ accent }))
   justify-content: center;
   align-items: center;
 
-  &.story {
-    position: relative;
-    height: 100%;
-  }
-
   .modal {
     display: flex;
     flex-direction: column;

--- a/@xen-orchestra/web-core/lib/components/ui/modal/UiModal.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/modal/UiModal.vue
@@ -1,4 +1,4 @@
-<!-- v2 -->
+<!-- v3 -->
 <template>
   <form :class="className" class="ui-modal" @click.self="emit('dismiss')">
     <div class="modal">
@@ -7,8 +7,8 @@
         :accent="closeIconAccent"
         :target-scale="2"
         class="dismiss-button"
-        icon="fa:xmark"
-        size="small"
+        icon="action:close-cancel-clear"
+        size="medium"
         @click="emit('dismiss')"
       />
       <main class="main">
@@ -84,7 +84,10 @@ const className = computed(() => toVariants({ accent }))
     max-height: min(90vh, 80rem);
     padding: 3.2rem 2.4rem 2.4rem;
     gap: 2.4rem;
+    background-color: var(--color-neutral-background-primary);
     border-radius: 1rem;
+    border-width: 0.1rem;
+    border-style: solid;
 
     &:not(:has(.buttons)) {
       padding-bottom: 3.2rem;
@@ -122,7 +125,7 @@ const className = computed(() => toVariants({ accent }))
 
   &.accent--info {
     .modal {
-      background-color: var(--color-info-background-selected);
+      border-color: var(--color-info-item-base);
     }
 
     .main .icon {
@@ -132,7 +135,7 @@ const className = computed(() => toVariants({ accent }))
 
   &.accent--success {
     .modal {
-      background-color: var(--color-success-background-selected);
+      border-color: var(--color-success-item-base);
     }
 
     .main .icon {
@@ -142,7 +145,7 @@ const className = computed(() => toVariants({ accent }))
 
   &.accent--warning {
     .modal {
-      background-color: var(--color-warning-background-selected);
+      border-color: var(--color-warning-item-base);
     }
 
     .main .icon {
@@ -152,7 +155,7 @@ const className = computed(() => toVariants({ accent }))
 
   &.accent--danger {
     .modal {
-      background-color: var(--color-danger-background-selected);
+      border-color: var(--color-danger-item-base);
     }
 
     .main .icon {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -45,6 +45,7 @@
 - [Pool/System] Add `Reboot VM on internal shutdown` in pool's system tab (PR [#9962](https://github.com/vatesfr/xen-orchestra/pull/9962))
 - [Netbox] Support Netbox v4.6.x [#9818](https://github.com/vatesfr/xen-orchestra/issues/9818) (PR [#9939](https://github.com/vatesfr/xen-orchestra/pull/9939))
 - [Icons] Updated connect/disconnect icons to use a plug icon (PR [#9942](https://github.com/vatesfr/xen-orchestra/pull/9942))
+- [web-core] Updated modal windows with a border and unified backgound color for better readability (PR [#9825](https://github.com/vatesfr/xen-orchestra/pull/9825))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -45,7 +45,7 @@
 - [Pool/System] Add `Reboot VM on internal shutdown` in pool's system tab (PR [#9962](https://github.com/vatesfr/xen-orchestra/pull/9962))
 - [Netbox] Support Netbox v4.6.x [#9818](https://github.com/vatesfr/xen-orchestra/issues/9818) (PR [#9939](https://github.com/vatesfr/xen-orchestra/pull/9939))
 - [Icons] Updated connect/disconnect icons to use a plug icon (PR [#9942](https://github.com/vatesfr/xen-orchestra/pull/9942))
-- [web-core] Updated modal windows with a border and unified backgound color for better readability (PR [#9825](https://github.com/vatesfr/xen-orchestra/pull/9825))
+- [Modal] Updated modal windows with a border and unified backgound color for better readability (PR [#9825](https://github.com/vatesfr/xen-orchestra/pull/9825))
 
 ### Bug fixes
 


### PR DESCRIPTION
**[Web-core] Update `UiModal` component**

- Added colored border
- Unified background
- Updated close icon to v5

### Screenshots:

|  | Light | Dark |
|---|---|---|
| Info | <img width="1055" height="297" alt="Screenshot 2026-05-07 at 17-31-12 Xen Orchestra" src="https://github.com/user-attachments/assets/143f786a-eea8-49d4-9d2e-9ff795faffe9" /> | <img width="1065" height="305" alt="Screenshot 2026-05-07 at 17-30-37 Xen Orchestra" src="https://github.com/user-attachments/assets/0a632275-6d48-4fe0-9658-b6b9aa6cbc28" /> |
| Warning | <img width="1054" height="300" alt="Screenshot 2026-05-07 at 17-31-24 Xen Orchestra" src="https://github.com/user-attachments/assets/b805d87f-5cf1-4fbd-89a9-794e9412e0c9" /> | <img width="1069" height="307" alt="Screenshot 2026-05-07 at 17-30-48 Xen Orchestra" src="https://github.com/user-attachments/assets/e0e65d94-9e7f-4552-b1fa-55957f2b79a8" /> |
| Danger | <img width="610" height="301" alt="Screenshot 2026-05-07 at 17-31-31 Xen Orchestra" src="https://github.com/user-attachments/assets/5c4ec07f-ed1b-4717-bcf7-a0d55b32f431" /> | <img width="613" height="305" alt="Screenshot 2026-05-07 at 17-30-57 Xen Orchestra" src="https://github.com/user-attachments/assets/969c68e2-4ddd-4597-b32b-b599fe566b08" /> |
