### PR TITLE
feat(web-core/web/lite): updated UiPanel to v5

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@
 
 # Generated files
 /@xen-orchestra/web/src/route-map.d.ts
+/@xen-orchestra/lite/src/route-map.d.ts

--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update the UiCard component to use the one from web-core (PR [#9980](https://github.com/vatesfr/xen-orchestra/pull/9980))
 - Update the UiCardTitle component to use the one from web-core (PR [#9982](https://github.com/vatesfr/xen-orchestra/pull/9982))
 - Replacement of the UiSeparator component with VtsDivider from web-core (PR [#10017](https://github.com/vatesfr/xen-orchestra/pull/10017))
+- Update side panels (PR [#9836](https://github.com/vatesfr/xen-orchestra/pull/9836))
 
 ## **0.22.0** (2026-05-28)
 

--- a/@xen-orchestra/lite/src/components/host/network/HostPifSidePanel.vue
+++ b/@xen-orchestra/lite/src/components/host/network/HostPifSidePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsSidePanel :selected="!!pif" :closable="!!pif" @close="emit('close')">
+  <VtsSidePanel :has-selection="!!pif" @close="emit('close')">
     <template v-if="pif" #actions>
       <UiButton
         v-tooltip="t('coming-soon!')"
@@ -22,255 +22,252 @@
         {{ t('action:delete') }}
       </UiButton>
     </template>
-    <template #default>
-      <VtsStateHero v-if="!pif" format="panel" type="no-selection" size="medium" />
-      <template v-else>
-        <!-- PIF -->
-        <UiCard class="card">
-          <UiCardTitle>{{ isBond ? t('bond') : t('pif') }}</UiCardTitle>
-          <div class="content">
-            <!-- UUID -->
-            <VtsCardRowKeyValue>
+    <template v-if="pif" #default>
+      <!-- PIF -->
+      <UiCard class="card">
+        <UiCardTitle>{{ isBond ? t('bond') : t('pif') }}</UiCardTitle>
+        <div class="content">
+          <!-- UUID -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('uuid') }}
+            </template>
+            <template #value>
+              {{ pif.uuid }}
+            </template>
+            <template #addons>
+              <VtsIcon v-if="pif.management" v-tooltip="t('management')" name="status:primary-circle" size="medium" />
+              <VtsCopyButton :value="pif.uuid" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- NETWORK -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('network') }}
+            </template>
+            <template #value>
+              <div class="network">
+                <!-- TODO Remove the span when the link works and the icon is fixed -->
+                <span v-tooltip class="value">{{ network?.name_label }}</span>
+              </div>
+            </template>
+            <template v-if="network?.name_label" #addons>
+              <VtsCopyButton :value="network.name_label" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- DEVICE -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('device') }}
+            </template>
+            <template #value>
+              {{ pif.device }}
+            </template>
+            <template #addons>
+              <VtsCopyButton :value="pif.device" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- PIF STATUS -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ isBond ? t('bond-status') : t('pif-status') }}
+            </template>
+            <template #value>
+              <VtsStatus :status />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- PHYSICAL INTERFACE STATUS -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('physical-interface-status') }}
+            </template>
+            <template #value>
+              <VtsStatus :status="physicalInterfaceStatus" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- VLAN -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('vlan') }}
+            </template>
+            <template #value>
+              {{ pif.VLAN === -1 ? t('none') : pif.VLAN }}
+            </template>
+            <template v-if="pif.VLAN !== -1" #addons>
+              <VtsCopyButton :value="String(pif.VLAN)" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- TAGS -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('tags') }}
+            </template>
+            <template #value>
+              <UiTagsList class="tags value">
+                <VtsTag v-for="tag in network?.tags" :key="tag" :value="tag" />
+              </UiTagsList>
+            </template>
+          </VtsCardRowKeyValue>
+        </div>
+      </UiCard>
+      <!-- NETWORK INFORMATION -->
+      <UiCard class="card">
+        <UiCardTitle>{{ t('network-information') }}</UiCardTitle>
+        <div class="content">
+          <!-- IP ADDRESSES -->
+          <div v-if="ipAddresses.length">
+            <VtsCardRowKeyValue v-for="(ip, index) in ipAddresses" :key="ip">
               <template #key>
-                {{ t('uuid') }}
+                <div v-if="index === 0">{{ t('ip-addresses') }}</div>
               </template>
               <template #value>
-                {{ pif.uuid }}
+                <span v-tooltip class="text-ellipsis">{{ ip }}</span>
               </template>
               <template #addons>
-                <VtsIcon v-if="pif.management" v-tooltip="t('management')" name="status:primary-circle" size="medium" />
-                <VtsCopyButton :value="pif.uuid" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- NETWORK -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('network') }}
-              </template>
-              <template #value>
-                <div class="network">
-                  <!-- TODO Remove the span when the link works and the icon is fixed -->
-                  <span v-tooltip class="value">{{ network?.name_label }}</span>
-                </div>
-              </template>
-              <template v-if="network?.name_label" #addons>
-                <VtsCopyButton :value="network.name_label" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- DEVICE -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('device') }}
-              </template>
-              <template #value>
-                {{ pif.device }}
-              </template>
-              <template #addons>
-                <VtsCopyButton :value="pif.device" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- PIF STATUS -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ isBond ? t('bond-status') : t('pif-status') }}
-              </template>
-              <template #value>
-                <VtsStatus :status />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- PHYSICAL INTERFACE STATUS -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('physical-interface-status') }}
-              </template>
-              <template #value>
-                <VtsStatus :status="physicalInterfaceStatus" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- VLAN -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('vlan') }}
-              </template>
-              <template #value>
-                {{ pif.VLAN === -1 ? t('none') : pif.VLAN }}
-              </template>
-              <template v-if="pif.VLAN !== -1" #addons>
-                <VtsCopyButton :value="String(pif.VLAN)" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- TAGS -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('tags') }}
-              </template>
-              <template #value>
-                <UiTagsList class="tags value">
-                  <VtsTag v-for="tag in network?.tags" :key="tag" :value="tag" />
-                </UiTagsList>
+                <VtsCopyButton :value="ip" />
+                <UiButtonIcon
+                  v-if="index === 0 && ipAddresses.length > 1"
+                  v-tooltip="t('coming-soon!')"
+                  disabled
+                  icon="fa:ellipsis"
+                  size="small"
+                  accent="brand"
+                />
               </template>
             </VtsCardRowKeyValue>
           </div>
-        </UiCard>
-        <!-- NETWORK INFORMATION -->
-        <UiCard class="card">
-          <UiCardTitle>{{ t('network-information') }}</UiCardTitle>
-          <div class="content">
-            <!-- IP ADDRESSES -->
-            <div v-if="ipAddresses.length">
-              <VtsCardRowKeyValue v-for="(ip, index) in ipAddresses" :key="ip">
-                <template #key>
-                  <div v-if="index === 0">{{ t('ip-addresses') }}</div>
-                </template>
-                <template #value>
-                  <span v-tooltip class="text-ellipsis">{{ ip }}</span>
-                </template>
-                <template #addons>
-                  <VtsCopyButton :value="ip" />
-                  <UiButtonIcon
-                    v-if="index === 0 && ipAddresses.length > 1"
-                    v-tooltip="t('coming-soon!')"
-                    disabled
-                    icon="fa:ellipsis"
-                    size="small"
-                    accent="brand"
-                  />
-                </template>
-              </VtsCardRowKeyValue>
-            </div>
-            <VtsCardRowKeyValue v-else>
+          <VtsCardRowKeyValue v-else>
+            <template #key>
+              {{ t('ip-addresses') }}
+            </template>
+            <template #value>
+              <span class="value" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- MAC ADDRESSES -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('mac-address') }}
+            </template>
+            <template #value>
+              {{ pif.MAC }}
+            </template>
+            <template #addons>
+              <VtsCopyButton :value="pif.MAC" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- NETMASK -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('netmask') }}
+            </template>
+            <template #value>
+              <span class="value">{{ pif.netmask }}</span>
+            </template>
+            <template v-if="pif.netmask" #addons>
+              <VtsCopyButton :value="String(pif.netmask)" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- DNS -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('dns') }}
+            </template>
+            <template #value>
+              <span class="value">
+                {{ pif.DNS }}
+              </span>
+            </template>
+            <template v-if="pif.DNS" #addons>
+              <VtsCopyButton :value="String(pif.DNS)" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- GATEWAY -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('gateway') }}
+            </template>
+            <template #value>
+              <span class="value">
+                {{ pif.gateway }}
+              </span>
+            </template>
+            <template v-if="pif.gateway" #addons>
+              <VtsCopyButton :value="String(pif.gateway)" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- IP CONFIGURATION MODE -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('ip-mode') }}
+            </template>
+            <template #value>
+              {{ ipConfigurationMode }}
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- BOND DEVICES -->
+          <div>
+            <VtsCardRowKeyValue v-for="(device, index) in bondDevices" :key="device">
               <template #key>
-                {{ t('ip-addresses') }}
+                <div v-if="index === 0">{{ t('bond-devices') }}</div>
               </template>
               <template #value>
-                <span class="value" />
+                <span v-tooltip class="text-ellipsis">{{ device }}</span>
               </template>
-            </VtsCardRowKeyValue>
-            <!-- MAC ADDRESSES -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('mac-address') }}
-              </template>
-              <template #value>
-                {{ pif.MAC }}
-              </template>
-              <template #addons>
-                <VtsCopyButton :value="pif.MAC" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- NETMASK -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('netmask') }}
-              </template>
-              <template #value>
-                <span class="value">{{ pif.netmask }}</span>
-              </template>
-              <template v-if="pif.netmask" #addons>
-                <VtsCopyButton :value="String(pif.netmask)" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- DNS -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('dns') }}
-              </template>
-              <template #value>
-                <span class="value">
-                  {{ pif.DNS }}
-                </span>
-              </template>
-              <template v-if="pif.DNS" #addons>
-                <VtsCopyButton :value="String(pif.DNS)" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- GATEWAY -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('gateway') }}
-              </template>
-              <template #value>
-                <span class="value">
-                  {{ pif.gateway }}
-                </span>
-              </template>
-              <template v-if="pif.gateway" #addons>
-                <VtsCopyButton :value="String(pif.gateway)" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- IP CONFIGURATION MODE -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('ip-mode') }}
-              </template>
-              <template #value>
-                {{ ipConfigurationMode }}
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- BOND DEVICES -->
-            <div>
-              <VtsCardRowKeyValue v-for="(device, index) in bondDevices" :key="device">
-                <template #key>
-                  <div v-if="index === 0">{{ t('bond-devices') }}</div>
-                </template>
-                <template #value>
-                  <span v-tooltip class="text-ellipsis">{{ device }}</span>
-                </template>
-                <template v-if="device" #addons>
-                  <VtsCopyButton :value="device" />
-                  <UiButtonIcon
-                    v-if="index === 0 && bondDevices.length > 1"
-                    v-tooltip="t('coming-soon!')"
-                    disabled
-                    icon="fa:ellipsis"
-                    size="small"
-                    accent="brand"
-                  />
-                </template>
-              </VtsCardRowKeyValue>
-            </div>
-          </div>
-        </UiCard>
-        <!-- PROPERTIES -->
-        <UiCard class="card">
-          <UiCardTitle>{{ t('properties') }}</UiCardTitle>
-          <div class="content">
-            <!-- MTU -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('mtu') }}
-              </template>
-              <template #value>
-                {{ pif.MTU === -1 ? t('none') : pif.MTU }}
-              </template>
-              <template v-if="pif.MTU !== -1" #addons>
-                <VtsCopyButton :value="String(pif.MTU)" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- SPEED -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('speed') }}
-              </template>
-              <template #value>
-                {{ speed }}
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- NETWORK BLOCK DEVICE -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('network-block-device') }}
-              </template>
-              <template #value>
-                {{ networkPurpose }}
-              </template>
-              <template #addons>
-                <VtsCopyButton :value="networkPurpose" />
+              <template v-if="device" #addons>
+                <VtsCopyButton :value="device" />
+                <UiButtonIcon
+                  v-if="index === 0 && bondDevices.length > 1"
+                  v-tooltip="t('coming-soon!')"
+                  disabled
+                  icon="fa:ellipsis"
+                  size="small"
+                  accent="brand"
+                />
               </template>
             </VtsCardRowKeyValue>
           </div>
-        </UiCard>
-      </template>
+        </div>
+      </UiCard>
+      <!-- PROPERTIES -->
+      <UiCard class="card">
+        <UiCardTitle>{{ t('properties') }}</UiCardTitle>
+        <div class="content">
+          <!-- MTU -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('mtu') }}
+            </template>
+            <template #value>
+              {{ pif.MTU === -1 ? t('none') : pif.MTU }}
+            </template>
+            <template v-if="pif.MTU !== -1" #addons>
+              <VtsCopyButton :value="String(pif.MTU)" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- SPEED -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('speed') }}
+            </template>
+            <template #value>
+              {{ speed }}
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- NETWORK BLOCK DEVICE -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('network-block-device') }}
+            </template>
+            <template #value>
+              {{ networkPurpose }}
+            </template>
+            <template #addons>
+              <VtsCopyButton :value="networkPurpose" />
+            </template>
+          </VtsCardRowKeyValue>
+        </div>
+      </UiCard>
     </template>
   </VtsSidePanel>
 </template>
@@ -284,7 +281,6 @@ import VtsCardRowKeyValue from '@core/components/card/VtsCardRowKeyValue.vue'
 import VtsCopyButton from '@core/components/copy-button/VtsCopyButton.vue'
 import VtsIcon from '@core/components/icon/VtsIcon.vue'
 import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import VtsStatus from '@core/components/status/VtsStatus.vue'
 import VtsTag from '@core/components/tag/VtsTag.vue'
 import UiButton from '@core/components/ui/button/UiButton.vue'

--- a/@xen-orchestra/lite/src/components/host/network/HostPifSidePanel.vue
+++ b/@xen-orchestra/lite/src/components/host/network/HostPifSidePanel.vue
@@ -1,16 +1,7 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }">
+  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
     <template #header>
-      <div :class="{ 'action-buttons-container': uiStore.isSmall }">
-        <UiButtonIcon
-          v-if="uiStore.isSmall"
-          v-tooltip="t('action:close')"
-          size="small"
-          variant="tertiary"
-          accent="brand"
-          icon="fa:angle-left"
-          @click="emit('close')"
-        />
+      <div class="action-buttons-container">
         <div class="action-buttons">
           <UiButton
             v-tooltip="t('coming-soon!')"
@@ -383,6 +374,10 @@ const speed = computed(() => {
   .value:empty::before {
     content: '-';
   }
+}
+
+.action-buttons-container {
+  margin-inline-end: auto;
 }
 
 .mobile-drawer {

--- a/@xen-orchestra/lite/src/components/host/network/HostPifSidePanel.vue
+++ b/@xen-orchestra/lite/src/components/host/network/HostPifSidePanel.vue
@@ -1,279 +1,278 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
-    <template #header>
-      <div class="action-buttons-container">
-        <div class="action-buttons">
-          <UiButton
-            v-tooltip="t('coming-soon!')"
-            disabled
-            size="medium"
-            variant="tertiary"
-            accent="brand"
-            left-icon="fa:edit"
-          >
-            {{ t('action:edit') }}
-          </UiButton>
-          <UiButton
-            v-tooltip="t('coming-soon!')"
-            disabled
-            size="medium"
-            variant="tertiary"
-            accent="danger"
-            left-icon="fa:trash"
-          >
-            {{ t('action:delete') }}
-          </UiButton>
-        </div>
-      </div>
+  <VtsSidePanel :selected="!!pif" :closable="!!pif" @close="emit('close')">
+    <template v-if="pif" #actions>
+      <UiButton
+        v-tooltip="t('coming-soon!')"
+        disabled
+        size="medium"
+        variant="tertiary"
+        accent="brand"
+        left-icon="fa:edit"
+      >
+        {{ t('action:edit') }}
+      </UiButton>
+      <UiButton
+        v-tooltip="t('coming-soon!')"
+        disabled
+        size="medium"
+        variant="tertiary"
+        accent="danger"
+        left-icon="fa:trash"
+      >
+        {{ t('action:delete') }}
+      </UiButton>
     </template>
     <template #default>
-      <!-- PIF -->
-      <UiCard class="card">
-        <UiCardTitle>{{ isBond ? t('bond') : t('pif') }}</UiCardTitle>
-        <div class="content">
-          <!-- UUID -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('uuid') }}
-            </template>
-            <template #value>
-              {{ pif.uuid }}
-            </template>
-            <template #addons>
-              <VtsIcon v-if="pif.management" v-tooltip="t('management')" name="status:primary-circle" size="medium" />
-              <VtsCopyButton :value="pif.uuid" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- NETWORK -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('network') }}
-            </template>
-            <template #value>
-              <div class="network">
-                <!-- TODO Remove the span when the link works and the icon is fixed -->
-                <span v-tooltip class="value">{{ network?.name_label }}</span>
-              </div>
-            </template>
-            <template v-if="network?.name_label" #addons>
-              <VtsCopyButton :value="network.name_label" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- DEVICE -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('device') }}
-            </template>
-            <template #value>
-              {{ pif.device }}
-            </template>
-            <template #addons>
-              <VtsCopyButton :value="pif.device" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- PIF STATUS -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ isBond ? t('bond-status') : t('pif-status') }}
-            </template>
-            <template #value>
-              <VtsStatus :status />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- PHYSICAL INTERFACE STATUS -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('physical-interface-status') }}
-            </template>
-            <template #value>
-              <VtsStatus :status="physicalInterfaceStatus" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- VLAN -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('vlan') }}
-            </template>
-            <template #value>
-              {{ pif.VLAN === -1 ? t('none') : pif.VLAN }}
-            </template>
-            <template v-if="pif.VLAN !== -1" #addons>
-              <VtsCopyButton :value="String(pif.VLAN)" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- TAGS -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('tags') }}
-            </template>
-            <template #value>
-              <UiTagsList class="tags value">
-                <VtsTag v-for="tag in network?.tags" :key="tag" :value="tag" />
-              </UiTagsList>
-            </template>
-          </VtsCardRowKeyValue>
-        </div>
-      </UiCard>
-      <!-- NETWORK INFORMATION -->
-      <UiCard class="card">
-        <UiCardTitle>{{ t('network-information') }}</UiCardTitle>
-        <div class="content">
-          <!-- IP ADDRESSES -->
-          <div v-if="ipAddresses.length">
-            <VtsCardRowKeyValue v-for="(ip, index) in ipAddresses" :key="ip">
+      <VtsStateHero v-if="!pif" format="panel" type="no-selection" size="medium" />
+      <template v-else>
+        <!-- PIF -->
+        <UiCard class="card">
+          <UiCardTitle>{{ isBond ? t('bond') : t('pif') }}</UiCardTitle>
+          <div class="content">
+            <!-- UUID -->
+            <VtsCardRowKeyValue>
               <template #key>
-                <div v-if="index === 0">{{ t('ip-addresses') }}</div>
+                {{ t('uuid') }}
               </template>
               <template #value>
-                <span v-tooltip class="text-ellipsis">{{ ip }}</span>
+                {{ pif.uuid }}
               </template>
               <template #addons>
-                <VtsCopyButton :value="ip" />
-                <UiButtonIcon
-                  v-if="index === 0 && ipAddresses.length > 1"
-                  v-tooltip="t('coming-soon!')"
-                  disabled
-                  icon="fa:ellipsis"
-                  size="small"
-                  accent="brand"
-                />
+                <VtsIcon v-if="pif.management" v-tooltip="t('management')" name="status:primary-circle" size="medium" />
+                <VtsCopyButton :value="pif.uuid" />
               </template>
             </VtsCardRowKeyValue>
-          </div>
-          <VtsCardRowKeyValue v-else>
-            <template #key>
-              {{ t('ip-addresses') }}
-            </template>
-            <template #value>
-              <span class="value" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- MAC ADDRESSES -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('mac-address') }}
-            </template>
-            <template #value>
-              {{ pif.MAC }}
-            </template>
-            <template #addons>
-              <VtsCopyButton :value="pif.MAC" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- NETMASK -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('netmask') }}
-            </template>
-            <template #value>
-              <span class="value">{{ pif.netmask }}</span>
-            </template>
-            <template v-if="pif.netmask" #addons>
-              <VtsCopyButton :value="String(pif.netmask)" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- DNS -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('dns') }}
-            </template>
-            <template #value>
-              <span class="value">
-                {{ pif.DNS }}
-              </span>
-            </template>
-            <template v-if="pif.DNS" #addons>
-              <VtsCopyButton :value="String(pif.DNS)" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- GATEWAY -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('gateway') }}
-            </template>
-            <template #value>
-              <span class="value">
-                {{ pif.gateway }}
-              </span>
-            </template>
-            <template v-if="pif.gateway" #addons>
-              <VtsCopyButton :value="String(pif.gateway)" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- IP CONFIGURATION MODE -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('ip-mode') }}
-            </template>
-            <template #value>
-              {{ ipConfigurationMode }}
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- BOND DEVICES -->
-          <div>
-            <VtsCardRowKeyValue v-for="(device, index) in bondDevices" :key="device">
+            <!-- NETWORK -->
+            <VtsCardRowKeyValue>
               <template #key>
-                <div v-if="index === 0">{{ t('bond-devices') }}</div>
+                {{ t('network') }}
               </template>
               <template #value>
-                <span v-tooltip class="text-ellipsis">{{ device }}</span>
+                <div class="network">
+                  <!-- TODO Remove the span when the link works and the icon is fixed -->
+                  <span v-tooltip class="value">{{ network?.name_label }}</span>
+                </div>
               </template>
-              <template v-if="device" #addons>
-                <VtsCopyButton :value="device" />
-                <UiButtonIcon
-                  v-if="index === 0 && bondDevices.length > 1"
-                  v-tooltip="t('coming-soon!')"
-                  disabled
-                  icon="fa:ellipsis"
-                  size="small"
-                  accent="brand"
-                />
+              <template v-if="network?.name_label" #addons>
+                <VtsCopyButton :value="network.name_label" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- DEVICE -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('device') }}
+              </template>
+              <template #value>
+                {{ pif.device }}
+              </template>
+              <template #addons>
+                <VtsCopyButton :value="pif.device" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- PIF STATUS -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ isBond ? t('bond-status') : t('pif-status') }}
+              </template>
+              <template #value>
+                <VtsStatus :status />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- PHYSICAL INTERFACE STATUS -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('physical-interface-status') }}
+              </template>
+              <template #value>
+                <VtsStatus :status="physicalInterfaceStatus" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- VLAN -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('vlan') }}
+              </template>
+              <template #value>
+                {{ pif.VLAN === -1 ? t('none') : pif.VLAN }}
+              </template>
+              <template v-if="pif.VLAN !== -1" #addons>
+                <VtsCopyButton :value="String(pif.VLAN)" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- TAGS -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('tags') }}
+              </template>
+              <template #value>
+                <UiTagsList class="tags value">
+                  <VtsTag v-for="tag in network?.tags" :key="tag" :value="tag" />
+                </UiTagsList>
               </template>
             </VtsCardRowKeyValue>
           </div>
-        </div>
-      </UiCard>
-      <!-- PROPERTIES -->
-      <UiCard class="card">
-        <UiCardTitle>{{ t('properties') }}</UiCardTitle>
-        <div class="content">
-          <!-- MTU -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('mtu') }}
-            </template>
-            <template #value>
-              {{ pif.MTU === -1 ? t('none') : pif.MTU }}
-            </template>
-            <template v-if="pif.MTU !== -1" #addons>
-              <VtsCopyButton :value="String(pif.MTU)" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- SPEED -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('speed') }}
-            </template>
-            <template #value>
-              {{ speed }}
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- NETWORK BLOCK DEVICE -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('network-block-device') }}
-            </template>
-            <template #value>
-              {{ networkPurpose }}
-            </template>
-            <template #addons>
-              <VtsCopyButton :value="networkPurpose" />
-            </template>
-          </VtsCardRowKeyValue>
-        </div>
-      </UiCard>
+        </UiCard>
+        <!-- NETWORK INFORMATION -->
+        <UiCard class="card">
+          <UiCardTitle>{{ t('network-information') }}</UiCardTitle>
+          <div class="content">
+            <!-- IP ADDRESSES -->
+            <div v-if="ipAddresses.length">
+              <VtsCardRowKeyValue v-for="(ip, index) in ipAddresses" :key="ip">
+                <template #key>
+                  <div v-if="index === 0">{{ t('ip-addresses') }}</div>
+                </template>
+                <template #value>
+                  <span v-tooltip class="text-ellipsis">{{ ip }}</span>
+                </template>
+                <template #addons>
+                  <VtsCopyButton :value="ip" />
+                  <UiButtonIcon
+                    v-if="index === 0 && ipAddresses.length > 1"
+                    v-tooltip="t('coming-soon!')"
+                    disabled
+                    icon="fa:ellipsis"
+                    size="small"
+                    accent="brand"
+                  />
+                </template>
+              </VtsCardRowKeyValue>
+            </div>
+            <VtsCardRowKeyValue v-else>
+              <template #key>
+                {{ t('ip-addresses') }}
+              </template>
+              <template #value>
+                <span class="value" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- MAC ADDRESSES -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('mac-address') }}
+              </template>
+              <template #value>
+                {{ pif.MAC }}
+              </template>
+              <template #addons>
+                <VtsCopyButton :value="pif.MAC" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- NETMASK -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('netmask') }}
+              </template>
+              <template #value>
+                <span class="value">{{ pif.netmask }}</span>
+              </template>
+              <template v-if="pif.netmask" #addons>
+                <VtsCopyButton :value="String(pif.netmask)" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- DNS -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('dns') }}
+              </template>
+              <template #value>
+                <span class="value">
+                  {{ pif.DNS }}
+                </span>
+              </template>
+              <template v-if="pif.DNS" #addons>
+                <VtsCopyButton :value="String(pif.DNS)" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- GATEWAY -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('gateway') }}
+              </template>
+              <template #value>
+                <span class="value">
+                  {{ pif.gateway }}
+                </span>
+              </template>
+              <template v-if="pif.gateway" #addons>
+                <VtsCopyButton :value="String(pif.gateway)" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- IP CONFIGURATION MODE -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('ip-mode') }}
+              </template>
+              <template #value>
+                {{ ipConfigurationMode }}
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- BOND DEVICES -->
+            <div>
+              <VtsCardRowKeyValue v-for="(device, index) in bondDevices" :key="device">
+                <template #key>
+                  <div v-if="index === 0">{{ t('bond-devices') }}</div>
+                </template>
+                <template #value>
+                  <span v-tooltip class="text-ellipsis">{{ device }}</span>
+                </template>
+                <template v-if="device" #addons>
+                  <VtsCopyButton :value="device" />
+                  <UiButtonIcon
+                    v-if="index === 0 && bondDevices.length > 1"
+                    v-tooltip="t('coming-soon!')"
+                    disabled
+                    icon="fa:ellipsis"
+                    size="small"
+                    accent="brand"
+                  />
+                </template>
+              </VtsCardRowKeyValue>
+            </div>
+          </div>
+        </UiCard>
+        <!-- PROPERTIES -->
+        <UiCard class="card">
+          <UiCardTitle>{{ t('properties') }}</UiCardTitle>
+          <div class="content">
+            <!-- MTU -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('mtu') }}
+              </template>
+              <template #value>
+                {{ pif.MTU === -1 ? t('none') : pif.MTU }}
+              </template>
+              <template v-if="pif.MTU !== -1" #addons>
+                <VtsCopyButton :value="String(pif.MTU)" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- SPEED -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('speed') }}
+              </template>
+              <template #value>
+                {{ speed }}
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- NETWORK BLOCK DEVICE -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('network-block-device') }}
+              </template>
+              <template #value>
+                {{ networkPurpose }}
+              </template>
+              <template #addons>
+                <VtsCopyButton :value="networkPurpose" />
+              </template>
+            </VtsCardRowKeyValue>
+          </div>
+        </UiCard>
+      </template>
     </template>
-  </UiPanel>
+  </VtsSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -284,22 +283,22 @@ import { usePifStore } from '@/stores/xen-api/pif.store'
 import VtsCardRowKeyValue from '@core/components/card/VtsCardRowKeyValue.vue'
 import VtsCopyButton from '@core/components/copy-button/VtsCopyButton.vue'
 import VtsIcon from '@core/components/icon/VtsIcon.vue'
+import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import VtsStatus from '@core/components/status/VtsStatus.vue'
 import VtsTag from '@core/components/tag/VtsTag.vue'
 import UiButton from '@core/components/ui/button/UiButton.vue'
 import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiCardTitle from '@core/components/ui/card-title/UiCardTitle.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import UiTagsList from '@core/components/ui/tag/UiTagsList.vue'
 import { vTooltip } from '@core/directives/tooltip.directive'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import humanFormat from 'human-format'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const { pif } = defineProps<{
-  pif: XenApiPif
+  pif?: XenApiPif
 }>()
 
 const emit = defineEmits<{
@@ -309,21 +308,32 @@ const emit = defineEmits<{
 const { getByOpaqueRef: getPifMetricsByOpaqueRef, getPifCarrier } = usePifMetricsStore().subscribe()
 const { getByOpaqueRef: getNetworkByOpaqueRef } = useNetworkStore().subscribe()
 const { getBondsDevices, isBondMaster } = usePifStore().subscribe()
-const uiStore = useUiStore()
 
 const { t } = useI18n()
 
-const ipAddresses = computed(() => [pif.IP, ...pif.IPv6].filter(ip => ip))
+const ipAddresses = computed(() => {
+  if (pif === undefined) {
+    return []
+  }
 
-const network = computed(() => getNetworkByOpaqueRef(pif.network))
+  return [pif.IP, ...pif.IPv6].filter(ip => ip)
+})
+
+const network = computed(() => (pif !== undefined ? getNetworkByOpaqueRef(pif.network) : undefined))
 
 const networkPurpose = computed(() => (network.value?.purpose?.[0] ? t('on') : t('off')))
 
-const status = computed(() => (pif.currently_attached ? 'connected' : 'disconnected'))
+const status = computed(() => (pif?.currently_attached ? 'connected' : 'disconnected'))
 
-const physicalInterfaceStatus = computed(() => (getPifCarrier(pif) ? 'connected' : 'physically-disconnected'))
+const physicalInterfaceStatus = computed(() =>
+  pif !== undefined && getPifCarrier(pif) ? 'connected' : 'physically-disconnected'
+)
 
 const ipConfigurationMode = computed(() => {
+  if (pif === undefined) {
+    return t('none')
+  }
+
   switch (pif.ip_configuration_mode) {
     case 'Static':
       return t('static')
@@ -334,11 +344,15 @@ const ipConfigurationMode = computed(() => {
   }
 })
 
-const bondDevices = computed(() => getBondsDevices(pif))
+const bondDevices = computed(() => (pif !== undefined ? getBondsDevices(pif) : []))
 
-const isBond = computed(() => isBondMaster(pif))
+const isBond = computed(() => (pif !== undefined ? isBondMaster(pif) : false))
 
 const speed = computed(() => {
+  if (pif === undefined) {
+    return ''
+  }
+
   const speed = getPifMetricsByOpaqueRef(pif.metrics)?.speed || 0
   const speedInBytes = speed * 1000000
 
@@ -374,26 +388,5 @@ const speed = computed(() => {
   .value:empty::before {
     content: '-';
   }
-}
-
-.action-buttons-container {
-  margin-inline-end: auto;
-}
-
-.mobile-drawer {
-  position: fixed;
-  inset: 0;
-
-  .action-buttons-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-  }
-}
-
-.action-buttons {
-  display: flex;
-  align-items: center;
 }
 </style>

--- a/@xen-orchestra/lite/src/components/host/network/HostPifSidePanel.vue
+++ b/@xen-orchestra/lite/src/components/host/network/HostPifSidePanel.vue
@@ -7,7 +7,7 @@
         size="medium"
         variant="tertiary"
         accent="brand"
-        left-icon="fa:edit"
+        left-icon="action:edit"
       >
         {{ t('action:edit') }}
       </UiButton>
@@ -17,7 +17,7 @@
         size="medium"
         variant="tertiary"
         accent="danger"
-        left-icon="fa:trash"
+        left-icon="action:delete"
       >
         {{ t('action:delete') }}
       </UiButton>

--- a/@xen-orchestra/lite/src/components/pool/network/PoolHostInternalNetworksTable.vue
+++ b/@xen-orchestra/lite/src/components/pool/network/PoolHostInternalNetworksTable.vue
@@ -125,7 +125,7 @@ const { HeadCells, BodyCells } = useNetworkColumns({
     description: r => r(network.name_description),
     mtu: r => r(network.MTU),
     defaultLockingMode: r => r(getLockingMode(network.default_locking_mode)),
-    selectItem: r => r(() => selectedNetworkId.value === network.uuid),
+    selectItem: r => r(() => (selectedNetworkId.value = network.uuid)),
   }),
 })
 </script>

--- a/@xen-orchestra/lite/src/components/pool/network/PoolNetworkSidePanel.vue
+++ b/@xen-orchestra/lite/src/components/pool/network/PoolNetworkSidePanel.vue
@@ -1,16 +1,7 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }">
+  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
     <template #header>
-      <div :class="{ 'action-buttons-container': uiStore.isSmall }">
-        <UiButtonIcon
-          v-if="uiStore.isSmall"
-          v-tooltip="t('action:close')"
-          size="small"
-          variant="tertiary"
-          accent="brand"
-          icon="fa:angle-left"
-          @click="emit('close')"
-        />
+      <div class="action-buttons-container">
         <div class="action-buttons">
           <UiButton
             v-tooltip="t('coming-soon!')"
@@ -194,6 +185,10 @@ const pifsCount = computed(() => pifs.value.length)
   .value:empty::before {
     content: '-';
   }
+}
+
+.action-buttons-container {
+  margin-inline-end: auto;
 }
 
 .mobile-drawer {

--- a/@xen-orchestra/lite/src/components/pool/network/PoolNetworkSidePanel.vue
+++ b/@xen-orchestra/lite/src/components/pool/network/PoolNetworkSidePanel.vue
@@ -1,110 +1,108 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
-    <template #header>
-      <div class="action-buttons-container">
-        <div class="action-buttons">
-          <UiButton
-            v-tooltip="t('coming-soon!')"
-            disabled
-            size="medium"
-            variant="tertiary"
-            accent="brand"
-            left-icon="fa:edit"
-          >
-            {{ t('action:edit') }}
-          </UiButton>
-          <UiButton
-            v-tooltip="t('coming-soon!')"
-            disabled
-            size="medium"
-            variant="tertiary"
-            accent="danger"
-            left-icon="fa:trash"
-          >
-            {{ t('action:delete') }}
-          </UiButton>
-          <UiButtonIcon v-tooltip="t('coming-soon!')" disabled accent="brand" size="small" icon="fa:ellipsis" />
-        </div>
-      </div>
+  <VtsSidePanel :selected="!!network" :closable="!!network" @close="emit('close')">
+    <template v-if="network" #actions>
+      <UiButton
+        v-tooltip="t('coming-soon!')"
+        disabled
+        size="medium"
+        variant="tertiary"
+        accent="brand"
+        left-icon="fa:edit"
+      >
+        {{ t('action:edit') }}
+      </UiButton>
+      <UiButton
+        v-tooltip="t('coming-soon!')"
+        disabled
+        size="medium"
+        variant="tertiary"
+        accent="danger"
+        left-icon="fa:trash"
+      >
+        {{ t('action:delete') }}
+      </UiButton>
     </template>
     <template #default>
-      <UiCard class="card-container">
-        <UiCardTitle v-tooltip="{ placement: 'bottom-end' }" class="typo-body-bold">
-          {{ network.name_label }}
-        </UiCardTitle>
-        <div class="content">
-          <!-- UUID -->
-          <VtsCodeSnippet :content="network.uuid" copy />
-          <!-- DESCRIPTION -->
-          <VtsCardRowKeyValue truncate align-top>
-            <template #key>{{ t('description') }}</template>
-            <template #value>
-              <span class="value">{{ network.name_description }}</span>
-            </template>
-            <template v-if="network.name_description" #addons>
-              <VtsCopyButton :value="network.name_description" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- VLAN -->
-          <VtsCardRowKeyValue v-if="networkVlan">
-            <template #key>{{ t('vlan') }}</template>
-            <template #value>{{ networkVlan }}</template>
-            <template #addons>
-              <VtsCopyButton :value="String(networkVlan)" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- MTU -->
-          <VtsCardRowKeyValue>
-            <template #key>{{ t('mtu') }}</template>
-            <template #value>
-              <span>{{ network.MTU }}</span>
-            </template>
-            <template #addons>
-              <VtsCopyButton :value="String(network.MTU)" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- NBD -->
-          <VtsCardRowKeyValue>
-            <template #key>{{ t('network-block-device') }}</template>
-            <template #value>{{ networkNbd }}</template>
-            <template #addons>
-              <VtsCopyButton :value="networkNbd" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- DEFAULT LOCKING MODE -->
-          <VtsCardRowKeyValue>
-            <template #key>{{ t('locking-mode-default') }}</template>
-            <template #value>{{ networkDefaultLockingMode }}</template>
-          </VtsCardRowKeyValue>
-        </div>
-      </UiCard>
-      <UiCard v-if="pifsCount && pifsCount > 0" class="card-container">
-        <div class="typo-body-bold">
-          {{ t('pifs') }}
-          <UiCounter :value="pifsCount" variant="primary" size="small" accent="neutral" />
-        </div>
-        <table class="simple-table">
-          <thead>
-            <tr>
-              <th class="text-left typo-body-regular-small">
-                {{ t('host') }}
-              </th>
-              <th class="text-left typo-body-regular-small">
-                {{ t('device') }}
-              </th>
-              <th class="text-left typo-body-regular-small">
-                {{ t('pifs-status') }}
-              </th>
-              <th />
-            </tr>
-          </thead>
-          <tbody>
-            <PifRow v-for="pif in pifs" :key="pif.uuid" :pif />
-          </tbody>
-        </table>
-      </UiCard>
+      <VtsStateHero v-if="!network" format="panel" type="no-selection" size="medium" />
+      <template v-else>
+        <UiCard class="card-container">
+          <UiCardTitle v-tooltip="{ placement: 'bottom-end' }" class="typo-body-bold">
+            {{ network.name_label }}
+          </UiCardTitle>
+          <div class="content">
+            <!-- UUID -->
+            <VtsCodeSnippet :content="network.uuid" copy />
+            <!-- DESCRIPTION -->
+            <VtsCardRowKeyValue truncate align-top>
+              <template #key>{{ t('description') }}</template>
+              <template #value>
+                <span class="value">{{ network.name_description }}</span>
+              </template>
+              <template v-if="network.name_description" #addons>
+                <VtsCopyButton :value="network.name_description" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- VLAN -->
+            <VtsCardRowKeyValue v-if="networkVlan">
+              <template #key>{{ t('vlan') }}</template>
+              <template #value>{{ networkVlan }}</template>
+              <template #addons>
+                <VtsCopyButton :value="String(networkVlan)" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- MTU -->
+            <VtsCardRowKeyValue>
+              <template #key>{{ t('mtu') }}</template>
+              <template #value>
+                <span>{{ network.MTU }}</span>
+              </template>
+              <template #addons>
+                <VtsCopyButton :value="String(network.MTU)" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- NBD -->
+            <VtsCardRowKeyValue>
+              <template #key>{{ t('network-block-device') }}</template>
+              <template #value>{{ networkNbd }}</template>
+              <template #addons>
+                <VtsCopyButton :value="networkNbd" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- DEFAULT LOCKING MODE -->
+            <VtsCardRowKeyValue>
+              <template #key>{{ t('locking-mode-default') }}</template>
+              <template #value>{{ networkDefaultLockingMode }}</template>
+            </VtsCardRowKeyValue>
+          </div>
+        </UiCard>
+        <UiCard v-if="pifsCount && pifsCount > 0" class="card-container">
+          <div class="typo-body-bold">
+            {{ t('pifs') }}
+            <UiCounter :value="pifsCount" variant="primary" size="small" accent="neutral" />
+          </div>
+          <table class="simple-table">
+            <thead>
+              <tr>
+                <th class="text-left typo-body-regular-small">
+                  {{ t('host') }}
+                </th>
+                <th class="text-left typo-body-regular-small">
+                  {{ t('device') }}
+                </th>
+                <th class="text-left typo-body-regular-small">
+                  {{ t('pifs-status') }}
+                </th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              <PifRow v-for="pif in pifs" :key="pif.uuid" :pif />
+            </tbody>
+          </table>
+        </UiCard>
+      </template>
     </template>
-  </UiPanel>
+  </VtsSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -114,19 +112,18 @@ import { usePifStore } from '@/stores/xen-api/pif.store'
 import VtsCardRowKeyValue from '@core/components/card/VtsCardRowKeyValue.vue'
 import VtsCodeSnippet from '@core/components/code-snippet/VtsCodeSnippet.vue'
 import VtsCopyButton from '@core/components/copy-button/VtsCopyButton.vue'
+import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiButton from '@core/components/ui/button/UiButton.vue'
-import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiCardTitle from '@core/components/ui/card-title/UiCardTitle.vue'
 import UiCounter from '@core/components/ui/counter/UiCounter.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { vTooltip } from '@core/directives/tooltip.directive'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const { network } = defineProps<{
-  network: XenApiNetwork
+  network?: XenApiNetwork
 }>()
 
 const emit = defineEmits<{
@@ -134,11 +131,10 @@ const emit = defineEmits<{
 }>()
 
 const { getPifsByNetworkRef } = usePifStore().subscribe()
-const uiStore = useUiStore()
 
 const { t } = useI18n()
 
-const pifs = computed(() => getPifsByNetworkRef(network.$ref))
+const pifs = computed(() => (network !== undefined ? getPifsByNetworkRef(network.$ref) : []))
 
 const networkVlan = computed(() => {
   if (pifs.value.length === 0) {
@@ -148,10 +144,10 @@ const networkVlan = computed(() => {
   return pifs.value[0].VLAN !== -1 ? pifs.value[0].VLAN.toString() : t('none')
 })
 
-const networkNbd = computed(() => (network.purpose[0] ? t('on') : t('off')))
+const networkNbd = computed(() => (network?.purpose[0] ? t('on') : t('off')))
 
 const networkDefaultLockingMode = computed(() =>
-  network.default_locking_mode === 'disabled' ? t('disabled') : t('unlocked')
+  network?.default_locking_mode === 'disabled' ? t('disabled') : t('unlocked')
 )
 
 const pifsCount = computed(() => pifs.value.length)
@@ -185,26 +181,5 @@ const pifsCount = computed(() => pifs.value.length)
   .value:empty::before {
     content: '-';
   }
-}
-
-.action-buttons-container {
-  margin-inline-end: auto;
-}
-
-.mobile-drawer {
-  position: fixed;
-  inset: 0;
-
-  .action-buttons-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-  }
-}
-
-.action-buttons {
-  display: flex;
-  align-items: center;
 }
 </style>

--- a/@xen-orchestra/lite/src/components/pool/network/PoolNetworkSidePanel.vue
+++ b/@xen-orchestra/lite/src/components/pool/network/PoolNetworkSidePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsSidePanel :selected="!!network" :closable="!!network" @close="emit('close')">
+  <VtsSidePanel :has-selection="!!network" @close="emit('close')">
     <template v-if="network" #actions>
       <UiButton
         v-tooltip="t('coming-soon!')"
@@ -22,85 +22,82 @@
         {{ t('action:delete') }}
       </UiButton>
     </template>
-    <template #default>
-      <VtsStateHero v-if="!network" format="panel" type="no-selection" size="medium" />
-      <template v-else>
-        <UiCard class="card-container">
-          <UiCardTitle v-tooltip="{ placement: 'bottom-end' }" class="typo-body-bold">
-            {{ network.name_label }}
-          </UiCardTitle>
-          <div class="content">
-            <!-- UUID -->
-            <VtsCodeSnippet :content="network.uuid" copy />
-            <!-- DESCRIPTION -->
-            <VtsCardRowKeyValue truncate align-top>
-              <template #key>{{ t('description') }}</template>
-              <template #value>
-                <span class="value">{{ network.name_description }}</span>
-              </template>
-              <template v-if="network.name_description" #addons>
-                <VtsCopyButton :value="network.name_description" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- VLAN -->
-            <VtsCardRowKeyValue v-if="networkVlan">
-              <template #key>{{ t('vlan') }}</template>
-              <template #value>{{ networkVlan }}</template>
-              <template #addons>
-                <VtsCopyButton :value="String(networkVlan)" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- MTU -->
-            <VtsCardRowKeyValue>
-              <template #key>{{ t('mtu') }}</template>
-              <template #value>
-                <span>{{ network.MTU }}</span>
-              </template>
-              <template #addons>
-                <VtsCopyButton :value="String(network.MTU)" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- NBD -->
-            <VtsCardRowKeyValue>
-              <template #key>{{ t('network-block-device') }}</template>
-              <template #value>{{ networkNbd }}</template>
-              <template #addons>
-                <VtsCopyButton :value="networkNbd" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- DEFAULT LOCKING MODE -->
-            <VtsCardRowKeyValue>
-              <template #key>{{ t('locking-mode-default') }}</template>
-              <template #value>{{ networkDefaultLockingMode }}</template>
-            </VtsCardRowKeyValue>
-          </div>
-        </UiCard>
-        <UiCard v-if="pifsCount && pifsCount > 0" class="card-container">
-          <div class="typo-body-bold">
-            {{ t('pifs') }}
-            <UiCounter :value="pifsCount" variant="primary" size="small" accent="neutral" />
-          </div>
-          <table class="simple-table">
-            <thead>
-              <tr>
-                <th class="text-left typo-body-regular-small">
-                  {{ t('host') }}
-                </th>
-                <th class="text-left typo-body-regular-small">
-                  {{ t('device') }}
-                </th>
-                <th class="text-left typo-body-regular-small">
-                  {{ t('pifs-status') }}
-                </th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              <PifRow v-for="pif in pifs" :key="pif.uuid" :pif />
-            </tbody>
-          </table>
-        </UiCard>
-      </template>
+    <template v-if="network" #default>
+      <UiCard class="card-container">
+        <UiCardTitle v-tooltip="{ placement: 'bottom-end' }" class="typo-body-bold">
+          {{ network.name_label }}
+        </UiCardTitle>
+        <div class="content">
+          <!-- UUID -->
+          <VtsCodeSnippet :content="network.uuid" copy />
+          <!-- DESCRIPTION -->
+          <VtsCardRowKeyValue truncate align-top>
+            <template #key>{{ t('description') }}</template>
+            <template #value>
+              <span class="value">{{ network.name_description }}</span>
+            </template>
+            <template v-if="network.name_description" #addons>
+              <VtsCopyButton :value="network.name_description" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- VLAN -->
+          <VtsCardRowKeyValue v-if="networkVlan">
+            <template #key>{{ t('vlan') }}</template>
+            <template #value>{{ networkVlan }}</template>
+            <template #addons>
+              <VtsCopyButton :value="String(networkVlan)" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- MTU -->
+          <VtsCardRowKeyValue>
+            <template #key>{{ t('mtu') }}</template>
+            <template #value>
+              <span>{{ network.MTU }}</span>
+            </template>
+            <template #addons>
+              <VtsCopyButton :value="String(network.MTU)" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- NBD -->
+          <VtsCardRowKeyValue>
+            <template #key>{{ t('network-block-device') }}</template>
+            <template #value>{{ networkNbd }}</template>
+            <template #addons>
+              <VtsCopyButton :value="networkNbd" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- DEFAULT LOCKING MODE -->
+          <VtsCardRowKeyValue>
+            <template #key>{{ t('locking-mode-default') }}</template>
+            <template #value>{{ networkDefaultLockingMode }}</template>
+          </VtsCardRowKeyValue>
+        </div>
+      </UiCard>
+      <UiCard v-if="pifsCount && pifsCount > 0" class="card-container">
+        <div class="typo-body-bold">
+          {{ t('pifs') }}
+          <UiCounter :value="pifsCount" variant="primary" size="small" accent="neutral" />
+        </div>
+        <table class="simple-table">
+          <thead>
+            <tr>
+              <th class="text-left typo-body-regular-small">
+                {{ t('host') }}
+              </th>
+              <th class="text-left typo-body-regular-small">
+                {{ t('device') }}
+              </th>
+              <th class="text-left typo-body-regular-small">
+                {{ t('pifs-status') }}
+              </th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            <PifRow v-for="pif in pifs" :key="pif.uuid" :pif />
+          </tbody>
+        </table>
+      </UiCard>
     </template>
   </VtsSidePanel>
 </template>
@@ -113,7 +110,6 @@ import VtsCardRowKeyValue from '@core/components/card/VtsCardRowKeyValue.vue'
 import VtsCodeSnippet from '@core/components/code-snippet/VtsCodeSnippet.vue'
 import VtsCopyButton from '@core/components/copy-button/VtsCopyButton.vue'
 import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiButton from '@core/components/ui/button/UiButton.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiCardTitle from '@core/components/ui/card-title/UiCardTitle.vue'

--- a/@xen-orchestra/lite/src/components/pool/network/PoolNetworkSidePanel.vue
+++ b/@xen-orchestra/lite/src/components/pool/network/PoolNetworkSidePanel.vue
@@ -7,7 +7,7 @@
         size="medium"
         variant="tertiary"
         accent="brand"
-        left-icon="fa:edit"
+        left-icon="action:edit"
       >
         {{ t('action:edit') }}
       </UiButton>
@@ -17,7 +17,7 @@
         size="medium"
         variant="tertiary"
         accent="danger"
-        left-icon="fa:trash"
+        left-icon="action:delete"
       >
         {{ t('action:delete') }}
       </UiButton>

--- a/@xen-orchestra/lite/src/components/vm/network/VmVifsSidePanel.vue
+++ b/@xen-orchestra/lite/src/components/vm/network/VmVifsSidePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsSidePanel :selected="!!vif" :closable="!!vif" @close="emit('close')">
+  <VtsSidePanel :has-selection="!!vif" @close="emit('close')">
     <template v-if="vif" #actions>
       <UiButton
         v-tooltip="t('coming-soon!')"
@@ -22,117 +22,114 @@
         {{ t('action:delete') }}
       </UiButton>
     </template>
-    <template #default>
-      <VtsStateHero v-if="!vif" format="panel" type="no-selection" size="medium" />
-      <template v-else>
-        <!-- VIF -->
-        <UiCard class="card">
-          <UiCardTitle>{{ t('vif') }}</UiCardTitle>
-          <div class="content">
-            <!-- UUID -->
-            <VtsCodeSnippet :content="vif.uuid" copy />
-            <!-- NETWORK -->
-            <VtsCardRowKeyValue>
+    <template v-if="vif" #default>
+      <!-- VIF -->
+      <UiCard class="card">
+        <UiCardTitle>{{ t('vif') }}</UiCardTitle>
+        <div class="content">
+          <!-- UUID -->
+          <VtsCodeSnippet :content="vif.uuid" copy />
+          <!-- NETWORK -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('network') }}
+            </template>
+            <template #value>{{ network?.name_label }}</template>
+            <template v-if="network?.name_label" #addons>
+              <VtsCopyButton :value="network.name_label" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- DEVICE -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('device') }}
+            </template>
+            <template #value>
+              {{ t('vif-device', { device: vif.device }) }}
+            </template>
+            <template #addons>
+              <VtsCopyButton :value="vif.device" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- VIF STATUS -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('vif-status') }}
+            </template>
+            <template #value>
+              <VtsStatus :status />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- MTU -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('mtu') }}
+            </template>
+            <template #value>
+              {{ vif.MTU }}
+            </template>
+            <template #addons>
+              <VtsCopyButton :value="String(vif.MTU)" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- LOCKING MODE -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('locking-mode') }}
+            </template>
+            <template #value>
+              {{ vif.locking_mode }}
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- TODO Need to add TX Checksumming -->
+        </div>
+      </UiCard>
+      <!-- VIF NETWORK INFORMATION -->
+      <UiCard class="card">
+        <UiCardTitle>{{ t('network-information') }}</UiCardTitle>
+        <div class="content">
+          <!-- IP ADDRESSES -->
+          <div v-if="ipAddresses.length">
+            <VtsCardRowKeyValue v-for="(ip, index) in ipAddresses" :key="ip">
               <template #key>
-                {{ t('network') }}
+                <div v-if="index === 0">{{ t('ip-addresses') }}</div>
               </template>
-              <template #value>{{ network?.name_label }}</template>
-              <template v-if="network?.name_label" #addons>
-                <VtsCopyButton :value="network.name_label" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- DEVICE -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('device') }}
-              </template>
-              <template #value>
-                {{ t('vif-device', { device: vif.device }) }}
-              </template>
+              <template #value>{{ ip }}</template>
               <template #addons>
-                <VtsCopyButton :value="vif.device" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- VIF STATUS -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('vif-status') }}
-              </template>
-              <template #value>
-                <VtsStatus :status />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- MTU -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('mtu') }}
-              </template>
-              <template #value>
-                {{ vif.MTU }}
-              </template>
-              <template #addons>
-                <VtsCopyButton :value="String(vif.MTU)" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- LOCKING MODE -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('locking-mode') }}
-              </template>
-              <template #value>
-                {{ vif.locking_mode }}
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- TODO Need to add TX Checksumming -->
-          </div>
-        </UiCard>
-        <!-- VIF NETWORK INFORMATION -->
-        <UiCard class="card">
-          <UiCardTitle>{{ t('network-information') }}</UiCardTitle>
-          <div class="content">
-            <!-- IP ADDRESSES -->
-            <div v-if="ipAddresses.length">
-              <VtsCardRowKeyValue v-for="(ip, index) in ipAddresses" :key="ip">
-                <template #key>
-                  <div v-if="index === 0">{{ t('ip-addresses') }}</div>
-                </template>
-                <template #value>{{ ip }}</template>
-                <template #addons>
-                  <VtsCopyButton :value="ip" />
-                  <UiButtonIcon
-                    v-if="index === 0 && ipAddresses.length > 1"
-                    v-tooltip="t('coming-soon!')"
-                    disabled
-                    icon="fa:ellipsis"
-                    size="small"
-                    accent="brand"
-                  />
-                </template>
-              </VtsCardRowKeyValue>
-            </div>
-            <VtsCardRowKeyValue v-else>
-              <template #key>
-                {{ t('ip-addresses') }}
-              </template>
-              <template #value>
-                <span class="value" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- MAC ADDRESSES -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('mac-address') }}
-              </template>
-              <template #value>
-                {{ vif.MAC }}
-              </template>
-              <template #addons>
-                <VtsCopyButton :value="vif.MAC" />
+                <VtsCopyButton :value="ip" />
+                <UiButtonIcon
+                  v-if="index === 0 && ipAddresses.length > 1"
+                  v-tooltip="t('coming-soon!')"
+                  disabled
+                  icon="fa:ellipsis"
+                  size="small"
+                  accent="brand"
+                />
               </template>
             </VtsCardRowKeyValue>
           </div>
-        </UiCard>
-      </template>
+          <VtsCardRowKeyValue v-else>
+            <template #key>
+              {{ t('ip-addresses') }}
+            </template>
+            <template #value>
+              <span class="value" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- MAC ADDRESSES -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('mac-address') }}
+            </template>
+            <template #value>
+              {{ vif.MAC }}
+            </template>
+            <template #addons>
+              <VtsCopyButton :value="vif.MAC" />
+            </template>
+          </VtsCardRowKeyValue>
+        </div>
+      </UiCard>
     </template>
   </VtsSidePanel>
 </template>
@@ -146,7 +143,6 @@ import VtsCardRowKeyValue from '@core/components/card/VtsCardRowKeyValue.vue'
 import VtsCodeSnippet from '@core/components/code-snippet/VtsCodeSnippet.vue'
 import VtsCopyButton from '@core/components/copy-button/VtsCopyButton.vue'
 import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import VtsStatus from '@core/components/status/VtsStatus.vue'
 import UiButton from '@core/components/ui/button/UiButton.vue'
 import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'

--- a/@xen-orchestra/lite/src/components/vm/network/VmVifsSidePanel.vue
+++ b/@xen-orchestra/lite/src/components/vm/network/VmVifsSidePanel.vue
@@ -1,141 +1,140 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
-    <template #header>
-      <div class="action-buttons-container">
-        <div class="action-buttons">
-          <UiButton
-            v-tooltip="t('coming-soon!')"
-            disabled
-            size="medium"
-            variant="tertiary"
-            accent="brand"
-            left-icon="fa:edit"
-          >
-            {{ t('action:edit') }}
-          </UiButton>
-          <UiButton
-            v-tooltip="t('coming-soon!')"
-            disabled
-            size="medium"
-            variant="tertiary"
-            accent="danger"
-            left-icon="fa:trash"
-          >
-            {{ t('action:delete') }}
-          </UiButton>
-        </div>
-      </div>
+  <VtsSidePanel :selected="!!vif" :closable="!!vif" @close="emit('close')">
+    <template v-if="vif" #actions>
+      <UiButton
+        v-tooltip="t('coming-soon!')"
+        disabled
+        size="medium"
+        variant="tertiary"
+        accent="brand"
+        left-icon="fa:edit"
+      >
+        {{ t('action:edit') }}
+      </UiButton>
+      <UiButton
+        v-tooltip="t('coming-soon!')"
+        disabled
+        size="medium"
+        variant="tertiary"
+        accent="danger"
+        left-icon="fa:trash"
+      >
+        {{ t('action:delete') }}
+      </UiButton>
     </template>
     <template #default>
-      <!-- VIF -->
-      <UiCard class="card">
-        <UiCardTitle>{{ t('vif') }}</UiCardTitle>
-        <div class="content">
-          <!-- UUID -->
-          <VtsCodeSnippet :content="vif.uuid" copy />
-          <!-- NETWORK -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('network') }}
-            </template>
-            <template #value>{{ network?.name_label }}</template>
-            <template v-if="network?.name_label" #addons>
-              <VtsCopyButton :value="network.name_label" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- DEVICE -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('device') }}
-            </template>
-            <template #value>
-              {{ t('vif-device', { device: vif.device }) }}
-            </template>
-            <template #addons>
-              <VtsCopyButton :value="vif.device" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- VIF STATUS -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('vif-status') }}
-            </template>
-            <template #value>
-              <VtsStatus :status />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- MTU -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('mtu') }}
-            </template>
-            <template #value>
-              {{ vif.MTU }}
-            </template>
-            <template #addons>
-              <VtsCopyButton :value="String(vif.MTU)" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- LOCKING MODE -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('locking-mode') }}
-            </template>
-            <template #value>
-              {{ vif.locking_mode }}
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- TODO Need to add TX Checksumming -->
-        </div>
-      </UiCard>
-      <!-- VIF NETWORK INFORMATION -->
-      <UiCard class="card">
-        <UiCardTitle>{{ t('network-information') }}</UiCardTitle>
-        <div class="content">
-          <!-- IP ADDRESSES -->
-          <div v-if="ipAddresses.length">
-            <VtsCardRowKeyValue v-for="(ip, index) in ipAddresses" :key="ip">
+      <VtsStateHero v-if="!vif" format="panel" type="no-selection" size="medium" />
+      <template v-else>
+        <!-- VIF -->
+        <UiCard class="card">
+          <UiCardTitle>{{ t('vif') }}</UiCardTitle>
+          <div class="content">
+            <!-- UUID -->
+            <VtsCodeSnippet :content="vif.uuid" copy />
+            <!-- NETWORK -->
+            <VtsCardRowKeyValue>
               <template #key>
-                <div v-if="index === 0">{{ t('ip-addresses') }}</div>
+                {{ t('network') }}
               </template>
-              <template #value>{{ ip }}</template>
+              <template #value>{{ network?.name_label }}</template>
+              <template v-if="network?.name_label" #addons>
+                <VtsCopyButton :value="network.name_label" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- DEVICE -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('device') }}
+              </template>
+              <template #value>
+                {{ t('vif-device', { device: vif.device }) }}
+              </template>
               <template #addons>
-                <VtsCopyButton :value="ip" />
-                <UiButtonIcon
-                  v-if="index === 0 && ipAddresses.length > 1"
-                  v-tooltip="t('coming-soon!')"
-                  disabled
-                  icon="fa:ellipsis"
-                  size="small"
-                  accent="brand"
-                />
+                <VtsCopyButton :value="vif.device" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- VIF STATUS -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('vif-status') }}
+              </template>
+              <template #value>
+                <VtsStatus :status />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- MTU -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('mtu') }}
+              </template>
+              <template #value>
+                {{ vif.MTU }}
+              </template>
+              <template #addons>
+                <VtsCopyButton :value="String(vif.MTU)" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- LOCKING MODE -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('locking-mode') }}
+              </template>
+              <template #value>
+                {{ vif.locking_mode }}
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- TODO Need to add TX Checksumming -->
+          </div>
+        </UiCard>
+        <!-- VIF NETWORK INFORMATION -->
+        <UiCard class="card">
+          <UiCardTitle>{{ t('network-information') }}</UiCardTitle>
+          <div class="content">
+            <!-- IP ADDRESSES -->
+            <div v-if="ipAddresses.length">
+              <VtsCardRowKeyValue v-for="(ip, index) in ipAddresses" :key="ip">
+                <template #key>
+                  <div v-if="index === 0">{{ t('ip-addresses') }}</div>
+                </template>
+                <template #value>{{ ip }}</template>
+                <template #addons>
+                  <VtsCopyButton :value="ip" />
+                  <UiButtonIcon
+                    v-if="index === 0 && ipAddresses.length > 1"
+                    v-tooltip="t('coming-soon!')"
+                    disabled
+                    icon="fa:ellipsis"
+                    size="small"
+                    accent="brand"
+                  />
+                </template>
+              </VtsCardRowKeyValue>
+            </div>
+            <VtsCardRowKeyValue v-else>
+              <template #key>
+                {{ t('ip-addresses') }}
+              </template>
+              <template #value>
+                <span class="value" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- MAC ADDRESSES -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('mac-address') }}
+              </template>
+              <template #value>
+                {{ vif.MAC }}
+              </template>
+              <template #addons>
+                <VtsCopyButton :value="vif.MAC" />
               </template>
             </VtsCardRowKeyValue>
           </div>
-          <VtsCardRowKeyValue v-else>
-            <template #key>
-              {{ t('ip-addresses') }}
-            </template>
-            <template #value>
-              <span class="value" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- MAC ADDRESSES -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('mac-address') }}
-            </template>
-            <template #value>
-              {{ vif.MAC }}
-            </template>
-            <template #addons>
-              <VtsCopyButton :value="vif.MAC" />
-            </template>
-          </VtsCardRowKeyValue>
-        </div>
-      </UiCard>
+        </UiCard>
+      </template>
     </template>
-  </UiPanel>
+  </VtsSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -146,20 +145,20 @@ import { useVmStore } from '@/stores/xen-api/vm.store'
 import VtsCardRowKeyValue from '@core/components/card/VtsCardRowKeyValue.vue'
 import VtsCodeSnippet from '@core/components/code-snippet/VtsCodeSnippet.vue'
 import VtsCopyButton from '@core/components/copy-button/VtsCopyButton.vue'
+import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import VtsStatus from '@core/components/status/VtsStatus.vue'
 import UiButton from '@core/components/ui/button/UiButton.vue'
 import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiCardTitle from '@core/components/ui/card-title/UiCardTitle.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { vTooltip } from '@core/directives/tooltip.directive'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import { getUniqueIpAddressesForDevice } from '@core/utils/ip-address.utils.ts'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const { vif } = defineProps<{
-  vif: XenApiVif
+  vif?: XenApiVif
 }>()
 
 const emit = defineEmits<{
@@ -171,9 +170,12 @@ const { t } = useI18n()
 const { getByOpaqueRef: getNetworkByOpaqueRef } = useNetworkStore().subscribe()
 const { getByOpaqueRef: getGuestMetricsByOpaqueRef } = useVmGuestMetricsStore().subscribe()
 const { getByOpaqueRef: getVmByOpaqueRef } = useVmStore().subscribe()
-const uiStore = useUiStore()
 
 const ipAddresses = computed(() => {
+  if (vif === undefined) {
+    return []
+  }
+
   const vm = getVmByOpaqueRef(vif.VM)
 
   if (!vm) {
@@ -185,9 +187,9 @@ const ipAddresses = computed(() => {
   return getUniqueIpAddressesForDevice(networks, vif.device)
 })
 
-const network = computed(() => getNetworkByOpaqueRef(vif.network))
+const network = computed(() => (vif !== undefined ? getNetworkByOpaqueRef(vif.network) : undefined))
 
-const status = computed(() => (vif.currently_attached ? 'connected' : 'disconnected'))
+const status = computed(() => (vif?.currently_attached ? 'connected' : 'disconnected'))
 </script>
 
 <style scoped lang="postcss">
@@ -203,26 +205,5 @@ const status = computed(() => (vif.currently_attached ? 'connected' : 'disconnec
   .value:empty::before {
     content: '-';
   }
-}
-
-.action-buttons-container {
-  margin-inline-end: auto;
-}
-
-.mobile-drawer {
-  position: fixed;
-  inset: 0;
-
-  .action-buttons-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-  }
-}
-
-.action-buttons {
-  display: flex;
-  align-items: center;
 }
 </style>

--- a/@xen-orchestra/lite/src/components/vm/network/VmVifsSidePanel.vue
+++ b/@xen-orchestra/lite/src/components/vm/network/VmVifsSidePanel.vue
@@ -1,16 +1,7 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }">
+  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
     <template #header>
-      <div :class="{ 'action-buttons-container': uiStore.isSmall }">
-        <UiButtonIcon
-          v-if="uiStore.isSmall"
-          v-tooltip="t('action:close')"
-          size="small"
-          variant="tertiary"
-          accent="brand"
-          icon="fa:angle-left"
-          @click="emit('close')"
-        />
+      <div class="action-buttons-container">
         <div class="action-buttons">
           <UiButton
             v-tooltip="t('coming-soon!')"
@@ -212,6 +203,10 @@ const status = computed(() => (vif.currently_attached ? 'connected' : 'disconnec
   .value:empty::before {
     content: '-';
   }
+}
+
+.action-buttons-container {
+  margin-inline-end: auto;
 }
 
 .mobile-drawer {

--- a/@xen-orchestra/lite/src/pages/host/[uuid]/network.vue
+++ b/@xen-orchestra/lite/src/pages/host/[uuid]/network.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="host-network-view" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="network">
     <UiCard class="container">
       <HostPifsTable :pifs />
     </UiCard>
     <HostPifSidePanel :pif="selectedPif" @close="selectedPif = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script lang="ts" setup>
@@ -14,18 +14,15 @@ import type { XenApiPif } from '@/libs/xen-api/xen-api.types'
 import { usePageTitleStore } from '@/stores/page-title.store'
 import { useHostStore } from '@/stores/xen-api/host.store'
 import { usePifStore } from '@/stores/xen-api/pif.store'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 
 const { records } = usePifStore().subscribe()
 const { getByOpaqueRef: getHostOpaqueRef } = useHostStore().subscribe()
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const route = useRoute<'/host/[uuid]/network'>()
 
@@ -47,12 +44,7 @@ const selectedPif = useRouteQuery<XenApiPif | undefined>('id', {
 </script>
 
 <style lang="postcss" scoped>
-.host-network-view {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
+.network {
   .container {
     height: fit-content;
     margin: 0.8rem;

--- a/@xen-orchestra/lite/src/pages/host/[uuid]/network.vue
+++ b/@xen-orchestra/lite/src/pages/host/[uuid]/network.vue
@@ -5,9 +5,7 @@
     </UiCard>
     <HostPifSidePanel v-if="selectedPif" :pif="selectedPif" @close="selectedPif = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>

--- a/@xen-orchestra/lite/src/pages/host/[uuid]/network.vue
+++ b/@xen-orchestra/lite/src/pages/host/[uuid]/network.vue
@@ -1,12 +1,9 @@
 <template>
-  <div class="host-network-view" :class="{ mobile: uiStore.isSmall }">
+  <div class="host-network-view" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <HostPifsTable :pifs />
     </UiCard>
-    <HostPifSidePanel v-if="selectedPif" :pif="selectedPif" @close="selectedPif = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <HostPifSidePanel :pif="selectedPif" @close="selectedPif = undefined" />
   </div>
 </template>
 
@@ -17,10 +14,9 @@ import type { XenApiPif } from '@/libs/xen-api/xen-api.types'
 import { usePageTitleStore } from '@/stores/page-title.store'
 import { useHostStore } from '@/stores/xen-api/host.store'
 import { usePifStore } from '@/stores/xen-api/pif.store'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -28,6 +24,7 @@ import { useRoute } from 'vue-router'
 
 const { records } = usePifStore().subscribe()
 const { getByOpaqueRef: getHostOpaqueRef } = useHostStore().subscribe()
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const route = useRoute<'/host/[uuid]/network'>()
@@ -51,7 +48,7 @@ const selectedPif = useRouteQuery<XenApiPif | undefined>('id', {
 
 <style lang="postcss" scoped>
 .host-network-view {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/lite/src/pages/pool/[uuid]/network.vue
+++ b/@xen-orchestra/lite/src/pages/pool/[uuid]/network.vue
@@ -6,9 +6,7 @@
     </UiCard>
     <PoolNetworkSidePanel v-if="selectedNetwork" :network="selectedNetwork" @close="selectedNetwork = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>

--- a/@xen-orchestra/lite/src/pages/pool/[uuid]/network.vue
+++ b/@xen-orchestra/lite/src/pages/pool/[uuid]/network.vue
@@ -1,13 +1,10 @@
 <template>
-  <div class="pool-network-view" :class="{ mobile: uiStore.isSmall }">
+  <div class="pool-network-view" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <PoolNetworksTable :networks="networksWithPifs" />
       <PoolHostInternalNetworksTable :networks="networksWithoutPifs" />
     </UiCard>
-    <PoolNetworkSidePanel v-if="selectedNetwork" :network="selectedNetwork" @close="selectedNetwork = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <PoolNetworkSidePanel :network="selectedNetwork" @close="selectedNetwork = undefined" />
   </div>
 </template>
 
@@ -18,10 +15,9 @@ import PoolNetworksTable from '@/components/pool/network/PoolNetworksTable.vue'
 import type { XenApiNetwork } from '@/libs/xen-api/xen-api.types'
 import { usePageTitleStore } from '@/stores/page-title.store'
 import { useNetworkStore } from '@/stores/xen-api/network.store'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { useI18n } from 'vue-i18n'
 
@@ -29,6 +25,7 @@ const { t } = useI18n()
 usePageTitleStore().setTitle(t('network'))
 
 const { getByUuid, networksWithPifs, networksWithoutPifs } = useNetworkStore().subscribe()
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const selectedNetwork = useRouteQuery<XenApiNetwork | undefined>('id', {
@@ -39,7 +36,7 @@ const selectedNetwork = useRouteQuery<XenApiNetwork | undefined>('id', {
 
 <style lang="postcss" scoped>
 .pool-network-view {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/lite/src/pages/pool/[uuid]/network.vue
+++ b/@xen-orchestra/lite/src/pages/pool/[uuid]/network.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="pool-network-view" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="network">
     <UiCard class="container">
       <PoolNetworksTable :networks="networksWithPifs" />
       <PoolHostInternalNetworksTable :networks="networksWithoutPifs" />
     </UiCard>
     <PoolNetworkSidePanel :network="selectedNetwork" @close="selectedNetwork = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script lang="ts" setup>
@@ -15,18 +15,15 @@ import PoolNetworksTable from '@/components/pool/network/PoolNetworksTable.vue'
 import type { XenApiNetwork } from '@/libs/xen-api/xen-api.types'
 import { usePageTitleStore } from '@/stores/page-title.store'
 import { useNetworkStore } from '@/stores/xen-api/network.store'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 usePageTitleStore().setTitle(t('network'))
 
 const { getByUuid, networksWithPifs, networksWithoutPifs } = useNetworkStore().subscribe()
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const selectedNetwork = useRouteQuery<XenApiNetwork | undefined>('id', {
   toData: id => getByUuid(id as XenApiNetwork['uuid']),
@@ -35,12 +32,7 @@ const selectedNetwork = useRouteQuery<XenApiNetwork | undefined>('id', {
 </script>
 
 <style lang="postcss" scoped>
-.pool-network-view {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
+.network {
   .container {
     height: fit-content;
     margin: 0.8rem;

--- a/@xen-orchestra/lite/src/pages/vm/[uuid]/network.vue
+++ b/@xen-orchestra/lite/src/pages/vm/[uuid]/network.vue
@@ -5,9 +5,7 @@
     </UiCard>
     <VmVifsSidePanel v-if="selectedVif" :vif="selectedVif" @close="selectedVif = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>

--- a/@xen-orchestra/lite/src/pages/vm/[uuid]/network.vue
+++ b/@xen-orchestra/lite/src/pages/vm/[uuid]/network.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="vm-network-view" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="network">
     <UiCard class="container">
       <VmVifsTable :vifs />
     </UiCard>
     <VmVifsSidePanel :vif="selectedVif" @close="selectedVif = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script lang="ts" setup>
@@ -14,18 +14,15 @@ import type { XenApiVif } from '@/libs/xen-api/xen-api.types'
 import { usePageTitleStore } from '@/stores/page-title.store'
 import { useVifStore } from '@/stores/xen-api/vif.store'
 import { useVmStore } from '@/stores/xen-api/vm.store'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import { useArrayFilter } from '@vueuse/shared'
 import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 
 const { records } = useVifStore().subscribe()
 const { getByOpaqueRef } = useVmStore().subscribe()
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const route = useRoute<'/vm/[uuid]/network'>()
 
@@ -45,12 +42,7 @@ const selectedVif = useRouteQuery<XenApiVif | undefined>('id', {
 </script>
 
 <style lang="postcss" scoped>
-.vm-network-view {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
+.network {
   .container {
     height: fit-content;
     margin: 0.8rem;

--- a/@xen-orchestra/lite/src/pages/vm/[uuid]/network.vue
+++ b/@xen-orchestra/lite/src/pages/vm/[uuid]/network.vue
@@ -1,12 +1,9 @@
 <template>
-  <div class="vm-network-view" :class="{ mobile: uiStore.isSmall }">
+  <div class="vm-network-view" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <VmVifsTable :vifs />
     </UiCard>
-    <VmVifsSidePanel v-if="selectedVif" :vif="selectedVif" @close="selectedVif = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <VmVifsSidePanel :vif="selectedVif" @close="selectedVif = undefined" />
   </div>
 </template>
 
@@ -17,10 +14,9 @@ import type { XenApiVif } from '@/libs/xen-api/xen-api.types'
 import { usePageTitleStore } from '@/stores/page-title.store'
 import { useVifStore } from '@/stores/xen-api/vif.store'
 import { useVmStore } from '@/stores/xen-api/vm.store'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { useArrayFilter } from '@vueuse/shared'
 import { useI18n } from 'vue-i18n'
@@ -28,6 +24,7 @@ import { useRoute } from 'vue-router'
 
 const { records } = useVifStore().subscribe()
 const { getByOpaqueRef } = useVmStore().subscribe()
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const route = useRoute<'/vm/[uuid]/network'>()
@@ -49,7 +46,7 @@ const selectedVif = useRouteQuery<XenApiVif | undefined>('id', {
 
 <style lang="postcss" scoped>
 .vm-network-view {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/lite/src/route-map.d.ts
+++ b/@xen-orchestra/lite/src/route-map.d.ts
@@ -386,6 +386,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/story/web-core/panel/vts-panel': RouteRecordInfo<
+      '/story/web-core/panel/vts-panel',
+      '/story/web-core/panel/vts-panel',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/story/web-core/resources/vts-resource': RouteRecordInfo<
       '/story/web-core/resources/vts-resource',
       '/story/web-core/resources/vts-resource',
@@ -1314,6 +1321,12 @@ declare module 'vue-router/auto-routes' {
     'src/stories/web-core/object-icon/vts-object-icon.story.vue': {
       routes:
         | '/story/web-core/object-icon/vts-object-icon'
+      views:
+        | never
+    }
+    'src/stories/web-core/panel/vts-panel.story.vue': {
+      routes:
+        | '/story/web-core/panel/vts-panel'
       views:
         | never
     }

--- a/@xen-orchestra/lite/src/stories/web-core/panel/vts-panel.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/panel/vts-panel.story.vue
@@ -1,0 +1,82 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties, settings }"
+    :params="[
+      prop('error').bool().widget().preset(false),
+      prop('closable').bool().widget().preset(true),
+      iconProp('closeIcon')
+        .preset('action:close-cancel-clear')
+        .default('action:close-cancel-clear')
+        .help('The close icon (can be different on mobile)'),
+      event('close').args({}).help('Emitted when the user clicks the close button'),
+      slot(),
+      slot('header').help('Meant to receive text or other information'),
+      slot('actions').help('For the main action buttons'),
+      slot('more-actions').help('For other action buttons, shown in a dropdown menu'),
+      slot('corner-actions').help('For action icon buttons, like the pin button on VtsSidePanel'),
+      setting('headerText').widget(text()),
+      setting('forceMaxWidth').widget(boolean()).preset(true).help('Simulate the side panel\'s default width'),
+      setting('showButtons').widget(boolean()).preset(true),
+      setting('showMoreButtons').widget(boolean()).preset(false),
+      setting('showHero').widget(boolean()).preset(true),
+      setting('heroType')
+        .widget(choice(...stateHeroTypes))
+        .preset('no-selection'),
+    ]"
+  >
+    <VtsPanel v-bind="properties" :class="{ 'force-max-width': settings.forceMaxWidth }">
+      <template v-if="settings.headerText" #header>
+        <span>{{ settings.headerText }}</span>
+      </template>
+      <template v-if="settings.showButtons" #actions>
+        <UiButton variant="tertiary" size="medium" accent="brand" left-icon="action:edit">Edit</UiButton>
+        <UiButton variant="tertiary" size="medium" accent="danger" left-icon="action:delete">Delete</UiButton>
+      </template>
+      <template v-if="settings.showMoreButtons" #more-actions>
+        <UiButton variant="tertiary" size="medium" accent="warning" left-icon="action:disconnect">
+          Disconnect<UiCounter value="3" accent="warning" variant="primary" size="small" />
+        </UiButton>
+        <UiButton variant="tertiary" size="medium" accent="brand" left-icon="action:copy">Copy</UiButton>
+        <UiButton variant="tertiary" size="medium" accent="brand" left-icon="action:download">Download</UiButton>
+      </template>
+      <template #default>
+        <VtsStateHero v-if="settings.showHero" format="card" :type="settings.heroType" size="medium" />
+        <UiCard v-else>
+          <div>Card Content</div>
+        </UiCard>
+      </template>
+    </VtsPanel>
+  </ComponentStory>
+</template>
+
+<script setup lang="ts">
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import { event, iconProp, prop, setting, slot } from '@/libs/story/story-param'
+import { boolean, choice, text } from '@/libs/story/story-widget'
+import VtsPanel from '@core/components/panel/VtsPanel.vue'
+import VtsStateHero, { type StateHeroType } from '@core/components/state-hero/VtsStateHero.vue'
+import UiButton from '@core/components/ui/button/UiButton.vue'
+import UiCard from '@core/components/ui/card/UiCard.vue'
+import UiCounter from '@core/components/ui/counter/UiCounter.vue'
+
+const stateHeroTypes = [
+  'busy',
+  'no-result',
+  'under-construction',
+  'no-data',
+  'no-selection',
+  'error',
+  'not-found',
+  'offline',
+  'all-good',
+  'all-done',
+  'creating',
+] as const satisfies readonly StateHeroType[]
+</script>
+
+<style scoped lang="postcss">
+.force-max-width {
+  max-width: 40rem;
+  margin: 0 auto;
+}
+</style>

--- a/@xen-orchestra/lite/src/stories/web-core/panel/vts-panel.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/panel/vts-panel.story.vue
@@ -20,7 +20,7 @@
       setting('showMoreButtons').widget(boolean()).preset(false),
       setting('showHero').widget(boolean()).preset(true),
       setting('heroType')
-        .widget(choice(...stateHeroTypes))
+        .widget(choice(...STATE_HERO_TYPES))
         .preset('no-selection'),
     ]"
   >
@@ -54,24 +54,11 @@ import ComponentStory from '@/components/component-story/ComponentStory.vue'
 import { event, iconProp, prop, setting, slot } from '@/libs/story/story-param'
 import { boolean, choice, text } from '@/libs/story/story-widget'
 import VtsPanel from '@core/components/panel/VtsPanel.vue'
-import VtsStateHero, { type StateHeroType } from '@core/components/state-hero/VtsStateHero.vue'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiButton from '@core/components/ui/button/UiButton.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiCounter from '@core/components/ui/counter/UiCounter.vue'
-
-const stateHeroTypes = [
-  'busy',
-  'no-result',
-  'under-construction',
-  'no-data',
-  'no-selection',
-  'error',
-  'not-found',
-  'offline',
-  'all-good',
-  'all-done',
-  'creating',
-] as const satisfies readonly StateHeroType[]
+import { STATE_HERO_TYPES } from '@core/types/state-hero.type.ts'
 </script>
 
 <style scoped lang="postcss">

--- a/@xen-orchestra/lite/src/stories/web-core/state-hero/vts-state-hero.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/state-hero/vts-state-hero.story.vue
@@ -7,17 +7,7 @@
       prop('horizontal').bool().widget(),
       prop('imageSize').enum('small', 'medium', 'large').preset('medium').widget(),
       prop('type')
-        .enum(
-          'no-result',
-          'under-construction',
-          'no-data',
-          'no-selection',
-          'error',
-          'not-found',
-          'offline',
-          'all-good',
-          'all-done'
-        )
+        .enum(...STATE_HERO_TYPES)
         .widget(),
       prop('noBackground').bool().widget(),
       slot(),
@@ -34,4 +24,5 @@
 import ComponentStory from '@/components/component-story/ComponentStory.vue'
 import { prop, setting, slot } from '@/libs/story/story-param'
 import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
+import { STATE_HERO_TYPES } from '@core/types/state-hero.type.ts'
 </script>

--- a/@xen-orchestra/lite/src/stories/web-core/ui/panel/ui-panel.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/panel/ui-panel.story.vue
@@ -2,38 +2,37 @@
   <ComponentStory
     v-slot="{ properties, settings }"
     :params="[
-      prop('error').bool().widget(),
-      setting('action1').widget(text()).preset('Edit'),
-      setting('action2').widget(text()).preset('Delete'),
+      prop('error').bool().widget().preset(false),
+      prop('closable').bool().widget().preset(true),
       slot(),
       slot('header').help('Meant to receive UiButton or other information'),
+      setting('forceMaxWidth').widget(boolean()).preset(true).help('Simulate the side panel\'s default width'),
+      setting('showDemoButtons').widget(boolean()).preset(true),
+      setting('moreButtons')
+        .widget(boolean())
+        .preset(false)
+        .help('Combine with forceMaxWidth to test the header scroll behaviour'),
+      setting('showHero').widget(boolean()).preset(true),
+      setting('heroType')
+        .widget(choice(...stateHeroTypes))
+        .preset('no-selection'),
     ]"
-    :presets="{
-      Normal: {
-        props: {
-          error: false,
-        },
-      },
-      Error: {
-        props: {
-          error: true,
-        },
-      },
-    }"
   >
-    <UiSidePanel v-bind="properties" :error="properties.error">
+    <UiSidePanel v-bind="properties" :class="{ 'force-max-width': settings.forceMaxWidth }">
       <template #header>
-        <UiButton variant="tertiary" size="medium" accent="brand" @click="toggle()">Toggle</UiButton>
-        <UiButton variant="tertiary" size="medium" accent="brand" left-icon="fa:edit"> {{ settings.action1 }}</UiButton>
-        <UiButton variant="tertiary" size="medium" accent="danger" left-icon="fa:trash">
-          {{ settings.action2 }}
-        </UiButton>
+        <template v-if="settings.showDemoButtons">
+          <UiButton variant="tertiary" size="medium" accent="brand" left-icon="action:edit">Edit</UiButton>
+          <UiButton variant="tertiary" size="medium" accent="danger" left-icon="action:delete">Delete</UiButton>
+          <template v-if="settings.moreButtons">
+            <UiButton variant="tertiary" size="medium" accent="warning" left-icon="action:disconnect">
+              Disconnect<UiCounter value="3" accent="warning" variant="primary" size="small" />
+            </UiButton>
+          </template>
+        </template>
       </template>
-      <VtsStateHero v-if="!isReady" format="card" type="busy" size="medium" />
-      <UiCard v-else-if="!properties.error">
-        <div>Content 1</div>
-        <div>Content 1</div>
-        <div>Content 1</div>
+      <VtsStateHero v-if="settings.showHero" format="card" :type="settings.heroType" size="medium" />
+      <UiCard v-else>
+        <div>Card Content</div>
       </UiCard>
     </UiSidePanel>
   </ComponentStory>
@@ -42,14 +41,31 @@
 <script setup lang="ts">
 import ComponentStory from '@/components/component-story/ComponentStory.vue'
 import { prop, setting, slot } from '@/libs/story/story-param'
-import { text } from '@/libs/story/story-widget'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
+import { boolean, choice } from '@/libs/story/story-widget'
+import VtsStateHero, { type StateHeroType } from '@core/components/state-hero/VtsStateHero.vue'
 import UiButton from '@core/components/ui/button/UiButton.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
+import UiCounter from '@core/components/ui/counter/UiCounter.vue'
 import UiSidePanel from '@core/components/ui/panel/UiPanel.vue'
-import { useToggle } from '@vueuse/core'
-import { computed } from 'vue'
 
-const [isToggled, toggle] = useToggle()
-const isReady = computed(() => isToggled.value)
+const stateHeroTypes = [
+  'busy',
+  'no-result',
+  'under-construction',
+  'no-data',
+  'no-selection',
+  'error',
+  'not-found',
+  'offline',
+  'all-good',
+  'all-done',
+  'creating',
+] as const satisfies readonly StateHeroType[]
 </script>
+
+<style scoped lang="postcss">
+.force-max-width {
+  max-width: 40rem;
+  margin: 0 auto;
+}
+</style>

--- a/@xen-orchestra/lite/src/stories/web-core/ui/panel/ui-panel.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/panel/ui-panel.story.vue
@@ -3,69 +3,25 @@
     v-slot="{ properties, settings }"
     :params="[
       prop('error').bool().widget().preset(false),
-      prop('closable').bool().widget().preset(true),
       slot(),
-      slot('header').help('Meant to receive UiButton or other information'),
-      setting('forceMaxWidth').widget(boolean()).preset(true).help('Simulate the side panel\'s default width'),
-      setting('showDemoButtons').widget(boolean()).preset(true),
-      setting('moreButtons')
-        .widget(boolean())
-        .preset(false)
-        .help('Combine with forceMaxWidth to test the header scroll behaviour'),
-      setting('showHero').widget(boolean()).preset(true),
-      setting('heroType')
-        .widget(choice(...stateHeroTypes))
-        .preset('no-selection'),
+      slot('header').help('Optional panel header'),
+      setting('showHeader').widget(boolean()).preset(true),
+      setting('headerContent').widget(text()).preset('Panel header'),
     ]"
   >
-    <UiSidePanel v-bind="properties" :class="{ 'force-max-width': settings.forceMaxWidth }">
-      <template #header>
-        <template v-if="settings.showDemoButtons">
-          <UiButton variant="tertiary" size="medium" accent="brand" left-icon="action:edit">Edit</UiButton>
-          <UiButton variant="tertiary" size="medium" accent="danger" left-icon="action:delete">Delete</UiButton>
-          <template v-if="settings.moreButtons">
-            <UiButton variant="tertiary" size="medium" accent="warning" left-icon="action:disconnect">
-              Disconnect<UiCounter value="3" accent="warning" variant="primary" size="small" />
-            </UiButton>
-          </template>
-        </template>
-      </template>
-      <VtsStateHero v-if="settings.showHero" format="card" :type="settings.heroType" size="medium" />
-      <UiCard v-else>
-        <div>Card Content</div>
+    <UiPanel v-bind="properties">
+      <template v-if="settings.showHeader" #header>{{ settings.headerContent }}</template>
+      <UiCard>
+        <div>Card content</div>
       </UiCard>
-    </UiSidePanel>
+    </UiPanel>
   </ComponentStory>
 </template>
 
 <script setup lang="ts">
 import ComponentStory from '@/components/component-story/ComponentStory.vue'
 import { prop, setting, slot } from '@/libs/story/story-param'
-import { boolean, choice } from '@/libs/story/story-widget'
-import VtsStateHero, { type StateHeroType } from '@core/components/state-hero/VtsStateHero.vue'
-import UiButton from '@core/components/ui/button/UiButton.vue'
+import { boolean, text } from '@/libs/story/story-widget'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiCounter from '@core/components/ui/counter/UiCounter.vue'
-import UiSidePanel from '@core/components/ui/panel/UiPanel.vue'
-
-const stateHeroTypes = [
-  'busy',
-  'no-result',
-  'under-construction',
-  'no-data',
-  'no-selection',
-  'error',
-  'not-found',
-  'offline',
-  'all-good',
-  'all-done',
-  'creating',
-] as const satisfies readonly StateHeroType[]
+import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 </script>
-
-<style scoped lang="postcss">
-.force-max-width {
-  max-width: 40rem;
-  margin: 0 auto;
-}
-</style>

--- a/@xen-orchestra/web-core/lib/components/layout/VtsContentSidePanel.vue
+++ b/@xen-orchestra/web-core/lib/components/layout/VtsContentSidePanel.vue
@@ -1,0 +1,25 @@
+<template>
+  <div
+    class="vts-content-side-panel"
+    :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }"
+  >
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { usePanelStore } from '@core/stores/panel.store'
+import { useUiStore } from '@core/stores/ui.store'
+
+const panelStore = usePanelStore()
+const uiStore = useUiStore()
+</script>
+
+<style scoped lang="postcss">
+.vts-content-side-panel {
+  &.locked:not(.mobile) {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 40rem;
+  }
+}
+</style>

--- a/@xen-orchestra/web-core/lib/components/layout/VtsContentSidePanel.vue
+++ b/@xen-orchestra/web-core/lib/components/layout/VtsContentSidePanel.vue
@@ -1,7 +1,10 @@
 <template>
   <div
     class="vts-content-side-panel"
-    :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }"
+    :class="{
+      mobile: uiStore.isSmall,
+      'has-panel-column': hasPanelColumn,
+    }"
   >
     <slot />
   </div>
@@ -10,16 +13,29 @@
 <script setup lang="ts">
 import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store'
+import { computed } from 'vue'
 
 const panelStore = usePanelStore()
 const uiStore = useUiStore()
+
+const hasPanelColumn = computed(() => (panelStore.isLocked || panelStore.isExpanded) && !uiStore.isSmall)
 </script>
 
 <style scoped lang="postcss">
 .vts-content-side-panel {
-  &.locked:not(.mobile) {
+  --side-panel-width: 40rem;
+
+  &:not(.mobile) {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
+    grid-template-columns: minmax(0, 1fr) 0;
+    align-items: start;
+    overflow-x: clip;
+    min-height: min-content;
+    transition: grid-template-columns 0.25s;
+
+    &.has-panel-column {
+      grid-template-columns: minmax(0, 1fr) var(--side-panel-width);
+    }
   }
 }
 </style>

--- a/@xen-orchestra/web-core/lib/components/operation-card/VtsOperationCard.vue
+++ b/@xen-orchestra/web-core/lib/components/operation-card/VtsOperationCard.vue
@@ -12,9 +12,10 @@
 </template>
 
 <script lang="ts" setup>
-import VtsStateHero, { type StateHeroType } from '@core/components/state-hero/VtsStateHero.vue'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useUiStore } from '@core/stores/ui.store.ts'
+import type { StateHeroType } from '@core/types/state-hero.type.ts'
 
 defineProps<{
   title: string

--- a/@xen-orchestra/web-core/lib/components/panel/VtsPanel.vue
+++ b/@xen-orchestra/web-core/lib/components/panel/VtsPanel.vue
@@ -1,10 +1,7 @@
 <!-- v5 -->
 <template>
-  <UiPanel :error class="vts-panel">
-    <template
-      v-if="slots.header || slots.actions || slots['more-actions'] || slots['corner-actions'] || closable"
-      #header
-    >
+  <UiPanel :error>
+    <template v-if="needsHeader" #header>
       <slot v-if="slots.header" name="header" />
       <div v-if="slots.actions || slots['more-actions']" class="action-buttons">
         <template v-if="slots.actions">
@@ -40,18 +37,14 @@ import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { vTooltip } from '@core/directives/tooltip.directive'
 import type { IconName } from '@core/icons'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-withDefaults(
-  defineProps<{
-    error?: boolean
-    closable?: boolean
-    closeIcon?: IconName
-  }>(),
-  {
-    closeIcon: 'action:close-cancel-clear',
-  }
-)
+const { closable, closeIcon = 'action:close-cancel-clear' } = defineProps<{
+  error?: boolean
+  closable?: boolean
+  closeIcon?: IconName
+}>()
 
 const emit = defineEmits<{
   close: []
@@ -66,6 +59,10 @@ const slots = defineSlots<{
 }>()
 
 const { t } = useI18n()
+
+const needsHeader = computed(
+  () => slots.header || slots.actions || slots['more-actions'] || slots['corner-actions'] || closable
+)
 </script>
 
 <style scoped lang="postcss">
@@ -79,11 +76,5 @@ const { t } = useI18n()
   align-items: center;
   margin-inline-start: auto;
   gap: 0.8rem;
-}
-.mobile {
-  .corner-actions {
-    margin-inline-start: 0;
-    margin-inline-end: auto;
-  }
 }
 </style>

--- a/@xen-orchestra/web-core/lib/components/panel/VtsPanel.vue
+++ b/@xen-orchestra/web-core/lib/components/panel/VtsPanel.vue
@@ -1,0 +1,89 @@
+<!-- v5 -->
+<template>
+  <UiPanel :error class="vts-panel">
+    <template
+      v-if="slots.header || slots.actions || slots['more-actions'] || slots['corner-actions'] || closable"
+      #header
+    >
+      <slot v-if="slots.header" name="header" />
+      <div v-if="slots.actions || slots['more-actions']" class="action-buttons">
+        <template v-if="slots.actions">
+          <slot name="actions" />
+        </template>
+        <MenuList v-if="slots['more-actions']" placement="bottom-end">
+          <template #trigger="{ open }">
+            <UiButtonIcon icon="action:more-actions" accent="brand" size="medium" @click="open($event)" />
+          </template>
+          <slot name="more-actions" />
+        </MenuList>
+      </div>
+      <div v-if="slots['corner-actions'] || closable" class="corner-actions">
+        <slot v-if="slots['corner-actions']" name="corner-actions" />
+        <UiButtonIcon
+          v-if="closable"
+          v-tooltip="t('action:close')"
+          size="small"
+          variant="tertiary"
+          accent="brand"
+          :icon="closeIcon"
+          @click="emit('close')"
+        />
+      </div>
+    </template>
+    <slot />
+  </UiPanel>
+</template>
+
+<script setup lang="ts">
+import MenuList from '@core/components/menu/MenuList.vue'
+import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
+import UiPanel from '@core/components/ui/panel/UiPanel.vue'
+import { vTooltip } from '@core/directives/tooltip.directive'
+import type { IconName } from '@core/icons'
+import { useI18n } from 'vue-i18n'
+
+withDefaults(
+  defineProps<{
+    error?: boolean
+    closable?: boolean
+    closeIcon?: IconName
+  }>(),
+  {
+    closeIcon: 'action:close-cancel-clear',
+  }
+)
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const slots = defineSlots<{
+  default(): any
+  header?(): any
+  actions?(): any
+  'more-actions'?(): any
+  'corner-actions'?(): any
+}>()
+
+const { t } = useI18n()
+</script>
+
+<style scoped lang="postcss">
+.action-buttons {
+  display: flex;
+  align-items: center;
+  gap: 1.6rem;
+}
+.corner-actions {
+  display: flex;
+  align-items: center;
+  margin-inline-start: auto;
+  gap: 0.8rem;
+}
+.mobile {
+  .corner-actions {
+    margin-inline-start: 0;
+    margin-inline-end: auto;
+  }
+}
+</style>

--- a/@xen-orchestra/web-core/lib/components/panel/VtsSidePanel.vue
+++ b/@xen-orchestra/web-core/lib/components/panel/VtsSidePanel.vue
@@ -1,0 +1,142 @@
+<!-- v5 -->
+<template>
+  <VtsPanel
+    :error
+    :closable
+    :close-icon="uiStore.isSmall ? 'fa:angle-left' : 'action:close-cancel-clear'"
+    class="vts-side-panel"
+    :class="{
+      locked: panelStore.isLocked && !uiStore.isSmall,
+      mobile: uiStore.isSmall,
+    }"
+    @close="handleClose"
+  >
+    <template v-if="slots.actions" #actions>
+      <slot name="actions" />
+    </template>
+
+    <template v-if="slots['more-actions']" #more-actions>
+      <slot name="more-actions" />
+    </template>
+
+    <template v-if="slots['corner-actions'] || !uiStore.isSmall" #corner-actions>
+      <slot v-if="slots['corner-actions']" name="corner-actions" />
+      <UiButtonIcon
+        v-if="!uiStore.isSmall"
+        v-tooltip="{
+          content: panelStore.isLocked ? t('action:sidebar-unlock') : t('action:sidebar-lock'),
+          placement: 'left',
+        }"
+        accent="brand"
+        size="small"
+        :icon="panelStore.isLocked ? 'action:pin-panel-hide' : 'action:pin-panel'"
+        @click="panelStore.toggleLock()"
+      />
+    </template>
+
+    <slot />
+  </VtsPanel>
+</template>
+
+<script setup lang="ts">
+import VtsPanel from '@core/components/panel/VtsPanel.vue'
+import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
+import { vTooltip } from '@core/directives/tooltip.directive'
+import { usePanelStore } from '@core/stores/panel.store'
+import { useUiStore } from '@core/stores/ui.store'
+import { watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const props = defineProps<{
+  closable?: boolean
+  error?: boolean
+  selected?: boolean
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const slots = defineSlots<{
+  default(): any
+  actions?(): any
+  'more-actions'?(): any
+  'corner-actions'?(): any
+}>()
+
+const panelStore = usePanelStore()
+const uiStore = useUiStore()
+
+const { t } = useI18n()
+
+watch(
+  [() => props.selected, () => panelStore.isLocked, () => uiStore.isSmall],
+  ([selected]) => {
+    if (selected === undefined) return
+    panelStore.syncWithSelection(!!selected)
+  },
+  { immediate: true }
+)
+
+function handleClose() {
+  if (panelStore.actsAsFloating) {
+    panelStore.collapse()
+  }
+
+  emit('close')
+}
+</script>
+
+<style scoped lang="postcss">
+.vts-side-panel {
+  width: 40rem;
+  z-index: 1010;
+  transition:
+    transform 0.25s,
+    margin-right 0.25s;
+
+  &:not(.mobile) {
+    position: relative;
+    top: 0;
+    min-height: calc(100dvh - v-bind('panelStore.cssVerticalOffset'));
+
+    &.locked {
+      margin-right: calc(-1 * v-bind('panelStore.cssHorizontalOffset'));
+    }
+
+    &:not(.locked) {
+      position: fixed;
+      top: v-bind('panelStore.cssVerticalOffset');
+      right: 0;
+      bottom: 0;
+      transform: translateX(v-bind('panelStore.cssHorizontalOffset'));
+      border-block-start: 0.1rem solid var(--color-neutral-border);
+      border-start-start-radius: 0.8rem;
+
+      :deep(.header) {
+        border-start-start-radius: 0.8rem;
+      }
+
+      :deep(> .content) {
+        overflow: auto;
+      }
+    }
+  }
+
+  &.mobile {
+    position: fixed;
+    width: 100dvw;
+    height: 100dvh;
+    inset: 0;
+    transform: translateX(v-bind('panelStore.cssHorizontalOffset'));
+
+    :deep(.corner-actions) {
+      order: -1;
+    }
+
+    :deep(> .content) {
+      overflow: auto;
+    }
+  }
+}
+</style>

--- a/@xen-orchestra/web-core/lib/components/panel/VtsSidePanel.vue
+++ b/@xen-orchestra/web-core/lib/components/panel/VtsSidePanel.vue
@@ -72,8 +72,10 @@ const { t } = useI18n()
 watch(
   [() => props.selected, () => panelStore.isLocked, () => uiStore.isSmall],
   ([selected]) => {
-    if (selected === undefined) return
-    panelStore.syncWithSelection(!!selected)
+    if (selected === undefined) {
+      return
+    }
+    panelStore.syncWithSelection(selected)
   },
   { immediate: true }
 )
@@ -89,6 +91,7 @@ function handleClose() {
 
 <style scoped lang="postcss">
 .vts-side-panel {
+  --panel-vertical-offset: 16.5rem;
   width: 40rem;
   z-index: 1010;
   transition:
@@ -98,7 +101,7 @@ function handleClose() {
   &:not(.mobile) {
     position: relative;
     top: 0;
-    min-height: calc(100dvh - v-bind('panelStore.cssVerticalOffset'));
+    min-height: calc(100dvh - var(--panel-vertical-offset));
 
     &.locked {
       margin-right: calc(-1 * v-bind('panelStore.cssHorizontalOffset'));
@@ -106,7 +109,7 @@ function handleClose() {
 
     &:not(.locked) {
       position: fixed;
-      top: v-bind('panelStore.cssVerticalOffset');
+      top: var(--panel-vertical-offset);
       right: 0;
       bottom: 0;
       transform: translateX(v-bind('panelStore.cssHorizontalOffset'));
@@ -131,6 +134,8 @@ function handleClose() {
     transform: translateX(v-bind('panelStore.cssHorizontalOffset'));
 
     :deep(.corner-actions) {
+      margin-inline-start: 0;
+      margin-inline-end: auto;
       order: -1;
     }
 

--- a/@xen-orchestra/web-core/lib/components/panel/VtsSidePanel.vue
+++ b/@xen-orchestra/web-core/lib/components/panel/VtsSidePanel.vue
@@ -1,41 +1,43 @@
 <!-- v5 -->
 <template>
-  <VtsPanel
-    :error
-    :closable
-    :close-icon="uiStore.isSmall ? 'fa:angle-left' : 'action:close-cancel-clear'"
-    class="vts-side-panel"
-    :class="{
-      locked: panelStore.isLocked && !uiStore.isSmall,
-      mobile: uiStore.isSmall,
-    }"
-    @close="handleClose"
-  >
-    <template v-if="slots.actions" #actions>
-      <slot name="actions" />
-    </template>
+  <div class="vts-side-panel-sticky" :class="{ mobile: uiStore.isSmall }">
+    <VtsPanel
+      :error
+      :closable
+      :close-icon="uiStore.isSmall ? 'fa:angle-left' : 'action:close-cancel-clear'"
+      class="vts-side-panel"
+      :class="{
+        locked: panelStore.isLocked && !uiStore.isSmall,
+        mobile: uiStore.isSmall,
+      }"
+      @close="handleClose"
+    >
+      <template v-if="slots.actions" #actions>
+        <slot name="actions" />
+      </template>
 
-    <template v-if="slots['more-actions']" #more-actions>
-      <slot name="more-actions" />
-    </template>
+      <template v-if="slots['more-actions']" #more-actions>
+        <slot name="more-actions" />
+      </template>
 
-    <template v-if="slots['corner-actions'] || !uiStore.isSmall" #corner-actions>
-      <slot v-if="slots['corner-actions']" name="corner-actions" />
-      <UiButtonIcon
-        v-if="!uiStore.isSmall"
-        v-tooltip="{
-          content: panelStore.isLocked ? t('action:sidebar-unlock') : t('action:sidebar-lock'),
-          placement: 'left',
-        }"
-        accent="brand"
-        size="small"
-        :icon="panelStore.isLocked ? 'action:pin-panel-hide' : 'action:pin-panel'"
-        @click="panelStore.toggleLock()"
-      />
-    </template>
+      <template v-if="slots['corner-actions'] || !uiStore.isSmall" #corner-actions>
+        <slot v-if="slots['corner-actions']" name="corner-actions" />
+        <UiButtonIcon
+          v-if="!uiStore.isSmall"
+          v-tooltip="{
+            content: panelStore.isLocked ? t('action:sidebar-unlock') : t('action:sidebar-lock'),
+            placement: 'left',
+          }"
+          accent="brand"
+          size="small"
+          :icon="panelStore.isLocked ? 'action:pin-panel-hide' : 'action:pin-panel'"
+          @click="panelStore.toggleLock()"
+        />
+      </template>
 
-    <slot />
-  </VtsPanel>
+      <slot />
+    </VtsPanel>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -71,17 +73,25 @@ const { t } = useI18n()
 
 watch(
   [() => props.selected, () => panelStore.isLocked, () => uiStore.isSmall],
-  ([selected]) => {
+  ([selected, isLocked, isSmall], previousState) => {
+    const [, previousIsLocked] = previousState ?? []
+
+    /* Collapse when coming back from locked to unlocked, if empty */
+    if (!isSmall && previousIsLocked && !isLocked && !selected) {
+      panelStore.collapse()
+    }
+
     if (selected === undefined) {
       return
     }
+
     panelStore.syncWithSelection(selected)
   },
   { immediate: true }
 )
 
 function handleClose() {
-  if (panelStore.actsAsFloating) {
+  if (panelStore.syncsOpenStateWithSelection) {
     panelStore.collapse()
   }
 
@@ -90,43 +100,34 @@ function handleClose() {
 </script>
 
 <style scoped lang="postcss">
+.vts-side-panel-sticky:not(.mobile) {
+  position: sticky;
+  top: 0;
+  align-self: start;
+}
+
 .vts-side-panel {
-  --panel-vertical-offset: 16.5rem;
-  width: 40rem;
-  z-index: 1010;
-  transition:
-    transform 0.25s,
-    margin-right 0.25s;
+  width: var(--side-panel-width, 40rem);
+  transition: transform 0.25s;
 
   &:not(.mobile) {
-    position: relative;
-    top: 0;
-    min-height: calc(100dvh - var(--panel-vertical-offset));
+    --panel-viewport-height: calc(100dvh - 5.6rem);
+    --panel-min-height: calc(100dvh - 16.6rem);
 
-    &.locked {
-      margin-right: calc(-1 * v-bind('panelStore.cssHorizontalOffset'));
-    }
+    min-height: var(--panel-min-height);
+    max-height: var(--panel-viewport-height);
+    overflow: hidden;
+    transform: translateX(v-bind('panelStore.cssHorizontalOffset'));
 
-    &:not(.locked) {
-      position: fixed;
-      top: var(--panel-vertical-offset);
-      right: 0;
-      bottom: 0;
-      transform: translateX(v-bind('panelStore.cssHorizontalOffset'));
-      border-block-start: 0.1rem solid var(--color-neutral-border);
-      border-start-start-radius: 0.8rem;
-
-      :deep(.header) {
-        border-start-start-radius: 0.8rem;
-      }
-
-      :deep(> .content) {
-        overflow: auto;
-      }
+    :deep(> .content) {
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow-y: auto;
     }
   }
 
   &.mobile {
+    z-index: 1010;
     position: fixed;
     width: 100dvw;
     height: 100dvh;

--- a/@xen-orchestra/web-core/lib/components/panel/VtsSidePanel.vue
+++ b/@xen-orchestra/web-core/lib/components/panel/VtsSidePanel.vue
@@ -2,8 +2,7 @@
 <template>
   <div class="vts-side-panel-sticky" :class="{ mobile: uiStore.isSmall }">
     <VtsPanel
-      :error
-      :closable
+      :closable="hasSelection"
       :close-icon="uiStore.isSmall ? 'fa:angle-left' : 'action:close-cancel-clear'"
       class="vts-side-panel"
       :class="{
@@ -35,13 +34,15 @@
         />
       </template>
 
-      <slot />
+      <VtsStateHero v-if="!hasSelection" format="panel" type="no-selection" size="medium" />
+      <slot v-else />
     </VtsPanel>
   </div>
 </template>
 
 <script setup lang="ts">
 import VtsPanel from '@core/components/panel/VtsPanel.vue'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import { vTooltip } from '@core/directives/tooltip.directive'
 import { usePanelStore } from '@core/stores/panel.store'
@@ -49,10 +50,8 @@ import { useUiStore } from '@core/stores/ui.store'
 import { watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-const props = defineProps<{
-  closable?: boolean
-  error?: boolean
-  selected?: boolean
+const { hasSelection } = defineProps<{
+  hasSelection?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -72,20 +71,13 @@ const uiStore = useUiStore()
 const { t } = useI18n()
 
 watch(
-  [() => props.selected, () => panelStore.isLocked, () => uiStore.isSmall],
-  ([selected, isLocked, isSmall], previousState) => {
-    const [, previousIsLocked] = previousState ?? []
-
-    /* Collapse when coming back from locked to unlocked, if empty */
-    if (!isSmall && previousIsLocked && !isLocked && !selected) {
-      panelStore.collapse()
-    }
-
-    if (selected === undefined) {
+  [() => hasSelection, () => panelStore.isLocked, () => uiStore.isSmall],
+  ([hasSelection]) => {
+    if (hasSelection === undefined) {
       return
     }
 
-    panelStore.syncWithSelection(selected)
+    panelStore.syncWithSelection(hasSelection)
   },
   { immediate: true }
 )

--- a/@xen-orchestra/web-core/lib/components/state-hero/VtsStateHero.vue
+++ b/@xen-orchestra/web-core/lib/components/state-hero/VtsStateHero.vue
@@ -9,6 +9,13 @@
       <div v-if="success">{{ t('all-good!') }}</div>
       <slot />
     </div>
+    <div v-else-if="type === 'no-selection'" :class="typoClass" class="content">
+      <I18nT keypath="select-to-see-details" tag="p">
+        <template #icon>
+          <VtsIcon name="fa:eye" size="current" />
+        </template>
+      </I18nT>
+    </div>
   </div>
 </template>
 
@@ -18,6 +25,7 @@ import { useUiStore } from '@core/stores/ui.store'
 import { toVariants } from '@core/utils/to-variants.util.ts'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import VtsIcon from '../icon/VtsIcon.vue'
 
 export type StateHeroFormat = 'page' | 'card' | 'panel' | 'table'
 

--- a/@xen-orchestra/web-core/lib/components/state-hero/VtsStateHero.vue
+++ b/@xen-orchestra/web-core/lib/components/state-hero/VtsStateHero.vue
@@ -10,7 +10,7 @@
       <slot />
     </div>
     <div v-else-if="type === 'no-selection'" :class="typoClass" class="content">
-      <I18nT keypath="select-to-see-details" tag="p">
+      <I18nT keypath="select-to-see-details" scope="global" tag="p">
         <template #icon>
           <VtsIcon name="fa:eye" size="current" />
         </template>
@@ -22,27 +22,11 @@
 <script lang="ts" setup>
 import UiLoader from '@core/components/ui/loader/UiLoader.vue'
 import { useUiStore } from '@core/stores/ui.store'
+import type { StateHeroFormat, StateHeroSize, StateHeroType } from '@core/types/state-hero.type.ts'
 import { toVariants } from '@core/utils/to-variants.util.ts'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import VtsIcon from '../icon/VtsIcon.vue'
-
-export type StateHeroFormat = 'page' | 'card' | 'panel' | 'table'
-
-export type StateHeroSize = 'extra-small' | 'small' | 'medium' | 'large'
-
-export type StateHeroType =
-  | 'busy'
-  | 'no-result'
-  | 'under-construction'
-  | 'no-data'
-  | 'no-selection'
-  | 'error'
-  | 'not-found'
-  | 'offline'
-  | 'all-good'
-  | 'all-done'
-  | 'creating'
 
 const { format, type, size, horizontal } = defineProps<{
   format: StateHeroFormat

--- a/@xen-orchestra/web-core/lib/components/table/VtsTable.vue
+++ b/@xen-orchestra/web-core/lib/components/table/VtsTable.vue
@@ -16,9 +16,10 @@
 </template>
 
 <script lang="ts" setup>
-import VtsStateHero, { type StateHeroSize, type StateHeroType } from '@core/components/state-hero/VtsStateHero.vue'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiTablePagination from '@core/components/ui/table-pagination/UiTablePagination.vue'
 import type { PaginationBindings } from '@core/composables/pagination.composable'
+import type { StateHeroType, StateHeroSize } from '@core/types/state-hero.type.ts'
 import { hasEllipsis } from '@core/utils/has-ellipsis.util'
 import { toVariants } from '@core/utils/to-variants.util'
 import { useResizeObserver, useScroll } from '@vueuse/core'

--- a/@xen-orchestra/web-core/lib/components/ui/head-bar/UiHeadBar.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/head-bar/UiHeadBar.vue
@@ -37,7 +37,7 @@ const slots = defineSlots<{
 
 <style lang="postcss" scoped>
 .ui-head-bar {
-  min-height: 5.6rem;
+  min-height: 6rem;
   padding: 0.8rem 1.6rem;
   display: flex;
   gap: 1.6rem;

--- a/@xen-orchestra/web-core/lib/components/ui/panel/UiPanel.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/panel/UiPanel.vue
@@ -26,9 +26,12 @@ const slots = defineSlots<{
   display: flex;
   flex-direction: column;
   border-inline-start: 0.1rem solid var(--color-neutral-border);
+  border-block-end: 0.1rem solid var(--color-neutral-border);
+  border-end-start-radius: 0.8rem;
   background-color: var(--color-neutral-background-secondary);
 
   .header {
+    flex-shrink: 0;
     padding: 0.4rem 1.6rem;
     border-bottom: 0.1rem solid var(--color-neutral-border);
     background-color: var(--color-neutral-background-primary);
@@ -42,6 +45,7 @@ const slots = defineSlots<{
     flex-direction: column;
     padding: 0.8rem;
     gap: 0.8rem;
+    scrollbar-width: thin;
   }
 
   &.error {

--- a/@xen-orchestra/web-core/lib/components/ui/panel/UiPanel.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/panel/UiPanel.vue
@@ -1,4 +1,4 @@
-<!-- v2 -->
+<!-- v3 -->
 <template>
   <div class="ui-panel" :class="{ error, 'mobile-drawer': uiStore.isSmall }">
     <div v-if="slots.header" class="header">

--- a/@xen-orchestra/web-core/lib/components/ui/panel/UiPanel.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/panel/UiPanel.vue
@@ -1,22 +1,8 @@
 <!-- v5 -->
-<!-- TODO Pinning behaviour waiting for design clarifications -->
 <template>
-  <div class="ui-panel" :class="{ error, 'mobile-drawer': uiStore.isSmall }">
-    <div v-if="slots.header || closable" class="header">
-      <div v-if="slots.header" class="header-content">
-        <slot name="header" />
-      </div>
-      <div v-if="closable" class="built-in-buttons">
-        <UiButtonIcon
-          v-if="closable"
-          v-tooltip="t('action:close')"
-          size="small"
-          variant="tertiary"
-          accent="brand"
-          :icon="uiStore.isSmall ? 'fa:angle-left' : 'action:close-cancel-clear'"
-          @click="emit('close')"
-        />
-      </div>
+  <div class="ui-panel" :class="{ error }">
+    <div v-if="slots.header" class="header">
+      <slot name="header" />
     </div>
     <div class="content">
       <slot />
@@ -25,57 +11,30 @@
 </template>
 
 <script setup lang="ts">
-import { useUiStore } from '@core/stores/ui.store'
-import { useI18n } from 'vue-i18n'
-import UiButtonIcon from '../button-icon/UiButtonIcon.vue'
-
 defineProps<{
   error?: boolean
-  closable?: boolean
-}>()
-
-const emit = defineEmits<{
-  close: []
 }>()
 
 const slots = defineSlots<{
   default(): any
   header?(): any
 }>()
-
-const uiStore = useUiStore()
-
-const { t } = useI18n()
 </script>
 
 <style scoped lang="postcss">
 .ui-panel {
-  position: sticky;
-  top: 0;
   display: flex;
   flex-direction: column;
   border-inline-start: 0.1rem solid var(--color-neutral-border);
   background-color: var(--color-neutral-background-secondary);
 
-  &:not(.mobile-drawer) {
-    min-height: calc(100dvh - 16rem);
-  }
-
   .header {
+    padding: 0.4rem 1.6rem;
     border-bottom: 0.1rem solid var(--color-neutral-border);
     background-color: var(--color-neutral-background-primary);
     display: flex;
-    justify-content: flex-end;
     align-items: center;
     gap: 1.6rem;
-    padding: 0.4rem 1.6rem;
-
-    .header-content {
-      flex: 1;
-      display: flex;
-      gap: 0.8rem;
-      overflow-x: scroll;
-    }
   }
 
   .content {
@@ -85,23 +44,8 @@ const { t } = useI18n()
     gap: 0.8rem;
   }
 
-  &.mobile-drawer {
-    .header {
-      .built-in-buttons {
-        order: -1;
-      }
-    }
-    .content {
-      overflow: auto;
-    }
-  }
-
   &.error {
     background-color: var(--color-danger-background-selected);
-
-    .content {
-      padding-top: 15rem;
-    }
   }
 }
 </style>

--- a/@xen-orchestra/web-core/lib/components/ui/panel/UiPanel.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/panel/UiPanel.vue
@@ -3,7 +3,9 @@
 <template>
   <div class="ui-panel" :class="{ error, 'mobile-drawer': uiStore.isSmall }">
     <div v-if="slots.header || closable" class="header">
-      <slot v-if="slots.header" name="header" />
+      <div v-if="slots.header" class="header-content">
+        <slot name="header" />
+      </div>
       <div v-if="closable" class="built-in-buttons">
         <UiButtonIcon
           v-if="closable"
@@ -67,6 +69,13 @@ const { t } = useI18n()
     align-items: center;
     gap: 1.6rem;
     padding: 0.4rem 1.6rem;
+
+    .header-content {
+      flex: 1;
+      display: flex;
+      gap: 0.8rem;
+      overflow-x: scroll;
+    }
   }
 
   .content {

--- a/@xen-orchestra/web-core/lib/components/ui/panel/UiPanel.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/panel/UiPanel.vue
@@ -1,8 +1,20 @@
-<!-- v3 -->
+<!-- v5 -->
+<!-- TODO Pinning behaviour waiting for design clarifications -->
 <template>
   <div class="ui-panel" :class="{ error, 'mobile-drawer': uiStore.isSmall }">
-    <div v-if="slots.header" class="header">
-      <slot name="header" />
+    <div v-if="slots.header || closable" class="header">
+      <slot v-if="slots.header" name="header" />
+      <div v-if="closable" class="built-in-buttons">
+        <UiButtonIcon
+          v-if="closable"
+          v-tooltip="t('action:close')"
+          size="small"
+          variant="tertiary"
+          accent="brand"
+          :icon="uiStore.isSmall ? 'fa:angle-left' : 'action:close-cancel-clear'"
+          @click="emit('close')"
+        />
+      </div>
     </div>
     <div class="content">
       <slot />
@@ -12,9 +24,16 @@
 
 <script setup lang="ts">
 import { useUiStore } from '@core/stores/ui.store'
+import { useI18n } from 'vue-i18n'
+import UiButtonIcon from '../button-icon/UiButtonIcon.vue'
 
 defineProps<{
   error?: boolean
+  closable?: boolean
+}>()
+
+const emit = defineEmits<{
+  close: []
 }>()
 
 const slots = defineSlots<{
@@ -23,6 +42,8 @@ const slots = defineSlots<{
 }>()
 
 const uiStore = useUiStore()
+
+const { t } = useI18n()
 </script>
 
 <style scoped lang="postcss">
@@ -56,6 +77,11 @@ const uiStore = useUiStore()
   }
 
   &.mobile-drawer {
+    .header {
+      .built-in-buttons {
+        order: -1;
+      }
+    }
     .content {
       overflow: auto;
     }

--- a/@xen-orchestra/web-core/lib/composables/table-state.composable.ts
+++ b/@xen-orchestra/web-core/lib/composables/table-state.composable.ts
@@ -1,5 +1,5 @@
-import type { StateHeroType } from '@core/components/state-hero/VtsStateHero.vue'
 import type { TableState } from '@core/components/table/VtsTable.vue'
+import type { StateHeroType } from '@core/types/state-hero.type.ts'
 import { computed, toValue, type MaybeRefOrGetter } from 'vue'
 import { useI18n } from 'vue-i18n'
 

--- a/@xen-orchestra/web-core/lib/locales/en.json
+++ b/@xen-orchestra/web-core/lib/locales/en.json
@@ -886,7 +886,7 @@
   "select-compression": "Select a compression",
   "select-destination-host": "Select a destination host",
   "select-host": "Select host",
-  "select-to-see-details": "Select an element to see details",
+  "select-to-see-details": "Click on {icon} to see details",
   "selected-vms-in-execution": "Some selected VMs are running",
   "self-signed-certificates": "Self-signed certificates",
   "send-us-feedback": "Send us feedback",

--- a/@xen-orchestra/web-core/lib/locales/fr.json
+++ b/@xen-orchestra/web-core/lib/locales/fr.json
@@ -886,7 +886,7 @@
   "select-compression": "Sélectionnez une compression",
   "select-destination-host": "Sélectionnez un hôte de destination",
   "select-host": "Sélectionnez un hôte",
-  "select-to-see-details": "Sélectionnez un élément pour voir les détails",
+  "select-to-see-details": "Cliquez sur {icon} pour voir les détails",
   "selected-vms-in-execution": "Certaines VMs sélectionnées sont en cours d'exécution",
   "self-signed-certificates": "Certificats auto-signés",
   "send-us-feedback": "Envoyez-nous vos commentaires",

--- a/@xen-orchestra/web-core/lib/stores/panel.store.ts
+++ b/@xen-orchestra/web-core/lib/stores/panel.store.ts
@@ -1,12 +1,53 @@
 import { useUiStore } from '@core/stores/ui.store'
+import { useLocalStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 
 export const usePanelStore = defineStore('panel', () => {
   const uiStore = useUiStore()
-  const isExpanded = ref(false)
-  const open = () => (isExpanded.value = true)
-  const close = () => (isExpanded.value = false)
+  const isExpanded = useLocalStorage('panel.expanded', true)
+  const isLocked = useLocalStorage('panel.locked', true)
 
-  return { open, close, isExpanded: computed(() => !uiStore.isSmall || isExpanded.value) }
+  const cssVerticalOffset = '16.5rem'
+  const cssHorizontalOffset = computed(() => (isExpanded.value ? 0 : '100%'))
+  const actsAsFloating = computed(() => uiStore.isSmall || !isLocked.value)
+
+  function expand() {
+    isExpanded.value = true
+  }
+
+  function collapse() {
+    isExpanded.value = false
+  }
+
+  function toggleExpand(value?: boolean) {
+    isExpanded.value = typeof value === 'boolean' ? value : !isExpanded.value
+  }
+
+  function syncWithSelection(hasSelection: boolean) {
+    if (!actsAsFloating.value) return
+    if (!hasSelection && isExpanded.value) collapse()
+    else if (hasSelection && !isExpanded.value) expand()
+  }
+
+  function toggleLock(value?: boolean) {
+    const next = typeof value === 'boolean' ? value : !isLocked.value
+    isLocked.value = next
+    if (next && !uiStore.isSmall && !isExpanded.value) {
+      expand()
+    }
+  }
+
+  return {
+    actsAsFloating,
+    collapse,
+    cssHorizontalOffset,
+    cssVerticalOffset,
+    expand,
+    isExpanded,
+    isLocked,
+    syncWithSelection,
+    toggleExpand,
+    toggleLock,
+  }
 })

--- a/@xen-orchestra/web-core/lib/stores/panel.store.ts
+++ b/@xen-orchestra/web-core/lib/stores/panel.store.ts
@@ -8,7 +8,6 @@ export const usePanelStore = defineStore('panel', () => {
   const isExpanded = useLocalStorage('panel.expanded', true)
   const isLocked = useLocalStorage('panel.locked', true)
 
-  const cssVerticalOffset = '16.5rem'
   const cssHorizontalOffset = computed(() => (isExpanded.value ? 0 : '100%'))
   const actsAsFloating = computed(() => uiStore.isSmall || !isLocked.value)
 
@@ -20,18 +19,19 @@ export const usePanelStore = defineStore('panel', () => {
     isExpanded.value = false
   }
 
-  function toggleExpand(value?: boolean) {
-    isExpanded.value = typeof value === 'boolean' ? value : !isExpanded.value
-  }
-
   function syncWithSelection(hasSelection: boolean) {
-    if (!actsAsFloating.value) return
-    if (!hasSelection && isExpanded.value) collapse()
-    else if (hasSelection && !isExpanded.value) expand()
+    if (!actsAsFloating.value) {
+      return
+    }
+    if (!hasSelection && isExpanded.value) {
+      collapse()
+    } else if (hasSelection && !isExpanded.value) {
+      expand()
+    }
   }
 
-  function toggleLock(value?: boolean) {
-    const next = typeof value === 'boolean' ? value : !isLocked.value
+  function toggleLock() {
+    const next = !isLocked.value
     isLocked.value = next
     if (next && !uiStore.isSmall && !isExpanded.value) {
       expand()
@@ -39,15 +39,13 @@ export const usePanelStore = defineStore('panel', () => {
   }
 
   return {
-    actsAsFloating,
-    collapse,
-    cssHorizontalOffset,
-    cssVerticalOffset,
-    expand,
     isExpanded,
     isLocked,
-    syncWithSelection,
-    toggleExpand,
+    actsAsFloating,
+    expand,
+    collapse,
     toggleLock,
+    syncWithSelection,
+    cssHorizontalOffset,
   }
 })

--- a/@xen-orchestra/web-core/lib/stores/panel.store.ts
+++ b/@xen-orchestra/web-core/lib/stores/panel.store.ts
@@ -1,7 +1,7 @@
 import { useUiStore } from '@core/stores/ui.store'
 import { useLocalStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 
 export const usePanelStore = defineStore('panel', () => {
   const uiStore = useUiStore()
@@ -9,7 +9,8 @@ export const usePanelStore = defineStore('panel', () => {
   const isLocked = useLocalStorage('panel.locked', true)
 
   const cssHorizontalOffset = computed(() => (isExpanded.value ? 0 : '100%'))
-  const actsAsFloating = computed(() => uiStore.isSmall || !isLocked.value)
+  /* Panel closes automatically when it has no content (true on small UI or when not locked) */
+  const syncsOpenStateWithSelection = computed(() => uiStore.isSmall || !isLocked.value)
 
   function expand() {
     isExpanded.value = true
@@ -20,7 +21,7 @@ export const usePanelStore = defineStore('panel', () => {
   }
 
   function syncWithSelection(hasSelection: boolean) {
-    if (!actsAsFloating.value) {
+    if (!syncsOpenStateWithSelection.value) {
       return
     }
     if (!hasSelection && isExpanded.value) {
@@ -38,10 +39,21 @@ export const usePanelStore = defineStore('panel', () => {
     }
   }
 
+  watch(
+    () => uiStore.isSmall,
+    isSmall => {
+      /* Expand when coming back from small to large UI, if locked and not expanded */
+      if (!isSmall && isLocked.value && !isExpanded.value) {
+        expand()
+      }
+    },
+    { immediate: true }
+  )
+
   return {
     isExpanded,
     isLocked,
-    actsAsFloating,
+    syncsOpenStateWithSelection,
     expand,
     collapse,
     toggleLock,

--- a/@xen-orchestra/web-core/lib/types/state-hero.type.ts
+++ b/@xen-orchestra/web-core/lib/types/state-hero.type.ts
@@ -1,0 +1,19 @@
+export const STATE_HERO_TYPES = [
+  'busy',
+  'no-result',
+  'under-construction',
+  'no-data',
+  'no-selection',
+  'error',
+  'not-found',
+  'offline',
+  'all-good',
+  'all-done',
+  'creating',
+] as const
+
+export type StateHeroType = (typeof STATE_HERO_TYPES)[number]
+
+export type StateHeroFormat = 'page' | 'card' | 'panel' | 'table'
+
+export type StateHeroSize = 'extra-small' | 'small' | 'medium' | 'large'

--- a/@xen-orchestra/web/src/modules/backup/components/jobs/panel/BackupJobSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/backup/components/jobs/panel/BackupJobSidePanel.vue
@@ -1,17 +1,14 @@
 <template>
-  <VtsSidePanel :selected="!!backupJob" :closable="!!backupJob" @close="emit('close')">
-    <template #default>
-      <VtsStateHero v-if="!backupJob" format="panel" type="no-selection" size="medium" />
-      <template v-else>
-        <BackupJobInfosCard :backup-job />
-        <BackupJobSchedulesCard :backup-job-schedules />
-        <BackupJobLogsCard v-if="lastThreeLogs.length > 0" :backup-logs="lastThreeLogs" />
-        <BackupJobBackedUpVmsCard v-if="backupJob.type === 'backup' && backupJob.vms" :backed-up-vms="backupJob.vms" />
-        <BackupJobBackedUpPoolsCard v-if="backedUpPools.length > 0" :backed-up-pools />
-        <BackupJobSourceRepositoryCard v-if="backupJob.type === 'mirrorBackup'" :mirror-backup-job="backupJob" />
-        <BackupJobTargetsCard :storage-repository-targets :backup-repository-targets />
-        <BackupJobSettingsCard v-if="hasSettings" :backup-job />
-      </template>
+  <VtsSidePanel :has-selection="!!backupJob" @close="emit('close')">
+    <template v-if="backupJob">
+      <BackupJobInfosCard :backup-job />
+      <BackupJobSchedulesCard :backup-job-schedules />
+      <BackupJobLogsCard v-if="lastThreeLogs.length > 0" :backup-logs="lastThreeLogs" />
+      <BackupJobBackedUpVmsCard v-if="backupJob.type === 'backup' && backupJob.vms" :backed-up-vms="backupJob.vms" />
+      <BackupJobBackedUpPoolsCard v-if="backedUpPools.length > 0" :backed-up-pools />
+      <BackupJobSourceRepositoryCard v-if="backupJob.type === 'mirrorBackup'" :mirror-backup-job="backupJob" />
+      <BackupJobTargetsCard :storage-repository-targets :backup-repository-targets />
+      <BackupJobSettingsCard v-if="hasSettings" :backup-job />
     </template>
   </VtsSidePanel>
 </template>
@@ -36,7 +33,6 @@ import { useXoScheduleCollection } from '@/modules/schedule/remote-resources/use
 import { useXoSrCollection } from '@/modules/storage-repository/remote-resources/use-xo-sr-collection.ts'
 import { extractIdsFromSimplePattern } from '@/shared/utils/pattern.util.ts'
 import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import type { XoSr, XoPool, XoBackupRepository } from '@vates/types'
 import { computed } from 'vue'
 

--- a/@xen-orchestra/web/src/modules/backup/components/jobs/panel/BackupJobSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/backup/components/jobs/panel/BackupJobSidePanel.vue
@@ -1,16 +1,19 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
+  <VtsSidePanel :selected="!!backupJob" :closable="!!backupJob" @close="emit('close')">
     <template #default>
-      <BackupJobInfosCard :backup-job />
-      <BackupJobSchedulesCard :backup-job-schedules />
-      <BackupJobLogsCard v-if="lastThreeLogs.length > 0" :backup-logs="lastThreeLogs" />
-      <BackupJobBackedUpVmsCard v-if="backupJob.type === 'backup' && backupJob.vms" :backed-up-vms="backupJob.vms" />
-      <BackupJobBackedUpPoolsCard v-if="backedUpPools.length > 0" :backed-up-pools />
-      <BackupJobSourceRepositoryCard v-if="backupJob.type === 'mirrorBackup'" :mirror-backup-job="backupJob" />
-      <BackupJobTargetsCard :storage-repository-targets :backup-repository-targets />
-      <BackupJobSettingsCard v-if="hasSettings" :backup-job />
+      <VtsStateHero v-if="!backupJob" format="panel" type="no-selection" size="medium" />
+      <template v-else>
+        <BackupJobInfosCard :backup-job />
+        <BackupJobSchedulesCard :backup-job-schedules />
+        <BackupJobLogsCard v-if="lastThreeLogs.length > 0" :backup-logs="lastThreeLogs" />
+        <BackupJobBackedUpVmsCard v-if="backupJob.type === 'backup' && backupJob.vms" :backed-up-vms="backupJob.vms" />
+        <BackupJobBackedUpPoolsCard v-if="backedUpPools.length > 0" :backed-up-pools />
+        <BackupJobSourceRepositoryCard v-if="backupJob.type === 'mirrorBackup'" :mirror-backup-job="backupJob" />
+        <BackupJobTargetsCard :storage-repository-targets :backup-repository-targets />
+        <BackupJobSettingsCard v-if="hasSettings" :backup-job />
+      </template>
     </template>
-  </UiPanel>
+  </VtsSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -22,7 +25,9 @@ import BackupJobLogsCard from '@/modules/backup/components/panel/cards/BackupJob
 import BackupJobSchedulesCard from '@/modules/backup/components/panel/cards/BackupJobSchedulesCard.vue'
 import BackupJobSourceRepositoryCard from '@/modules/backup/components/panel/cards/BackupJobSourceRepositoryCard.vue'
 import BackupJobTargetsCard from '@/modules/backup/components/panel/cards/BackupJobTargetsCard.vue'
-import { useXoBackupJobSettingsUtils } from '@/modules/backup/composables/backup-job-settings/xo-backup-job-settings.composable.ts'
+import { getMetadataBackupJobSettings } from '@/modules/backup/composables/backup-job-settings/get-metadata-backup-job-settings'
+import { getMirrorBackupJobSettings } from '@/modules/backup/composables/backup-job-settings/get-mirror-backup-job-settings'
+import { getVmBackupJobSettings } from '@/modules/backup/composables/backup-job-settings/get-vm-backup-job-settings'
 import type { FrontAnyXoBackupJob } from '@/modules/backup/remote-resources/use-xo-backup-job-collection.ts'
 import { useXoBackupLogCollection } from '@/modules/backup/remote-resources/use-xo-backup-log-collection.ts'
 import { useXoBackupRepositoryCollection } from '@/modules/backup/remote-resources/use-xo-br-collection.ts'
@@ -30,20 +35,18 @@ import { useXoPoolCollection } from '@/modules/pool/remote-resources/use-xo-pool
 import { useXoScheduleCollection } from '@/modules/schedule/remote-resources/use-xo-schedule-collection.ts'
 import { useXoSrCollection } from '@/modules/storage-repository/remote-resources/use-xo-sr-collection.ts'
 import { extractIdsFromSimplePattern } from '@/shared/utils/pattern.util.ts'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { useUiStore } from '@core/stores/ui.store.ts'
+import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import type { XoSr, XoPool, XoBackupRepository } from '@vates/types'
 import { computed } from 'vue'
 
 const { backupJob } = defineProps<{
-  backupJob: FrontAnyXoBackupJob
+  backupJob?: FrontAnyXoBackupJob
 }>()
 
 const emit = defineEmits<{
   close: []
 }>()
-
-const uiStore = useUiStore()
 
 const { getSrsByIds } = useXoSrCollection()
 const { getBackupRepositoriesByIds } = useXoBackupRepositoryCollection()
@@ -51,12 +54,14 @@ const { getLastNBackupLogsByJobId } = useXoBackupLogCollection()
 const { schedulesByJobId } = useXoScheduleCollection()
 const { getPoolsByIds } = useXoPoolCollection()
 
-const backupJobSchedules = computed(() => schedulesByJobId.value.get(backupJob.id) ?? [])
+const backupJobSchedules = computed(() =>
+  backupJob !== undefined ? (schedulesByJobId.value.get(backupJob.id) ?? []) : []
+)
 
-const lastThreeLogs = computed(() => getLastNBackupLogsByJobId(backupJob.id))
+const lastThreeLogs = computed(() => (backupJob !== undefined ? getLastNBackupLogsByJobId(backupJob.id) : []))
 
 const backedUpPools = computed(() => {
-  if (backupJob.type !== 'metadataBackup' || backupJob.pools === undefined) {
+  if (backupJob?.type !== 'metadataBackup' || backupJob.pools === undefined) {
     return []
   }
 
@@ -64,32 +69,31 @@ const backedUpPools = computed(() => {
 })
 
 const backupRepositoryTargets = computed(() =>
-  getBackupRepositoriesByIds(extractIdsFromSimplePattern(backupJob.remotes) as XoBackupRepository['id'][])
+  backupJob !== undefined
+    ? getBackupRepositoriesByIds(extractIdsFromSimplePattern(backupJob.remotes) as XoBackupRepository['id'][])
+    : []
 )
 
 const storageRepositoryTargets = computed(() => {
-  if (!(backupJob.type === 'backup' && backupJob.srs)) {
+  if (!(backupJob?.type === 'backup' && backupJob.srs)) {
     return []
   }
 
   return getSrsByIds(extractIdsFromSimplePattern(backupJob.srs) as XoSr['id'][])
 })
 
-const { settings: backupJobSettings } = useXoBackupJobSettingsUtils(() => backupJob)
-
-const hasSettings = computed(() => Object.values(backupJobSettings).some(value => value !== undefined))
-</script>
-
-<style scoped lang="postcss">
-.mobile-drawer {
-  position: fixed;
-  inset: 0;
-
-  .action-buttons-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
+const hasSettings = computed(() => {
+  if (backupJob === undefined) {
+    return false
   }
-}
-</style>
+
+  const settings =
+    backupJob.type === 'backup'
+      ? getVmBackupJobSettings(backupJob)
+      : backupJob.type === 'metadataBackup'
+        ? getMetadataBackupJobSettings(backupJob)
+        : getMirrorBackupJobSettings(backupJob)
+
+  return Object.values(settings).some(value => value !== undefined)
+})
+</script>

--- a/@xen-orchestra/web/src/modules/backup/components/jobs/panel/BackupJobSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/backup/components/jobs/panel/BackupJobSidePanel.vue
@@ -1,17 +1,5 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }">
-    <template #header>
-      <div :class="{ 'action-buttons-container': uiStore.isSmall }">
-        <UiButtonIcon
-          v-tooltip="t('action:close')"
-          size="small"
-          variant="tertiary"
-          accent="brand"
-          :icon="uiStore.isSmall ? 'fa:angle-left' : 'fa:close'"
-          @click="emit('close')"
-        />
-      </div>
-    </template>
+  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
     <template #default>
       <BackupJobInfosCard :backup-job />
       <BackupJobSchedulesCard :backup-job-schedules />
@@ -42,13 +30,10 @@ import { useXoPoolCollection } from '@/modules/pool/remote-resources/use-xo-pool
 import { useXoScheduleCollection } from '@/modules/schedule/remote-resources/use-xo-schedule-collection.ts'
 import { useXoSrCollection } from '@/modules/storage-repository/remote-resources/use-xo-sr-collection.ts'
 import { extractIdsFromSimplePattern } from '@/shared/utils/pattern.util.ts'
-import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { vTooltip } from '@core/directives/tooltip.directive.ts'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import type { XoSr, XoPool, XoBackupRepository } from '@vates/types'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 const { backupJob } = defineProps<{
   backupJob: FrontAnyXoBackupJob
@@ -58,7 +43,6 @@ const emit = defineEmits<{
   close: []
 }>()
 
-const { t } = useI18n()
 const uiStore = useUiStore()
 
 const { getSrsByIds } = useXoSrCollection()

--- a/@xen-orchestra/web/src/modules/backup/components/logs/panel/BackupLogSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/backup/components/logs/panel/BackupLogSidePanel.vue
@@ -1,17 +1,20 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
+  <VtsSidePanel :selected="!!backupLog" :closable="!!backupLog" @close="emit('close')">
     <template #default>
-      <BackupLogInfosCard :backup-log />
-      <BackupJobSchedulesCard :backup-job-schedules />
-      <template v-if="backupLogResults !== undefined">
-        <template v-for="[type, data] of Object.entries(backupLogResults)" :key="type">
-          <BackupLogResultsCard v-if="data.length > 0" :results="data" :type="type as BackupLogResultType" />
+      <VtsStateHero v-if="!backupLog" format="panel" type="no-selection" size="medium" />
+      <template v-else>
+        <BackupLogInfosCard :backup-log />
+        <BackupJobSchedulesCard :backup-job-schedules />
+        <template v-if="backupLogResults !== undefined">
+          <template v-for="[type, data] of Object.entries(backupLogResults)" :key="type">
+            <BackupLogResultsCard v-if="data.length > 0" :results="data" :type="type as BackupLogResultType" />
+          </template>
         </template>
+        <BackupJobBackedUpVmsCard v-if="backupJob?.type === 'backup' && backupJob.vms" :backed-up-vms="backupJob.vms" />
+        <BackupJobBackedUpPoolsCard v-if="backedUpPools.length > 0" :backed-up-pools />
       </template>
-      <BackupJobBackedUpVmsCard v-if="backupJob?.type === 'backup' && backupJob.vms" :backed-up-vms="backupJob.vms" />
-      <BackupJobBackedUpPoolsCard v-if="backedUpPools.length > 0" :backed-up-pools />
     </template>
-  </UiPanel>
+  </VtsSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -28,33 +31,31 @@ import { useXoPoolCollection } from '@/modules/pool/remote-resources/use-xo-pool
 import { useXoScheduleCollection } from '@/modules/schedule/remote-resources/use-xo-schedule-collection.ts'
 import { getTasksResultsRecursively } from '@/modules/task/utils/xo-task.util.ts'
 import { extractIdsFromSimplePattern } from '@/shared/utils/pattern.util.ts'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { useUiStore } from '@core/stores/ui.store.ts'
+import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import type { XoPool } from '@vates/types'
 import { computed } from 'vue'
 
 const { backupLog } = defineProps<{
-  backupLog: FrontXoBackupLog
+  backupLog?: FrontXoBackupLog
 }>()
 
 const emit = defineEmits<{
   close: []
 }>()
 
-const uiStore = useUiStore()
-
 const { useGetBackupJobById } = useXoBackupJobCollection()
 const { schedulesByJobId } = useXoScheduleCollection()
 const { getPoolsByIds } = useXoPoolCollection()
 
-const backupJob = useGetBackupJobById(() => backupLog.jobId)
+const backupJob = useGetBackupJobById(() => backupLog?.jobId)
 
 const backupJobSchedules = computed(() =>
   backupJob.value ? (schedulesByJobId.value.get(backupJob.value.id) ?? []) : []
 )
 
 const backedUpPools = computed(() => {
-  if (backupJob.value?.type !== 'metadataBackup' || backupJob.value?.pools === undefined) {
+  if (backupJob.value?.type !== 'metadataBackup' || backupJob.value.pools === undefined) {
     return []
   }
 
@@ -62,7 +63,7 @@ const backedUpPools = computed(() => {
 })
 
 const backupLogResults = computed(() => {
-  if (backupLog.tasks === undefined) {
+  if (backupLog?.tasks === undefined) {
     return undefined
   }
 
@@ -73,17 +74,3 @@ const backupLogResults = computed(() => {
   }
 })
 </script>
-
-<style scoped lang="postcss">
-.mobile-drawer {
-  position: fixed;
-  inset: 0;
-
-  .action-buttons-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-  }
-}
-</style>

--- a/@xen-orchestra/web/src/modules/backup/components/logs/panel/BackupLogSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/backup/components/logs/panel/BackupLogSidePanel.vue
@@ -1,18 +1,15 @@
 <template>
-  <VtsSidePanel :selected="!!backupLog" :closable="!!backupLog" @close="emit('close')">
-    <template #default>
-      <VtsStateHero v-if="!backupLog" format="panel" type="no-selection" size="medium" />
-      <template v-else>
-        <BackupLogInfosCard :backup-log />
-        <BackupJobSchedulesCard :backup-job-schedules />
-        <template v-if="backupLogResults !== undefined">
-          <template v-for="[type, data] of Object.entries(backupLogResults)" :key="type">
-            <BackupLogResultsCard v-if="data.length > 0" :results="data" :type="type as BackupLogResultType" />
-          </template>
+  <VtsSidePanel :has-selection="!!backupLog" @close="emit('close')">
+    <template v-if="backupLog">
+      <BackupLogInfosCard :backup-log />
+      <BackupJobSchedulesCard :backup-job-schedules />
+      <template v-if="backupLogResults !== undefined">
+        <template v-for="[type, data] of Object.entries(backupLogResults)" :key="type">
+          <BackupLogResultsCard v-if="data.length > 0" :results="data" :type="type as BackupLogResultType" />
         </template>
-        <BackupJobBackedUpVmsCard v-if="backupJob?.type === 'backup' && backupJob.vms" :backed-up-vms="backupJob.vms" />
-        <BackupJobBackedUpPoolsCard v-if="backedUpPools.length > 0" :backed-up-pools />
       </template>
+      <BackupJobBackedUpVmsCard v-if="backupJob?.type === 'backup' && backupJob.vms" :backed-up-vms="backupJob.vms" />
+      <BackupJobBackedUpPoolsCard v-if="backedUpPools.length > 0" :backed-up-pools />
     </template>
   </VtsSidePanel>
 </template>
@@ -32,7 +29,6 @@ import { useXoScheduleCollection } from '@/modules/schedule/remote-resources/use
 import { getTasksResultsRecursively } from '@/modules/task/utils/xo-task.util.ts'
 import { extractIdsFromSimplePattern } from '@/shared/utils/pattern.util.ts'
 import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import type { XoPool } from '@vates/types'
 import { computed } from 'vue'
 

--- a/@xen-orchestra/web/src/modules/backup/components/logs/panel/BackupLogSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/backup/components/logs/panel/BackupLogSidePanel.vue
@@ -1,17 +1,5 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }">
-    <template #header>
-      <div :class="{ 'action-buttons-container': uiStore.isSmall }">
-        <UiButtonIcon
-          v-tooltip="t('action:close')"
-          size="small"
-          variant="tertiary"
-          accent="brand"
-          :icon="uiStore.isSmall ? 'fa:angle-left' : 'fa:close'"
-          @click="emit('close')"
-        />
-      </div>
-    </template>
+  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
     <template #default>
       <BackupLogInfosCard :backup-log />
       <BackupJobSchedulesCard :backup-job-schedules />
@@ -40,13 +28,10 @@ import { useXoPoolCollection } from '@/modules/pool/remote-resources/use-xo-pool
 import { useXoScheduleCollection } from '@/modules/schedule/remote-resources/use-xo-schedule-collection.ts'
 import { getTasksResultsRecursively } from '@/modules/task/utils/xo-task.util.ts'
 import { extractIdsFromSimplePattern } from '@/shared/utils/pattern.util.ts'
-import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { vTooltip } from '@core/directives/tooltip.directive.ts'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import type { XoPool } from '@vates/types'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 const { backupLog } = defineProps<{
   backupLog: FrontXoBackupLog
@@ -56,7 +41,6 @@ const emit = defineEmits<{
   close: []
 }>()
 
-const { t } = useI18n()
 const uiStore = useUiStore()
 
 const { useGetBackupJobById } = useXoBackupJobCollection()

--- a/@xen-orchestra/web/src/modules/host/components/list/panel/HostSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/host/components/list/panel/HostSidePanel.vue
@@ -1,15 +1,12 @@
 <template>
-  <VtsSidePanel :selected="!!host" :closable="!!host" @close="emit('close')">
-    <template #default>
-      <VtsStateHero v-if="!host" format="panel" type="no-selection" size="medium" />
-      <template v-else>
-        <HostInfoCard :host />
-        <HostNetworkCard :host />
-        <!-- host licensing -->
-        <HostSoftwareCard :host />
-        <HostHardwareSpecificationsCard :host />
-        <!-- host hardware health -->
-      </template>
+  <VtsSidePanel :has-selection="!!host" @close="emit('close')">
+    <template v-if="host">
+      <HostInfoCard :host />
+      <HostNetworkCard :host />
+      <!-- host licensing -->
+      <HostSoftwareCard :host />
+      <HostHardwareSpecificationsCard :host />
+      <!-- host hardware health -->
     </template>
   </VtsSidePanel>
 </template>
@@ -21,7 +18,6 @@ import HostNetworkCard from '@/modules/host/components/list/panel/card/HostNetwo
 import HostSoftwareCard from '@/modules/host/components/list/panel/card/HostSoftwareCard.vue'
 import type { FrontXoHost } from '@/modules/host/remote-resources/use-xo-host-collection.ts'
 import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 
 defineProps<{
   host?: FrontXoHost

--- a/@xen-orchestra/web/src/modules/host/components/list/panel/HostSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/host/components/list/panel/HostSidePanel.vue
@@ -1,14 +1,17 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
+  <VtsSidePanel :selected="!!host" :closable="!!host" @close="emit('close')">
     <template #default>
-      <HostInfoCard :host />
-      <HostNetworkCard :host />
-      <!-- host licensing -->
-      <HostSoftwareCard :host />
-      <HostHardwareSpecificationsCard :host />
-      <!-- host hardware health -->
+      <VtsStateHero v-if="!host" format="panel" type="no-selection" size="medium" />
+      <template v-else>
+        <HostInfoCard :host />
+        <HostNetworkCard :host />
+        <!-- host licensing -->
+        <HostSoftwareCard :host />
+        <HostHardwareSpecificationsCard :host />
+        <!-- host hardware health -->
+      </template>
     </template>
-  </UiPanel>
+  </VtsSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -17,30 +20,14 @@ import HostInfoCard from '@/modules/host/components/list/panel/card/HostInfoCard
 import HostNetworkCard from '@/modules/host/components/list/panel/card/HostNetworkCard.vue'
 import HostSoftwareCard from '@/modules/host/components/list/panel/card/HostSoftwareCard.vue'
 import type { FrontXoHost } from '@/modules/host/remote-resources/use-xo-host-collection.ts'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { useUiStore } from '@core/stores/ui.store.ts'
+import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 
 defineProps<{
-  host: FrontXoHost
+  host?: FrontXoHost
 }>()
 
 const emit = defineEmits<{
   close: []
 }>()
-
-const uiStore = useUiStore()
 </script>
-
-<style scoped lang="postcss">
-.mobile-drawer {
-  position: fixed;
-  inset: 0;
-
-  .action-buttons-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-  }
-}
-</style>

--- a/@xen-orchestra/web/src/modules/host/components/list/panel/HostSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/host/components/list/panel/HostSidePanel.vue
@@ -1,17 +1,5 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }">
-    <template #header>
-      <div :class="{ 'action-buttons-container': uiStore.isSmall }">
-        <UiButtonIcon
-          v-tooltip="t('action:close')"
-          size="small"
-          variant="tertiary"
-          accent="brand"
-          :icon="uiStore.isSmall ? 'fa:angle-left' : 'fa:close'"
-          @click="emit('close')"
-        />
-      </div>
-    </template>
+  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
     <template #default>
       <HostInfoCard :host />
       <HostNetworkCard :host />
@@ -29,11 +17,8 @@ import HostInfoCard from '@/modules/host/components/list/panel/card/HostInfoCard
 import HostNetworkCard from '@/modules/host/components/list/panel/card/HostNetworkCard.vue'
 import HostSoftwareCard from '@/modules/host/components/list/panel/card/HostSoftwareCard.vue'
 import type { FrontXoHost } from '@/modules/host/remote-resources/use-xo-host-collection.ts'
-import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { vTooltip } from '@core/directives/tooltip.directive.ts'
 import { useUiStore } from '@core/stores/ui.store.ts'
-import { useI18n } from 'vue-i18n'
 
 defineProps<{
   host: FrontXoHost
@@ -42,8 +27,6 @@ defineProps<{
 const emit = defineEmits<{
   close: []
 }>()
-
-const { t } = useI18n()
 
 const uiStore = useUiStore()
 </script>

--- a/@xen-orchestra/web/src/modules/network/components/panel/NetworkSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/network/components/panel/NetworkSidePanel.vue
@@ -1,65 +1,62 @@
 <template>
-  <VtsSidePanel :selected="!!network" :closable="!!network" @close="emit('close')">
+  <VtsSidePanel :has-selection="!!network" @close="emit('close')">
     <template v-if="network" #actions>
       <VtsDeleteButton :busy="isDeletingNetwork" @click="openDeleteModal()" />
     </template>
-    <template #default>
-      <VtsStateHero v-if="!network" format="panel" type="no-selection" size="medium" />
-      <template v-else>
-        <UiCard class="card-container">
-          <UiCardTitle v-tooltip="{ placement: 'bottom-end' }" class="typo-body-bold">
-            {{ network.name_label }}
-          </UiCardTitle>
-          <div class="content">
-            <!-- ID -->
-            <VtsCodeSnippet :content="network.id" copy />
-            <!-- DESCRIPTION -->
-            <VtsCardRowKeyValue truncate align-top>
-              <template #key>{{ t('description') }}</template>
-              <template #value>
-                {{ network.name_description }}
-              </template>
-              <template v-if="network.name_description" #addons>
-                <VtsCopyButton :value="network.name_description" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- VLAN -->
-            <VtsCardRowKeyValue v-if="networkVlan">
-              <template #key>{{ t('vlan') }}</template>
-              <template #value>{{ networkVlan }}</template>
-              <template #addons>
-                <VtsCopyButton :value="String(networkVlan)" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- MTU -->
-            <VtsCardRowKeyValue>
-              <template #key>{{ t('mtu') }}</template>
-              <template #value>
-                <span>
-                  {{ network.MTU }}
-                </span>
-              </template>
-              <template #addons>
-                <VtsCopyButton :value="String(network.MTU)" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- NBD -->
-            <VtsCardRowKeyValue>
-              <template #key>{{ t('network-block-device') }}</template>
-              <template #value>{{ networkNbd }}</template>
-              <template #addons>
-                <VtsCopyButton :value="networkNbd" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- DEFAULT LOCKING MODE -->
-            <VtsCardRowKeyValue>
-              <template #key>{{ t('locking-mode-default') }}</template>
-              <template #value>{{ networkDefaultLockingMode }}</template>
-            </VtsCardRowKeyValue>
-          </div>
-        </UiCard>
-        <NetworkPifsInfoCard :network />
-      </template>
+    <template v-if="network" #default>
+      <UiCard class="card-container">
+        <UiCardTitle v-tooltip="{ placement: 'bottom-end' }" class="typo-body-bold">
+          {{ network.name_label }}
+        </UiCardTitle>
+        <div class="content">
+          <!-- ID -->
+          <VtsCodeSnippet :content="network.id" copy />
+          <!-- DESCRIPTION -->
+          <VtsCardRowKeyValue truncate align-top>
+            <template #key>{{ t('description') }}</template>
+            <template #value>
+              {{ network.name_description }}
+            </template>
+            <template v-if="network.name_description" #addons>
+              <VtsCopyButton :value="network.name_description" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- VLAN -->
+          <VtsCardRowKeyValue v-if="networkVlan">
+            <template #key>{{ t('vlan') }}</template>
+            <template #value>{{ networkVlan }}</template>
+            <template #addons>
+              <VtsCopyButton :value="String(networkVlan)" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- MTU -->
+          <VtsCardRowKeyValue>
+            <template #key>{{ t('mtu') }}</template>
+            <template #value>
+              <span>
+                {{ network.MTU }}
+              </span>
+            </template>
+            <template #addons>
+              <VtsCopyButton :value="String(network.MTU)" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- NBD -->
+          <VtsCardRowKeyValue>
+            <template #key>{{ t('network-block-device') }}</template>
+            <template #value>{{ networkNbd }}</template>
+            <template #addons>
+              <VtsCopyButton :value="networkNbd" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- DEFAULT LOCKING MODE -->
+          <VtsCardRowKeyValue>
+            <template #key>{{ t('locking-mode-default') }}</template>
+            <template #value>{{ networkDefaultLockingMode }}</template>
+          </VtsCardRowKeyValue>
+        </div>
+      </UiCard>
+      <NetworkPifsInfoCard :network />
     </template>
   </VtsSidePanel>
 </template>
@@ -74,7 +71,6 @@ import VtsCodeSnippet from '@core/components/code-snippet/VtsCodeSnippet.vue'
 import VtsCopyButton from '@core/components/copy-button/VtsCopyButton.vue'
 import VtsDeleteButton from '@core/components/delete-button/VtsDeleteButton.vue'
 import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiCardTitle from '@core/components/ui/card-title/UiCardTitle.vue'
 import { vTooltip } from '@core/directives/tooltip.directive.ts'

--- a/@xen-orchestra/web/src/modules/network/components/panel/NetworkSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/network/components/panel/NetworkSidePanel.vue
@@ -1,17 +1,7 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }">
+  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
     <template #header>
       <VtsDeleteButton :busy="isDeletingNetwork" class="delete-button" @click="openDeleteModal()" />
-      <div :class="{ 'action-buttons-container': uiStore.isSmall }">
-        <UiButtonIcon
-          v-tooltip="t('action:close')"
-          size="small"
-          variant="tertiary"
-          accent="brand"
-          :icon="uiStore.isSmall ? 'fa:angle-left' : 'fa:close'"
-          @click="emit('close')"
-        />
-      </div>
     </template>
     <template #default>
       <UiCard class="card-container">
@@ -80,7 +70,6 @@ import VtsCardRowKeyValue from '@core/components/card/VtsCardRowKeyValue.vue'
 import VtsCodeSnippet from '@core/components/code-snippet/VtsCodeSnippet.vue'
 import VtsCopyButton from '@core/components/copy-button/VtsCopyButton.vue'
 import VtsDeleteButton from '@core/components/delete-button/VtsDeleteButton.vue'
-import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiCardTitle from '@core/components/ui/card-title/UiCardTitle.vue'
 import UiPanel from '@core/components/ui/panel/UiPanel.vue'

--- a/@xen-orchestra/web/src/modules/network/components/panel/NetworkSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/network/components/panel/NetworkSidePanel.vue
@@ -1,64 +1,67 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
-    <template #header>
-      <VtsDeleteButton :busy="isDeletingNetwork" class="delete-button" @click="openDeleteModal()" />
+  <VtsSidePanel :selected="!!network" :closable="!!network" @close="emit('close')">
+    <template v-if="network" #actions>
+      <VtsDeleteButton :busy="isDeletingNetwork" @click="openDeleteModal()" />
     </template>
     <template #default>
-      <UiCard class="card-container">
-        <UiCardTitle v-tooltip="{ placement: 'bottom-end' }" class="typo-body-bold">
-          {{ network.name_label }}
-        </UiCardTitle>
-        <div class="content">
-          <!-- ID -->
-          <VtsCodeSnippet :content="network.id" copy />
-          <!-- DESCRIPTION -->
-          <VtsCardRowKeyValue truncate align-top>
-            <template #key>{{ t('description') }}</template>
-            <template #value>
-              {{ network.name_description }}
-            </template>
-            <template v-if="network.name_description" #addons>
-              <VtsCopyButton :value="network.name_description" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- VLAN -->
-          <VtsCardRowKeyValue v-if="networkVlan">
-            <template #key>{{ t('vlan') }}</template>
-            <template #value>{{ networkVlan }}</template>
-            <template #addons>
-              <VtsCopyButton :value="String(networkVlan)" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- MTU -->
-          <VtsCardRowKeyValue>
-            <template #key>{{ t('mtu') }}</template>
-            <template #value>
-              <span>
-                {{ network.MTU }}
-              </span>
-            </template>
-            <template #addons>
-              <VtsCopyButton :value="String(network.MTU)" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- NBD -->
-          <VtsCardRowKeyValue>
-            <template #key>{{ t('network-block-device') }}</template>
-            <template #value>{{ networkNbd }}</template>
-            <template #addons>
-              <VtsCopyButton :value="networkNbd" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- DEFAULT LOCKING MODE -->
-          <VtsCardRowKeyValue>
-            <template #key>{{ t('locking-mode-default') }}</template>
-            <template #value>{{ networkDefaultLockingMode }}</template>
-          </VtsCardRowKeyValue>
-        </div>
-      </UiCard>
-      <NetworkPifsInfoCard :network />
+      <VtsStateHero v-if="!network" format="panel" type="no-selection" size="medium" />
+      <template v-else>
+        <UiCard class="card-container">
+          <UiCardTitle v-tooltip="{ placement: 'bottom-end' }" class="typo-body-bold">
+            {{ network.name_label }}
+          </UiCardTitle>
+          <div class="content">
+            <!-- ID -->
+            <VtsCodeSnippet :content="network.id" copy />
+            <!-- DESCRIPTION -->
+            <VtsCardRowKeyValue truncate align-top>
+              <template #key>{{ t('description') }}</template>
+              <template #value>
+                {{ network.name_description }}
+              </template>
+              <template v-if="network.name_description" #addons>
+                <VtsCopyButton :value="network.name_description" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- VLAN -->
+            <VtsCardRowKeyValue v-if="networkVlan">
+              <template #key>{{ t('vlan') }}</template>
+              <template #value>{{ networkVlan }}</template>
+              <template #addons>
+                <VtsCopyButton :value="String(networkVlan)" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- MTU -->
+            <VtsCardRowKeyValue>
+              <template #key>{{ t('mtu') }}</template>
+              <template #value>
+                <span>
+                  {{ network.MTU }}
+                </span>
+              </template>
+              <template #addons>
+                <VtsCopyButton :value="String(network.MTU)" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- NBD -->
+            <VtsCardRowKeyValue>
+              <template #key>{{ t('network-block-device') }}</template>
+              <template #value>{{ networkNbd }}</template>
+              <template #addons>
+                <VtsCopyButton :value="networkNbd" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- DEFAULT LOCKING MODE -->
+            <VtsCardRowKeyValue>
+              <template #key>{{ t('locking-mode-default') }}</template>
+              <template #value>{{ networkDefaultLockingMode }}</template>
+            </VtsCardRowKeyValue>
+          </div>
+        </UiCard>
+        <NetworkPifsInfoCard :network />
+      </template>
     </template>
-  </UiPanel>
+  </VtsSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -70,30 +73,31 @@ import VtsCardRowKeyValue from '@core/components/card/VtsCardRowKeyValue.vue'
 import VtsCodeSnippet from '@core/components/code-snippet/VtsCodeSnippet.vue'
 import VtsCopyButton from '@core/components/copy-button/VtsCopyButton.vue'
 import VtsDeleteButton from '@core/components/delete-button/VtsDeleteButton.vue'
+import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiCardTitle from '@core/components/ui/card-title/UiCardTitle.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { vTooltip } from '@core/directives/tooltip.directive.ts'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const { network } = defineProps<{
-  network: FrontXoNetwork
+  network?: FrontXoNetwork
 }>()
 
 const emit = defineEmits<{
   close: []
 }>()
 
-const { openModal: openDeleteModal, isRunning: isDeletingNetwork } = useNetworkDeleteModal(() => [network])
+const { openModal: openDeleteModal, isRunning: isDeletingNetwork } = useNetworkDeleteModal(() =>
+  network !== undefined ? [network] : []
+)
 
 const { getPifsByNetworkId } = useXoPifCollection()
-const uiStore = useUiStore()
 
 const { t } = useI18n()
 
-const pifs = computed(() => getPifsByNetworkId(network.id))
+const pifs = computed(() => (network !== undefined ? getPifsByNetworkId(network.id) : []))
 
 const networkVlan = computed(() => {
   if (pifs.value.length === 0) {
@@ -103,16 +107,12 @@ const networkVlan = computed(() => {
   return pifs.value[0].vlan !== -1 ? pifs.value[0].vlan.toString() : t('none')
 })
 
-const networkNbd = computed(() => (network.nbd ? t('on') : t('off')))
+const networkNbd = computed(() => (network?.nbd ? t('on') : t('off')))
 
-const networkDefaultLockingMode = computed(() => (network.defaultIsLocked ? t('disabled') : t('unlocked')))
+const networkDefaultLockingMode = computed(() => (network?.defaultIsLocked ? t('disabled') : t('unlocked')))
 </script>
 
 <style scoped lang="postcss">
-.delete-button {
-  margin-inline-end: auto;
-}
-
 .card-container {
   display: flex;
   flex-direction: column;
@@ -126,18 +126,6 @@ const networkDefaultLockingMode = computed(() => (network.defaultIsLocked ? t('d
     .value:empty::before {
       content: '-';
     }
-  }
-}
-
-.mobile-drawer {
-  position: fixed;
-  inset: 0;
-
-  .action-buttons-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
   }
 }
 </style>

--- a/@xen-orchestra/web/src/modules/pif/components/list/panel/PifSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/pif/components/list/panel/PifSidePanel.vue
@@ -1,242 +1,239 @@
 <template>
-  <VtsSidePanel :selected="!!pif" :closable="!!pif" @close="emit('close')">
-    <template #default>
-      <VtsStateHero v-if="!pif" format="panel" type="no-selection" size="medium" />
-      <template v-else>
-        <!-- PIF -->
-        <UiCard class="card">
-          <UiCardTitle>{{ pif.isBondMaster ? t('bond') : t('pif') }}</UiCardTitle>
-          <div class="content">
-            <!-- UUID -->
-            <VtsCodeSnippet :content="pif.id" copy />
-            <!-- NETWORK -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('network') }}
-              </template>
-              <template #value>
-                <UiLink v-if="network" size="medium" :to="networkTo" icon="object:network">
-                  <span v-tooltip class="text-ellipsis">{{ network.name_label }}</span>
-                </UiLink>
-              </template>
-              <template v-if="network" #addons>
-                <VtsCopyButton :value="network.name_label" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- DEVICE -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('device') }}
-              </template>
-              <template #value>
-                {{ pif.device }}
-                <VtsIcon v-if="pif.management" v-tooltip="t('management')" name="status:primary-circle" size="medium" />
-              </template>
-              <template #addons>
-                <VtsCopyButton :value="pif.device" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- PIF STATUS -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ pif.isBondMaster ? t('bond-status') : t('pif-status') }}
-              </template>
-              <template #value>
-                <VtsStatus :status />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- PHYSICAL INTERFACE STATUS -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('physical-interface-status') }}
-              </template>
-              <template #value>
-                <VtsStatus :status="physicalInterfaceStatus" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- VLAN -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('vlan') }}
-              </template>
-              <template #value>
-                {{ pif.vlan === -1 ? t('none') : pif.vlan }}
-              </template>
-              <template v-if="pif.vlan !== -1" #addons>
-                <VtsCopyButton :value="String(pif.vlan)" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- TAGS -->
-            <VtsCardRowKeyValue align-top>
-              <template #key>{{ t('tags') }}</template>
-              <template #value>
-                <UiTagsList v-if="network && network.tags.length > 0">
-                  <VtsTag v-for="tag in network.tags" :key="tag" :value="tag" />
-                </UiTagsList>
-              </template>
-              <template v-if="network && network.tags.length > 0" #addons>
-                <VtsCopyButton :value="network.tags.join(', ')" />
-              </template>
-            </VtsCardRowKeyValue>
-          </div>
-        </UiCard>
-        <!-- NETWORK INFORMATION -->
-        <UiCard class="card">
-          <UiCardTitle>{{ t('network-information') }}</UiCardTitle>
-          <div class="content">
-            <!-- IP ADDRESSES -->
-            <template v-if="ipAddresses.length">
-              <VtsCardRowKeyValue v-for="(ip, index) in ipAddresses" :key="ip">
-                <template #key>
-                  <div v-if="index === 0">{{ t('ip-addresses') }}</div>
-                </template>
-                <template #value>
-                  <span class="text-ellipsis">{{ ip }}</span>
-                </template>
-                <template #addons>
-                  <VtsCopyButton :value="ip" />
-                  <UiButtonIcon
-                    v-if="index === 0 && ipAddresses.length > 1"
-                    v-tooltip="t('coming-soon!')"
-                    disabled
-                    icon="fa:ellipsis"
-                    size="small"
-                    accent="brand"
-                  />
-                </template>
-              </VtsCardRowKeyValue>
+  <VtsSidePanel :has-selection="!!pif" @close="emit('close')">
+    <template v-if="pif">
+      <!-- PIF -->
+      <UiCard class="card">
+        <UiCardTitle>{{ pif.isBondMaster ? t('bond') : t('pif') }}</UiCardTitle>
+        <div class="content">
+          <!-- UUID -->
+          <VtsCodeSnippet :content="pif.id" copy />
+          <!-- NETWORK -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('network') }}
             </template>
-            <VtsCardRowKeyValue v-else>
+            <template #value>
+              <UiLink v-if="network" size="medium" :to="networkTo" icon="object:network">
+                <span v-tooltip class="text-ellipsis">{{ network.name_label }}</span>
+              </UiLink>
+            </template>
+            <template v-if="network" #addons>
+              <VtsCopyButton :value="network.name_label" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- DEVICE -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('device') }}
+            </template>
+            <template #value>
+              {{ pif.device }}
+              <VtsIcon v-if="pif.management" v-tooltip="t('management')" name="status:primary-circle" size="medium" />
+            </template>
+            <template #addons>
+              <VtsCopyButton :value="pif.device" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- PIF STATUS -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ pif.isBondMaster ? t('bond-status') : t('pif-status') }}
+            </template>
+            <template #value>
+              <VtsStatus :status />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- PHYSICAL INTERFACE STATUS -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('physical-interface-status') }}
+            </template>
+            <template #value>
+              <VtsStatus :status="physicalInterfaceStatus" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- VLAN -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('vlan') }}
+            </template>
+            <template #value>
+              {{ pif.vlan === -1 ? t('none') : pif.vlan }}
+            </template>
+            <template v-if="pif.vlan !== -1" #addons>
+              <VtsCopyButton :value="String(pif.vlan)" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- TAGS -->
+          <VtsCardRowKeyValue align-top>
+            <template #key>{{ t('tags') }}</template>
+            <template #value>
+              <UiTagsList v-if="network && network.tags.length > 0">
+                <VtsTag v-for="tag in network.tags" :key="tag" :value="tag" />
+              </UiTagsList>
+            </template>
+            <template v-if="network && network.tags.length > 0" #addons>
+              <VtsCopyButton :value="network.tags.join(', ')" />
+            </template>
+          </VtsCardRowKeyValue>
+        </div>
+      </UiCard>
+      <!-- NETWORK INFORMATION -->
+      <UiCard class="card">
+        <UiCardTitle>{{ t('network-information') }}</UiCardTitle>
+        <div class="content">
+          <!-- IP ADDRESSES -->
+          <template v-if="ipAddresses.length">
+            <VtsCardRowKeyValue v-for="(ip, index) in ipAddresses" :key="ip">
               <template #key>
-                {{ t('ip-addresses') }}
+                <div v-if="index === 0">{{ t('ip-addresses') }}</div>
               </template>
               <template #value>
-                <span class="value" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- MAC ADDRESSES -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('mac-address') }}
-              </template>
-              <template #value>
-                {{ pif.mac }}
+                <span class="text-ellipsis">{{ ip }}</span>
               </template>
               <template #addons>
-                <VtsCopyButton :value="pif.mac" />
+                <VtsCopyButton :value="ip" />
+                <UiButtonIcon
+                  v-if="index === 0 && ipAddresses.length > 1"
+                  v-tooltip="t('coming-soon!')"
+                  disabled
+                  icon="fa:ellipsis"
+                  size="small"
+                  accent="brand"
+                />
               </template>
             </VtsCardRowKeyValue>
-            <!-- NETMASK -->
-            <VtsCardRowKeyValue>
+          </template>
+          <VtsCardRowKeyValue v-else>
+            <template #key>
+              {{ t('ip-addresses') }}
+            </template>
+            <template #value>
+              <span class="value" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- MAC ADDRESSES -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('mac-address') }}
+            </template>
+            <template #value>
+              {{ pif.mac }}
+            </template>
+            <template #addons>
+              <VtsCopyButton :value="pif.mac" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- NETMASK -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('netmask') }}
+            </template>
+            <template #value>
+              <span class="value">{{ pif.netmask }}</span>
+            </template>
+            <template v-if="pif.netmask" #addons>
+              <VtsCopyButton :value="pif.netmask" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- DNS -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('dns') }}
+            </template>
+            <template #value>
+              <span class="value">
+                {{ pif.dns }}
+              </span>
+            </template>
+            <template v-if="pif.dns" #addons>
+              <VtsCopyButton :value="pif.dns" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- GATEWAY -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('gateway') }}
+            </template>
+            <template #value>
+              <span class="value">
+                {{ pif.gateway }}
+              </span>
+            </template>
+            <template v-if="pif.gateway" #addons>
+              <VtsCopyButton :value="pif.gateway" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- IP CONFIGURATION MODE -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('ip-mode') }}
+            </template>
+            <template #value>
+              {{ ipConfigurationMode }}
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- BOND DEVICES -->
+          <div>
+            <VtsCardRowKeyValue v-for="(device, index) in bondDevices" :key="device">
               <template #key>
-                {{ t('netmask') }}
+                <div v-if="index === 0">{{ t('bond-devices') }}</div>
               </template>
-              <template #value>
-                <span class="value">{{ pif.netmask }}</span>
-              </template>
-              <template v-if="pif.netmask" #addons>
-                <VtsCopyButton :value="pif.netmask" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- DNS -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('dns') }}
-              </template>
-              <template #value>
-                <span class="value">
-                  {{ pif.dns }}
-                </span>
-              </template>
-              <template v-if="pif.dns" #addons>
-                <VtsCopyButton :value="pif.dns" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- GATEWAY -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('gateway') }}
-              </template>
-              <template #value>
-                <span class="value">
-                  {{ pif.gateway }}
-                </span>
-              </template>
-              <template v-if="pif.gateway" #addons>
-                <VtsCopyButton :value="pif.gateway" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- IP CONFIGURATION MODE -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('ip-mode') }}
-              </template>
-              <template #value>
-                {{ ipConfigurationMode }}
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- BOND DEVICES -->
-            <div>
-              <VtsCardRowKeyValue v-for="(device, index) in bondDevices" :key="device">
-                <template #key>
-                  <div v-if="index === 0">{{ t('bond-devices') }}</div>
-                </template>
-                <template #value>{{ device }}</template>
-                <template #addons>
-                  <VtsCopyButton :value="device" />
-                  <UiButtonIcon
-                    v-if="index === 0 && bondDevices.length > 1"
-                    v-tooltip="t('coming-soon!')"
-                    disabled
-                    icon="fa:ellipsis"
-                    size="small"
-                    accent="brand"
-                  />
-                </template>
-              </VtsCardRowKeyValue>
-            </div>
-          </div>
-        </UiCard>
-        <!-- PROPERTIES -->
-        <UiCard class="card">
-          <UiCardTitle>{{ t('properties') }}</UiCardTitle>
-          <div class="content">
-            <!-- MTU -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('mtu') }}
-              </template>
-              <template #value>
-                {{ pif.mtu === -1 ? t('none') : pif.mtu }}
-              </template>
-              <template v-if="pif.mtu !== -1" #addons>
-                <VtsCopyButton :value="String(pif.mtu)" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- SPEED -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('speed') }}
-              </template>
-              <template #value>
-                {{ speed }}
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- NETWORK BLOCK DEVICE -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('network-block-device') }}
-              </template>
-              <template #value>
-                {{ networkNbd }}
-              </template>
+              <template #value>{{ device }}</template>
               <template #addons>
-                <VtsCopyButton :value="networkNbd" />
+                <VtsCopyButton :value="device" />
+                <UiButtonIcon
+                  v-if="index === 0 && bondDevices.length > 1"
+                  v-tooltip="t('coming-soon!')"
+                  disabled
+                  icon="fa:ellipsis"
+                  size="small"
+                  accent="brand"
+                />
               </template>
             </VtsCardRowKeyValue>
           </div>
-        </UiCard>
-      </template>
+        </div>
+      </UiCard>
+      <!-- PROPERTIES -->
+      <UiCard class="card">
+        <UiCardTitle>{{ t('properties') }}</UiCardTitle>
+        <div class="content">
+          <!-- MTU -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('mtu') }}
+            </template>
+            <template #value>
+              {{ pif.mtu === -1 ? t('none') : pif.mtu }}
+            </template>
+            <template v-if="pif.mtu !== -1" #addons>
+              <VtsCopyButton :value="String(pif.mtu)" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- SPEED -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('speed') }}
+            </template>
+            <template #value>
+              {{ speed }}
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- NETWORK BLOCK DEVICE -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('network-block-device') }}
+            </template>
+            <template #value>
+              {{ networkNbd }}
+            </template>
+            <template #addons>
+              <VtsCopyButton :value="networkNbd" />
+            </template>
+          </VtsCardRowKeyValue>
+        </div>
+      </UiCard>
     </template>
   </VtsSidePanel>
 </template>
@@ -250,7 +247,6 @@ import VtsCodeSnippet from '@core/components/code-snippet/VtsCodeSnippet.vue'
 import VtsCopyButton from '@core/components/copy-button/VtsCopyButton.vue'
 import VtsIcon from '@core/components/icon/VtsIcon.vue'
 import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import VtsStatus from '@core/components/status/VtsStatus.vue'
 import VtsTag from '@core/components/tag/VtsTag.vue'
 import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'

--- a/@xen-orchestra/web/src/modules/pif/components/list/panel/PifSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/pif/components/list/panel/PifSidePanel.vue
@@ -1,241 +1,244 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
+  <VtsSidePanel :selected="!!pif" :closable="!!pif" @close="emit('close')">
     <template #default>
-      <!-- PIF -->
-      <UiCard class="card">
-        <UiCardTitle>{{ pif.isBondMaster ? t('bond') : t('pif') }}</UiCardTitle>
-        <div class="content">
-          <!-- UUID -->
-          <VtsCodeSnippet :content="pif.id" copy />
-          <!-- NETWORK -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('network') }}
-            </template>
-            <template #value>
-              <UiLink v-if="network" size="medium" :to="networkTo" icon="object:network">
-                <span v-tooltip class="text-ellipsis">{{ network.name_label }}</span>
-              </UiLink>
-            </template>
-            <template v-if="network" #addons>
-              <VtsCopyButton :value="network.name_label" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- DEVICE -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('device') }}
-            </template>
-            <template #value>
-              {{ pif.device }}
-              <VtsIcon v-if="pif.management" v-tooltip="t('management')" name="status:primary-circle" size="medium" />
-            </template>
-            <template #addons>
-              <VtsCopyButton :value="pif.device" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- PIF STATUS -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ pif.isBondMaster ? t('bond-status') : t('pif-status') }}
-            </template>
-            <template #value>
-              <VtsStatus :status />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- PHYSICAL INTERFACE STATUS -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('physical-interface-status') }}
-            </template>
-            <template #value>
-              <VtsStatus :status="physicalInterfaceStatus" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- VLAN -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('vlan') }}
-            </template>
-            <template #value>
-              {{ pif.vlan === -1 ? t('none') : pif.vlan }}
-            </template>
-            <template v-if="pif.vlan !== -1" #addons>
-              <VtsCopyButton :value="String(pif.vlan)" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- TAGS -->
-          <VtsCardRowKeyValue align-top>
-            <template #key>{{ t('tags') }}</template>
-            <template #value>
-              <UiTagsList v-if="network && network.tags.length > 0">
-                <VtsTag v-for="tag in network.tags" :key="tag" :value="tag" />
-              </UiTagsList>
-            </template>
-            <template v-if="network && network.tags.length > 0" #addons>
-              <VtsCopyButton :value="network.tags.join(', ')" />
-            </template>
-          </VtsCardRowKeyValue>
-        </div>
-      </UiCard>
-      <!-- NETWORK INFORMATION -->
-      <UiCard class="card">
-        <UiCardTitle>{{ t('network-information') }}</UiCardTitle>
-        <div class="content">
-          <!-- IP ADDRESSES -->
-          <template v-if="ipAddresses.length">
-            <VtsCardRowKeyValue v-for="(ip, index) in ipAddresses" :key="ip">
+      <VtsStateHero v-if="!pif" format="panel" type="no-selection" size="medium" />
+      <template v-else>
+        <!-- PIF -->
+        <UiCard class="card">
+          <UiCardTitle>{{ pif.isBondMaster ? t('bond') : t('pif') }}</UiCardTitle>
+          <div class="content">
+            <!-- UUID -->
+            <VtsCodeSnippet :content="pif.id" copy />
+            <!-- NETWORK -->
+            <VtsCardRowKeyValue>
               <template #key>
-                <div v-if="index === 0">{{ t('ip-addresses') }}</div>
+                {{ t('network') }}
               </template>
               <template #value>
-                <span class="text-ellipsis">{{ ip }}</span>
+                <UiLink v-if="network" size="medium" :to="networkTo" icon="object:network">
+                  <span v-tooltip class="text-ellipsis">{{ network.name_label }}</span>
+                </UiLink>
               </template>
-              <template #addons>
-                <VtsCopyButton :value="ip" />
-                <UiButtonIcon
-                  v-if="index === 0 && ipAddresses.length > 1"
-                  v-tooltip="t('coming-soon!')"
-                  disabled
-                  icon="fa:ellipsis"
-                  size="small"
-                  accent="brand"
-                />
+              <template v-if="network" #addons>
+                <VtsCopyButton :value="network.name_label" />
               </template>
             </VtsCardRowKeyValue>
-          </template>
-          <VtsCardRowKeyValue v-else>
-            <template #key>
-              {{ t('ip-addresses') }}
-            </template>
-            <template #value>
-              <span class="value" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- MAC ADDRESSES -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('mac-address') }}
-            </template>
-            <template #value>
-              {{ pif.mac }}
-            </template>
-            <template #addons>
-              <VtsCopyButton :value="pif.mac" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- NETMASK -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('netmask') }}
-            </template>
-            <template #value>
-              <span class="value">{{ pif.netmask }}</span>
-            </template>
-            <template v-if="pif.netmask" #addons>
-              <VtsCopyButton :value="pif.netmask" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- DNS -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('dns') }}
-            </template>
-            <template #value>
-              <span class="value">
-                {{ pif.dns }}
-              </span>
-            </template>
-            <template v-if="pif.dns" #addons>
-              <VtsCopyButton :value="pif.dns" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- GATEWAY -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('gateway') }}
-            </template>
-            <template #value>
-              <span class="value">
-                {{ pif.gateway }}
-              </span>
-            </template>
-            <template v-if="pif.gateway" #addons>
-              <VtsCopyButton :value="pif.gateway" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- IP CONFIGURATION MODE -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('ip-mode') }}
-            </template>
-            <template #value>
-              {{ ipConfigurationMode }}
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- BOND DEVICES -->
-          <div>
-            <VtsCardRowKeyValue v-for="(device, index) in bondDevices" :key="device">
+            <!-- DEVICE -->
+            <VtsCardRowKeyValue>
               <template #key>
-                <div v-if="index === 0">{{ t('bond-devices') }}</div>
+                {{ t('device') }}
               </template>
-              <template #value>{{ device }}</template>
+              <template #value>
+                {{ pif.device }}
+                <VtsIcon v-if="pif.management" v-tooltip="t('management')" name="status:primary-circle" size="medium" />
+              </template>
               <template #addons>
-                <VtsCopyButton :value="device" />
-                <UiButtonIcon
-                  v-if="index === 0 && bondDevices.length > 1"
-                  v-tooltip="t('coming-soon!')"
-                  disabled
-                  icon="fa:ellipsis"
-                  size="small"
-                  accent="brand"
-                />
+                <VtsCopyButton :value="pif.device" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- PIF STATUS -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ pif.isBondMaster ? t('bond-status') : t('pif-status') }}
+              </template>
+              <template #value>
+                <VtsStatus :status />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- PHYSICAL INTERFACE STATUS -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('physical-interface-status') }}
+              </template>
+              <template #value>
+                <VtsStatus :status="physicalInterfaceStatus" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- VLAN -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('vlan') }}
+              </template>
+              <template #value>
+                {{ pif.vlan === -1 ? t('none') : pif.vlan }}
+              </template>
+              <template v-if="pif.vlan !== -1" #addons>
+                <VtsCopyButton :value="String(pif.vlan)" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- TAGS -->
+            <VtsCardRowKeyValue align-top>
+              <template #key>{{ t('tags') }}</template>
+              <template #value>
+                <UiTagsList v-if="network && network.tags.length > 0">
+                  <VtsTag v-for="tag in network.tags" :key="tag" :value="tag" />
+                </UiTagsList>
+              </template>
+              <template v-if="network && network.tags.length > 0" #addons>
+                <VtsCopyButton :value="network.tags.join(', ')" />
               </template>
             </VtsCardRowKeyValue>
           </div>
-        </div>
-      </UiCard>
-      <!-- PROPERTIES -->
-      <UiCard class="card">
-        <UiCardTitle>{{ t('properties') }}</UiCardTitle>
-        <div class="content">
-          <!-- MTU -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('mtu') }}
+        </UiCard>
+        <!-- NETWORK INFORMATION -->
+        <UiCard class="card">
+          <UiCardTitle>{{ t('network-information') }}</UiCardTitle>
+          <div class="content">
+            <!-- IP ADDRESSES -->
+            <template v-if="ipAddresses.length">
+              <VtsCardRowKeyValue v-for="(ip, index) in ipAddresses" :key="ip">
+                <template #key>
+                  <div v-if="index === 0">{{ t('ip-addresses') }}</div>
+                </template>
+                <template #value>
+                  <span class="text-ellipsis">{{ ip }}</span>
+                </template>
+                <template #addons>
+                  <VtsCopyButton :value="ip" />
+                  <UiButtonIcon
+                    v-if="index === 0 && ipAddresses.length > 1"
+                    v-tooltip="t('coming-soon!')"
+                    disabled
+                    icon="fa:ellipsis"
+                    size="small"
+                    accent="brand"
+                  />
+                </template>
+              </VtsCardRowKeyValue>
             </template>
-            <template #value>
-              {{ pif.mtu === -1 ? t('none') : pif.mtu }}
-            </template>
-            <template v-if="pif.mtu !== -1" #addons>
-              <VtsCopyButton :value="String(pif.mtu)" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- SPEED -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('speed') }}
-            </template>
-            <template #value>
-              {{ speed }}
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- NETWORK BLOCK DEVICE -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('network-block-device') }}
-            </template>
-            <template #value>
-              {{ networkNbd }}
-            </template>
-            <template #addons>
-              <VtsCopyButton :value="networkNbd" />
-            </template>
-          </VtsCardRowKeyValue>
-        </div>
-      </UiCard>
+            <VtsCardRowKeyValue v-else>
+              <template #key>
+                {{ t('ip-addresses') }}
+              </template>
+              <template #value>
+                <span class="value" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- MAC ADDRESSES -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('mac-address') }}
+              </template>
+              <template #value>
+                {{ pif.mac }}
+              </template>
+              <template #addons>
+                <VtsCopyButton :value="pif.mac" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- NETMASK -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('netmask') }}
+              </template>
+              <template #value>
+                <span class="value">{{ pif.netmask }}</span>
+              </template>
+              <template v-if="pif.netmask" #addons>
+                <VtsCopyButton :value="pif.netmask" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- DNS -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('dns') }}
+              </template>
+              <template #value>
+                <span class="value">
+                  {{ pif.dns }}
+                </span>
+              </template>
+              <template v-if="pif.dns" #addons>
+                <VtsCopyButton :value="pif.dns" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- GATEWAY -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('gateway') }}
+              </template>
+              <template #value>
+                <span class="value">
+                  {{ pif.gateway }}
+                </span>
+              </template>
+              <template v-if="pif.gateway" #addons>
+                <VtsCopyButton :value="pif.gateway" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- IP CONFIGURATION MODE -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('ip-mode') }}
+              </template>
+              <template #value>
+                {{ ipConfigurationMode }}
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- BOND DEVICES -->
+            <div>
+              <VtsCardRowKeyValue v-for="(device, index) in bondDevices" :key="device">
+                <template #key>
+                  <div v-if="index === 0">{{ t('bond-devices') }}</div>
+                </template>
+                <template #value>{{ device }}</template>
+                <template #addons>
+                  <VtsCopyButton :value="device" />
+                  <UiButtonIcon
+                    v-if="index === 0 && bondDevices.length > 1"
+                    v-tooltip="t('coming-soon!')"
+                    disabled
+                    icon="fa:ellipsis"
+                    size="small"
+                    accent="brand"
+                  />
+                </template>
+              </VtsCardRowKeyValue>
+            </div>
+          </div>
+        </UiCard>
+        <!-- PROPERTIES -->
+        <UiCard class="card">
+          <UiCardTitle>{{ t('properties') }}</UiCardTitle>
+          <div class="content">
+            <!-- MTU -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('mtu') }}
+              </template>
+              <template #value>
+                {{ pif.mtu === -1 ? t('none') : pif.mtu }}
+              </template>
+              <template v-if="pif.mtu !== -1" #addons>
+                <VtsCopyButton :value="String(pif.mtu)" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- SPEED -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('speed') }}
+              </template>
+              <template #value>
+                {{ speed }}
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- NETWORK BLOCK DEVICE -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('network-block-device') }}
+              </template>
+              <template #value>
+                {{ networkNbd }}
+              </template>
+              <template #addons>
+                <VtsCopyButton :value="networkNbd" />
+              </template>
+            </VtsCardRowKeyValue>
+          </div>
+        </UiCard>
+      </template>
     </template>
-  </UiPanel>
+  </VtsSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -246,23 +249,23 @@ import VtsCardRowKeyValue from '@core/components/card/VtsCardRowKeyValue.vue'
 import VtsCodeSnippet from '@core/components/code-snippet/VtsCodeSnippet.vue'
 import VtsCopyButton from '@core/components/copy-button/VtsCopyButton.vue'
 import VtsIcon from '@core/components/icon/VtsIcon.vue'
+import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import VtsStatus from '@core/components/status/VtsStatus.vue'
 import VtsTag from '@core/components/tag/VtsTag.vue'
 import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiCardTitle from '@core/components/ui/card-title/UiCardTitle.vue'
 import UiLink from '@core/components/ui/link/UiLink.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import UiTagsList from '@core/components/ui/tag/UiTagsList.vue'
 import { vTooltip } from '@core/directives/tooltip.directive.ts'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import { CONNECTION_STATUS } from '@core/types/connection.ts'
 import humanFormat from 'human-format'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const { pif } = defineProps<{
-  pif: FrontXoPif
+  pif?: FrontXoPif
 }>()
 
 const emit = defineEmits<{
@@ -271,13 +274,18 @@ const emit = defineEmits<{
 
 const { useGetNetworkById } = useXoNetworkCollection()
 const { getBondsDevices } = useXoPifCollection()
-const uiStore = useUiStore()
 
 const { t } = useI18n()
 
-const ipAddresses = computed(() => [pif.ip, ...pif.ipv6].filter(ip => ip))
+const ipAddresses = computed(() => {
+  if (pif === undefined) {
+    return []
+  }
 
-const network = useGetNetworkById(() => pif.$network)
+  return [pif.ip, ...pif.ipv6].filter(ip => ip)
+})
+
+const network = useGetNetworkById(() => pif?.$network)
 
 const networkTo = computed(() =>
   network.value ? getPoolNetworkRoute(network.value.$pool, network.value.id) : undefined
@@ -285,13 +293,17 @@ const networkTo = computed(() =>
 
 const networkNbd = computed(() => (network.value?.nbd ? t('on') : t('off')))
 
-const status = computed(() => (pif.attached ? CONNECTION_STATUS.CONNECTED : CONNECTION_STATUS.DISCONNECTED))
+const status = computed(() => (pif?.attached ? CONNECTION_STATUS.CONNECTED : CONNECTION_STATUS.DISCONNECTED))
 
 const physicalInterfaceStatus = computed(() =>
-  pif.carrier ? CONNECTION_STATUS.CONNECTED : CONNECTION_STATUS.PHYSICALLY_DISCONNECTED
+  pif?.carrier ? CONNECTION_STATUS.CONNECTED : CONNECTION_STATUS.PHYSICALLY_DISCONNECTED
 )
 
 const ipConfigurationMode = computed(() => {
+  if (pif === undefined) {
+    return t('none')
+  }
+
   switch (pif.mode) {
     case 'Static':
       return t('static')
@@ -302,9 +314,13 @@ const ipConfigurationMode = computed(() => {
   }
 })
 
-const bondDevices = computed(() => getBondsDevices(pif))
+const bondDevices = computed(() => (pif !== undefined ? getBondsDevices(pif) : []))
 
 const speed = computed(() => {
+  if (pif === undefined) {
+    return ''
+  }
+
   const speed = pif.speed || 0
   const speedInBytes = speed * 1000000
 
@@ -328,18 +344,6 @@ const speed = computed(() => {
 
   .value:empty::before {
     content: '-';
-  }
-}
-
-.mobile-drawer {
-  position: fixed;
-  inset: 0;
-
-  .action-buttons-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
   }
 }
 </style>

--- a/@xen-orchestra/web/src/modules/pif/components/list/panel/PifSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/pif/components/list/panel/PifSidePanel.vue
@@ -1,17 +1,5 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }">
-    <template #header>
-      <div :class="{ 'action-buttons-container': uiStore.isSmall }">
-        <UiButtonIcon
-          v-tooltip="t('action:close')"
-          size="small"
-          variant="tertiary"
-          accent="brand"
-          :icon="uiStore.isSmall ? 'fa:angle-left' : 'fa:close'"
-          @click="emit('close')"
-        />
-      </div>
-    </template>
+  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
     <template #default>
       <!-- PIF -->
       <UiCard class="card">

--- a/@xen-orchestra/web/src/modules/pool/components/list/panel/PoolSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/pool/components/list/panel/PoolSidePanel.vue
@@ -1,18 +1,6 @@
 <template>
   <VtsStateHero v-if="!arePoolsReady" format="panel" type="busy" size="medium" />
-  <UiPanel v-else :class="{ 'mobile-drawer': uiStore.isSmall }">
-    <template #header>
-      <div :class="{ 'action-buttons-container': uiStore.isSmall }">
-        <UiButtonIcon
-          v-tooltip="t('action:close')"
-          size="small"
-          variant="tertiary"
-          accent="brand"
-          :icon="uiStore.isSmall ? 'fa:angle-left' : 'fa:close'"
-          @click="emit('close')"
-        />
-      </div>
-    </template>
+  <UiPanel v-else :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
     <template #default>
       <UiCard v-if="server.error === undefined" class="card-container">
         <UiCardTitle>
@@ -184,7 +172,6 @@ import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import VtsStatus from '@core/components/status/VtsStatus.vue'
 import VtsTag from '@core/components/tag/VtsTag.vue'
 import UiAlert from '@core/components/ui/alert/UiAlert.vue'
-import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiCardTitle from '@core/components/ui/card-title/UiCardTitle.vue'
 import UiCounter from '@core/components/ui/counter/UiCounter.vue'
@@ -193,7 +180,6 @@ import UiLink from '@core/components/ui/link/UiLink.vue'
 import UiLogEntryViewer from '@core/components/ui/log-entry-viewer/UiLogEntryViewer.vue'
 import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import UiTagsList from '@core/components/ui/tag/UiTagsList.vue'
-import { vTooltip } from '@core/directives/tooltip.directive.ts'
 import { useMapper } from '@core/packages/mapper'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { toLower } from 'lodash-es'

--- a/@xen-orchestra/web/src/modules/pool/components/list/panel/PoolSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/pool/components/list/panel/PoolSidePanel.vue
@@ -1,163 +1,166 @@
 <template>
-  <VtsStateHero v-if="!arePoolsReady" format="panel" type="busy" size="medium" />
-  <UiPanel v-else :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
+  <VtsSidePanel :selected="!!server" :closable="!!server" @close="emit('close')">
     <template #default>
-      <UiCard v-if="server.error === undefined" class="card-container">
-        <UiCardTitle>
-          {{ t('general-information') }}
-        </UiCardTitle>
-        <div class="content">
-          <!-- ID -->
-          <VtsCodeSnippet :content="server.id" copy />
-          <!-- Pool -->
+      <VtsStateHero v-if="!server" format="panel" type="no-selection" size="medium" />
+      <VtsStateHero v-else-if="!arePoolsReady" format="panel" type="busy" size="medium" />
+      <template v-else>
+        <UiCard v-if="server.error === undefined" class="card-container">
+          <UiCardTitle>
+            {{ t('general-information') }}
+          </UiCardTitle>
+          <div class="content">
+            <!-- ID -->
+            <VtsCodeSnippet :content="server.id" copy />
+            <!-- Pool -->
+            <VtsCardRowKeyValue>
+              <template #key>{{ t('pool') }}</template>
+              <template #value>
+                <UiLink
+                  v-if="server.poolId !== undefined && server.poolNameLabel !== undefined"
+                  icon="object:pool"
+                  size="small"
+                  :to="{ name: '/pool/[id]/dashboard', params: { id: server.poolId } }"
+                >
+                  {{ server.poolNameLabel }}
+                </UiLink>
+              </template>
+              <template v-if="server.poolId !== undefined" #addons>
+                <VtsCopyButton :value="server.poolId" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- Description -->
+            <VtsCardRowKeyValue truncate align-top>
+              <template #key>{{ t('description') }}</template>
+              <template #value>{{ server.poolNameDescription }}</template>
+              <template v-if="server.poolNameDescription !== undefined" #addons>
+                <VtsCopyButton :value="server.poolNameDescription" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- tag -->
+            <VtsCardRowKeyValue>
+              <template #key>{{ t('tags') }}</template>
+              <template #value>
+                <UiTagsList v-if="pool !== undefined && pool.tags.length > 0">
+                  <VtsTag v-for="tag in pool.tags" :key="tag" :value="tag" />
+                </UiTagsList>
+              </template>
+              <template v-if="pool !== undefined && pool.tags.length > 0" #addons>
+                <VtsCopyButton :value="pool.tags.join(', ')" />
+              </template>
+            </VtsCardRowKeyValue>
+          </div>
+        </UiCard>
+        <UiAlert v-else accent="danger">
+          {{ t('connection-failed') }}
+          <template #description>
+            {{ t('unable-to-connect-to-the-pool') }}
+          </template>
+        </UiAlert>
+        <UiCard class="card-container">
+          <UiCardTitle>
+            {{ t('connection') }}
+          </UiCardTitle>
+          <!-- status -->
           <VtsCardRowKeyValue>
-            <template #key>{{ t('pool') }}</template>
+            <template #key>{{ t('status') }}</template>
+            <template #value>
+              <UiInfo :accent="connectionStatus.accent">
+                {{ connectionStatus.text }}
+              </UiInfo>
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- primary-host -->
+          <VtsCardRowKeyValue>
+            <template #key>{{ t('master') }}</template>
             <template #value>
               <UiLink
-                v-if="server.poolId !== undefined && server.poolNameLabel !== undefined"
-                icon="object:pool"
+                v-if="primaryHost !== undefined"
+                :icon="`object:host:${toLower(primaryHost.power_state)}`"
                 size="small"
-                :to="{ name: '/pool/[id]/dashboard', params: { id: server.poolId } }"
+                :to="{ name: '/host/[id]/dashboard', params: { id: primaryHost.id } }"
+                is-primary
+                :primary-tooltip="t('master')"
               >
-                {{ server.poolNameLabel }}
+                {{ primaryHost.name_label }}
               </UiLink>
             </template>
-            <template v-if="server.poolId !== undefined" #addons>
-              <VtsCopyButton :value="server.poolId" />
+            <template v-if="primaryHost !== undefined" #addons>
+              <VtsCopyButton :value="primaryHost.id" />
             </template>
           </VtsCardRowKeyValue>
-          <!-- Description -->
-          <VtsCardRowKeyValue truncate align-top>
-            <template #key>{{ t('description') }}</template>
-            <template #value>{{ server.poolNameDescription }}</template>
-            <template v-if="server.poolNameDescription !== undefined" #addons>
-              <VtsCopyButton :value="server.poolNameDescription" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- tag -->
+          <!-- ip-address -->
           <VtsCardRowKeyValue>
-            <template #key>{{ t('tags') }}</template>
-            <template #value>
-              <UiTagsList v-if="pool !== undefined && pool.tags.length > 0">
-                <VtsTag v-for="tag in pool.tags" :key="tag" :value="tag" />
-              </UiTagsList>
-            </template>
-            <template v-if="pool !== undefined && pool.tags.length > 0" #addons>
-              <VtsCopyButton :value="pool.tags.join(', ')" />
+            <template #key>{{ t('ip-address') }}</template>
+            <template #value>{{ server.host }}</template>
+            <template #addons>
+              <VtsCopyButton :value="server.host" />
             </template>
           </VtsCardRowKeyValue>
-        </div>
-      </UiCard>
-      <UiAlert v-else accent="danger">
-        {{ t('connection-failed') }}
-        <template #description>
-          {{ t('unable-to-connect-to-the-pool') }}
-        </template>
-      </UiAlert>
-      <UiCard class="card-container">
-        <UiCardTitle>
-          {{ t('connection') }}
-        </UiCardTitle>
-        <!-- status -->
-        <VtsCardRowKeyValue>
-          <template #key>{{ t('status') }}</template>
-          <template #value>
-            <UiInfo :accent="connectionStatus.accent">
-              {{ connectionStatus.text }}
-            </UiInfo>
-          </template>
-        </VtsCardRowKeyValue>
-        <!-- primary-host -->
-        <VtsCardRowKeyValue>
-          <template #key>{{ t('master') }}</template>
-          <template #value>
+          <!-- proxy-url -->
+          <VtsCardRowKeyValue>
+            <template #key>{{ t('proxy-url') }}</template>
+            <template #value>{{ server.httpProxy }}</template>
+            <template v-if="server.httpProxy !== undefined" #addons>
+              <VtsCopyButton :value="server.httpProxy" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- username -->
+          <VtsCardRowKeyValue>
+            <template #key>{{ t('username') }}</template>
+            <template #value>{{ server.username }}</template>
+            <template #addons>
+              <VtsCopyButton :value="server.username" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- read-only -->
+          <VtsCardRowKeyValue>
+            <template #key>{{ t('read-only') }}</template>
+            <template #value>
+              <VtsStatus :status="server.readOnly" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- self-signed-certificates -->
+          <VtsCardRowKeyValue>
+            <template #key>{{ t('self-signed-certificates') }}</template>
+            <template #value>
+              <!-- todo add information button. waiting modal -->
+              <VtsStatus :status="server.allowUnauthorized" />
+            </template>
+          </VtsCardRowKeyValue>
+        </UiCard>
+        <UiCard v-if="hosts !== undefined">
+          <UiCardTitle>
+            <span>
+              {{ t('hosts') }}
+              <UiCounter :value="hosts.length" accent="neutral" size="small" variant="primary" />
+            </span>
+          </UiCardTitle>
+          <VtsStateHero v-if="hosts.length === 0" format="card" type="no-data" size="small">
+            {{ t('no-data') }}
+          </VtsStateHero>
+          <template v-else>
             <UiLink
-              v-if="primaryHost !== undefined"
-              :icon="`object:host:${toLower(primaryHost.power_state)}`"
+              v-for="host in hosts"
+              :key="host.id"
+              :to="{ name: '/host/[id]/dashboard', params: { id: host.id } }"
+              :icon="`object:host:${toLower(host.power_state)}`"
               size="small"
-              :to="{ name: '/host/[id]/dashboard', params: { id: primaryHost.id } }"
-              is-primary
-              :primary-tooltip="t('master')"
             >
-              {{ primaryHost.name_label }}
+              {{ host.name_label }}
+              <VtsIcon v-if="primaryHost?.id === host.id" accent="info" name="status:primary-circle" size="medium" />
             </UiLink>
           </template>
-          <template v-if="primaryHost !== undefined" #addons>
-            <VtsCopyButton :value="primaryHost.id" />
-          </template>
-        </VtsCardRowKeyValue>
-        <!-- ip-address -->
-        <VtsCardRowKeyValue>
-          <template #key>{{ t('ip-address') }}</template>
-          <template #value>{{ server.host }}</template>
-          <template #addons>
-            <VtsCopyButton :value="server.host" />
-          </template>
-        </VtsCardRowKeyValue>
-        <!-- proxy-url -->
-        <VtsCardRowKeyValue>
-          <template #key>{{ t('proxy-url') }}</template>
-          <template #value>{{ server.httpProxy }}</template>
-          <template v-if="server.httpProxy !== undefined" #addons>
-            <VtsCopyButton :value="server.httpProxy" />
-          </template>
-        </VtsCardRowKeyValue>
-        <!-- username -->
-        <VtsCardRowKeyValue>
-          <template #key>{{ t('username') }}</template>
-          <template #value>{{ server.username }}</template>
-          <template #addons>
-            <VtsCopyButton :value="server.username" />
-          </template>
-        </VtsCardRowKeyValue>
-        <!-- read-only -->
-        <VtsCardRowKeyValue>
-          <template #key>{{ t('read-only') }}</template>
-          <template #value>
-            <VtsStatus :status="server.readOnly" />
-          </template>
-        </VtsCardRowKeyValue>
-        <!-- self-signed-certificates -->
-        <VtsCardRowKeyValue>
-          <template #key>{{ t('self-signed-certificates') }}</template>
-          <template #value>
-            <!-- todo add information button. waiting modal -->
-            <VtsStatus :status="server.allowUnauthorized" />
-          </template>
-        </VtsCardRowKeyValue>
-      </UiCard>
-      <UiCard v-if="hosts !== undefined">
-        <UiCardTitle>
-          <span>
-            {{ t('hosts') }}
-            <UiCounter :value="hosts.length" accent="neutral" size="small" variant="primary" />
-          </span>
-        </UiCardTitle>
-        <VtsStateHero v-if="hosts.length === 0" format="card" type="no-data" size="small">
-          {{ t('no-data') }}
-        </VtsStateHero>
-        <template v-else>
-          <UiLink
-            v-for="host in hosts"
-            :key="host.id"
-            :to="{ name: '/host/[id]/dashboard', params: { id: host.id } }"
-            :icon="`object:host:${toLower(host.power_state)}`"
-            size="small"
-          >
-            {{ host.name_label }}
-            <VtsIcon v-if="primaryHost?.id === host.id" accent="info" name="status:primary-circle" size="medium" />
-          </UiLink>
-        </template>
-      </UiCard>
-      <UiCard v-if="server.error">
-        <UiCardTitle>
-          {{ t('error') }}
-          <UiCounter :value="1" accent="danger" size="small" variant="primary" />
-        </UiCardTitle>
-        <UiLogEntryViewer accent="danger" :label="t('api-error-details')" size="small" :content="server.error" />
-      </UiCard>
+        </UiCard>
+        <UiCard v-if="server.error">
+          <UiCardTitle>
+            {{ t('error') }}
+            <UiCounter :value="1" accent="danger" size="small" variant="primary" />
+          </UiCardTitle>
+          <UiLogEntryViewer accent="danger" :label="t('api-error-details')" size="small" :content="server.error" />
+        </UiCard>
+      </template>
     </template>
-  </UiPanel>
+  </VtsSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -168,6 +171,7 @@ import VtsCardRowKeyValue from '@core/components/card/VtsCardRowKeyValue.vue'
 import VtsCodeSnippet from '@core/components/code-snippet/VtsCodeSnippet.vue'
 import VtsCopyButton from '@core/components/copy-button/VtsCopyButton.vue'
 import VtsIcon from '@core/components/icon/VtsIcon.vue'
+import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
 import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import VtsStatus from '@core/components/status/VtsStatus.vue'
 import VtsTag from '@core/components/tag/VtsTag.vue'
@@ -178,16 +182,14 @@ import UiCounter from '@core/components/ui/counter/UiCounter.vue'
 import UiInfo from '@core/components/ui/info/UiInfo.vue'
 import UiLink from '@core/components/ui/link/UiLink.vue'
 import UiLogEntryViewer from '@core/components/ui/log-entry-viewer/UiLogEntryViewer.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import UiTagsList from '@core/components/ui/tag/UiTagsList.vue'
 import { useMapper } from '@core/packages/mapper'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import { toLower } from 'lodash-es'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const { server } = defineProps<{
-  server: FrontXoServer
+  server?: FrontXoServer
 }>()
 
 const emit = defineEmits<{
@@ -195,16 +197,15 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const uiStore = useUiStore()
 const { arePoolsReady, useGetPoolById } = useXoPoolCollection()
 const { useGetHostById, hostsByPool } = useXoHostCollection()
 
-const pool = useGetPoolById(() => server.poolId)
-const primaryHost = useGetHostById(() => server.master)
-const hosts = computed(() => (server.poolId ? hostsByPool.value.get(server.poolId) : undefined))
+const pool = useGetPoolById(() => server?.poolId)
+const primaryHost = useGetHostById(() => server?.master)
+const hosts = computed(() => (server?.poolId ? hostsByPool.value.get(server.poolId) : undefined))
 
 const connectionStatus = useMapper(
-  () => (server.error ? 'error' : server.status),
+  () => (server ? (server.error ? 'error' : server.status) : 'error'),
   {
     error: { accent: 'danger', text: t('unable-to-connect-to-the-pool') },
     disconnected: { accent: 'muted', text: t('disconnected') },
@@ -225,18 +226,6 @@ const connectionStatus = useMapper(
     display: flex;
     flex-direction: column;
     gap: 0.4rem;
-  }
-}
-
-.mobile-drawer {
-  position: fixed;
-  inset: 0;
-
-  .action-buttons-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
   }
 }
 </style>

--- a/@xen-orchestra/web/src/modules/pool/components/list/panel/PoolSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/pool/components/list/panel/PoolSidePanel.vue
@@ -1,8 +1,7 @@
 <template>
-  <VtsSidePanel :selected="!!server" :closable="!!server" @close="emit('close')">
-    <template #default>
-      <VtsStateHero v-if="!server" format="panel" type="no-selection" size="medium" />
-      <VtsStateHero v-else-if="!arePoolsReady" format="panel" type="busy" size="medium" />
+  <VtsSidePanel :has-selection="!!server" @close="emit('close')">
+    <template v-if="server">
+      <VtsStateHero v-if="!arePoolsReady" format="panel" type="busy" size="medium" />
       <template v-else>
         <UiCard v-if="server.error === undefined" class="card-container">
           <UiCardTitle>

--- a/@xen-orchestra/web/src/modules/snapshot/components/list/panel/SnapshotSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/snapshot/components/list/panel/SnapshotSidePanel.vue
@@ -1,6 +1,6 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
-    <template #header>
+  <VtsSidePanel :selected="!!snapshot" :closable="!!snapshot" @close="emit('close')">
+    <template v-if="snapshot" #actions>
       <UiButton
         :disabled="!canRevertSnapshot || isDeletingSnapshot"
         :busy="isRevertingSnapshot"
@@ -15,15 +15,17 @@
       <VtsDeleteButton
         :disabled="!canDeleteSnapshot || isRevertingSnapshot"
         :busy="isDeletingSnapshot"
-        class="delete-button"
         @click="openSnapshotDeleteModal()"
       />
     </template>
     <template #default>
-      <SnapshotInfoCard :snapshot />
-      <SnapshotVdiCard :snapshot />
+      <VtsStateHero v-if="!snapshot" format="panel" type="no-selection" size="medium" />
+      <template v-else>
+        <SnapshotInfoCard :snapshot />
+        <SnapshotVdiCard :snapshot />
+      </template>
     </template>
-  </UiPanel>
+  </VtsSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -33,14 +35,12 @@ import type { FrontXoVmSnapshot } from '@/modules/snapshot/components/remote-res
 import { useVmSnapshotDeleteModal } from '@/modules/snapshot/composables/use-vm-snapshot-delete-modal.composable.ts'
 import { useVmSnapshotRevertModal } from '@/modules/snapshot/composables/use-vm-snapshot-revert-modal.composable.ts'
 import VtsDeleteButton from '@core/components/delete-button/VtsDeleteButton.vue'
+import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiButton from '@core/components/ui/button/UiButton.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import { useI18n } from 'vue-i18n'
 
-const { snapshot } = defineProps<{
-  snapshot: FrontXoVmSnapshot
-}>()
+const { snapshot } = defineProps<{ snapshot?: FrontXoVmSnapshot }>()
 
 const emit = defineEmits<{
   close: []
@@ -48,35 +48,15 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
-const uiStore = useUiStore()
-
 const {
   openModal: openSnapshotDeleteModal,
   canRun: canDeleteSnapshot,
   isRunning: isDeletingSnapshot,
-} = useVmSnapshotDeleteModal(() => [snapshot])
+} = useVmSnapshotDeleteModal(() => (snapshot !== undefined ? [snapshot] : []))
 
 const {
   openModal: openSnapshotRevertModal,
   canRun: canRevertSnapshot,
   isRunning: isRevertingSnapshot,
-} = useVmSnapshotRevertModal(() => snapshot)
+} = useVmSnapshotRevertModal(() => snapshot as FrontXoVmSnapshot)
 </script>
-
-<style scoped lang="postcss">
-.delete-button {
-  margin-inline-end: auto;
-}
-
-.mobile-drawer {
-  position: fixed;
-  inset: 0;
-
-  .action-buttons-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-  }
-}
-</style>

--- a/@xen-orchestra/web/src/modules/snapshot/components/list/panel/SnapshotSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/snapshot/components/list/panel/SnapshotSidePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsSidePanel :selected="!!snapshot" :closable="!!snapshot" @close="emit('close')">
+  <VtsSidePanel :has-selection="!!snapshot" @close="emit('close')">
     <template v-if="snapshot" #actions>
       <UiButton
         :disabled="!canRevertSnapshot || isDeletingSnapshot"
@@ -18,12 +18,9 @@
         @click="openSnapshotDeleteModal()"
       />
     </template>
-    <template #default>
-      <VtsStateHero v-if="!snapshot" format="panel" type="no-selection" size="medium" />
-      <template v-else>
-        <SnapshotInfoCard :snapshot />
-        <SnapshotVdiCard :snapshot />
-      </template>
+    <template v-if="snapshot" #default>
+      <SnapshotInfoCard :snapshot />
+      <SnapshotVdiCard :snapshot />
     </template>
   </VtsSidePanel>
 </template>
@@ -36,7 +33,6 @@ import { useVmSnapshotDeleteModal } from '@/modules/snapshot/composables/use-vm-
 import { useVmSnapshotRevertModal } from '@/modules/snapshot/composables/use-vm-snapshot-revert-modal.composable.ts'
 import VtsDeleteButton from '@core/components/delete-button/VtsDeleteButton.vue'
 import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiButton from '@core/components/ui/button/UiButton.vue'
 import { useI18n } from 'vue-i18n'
 

--- a/@xen-orchestra/web/src/modules/snapshot/components/list/panel/SnapshotSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/snapshot/components/list/panel/SnapshotSidePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }">
+  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
     <template #header>
       <UiButton
         :disabled="!canRevertSnapshot || isDeletingSnapshot"
@@ -18,16 +18,6 @@
         class="delete-button"
         @click="openSnapshotDeleteModal()"
       />
-      <div :class="{ 'action-buttons-container': uiStore.isSmall }">
-        <UiButtonIcon
-          v-tooltip="t('action:close')"
-          size="small"
-          variant="tertiary"
-          accent="brand"
-          :icon="uiStore.isSmall ? 'fa:angle-left' : 'fa:close'"
-          @click="emit('close')"
-        />
-      </div>
     </template>
     <template #default>
       <SnapshotInfoCard :snapshot />
@@ -44,9 +34,7 @@ import { useVmSnapshotDeleteModal } from '@/modules/snapshot/composables/use-vm-
 import { useVmSnapshotRevertModal } from '@/modules/snapshot/composables/use-vm-snapshot-revert-modal.composable.ts'
 import VtsDeleteButton from '@core/components/delete-button/VtsDeleteButton.vue'
 import UiButton from '@core/components/ui/button/UiButton.vue'
-import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { vTooltip } from '@core/directives/tooltip.directive.ts'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { useI18n } from 'vue-i18n'
 
@@ -58,9 +46,9 @@ const emit = defineEmits<{
   close: []
 }>()
 
-const uiStore = useUiStore()
-
 const { t } = useI18n()
+
+const uiStore = useUiStore()
 
 const {
   openModal: openSnapshotDeleteModal,

--- a/@xen-orchestra/web/src/modules/snapshot/components/list/panel/SnapshotSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/snapshot/components/list/panel/SnapshotSidePanel.vue
@@ -58,5 +58,5 @@ const {
   openModal: openSnapshotRevertModal,
   canRun: canRevertSnapshot,
   isRunning: isRevertingSnapshot,
-} = useVmSnapshotRevertModal(() => snapshot as FrontXoVmSnapshot)
+} = useVmSnapshotRevertModal(() => snapshot)
 </script>

--- a/@xen-orchestra/web/src/modules/snapshot/composables/use-vm-snapshot-revert-modal.composable.ts
+++ b/@xen-orchestra/web/src/modules/snapshot/composables/use-vm-snapshot-revert-modal.composable.ts
@@ -4,7 +4,7 @@ import { useModal } from '@core/packages/modal/use-modal.ts'
 import { toComputed } from '@core/utils/to-computed.util.ts'
 import { type MaybeRefOrGetter, ref } from 'vue'
 
-export function useVmSnapshotRevertModal(rawSnapshot: MaybeRefOrGetter<FrontXoVmSnapshot>) {
+export function useVmSnapshotRevertModal(rawSnapshot: MaybeRefOrGetter<FrontXoVmSnapshot | undefined>) {
   const snapshot = toComputed(rawSnapshot)
   const snapshotBefore = ref(true)
 

--- a/@xen-orchestra/web/src/modules/storage-repository/components/list/panel/StorageRepositorySidePanel.vue
+++ b/@xen-orchestra/web/src/modules/storage-repository/components/list/panel/StorageRepositorySidePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsSidePanel :key="panelSignature" :selected="!!sr" :closable="!!sr" @close="emit('close')">
+  <VtsSidePanel :key="panelSignature" :has-selection="!!sr" @close="emit('close')">
     <template v-if="sr" #actions>
       <SrConnectButton :scope :sr />
       <MenuList placement="bottom-end">
@@ -10,9 +10,8 @@
         <SrDeleteButton :sr />
       </MenuList>
     </template>
-    <template #default>
-      <VtsStateHero v-if="!sr" format="panel" type="no-selection" size="medium" />
-      <VtsStateHero v-else-if="!isReady" format="panel" type="busy" size="medium" />
+    <template v-if="sr" #default>
+      <VtsStateHero v-if="!isReady" format="panel" type="busy" size="medium" />
       <template v-else>
         <StorageRepositoryInfosCard :scope :sr />
         <StorageRepositorySpaceCard :sr />

--- a/@xen-orchestra/web/src/modules/storage-repository/components/list/panel/StorageRepositorySidePanel.vue
+++ b/@xen-orchestra/web/src/modules/storage-repository/components/list/panel/StorageRepositorySidePanel.vue
@@ -1,6 +1,6 @@
 <template>
   <VtsStateHero v-if="!isReady" format="panel" size="medium" type="busy" />
-  <UiPanel v-else :key="panelSignature" :class="{ 'mobile-drawer': uiStore.isSmall }">
+  <UiPanel v-else :key="panelSignature" :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
     <template #header>
       <div class="action-buttons">
         <SrConnectButton :scope :sr />
@@ -11,17 +11,6 @@
           <SrDisconnectButton :scope :sr />
           <SrDeleteButton :sr />
         </MenuList>
-      </div>
-
-      <div :class="{ 'action-buttons-container': uiStore.isSmall }">
-        <UiButtonIcon
-          v-tooltip="t('action:close')"
-          :icon="uiStore.isSmall ? 'fa:angle-left' : 'fa:close'"
-          accent="brand"
-          size="small"
-          variant="tertiary"
-          @click="emit('close')"
-        />
       </div>
     </template>
     <template #default>
@@ -59,12 +48,10 @@ import MenuList from '@core/components/menu/MenuList.vue'
 import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { vTooltip } from '@core/directives/tooltip.directive.ts'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import type { XoVdi } from '@vates/types'
 import { logicAnd } from '@vueuse/math'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 const { sr, scope } = defineProps<{
   sr: FrontXoSr
@@ -75,7 +62,6 @@ const emit = defineEmits<{
   close: []
 }>()
 
-const { t } = useI18n()
 const uiStore = useUiStore()
 
 const { useGetVdisByIds, areVdisReady } = useXoVdiCollection()

--- a/@xen-orchestra/web/src/modules/storage-repository/components/list/panel/StorageRepositorySidePanel.vue
+++ b/@xen-orchestra/web/src/modules/storage-repository/components/list/panel/StorageRepositorySidePanel.vue
@@ -71,7 +71,7 @@ const isReady = logicAnd(areVdisReady, areHostsReady, arePbdsReady, areVdiSnapsh
 
 const vdis = useGetVdisByIds(() => (sr?.VDIs ?? []) as XoVdi['id'][])
 
-const vdiSnapshots = useGetVdiSnapshotsByIds(() => sr.VDIs as FrontXoVdiSnapshot['id'][])
+const vdiSnapshots = useGetVdiSnapshotsByIds(() => (sr?.VDIs ?? []) as FrontXoVdiSnapshot['id'][])
 
 const { getSrPbdsSignature } = useGetPbdsInScope()
 

--- a/@xen-orchestra/web/src/modules/storage-repository/components/list/panel/StorageRepositorySidePanel.vue
+++ b/@xen-orchestra/web/src/modules/storage-repository/components/list/panel/StorageRepositorySidePanel.vue
@@ -1,27 +1,28 @@
 <template>
-  <VtsStateHero v-if="!isReady" format="panel" size="medium" type="busy" />
-  <UiPanel v-else :key="panelSignature" :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
-    <template #header>
-      <div class="action-buttons">
-        <SrConnectButton :scope :sr />
-        <MenuList placement="bottom-end">
-          <template #trigger="{ open }">
-            <UiButtonIcon accent="brand" icon="action:more-actions" size="medium" @click="open($event)" />
-          </template>
-          <SrDisconnectButton :scope :sr />
-          <SrDeleteButton :sr />
-        </MenuList>
-      </div>
+  <VtsSidePanel :key="panelSignature" :selected="!!sr" :closable="!!sr" @close="emit('close')">
+    <template v-if="sr" #actions>
+      <SrConnectButton :scope :sr />
+      <MenuList placement="bottom-end">
+        <template #trigger="{ open }">
+          <UiButtonIcon accent="brand" icon="action:more-actions" size="medium" @click="open($event)" />
+        </template>
+        <SrDisconnectButton :scope :sr />
+        <SrDeleteButton :sr />
+      </MenuList>
     </template>
     <template #default>
-      <StorageRepositoryInfosCard :scope :sr />
-      <StorageRepositorySpaceCard :sr />
-      <StorageRepositoryVdisCard :vdi-snapshots :vdis />
-      <StorageRepositoryHostsCard :hosts />
-      <StorageRepositoryPbdsCard :scope :sr />
-      <StorageRepositoryCustomFieldsCard :custom-fields />
+      <VtsStateHero v-if="!sr" format="panel" type="no-selection" size="medium" />
+      <VtsStateHero v-else-if="!isReady" format="panel" type="busy" size="medium" />
+      <template v-else>
+        <StorageRepositoryInfosCard :scope :sr />
+        <StorageRepositorySpaceCard :sr />
+        <StorageRepositoryVdisCard :vdi-snapshots :vdis />
+        <StorageRepositoryHostsCard :hosts />
+        <StorageRepositoryPbdsCard :scope :sr />
+        <StorageRepositoryCustomFieldsCard :custom-fields />
+      </template>
     </template>
-  </UiPanel>
+  </VtsSidePanel>
 </template>
 
 <script lang="ts" setup>
@@ -45,24 +46,21 @@ import {
 } from '@/modules/vdi/remote-resources/use-xo-vdi-snapshot-collection.ts'
 import type { SrScope } from '@core/types/storage-repository.type.ts'
 import MenuList from '@core/components/menu/MenuList.vue'
+import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
 import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import type { XoVdi } from '@vates/types'
 import { logicAnd } from '@vueuse/math'
 import { computed } from 'vue'
 
 const { sr, scope } = defineProps<{
-  sr: FrontXoSr
+  sr?: FrontXoSr
   scope: SrScope
 }>()
 
 const emit = defineEmits<{
   close: []
 }>()
-
-const uiStore = useUiStore()
 
 const { useGetVdisByIds, areVdisReady } = useXoVdiCollection()
 const { getHostById, areHostsReady } = useXoHostCollection()
@@ -71,7 +69,7 @@ const { useGetVdiSnapshotsByIds, areVdiSnapshotsReady } = useXoVdiSnapshotCollec
 
 const isReady = logicAnd(areVdisReady, areHostsReady, arePbdsReady, areVdiSnapshotsReady)
 
-const vdis = useGetVdisByIds(() => sr.VDIs as XoVdi['id'][])
+const vdis = useGetVdisByIds(() => (sr?.VDIs ?? []) as XoVdi['id'][])
 
 const vdiSnapshots = useGetVdiSnapshotsByIds(() => sr.VDIs as FrontXoVdiSnapshot['id'][])
 
@@ -79,7 +77,7 @@ const { getSrPbdsSignature } = useGetPbdsInScope()
 
 const panelSignature = computed(() => getSrPbdsSignature(sr, scope))
 
-const pbds = computed(() => pbdsBySr.value.get(sr.id) ?? [])
+const pbds = computed(() => (sr !== undefined ? pbdsBySr.value.get(sr.id) : undefined) ?? [])
 
 const hosts = computed(() =>
   pbds.value.reduce<FrontXoHost[]>((acc, pbd) => {
@@ -94,6 +92,10 @@ const hosts = computed(() =>
 )
 
 const customFields = computed(() => {
+  if (sr === undefined) {
+    return {}
+  }
+
   const prefix = 'XenCenter.CustomFields.'
 
   return Object.entries(sr.other_config).reduce<Record<string, unknown>>((acc, [key, value]) => {
@@ -105,22 +107,3 @@ const customFields = computed(() => {
   }, {})
 })
 </script>
-
-<style lang="postcss" scoped>
-.action-buttons {
-  display: flex;
-  align-items: center;
-  margin-inline-end: auto;
-}
-.mobile-drawer {
-  position: fixed;
-  inset: 0;
-
-  .action-buttons-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-  }
-}
-</style>

--- a/@xen-orchestra/web/src/modules/storage-repository/composables/xo-sr-utils.composable.ts
+++ b/@xen-orchestra/web/src/modules/storage-repository/composables/xo-sr-utils.composable.ts
@@ -31,7 +31,11 @@ export function useGetPbdsInScope() {
     return getPbdsInScope(sr, scope).filter(pbd => !pbd.attached)
   }
 
-  function getSrPbdsSignature(sr: FrontXoSr, scope: SrScope) {
+  function getSrPbdsSignature(sr: FrontXoSr | undefined, scope: SrScope) {
+    if (sr === undefined) {
+      return scope.type === 'host' ? `host:${scope.hostId}` : 'pool'
+    }
+
     const scopedPbds = getPbdsInScope(sr, scope)
 
     return scopedPbds.map(pbd => `${pbd.id}:${pbd.attached}`).join('|') || sr.id

--- a/@xen-orchestra/web/src/modules/task/components/list/panel/TaskSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/task/components/list/panel/TaskSidePanel.vue
@@ -1,17 +1,5 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }">
-    <template #header>
-      <div :class="{ 'action-buttons-container': uiStore.isSmall }">
-        <UiButtonIcon
-          v-tooltip="t('action:close')"
-          size="medium"
-          variant="tertiary"
-          accent="brand"
-          :icon="uiStore.isSmall ? 'fa:angle-left' : 'fa:close'"
-          @click="emit('close')"
-        />
-      </div>
-    </template>
+  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
     <template #default>
       <TaskQuickInfosCard :task />
       <TaskInfosCard v-if="task.infos" :task />
@@ -32,12 +20,9 @@ import TaskQuickInfosCard from '@/modules/task/components/list/panel/cards/TaskQ
 import TaskWarningsCard from '@/modules/task/components/list/panel/cards/TaskWarningsCard.vue'
 import { useXoTaskPropertiesUtils } from '@/modules/task/composables/xo-task-properties-utils.composable.ts'
 import type { FrontXoTask } from '@/modules/task/remote-resources/use-xo-task-collection.ts'
-import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { vTooltip } from '@core/directives/tooltip.directive.ts'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 const { task } = defineProps<{
   task: FrontXoTask
@@ -47,7 +32,6 @@ const emit = defineEmits<{
   close: []
 }>()
 
-const { t } = useI18n()
 const uiStore = useUiStore()
 
 const { properties } = useXoTaskPropertiesUtils(() => task)

--- a/@xen-orchestra/web/src/modules/task/components/list/panel/TaskSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/task/components/list/panel/TaskSidePanel.vue
@@ -1,15 +1,12 @@
 <template>
-  <VtsSidePanel :selected="!!task" :closable="!!task" @close="emit('close')">
-    <template #default>
-      <VtsStateHero v-if="!task" format="panel" type="no-selection" size="medium" />
-      <template v-else>
-        <TaskQuickInfosCard :task />
-        <TaskInfosCard v-if="task.infos" :task />
-        <TaskWarningsCard v-if="task.warnings" :task />
-        <TaskErrorsCard v-if="isError" :task />
-        <TaskObjectsCard v-if="task.properties.objectId" :task />
-        <TaskPropertiesCard v-if="properties.other && Object.keys(properties.other).length > 0" :task />
-      </template>
+  <VtsSidePanel :has-selection="!!task" @close="emit('close')">
+    <template v-if="task">
+      <TaskQuickInfosCard :task />
+      <TaskInfosCard v-if="task.infos" :task />
+      <TaskWarningsCard v-if="task.warnings" :task />
+      <TaskErrorsCard v-if="isError" :task />
+      <TaskObjectsCard v-if="task.properties.objectId" :task />
+      <TaskPropertiesCard v-if="properties.other && Object.keys(properties.other).length > 0" :task />
     </template>
   </VtsSidePanel>
 </template>
@@ -24,7 +21,6 @@ import TaskWarningsCard from '@/modules/task/components/list/panel/cards/TaskWar
 import { useXoTaskPropertiesUtils } from '@/modules/task/composables/xo-task-properties-utils.composable.ts'
 import type { FrontXoTask } from '@/modules/task/remote-resources/use-xo-task-collection.ts'
 import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import { computed } from 'vue'
 
 const { task } = defineProps<{

--- a/@xen-orchestra/web/src/modules/task/components/list/panel/TaskSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/task/components/list/panel/TaskSidePanel.vue
@@ -35,7 +35,7 @@ const emit = defineEmits<{
   close: []
 }>()
 
-const { properties } = useXoTaskPropertiesUtils(() => task ?? ({ properties: {} } as FrontXoTask))
+const { properties } = useXoTaskPropertiesUtils(() => task)
 
 const isError = computed(() => task && task.result && (task.status === 'failure' || task.status === 'interrupted'))
 </script>

--- a/@xen-orchestra/web/src/modules/task/components/list/panel/TaskSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/task/components/list/panel/TaskSidePanel.vue
@@ -1,14 +1,17 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
+  <VtsSidePanel :selected="!!task" :closable="!!task" @close="emit('close')">
     <template #default>
-      <TaskQuickInfosCard :task />
-      <TaskInfosCard v-if="task.infos" :task />
-      <TaskWarningsCard v-if="task.warnings" :task />
-      <TaskErrorsCard v-if="isError" :task />
-      <TaskObjectsCard v-if="task.properties.objectId" :task />
-      <TaskPropertiesCard v-if="properties.other && Object.keys(properties.other).length > 0" :task />
+      <VtsStateHero v-if="!task" format="panel" type="no-selection" size="medium" />
+      <template v-else>
+        <TaskQuickInfosCard :task />
+        <TaskInfosCard v-if="task.infos" :task />
+        <TaskWarningsCard v-if="task.warnings" :task />
+        <TaskErrorsCard v-if="isError" :task />
+        <TaskObjectsCard v-if="task.properties.objectId" :task />
+        <TaskPropertiesCard v-if="properties.other && Object.keys(properties.other).length > 0" :task />
+      </template>
     </template>
-  </UiPanel>
+  </VtsSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -20,35 +23,19 @@ import TaskQuickInfosCard from '@/modules/task/components/list/panel/cards/TaskQ
 import TaskWarningsCard from '@/modules/task/components/list/panel/cards/TaskWarningsCard.vue'
 import { useXoTaskPropertiesUtils } from '@/modules/task/composables/xo-task-properties-utils.composable.ts'
 import type { FrontXoTask } from '@/modules/task/remote-resources/use-xo-task-collection.ts'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { useUiStore } from '@core/stores/ui.store.ts'
+import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import { computed } from 'vue'
 
 const { task } = defineProps<{
-  task: FrontXoTask
+  task?: FrontXoTask
 }>()
 
 const emit = defineEmits<{
   close: []
 }>()
 
-const uiStore = useUiStore()
+const { properties } = useXoTaskPropertiesUtils(() => task ?? ({ properties: {} } as FrontXoTask))
 
-const { properties } = useXoTaskPropertiesUtils(() => task)
-
-const isError = computed(() => task.result && (task.status === 'failure' || task.status === 'interrupted'))
+const isError = computed(() => task && task.result && (task.status === 'failure' || task.status === 'interrupted'))
 </script>
-
-<style scoped lang="postcss">
-.mobile-drawer {
-  position: fixed;
-  inset: 0;
-
-  .action-buttons-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-  }
-}
-</style>

--- a/@xen-orchestra/web/src/modules/task/composables/xo-task-properties-utils.composable.ts
+++ b/@xen-orchestra/web/src/modules/task/composables/xo-task-properties-utils.composable.ts
@@ -2,15 +2,17 @@ import type { FrontXoTask } from '@/modules/task/remote-resources/use-xo-task-co
 import { toComputed } from '@core/utils/to-computed.util.ts'
 import { computed, type MaybeRefOrGetter } from 'vue'
 
-export function useXoTaskPropertiesUtils(rawTask: MaybeRefOrGetter<FrontXoTask>) {
+export function useXoTaskPropertiesUtils(rawTask: MaybeRefOrGetter<FrontXoTask | undefined>) {
   const task = toComputed(rawTask)
 
   const properties = computed(() => {
-    if (!task.value.properties) {
+    const taskProperties = task.value?.properties
+
+    if (!taskProperties) {
       return {}
     }
 
-    const { method, name, type, objectId, progress, userId, ...other } = task.value.properties
+    const { method, name, type, objectId, progress, userId, ...other } = taskProperties
 
     return {
       method,

--- a/@xen-orchestra/web/src/modules/traffic-rules/components/list/panel/TrafficRulesSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/traffic-rules/components/list/panel/TrafficRulesSidePanel.vue
@@ -1,24 +1,27 @@
 <template>
-  <VtsStateHero v-if="!isReady" format="panel" type="busy" size="medium" />
-
-  <UiPanel v-else :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
+  <VtsSidePanel :selected="!!rule" :closable="!!rule" @close="emit('close')">
     <template #header>
       <TrafficRuleActions :rule class="delete-button" />
     </template>
+
     <template #default>
-      <TrafficRuleSummaryCard :rule />
+      <VtsStateHero v-if="!rule" format="panel" type="no-selection" size="medium" />
+      <VtsStateHero v-else-if="!isReady" format="panel" type="busy" size="medium" />
+      <template v-else>
+        <TrafficRuleSummaryCard :rule />
 
-      <template v-if="vif">
-        <TrafficRuleVifInfosCard :rule :vif />
-        <TrafficRuleVifNetworkInfoCard :rule :vif />
-      </template>
+        <template v-if="vif">
+          <TrafficRuleVifInfosCard :rule :vif />
+          <TrafficRuleVifNetworkInfoCard :rule :vif />
+        </template>
 
-      <template v-else-if="network">
-        <TrafficRuleNetworkInfosCard :rule :network />
-        <TrafficRuleNetworkPifsCard :rule :network />
+        <template v-else-if="network">
+          <TrafficRuleNetworkInfosCard :rule :network />
+          <TrafficRuleNetworkPifsCard :rule :network />
+        </template>
       </template>
     </template>
-  </UiPanel>
+  </VtsSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -30,46 +33,24 @@ import TrafficRuleSummaryCard from '@/modules/traffic-rules/components/list/pane
 import TrafficRuleVifInfosCard from '@/modules/traffic-rules/components/list/panel/cards/TrafficRuleVifInfosCard.vue'
 import TrafficRuleVifNetworkInfoCard from '@/modules/traffic-rules/components/list/panel/cards/TrafficRuleVifNetworkInfoCard.vue'
 import { useXoVifCollection } from '@/modules/vif/remote-resources/use-xo-vif-collection.ts'
+import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
 import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import type { TrafficRule } from '@vates/types'
 import { logicAnd } from '@vueuse/math'
 import { computed } from 'vue'
 
-const { rule } = defineProps<{
-  rule: TrafficRule
-}>()
+const { rule } = defineProps<{ rule?: TrafficRule }>()
 
 const emit = defineEmits<{
   close: []
 }>()
 
-const uiStore = useUiStore()
-
 const { getVifById, areVifsReady } = useXoVifCollection()
 const { getNetworkById, areNetworksReady } = useXoNetworkCollection()
 
-const vif = computed(() => (rule.type === 'VIF' ? getVifById(rule.sourceId) : undefined))
-const network = computed(() => getNetworkById(rule.networkId))
+const vif = computed(() => (rule?.type === 'VIF' ? getVifById(rule.sourceId) : undefined))
+
+const network = computed(() => (rule !== undefined ? getNetworkById(rule.networkId) : undefined))
 
 const isReady = logicAnd(areVifsReady, areNetworksReady)
 </script>
-
-<style scoped lang="postcss">
-.mobile-drawer {
-  position: fixed;
-  inset: 0;
-
-  .action-buttons-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-  }
-}
-
-.delete-button {
-  margin-inline-end: auto;
-}
-</style>

--- a/@xen-orchestra/web/src/modules/traffic-rules/components/list/panel/TrafficRulesSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/traffic-rules/components/list/panel/TrafficRulesSidePanel.vue
@@ -1,22 +1,10 @@
 <template>
   <VtsStateHero v-if="!isReady" format="panel" type="busy" size="medium" />
 
-  <UiPanel v-else :class="{ 'mobile-drawer': uiStore.isSmall }">
+  <UiPanel v-else :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
     <template #header>
       <TrafficRuleActions :rule class="delete-button" />
-
-      <div :class="{ 'action-buttons-container': uiStore.isSmall }">
-        <UiButtonIcon
-          v-tooltip="t('action:close')"
-          size="small"
-          variant="tertiary"
-          accent="brand"
-          :icon="uiStore.isSmall ? 'fa:angle-left' : 'fa:close'"
-          @click="emit('close')"
-        />
-      </div>
     </template>
-
     <template #default>
       <TrafficRuleSummaryCard :rule />
 
@@ -43,14 +31,11 @@ import TrafficRuleVifInfosCard from '@/modules/traffic-rules/components/list/pan
 import TrafficRuleVifNetworkInfoCard from '@/modules/traffic-rules/components/list/panel/cards/TrafficRuleVifNetworkInfoCard.vue'
 import { useXoVifCollection } from '@/modules/vif/remote-resources/use-xo-vif-collection.ts'
 import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
-import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { vTooltip } from '@core/directives/tooltip.directive.ts'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import type { TrafficRule } from '@vates/types'
 import { logicAnd } from '@vueuse/math'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 const { rule } = defineProps<{
   rule: TrafficRule
@@ -61,7 +46,6 @@ const emit = defineEmits<{
 }>()
 
 const uiStore = useUiStore()
-const { t } = useI18n()
 
 const { getVifById, areVifsReady } = useXoVifCollection()
 const { getNetworkById, areNetworksReady } = useXoNetworkCollection()

--- a/@xen-orchestra/web/src/modules/traffic-rules/components/list/panel/TrafficRulesSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/traffic-rules/components/list/panel/TrafficRulesSidePanel.vue
@@ -1,12 +1,11 @@
 <template>
-  <VtsSidePanel :selected="!!rule" :closable="!!rule" @close="emit('close')">
+  <VtsSidePanel :has-selection="!!rule" @close="emit('close')">
     <template v-if="rule" #actions>
       <TrafficRuleActions :rule class="delete-button" />
     </template>
 
-    <template #default>
-      <VtsStateHero v-if="!rule" format="panel" type="no-selection" size="medium" />
-      <VtsStateHero v-else-if="!isReady" format="panel" type="busy" size="medium" />
+    <template v-if="rule" #default>
+      <VtsStateHero v-if="!isReady" format="panel" type="busy" size="medium" />
       <template v-else>
         <TrafficRuleSummaryCard :rule />
 

--- a/@xen-orchestra/web/src/modules/traffic-rules/components/list/panel/TrafficRulesSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/traffic-rules/components/list/panel/TrafficRulesSidePanel.vue
@@ -1,6 +1,6 @@
 <template>
   <VtsSidePanel :selected="!!rule" :closable="!!rule" @close="emit('close')">
-    <template #header>
+    <template v-if="rule" #actions>
       <TrafficRuleActions :rule class="delete-button" />
     </template>
 

--- a/@xen-orchestra/web/src/modules/vdi/components/list/panel/VdiSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/vdi/components/list/panel/VdiSidePanel.vue
@@ -1,25 +1,21 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
-    <template #header>
-      <div class="action-buttons">
-        <template v-if="vbd">
-          <VbdConnectButton v-if="!vbd.attached" :vbd :vm />
-          <VbdDisconnectButton v-else :vbd :vm />
-        </template>
-        <MenuList placement="bottom-end">
-          <template #trigger="{ open }">
-            <UiButtonIcon icon="action:more-actions" accent="brand" size="medium" @click="open($event)" />
-          </template>
-          <VdiActions :vdi :vbd :vm />
-        </MenuList>
-      </div>
+  <VtsSidePanel :selected="!!vdi" :closable="!!vdi" @close="emit('close')">
+    <template v-if="vbd" #actions>
+      <VbdConnectButton v-if="!vbd.attached" :vbd :vm />
+      <VbdDisconnectButton v-else :vbd :vm />
+    </template>
+    <template v-if="vdi" #more-actions>
+      <VdiActions :vdi :vbd :vm />
     </template>
     <template #default>
-      <VdiInfosCard :vdi :vm />
-      <VdiSpaceCard :vdi />
-      <VdiConfigurationCard :vdi :vm />
+      <VtsStateHero v-if="!vdi" format="panel" type="no-selection" size="medium" />
+      <template v-else>
+        <VdiInfosCard :vdi :vm />
+        <VdiSpaceCard :vdi />
+        <VdiConfigurationCard :vdi :vm />
+      </template>
     </template>
-  </UiPanel>
+  </VtsSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -32,14 +28,12 @@ import VdiInfosCard from '@/modules/vdi/components/list/panel/cards/VdiInfosCard
 import VdiSpaceCard from '@/modules/vdi/components/list/panel/cards/VdiSpaceCard.vue'
 import type { FrontXoVdi } from '@/modules/vdi/remote-resources/use-xo-vdi-collection.ts'
 import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
-import MenuList from '@core/components/menu/MenuList.vue'
-import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { useUiStore } from '@core/stores/ui.store.ts'
+import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import { computed } from 'vue'
 
 const { vdi, vm } = defineProps<{
-  vdi: FrontXoVdi
+  vdi?: FrontXoVdi
   vm: FrontXoVm
 }>()
 
@@ -47,30 +41,9 @@ const emit = defineEmits<{
   close: []
 }>()
 
-const uiStore = useUiStore()
-
 const { useGetVbdsByIds } = useXoVbdCollection()
 
-const vbds = useGetVbdsByIds(vdi.$VBDs)
+const vbds = useGetVbdsByIds(vdi?.$VBDs ?? [])
 
 const vbd = computed(() => vbds.value.find(vbd => vbd.VM === vm.id))
 </script>
-
-<style scoped lang="postcss">
-.action-buttons {
-  display: flex;
-  align-items: center;
-  margin-inline-end: auto;
-}
-
-.mobile-drawer {
-  position: fixed;
-  inset: 0;
-
-  .close-button {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-}
-</style>

--- a/@xen-orchestra/web/src/modules/vdi/components/list/panel/VdiSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/vdi/components/list/panel/VdiSidePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }">
+  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
     <template #header>
       <div class="action-buttons">
         <template v-if="vbd">
@@ -12,16 +12,6 @@
           </template>
           <VdiActions :vdi :vbd :vm />
         </MenuList>
-      </div>
-      <div :class="{ 'close-button': uiStore.isSmall }">
-        <UiButtonIcon
-          v-tooltip="t('action:close')"
-          size="small"
-          variant="tertiary"
-          accent="brand"
-          :icon="uiStore.isSmall ? 'fa:angle-left' : 'fa:close'"
-          @click="emit('close')"
-        />
       </div>
     </template>
     <template #default>
@@ -45,10 +35,8 @@ import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collecti
 import MenuList from '@core/components/menu/MenuList.vue'
 import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { vTooltip } from '@core/directives/tooltip.directive.ts'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 const { vdi, vm } = defineProps<{
   vdi: FrontXoVdi
@@ -58,8 +46,6 @@ const { vdi, vm } = defineProps<{
 const emit = defineEmits<{
   close: []
 }>()
-
-const { t } = useI18n()
 
 const uiStore = useUiStore()
 

--- a/@xen-orchestra/web/src/modules/vdi/components/list/panel/VdiSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/vdi/components/list/panel/VdiSidePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsSidePanel :selected="!!vdi" :closable="!!vdi" @close="emit('close')">
+  <VtsSidePanel :has-selection="!!vdi" @close="emit('close')">
     <template v-if="vbd" #actions>
       <VbdConnectButton v-if="!vbd.attached" :vbd :vm />
       <VbdDisconnectButton v-else :vbd :vm />
@@ -7,13 +7,10 @@
     <template v-if="vdi" #more-actions>
       <VdiActions :vdi :vbd :vm />
     </template>
-    <template #default>
-      <VtsStateHero v-if="!vdi" format="panel" type="no-selection" size="medium" />
-      <template v-else>
-        <VdiInfosCard :vdi :vm />
-        <VdiSpaceCard :vdi />
-        <VdiConfigurationCard :vdi :vm />
-      </template>
+    <template v-if="vdi" #default>
+      <VdiInfosCard :vdi :vm />
+      <VdiSpaceCard :vdi />
+      <VdiConfigurationCard :vdi :vm />
     </template>
   </VtsSidePanel>
 </template>
@@ -29,7 +26,6 @@ import VdiSpaceCard from '@/modules/vdi/components/list/panel/cards/VdiSpaceCard
 import type { FrontXoVdi } from '@/modules/vdi/remote-resources/use-xo-vdi-collection.ts'
 import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
 import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import { computed } from 'vue'
 
 const { vdi, vm } = defineProps<{

--- a/@xen-orchestra/web/src/modules/vdi/components/list/panel/VdiSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/vdi/components/list/panel/VdiSidePanel.vue
@@ -43,7 +43,7 @@ const emit = defineEmits<{
 
 const { useGetVbdsByIds } = useXoVbdCollection()
 
-const vbds = useGetVbdsByIds(vdi?.$VBDs ?? [])
+const vbds = useGetVbdsByIds(() => vdi?.$VBDs ?? [])
 
 const vbd = computed(() => vbds.value.find(vbd => vbd.VM === vm.id))
 </script>

--- a/@xen-orchestra/web/src/modules/vif/components/panel/VifSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/vif/components/panel/VifSidePanel.vue
@@ -1,140 +1,137 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
-    <template #header>
-      <div class="action-buttons">
-        <VifConnectButton v-if="!vif.attached" :vif :vm />
-        <VifDisconnectButton v-else :vif :vm />
-        <MenuList placement="bottom-end">
-          <template #trigger="{ open }">
-            <UiButtonIcon icon="action:more-actions" accent="brand" size="medium" @click="open($event)" />
-          </template>
-          <VifActions :vif />
-        </MenuList>
-      </div>
+  <VtsSidePanel :selected="!!vif" :closable="!!vif" @close="emit('close')">
+    <template v-if="vif" #actions>
+      <VifConnectButton v-if="!vif.attached" :vif :vm />
+      <VifDisconnectButton v-else :vif :vm />
     </template>
-
+    <template v-if="vif" #more-actions>
+      <VifActions :vif />
+    </template>
     <template #default>
-      <!-- VIF -->
-      <UiCard class="card">
-        <UiCardTitle>{{ t('vif') }}</UiCardTitle>
-        <div class="content">
-          <!-- UUID -->
-          <VtsCodeSnippet :content="vif.id" copy />
-          <!-- NETWORK -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('network') }}
-            </template>
-            <template #value>
-              <UiLink v-if="network" size="medium" :to="networkTo" icon="object:network">
-                {{ network.name_label }}
-              </UiLink>
-            </template>
-            <template v-if="network" #addons>
-              <VtsCopyButton :value="network.name_label" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- DEVICE -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('device') }}
-            </template>
-            <template #value>
-              {{ t('vif-device', { device: vif.device }) }}
-            </template>
-            <template #addons>
-              <VtsCopyButton :value="vif.device" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- VIF STATUS -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('vif-status') }}
-            </template>
-            <template #value>
-              <VtsStatus :status />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- MTU -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('mtu') }}
-            </template>
-            <template #value>
-              {{ vif.MTU }}
-            </template>
-            <template #addons>
-              <VtsCopyButton :value="String(vif.MTU)" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- LOCKING MODE -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('locking-mode') }}
-            </template>
-            <template #value>
-              {{ vif.lockingMode }}
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- TX CHECK SUMMING -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('check-summing') }}
-            </template>
-            <template #value>
-              {{ vif.txChecksumming }}
-            </template>
-          </VtsCardRowKeyValue>
-        </div>
-      </UiCard>
-      <!-- NETWORK INFORMATION -->
-      <UiCard class="card">
-        <UiCardTitle>{{ t('network-information') }}</UiCardTitle>
-        <div class="content">
-          <!-- IP ADDRESSES -->
-          <template v-if="ipAddresses.length">
-            <VtsCardRowKeyValue v-for="(ip, index) in ipAddresses" :key="ip">
+      <VtsStateHero v-if="!vif" format="panel" type="no-selection" size="medium" />
+      <template v-else>
+        <!-- VIF -->
+        <UiCard class="card">
+          <UiCardTitle>{{ t('vif') }}</UiCardTitle>
+          <div class="content">
+            <!-- UUID -->
+            <VtsCodeSnippet :content="vif.id" copy />
+            <!-- NETWORK -->
+            <VtsCardRowKeyValue>
               <template #key>
-                <div v-if="index === 0">{{ t('ip-addresses') }}</div>
+                {{ t('network') }}
               </template>
-              <template #value>{{ ip }}</template>
-              <template #addons>
-                <VtsCopyButton :value="ip" />
-                <UiButtonIcon
-                  v-if="index === 0 && ipAddresses.length > 1"
-                  v-tooltip="t('coming-soon!')"
-                  disabled
-                  icon="fa:ellipsis"
-                  size="small"
-                  accent="brand"
-                />
+              <template #value>
+                <UiLink v-if="network" size="medium" :to="networkTo" icon="object:network">
+                  {{ network.name_label }}
+                </UiLink>
+              </template>
+              <template v-if="network" #addons>
+                <VtsCopyButton :value="network.name_label" />
               </template>
             </VtsCardRowKeyValue>
-          </template>
-          <VtsCardRowKeyValue v-else>
-            <template #key>
-              {{ t('ip-addresses') }}
+            <!-- DEVICE -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('device') }}
+              </template>
+              <template #value>
+                {{ t('vif-device', { device: vif.device }) }}
+              </template>
+              <template #addons>
+                <VtsCopyButton :value="vif.device" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- VIF STATUS -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('vif-status') }}
+              </template>
+              <template #value>
+                <VtsStatus :status />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- MTU -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('mtu') }}
+              </template>
+              <template #value>
+                {{ vif.MTU }}
+              </template>
+              <template #addons>
+                <VtsCopyButton :value="String(vif.MTU)" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- LOCKING MODE -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('locking-mode') }}
+              </template>
+              <template #value>
+                {{ vif.lockingMode }}
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- TX CHECK SUMMING -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('check-summing') }}
+              </template>
+              <template #value>
+                {{ vif.txChecksumming }}
+              </template>
+            </VtsCardRowKeyValue>
+          </div>
+        </UiCard>
+        <!-- NETWORK INFORMATION -->
+        <UiCard class="card">
+          <UiCardTitle>{{ t('network-information') }}</UiCardTitle>
+          <div class="content">
+            <!-- IP ADDRESSES -->
+            <template v-if="ipAddresses.length">
+              <VtsCardRowKeyValue v-for="(ip, index) in ipAddresses" :key="ip">
+                <template #key>
+                  <div v-if="index === 0">{{ t('ip-addresses') }}</div>
+                </template>
+                <template #value>{{ ip }}</template>
+                <template #addons>
+                  <VtsCopyButton :value="ip" />
+                  <UiButtonIcon
+                    v-if="index === 0 && ipAddresses.length > 1"
+                    v-tooltip="t('coming-soon!')"
+                    disabled
+                    icon="fa:ellipsis"
+                    size="small"
+                    accent="brand"
+                  />
+                </template>
+              </VtsCardRowKeyValue>
             </template>
-            <template #value>
-              <span class="value" />
-            </template>
-          </VtsCardRowKeyValue>
-          <!-- MAC ADDRESSES -->
-          <VtsCardRowKeyValue>
-            <template #key>
-              {{ t('mac-address') }}
-            </template>
-            <template #value>
-              {{ vif.MAC }}
-            </template>
-            <template #addons>
-              <VtsCopyButton :value="vif.MAC" />
-            </template>
-          </VtsCardRowKeyValue>
-        </div>
-      </UiCard>
+            <VtsCardRowKeyValue v-else>
+              <template #key>
+                {{ t('ip-addresses') }}
+              </template>
+              <template #value>
+                <span class="value" />
+              </template>
+            </VtsCardRowKeyValue>
+            <!-- MAC ADDRESSES -->
+            <VtsCardRowKeyValue>
+              <template #key>
+                {{ t('mac-address') }}
+              </template>
+              <template #value>
+                {{ vif.MAC }}
+              </template>
+              <template #addons>
+                <VtsCopyButton :value="vif.MAC" />
+              </template>
+            </VtsCardRowKeyValue>
+          </div>
+        </UiCard>
+      </template>
     </template>
-  </UiPanel>
+  </VtsSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -148,22 +145,21 @@ import { type FrontXoVm, useXoVmCollection } from '@/modules/vm/remote-resources
 import VtsCardRowKeyValue from '@core/components/card/VtsCardRowKeyValue.vue'
 import VtsCodeSnippet from '@core/components/code-snippet/VtsCodeSnippet.vue'
 import VtsCopyButton from '@core/components/copy-button/VtsCopyButton.vue'
-import MenuList from '@core/components/menu/MenuList.vue'
+import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import VtsStatus from '@core/components/status/VtsStatus.vue'
 import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiCardTitle from '@core/components/ui/card-title/UiCardTitle.vue'
 import UiLink from '@core/components/ui/link/UiLink.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { vTooltip } from '@core/directives/tooltip.directive.ts'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import { CONNECTION_STATUS } from '@core/types/connection.ts'
 import { getUniqueIpAddressesForDevice } from '@core/utils/ip-address.utils.ts'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const { vif, vm } = defineProps<{
-  vif: FrontXoVif
+  vif?: FrontXoVif
   vm: FrontXoVm
 }>()
 
@@ -175,30 +171,27 @@ const { t } = useI18n()
 
 const { useGetNetworkById } = useXoNetworkCollection()
 const { getVmById } = useXoVmCollection()
-const uiStore = useUiStore()
 
 const ipAddresses = computed(() => {
+  if (vif === undefined) {
+    return []
+  }
+
   const addresses = getVmById(vif.$VM)?.addresses
 
   return getUniqueIpAddressesForDevice(addresses, vif.device)
 })
 
-const network = useGetNetworkById(() => vif.$network)
+const network = useGetNetworkById(() => vif?.$network)
 
 const networkTo = computed(() =>
   network.value ? getPoolNetworkRoute(network.value.$pool, network.value.id) : undefined
 )
 
-const status = computed(() => (vif.attached ? CONNECTION_STATUS.CONNECTED : CONNECTION_STATUS.DISCONNECTED))
+const status = computed(() => (vif?.attached ? CONNECTION_STATUS.CONNECTED : CONNECTION_STATUS.DISCONNECTED))
 </script>
 
 <style scoped lang="postcss">
-.action-buttons {
-  display: flex;
-  align-items: center;
-  margin-inline-end: auto;
-}
-
 .card {
   gap: 1.6rem;
 
@@ -210,18 +203,6 @@ const status = computed(() => (vif.attached ? CONNECTION_STATUS.CONNECTED : CONN
 
   .value:empty::before {
     content: '-';
-  }
-}
-
-.mobile-drawer {
-  position: fixed;
-  inset: 0;
-
-  .action-buttons-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
   }
 }
 </style>

--- a/@xen-orchestra/web/src/modules/vif/components/panel/VifSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/vif/components/panel/VifSidePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsSidePanel :selected="!!vif" :closable="!!vif" @close="emit('close')">
+  <VtsSidePanel :has-selection="!!vif" @close="emit('close')">
     <template v-if="vif" #actions>
       <VifConnectButton v-if="!vif.attached" :vif :vm />
       <VifDisconnectButton v-else :vif :vm />
@@ -7,129 +7,126 @@
     <template v-if="vif" #more-actions>
       <VifActions :vif />
     </template>
-    <template #default>
-      <VtsStateHero v-if="!vif" format="panel" type="no-selection" size="medium" />
-      <template v-else>
-        <!-- VIF -->
-        <UiCard class="card">
-          <UiCardTitle>{{ t('vif') }}</UiCardTitle>
-          <div class="content">
-            <!-- UUID -->
-            <VtsCodeSnippet :content="vif.id" copy />
-            <!-- NETWORK -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('network') }}
-              </template>
-              <template #value>
-                <UiLink v-if="network" size="medium" :to="networkTo" icon="object:network">
-                  {{ network.name_label }}
-                </UiLink>
-              </template>
-              <template v-if="network" #addons>
-                <VtsCopyButton :value="network.name_label" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- DEVICE -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('device') }}
-              </template>
-              <template #value>
-                {{ t('vif-device', { device: vif.device }) }}
-              </template>
-              <template #addons>
-                <VtsCopyButton :value="vif.device" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- VIF STATUS -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('vif-status') }}
-              </template>
-              <template #value>
-                <VtsStatus :status />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- MTU -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('mtu') }}
-              </template>
-              <template #value>
-                {{ vif.MTU }}
-              </template>
-              <template #addons>
-                <VtsCopyButton :value="String(vif.MTU)" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- LOCKING MODE -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('locking-mode') }}
-              </template>
-              <template #value>
-                {{ vif.lockingMode }}
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- TX CHECK SUMMING -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('check-summing') }}
-              </template>
-              <template #value>
-                {{ vif.txChecksumming }}
-              </template>
-            </VtsCardRowKeyValue>
-          </div>
-        </UiCard>
-        <!-- NETWORK INFORMATION -->
-        <UiCard class="card">
-          <UiCardTitle>{{ t('network-information') }}</UiCardTitle>
-          <div class="content">
-            <!-- IP ADDRESSES -->
-            <template v-if="ipAddresses.length">
-              <VtsCardRowKeyValue v-for="(ip, index) in ipAddresses" :key="ip">
-                <template #key>
-                  <div v-if="index === 0">{{ t('ip-addresses') }}</div>
-                </template>
-                <template #value>{{ ip }}</template>
-                <template #addons>
-                  <VtsCopyButton :value="ip" />
-                  <UiButtonIcon
-                    v-if="index === 0 && ipAddresses.length > 1"
-                    v-tooltip="t('coming-soon!')"
-                    disabled
-                    icon="fa:ellipsis"
-                    size="small"
-                    accent="brand"
-                  />
-                </template>
-              </VtsCardRowKeyValue>
+    <template v-if="vif" #default>
+      <!-- VIF -->
+      <UiCard class="card">
+        <UiCardTitle>{{ t('vif') }}</UiCardTitle>
+        <div class="content">
+          <!-- UUID -->
+          <VtsCodeSnippet :content="vif.id" copy />
+          <!-- NETWORK -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('network') }}
             </template>
-            <VtsCardRowKeyValue v-else>
+            <template #value>
+              <UiLink v-if="network" size="medium" :to="networkTo" icon="object:network">
+                {{ network.name_label }}
+              </UiLink>
+            </template>
+            <template v-if="network" #addons>
+              <VtsCopyButton :value="network.name_label" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- DEVICE -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('device') }}
+            </template>
+            <template #value>
+              {{ t('vif-device', { device: vif.device }) }}
+            </template>
+            <template #addons>
+              <VtsCopyButton :value="vif.device" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- VIF STATUS -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('vif-status') }}
+            </template>
+            <template #value>
+              <VtsStatus :status />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- MTU -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('mtu') }}
+            </template>
+            <template #value>
+              {{ vif.MTU }}
+            </template>
+            <template #addons>
+              <VtsCopyButton :value="String(vif.MTU)" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- LOCKING MODE -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('locking-mode') }}
+            </template>
+            <template #value>
+              {{ vif.lockingMode }}
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- TX CHECK SUMMING -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('check-summing') }}
+            </template>
+            <template #value>
+              {{ vif.txChecksumming }}
+            </template>
+          </VtsCardRowKeyValue>
+        </div>
+      </UiCard>
+      <!-- NETWORK INFORMATION -->
+      <UiCard class="card">
+        <UiCardTitle>{{ t('network-information') }}</UiCardTitle>
+        <div class="content">
+          <!-- IP ADDRESSES -->
+          <template v-if="ipAddresses.length">
+            <VtsCardRowKeyValue v-for="(ip, index) in ipAddresses" :key="ip">
               <template #key>
-                {{ t('ip-addresses') }}
+                <div v-if="index === 0">{{ t('ip-addresses') }}</div>
               </template>
-              <template #value>
-                <span class="value" />
-              </template>
-            </VtsCardRowKeyValue>
-            <!-- MAC ADDRESSES -->
-            <VtsCardRowKeyValue>
-              <template #key>
-                {{ t('mac-address') }}
-              </template>
-              <template #value>
-                {{ vif.MAC }}
-              </template>
+              <template #value>{{ ip }}</template>
               <template #addons>
-                <VtsCopyButton :value="vif.MAC" />
+                <VtsCopyButton :value="ip" />
+                <UiButtonIcon
+                  v-if="index === 0 && ipAddresses.length > 1"
+                  v-tooltip="t('coming-soon!')"
+                  disabled
+                  icon="fa:ellipsis"
+                  size="small"
+                  accent="brand"
+                />
               </template>
             </VtsCardRowKeyValue>
-          </div>
-        </UiCard>
-      </template>
+          </template>
+          <VtsCardRowKeyValue v-else>
+            <template #key>
+              {{ t('ip-addresses') }}
+            </template>
+            <template #value>
+              <span class="value" />
+            </template>
+          </VtsCardRowKeyValue>
+          <!-- MAC ADDRESSES -->
+          <VtsCardRowKeyValue>
+            <template #key>
+              {{ t('mac-address') }}
+            </template>
+            <template #value>
+              {{ vif.MAC }}
+            </template>
+            <template #addons>
+              <VtsCopyButton :value="vif.MAC" />
+            </template>
+          </VtsCardRowKeyValue>
+        </div>
+      </UiCard>
     </template>
   </VtsSidePanel>
 </template>
@@ -146,7 +143,6 @@ import VtsCardRowKeyValue from '@core/components/card/VtsCardRowKeyValue.vue'
 import VtsCodeSnippet from '@core/components/code-snippet/VtsCodeSnippet.vue'
 import VtsCopyButton from '@core/components/copy-button/VtsCopyButton.vue'
 import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import VtsStatus from '@core/components/status/VtsStatus.vue'
 import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'

--- a/@xen-orchestra/web/src/modules/vif/components/panel/VifSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/vif/components/panel/VifSidePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }">
+  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
     <template #header>
       <div class="action-buttons">
         <VifConnectButton v-if="!vif.attached" :vif :vm />
@@ -11,17 +11,8 @@
           <VifActions :vif />
         </MenuList>
       </div>
-      <div :class="{ 'action-buttons-container': uiStore.isSmall }">
-        <UiButtonIcon
-          v-tooltip="t('action:close')"
-          size="small"
-          variant="tertiary"
-          accent="brand"
-          :icon="uiStore.isSmall ? 'fa:angle-left' : 'fa:close'"
-          @click="emit('close')"
-        />
-      </div>
     </template>
+
     <template #default>
       <!-- VIF -->
       <UiCard class="card">

--- a/@xen-orchestra/web/src/modules/vm/components/list/panel/VmSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/vm/components/list/panel/VmSidePanel.vue
@@ -1,11 +1,14 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
+  <VtsSidePanel :selected="!!vm" :closable="!!vm" @close="emit('close')">
     <template #default>
-      <VmInfoCard :vm />
-      <VmNetworkCard :vm />
-      <VmResourcesCard :vm />
+      <VtsStateHero v-if="!vm" format="panel" type="no-selection" size="medium" />
+      <template v-else>
+        <VmInfoCard :vm />
+        <VmNetworkCard :vm />
+        <VmResourcesCard :vm />
+      </template>
     </template>
-  </UiPanel>
+  </VtsSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -13,30 +16,14 @@ import VmInfoCard from '@/modules/vm/components/list/panel/cards/VmInfoCard.vue'
 import VmNetworkCard from '@/modules/vm/components/list/panel/cards/VmNetworkCard.vue'
 import VmResourcesCard from '@/modules/vm/components/list/panel/cards/VmResourcesCard.vue'
 import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { useUiStore } from '@core/stores/ui.store.ts'
+import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
+import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 
 defineProps<{
-  vm: FrontXoVm
+  vm?: FrontXoVm
 }>()
 
 const emit = defineEmits<{
   close: []
 }>()
-
-const uiStore = useUiStore()
 </script>
-
-<style scoped lang="postcss">
-.mobile-drawer {
-  position: fixed;
-  inset: 0;
-
-  .action-buttons-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-  }
-}
-</style>

--- a/@xen-orchestra/web/src/modules/vm/components/list/panel/VmSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/vm/components/list/panel/VmSidePanel.vue
@@ -1,17 +1,5 @@
 <template>
-  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }">
-    <template #header>
-      <div :class="{ 'action-buttons-container': uiStore.isSmall }">
-        <UiButtonIcon
-          v-tooltip="t('action:close')"
-          size="small"
-          variant="tertiary"
-          accent="brand"
-          :icon="uiStore.isSmall ? 'fa:angle-left' : 'fa:close'"
-          @click="emit('close')"
-        />
-      </div>
-    </template>
+  <UiPanel :class="{ 'mobile-drawer': uiStore.isSmall }" closable @close="emit('close')">
     <template #default>
       <VmInfoCard :vm />
       <VmNetworkCard :vm />
@@ -25,11 +13,8 @@ import VmInfoCard from '@/modules/vm/components/list/panel/cards/VmInfoCard.vue'
 import VmNetworkCard from '@/modules/vm/components/list/panel/cards/VmNetworkCard.vue'
 import VmResourcesCard from '@/modules/vm/components/list/panel/cards/VmResourcesCard.vue'
 import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
-import UiButtonIcon from '@core/components/ui/button-icon/UiButtonIcon.vue'
 import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { vTooltip } from '@core/directives/tooltip.directive.ts'
 import { useUiStore } from '@core/stores/ui.store.ts'
-import { useI18n } from 'vue-i18n'
 
 defineProps<{
   vm: FrontXoVm
@@ -38,8 +23,6 @@ defineProps<{
 const emit = defineEmits<{
   close: []
 }>()
-
-const { t } = useI18n()
 
 const uiStore = useUiStore()
 </script>

--- a/@xen-orchestra/web/src/modules/vm/components/list/panel/VmSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/vm/components/list/panel/VmSidePanel.vue
@@ -1,12 +1,9 @@
 <template>
-  <VtsSidePanel :selected="!!vm" :closable="!!vm" @close="emit('close')">
-    <template #default>
-      <VtsStateHero v-if="!vm" format="panel" type="no-selection" size="medium" />
-      <template v-else>
-        <VmInfoCard :vm />
-        <VmNetworkCard :vm />
-        <VmResourcesCard :vm />
-      </template>
+  <VtsSidePanel :has-selection="!!vm" @close="emit('close')">
+    <template v-if="vm">
+      <VmInfoCard :vm />
+      <VmNetworkCard :vm />
+      <VmResourcesCard :vm />
     </template>
   </VtsSidePanel>
 </template>
@@ -17,7 +14,6 @@ import VmNetworkCard from '@/modules/vm/components/list/panel/cards/VmNetworkCar
 import VmResourcesCard from '@/modules/vm/components/list/panel/cards/VmResourcesCard.vue'
 import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
 import VtsSidePanel from '@core/components/panel/VtsSidePanel.vue'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 
 defineProps<{
   vm?: FrontXoVm

--- a/@xen-orchestra/web/src/pages/(site)/backups.vue
+++ b/@xen-orchestra/web/src/pages/(site)/backups.vue
@@ -9,9 +9,7 @@
       @close="selectedBackupJob = undefined"
     />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>
@@ -28,13 +26,10 @@ import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
 import { useUiStore } from '@core/stores/ui.store'
-import { useI18n } from 'vue-i18n'
 
 const uiStore = useUiStore()
 
 const { backupJobs, getBackupJobById, areBackupJobsReady, hasBackupJobFetchError } = useXoBackupJobCollection()
-
-const { t } = useI18n()
 
 const selectedBackupJob = useRouteQuery<FrontAnyXoBackupJob | undefined>('id', {
   toData: id => getBackupJobById(id as FrontAnyXoBackupJob['id']),

--- a/@xen-orchestra/web/src/pages/(site)/backups.vue
+++ b/@xen-orchestra/web/src/pages/(site)/backups.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="backups" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="backups">
     <UiCard class="container">
       <BackupJobsTable :backup-jobs :busy="!areBackupJobsReady" :error="hasBackupJobFetchError" />
     </UiCard>
     <BackupJobSidePanel :backup-job="selectedBackupJob" @close="selectedBackupJob = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -14,13 +14,9 @@ import {
   useXoBackupJobCollection,
   type FrontAnyXoBackupJob,
 } from '@/modules/backup/remote-resources/use-xo-backup-job-collection.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store'
-
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const { backupJobs, getBackupJobById, areBackupJobsReady, hasBackupJobFetchError } = useXoBackupJobCollection()
 
@@ -32,11 +28,6 @@ const selectedBackupJob = useRouteQuery<FrontAnyXoBackupJob | undefined>('id', {
 
 <style scoped lang="postcss">
 .backups {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     gap: 4rem;

--- a/@xen-orchestra/web/src/pages/(site)/backups.vue
+++ b/@xen-orchestra/web/src/pages/(site)/backups.vue
@@ -1,16 +1,9 @@
 <template>
-  <div class="backups" :class="{ mobile: uiStore.isSmall }">
+  <div class="backups" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <BackupJobsTable :backup-jobs :busy="!areBackupJobsReady" :error="hasBackupJobFetchError" />
     </UiCard>
-    <BackupJobSidePanel
-      v-if="selectedBackupJob"
-      :backup-job="selectedBackupJob"
-      @close="selectedBackupJob = undefined"
-    />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <BackupJobSidePanel :backup-job="selectedBackupJob" @close="selectedBackupJob = undefined" />
   </div>
 </template>
 
@@ -21,12 +14,12 @@ import {
   useXoBackupJobCollection,
   type FrontAnyXoBackupJob,
 } from '@/modules/backup/remote-resources/use-xo-backup-job-collection.ts'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store'
 
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const { backupJobs, getBackupJobById, areBackupJobsReady, hasBackupJobFetchError } = useXoBackupJobCollection()
@@ -39,7 +32,7 @@ const selectedBackupJob = useRouteQuery<FrontAnyXoBackupJob | undefined>('id', {
 
 <style scoped lang="postcss">
 .backups {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/(site)/hosts.vue
+++ b/@xen-orchestra/web/src/pages/(site)/hosts.vue
@@ -1,23 +1,19 @@
 <template>
-  <div class="hosts" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="hosts">
     <UiCard class="container">
       <HostsTable :hosts :busy="!areHostsReady" :error="hasHostFetchError" />
     </UiCard>
     <HostSidePanel :host="selectedHost" @close="selectedHost = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
 import HostsTable from '@/modules/host/components/list/HostsTable.vue'
 import HostSidePanel from '@/modules/host/components/list/panel/HostSidePanel.vue'
 import { useXoHostCollection, type FrontXoHost } from '@/modules/host/remote-resources/use-xo-host-collection.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store'
-
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const { hosts, getHostById, hasHostFetchError, areHostsReady } = useXoHostCollection()
 
@@ -29,11 +25,6 @@ const selectedHost = useRouteQuery<FrontXoHost | undefined>('id', {
 
 <style scoped lang="postcss">
 .hosts {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     gap: 4rem;

--- a/@xen-orchestra/web/src/pages/(site)/hosts.vue
+++ b/@xen-orchestra/web/src/pages/(site)/hosts.vue
@@ -1,12 +1,9 @@
 <template>
-  <div class="hosts" :class="{ mobile: uiStore.isSmall }">
+  <div class="hosts" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <HostsTable :hosts :busy="!areHostsReady" :error="hasHostFetchError" />
     </UiCard>
-    <HostSidePanel v-if="selectedHost" :host="selectedHost" @close="selectedHost = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <HostSidePanel :host="selectedHost" @close="selectedHost = undefined" />
   </div>
 </template>
 
@@ -14,12 +11,12 @@
 import HostsTable from '@/modules/host/components/list/HostsTable.vue'
 import HostSidePanel from '@/modules/host/components/list/panel/HostSidePanel.vue'
 import { useXoHostCollection, type FrontXoHost } from '@/modules/host/remote-resources/use-xo-host-collection.ts'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store'
 
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const { hosts, getHostById, hasHostFetchError, areHostsReady } = useXoHostCollection()
@@ -32,7 +29,7 @@ const selectedHost = useRouteQuery<FrontXoHost | undefined>('id', {
 
 <style scoped lang="postcss">
 .hosts {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/(site)/hosts.vue
+++ b/@xen-orchestra/web/src/pages/(site)/hosts.vue
@@ -5,9 +5,7 @@
     </UiCard>
     <HostSidePanel v-if="selectedHost" :host="selectedHost" @close="selectedHost = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>
@@ -21,13 +19,10 @@ import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
 import { useUiStore } from '@core/stores/ui.store'
-import { useI18n } from 'vue-i18n'
 
 const uiStore = useUiStore()
 
 const { hosts, getHostById, hasHostFetchError, areHostsReady } = useXoHostCollection()
-
-const { t } = useI18n()
 
 const selectedHost = useRouteQuery<FrontXoHost | undefined>('id', {
   toData: id => getHostById(id as FrontXoHost['id']),

--- a/@xen-orchestra/web/src/pages/(site)/pools.vue
+++ b/@xen-orchestra/web/src/pages/(site)/pools.vue
@@ -1,12 +1,9 @@
 <template>
-  <div class="pools" :class="{ mobile: uiStore.isSmall }">
+  <div class="pools" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <PoolsTable :servers />
     </UiCard>
-    <PoolSidePanel v-if="selectedServer" :server="selectedServer" @close="selectedServer = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <PoolSidePanel :server="selectedServer" @close="selectedServer = undefined" />
   </div>
 </template>
 
@@ -17,13 +14,13 @@ import {
   useXoServerCollection,
   type FrontXoServer,
 } from '@/modules/server/remote-resources/use-xo-server-collection.ts'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store'
 
 const { servers, getServerById } = useXoServerCollection()
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const selectedServer = useRouteQuery<FrontXoServer | undefined>('id', {
@@ -34,7 +31,7 @@ const selectedServer = useRouteQuery<FrontXoServer | undefined>('id', {
 
 <style scoped lang="postcss">
 .pools {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/(site)/pools.vue
+++ b/@xen-orchestra/web/src/pages/(site)/pools.vue
@@ -5,9 +5,7 @@
     </UiCard>
     <PoolSidePanel v-if="selectedServer" :server="selectedServer" @close="selectedServer = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>
@@ -24,7 +22,6 @@ import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
 import { useUiStore } from '@core/stores/ui.store'
-import { useI18n } from 'vue-i18n'
 
 const { servers, getServerById } = useXoServerCollection()
 const uiStore = useUiStore()
@@ -33,8 +30,6 @@ const selectedServer = useRouteQuery<FrontXoServer | undefined>('id', {
   toData: id => getServerById(id as FrontXoServer['id']),
   toQuery: server => server?.id ?? '',
 })
-
-const { t } = useI18n()
 </script>
 
 <style scoped lang="postcss">

--- a/@xen-orchestra/web/src/pages/(site)/pools.vue
+++ b/@xen-orchestra/web/src/pages/(site)/pools.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="pools" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="pools">
     <UiCard class="container">
       <PoolsTable :servers />
     </UiCard>
     <PoolSidePanel :server="selectedServer" @close="selectedServer = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -14,14 +14,11 @@ import {
   useXoServerCollection,
   type FrontXoServer,
 } from '@/modules/server/remote-resources/use-xo-server-collection.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store'
 
 const { servers, getServerById } = useXoServerCollection()
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const selectedServer = useRouteQuery<FrontXoServer | undefined>('id', {
   toData: id => getServerById(id as FrontXoServer['id']),
@@ -31,11 +28,6 @@ const selectedServer = useRouteQuery<FrontXoServer | undefined>('id', {
 
 <style scoped lang="postcss">
 .pools {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     gap: 4rem;

--- a/@xen-orchestra/web/src/pages/(site)/tasks.vue
+++ b/@xen-orchestra/web/src/pages/(site)/tasks.vue
@@ -5,9 +5,7 @@
     </UiCard>
     <TaskSidePanel v-if="selectedTask" :task="selectedTask" @close="selectedTask = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>
@@ -25,14 +23,11 @@ import { useRouteQuery } from '@core/composables/route-query.composable.ts'
 import { useUiStore } from '@core/stores/ui.store'
 import type { XoUser } from '@vates/types'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 const uiStore = useUiStore()
 
 const { getTaskById, sortedTasks, hasTaskFetchError, areTasksReady } = useXoTaskCollection()
 const { getUserById } = useXoUserCollection()
-
-const { t } = useI18n()
 
 const selectedTask = useRouteQuery<FrontXoTask | undefined>('id', {
   toData: id => getTaskById(id as FrontXoTask['id']),

--- a/@xen-orchestra/web/src/pages/(site)/tasks.vue
+++ b/@xen-orchestra/web/src/pages/(site)/tasks.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="tasks" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="tasks">
     <UiCard class="container">
       <TasksList :tasks="convertedTasks" :has-error="hasTaskFetchError" :busy="!areTasksReady" />
     </UiCard>
     <TaskSidePanel :task="selectedTask" @close="selectedTask = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -13,15 +13,11 @@ import TasksList from '@/modules/task/components/list/TasksList.vue'
 import { useXoTaskCollection, type FrontXoTask } from '@/modules/task/remote-resources/use-xo-task-collection.ts'
 import { convertXoTaskToCore } from '@/modules/task/utils/convert-xo-task-to-core.util.ts'
 import { useXoUserCollection } from '@/modules/user/remote-resources/use-xo-user-collection.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store'
 import type { XoUser } from '@vates/types'
 import { computed } from 'vue'
-
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const { getTaskById, sortedTasks, hasTaskFetchError, areTasksReady } = useXoTaskCollection()
 const { getUserById } = useXoUserCollection()
@@ -49,11 +45,6 @@ const convertedTasks = computed(() =>
 
 <style scoped lang="postcss">
 .tasks {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     gap: 4rem;

--- a/@xen-orchestra/web/src/pages/(site)/tasks.vue
+++ b/@xen-orchestra/web/src/pages/(site)/tasks.vue
@@ -1,12 +1,9 @@
 <template>
-  <div class="tasks" :class="{ mobile: uiStore.isSmall }">
+  <div class="tasks" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <TasksList :tasks="convertedTasks" :has-error="hasTaskFetchError" :busy="!areTasksReady" />
     </UiCard>
-    <TaskSidePanel v-if="selectedTask" :task="selectedTask" @close="selectedTask = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <TaskSidePanel :task="selectedTask" @close="selectedTask = undefined" />
   </div>
 </template>
 
@@ -16,14 +13,14 @@ import TasksList from '@/modules/task/components/list/TasksList.vue'
 import { useXoTaskCollection, type FrontXoTask } from '@/modules/task/remote-resources/use-xo-task-collection.ts'
 import { convertXoTaskToCore } from '@/modules/task/utils/convert-xo-task-to-core.util.ts'
 import { useXoUserCollection } from '@/modules/user/remote-resources/use-xo-user-collection.ts'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store'
 import type { XoUser } from '@vates/types'
 import { computed } from 'vue'
 
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const { getTaskById, sortedTasks, hasTaskFetchError, areTasksReady } = useXoTaskCollection()
@@ -52,7 +49,7 @@ const convertedTasks = computed(() =>
 
 <style scoped lang="postcss">
 .tasks {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/(site)/vms.vue
+++ b/@xen-orchestra/web/src/pages/(site)/vms.vue
@@ -1,12 +1,9 @@
 <template>
-  <div class="vms" :class="{ mobile: uiStore.isSmall }">
+  <div class="vms" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <VmsTable :vms :busy="!areVmsReady" :error="hasVmFetchError" />
     </UiCard>
-    <VmSidePanel v-if="selectedVm" :vm="selectedVm" @close="selectedVm = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <VmSidePanel :vm="selectedVm" @close="selectedVm = undefined" />
   </div>
 </template>
 
@@ -14,14 +11,14 @@
 import VmSidePanel from '@/modules/vm/components/list/panel/VmSidePanel.vue'
 import VmsTable from '@/modules/vm/components/list/VmsTable.vue'
 import { useXoVmCollection, type FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store'
 
 const { vms, getVmById, areVmsReady, hasVmFetchError } = useXoVmCollection()
 
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const selectedVm = useRouteQuery<FrontXoVm | undefined>('id', {
@@ -32,7 +29,7 @@ const selectedVm = useRouteQuery<FrontXoVm | undefined>('id', {
 
 <style scoped lang="postcss">
 .vms {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/(site)/vms.vue
+++ b/@xen-orchestra/web/src/pages/(site)/vms.vue
@@ -5,9 +5,7 @@
     </UiCard>
     <VmSidePanel v-if="selectedVm" :vm="selectedVm" @close="selectedVm = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>
@@ -21,9 +19,6 @@ import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
 import { useUiStore } from '@core/stores/ui.store'
-import { useI18n } from 'vue-i18n'
-
-const { t } = useI18n()
 
 const { vms, getVmById, areVmsReady, hasVmFetchError } = useXoVmCollection()
 

--- a/@xen-orchestra/web/src/pages/(site)/vms.vue
+++ b/@xen-orchestra/web/src/pages/(site)/vms.vue
@@ -1,25 +1,21 @@
 <template>
-  <div class="vms" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="vms">
     <UiCard class="container">
       <VmsTable :vms :busy="!areVmsReady" :error="hasVmFetchError" />
     </UiCard>
     <VmSidePanel :vm="selectedVm" @close="selectedVm = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
 import VmSidePanel from '@/modules/vm/components/list/panel/VmSidePanel.vue'
 import VmsTable from '@/modules/vm/components/list/VmsTable.vue'
 import { useXoVmCollection, type FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store'
 
 const { vms, getVmById, areVmsReady, hasVmFetchError } = useXoVmCollection()
-
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const selectedVm = useRouteQuery<FrontXoVm | undefined>('id', {
   toData: id => getVmById(id as FrontXoVm['id']),
@@ -29,11 +25,6 @@ const selectedVm = useRouteQuery<FrontXoVm | undefined>('id', {
 
 <style scoped lang="postcss">
 .vms {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     gap: 4rem;

--- a/@xen-orchestra/web/src/pages/backup/[id]/runs.vue
+++ b/@xen-orchestra/web/src/pages/backup/[id]/runs.vue
@@ -9,9 +9,7 @@
       @close="selectedBackupLog = undefined"
     />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>
@@ -30,13 +28,11 @@ import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
 import { useUiStore } from '@core/stores/ui.store'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 const { backupJob } = defineProps<{
   backupJob: FrontAnyXoBackupJob
 }>()
 
-const { t } = useI18n()
 const uiStore = useUiStore()
 
 const { backupLogsByJobId, hasBackupLogFetchError, areBackupLogsReady } = useXoBackupLogCollection()

--- a/@xen-orchestra/web/src/pages/backup/[id]/runs.vue
+++ b/@xen-orchestra/web/src/pages/backup/[id]/runs.vue
@@ -1,16 +1,9 @@
 <template>
-  <div class="backups" :class="{ mobile: uiStore.isSmall }">
+  <div class="backups" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <BackupLogsTable :backup-logs :busy="!areBackupLogsReady" :error="hasBackupLogFetchError" />
     </UiCard>
-    <BackupLogSidePanel
-      v-if="selectedBackupLog"
-      :backup-log="selectedBackupLog"
-      @close="selectedBackupLog = undefined"
-    />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <BackupLogSidePanel :backup-log="selectedBackupLog" @close="selectedBackupLog = undefined" />
   </div>
 </template>
 
@@ -22,10 +15,9 @@ import {
   useXoBackupLogCollection,
   type FrontXoBackupLog,
 } from '@/modules/backup/remote-resources/use-xo-backup-log-collection.ts'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store'
 import { computed } from 'vue'
 
@@ -33,6 +25,7 @@ const { backupJob } = defineProps<{
   backupJob: FrontAnyXoBackupJob
 }>()
 
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const { backupLogsByJobId, hasBackupLogFetchError, areBackupLogsReady } = useXoBackupLogCollection()
@@ -47,7 +40,7 @@ const selectedBackupLog = useRouteQuery<FrontXoBackupLog | undefined>('id', {
 
 <style scoped lang="postcss">
 .backups {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/backup/[id]/runs.vue
+++ b/@xen-orchestra/web/src/pages/backup/[id]/runs.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="backups" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="backups">
     <UiCard class="container">
       <BackupLogsTable :backup-logs :busy="!areBackupLogsReady" :error="hasBackupLogFetchError" />
     </UiCard>
     <BackupLogSidePanel :backup-log="selectedBackupLog" @close="selectedBackupLog = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -15,18 +15,14 @@ import {
   useXoBackupLogCollection,
   type FrontXoBackupLog,
 } from '@/modules/backup/remote-resources/use-xo-backup-log-collection.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store'
 import { computed } from 'vue'
 
 const { backupJob } = defineProps<{
   backupJob: FrontAnyXoBackupJob
 }>()
-
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const { backupLogsByJobId, hasBackupLogFetchError, areBackupLogsReady } = useXoBackupLogCollection()
 
@@ -40,11 +36,6 @@ const selectedBackupLog = useRouteQuery<FrontXoBackupLog | undefined>('id', {
 
 <style scoped lang="postcss">
 .backups {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     gap: 4rem;

--- a/@xen-orchestra/web/src/pages/host/[id]/networks.vue
+++ b/@xen-orchestra/web/src/pages/host/[id]/networks.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="networks" :class="{ mobile: uiStore.isSmall }">
+  <div class="networks" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <PifsTable :pifs>
         <template #title-actions>
@@ -9,10 +9,7 @@
         </template>
       </PifsTable>
     </UiCard>
-    <PifSidePanel v-if="selectedPif" :pif="selectedPif" @close="selectedPif = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="small" />
-    </UiPanel>
+    <PifSidePanel :pif="selectedPif" @close="selectedPif = undefined" />
   </div>
 </template>
 
@@ -22,11 +19,10 @@ import PifSidePanel from '@/modules/pif/components/list/panel/PifSidePanel.vue'
 import PifsTable from '@/modules/pif/components/list/PifsTable.vue'
 import { useXoPifCollection, type FrontXoPif } from '@/modules/pif/remote-resources/use-xo-pif-collection.ts'
 import { useXoRoutes } from '@/shared/remote-resources/use-xo-routes.ts'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiLink from '@core/components/ui/link/UiLink.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -39,6 +35,7 @@ const { buildXo5Route } = useXoRoutes()
 const xo5ScanPifsHref = computed(() => buildXo5Route(`/hosts/${host.id}/network`))
 
 const { pifsByHost } = useXoPifCollection()
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const { t } = useI18n()
@@ -53,7 +50,7 @@ const selectedPif = useRouteQuery<FrontXoPif | undefined>('id', {
 
 <style scoped lang="postcss">
 .networks {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/host/[id]/networks.vue
+++ b/@xen-orchestra/web/src/pages/host/[id]/networks.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="networks" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="networks">
     <UiCard class="container">
       <PifsTable :pifs>
         <template #title-actions>
@@ -10,7 +10,7 @@
       </PifsTable>
     </UiCard>
     <PifSidePanel :pif="selectedPif" @close="selectedPif = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -19,11 +19,10 @@ import PifSidePanel from '@/modules/pif/components/list/panel/PifSidePanel.vue'
 import PifsTable from '@/modules/pif/components/list/PifsTable.vue'
 import { useXoPifCollection, type FrontXoPif } from '@/modules/pif/remote-resources/use-xo-pif-collection.ts'
 import { useXoRoutes } from '@/shared/remote-resources/use-xo-routes.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiLink from '@core/components/ui/link/UiLink.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -35,8 +34,6 @@ const { buildXo5Route } = useXoRoutes()
 const xo5ScanPifsHref = computed(() => buildXo5Route(`/hosts/${host.id}/network`))
 
 const { pifsByHost } = useXoPifCollection()
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const { t } = useI18n()
 
@@ -50,11 +47,6 @@ const selectedPif = useRouteQuery<FrontXoPif | undefined>('id', {
 
 <style scoped lang="postcss">
 .networks {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     margin: 0.8rem;

--- a/@xen-orchestra/web/src/pages/host/[id]/networks.vue
+++ b/@xen-orchestra/web/src/pages/host/[id]/networks.vue
@@ -11,9 +11,7 @@
     </UiCard>
     <PifSidePanel v-if="selectedPif" :pif="selectedPif" @close="selectedPif = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="small">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="small" />
     </UiPanel>
   </div>
 </template>

--- a/@xen-orchestra/web/src/pages/host/[id]/storage.vue
+++ b/@xen-orchestra/web/src/pages/host/[id]/storage.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="storage" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="storage">
     <UiCard class="container">
       <StorageRepositoriesTable :srs :busy="!isReady" :error="hasSrFetchError" :scope />
     </UiCard>
     <StorageRepositorySidePanel :sr="selectedSr" :scope @close="selectedSr = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -16,10 +16,9 @@ import {
   useXoSrCollection,
   type FrontXoSr,
 } from '@/modules/storage-repository/remote-resources/use-xo-sr-collection.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import { SR_SCOPE_TYPE, type SrScope } from '@core/types/storage-repository.type.ts'
 import { sortByNameLabel } from '@core/utils/sort-by-name-label.util.ts'
 import { logicAnd } from '@vueuse/math'
@@ -33,9 +32,6 @@ const { hasSrFetchError, getSrById, areSrsReady } = useXoSrCollection()
 const { pbdsByHost, arePbdsReady } = useXoPbdCollection()
 
 const isReady = logicAnd(areSrsReady, arePbdsReady)
-
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const srs = computed(() => {
   const hostPbds = pbdsByHost.value.get(host.id) ?? []
@@ -63,11 +59,6 @@ const scope: SrScope = { type: SR_SCOPE_TYPE.HOST, hostId: host.id }
 
 <style scoped lang="postcss">
 .storage {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     margin: 0.8rem;

--- a/@xen-orchestra/web/src/pages/host/[id]/storage.vue
+++ b/@xen-orchestra/web/src/pages/host/[id]/storage.vue
@@ -1,12 +1,9 @@
 <template>
-  <div class="storage" :class="{ mobile: uiStore.isSmall }">
+  <div class="storage" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <StorageRepositoriesTable :srs :busy="!isReady" :error="hasSrFetchError" :scope />
     </UiCard>
-    <StorageRepositorySidePanel v-if="selectedSr" :sr="selectedSr" :scope @close="selectedSr = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <StorageRepositorySidePanel :sr="selectedSr" :scope @close="selectedSr = undefined" />
   </div>
 </template>
 
@@ -19,10 +16,9 @@ import {
   useXoSrCollection,
   type FrontXoSr,
 } from '@/modules/storage-repository/remote-resources/use-xo-sr-collection.ts'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { useRouteQuery } from '@core/composables/route-query.composable.ts'
+import { useRouteQuery } from '@core/composables/route-query.composable'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { SR_SCOPE_TYPE, type SrScope } from '@core/types/storage-repository.type.ts'
 import { sortByNameLabel } from '@core/utils/sort-by-name-label.util.ts'
@@ -38,6 +34,7 @@ const { pbdsByHost, arePbdsReady } = useXoPbdCollection()
 
 const isReady = logicAnd(areSrsReady, arePbdsReady)
 
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const srs = computed(() => {
@@ -66,7 +63,7 @@ const scope: SrScope = { type: SR_SCOPE_TYPE.HOST, hostId: host.id }
 
 <style scoped lang="postcss">
 .storage {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/host/[id]/storage.vue
+++ b/@xen-orchestra/web/src/pages/host/[id]/storage.vue
@@ -5,9 +5,7 @@
     </UiCard>
     <StorageRepositorySidePanel v-if="selectedSr" :sr="selectedSr" :scope @close="selectedSr = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>
@@ -30,13 +28,10 @@ import { SR_SCOPE_TYPE, type SrScope } from '@core/types/storage-repository.type
 import { sortByNameLabel } from '@core/utils/sort-by-name-label.util.ts'
 import { logicAnd } from '@vueuse/math'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 const { host } = defineProps<{
   host: FrontXoHost
 }>()
-
-const { t } = useI18n()
 
 const { hasSrFetchError, getSrById, areSrsReady } = useXoSrCollection()
 const { pbdsByHost, arePbdsReady } = useXoPbdCollection()

--- a/@xen-orchestra/web/src/pages/host/[id]/tasks.vue
+++ b/@xen-orchestra/web/src/pages/host/[id]/tasks.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="tasks" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="tasks">
     <UiCard class="container">
       <TasksList :tasks="convertedTasks" :has-error="hasTaskFetchError" :busy="!areTasksReady" />
     </UiCard>
     <TaskSidePanel :task="selectedTask" @close="selectedTask = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -15,19 +15,15 @@ import TasksList from '@/modules/task/components/list/TasksList.vue'
 import type { FrontXoTask } from '@/modules/task/remote-resources/use-xo-task-collection.ts'
 import { convertXoTaskToCore } from '@/modules/task/utils/convert-xo-task-to-core.util.ts'
 import { useXoUserCollection } from '@/modules/user/remote-resources/use-xo-user-collection.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store'
 import type { XoUser } from '@vates/types'
 import { computed } from 'vue'
 
 const { host } = defineProps<{
   host: FrontXoHost
 }>()
-
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const { getTaskById, sortedTasks, hasTaskFetchError, areTasksReady } = useXoHostTasksCollection({}, () => host.id)
 const { getUserById } = useXoUserCollection()
@@ -55,11 +51,6 @@ const convertedTasks = computed(() =>
 
 <style scoped lang="postcss">
 .tasks {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     gap: 4rem;

--- a/@xen-orchestra/web/src/pages/host/[id]/tasks.vue
+++ b/@xen-orchestra/web/src/pages/host/[id]/tasks.vue
@@ -1,12 +1,9 @@
 <template>
-  <div class="tasks" :class="{ mobile: uiStore.isSmall }">
+  <div class="tasks" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <TasksList :tasks="convertedTasks" :has-error="hasTaskFetchError" :busy="!areTasksReady" />
     </UiCard>
-    <TaskSidePanel v-if="selectedTask" :task="selectedTask" @close="selectedTask = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <TaskSidePanel :task="selectedTask" @close="selectedTask = undefined" />
   </div>
 </template>
 
@@ -18,10 +15,9 @@ import TasksList from '@/modules/task/components/list/TasksList.vue'
 import type { FrontXoTask } from '@/modules/task/remote-resources/use-xo-task-collection.ts'
 import { convertXoTaskToCore } from '@/modules/task/utils/convert-xo-task-to-core.util.ts'
 import { useXoUserCollection } from '@/modules/user/remote-resources/use-xo-user-collection.ts'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store'
 import type { XoUser } from '@vates/types'
 import { computed } from 'vue'
@@ -30,6 +26,7 @@ const { host } = defineProps<{
   host: FrontXoHost
 }>()
 
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const { getTaskById, sortedTasks, hasTaskFetchError, areTasksReady } = useXoHostTasksCollection({}, () => host.id)
@@ -58,7 +55,7 @@ const convertedTasks = computed(() =>
 
 <style scoped lang="postcss">
 .tasks {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/host/[id]/tasks.vue
+++ b/@xen-orchestra/web/src/pages/host/[id]/tasks.vue
@@ -5,9 +5,7 @@
     </UiCard>
     <TaskSidePanel v-if="selectedTask" :task="selectedTask" @close="selectedTask = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>
@@ -27,7 +25,6 @@ import { useRouteQuery } from '@core/composables/route-query.composable.ts'
 import { useUiStore } from '@core/stores/ui.store'
 import type { XoUser } from '@vates/types'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 const { host } = defineProps<{
   host: FrontXoHost
@@ -37,8 +34,6 @@ const uiStore = useUiStore()
 
 const { getTaskById, sortedTasks, hasTaskFetchError, areTasksReady } = useXoHostTasksCollection({}, () => host.id)
 const { getUserById } = useXoUserCollection()
-
-const { t } = useI18n()
 
 const selectedTask = useRouteQuery<FrontXoTask | undefined>('id', {
   toData: id => getTaskById(id as FrontXoTask['id']),

--- a/@xen-orchestra/web/src/pages/host/[id]/vms.vue
+++ b/@xen-orchestra/web/src/pages/host/[id]/vms.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="vms" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="vms">
     <UiCard class="container">
       <VmsTable :vms :busy="!areVmsReady" :error="hasVmFetchError" />
     </UiCard>
     <VmSidePanel :vm="selectedVm" @close="selectedVm = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script lang="ts" setup>
@@ -12,18 +12,14 @@ import type { FrontXoHost } from '@/modules/host/remote-resources/use-xo-host-co
 import VmSidePanel from '@/modules/vm/components/list/panel/VmSidePanel.vue'
 import VmsTable from '@/modules/vm/components/list/VmsTable.vue'
 import { useXoVmCollection, type FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import { computed } from 'vue'
 
 const { host } = defineProps<{
   host: FrontXoHost
 }>()
-
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const { areVmsReady, vmsByHost, hasVmFetchError } = useXoVmCollection()
 
@@ -37,11 +33,6 @@ const selectedVm = useRouteQuery<FrontXoVm | undefined>('id', {
 
 <style scoped lang="postcss">
 .vms {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     gap: 4rem;

--- a/@xen-orchestra/web/src/pages/host/[id]/vms.vue
+++ b/@xen-orchestra/web/src/pages/host/[id]/vms.vue
@@ -1,12 +1,9 @@
 <template>
-  <div class="vms" :class="{ mobile: uiStore.isSmall }">
+  <div class="vms" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <VmsTable :vms :busy="!areVmsReady" :error="hasVmFetchError" />
     </UiCard>
-    <VmSidePanel v-if="selectedVm" :vm="selectedVm" @close="selectedVm = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <VmSidePanel :vm="selectedVm" @close="selectedVm = undefined" />
   </div>
 </template>
 
@@ -15,10 +12,9 @@ import type { FrontXoHost } from '@/modules/host/remote-resources/use-xo-host-co
 import VmSidePanel from '@/modules/vm/components/list/panel/VmSidePanel.vue'
 import VmsTable from '@/modules/vm/components/list/VmsTable.vue'
 import { useXoVmCollection, type FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { computed } from 'vue'
 
@@ -26,6 +22,7 @@ const { host } = defineProps<{
   host: FrontXoHost
 }>()
 
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const { areVmsReady, vmsByHost, hasVmFetchError } = useXoVmCollection()
@@ -40,7 +37,7 @@ const selectedVm = useRouteQuery<FrontXoVm | undefined>('id', {
 
 <style scoped lang="postcss">
 .vms {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/host/[id]/vms.vue
+++ b/@xen-orchestra/web/src/pages/host/[id]/vms.vue
@@ -5,9 +5,7 @@
     </UiCard>
     <VmSidePanel v-if="selectedVm" :vm="selectedVm" @close="selectedVm = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>
@@ -23,15 +21,12 @@ import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 const { host } = defineProps<{
   host: FrontXoHost
 }>()
 
 const uiStore = useUiStore()
-
-const { t } = useI18n()
 
 const { areVmsReady, vmsByHost, hasVmFetchError } = useXoVmCollection()
 

--- a/@xen-orchestra/web/src/pages/pool/[id]/hosts.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/hosts.vue
@@ -5,9 +5,7 @@
     </UiCard>
     <HostSidePanel v-if="selectedHost" :host="selectedHost" @close="selectedHost = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>
@@ -23,7 +21,6 @@ import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
 import { useUiStore } from '@core/stores/ui.store'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 const { pool } = defineProps<{
   pool: FrontXoPool
@@ -32,8 +29,6 @@ const { pool } = defineProps<{
 const uiStore = useUiStore()
 
 const { areHostsReady, hostsByPool, hasHostFetchError } = useXoHostCollection()
-
-const { t } = useI18n()
 
 const hosts = computed(() => hostsByPool.value.get(pool.id) ?? [])
 

--- a/@xen-orchestra/web/src/pages/pool/[id]/hosts.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/hosts.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="hosts" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="hosts">
     <UiCard class="container">
       <HostsTable :hosts :busy="!areHostsReady" :error="hasHostFetchError" />
     </UiCard>
     <HostSidePanel :host="selectedHost" @close="selectedHost = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script lang="ts" setup>
@@ -12,18 +12,14 @@ import HostsTable from '@/modules/host/components/list/HostsTable.vue'
 import HostSidePanel from '@/modules/host/components/list/panel/HostSidePanel.vue'
 import { useXoHostCollection, type FrontXoHost } from '@/modules/host/remote-resources/use-xo-host-collection.ts'
 import type { FrontXoPool } from '@/modules/pool/remote-resources/use-xo-pool-collection.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store'
 import { computed } from 'vue'
 
 const { pool } = defineProps<{
   pool: FrontXoPool
 }>()
-
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const { areHostsReady, hostsByPool, hasHostFetchError } = useXoHostCollection()
 
@@ -37,11 +33,6 @@ const selectedHost = useRouteQuery<FrontXoHost | undefined>('id', {
 
 <style scoped lang="postcss">
 .hosts {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     gap: 4rem;

--- a/@xen-orchestra/web/src/pages/pool/[id]/hosts.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/hosts.vue
@@ -1,12 +1,9 @@
 <template>
-  <div class="hosts" :class="{ mobile: uiStore.isSmall }">
+  <div class="hosts" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <HostsTable :hosts :busy="!areHostsReady" :error="hasHostFetchError" />
     </UiCard>
-    <HostSidePanel v-if="selectedHost" :host="selectedHost" @close="selectedHost = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <HostSidePanel :host="selectedHost" @close="selectedHost = undefined" />
   </div>
 </template>
 
@@ -15,10 +12,9 @@ import HostsTable from '@/modules/host/components/list/HostsTable.vue'
 import HostSidePanel from '@/modules/host/components/list/panel/HostSidePanel.vue'
 import { useXoHostCollection, type FrontXoHost } from '@/modules/host/remote-resources/use-xo-host-collection.ts'
 import type { FrontXoPool } from '@/modules/pool/remote-resources/use-xo-pool-collection.ts'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store'
 import { computed } from 'vue'
 
@@ -26,6 +22,7 @@ const { pool } = defineProps<{
   pool: FrontXoPool
 }>()
 
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const { areHostsReady, hostsByPool, hasHostFetchError } = useXoHostCollection()
@@ -40,7 +37,7 @@ const selectedHost = useRouteQuery<FrontXoHost | undefined>('id', {
 
 <style scoped lang="postcss">
 .hosts {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/pool/[id]/networks.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/networks.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="networks" :class="{ mobile: uiStore.isSmall }">
+  <div class="networks" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <NetworksTable :busy="!areNetworksReady" :error="hasNetworkFetchError" :networks>
         <template #title-actions>
@@ -38,10 +38,7 @@
         </template>
       </NetworksTable>
     </UiCard>
-    <NetworkSidePanel v-if="selectedNetwork" :network="selectedNetwork" @close="selectedNetwork = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <NetworkSidePanel :network="selectedNetwork" @close="selectedNetwork = undefined" />
   </div>
 </template>
 
@@ -55,12 +52,11 @@ import {
 import type { FrontXoPool } from '@/modules/pool/remote-resources/use-xo-pool-collection.ts'
 import MenuItem from '@core/components/menu/MenuItem.vue'
 import MenuList from '@core/components/menu/MenuList.vue'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiDropdownButton from '@core/components/ui/dropdown-button/UiDropdownButton.vue'
 import UiLink from '@core/components/ui/link/UiLink.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -73,6 +69,7 @@ const { t } = useI18n()
 
 const { areNetworksReady, hasNetworkFetchError, networksWithoutPifs, networksWithPifs, getNetworkById } =
   useXoNetworkCollection()
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const internalNetworks = computed(() => networksWithoutPifs.value.filter(network => network.$pool === pool.id))
@@ -87,7 +84,7 @@ const selectedNetwork = useRouteQuery<FrontXoNetwork | undefined>('id', {
 
 <style scoped lang="postcss">
 .networks {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/pool/[id]/networks.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/networks.vue
@@ -40,9 +40,7 @@
     </UiCard>
     <NetworkSidePanel v-if="selectedNetwork" :network="selectedNetwork" @close="selectedNetwork = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>

--- a/@xen-orchestra/web/src/pages/pool/[id]/networks.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/networks.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="networks" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="networks">
     <UiCard class="container">
       <NetworksTable :busy="!areNetworksReady" :error="hasNetworkFetchError" :networks>
         <template #title-actions>
@@ -39,7 +39,7 @@
       </NetworksTable>
     </UiCard>
     <NetworkSidePanel :network="selectedNetwork" @close="selectedNetwork = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -50,14 +50,13 @@ import {
   useXoNetworkCollection,
 } from '@/modules/network/remote-resources/use-xo-network-collection.ts'
 import type { FrontXoPool } from '@/modules/pool/remote-resources/use-xo-pool-collection.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import MenuItem from '@core/components/menu/MenuItem.vue'
 import MenuList from '@core/components/menu/MenuList.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiDropdownButton from '@core/components/ui/dropdown-button/UiDropdownButton.vue'
 import UiLink from '@core/components/ui/link/UiLink.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -69,8 +68,6 @@ const { t } = useI18n()
 
 const { areNetworksReady, hasNetworkFetchError, networksWithoutPifs, networksWithPifs, getNetworkById } =
   useXoNetworkCollection()
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const internalNetworks = computed(() => networksWithoutPifs.value.filter(network => network.$pool === pool.id))
 
@@ -84,11 +81,6 @@ const selectedNetwork = useRouteQuery<FrontXoNetwork | undefined>('id', {
 
 <style scoped lang="postcss">
 .networks {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     margin: 0.8rem;

--- a/@xen-orchestra/web/src/pages/pool/[id]/security.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/security.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="security" :class="{ mobile: uiStore.isSmall }">
+  <div class="security" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <VtsStateHero v-if="!isReady" format="page" type="busy" size="medium" />
       <TrafficRulesTable v-else :rules="trafficRules" :pool>
@@ -10,10 +10,7 @@
         </template>
       </TrafficRulesTable>
     </UiCard>
-    <TrafficRulesSidePanel v-if="selectedRule" :rule="selectedRule" @close="selectedRule = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <TrafficRulesSidePanel :rule="selectedRule" @close="selectedRule = undefined" />
   </div>
 </template>
 
@@ -27,8 +24,8 @@ import { useXoVifCollection } from '@/modules/vif/remote-resources/use-xo-vif-co
 import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiLink from '@core/components/ui/link/UiLink.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
+import { usePanelStore } from '@core/stores/panel.store.ts'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import type { TrafficRule } from '@vates/types'
 import { logicAnd } from '@vueuse/math'
@@ -39,6 +36,7 @@ const { pool } = defineProps<{
   pool: FrontXoPool
 }>()
 
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const { t } = useI18n()
@@ -63,7 +61,7 @@ const selectedRule = useRouteQuery<TrafficRule | undefined>('id', {
 
 <style scoped lang="postcss">
 .security {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/pool/[id]/security.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/security.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="security" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="security">
     <UiCard class="container">
       <VtsStateHero v-if="!isReady" format="page" type="busy" size="medium" />
       <TrafficRulesTable v-else :rules="trafficRules" :pool>
@@ -11,7 +11,7 @@
       </TrafficRulesTable>
     </UiCard>
     <TrafficRulesSidePanel :rule="selectedRule" @close="selectedRule = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -21,12 +21,11 @@ import TrafficRulesSidePanel from '@/modules/traffic-rules/components/list/panel
 import TrafficRulesTable from '@/modules/traffic-rules/components/TrafficRulesTable.vue'
 import { useTrafficRules } from '@/modules/traffic-rules/composables/traffic-rules.composable'
 import { useXoVifCollection } from '@/modules/vif/remote-resources/use-xo-vif-collection.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiLink from '@core/components/ui/link/UiLink.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
-import { usePanelStore } from '@core/stores/panel.store.ts'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import type { TrafficRule } from '@vates/types'
 import { logicAnd } from '@vueuse/math'
 import { computed } from 'vue'
@@ -35,9 +34,6 @@ import { useI18n } from 'vue-i18n'
 const { pool } = defineProps<{
   pool: FrontXoPool
 }>()
-
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const { t } = useI18n()
 
@@ -61,11 +57,6 @@ const selectedRule = useRouteQuery<TrafficRule | undefined>('id', {
 
 <style scoped lang="postcss">
 .security {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     gap: 4rem;

--- a/@xen-orchestra/web/src/pages/pool/[id]/security.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/security.vue
@@ -12,9 +12,7 @@
     </UiCard>
     <TrafficRulesSidePanel v-if="selectedRule" :rule="selectedRule" @close="selectedRule = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>

--- a/@xen-orchestra/web/src/pages/pool/[id]/storage.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/storage.vue
@@ -5,9 +5,7 @@
     </UiCard>
     <StorageRepositorySidePanel v-if="selectedSr" :sr="selectedSr" :scope @close="selectedSr = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>
@@ -27,13 +25,10 @@ import { useRouteQuery } from '@core/composables/route-query.composable.ts'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { SR_SCOPE_TYPE, type SrScope } from '@core/types/storage-repository.type.ts'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 const { pool } = defineProps<{
   pool: FrontXoPool
 }>()
-
-const { t } = useI18n()
 
 const { srsByPool, hasSrFetchError, getSrById, areSrsReady } = useXoSrCollection()
 const uiStore = useUiStore()

--- a/@xen-orchestra/web/src/pages/pool/[id]/storage.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/storage.vue
@@ -1,12 +1,9 @@
 <template>
-  <div class="storage" :class="{ mobile: uiStore.isSmall }">
+  <div class="storage" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <StorageRepositoriesTable :srs :scope :busy="!areSrsReady" :error="hasSrFetchError" />
     </UiCard>
-    <StorageRepositorySidePanel v-if="selectedSr" :sr="selectedSr" :scope @close="selectedSr = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <StorageRepositorySidePanel :sr="selectedSr" :scope @close="selectedSr = undefined" />
   </div>
 </template>
 
@@ -18,10 +15,9 @@ import {
   useXoSrCollection,
   type FrontXoSr,
 } from '@/modules/storage-repository/remote-resources/use-xo-sr-collection.ts'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
-import { useRouteQuery } from '@core/composables/route-query.composable.ts'
+import { useRouteQuery } from '@core/composables/route-query.composable'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { SR_SCOPE_TYPE, type SrScope } from '@core/types/storage-repository.type.ts'
 import { computed } from 'vue'
@@ -31,6 +27,7 @@ const { pool } = defineProps<{
 }>()
 
 const { srsByPool, hasSrFetchError, getSrById, areSrsReady } = useXoSrCollection()
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const srs = computed(() => srsByPool.value.get(pool.id) ?? [])
@@ -45,7 +42,7 @@ const selectedSr = useRouteQuery<FrontXoSr | undefined>('id', {
 
 <style scoped lang="postcss">
 .storage {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/pool/[id]/storage.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/storage.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="storage" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="storage">
     <UiCard class="container">
       <StorageRepositoriesTable :srs :scope :busy="!areSrsReady" :error="hasSrFetchError" />
     </UiCard>
     <StorageRepositorySidePanel :sr="selectedSr" :scope @close="selectedSr = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -15,10 +15,9 @@ import {
   useXoSrCollection,
   type FrontXoSr,
 } from '@/modules/storage-repository/remote-resources/use-xo-sr-collection.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import { SR_SCOPE_TYPE, type SrScope } from '@core/types/storage-repository.type.ts'
 import { computed } from 'vue'
 
@@ -27,8 +26,6 @@ const { pool } = defineProps<{
 }>()
 
 const { srsByPool, hasSrFetchError, getSrById, areSrsReady } = useXoSrCollection()
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const srs = computed(() => srsByPool.value.get(pool.id) ?? [])
 
@@ -42,11 +39,6 @@ const selectedSr = useRouteQuery<FrontXoSr | undefined>('id', {
 
 <style scoped lang="postcss">
 .storage {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     margin: 0.8rem;

--- a/@xen-orchestra/web/src/pages/pool/[id]/tasks.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/tasks.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="tasks" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="tasks">
     <UiCard class="container">
       <TasksList :tasks="convertedTasks" :has-error="hasTaskFetchError" :busy="!areTasksReady" />
     </UiCard>
     <TaskSidePanel :task="selectedTask" @close="selectedTask = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -15,19 +15,15 @@ import TasksList from '@/modules/task/components/list/TasksList.vue'
 import type { FrontXoTask } from '@/modules/task/remote-resources/use-xo-task-collection.ts'
 import { convertXoTaskToCore } from '@/modules/task/utils/convert-xo-task-to-core.util.ts'
 import { useXoUserCollection } from '@/modules/user/remote-resources/use-xo-user-collection.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store'
 import type { XoUser } from '@vates/types'
 import { computed } from 'vue'
 
 const { pool } = defineProps<{
   pool: FrontXoPool
 }>()
-
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const { getTaskById, sortedTasks, hasTaskFetchError, areTasksReady } = useXoPoolTasksCollection({}, () => pool.id)
 const { getUserById } = useXoUserCollection()
@@ -55,11 +51,6 @@ const convertedTasks = computed(() =>
 
 <style scoped lang="postcss">
 .tasks {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     gap: 4rem;

--- a/@xen-orchestra/web/src/pages/pool/[id]/tasks.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/tasks.vue
@@ -1,12 +1,9 @@
 <template>
-  <div class="tasks" :class="{ mobile: uiStore.isSmall }">
+  <div class="tasks" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <TasksList :tasks="convertedTasks" :has-error="hasTaskFetchError" :busy="!areTasksReady" />
     </UiCard>
-    <TaskSidePanel v-if="selectedTask" :task="selectedTask" @close="selectedTask = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <TaskSidePanel :task="selectedTask" @close="selectedTask = undefined" />
   </div>
 </template>
 
@@ -18,10 +15,9 @@ import TasksList from '@/modules/task/components/list/TasksList.vue'
 import type { FrontXoTask } from '@/modules/task/remote-resources/use-xo-task-collection.ts'
 import { convertXoTaskToCore } from '@/modules/task/utils/convert-xo-task-to-core.util.ts'
 import { useXoUserCollection } from '@/modules/user/remote-resources/use-xo-user-collection.ts'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store'
 import type { XoUser } from '@vates/types'
 import { computed } from 'vue'
@@ -30,6 +26,7 @@ const { pool } = defineProps<{
   pool: FrontXoPool
 }>()
 
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const { getTaskById, sortedTasks, hasTaskFetchError, areTasksReady } = useXoPoolTasksCollection({}, () => pool.id)
@@ -58,7 +55,7 @@ const convertedTasks = computed(() =>
 
 <style scoped lang="postcss">
 .tasks {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/pool/[id]/tasks.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/tasks.vue
@@ -5,9 +5,7 @@
     </UiCard>
     <TaskSidePanel v-if="selectedTask" :task="selectedTask" @close="selectedTask = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>
@@ -27,7 +25,6 @@ import { useRouteQuery } from '@core/composables/route-query.composable.ts'
 import { useUiStore } from '@core/stores/ui.store'
 import type { XoUser } from '@vates/types'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 const { pool } = defineProps<{
   pool: FrontXoPool
@@ -37,8 +34,6 @@ const uiStore = useUiStore()
 
 const { getTaskById, sortedTasks, hasTaskFetchError, areTasksReady } = useXoPoolTasksCollection({}, () => pool.id)
 const { getUserById } = useXoUserCollection()
-
-const { t } = useI18n()
 
 const selectedTask = useRouteQuery<FrontXoTask | undefined>('id', {
   toData: id => getTaskById(id as FrontXoTask['id']),

--- a/@xen-orchestra/web/src/pages/pool/[id]/vms.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/vms.vue
@@ -1,12 +1,9 @@
 <template>
-  <div class="vms" :class="{ mobile: uiStore.isSmall }">
+  <div class="vms" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <VmsTable :vms :busy="!areVmsReady" :error="hasVmFetchError" />
     </UiCard>
-    <VmSidePanel v-if="selectedVm" :vm="selectedVm" @close="selectedVm = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <VmSidePanel :vm="selectedVm" @close="selectedVm = undefined" />
   </div>
 </template>
 
@@ -15,10 +12,9 @@ import type { FrontXoPool } from '@/modules/pool/remote-resources/use-xo-pool-co
 import VmSidePanel from '@/modules/vm/components/list/panel/VmSidePanel.vue'
 import VmsTable from '@/modules/vm/components/list/VmsTable.vue'
 import { useXoVmCollection, type FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { computed } from 'vue'
 
@@ -26,6 +22,7 @@ const { pool } = defineProps<{
   pool: FrontXoPool
 }>()
 
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const { areVmsReady, vmsByPool, hasVmFetchError } = useXoVmCollection()
@@ -40,7 +37,7 @@ const selectedVm = useRouteQuery<FrontXoVm | undefined>('id', {
 
 <style scoped lang="postcss">
 .vms {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/pool/[id]/vms.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/vms.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="vms" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="vms">
     <UiCard class="container">
       <VmsTable :vms :busy="!areVmsReady" :error="hasVmFetchError" />
     </UiCard>
     <VmSidePanel :vm="selectedVm" @close="selectedVm = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script lang="ts" setup>
@@ -12,18 +12,14 @@ import type { FrontXoPool } from '@/modules/pool/remote-resources/use-xo-pool-co
 import VmSidePanel from '@/modules/vm/components/list/panel/VmSidePanel.vue'
 import VmsTable from '@/modules/vm/components/list/VmsTable.vue'
 import { useXoVmCollection, type FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import { computed } from 'vue'
 
 const { pool } = defineProps<{
   pool: FrontXoPool
 }>()
-
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const { areVmsReady, vmsByPool, hasVmFetchError } = useXoVmCollection()
 
@@ -37,11 +33,6 @@ const selectedVm = useRouteQuery<FrontXoVm | undefined>('id', {
 
 <style scoped lang="postcss">
 .vms {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     gap: 4rem;

--- a/@xen-orchestra/web/src/pages/pool/[id]/vms.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/vms.vue
@@ -5,9 +5,7 @@
     </UiCard>
     <VmSidePanel v-if="selectedVm" :vm="selectedVm" @close="selectedVm = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>
@@ -23,15 +21,12 @@ import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 const { pool } = defineProps<{
   pool: FrontXoPool
 }>()
 
 const uiStore = useUiStore()
-
-const { t } = useI18n()
 
 const { areVmsReady, vmsByPool, hasVmFetchError } = useXoVmCollection()
 

--- a/@xen-orchestra/web/src/pages/vif/[id]/traffic-rules.vue
+++ b/@xen-orchestra/web/src/pages/vif/[id]/traffic-rules.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="traffic-rules" :class="{ mobile: uiStore.isSmall }">
+  <VtsContentSidePanel class="traffic-rules">
     <UiCard class="container">
       <TrafficRulesTable :rules="trafficRules" :pool>
         <template #title-action>
@@ -9,13 +9,8 @@
         </template>
       </TrafficRulesTable>
     </UiCard>
-    <TrafficRulesSidePanel v-if="selectedRule" :rule="selectedRule" @close="selectedRule = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
-    </UiPanel>
-  </div>
+    <TrafficRulesSidePanel :rule="selectedRule" @close="selectedRule = undefined" />
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -24,17 +19,14 @@ import TrafficRulesSidePanel from '@/modules/traffic-rules/components/list/panel
 import TrafficRulesTable from '@/modules/traffic-rules/components/TrafficRulesTable.vue'
 import { useTrafficRules } from '@/modules/traffic-rules/composables/traffic-rules.composable.ts'
 import { type FrontXoVif } from '@/modules/vif/remote-resources/use-xo-vif-collection.ts'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiLink from '@core/components/ui/link/UiLink.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import type { TrafficRule } from '@vates/types'
 import { useI18n } from 'vue-i18n'
 
 const { vif } = defineProps<{ vif: FrontXoVif }>()
-const uiStore = useUiStore()
 
 const { t } = useI18n()
 
@@ -51,11 +43,6 @@ const selectedRule = useRouteQuery<TrafficRule | undefined>('id', {
 
 <style scoped lang="postcss">
 .traffic-rules {
-  &:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     gap: 4rem;

--- a/@xen-orchestra/web/src/pages/vm/[id]/backups.vue
+++ b/@xen-orchestra/web/src/pages/vm/[id]/backups.vue
@@ -1,16 +1,9 @@
 <template>
-  <div class="backups" :class="{ mobile: uiStore.isSmall }">
+  <div class="backups" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <BackupJobsTable :backup-jobs="vmBackupJobs" :busy="!areVmBackupJobsReady" :error="hasVmBackupJobFetchError" />
     </UiCard>
-    <BackupJobSidePanel
-      v-if="selectedBackupJob"
-      :backup-job="selectedBackupJob"
-      @close="selectedBackupJob = undefined"
-    />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <BackupJobSidePanel :backup-job="selectedBackupJob" @close="selectedBackupJob = undefined" />
   </div>
 </template>
 
@@ -22,16 +15,16 @@ import {
   type FrontXoVmBackupJob,
 } from '@/modules/backup/remote-resources/use-xo-backup-job-collection.ts'
 import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store'
 
 const { vm } = defineProps<{
   vm: FrontXoVm
 }>()
 
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const {
@@ -48,7 +41,7 @@ const selectedBackupJob = useRouteQuery<FrontXoVmBackupJob | undefined>('id', {
 
 <style scoped lang="postcss">
 .backups {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/vm/[id]/backups.vue
+++ b/@xen-orchestra/web/src/pages/vm/[id]/backups.vue
@@ -9,9 +9,7 @@
       @close="selectedBackupJob = undefined"
     />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>
@@ -29,7 +27,6 @@ import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
 import { useUiStore } from '@core/stores/ui.store'
-import { useI18n } from 'vue-i18n'
 
 const { vm } = defineProps<{
   vm: FrontXoVm
@@ -42,8 +39,6 @@ const {
   areBackupJobsReady: areVmBackupJobsReady,
   hasBackupJobFetchError: hasVmBackupJobFetchError,
 } = useXoBackupJobCollection({}, () => vm.id)
-
-const { t } = useI18n()
 
 const selectedBackupJob = useRouteQuery<FrontXoVmBackupJob | undefined>('id', {
   toData: id => vmBackupJobs.value.find(backupJob => backupJob.id === id),

--- a/@xen-orchestra/web/src/pages/vm/[id]/backups.vue
+++ b/@xen-orchestra/web/src/pages/vm/[id]/backups.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="backups" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="backups">
     <UiCard class="container">
       <BackupJobsTable :backup-jobs="vmBackupJobs" :busy="!areVmBackupJobsReady" :error="hasVmBackupJobFetchError" />
     </UiCard>
     <BackupJobSidePanel :backup-job="selectedBackupJob" @close="selectedBackupJob = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -15,17 +15,13 @@ import {
   type FrontXoVmBackupJob,
 } from '@/modules/backup/remote-resources/use-xo-backup-job-collection.ts'
 import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store'
 
 const { vm } = defineProps<{
   vm: FrontXoVm
 }>()
-
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const {
   backupJobs: vmBackupJobs,
@@ -41,11 +37,6 @@ const selectedBackupJob = useRouteQuery<FrontXoVmBackupJob | undefined>('id', {
 
 <style scoped lang="postcss">
 .backups {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     gap: 4rem;

--- a/@xen-orchestra/web/src/pages/vm/[id]/networks.vue
+++ b/@xen-orchestra/web/src/pages/vm/[id]/networks.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="networks" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="networks">
     <UiCard class="container">
       <VifsTable :vifs :vm>
         <template #title-actions>
@@ -10,7 +10,7 @@
       </VifsTable>
     </UiCard>
     <VifSidePanel :vif="selectedVif" :vm @close="selectedVif = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -19,11 +19,10 @@ import VifsTable from '@/modules/vif/components/VifsTable.vue'
 import { type FrontXoVif, useXoVifCollection } from '@/modules/vif/remote-resources/use-xo-vif-collection.ts'
 import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
 import { useXoRoutes } from '@/shared/remote-resources/use-xo-routes.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiLink from '@core/components/ui/link/UiLink.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import { useArrayFilter } from '@vueuse/shared'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -37,9 +36,6 @@ const xo5VmVifHref = computed(() => buildXo5Route(`/vms/${vm.id}/network`))
 
 const { vifs: rawVifs, getVifById } = useXoVifCollection()
 
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
-
 const { t } = useI18n()
 
 const vifs = useArrayFilter(rawVifs, vif => vif.$VM === vm.id)
@@ -52,11 +48,6 @@ const selectedVif = useRouteQuery<FrontXoVif | undefined>('id', {
 
 <style scoped lang="postcss">
 .networks {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     margin: 0.8rem;

--- a/@xen-orchestra/web/src/pages/vm/[id]/networks.vue
+++ b/@xen-orchestra/web/src/pages/vm/[id]/networks.vue
@@ -11,9 +11,7 @@
     </UiCard>
     <VifSidePanel v-if="selectedVif" :vif="selectedVif" :vm @close="selectedVif = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>

--- a/@xen-orchestra/web/src/pages/vm/[id]/networks.vue
+++ b/@xen-orchestra/web/src/pages/vm/[id]/networks.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="networks" :class="{ mobile: uiStore.isSmall }">
+  <div class="networks" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <VifsTable :vifs :vm>
         <template #title-actions>
@@ -9,10 +9,7 @@
         </template>
       </VifsTable>
     </UiCard>
-    <VifSidePanel v-if="selectedVif" :vif="selectedVif" :vm @close="selectedVif = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <VifSidePanel :vif="selectedVif" :vm @close="selectedVif = undefined" />
   </div>
 </template>
 
@@ -22,11 +19,10 @@ import VifsTable from '@/modules/vif/components/VifsTable.vue'
 import { type FrontXoVif, useXoVifCollection } from '@/modules/vif/remote-resources/use-xo-vif-collection.ts'
 import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
 import { useXoRoutes } from '@/shared/remote-resources/use-xo-routes.ts'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiLink from '@core/components/ui/link/UiLink.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { useArrayFilter } from '@vueuse/shared'
 import { computed } from 'vue'
@@ -41,6 +37,7 @@ const xo5VmVifHref = computed(() => buildXo5Route(`/vms/${vm.id}/network`))
 
 const { vifs: rawVifs, getVifById } = useXoVifCollection()
 
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const { t } = useI18n()
@@ -55,7 +52,7 @@ const selectedVif = useRouteQuery<FrontXoVif | undefined>('id', {
 
 <style scoped lang="postcss">
 .networks {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/vm/[id]/snapshots.vue
+++ b/@xen-orchestra/web/src/pages/vm/[id]/snapshots.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="snapshots" :class="{ mobile: uiStore.isSmall }">
+  <div class="snapshots" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <div>
       <VtsColumns extra-space-around>
         <VtsColumn>
@@ -13,10 +13,7 @@
         <SnapshotsTable :snapshots :vm />
       </UiCard>
     </div>
-    <SnapshotSidePanel v-if="selectedSnapshot" :snapshot="selectedSnapshot" @close="selectedSnapshot = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <SnapshotSidePanel :snapshot="selectedSnapshot" @close="selectedSnapshot = undefined" />
   </div>
 </template>
 
@@ -31,10 +28,9 @@ import VmSnapshotCard from '@/modules/vm/components/snapshot/cards/VmSnapshotCar
 import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
 import VtsColumn from '@core/components/column/VtsColumn.vue'
 import VtsColumns from '@core/components/columns/VtsColumns.vue'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { useArrayFilter } from '@vueuse/shared'
 import { computed } from 'vue'
@@ -46,6 +42,7 @@ const { vm } = defineProps<{
 
 const { snapshots: snapshotsCollection, getSnapshotById } = useXoVmSnapshotCollection()
 
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const { t } = useI18n()
@@ -78,8 +75,10 @@ const lastRevertSnapshot = computed(() => {
 
 <style scoped lang="postcss">
 .snapshots {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 40rem;
+  &.locked:not(.mobile) {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 40rem;
+  }
 
   .container {
     height: fit-content;

--- a/@xen-orchestra/web/src/pages/vm/[id]/snapshots.vue
+++ b/@xen-orchestra/web/src/pages/vm/[id]/snapshots.vue
@@ -15,9 +15,7 @@
     </div>
     <SnapshotSidePanel v-if="selectedSnapshot" :snapshot="selectedSnapshot" @close="selectedSnapshot = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>

--- a/@xen-orchestra/web/src/pages/vm/[id]/snapshots.vue
+++ b/@xen-orchestra/web/src/pages/vm/[id]/snapshots.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="snapshots" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="snapshots">
     <div>
       <VtsColumns extra-space-around>
         <VtsColumn>
@@ -14,7 +14,7 @@
       </UiCard>
     </div>
     <SnapshotSidePanel :snapshot="selectedSnapshot" @close="selectedSnapshot = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -28,10 +28,9 @@ import VmSnapshotCard from '@/modules/vm/components/snapshot/cards/VmSnapshotCar
 import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
 import VtsColumn from '@core/components/column/VtsColumn.vue'
 import VtsColumns from '@core/components/columns/VtsColumns.vue'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import { useArrayFilter } from '@vueuse/shared'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -41,9 +40,6 @@ const { vm } = defineProps<{
 }>()
 
 const { snapshots: snapshotsCollection, getSnapshotById } = useXoVmSnapshotCollection()
-
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const { t } = useI18n()
 
@@ -75,11 +71,6 @@ const lastRevertSnapshot = computed(() => {
 
 <style scoped lang="postcss">
 .snapshots {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     margin: 0.8rem;

--- a/@xen-orchestra/web/src/pages/vm/[id]/tasks.vue
+++ b/@xen-orchestra/web/src/pages/vm/[id]/tasks.vue
@@ -1,12 +1,9 @@
 <template>
-  <div class="tasks" :class="{ mobile: uiStore.isSmall }">
+  <div class="tasks" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <TasksList :tasks="convertedTasks" :has-error="hasTaskFetchError" :busy="!areTasksReady" />
     </UiCard>
-    <TaskSidePanel v-if="selectedTask" :task="selectedTask" @close="selectedTask = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <TaskSidePanel :task="selectedTask" @close="selectedTask = undefined" />
   </div>
 </template>
 
@@ -18,10 +15,9 @@ import { convertXoTaskToCore } from '@/modules/task/utils/convert-xo-task-to-cor
 import { useXoUserCollection } from '@/modules/user/remote-resources/use-xo-user-collection.ts'
 import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
 import { useXoVmTasksCollection } from '@/modules/vm/remote-resources/use-xo-vm-tasks-collection.ts'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store'
 import type { XoUser } from '@vates/types'
 import { computed } from 'vue'
@@ -30,6 +26,7 @@ const { vm } = defineProps<{
   vm: FrontXoVm
 }>()
 
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const { getTaskById, sortedTasks, hasTaskFetchError, areTasksReady } = useXoVmTasksCollection({}, () => vm.id)
@@ -58,7 +55,7 @@ const convertedTasks = computed(() =>
 
 <style scoped lang="postcss">
 .tasks {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/vm/[id]/tasks.vue
+++ b/@xen-orchestra/web/src/pages/vm/[id]/tasks.vue
@@ -5,9 +5,7 @@
     </UiCard>
     <TaskSidePanel v-if="selectedTask" :task="selectedTask" @close="selectedTask = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>
@@ -27,7 +25,6 @@ import { useRouteQuery } from '@core/composables/route-query.composable.ts'
 import { useUiStore } from '@core/stores/ui.store'
 import type { XoUser } from '@vates/types'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 const { vm } = defineProps<{
   vm: FrontXoVm
@@ -37,8 +34,6 @@ const uiStore = useUiStore()
 
 const { getTaskById, sortedTasks, hasTaskFetchError, areTasksReady } = useXoVmTasksCollection({}, () => vm.id)
 const { getUserById } = useXoUserCollection()
-
-const { t } = useI18n()
 
 const selectedTask = useRouteQuery<FrontXoTask | undefined>('id', {
   toData: id => getTaskById(id as FrontXoTask['id']),

--- a/@xen-orchestra/web/src/pages/vm/[id]/tasks.vue
+++ b/@xen-orchestra/web/src/pages/vm/[id]/tasks.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="tasks" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="tasks">
     <UiCard class="container">
       <TasksList :tasks="convertedTasks" :has-error="hasTaskFetchError" :busy="!areTasksReady" />
     </UiCard>
     <TaskSidePanel :task="selectedTask" @close="selectedTask = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -15,19 +15,15 @@ import { convertXoTaskToCore } from '@/modules/task/utils/convert-xo-task-to-cor
 import { useXoUserCollection } from '@/modules/user/remote-resources/use-xo-user-collection.ts'
 import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
 import { useXoVmTasksCollection } from '@/modules/vm/remote-resources/use-xo-vm-tasks-collection.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store'
 import type { XoUser } from '@vates/types'
 import { computed } from 'vue'
 
 const { vm } = defineProps<{
   vm: FrontXoVm
 }>()
-
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const { getTaskById, sortedTasks, hasTaskFetchError, areTasksReady } = useXoVmTasksCollection({}, () => vm.id)
 const { getUserById } = useXoUserCollection()
@@ -55,11 +51,6 @@ const convertedTasks = computed(() =>
 
 <style scoped lang="postcss">
 .tasks {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     gap: 4rem;

--- a/@xen-orchestra/web/src/pages/vm/[id]/vdis.vue
+++ b/@xen-orchestra/web/src/pages/vm/[id]/vdis.vue
@@ -33,9 +33,7 @@
     </UiCard>
     <VdiSidePanel v-if="selectedVdi" :vdi="selectedVdi" :vm @close="selectedVdi = undefined" />
     <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium">
-        {{ t('select-to-see-details') }}
-      </VtsStateHero>
+      <VtsStateHero format="panel" type="no-selection" size="medium" />
     </UiPanel>
   </div>
 </template>
@@ -57,13 +55,10 @@ import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 const { vm } = defineProps<{
   vm: FrontXoVm
 }>()
-
-const { t } = useI18n()
 
 const { vmVdis, getVmVdiById, hasVmVdiFetchError, areVmVdisReady } = useXoVmVdisCollection({}, () => vm.id)
 const uiStore = useUiStore()

--- a/@xen-orchestra/web/src/pages/vm/[id]/vdis.vue
+++ b/@xen-orchestra/web/src/pages/vm/[id]/vdis.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="vdis" :class="{ mobile: uiStore.isSmall }">
+  <div class="vdis" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
     <UiCard class="container">
       <VdisTable :vdis="filteredVdisByNotCdVbd" :vm :busy="!areVmVdisReady" :error="hasVmVdiFetchError">
         <template #title-actions>
@@ -31,10 +31,7 @@
         </template>
       </VdisTable>
     </UiCard>
-    <VdiSidePanel v-if="selectedVdi" :vdi="selectedVdi" :vm @close="selectedVdi = undefined" />
-    <UiPanel v-else-if="!uiStore.isSmall">
-      <VtsStateHero format="panel" type="no-selection" size="medium" />
-    </UiPanel>
+    <VdiSidePanel :vdi="selectedVdi" :vm @close="selectedVdi = undefined" />
   </div>
 </template>
 
@@ -47,20 +44,24 @@ import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collecti
 import { useXoVmVdisCollection } from '@/modules/vm/remote-resources/use-xo-vm-vdis-collection.ts'
 import MenuItem from '@core/components/menu/MenuItem.vue'
 import MenuList from '@core/components/menu/MenuList.vue'
-import VtsStateHero from '@core/components/state-hero/VtsStateHero.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiDropdownButton from '@core/components/ui/dropdown-button/UiDropdownButton.vue'
 import UiLink from '@core/components/ui/link/UiLink.vue'
-import UiPanel from '@core/components/ui/panel/UiPanel.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
+import { usePanelStore } from '@core/stores/panel.store'
 import { useUiStore } from '@core/stores/ui.store.ts'
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 const { vm } = defineProps<{
   vm: FrontXoVm
 }>()
 
+const { t } = useI18n()
+
 const { vmVdis, getVmVdiById, hasVmVdiFetchError, areVmVdisReady } = useXoVmVdisCollection({}, () => vm.id)
+
+const panelStore = usePanelStore()
 const uiStore = useUiStore()
 
 const { notCdDriveVbds } = useXoVmVbdsUtils(() => vm)
@@ -77,7 +78,7 @@ const selectedVdi = useRouteQuery<FrontXoVdi | undefined>('id', {
 
 <style scoped lang="postcss">
 .vdis {
-  &:not(.mobile) {
+  &.locked:not(.mobile) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 40rem;
   }

--- a/@xen-orchestra/web/src/pages/vm/[id]/vdis.vue
+++ b/@xen-orchestra/web/src/pages/vm/[id]/vdis.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="vdis" :class="{ mobile: uiStore.isSmall, locked: panelStore.isLocked && !uiStore.isSmall }">
+  <VtsContentSidePanel class="vdis">
     <UiCard class="container">
       <VdisTable :vdis="filteredVdisByNotCdVbd" :vm :busy="!areVmVdisReady" :error="hasVmVdiFetchError">
         <template #title-actions>
@@ -32,7 +32,7 @@
       </VdisTable>
     </UiCard>
     <VdiSidePanel :vdi="selectedVdi" :vm @close="selectedVdi = undefined" />
-  </div>
+  </VtsContentSidePanel>
 </template>
 
 <script setup lang="ts">
@@ -42,14 +42,13 @@ import type { FrontXoVdi } from '@/modules/vdi/remote-resources/use-xo-vdi-colle
 import { useXoVmVbdsUtils } from '@/modules/vm/composables/xo-vm-vbd-utils.composable.ts'
 import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'
 import { useXoVmVdisCollection } from '@/modules/vm/remote-resources/use-xo-vm-vdis-collection.ts'
+import VtsContentSidePanel from '@core/components/layout/VtsContentSidePanel.vue'
 import MenuItem from '@core/components/menu/MenuItem.vue'
 import MenuList from '@core/components/menu/MenuList.vue'
 import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiDropdownButton from '@core/components/ui/dropdown-button/UiDropdownButton.vue'
 import UiLink from '@core/components/ui/link/UiLink.vue'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
-import { usePanelStore } from '@core/stores/panel.store'
-import { useUiStore } from '@core/stores/ui.store.ts'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -60,9 +59,6 @@ const { vm } = defineProps<{
 const { t } = useI18n()
 
 const { vmVdis, getVmVdiById, hasVmVdiFetchError, areVmVdisReady } = useXoVmVdisCollection({}, () => vm.id)
-
-const panelStore = usePanelStore()
-const uiStore = useUiStore()
 
 const { notCdDriveVbds } = useXoVmVbdsUtils(() => vm)
 
@@ -78,11 +74,6 @@ const selectedVdi = useRouteQuery<FrontXoVdi | undefined>('id', {
 
 <style scoped lang="postcss">
 .vdis {
-  &.locked:not(.mobile) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 40rem;
-  }
-
   .container {
     height: fit-content;
     margin: 0.8rem;

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -75,6 +75,7 @@
 - [REST API] `PATCH /rest/v0/vifs/{id}` to update VIF properties (allowed IPs, locking mode, rate limit, TX checksumming) (PR [#9935](https://github.com/vatesfr/xen-orchestra/pull/9935))
 - [XO 6] Add an Administration tab in the sidebar with a user management menu (PR [#9947](https://github.com/vatesfr/xen-orchestra/pull/9947))
 - [OpenMetrics] Include XO tags as a `tags` label on host, VM and SR metrics [#9628](https://github.com/vatesfr/xen-orchestra/issues/9628) (PR [#9971](https://github.com/vatesfr/xen-orchestra/pull/9971))
+- [Web stack] Updated side panels (PR [#9836](https://github.com/vatesfr/xen-orchestra/pull/9836))
 
 ### Bug fixes
 
@@ -100,7 +101,7 @@
 <!--packages-start-->
 
 - @xen-orchestra/backups patch
-- @xen-orchestra/web patch
-- @xen-orchestra/web-core patch
+- @xen-orchestra/web minor
+- @xen-orchestra/web-core minor
 
 <!--packages-end-->


### PR DESCRIPTION
**[web-core/web/lite] Updated UiPanel to v5**

- Added support for pinning and unpinning the panel from the right side
- Changed wording (EN+FR) for default "no-selection" content, unified in `VtsStateHero` component
- Unified close/back button behaviour with a `closable` prop
- Updated close icon to v5
- Updated all pages that previously used a plain UiPanel as a side panel, in XO 6 and XO Lite

### Screenshots:

|  | Light | Dark |
|---|---|---|
| Desktop, pinned, no selection | <img width="2880" height="1800" alt="Screen Shot 2026-06-16 at 17 31 11" src="https://github.com/user-attachments/assets/339e8d75-ee37-4da1-becb-76b71bf90676" /> | <img width="2880" height="1800" alt="Screen Shot 2026-06-16 at 17 31 05" src="https://github.com/user-attachments/assets/c9d3403a-44ad-4e17-a373-923085728946" /> |
| Desktop, unpinned, no selection | <img width="2880" height="1800" alt="Screen Shot 2026-06-16 at 17 31 38" src="https://github.com/user-attachments/assets/ee3fe36c-68b7-4de4-add9-f6fa413513e2" /> | <img width="2880" height="1800" alt="Screen Shot 2026-06-16 at 17 31 33" src="https://github.com/user-attachments/assets/61fc8689-9063-4c38-a0c9-4fb6fd2759c7" /> |
| Desktop, with selection | <img width="2880" height="1800" alt="Screen Shot 2026-06-16 at 17 31 25" src="https://github.com/user-attachments/assets/0fb2130b-b069-4561-a4aa-4be2c7968187" /> | <img width="2880" height="1800" alt="Screen Shot 2026-06-16 at 17 31 22" src="https://github.com/user-attachments/assets/6dcc315e-d0d5-4a44-973c-29337e90b019" /> |
| Mobile | <img width="1080" height="2340" alt="Screen Shot 2026-06-16 at 17 41 40" src="https://github.com/user-attachments/assets/b948d822-86f7-4988-8de3-6274d3a2b7f4" /> | <img width="1080" height="2340" alt="Screen Shot 2026-06-16 at 17 41 31" src="https://github.com/user-attachments/assets/b42b16a1-a5a3-4d35-94eb-a3c27a9ee4b8" /> |
 