### PR TITLE
feat(rest-api): connect/disable backup-repository

### DIFF
--- a/@vates/types/src/xo-app.mts
+++ b/@vates/types/src/xo-app.mts
@@ -294,6 +294,7 @@ export type XoApp = {
       name?: string
     }
   ): void
+  updateRemote(id: XoBackupRepository['id'], props: { enabled?: boolean }): Promise<void>
   getAllXapis(): Record<string, XapiConnection>
   getObjects(opts?: { filter?: Record<string, unknown>; limit?: number }): Record<string, XapiXoRecord>
 }

--- a/@xen-orchestra/acl/src/actions/backup-repository.mts
+++ b/@xen-orchestra/acl/src/actions/backup-repository.mts
@@ -1,3 +1,5 @@
 export default {
+  connect: true,
+  disable: true,
   read: true,
 }

--- a/@xen-orchestra/rest-api/src/backup-repositories/backup-repositories.controller.mts
+++ b/@xen-orchestra/rest-api/src/backup-repositories/backup-repositories.controller.mts
@@ -1,4 +1,17 @@
-import { Example, Get, Middlewares, Path, Query, Request, Response, Route, Security, Tags } from 'tsoa'
+import {
+  Example,
+  Get,
+  Middlewares,
+  Path,
+  Post,
+  Query,
+  Request,
+  Response,
+  Route,
+  Security,
+  SuccessResponse,
+  Tags,
+} from 'tsoa'
 import { inject } from 'inversify'
 import { provide } from 'inversify-binding-decorators'
 import { Request as ExRequest } from 'express'
@@ -6,8 +19,10 @@ import type { XoBackupRepository } from '@vates/types'
 
 import { acl } from '../middlewares/acl.middleware.mjs'
 import {
+  asynchronousActionResp,
   badRequestResp,
   forbiddenOperationResp,
+  noContentResp,
   notFoundResp,
   unauthorizedResp,
   type Unbrand,
@@ -20,6 +35,8 @@ import {
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
+import type { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
+import { taskLocation } from '../open-api/oa-examples/task.oa-example.mjs'
 
 @Route('backup-repositories')
 @Security('*')
@@ -86,5 +103,63 @@ export class BackupRepositoryController extends XoController<XoBackupRepository>
   @Response(notFoundResp.status, notFoundResp.description)
   getRepository(@Path() id: string): Promise<Unbrand<XoBackupRepository>> {
     return this.getObject(id as XoBackupRepository['id'])
+  }
+
+  /**
+   * Required privilege:
+   * - resource: backup-repository, action: connect
+   *
+   * @example id "c4284e12-37c9-7967-b9e8-83ef229c3e03"
+   */
+  @Example(taskLocation)
+  @Post('{id}/actions/connect')
+  @Middlewares(
+    acl({
+      resource: 'backup-repository',
+      action: 'connect',
+      objectId: 'params.id',
+      getObject: ({ restApi }) => restApi.xoApp.getRemote,
+    })
+  )
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  connectBackupRepository(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
+    const backupRepositoryId = id as XoBackupRepository['id']
+    return this.createAction<void>(() => this.restApi.xoApp.updateRemote(backupRepositoryId, { enabled: true }), {
+      statusCode: noContentResp.status,
+      sync,
+      taskProperties: { name: 'connect backup repository', objectId: backupRepositoryId },
+    })
+  }
+
+  /**
+   * Required privilege:
+   * - resource: backup-repository, action: disable
+   *
+   * @example id "c4284e12-37c9-7967-b9e8-83ef229c3e03"
+   */
+  @Example(taskLocation)
+  @Post('{id}/actions/disable')
+  @Middlewares(
+    acl({
+      resource: 'backup-repository',
+      action: 'disable',
+      objectId: 'params.id',
+      getObject: ({ restApi }) => restApi.xoApp.getRemote,
+    })
+  )
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(noContentResp.status, noContentResp.description)
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  disableBackupRepository(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
+    const backupRepositoryId = id as XoBackupRepository['id']
+    return this.createAction<void>(() => this.restApi.xoApp.updateRemote(backupRepositoryId, { enabled: false }), {
+      statusCode: noContentResp.status,
+      sync,
+      taskProperties: { name: 'disable backup repository', objectId: backupRepositoryId },
+    })
   }
 }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,7 +13,7 @@
 
 - [xo-web] support qcow2 format in disk > import (PR [#9817](https://github.com/vatesfr/xen-orchestra/pull/9817))
 - [xo-server] support qcow2 format in `disk.importContent` and `disk.import` jsonRPC api (PR [#9817](https://github.com/vatesfr/xen-orchestra/pull/9817))
-- [REST API] Expose POST `/backup-repositories/:id/actions/connect` and POST `/backup-repositories/:id/actions/disable` routes (PR [#](https://github.com/vatesfr/xen-orchestra/pull/))
+- [REST API] Expose POST `/backup-repositories/:id/actions/connect` and POST `/backup-repositories/:id/actions/disable` routes (PR [#9832](https://github.com/vatesfr/xen-orchestra/pull/9832))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,7 @@
 
 - [xo-web] support qcow2 format in disk > import (PR [#9817](https://github.com/vatesfr/xen-orchestra/pull/9817))
 - [xo-server] support qcow2 format in `disk.importContent` and `disk.import` jsonRPC api (PR [#9817](https://github.com/vatesfr/xen-orchestra/pull/9817))
+- [REST API] Expose POST `/backup-repositories/:id/actions/connect` and POST `/backup-repositories/:id/actions/disable` routes (PR [#](https://github.com/vatesfr/xen-orchestra/pull/))
 
 ### Bug fixes
 
@@ -36,7 +37,9 @@
 
 <!--packages-start-->
 
-- @xen-orchestra/rest-api patch
+- @vates/types minor
+- @xen-orchestra/acl minor
+- @xen-orchestra/rest-api minor
 - @xen-orchestra/web-core minor
 - xo-server minor
 - xo-web minor

--- a/docs/docs/xo6/acl-v2.md
+++ b/docs/docs/xo6/acl-v2.md
@@ -135,7 +135,7 @@ Actions are written using the exact string you pass in a privilege. A parent act
 | `backup-job`        | `read`                                              |
 | `backup-archive`    | `read`                                              |
 | `backup-log`        | `read`                                              |
-| `backup-repository` | `read`                                              |
+| `backup-repository` | `connect`, `disable`, `read`                        |
 | `schedule`          | `read`, `run`                                       |
 | `restore-log`       | `read`                                              |
 | `proxy`             | `read`                                              |


### PR DESCRIPTION
### Description

[XO-2183](https://project.vates.tech/vates-global/browse/XO-2183/)

Added `/backup-repositories/:id/actions/connect` and POST `/backup-repositories/:id/actions/disable` REST action routes, protected by ACLs.

Added connect and disable actions to backup-repository ACL.

"disable" used instead of "disconnect" as per card wording.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
