### PR TITLE
fix(xo6/tasks): issue with task type and size when accessing backup runs

### DIFF
--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -666,7 +666,7 @@ export type XoTask = {
     userId?: string
     [key: string]: unknown | undefined
   }
-  result: Record<string, unknown>
+  result?: Record<string, unknown>
   start: number
   status: 'failure' | 'interrupted' | 'pending' | 'success'
   tasks?: XoTask[]

--- a/@xen-orchestra/web/src/modules/backup/composables/xo-backup-log-utils.composable.ts
+++ b/@xen-orchestra/web/src/modules/backup/composables/xo-backup-log-utils.composable.ts
@@ -44,7 +44,7 @@ export function useXoBackupLogsUtils() {
           totalSize = (totalSize ?? 0) + nestedSize
         }
       } else {
-        if (!('message' in task) || task.message !== 'transfer' || typeof task.result.size !== 'number') {
+        if (!('message' in task) || task.message !== 'transfer' || typeof task.result?.size !== 'number') {
           return totalSize
         }
 

--- a/@xen-orchestra/web/src/modules/task/components/list/panel/cards/TaskErrorsCard.vue
+++ b/@xen-orchestra/web/src/modules/task/components/list/panel/cards/TaskErrorsCard.vue
@@ -2,19 +2,19 @@
   <UiCard class="card-container">
     <UiCardTitle>
       {{ t('errors') }}
-      <UiCounter :value="Array(task.result).length" accent="danger" size="small" variant="primary" />
+      <UiCounter :value="Array(task.result)?.length" accent="danger" size="small" variant="primary" />
     </UiCardTitle>
     <div class="content">
       <VtsCardRowKeyValue>
         <template #key>{{ t('message') }}</template>
-        <template #value>{{ task.result.message }}</template>
-        <template v-if="task.result.message" #addons>
+        <template #value>{{ task.result?.message }}</template>
+        <template v-if="task.result?.message" #addons>
           <VtsCopyButton :value="String(task.result.message)" />
         </template>
       </VtsCardRowKeyValue>
     </div>
     <UiLogEntryViewer
-      v-if="task.result.stack"
+      v-if="task.result?.stack"
       :content="task.result.stack"
       :label="t('api-error-details')"
       size="small"

--- a/@xen-orchestra/web/src/modules/task/components/list/panel/cards/TaskErrorsCard.vue
+++ b/@xen-orchestra/web/src/modules/task/components/list/panel/cards/TaskErrorsCard.vue
@@ -2,7 +2,7 @@
   <UiCard class="card-container">
     <UiCardTitle>
       {{ t('errors') }}
-      <UiCounter :value="Array(task.result)?.length" accent="danger" size="small" variant="primary" />
+      <UiCounter :value="1" accent="danger" size="small" variant="primary" />
     </UiCardTitle>
     <div class="content">
       <VtsCardRowKeyValue>

--- a/@xen-orchestra/web/src/route-map.d.ts
+++ b/@xen-orchestra/web/src/route-map.d.ts
@@ -8,11 +8,11 @@
 // Make sure to add this file to your tsconfig.json file as an "includes" or "files" entry.
 
 import type {
-  RouteRecordInfo,
   ParamValue,
   ParamValueOneOrMore,
   ParamValueZeroOrMore,
   ParamValueZeroOrOne,
+  RouteRecordInfo,
 } from 'vue-router'
 import type { _ExtractParamParserType } from 'vue-router/experimental'
 
@@ -88,17 +88,6 @@ declare module 'vue-router/auto-routes' {
       { id: ParamValue<false> },
       never
     >
-    '/dev/': RouteRecordInfo<'/dev/', '/dev', Record<never, never>, Record<never, never>, never>
-    '/dev/colors': RouteRecordInfo<'/dev/colors', '/dev/colors', Record<never, never>, Record<never, never>, never>
-    '/dev/icons/': RouteRecordInfo<'/dev/icons/', '/dev/icons', Record<never, never>, Record<never, never>, never>
-    '/dev/icons/[name]': RouteRecordInfo<
-      '/dev/icons/[name]',
-      '/dev/icons/:name',
-      { name: ParamValue<true> },
-      { name: ParamValue<false> },
-      never
-    >
-    '/dev/token': RouteRecordInfo<'/dev/token', '/dev/token', Record<never, never>, Record<never, never>, never>
     '/host/[id]': RouteRecordInfo<
       '/host/[id]',
       '/host/:id',
@@ -400,26 +389,6 @@ declare module 'vue-router/auto-routes' {
     }
     'src/pages/backup/[id]/targets.vue': {
       routes: '/backup/[id]/targets'
-      views: never
-    }
-    'src/pages/dev/index.vue': {
-      routes: '/dev/'
-      views: never
-    }
-    'src/pages/dev/colors.vue': {
-      routes: '/dev/colors'
-      views: never
-    }
-    'src/pages/dev/icons/index.vue': {
-      routes: '/dev/icons/'
-      views: never
-    }
-    'src/pages/dev/icons/[name].vue': {
-      routes: '/dev/icons/[name]'
-      views: never
-    }
-    'src/pages/dev/token.vue': {
-      routes: '/dev/token'
       views: never
     }
     'src/pages/host/[id].vue': {

--- a/@xen-orchestra/web/src/shared/composables/xo-task-utils.composable.ts
+++ b/@xen-orchestra/web/src/shared/composables/xo-task-utils.composable.ts
@@ -1,14 +1,14 @@
-import { useXoTaskCollection } from '@/modules/task/remote-resources/use-xo-task-collection.ts'
-import type { XoTask } from '@vates/types'
+import { type FrontXoTask, useXoTaskCollection } from '@/modules/task/remote-resources/use-xo-task-collection.ts'
 import { watch } from 'vue'
 
 /**
  * Normalize a Task error into a JS Error. Keep the original stacktrace
  */
-function normalizeError(taskError: Record<string, unknown> | undefined) {
+function normalizeError(taskError: Record<string, unknown> | undefined, taskId: FrontXoTask['id']) {
   const error = new Error()
 
   if (taskError === undefined) {
+    error.message = `Task ${taskId} failed without error details`
     return error
   }
 
@@ -30,7 +30,7 @@ function normalizeError(taskError: Record<string, unknown> | undefined) {
 export function useXoTaskUtils() {
   const { useGetTaskById } = useXoTaskCollection()
 
-  async function monitorTask<TResult>(taskId: XoTask['id']): Promise<TResult> {
+  async function monitorTask<TResult>(taskId: FrontXoTask['id']): Promise<TResult> {
     const task = useGetTaskById(taskId)
 
     return new Promise((resolve, reject) => {
@@ -50,10 +50,10 @@ export function useXoTaskUtils() {
               resolve(task.result as TResult)
             } else if (task.status === 'failure') {
               cleanup()
-              reject(normalizeError(task.result))
+              reject(normalizeError(task.result, taskId))
             } else if (task.status !== 'pending') {
               cleanup()
-              reject(normalizeError(task.result))
+              reject(normalizeError(task.result, taskId))
             }
           }
         },

--- a/@xen-orchestra/web/src/shared/composables/xo-task-utils.composable.ts
+++ b/@xen-orchestra/web/src/shared/composables/xo-task-utils.composable.ts
@@ -5,8 +5,12 @@ import { watch } from 'vue'
 /**
  * Normalize a Task error into a JS Error. Keep the original stacktrace
  */
-function normalizeError(taskError: Record<string, unknown>) {
+function normalizeError(taskError: Record<string, unknown> | undefined) {
   const error = new Error()
+
+  if (taskError === undefined) {
+    return error
+  }
 
   if ('message' in taskError) {
     error.message = taskError.message as string

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,7 +24,7 @@
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
 - [REST] Fixed ignored parameters in request body due to a tsoa bug (see https://github.com/lukeautry/tsoa/pull/1858) (PR [#9793](https://github.com/vatesfr/xen-orchestra/pull/9793))
-- [Tasks] Fixed issue with task type and backup runs on task size (PR [#9841](https://github.com/vatesfr/xen-orchestra/pull/9841))
+- [Tasks] Fixed issue with task without result and backup runs on task size (PR [#9841](https://github.com/vatesfr/xen-orchestra/pull/9841))
 - **XO 5**:
   - [Job] Error while using vm.set with `cpuMask` in job view (PR [#9823](https://github.com/vatesfr/xen-orchestra/pull/9823))
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
 - [REST] Fixed ignored parameters in request body due to a tsoa bug (see https://github.com/lukeautry/tsoa/pull/1858) (PR [#9793](https://github.com/vatesfr/xen-orchestra/pull/9793))
+- [Backups] Fixed issue in backup runs on task size (PR [#9841](https://github.com/vatesfr/xen-orchestra/pull/9841))
 - **XO 5**:
   - [Job] Error while using vm.set with `cpuMask` in job view (PR [#9823](https://github.com/vatesfr/xen-orchestra/pull/9823))
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,7 +24,7 @@
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
 - [REST] Fixed ignored parameters in request body due to a tsoa bug (see https://github.com/lukeautry/tsoa/pull/1858) (PR [#9793](https://github.com/vatesfr/xen-orchestra/pull/9793))
-- [Backups] Fixed issue in backup runs on task size (PR [#9841](https://github.com/vatesfr/xen-orchestra/pull/9841))
+- [Tasks] Fixed issue with task type and backup runs on task size (PR [#9841](https://github.com/vatesfr/xen-orchestra/pull/9841))
 - **XO 5**:
   - [Job] Error while using vm.set with `cpuMask` in job view (PR [#9823](https://github.com/vatesfr/xen-orchestra/pull/9823))
 


### PR DESCRIPTION
### Description

Issue with the task size when accessing backup runs : 

<img width="1569" height="484" alt="Screenshot from 2026-05-12 18-11-04" src="https://github.com/user-attachments/assets/6f603569-839c-4503-8d74-fba6b4f71913" />

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)

  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
