### PR TITLE
feat(openmetrics): expose XOSTOR metrics for Grafana dashboards

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,7 +18,7 @@
 - [Pool/Security] Implement possibility to add new traffic rule from pool (PR [#9809](https://github.com/vatesfr/xen-orchestra/pull/9809))
 - [VM/Snapshot] Add possibility to revert a snapshot on a VM (PR [#9862](https://github.com/vatesfr/xen-orchestra/pull/9862))
 - [MCP] Restrict which REST endpoints the AI assistant can reach: read-only endpoints are exposed by default, write actions require `XO_MCP_ENABLE_ACTIONS=1` with a confirmation step, and binary/stream endpoints stay hidden (PR [#9875](https://github.com/vatesfr/xen-orchestra/pull/9875))
-
+- [OpenMetrics] Add XOSTOR metrics (cluster status, replica health, SMART, alarms, pending updates) and an `sr_type` label on SR-tagged metrics so Grafana can filter by storage type (PR [#9849](https://github.com/vatesfr/xen-orchestra/pull/9849))
 ### Bug fixes
 
 > Users must be able to say: "I had this issue, happy to know it's fixed"
@@ -51,6 +51,7 @@
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor
 - xo-server patch
+- xo-server-openmetrics minor
 - xo-web patch
 
 <!--packages-end-->

--- a/docs/docs/xo5/advanced.md
+++ b/docs/docs/xo5/advanced.md
@@ -519,6 +519,33 @@ Infrastructure metrics are prefixed with `xcp_` and XO management plane metrics 
 
 VDI metrics include labels `vdi_uuid`, `vdi_name`, `sr_uuid`, `sr_name`, `pool_id`, `pool_name`, and optionally `vm_uuid`, `vm_name` when the VDI is attached to a VM.
 
+#### XOSTOR Metrics
+
+These metrics describe LINSTOR-backed XOSTOR clusters and only appear when the XO pool contains at least one SR with `SR_type === 'linstor'`.
+
+| Metric                                | Type  | Description                                                                                              |
+| ------------------------------------- | ----- | -------------------------------------------------------------------------------------------------------- |
+| `xcp_xostor_up`                       | gauge | Cluster reachability (1 = `linstor-manager.healthCheck` succeeded, 0 = collection failed)                |
+| `xcp_xostor_node_status`              | gauge | One series per LINSTOR node (always 1; `role` ∈ {master, satellite} and raw `state` are labels)          |
+| `xcp_xostor_resource_total`           | gauge | Total number of LINSTOR resources defined in the cluster                                                 |
+| `xcp_xostor_resource_state_count`     | gauge | Replica count per `disk-state` (UpToDate, Inconsistent, Outdated, Diskless, Unknown), summed per cluster |
+| `xcp_xostor_alarms_up`                | gauge | Alarm-collection status (1 = collected, 0 = collection failed)                                           |
+| `xcp_xostor_alarms_count`             | gauge | Active XAPI alarm count per `alarm_name` and `target_type` (only emitted when count > 0)                 |
+| `xcp_xostor_smart_up`                 | gauge | SMART-collection status per host (1 = `smartctl.py` replied, 0 = plugin missing or call failed)          |
+| `xcp_xostor_disk_smart_status`        | gauge | SMART overall-health per disk (always 1; `device` and `status` in labels)                                |
+| `xcp_xostor_updates_up`               | gauge | Update-check status per host (1 = `updater.py` replied, 0 = call failed or repo unreachable)             |
+| `xcp_xostor_package_update_available` | gauge | Pending XOSTOR-related package update on a host (always 1; emitted only when an update is pending)       |
+
+Packages watched by `xcp_xostor_package_update_available`: `xcp-ng-linstor`, `xcp-ng-release-linstor`, `linstor-satellite`, `linstor-controller`, `xcp-ng-xapi-plugins`.
+
+All XOSTOR metrics carry `sr_uuid`, `pool_id` and `pool_name`. Per-host metrics also expose `host_uuid` and `host_name`; per-node metrics add the LINSTOR `node_name` (the host's hostname) plus `role` and `state`.
+
+The four collectors don't share a cache. Cluster status and alarms refresh every 60 s, SMART every 5 minutes, updates every hour.
+
+#### Storage technology label (`sr_type`)
+
+Every SR-tagged metric (`xcp_host_disk_iops_*`, `xcp_host_disk_throughput_*`, `xcp_host_disk_*_latency_seconds`, `xcp_sr_*`, `xcp_vdi_*`, `xcp_vm_disk_*`) has an `sr_type` label taken straight from `XoSr.SR_type`. Common values are `linstor`, `lvm`, `nfs`, `ext`, `smb`. A `sr_type="linstor"` filter in PromQL gives you only the XOSTOR traffic.
+
 #### Connection Metrics
 
 | Metric               | Type  | Description                                                         |
@@ -578,6 +605,14 @@ All metrics include these labels for filtering:
 | `is_control_domain` | Whether the VM is a control domain / dom0 (`true`/`false`)                                                                            |
 | `power_state`       | Power state: `Running`, `Halted`, `Unknown` (for `xcp_host_status`); `Running`, `Paused`, `Halted`, `Suspended` (for `xcp_vm_status`) |
 | `enabled`           | Whether the host is enabled: `true`/`false` (for `xcp_host_status`)                                                                   |
+| `sr_type`           | XAPI SR type (e.g. `linstor`, `lvm`, `nfs`) — on every SR-tagged metric                                                               |
+| `node_name`         | LINSTOR node hostname (for XOSTOR node metrics)                                                                                       |
+| `role`              | LINSTOR node role: `master` or `satellite` (for `xcp_xostor_node_status`)                                                             |
+| `state`             | LINSTOR node state (verbatim from `healthCheck`, e.g. `ONLINE`) or replica `disk-state` (e.g. `UpToDate`)                             |
+| `alarm_name`        | XAPI alarm message name: `ALARM`, `BOND_STATUS_CHANGED`, `MULTIPATH_PERIODIC_ALERT`                                                   |
+| `target_type`       | Object targeted by an alarm: `sr` or `host`                                                                                           |
+| `package`           | XOSTOR-related RPM name for pending updates                                                                                           |
+| `status`            | SMART overall-health string: `PASSED`, `FAILED`, `UNKNOWN`                                                                            |
 
 ### PromQL Query Examples
 
@@ -666,6 +701,34 @@ xo_nodejs_event_loop_utilization{metric="p99"}
 
 # Detect potential memory leak (growing detached contexts)
 xo_nodejs_detached_contexts > 0
+
+# XOSTOR cluster health (1 = reachable, 0 = healthCheck failing)
+xcp_xostor_up
+
+# Offline LINSTOR nodes
+xcp_xostor_node_status{state!="ONLINE"}
+
+# Replica health percentage per cluster (1.0 = all UpToDate)
+sum by (sr_uuid) (xcp_xostor_resource_state_count{state="UpToDate"})
+  / sum by (sr_uuid) (xcp_xostor_resource_state_count)
+
+# Degraded replicas (Inconsistent or Outdated)
+sum by (sr_uuid, pool_name) (xcp_xostor_resource_state_count{state=~"Inconsistent|Outdated"}) > 0
+
+# IOPS on LINSTOR SRs only
+sum by (sr_name) (xcp_host_disk_iops_total{sr_type="linstor"})
+
+# Network throughput split by SR type
+sum by (sr_type) (rate(xcp_host_network_receive_bytes_total[5m]))
+
+# Disks failing SMART (PASSED and OK are the good values)
+xcp_xostor_disk_smart_status{status!~"PASSED|OK"}
+
+# Hosts with pending XOSTOR updates
+count by (host_name) (xcp_xostor_package_update_available)
+
+# Active XAPI alarms on XOSTOR pools
+xcp_xostor_alarms_count > 0
 ```
 
 ### Grafana Integration
@@ -700,6 +763,12 @@ label_values(xcp_vm_cpu_usage{pool_name="$pool"}, vm_name)
 label_values(xcp_sr_physical_size_bytes{pool_name="$pool"}, sr_name)
 ```
 
+**XOSTOR SR variable** (for dashboards scoped to LINSTOR clusters only):
+
+```promql
+label_values(xcp_xostor_up, sr_uuid)
+```
+
 #### Example Panels
 
 **Host CPU Overview:**
@@ -727,6 +796,19 @@ xcp_vm_memory_bytes{vm_name="$vm"} / 1024 / 1024 / 1024
 xcp_sr_physical_usage_bytes{pool_name="$pool"}
 # Free space
 xcp_sr_physical_size_bytes{pool_name="$pool"} - xcp_sr_physical_usage_bytes{pool_name="$pool"}
+```
+
+**XOSTOR Replica Health (donut):**
+
+```promql
+sum by (state) (xcp_xostor_resource_state_count{sr_uuid=~"$xostor_sr"})
+```
+
+**XOSTOR IOPS (read / write split):**
+
+```promql
+sum by (sr_name) (xcp_host_disk_iops_read{sr_type="linstor"})
+sum by (sr_name) (xcp_host_disk_iops_write{sr_type="linstor"})
 ```
 
 ### Alerting with Alertmanager
@@ -861,6 +943,42 @@ groups:
         annotations:
           summary: 'Possible memory leak in XO process'
           description: 'The XO main process has {{ $value }} detached V8 contexts, which may indicate a memory leak.'
+
+      - alert: XostorClusterUnreachable
+        expr: xcp_xostor_up == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'XOSTOR cluster unreachable on {{ $labels.pool_name }}'
+          description: 'linstor-manager.healthCheck has been failing on SR {{ $labels.sr_uuid }} for more than 2 minutes.'
+
+      - alert: XostorNodeOffline
+        expr: xcp_xostor_node_status{state!="ONLINE"} == 1
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'LINSTOR {{ $labels.role }} {{ $labels.node_name }} is {{ $labels.state }}'
+          description: 'XOSTOR node {{ $labels.node_name }} on pool {{ $labels.pool_name }} reports state {{ $labels.state }}.'
+
+      - alert: XostorReplicasDegraded
+        expr: sum by (sr_uuid, pool_name) (xcp_xostor_resource_state_count{state=~"Inconsistent|Outdated"}) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Degraded LINSTOR replicas on {{ $labels.pool_name }}'
+          description: '{{ $value }} replicas are not UpToDate on XOSTOR SR {{ $labels.sr_uuid }}.'
+
+      - alert: XostorDiskSmartFailed
+        expr: xcp_xostor_disk_smart_status{status!~"PASSED|OK|UNKNOWN"} == 1
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'SMART failure on {{ $labels.device }} ({{ $labels.host_name }})'
+          description: 'Device {{ $labels.device }} on host {{ $labels.host_name }} reports SMART status {{ $labels.status }}.'
 ```
 
 ### Security Recommendations

--- a/packages/xo-server-openmetrics/src/index.mts
+++ b/packages/xo-server-openmetrics/src/index.mts
@@ -581,9 +581,12 @@ function tryParsePluginJson(raw: unknown, pluginLabel: string, contextId: string
 /**
  * Validate and normalize the `smartctl.py health` plugin response.
  *
- * Expected shape: `{ [device: string]: { status?: string, ... } }`. Unknown
- * or malformed entries collapse to `status: 'UNKNOWN'` rather than being
- * dropped — operators see *something* even when the upstream format drifts.
+ * Real shape (confirmed against XCP-ng 8.3 and the consumer in
+ * `xo-web/src/xo-app/host/tab-advanced.js`): `{ [device]: string }` where
+ * the value is the overall-health string directly (e.g. `'PASSED'`).
+ * Older or variant builds may wrap each entry in `{ status: '...' }`; both
+ * shapes are accepted. Malformed entries collapse to `'UNKNOWN'`.
+ *
  * Throws when the response is not a JSON object at all (caller catches and
  * surfaces via `up: false`).
  */
@@ -596,7 +599,9 @@ function parseXostorSmartHealth(raw: unknown, hostUuid: string): XostorSmartDevi
   const devices: XostorSmartDevice[] = []
   for (const [device, entry] of Object.entries(obj)) {
     let status: string = 'UNKNOWN'
-    if (entry !== null && typeof entry === 'object') {
+    if (typeof entry === 'string' && entry !== '') {
+      status = entry
+    } else if (entry !== null && typeof entry === 'object') {
       const rawStatus = (entry as Record<string, unknown>).status
       if (typeof rawStatus === 'string' && rawStatus !== '') {
         status = rawStatus

--- a/packages/xo-server-openmetrics/src/index.mts
+++ b/packages/xo-server-openmetrics/src/index.mts
@@ -97,7 +97,7 @@ export interface LabelLookupData {
   vms: Record<XoVm['uuid'] | XoVmController['uuid'], VmLabelInfo>
   hosts: Record<XoHost['uuid'], HostLabelInfo>
   srs: Record<XoSr['uuid'], SrLabelInfo>
-  srSuffixToUuid: Record<string, XoSr['uuid']> // maps UUID suffix to full SR UUID
+  srTruncatedToUuid: Record<string, XoSr['uuid']> // maps any UUID truncation (prefix or suffix) to the full SR UUID
   vdiUuidToSrUuid: Record<XoVdi['uuid'], XoSr['uuid']> // maps VDI UUID to parent SR UUID
 }
 
@@ -488,6 +488,32 @@ function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promi
       }
     )
   })
+}
+
+/** UUID truncation lengths used by XAPI RRD legends. */
+export const SR_UUID_TRUNCATIONS: ReadonlyArray<number> = [8, 12, 16, 20]
+
+/**
+ * Insert every (prefix, suffix) truncation of `uuid` into `index`, mapping
+ * each truncation to the full UUID. XCP-ng RRD legends encode the SR as the
+ * first 8 chars of the UUID, but older / variant builds may use the suffix;
+ * indexing both keeps the SR-name and `sr_type` resolution stable across
+ * versions. First match wins, so existing entries are never overwritten.
+ *
+ * Exported for testability.
+ */
+export function indexSrUuidTruncations(uuid: string, index: Record<string, string>): void {
+  for (const truncLen of SR_UUID_TRUNCATIONS) {
+    if (uuid.length < truncLen) continue
+    const prefix = uuid.slice(0, truncLen)
+    const suffix = uuid.slice(-truncLen)
+    if (index[prefix] === undefined) {
+      index[prefix] = uuid
+    }
+    if (index[suffix] === undefined) {
+      index[suffix] = uuid
+    }
+  }
 }
 
 /**
@@ -1722,7 +1748,7 @@ class OpenMetricsPlugin {
       vms: {},
       hosts: {},
       srs: {},
-      srSuffixToUuid: {},
+      srTruncatedToUuid: {},
       vdiUuidToSrUuid: {},
     }
 
@@ -1900,24 +1926,12 @@ class OpenMetricsPlugin {
       }
     }
 
-    // Build SR labels with suffix mapping
     for (const sr of srs) {
       labels.srs[sr.uuid] = {
         name_label: sr.name_label,
         SR_type: sr.SR_type ?? '',
       }
-
-      // Create suffix mappings for different suffix lengths (8, 12, 16 chars)
-      // SR metrics in RRD use truncated UUIDs
-      for (const suffixLen of [8, 12, 16, 20]) {
-        if (sr.uuid.length >= suffixLen) {
-          const suffix = sr.uuid.slice(-suffixLen)
-          // Only store if not already mapped (first match wins)
-          if (labels.srSuffixToUuid[suffix] === undefined) {
-            labels.srSuffixToUuid[suffix] = sr.uuid
-          }
-        }
-      }
+      indexSrUuidTruncations(sr.uuid, labels.srTruncatedToUuid)
     }
 
     logger.debug('Label lookup data built', {

--- a/packages/xo-server-openmetrics/src/index.mts
+++ b/packages/xo-server-openmetrics/src/index.mts
@@ -9,7 +9,9 @@
 import type {
   XoApp,
   XoHost,
+  XoMessage,
   XoNetwork,
+  XoPbd,
   XoPif,
   XoPool,
   XoSr,
@@ -84,6 +86,11 @@ export interface HostLabelInfo {
 
 export interface SrLabelInfo {
   name_label: string
+  /**
+   * Mirrors `XoSr.SR_type` (kept in CamelCase to match the XAPI source field).
+   * Resolved into the `sr_type` snake_case OpenMetrics label by `transformMetric`.
+   */
+  SR_type: string
 }
 
 export interface LabelLookupData {
@@ -102,6 +109,12 @@ interface XapiCredentialsPayload {
 export type SrDataItem = Pick<XoSr, 'uuid' | 'name_label' | 'size' | 'physical_usage' | 'usage'> & {
   pool_id: string
   pool_name: string
+  /**
+   * Verbatim `XoSr.SR_type` (e.g. `'linstor'`, `'lvm'`, `'nfs'`). Emitted as
+   * the `sr_type` OpenMetrics label so Grafana queries can filter / split
+   * by storage technology.
+   */
+  sr_type: string
   host_id?: string
   host_name?: string
 }
@@ -149,6 +162,8 @@ export type VdiDataItem = {
   usage: number
   sr_uuid: string
   sr_name: string
+  /** SR_type of the parent SR, mirrored as the `sr_type` label. */
+  sr_type: string
   pool_id: string
   pool_name: string
   vm_uuid?: string
@@ -177,8 +192,208 @@ interface VmStatusPayload {
   vms: VmStatusItem[]
 }
 
+/**
+ * XOSTOR cluster node entry.
+ *
+ * Represents a single LINSTOR node in a XOSTOR cluster, identified by
+ * its hostname. The role label distinguishes the pool master from satellites.
+ * The state label carries the raw status returned by linstor-manager.healthCheck.
+ */
+export interface XostorNodeItem {
+  node_name: string
+  role: 'master' | 'satellite'
+  state: string
+}
+
+/**
+ * XOSTOR cluster summary for a single LINSTOR-backed SR.
+ *
+ * `up` indicates whether the healthCheck call succeeded. When false, `nodes`
+ * is empty, `resourceCount` is 0, and `replicaStates` is `{}`; consumers
+ * should treat the cluster as unreachable rather than empty.
+ *
+ * `replicaStates` maps each `disk-state` value reported by `linstor-manager`
+ * (e.g., `UpToDate`, `Inconsistent`, `Outdated`, `Diskless`, `Unknown`) to the
+ * number of replicas across all resources in that state. The sum equals
+ * `# resources × replica_factor`.
+ */
+export interface XostorClusterItem {
+  sr_uuid: string
+  pool_id: string
+  pool_name: string
+  up: boolean
+  nodes: XostorNodeItem[]
+  resourceCount: number
+  replicaStates: Record<string, number>
+}
+
+export interface XostorPayload {
+  clusters: XostorClusterItem[]
+}
+
+/**
+ * One aggregated alarm bucket for a XOSTOR cluster.
+ *
+ * Counts the number of XAPI messages whose `name` matches `alarm_name` and
+ * whose `$object` is either the XOSTOR SR itself (`target_type='sr'`) or one
+ * of the hosts backing it via a PBD (`target_type='host'`).
+ */
+export interface XostorAlarmEntry {
+  alarm_name: string
+  target_type: 'sr' | 'host'
+  count: number
+}
+
+export interface XostorAlarmsItem {
+  sr_uuid: string
+  pool_id: string
+  pool_name: string
+  up: boolean
+  entries: XostorAlarmEntry[]
+}
+
+export interface XostorAlarmsPayload {
+  clusters: XostorAlarmsItem[]
+}
+
+/**
+ * One disk reported by `smartctl.py health` on a XOSTOR host.
+ *
+ * `status` is the raw overall-health string returned by the plugin
+ * (e.g. `"PASSED"`, `"FAILED"`, `"UNKNOWN"`). Verbatim — dashboards
+ * normalize via regex if they need to.
+ */
+export interface XostorSmartDevice {
+  device: string
+  status: string
+}
+
+/**
+ * SMART-health snapshot of a single XOSTOR host.
+ *
+ * `up` indicates whether the plugin call succeeded. When false, `devices`
+ * is empty and the host is considered unreachable for SMART data — most
+ * commonly because `smartctl.py` is not installed on the host.
+ */
+export interface XostorSmartHost {
+  sr_uuid: string
+  pool_id: string
+  pool_name: string
+  host_uuid: string
+  host_name: string
+  up: boolean
+  devices: XostorSmartDevice[]
+}
+
+export interface XostorSmartPayload {
+  hosts: XostorSmartHost[]
+}
+
+/**
+ * RPMs whose updates are relevant to a running XOSTOR cluster.
+ *
+ * Each entry must exactly match the `name` field reported by `updater.py
+ * check_update`, since matching is done by string equality. Update this set
+ * (and the parser) in lock-step if XCP-ng renames a LINSTOR-related package.
+ */
+export const XOSTOR_UPDATE_PACKAGES: ReadonlySet<string> = new Set([
+  'xcp-ng-linstor',
+  'xcp-ng-release-linstor',
+  'linstor-satellite',
+  'linstor-controller',
+  'xcp-ng-xapi-plugins',
+])
+
+/**
+ * One pending XOSTOR-related package update on a host.
+ *
+ * Severity is intentionally absent: XCP-ng's `updater.py check_update`
+ * payload does not carry advisory severity. Adding it as a constant
+ * `'Unknown'` would be misleading.
+ */
+export interface XostorUpdatePackage {
+  package: string
+}
+
+export interface XostorUpdateItem {
+  sr_uuid: string
+  pool_id: string
+  pool_name: string
+  host_uuid: string
+  host_name: string
+  up: boolean
+  packages: XostorUpdatePackage[]
+}
+
+export interface XostorUpdatesPayload {
+  hosts: XostorUpdateItem[]
+}
+
 // Union type for all XO objects we handle
 type XoObject = XoHost | XoPool | XoVm | XoVmController | XoVbd | XoVdi | XoVif | XoPif | XoSr | XoNetwork
+
+/**
+ * Names of XAPI message types treated as "alarms" by XO's web UI.
+ *
+ * Mirrors `isAlarm` in `packages/xo-server/src/utils.mjs`. Kept as a local
+ * constant because `xo-server-openmetrics` is a separate package without a
+ * runtime dependency on `xo-server`. Update both files in lock-step if XO
+ * grows the alarm-name set.
+ */
+const XAPI_ALARM_NAMES = new Set<string>(['ALARM', 'BOND_STATUS_CHANGED', 'MULTIPATH_PERIODIC_ALERT'])
+
+/**
+ * Subset of `linstor-manager.healthCheck` response we consume.
+ *
+ * The plugin returns a JSON-encoded string. The shape is not versioned and
+ * can grow (the frontend tolerates `resources` being absent on older plugins).
+ * We only depend on the two top-level maps and treat everything else as
+ * untyped.
+ */
+interface XostorHealthCheckRaw {
+  nodes?: Record<string, unknown>
+  resources?: Record<string, unknown>
+}
+
+/**
+ * Time-based cache with in-flight call coalescing.
+ *
+ * `get()` returns the cached value while fresh; on miss it invokes the
+ * supplied loader once and shares the same in-flight promise with any
+ * concurrent caller until the loader settles. Keeps the parent process from
+ * issuing redundant XAPI plugin calls when several Prometheus scrapes
+ * overlap a cache miss.
+ */
+class TtlCache<T> {
+  #ttlMs: number
+  #snapshot: { value: T; expiresAt: number } | undefined
+  #inFlight: Promise<T> | undefined
+
+  constructor(ttlMs: number) {
+    this.#ttlMs = ttlMs
+  }
+
+  async get(load: () => Promise<T>): Promise<T> {
+    const now = Date.now()
+    const snap = this.#snapshot
+    if (snap !== undefined && snap.expiresAt > now) {
+      return snap.value
+    }
+    if (this.#inFlight !== undefined) {
+      return this.#inFlight
+    }
+    const pending = load()
+      .then(value => {
+        this.#snapshot = { value, expiresAt: Date.now() + this.#ttlMs }
+        return value
+      })
+      .finally(() => {
+        this.#inFlight = undefined
+      })
+    this.#inFlight = pending
+    return pending
+  }
+}
 
 // ============================================================================
 // Constants
@@ -201,6 +416,43 @@ const IPC_TIMEOUT_MS = 10_000
 /** Default timeout for graceful shutdown in milliseconds */
 const SHUTDOWN_TIMEOUT_MS = 5_000
 
+/**
+ * Cache lifetime for XOSTOR healthCheck payload (ms).
+ *
+ * Prometheus scrapes typically run every 15s; the LINSTOR controller is much
+ * slower to interrogate. Caching the healthCheck output for 60s keeps the
+ * controller idle between scrapes without making the dashboard noticeably
+ * stale.
+ */
+const XOSTOR_CACHE_TTL_MS = 60_000
+
+/** Timeout for a single XOSTOR healthCheck plugin call (ms). */
+const XOSTOR_HEALTHCHECK_TIMEOUT_MS = 8_000
+
+/**
+ * Cache lifetime for the per-host SMART payload (ms).
+ *
+ * SMART overall-status changes on a multi-hour scale; 5 minutes keeps
+ * hosts idle between scrapes without making dashboards stale.
+ */
+const XOSTOR_SMART_CACHE_TTL_MS = 300_000
+
+/** Timeout for a single `smartctl.py health` plugin call (ms). */
+const XOSTOR_SMART_TIMEOUT_MS = 10_000
+
+/**
+ * Cache lifetime for the per-host pending-update payload (ms).
+ *
+ * `updater.py check_update` triggers a yum metadata refresh, which is slow
+ * and hits the upstream repos. Pending updates change on a multi-hour
+ * timescale, so a 1 hour cache keeps hosts idle without sacrificing
+ * dashboard freshness in any operationally meaningful way.
+ */
+const XOSTOR_UPDATES_CACHE_TTL_MS = 3_600_000
+
+/** Timeout for a single `updater.py check_update` plugin call (ms). */
+const XOSTOR_UPDATES_TIMEOUT_MS = 30_000
+
 // ============================================================================
 // Configuration Schema (exported for xo-server)
 // ============================================================================
@@ -219,6 +471,192 @@ export const configurationSchema = {
 }
 
 // ============================================================================
+// XOSTOR helpers (module scope)
+// ============================================================================
+
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms)
+    promise.then(
+      value => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      err => {
+        clearTimeout(timer)
+        reject(err)
+      }
+    )
+  })
+}
+
+/**
+ * Set of host IDs that back a XOSTOR SR via its PBDs.
+ *
+ * Each PBD links one host to one SR; the set deduplicates in case the same
+ * host shows up via multiple PBDs (rare but possible).
+ */
+function xostorHostIdsFromPbds(sr: XoSr, allPbds: Record<string, XoPbd>): Set<string> {
+  const hostIds = new Set<string>()
+  for (const pbdId of sr.$PBDs) {
+    const pbd = allPbds[pbdId]
+    if (pbd !== undefined) {
+      hostIds.add(pbd.host)
+    }
+  }
+  return hostIds
+}
+
+function findLinstorGroupName(sr: XoSr, allPbds: Record<string, XoPbd>): string | undefined {
+  for (const pbdId of sr.$PBDs) {
+    const pbd = allPbds[pbdId]
+    if (pbd === undefined) continue
+    const cfg = pbd.device_config as Record<string, unknown>
+    const groupName = cfg['group-name']
+    if (typeof groupName === 'string' && groupName !== '') {
+      return groupName
+    }
+  }
+  return undefined
+}
+
+/**
+ * Aggregate the `disk-state` of every replica across all resources.
+ *
+ * For each resource → each node → first volume → `disk-state`, increment a
+ * bucket. A missing or non-string `disk-state` collapses into the `Unknown`
+ * bucket so that the sum of all buckets equals the total replica count.
+ */
+function countReplicaStates(resources: Record<string, unknown>): Record<string, number> {
+  const counts: Record<string, number> = {}
+  for (const resource of Object.values(resources)) {
+    if (resource === null || typeof resource !== 'object') continue
+    const nodes = (resource as { nodes?: unknown }).nodes
+    if (nodes === null || typeof nodes !== 'object') continue
+    for (const nodeInfo of Object.values(nodes as Record<string, unknown>)) {
+      if (nodeInfo === null || typeof nodeInfo !== 'object') continue
+      const volumes = (nodeInfo as { volumes?: unknown }).volumes
+      let state: string = 'Unknown'
+      if (Array.isArray(volumes) && volumes.length > 0) {
+        const first = volumes[0]
+        if (first !== null && typeof first === 'object') {
+          const rawState = (first as Record<string, unknown>)['disk-state']
+          if (typeof rawState === 'string' && rawState !== '') {
+            state = rawState
+          }
+        }
+      }
+      counts[state] = (counts[state] ?? 0) + 1
+    }
+  }
+  return counts
+}
+
+/**
+ * Try to coerce a XAPI plugin response to a `Record<string, unknown>`.
+ *
+ * Logs a warning and returns `undefined` when the payload is not a string of
+ * valid JSON object or not an object at all. Callers decide whether to
+ * surface this as a soft failure (return empty) or hard failure (throw).
+ */
+function tryParsePluginJson(raw: unknown, pluginLabel: string, contextId: string): Record<string, unknown> | undefined {
+  let value: unknown
+  if (typeof raw === 'string') {
+    try {
+      value = JSON.parse(raw)
+    } catch (err) {
+      logger.warn(`Failed to JSON-parse ${pluginLabel} response`, { contextId, error: err })
+      return undefined
+    }
+  } else {
+    value = raw
+  }
+  if (value === null || typeof value !== 'object') {
+    logger.warn(`Unexpected ${pluginLabel} shape (not an object)`, { contextId })
+    return undefined
+  }
+  return value as Record<string, unknown>
+}
+
+/**
+ * Validate and normalize the `smartctl.py health` plugin response.
+ *
+ * Expected shape: `{ [device: string]: { status?: string, ... } }`. Unknown
+ * or malformed entries collapse to `status: 'UNKNOWN'` rather than being
+ * dropped — operators see *something* even when the upstream format drifts.
+ * Throws when the response is not a JSON object at all (caller catches and
+ * surfaces via `up: false`).
+ */
+function parseXostorSmartHealth(raw: unknown, hostUuid: string): XostorSmartDevice[] {
+  const obj = tryParsePluginJson(raw, 'smartctl.py', hostUuid)
+  if (obj === undefined) {
+    throw new Error('smartctl.py returned malformed payload')
+  }
+
+  const devices: XostorSmartDevice[] = []
+  for (const [device, entry] of Object.entries(obj)) {
+    let status: string = 'UNKNOWN'
+    if (entry !== null && typeof entry === 'object') {
+      const rawStatus = (entry as Record<string, unknown>).status
+      if (typeof rawStatus === 'string' && rawStatus !== '') {
+        status = rawStatus
+      }
+    }
+    devices.push({ device, status })
+  }
+  return devices
+}
+
+/**
+ * Validate `updater.py check_update` and extract XOSTOR-relevant packages.
+ *
+ * Expected shape: `{ [uuid: string]: { name?: string, ... } }` or an object
+ * with a top-level `error` field on failure (which we propagate as a throw
+ * so the host gets `up=false`).
+ *
+ * Matching against `XOSTOR_UPDATE_PACKAGES` is by exact equality of
+ * `entry.name`. Duplicates are deduped here; if multiple advisories target
+ * the same package, only one bucket is emitted.
+ */
+function parseXostorCheckUpdate(raw: unknown, hostUuid: string): XostorUpdatePackage[] {
+  const obj = tryParsePluginJson(raw, 'updater.py', hostUuid)
+  if (obj === undefined) {
+    throw new Error('updater.py returned malformed payload')
+  }
+  if (obj.error !== undefined && obj.error !== null) {
+    throw new Error(`updater.py error: ${String(obj.error)}`)
+  }
+
+  const seen = new Set<string>()
+  const packages: XostorUpdatePackage[] = []
+  for (const entry of Object.values(obj)) {
+    if (entry === null || typeof entry !== 'object') continue
+    const name = (entry as Record<string, unknown>).name
+    if (typeof name !== 'string' || name === '') continue
+    if (!XOSTOR_UPDATE_PACKAGES.has(name)) continue
+    if (seen.has(name)) continue
+    seen.add(name)
+    packages.push({ package: name })
+  }
+  return packages
+}
+
+function parseXostorHealthCheck(raw: unknown, srUuid: string): XostorHealthCheckRaw {
+  const obj = tryParsePluginJson(raw, 'linstor-manager.healthCheck', srUuid)
+  if (obj === undefined) {
+    return {}
+  }
+  const result: XostorHealthCheckRaw = {}
+  if (obj.nodes !== undefined && typeof obj.nodes === 'object' && obj.nodes !== null) {
+    result.nodes = obj.nodes as Record<string, unknown>
+  }
+  if (obj.resources !== undefined && typeof obj.resources === 'object' && obj.resources !== null) {
+    result.resources = obj.resources as Record<string, unknown>
+  }
+  return result
+}
+
+// ============================================================================
 // Plugin Class
 // ============================================================================
 
@@ -234,6 +672,10 @@ class OpenMetricsPlugin {
   #lastEluSnapshot = performance.eventLoopUtilization()
   #lastCpuUsage = process.cpuUsage()
   #eluSamplerInterval: ReturnType<typeof setInterval> | undefined
+
+  #xostorHealthCheckCache = new TtlCache<XostorPayload>(XOSTOR_CACHE_TTL_MS)
+  #xostorSmartCache = new TtlCache<XostorSmartPayload>(XOSTOR_SMART_CACHE_TTL_MS)
+  #xostorUpdatesCache = new TtlCache<XostorUpdatesPayload>(XOSTOR_UPDATES_CACHE_TTL_MS)
 
   constructor(xo: XoApp) {
     this.#xo = xo
@@ -461,6 +903,85 @@ class OpenMetricsPlugin {
         break
       }
 
+      case 'GET_XOSTOR_DATA': {
+        this.#getXostorData()
+          .then((xostorPayload: XostorPayload) => {
+            this.#sendToChildNoWait({
+              type: 'XOSTOR_DATA',
+              requestId: message.requestId,
+              payload: xostorPayload,
+            })
+          })
+          .catch((err: unknown) => {
+            logger.error('Failed to collect XOSTOR data', { error: err })
+            this.#sendToChildNoWait({
+              type: 'XOSTOR_DATA',
+              requestId: message.requestId,
+              payload: { clusters: [] },
+            })
+          })
+        break
+      }
+
+      case 'GET_XOSTOR_ALARMS': {
+        try {
+          const alarmsPayload = this.#getXostorAlarms()
+          this.#sendToChildNoWait({
+            type: 'XOSTOR_ALARMS',
+            requestId: message.requestId,
+            payload: alarmsPayload,
+          })
+        } catch (err) {
+          logger.error('Failed to collect XOSTOR alarms', { error: err })
+          this.#sendToChildNoWait({
+            type: 'XOSTOR_ALARMS',
+            requestId: message.requestId,
+            payload: { clusters: [] },
+          })
+        }
+        break
+      }
+
+      case 'GET_XOSTOR_SMART': {
+        this.#getXostorSmartHealth()
+          .then((smartPayload: XostorSmartPayload) => {
+            this.#sendToChildNoWait({
+              type: 'XOSTOR_SMART',
+              requestId: message.requestId,
+              payload: smartPayload,
+            })
+          })
+          .catch((err: unknown) => {
+            logger.error('Failed to collect XOSTOR SMART data', { error: err })
+            this.#sendToChildNoWait({
+              type: 'XOSTOR_SMART',
+              requestId: message.requestId,
+              payload: { hosts: [] },
+            })
+          })
+        break
+      }
+
+      case 'GET_XOSTOR_UPDATES': {
+        this.#getXostorUpdates()
+          .then((updatesPayload: XostorUpdatesPayload) => {
+            this.#sendToChildNoWait({
+              type: 'XOSTOR_UPDATES',
+              requestId: message.requestId,
+              payload: updatesPayload,
+            })
+          })
+          .catch((err: unknown) => {
+            logger.error('Failed to collect XOSTOR pending updates', { error: err })
+            this.#sendToChildNoWait({
+              type: 'XOSTOR_UPDATES',
+              requestId: message.requestId,
+              payload: { hosts: [] },
+            })
+          })
+        break
+      }
+
       case 'GET_XO_METRICS': {
         this.#getXoMetrics()
           .then((xoMetrics: XoMetricsData) => {
@@ -615,6 +1136,7 @@ class OpenMetricsPlugin {
         name_label: sr.name_label,
         pool_id: sr.$poolId,
         pool_name: poolLabelMap.get(sr.$poolId) ?? '',
+        sr_type: sr.SR_type ?? '',
         size: sr.size,
         physical_usage: sr.physical_usage,
         usage: sr.usage,
@@ -678,6 +1200,7 @@ class OpenMetricsPlugin {
         usage: vdi.usage,
         sr_uuid: sr.uuid,
         sr_name: sr.name_label,
+        sr_type: sr.SR_type ?? '',
         pool_id: sr.$poolId,
         pool_name: poolLabelMap.get(sr.$poolId) ?? '',
       }
@@ -759,6 +1282,292 @@ class OpenMetricsPlugin {
 
     logger.debug('Returning VM status data', { vmCount: vms.length })
     return { vms }
+  }
+
+  /**
+   * Collect XOSTOR cluster health data for every LINSTOR-backed SR.
+   *
+   * The healthCheck XAPI plugin call goes to the pool master and is
+   * relatively expensive; `TtlCache` caches the result for
+   * `XOSTOR_CACHE_TTL_MS` and coalesces concurrent scrapes.
+   *
+   * Per-SR failures are isolated: a failure on one cluster yields an
+   * `up: false` entry, leaving the other clusters' data intact.
+   */
+  #getXostorData(): Promise<XostorPayload> {
+    return this.#xostorHealthCheckCache.get(() => this.#collectXostorData())
+  }
+
+  async #collectXostorData(): Promise<XostorPayload> {
+    const allSrs = this.#xo.getObjects({ filter: { type: 'SR' } }) as Record<string, XoSr>
+    const allPools = this.#xo.getObjects({ filter: { type: 'pool' } }) as Record<string, XoPool>
+    const allHosts = this.#xo.getObjects({ filter: { type: 'host' } }) as Record<string, XoHost>
+    const allPbds = this.#xo.getObjects({ filter: { type: 'PBD' } }) as Record<string, XoPbd>
+
+    const clusters: XostorClusterItem[] = []
+    for (const sr of Object.values(allSrs)) {
+      if (sr.SR_type !== 'linstor') {
+        continue
+      }
+
+      const pool = allPools[sr.$poolId]
+      const master = pool !== undefined ? allHosts[pool.master] : undefined
+      const poolName = pool?.name_label ?? ''
+
+      const groupName = findLinstorGroupName(sr, allPbds)
+
+      if (master === undefined || groupName === undefined) {
+        logger.warn('Skipping XOSTOR healthCheck (missing master or group-name)', {
+          srUuid: sr.uuid,
+          poolId: sr.$poolId,
+        })
+        clusters.push({
+          sr_uuid: sr.uuid,
+          pool_id: sr.$poolId,
+          pool_name: poolName,
+          up: false,
+          nodes: [],
+          resourceCount: 0,
+          replicaStates: {},
+        })
+        continue
+      }
+
+      try {
+        const xapi = this.#xo.getXapi(sr)
+        const rawResponse = await withTimeout(
+          xapi.callAsync<string>('host.call_plugin', master._xapiRef, 'linstor-manager', 'healthCheck', { groupName }),
+          XOSTOR_HEALTHCHECK_TIMEOUT_MS,
+          'linstor-manager healthCheck timed out'
+        )
+
+        const parsed = parseXostorHealthCheck(rawResponse, sr.uuid)
+        const nodes: XostorNodeItem[] = []
+        for (const [hostname, rawState] of Object.entries(parsed.nodes ?? {})) {
+          nodes.push({
+            node_name: hostname,
+            role: hostname === master.hostname ? 'master' : 'satellite',
+            state: typeof rawState === 'string' ? rawState : JSON.stringify(rawState),
+          })
+        }
+
+        clusters.push({
+          sr_uuid: sr.uuid,
+          pool_id: sr.$poolId,
+          pool_name: poolName,
+          up: true,
+          nodes,
+          resourceCount: Object.keys(parsed.resources ?? {}).length,
+          replicaStates: countReplicaStates(parsed.resources ?? {}),
+        })
+      } catch (error) {
+        logger.warn('XOSTOR healthCheck failed', { srUuid: sr.uuid, poolId: sr.$poolId, error })
+        clusters.push({
+          sr_uuid: sr.uuid,
+          pool_id: sr.$poolId,
+          pool_name: poolName,
+          up: false,
+          nodes: [],
+          resourceCount: 0,
+          replicaStates: {},
+        })
+      }
+    }
+
+    logger.debug('Returning XOSTOR data', { clusterCount: clusters.length })
+    return { clusters }
+  }
+
+  /**
+   * Aggregate XAPI alarm messages per XOSTOR cluster.
+   *
+   * Walks `xo.getObjects()` in-memory — no plugin call, no network IO, no
+   * cache (the call is sub-millisecond). For each LINSTOR-backed SR, counts
+   * the messages whose `name` is in `XAPI_ALARM_NAMES` and whose `$object`
+   * targets the SR (`target_type='sr'`) or one of the hosts backing it via
+   * a PBD (`target_type='host'`).
+   *
+   * A host shared between multiple XOSTOR SRs sees its alarms counted in
+   * each cluster it backs — by design, since an underlying host issue
+   * degrades every SR on that host.
+   */
+  #getXostorAlarms(): XostorAlarmsPayload {
+    const allSrs = this.#xo.getObjects({ filter: { type: 'SR' } }) as Record<string, XoSr>
+    const xostorSrs = Object.values(allSrs).filter(sr => sr.SR_type === 'linstor')
+
+    // Skip the (potentially expensive) message-store scan on non-XOSTOR
+    // deployments. The message store on a busy XAPI can be in the thousands.
+    if (xostorSrs.length === 0) {
+      return { clusters: [] }
+    }
+
+    const allPools = this.#xo.getObjects({ filter: { type: 'pool' } }) as Record<string, XoPool>
+    const allPbds = this.#xo.getObjects({ filter: { type: 'PBD' } }) as Record<string, XoPbd>
+    const allMessages = this.#xo.getObjects({ filter: { type: 'message' } }) as Record<string, XoMessage>
+
+    const alarmMessages: XoMessage[] = []
+    for (const msg of Object.values(allMessages)) {
+      if (XAPI_ALARM_NAMES.has(msg.name)) {
+        alarmMessages.push(msg)
+      }
+    }
+
+    const clusters: XostorAlarmsItem[] = []
+    for (const sr of xostorSrs) {
+      const hostIds = xostorHostIdsFromPbds(sr, allPbds)
+
+      const buckets = new Map<string, XostorAlarmEntry>()
+      for (const msg of alarmMessages) {
+        const target = msg.$object
+        let targetType: 'sr' | 'host' | undefined
+        if (target === sr.id) {
+          targetType = 'sr'
+        } else if (hostIds.has(target)) {
+          targetType = 'host'
+        } else {
+          continue
+        }
+
+        const key = `${msg.name}|${targetType}`
+        const existing = buckets.get(key)
+        if (existing !== undefined) {
+          existing.count += 1
+        } else {
+          buckets.set(key, { alarm_name: msg.name, target_type: targetType, count: 1 })
+        }
+      }
+
+      clusters.push({
+        sr_uuid: sr.uuid,
+        pool_id: sr.$poolId,
+        pool_name: allPools[sr.$poolId]?.name_label ?? '',
+        up: true,
+        entries: [...buckets.values()],
+      })
+    }
+
+    logger.debug('Returning XOSTOR alarms', { clusterCount: clusters.length })
+    return { clusters }
+  }
+
+  /**
+   * Collect SMART overall-health for every host backing a XOSTOR PBD.
+   *
+   * Cached with `XOSTOR_SMART_CACHE_TTL_MS`. Each (sr, host) pair becomes its
+   * own `XostorSmartHost`. Per-host failures are isolated and surfaced via
+   * `up: false`; missing `smartctl.py` on a host is the same path.
+   */
+  #getXostorSmartHealth(): Promise<XostorSmartPayload> {
+    return this.#xostorSmartCache.get(() => this.#collectXostorSmartHealth())
+  }
+
+  async #collectXostorSmartHealth(): Promise<XostorSmartPayload> {
+    const allSrs = this.#xo.getObjects({ filter: { type: 'SR' } }) as Record<string, XoSr>
+    const allPools = this.#xo.getObjects({ filter: { type: 'pool' } }) as Record<string, XoPool>
+    const allHosts = this.#xo.getObjects({ filter: { type: 'host' } }) as Record<string, XoHost>
+    const allPbds = this.#xo.getObjects({ filter: { type: 'PBD' } }) as Record<string, XoPbd>
+
+    const tasks: Array<Promise<XostorSmartHost>> = []
+    for (const sr of Object.values(allSrs)) {
+      if (sr.SR_type !== 'linstor') continue
+
+      const poolName = allPools[sr.$poolId]?.name_label ?? ''
+
+      for (const hostId of xostorHostIdsFromPbds(sr, allPbds)) {
+        const host = allHosts[hostId]
+        if (host === undefined) continue
+
+        tasks.push(this.#fetchHostSmart(sr, poolName, host))
+      }
+    }
+
+    const hosts = await Promise.all(tasks)
+    logger.debug('Returning XOSTOR SMART data', { hostCount: hosts.length })
+    return { hosts }
+  }
+
+  async #fetchHostSmart(sr: XoSr, poolName: string, host: XoHost): Promise<XostorSmartHost> {
+    const base = {
+      sr_uuid: sr.uuid,
+      pool_id: sr.$poolId,
+      pool_name: poolName,
+      host_uuid: host.uuid,
+      host_name: host.name_label,
+    }
+
+    try {
+      const xapi = this.#xo.getXapi(sr)
+      const rawResponse = await withTimeout(
+        xapi.callAsync<string>('host.call_plugin', host._xapiRef, 'smartctl.py', 'health', {}),
+        XOSTOR_SMART_TIMEOUT_MS,
+        'smartctl.py health timed out'
+      )
+      const devices = parseXostorSmartHealth(rawResponse, host.uuid)
+      return { ...base, up: true, devices }
+    } catch (error) {
+      logger.warn('smartctl.py health failed', { srUuid: sr.uuid, hostUuid: host.uuid, error })
+      return { ...base, up: false, devices: [] }
+    }
+  }
+
+  /**
+   * Collect pending XOSTOR-related package updates for every host backing a
+   * XOSTOR PBD.
+   *
+   * Cached with `XOSTOR_UPDATES_CACHE_TTL_MS` (1 h). `updater.py check_update`
+   * is yum-metadata-heavy and unsuitable for per-scrape invocation.
+   */
+  #getXostorUpdates(): Promise<XostorUpdatesPayload> {
+    return this.#xostorUpdatesCache.get(() => this.#collectXostorUpdates())
+  }
+
+  async #collectXostorUpdates(): Promise<XostorUpdatesPayload> {
+    const allSrs = this.#xo.getObjects({ filter: { type: 'SR' } }) as Record<string, XoSr>
+    const allPools = this.#xo.getObjects({ filter: { type: 'pool' } }) as Record<string, XoPool>
+    const allHosts = this.#xo.getObjects({ filter: { type: 'host' } }) as Record<string, XoHost>
+    const allPbds = this.#xo.getObjects({ filter: { type: 'PBD' } }) as Record<string, XoPbd>
+
+    const tasks: Array<Promise<XostorUpdateItem>> = []
+    for (const sr of Object.values(allSrs)) {
+      if (sr.SR_type !== 'linstor') continue
+
+      const poolName = allPools[sr.$poolId]?.name_label ?? ''
+
+      for (const hostId of xostorHostIdsFromPbds(sr, allPbds)) {
+        const host = allHosts[hostId]
+        if (host === undefined) continue
+
+        tasks.push(this.#fetchHostUpdates(sr, poolName, host))
+      }
+    }
+
+    const hosts = await Promise.all(tasks)
+    logger.debug('Returning XOSTOR pending updates', { hostCount: hosts.length })
+    return { hosts }
+  }
+
+  async #fetchHostUpdates(sr: XoSr, poolName: string, host: XoHost): Promise<XostorUpdateItem> {
+    const base = {
+      sr_uuid: sr.uuid,
+      pool_id: sr.$poolId,
+      pool_name: poolName,
+      host_uuid: host.uuid,
+      host_name: host.name_label,
+    }
+
+    try {
+      const xapi = this.#xo.getXapi(sr)
+      const rawResponse = await withTimeout(
+        xapi.callAsync<string>('host.call_plugin', host._xapiRef, 'updater.py', 'check_update', {}),
+        XOSTOR_UPDATES_TIMEOUT_MS,
+        'updater.py check_update timed out'
+      )
+      const packages = parseXostorCheckUpdate(rawResponse, host.uuid)
+      return { ...base, up: true, packages }
+    } catch (error) {
+      logger.warn('updater.py check_update failed', { srUuid: sr.uuid, hostUuid: host.uuid, error })
+      return { ...base, up: false, packages: [] }
+    }
   }
 
   /**
@@ -1090,6 +1899,7 @@ class OpenMetricsPlugin {
     for (const sr of srs) {
       labels.srs[sr.uuid] = {
         name_label: sr.name_label,
+        SR_type: sr.SR_type ?? '',
       }
 
       // Create suffix mappings for different suffix lengths (8, 12, 16 chars)

--- a/packages/xo-server-openmetrics/src/open-metric-server.mts
+++ b/packages/xo-server-openmetrics/src/open-metric-server.mts
@@ -30,11 +30,19 @@ import {
   formatVmStatusMetrics,
   formatVmUptimeMetrics,
   formatXoMetrics,
+  formatXostorAlarmsMetrics,
+  formatXostorClusterMetrics,
+  formatXostorSmartMetrics,
+  formatXostorUpdatesMetrics,
   type HostStatusItem,
   type SrDataItem,
   type VdiDataItem,
   type VmStatusItem,
   type XoMetricsData,
+  type XostorAlarmsPayload,
+  type XostorPayload,
+  type XostorSmartPayload,
+  type XostorUpdatesPayload,
 } from './openmetric-formatter.mjs'
 
 const logger = createLogger('xo:xo-server-openmetrics:child')
@@ -87,6 +95,8 @@ interface HostLabelInfo {
 
 interface SrLabelInfo {
   name_label: string
+  /** Mirrors `XoSr.SR_type` — see the canonical type in `index.mts`. */
+  SR_type: string
 }
 
 interface LabelLookupData {
@@ -177,6 +187,10 @@ function handleParentMessage(rawMessage: unknown): void {
     case 'HOST_STATUS':
     case 'VM_STATUS':
     case 'XO_METRICS':
+    case 'XOSTOR_DATA':
+    case 'XOSTOR_ALARMS':
+    case 'XOSTOR_SMART':
+    case 'XOSTOR_UPDATES':
       resolvePendingRequest(message)
       break
 
@@ -365,6 +379,82 @@ async function requestXoMetrics(): Promise<XoMetricsData> {
   })
 }
 
+async function requestXostorData(): Promise<XostorPayload> {
+  const requestId = `xostor-${++requestIdCounter}`
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      pendingRequests.delete(requestId)
+      reject(new Error('Timeout waiting for XOSTOR data from parent'))
+    }, IPC_REQUEST_TIMEOUT_MS)
+
+    pendingRequests.set(requestId, {
+      resolve: value => resolve(value as XostorPayload),
+      reject,
+      timer,
+    })
+
+    sendToParent({ type: 'GET_XOSTOR_DATA', requestId })
+  })
+}
+
+async function requestXostorAlarms(): Promise<XostorAlarmsPayload> {
+  const requestId = `xostor-alarms-${++requestIdCounter}`
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      pendingRequests.delete(requestId)
+      reject(new Error('Timeout waiting for XOSTOR alarms from parent'))
+    }, IPC_REQUEST_TIMEOUT_MS)
+
+    pendingRequests.set(requestId, {
+      resolve: value => resolve(value as XostorAlarmsPayload),
+      reject,
+      timer,
+    })
+
+    sendToParent({ type: 'GET_XOSTOR_ALARMS', requestId })
+  })
+}
+
+async function requestXostorSmart(): Promise<XostorSmartPayload> {
+  const requestId = `xostor-smart-${++requestIdCounter}`
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      pendingRequests.delete(requestId)
+      reject(new Error('Timeout waiting for XOSTOR SMART data from parent'))
+    }, IPC_REQUEST_TIMEOUT_MS)
+
+    pendingRequests.set(requestId, {
+      resolve: value => resolve(value as XostorSmartPayload),
+      reject,
+      timer,
+    })
+
+    sendToParent({ type: 'GET_XOSTOR_SMART', requestId })
+  })
+}
+
+async function requestXostorUpdates(): Promise<XostorUpdatesPayload> {
+  const requestId = `xostor-updates-${++requestIdCounter}`
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      pendingRequests.delete(requestId)
+      reject(new Error('Timeout waiting for XOSTOR updates from parent'))
+    }, IPC_REQUEST_TIMEOUT_MS)
+
+    pendingRequests.set(requestId, {
+      resolve: value => resolve(value as XostorUpdatesPayload),
+      reject,
+      timer,
+    })
+
+    sendToParent({ type: 'GET_XOSTOR_UPDATES', requestId })
+  })
+}
+
 // ============================================================================
 // RRD Data Fetching
 // ============================================================================
@@ -442,14 +532,41 @@ async function fetchRrdFromHost(host: HostCredentials): Promise<ParsedRrdData | 
  *
  * @returns OpenMetrics-formatted string
  */
+/**
+ * Wrap an XOSTOR IPC request so any failure logs a warning and yields the
+ * supplied fallback. Keeps `/metrics` responding even when one collector
+ * misbehaves.
+ */
+function safeXostorRequest<T>(promise: Promise<T>, label: string, empty: T): Promise<T> {
+  return promise.catch((err: unknown) => {
+    logger.warn(`XOSTOR ${label} request failed; emitting empty payload`, { error: err })
+    return empty
+  })
+}
+
 async function collectMetrics(): Promise<string> {
-  const [credentials, srData, vdiData, hostStatusData, vmStatusData, xoMetricsData] = await Promise.all([
+  const [
+    credentials,
+    srData,
+    vdiData,
+    hostStatusData,
+    vmStatusData,
+    xoMetricsData,
+    xostorData,
+    xostorAlarms,
+    xostorSmart,
+    xostorUpdates,
+  ] = await Promise.all([
     requestXapiCredentials(),
     requestSrData(),
     requestVdiData(),
     requestHostStatusData(),
     requestVmStatusData(),
     requestXoMetrics(),
+    safeXostorRequest(requestXostorData(), 'data', { clusters: [] } as XostorPayload),
+    safeXostorRequest(requestXostorAlarms(), 'alarms', { clusters: [] } as XostorAlarmsPayload),
+    safeXostorRequest(requestXostorSmart(), 'SMART', { hosts: [] } as XostorSmartPayload),
+    safeXostorRequest(requestXostorUpdates(), 'updates', { hosts: [] } as XostorUpdatesPayload),
   ])
 
   logger.debug('Collecting metrics', {
@@ -458,6 +575,10 @@ async function collectMetrics(): Promise<string> {
     vdiCount: vdiData.vdis.length,
     hostStatusCount: hostStatusData.hosts.length,
     vmStatusCount: vmStatusData.vms.length,
+    xostorClusterCount: xostorData.clusters.length,
+    xostorAlarmClusterCount: xostorAlarms.clusters.length,
+    xostorSmartHostCount: xostorSmart.hosts.length,
+    xostorUpdatesHostCount: xostorUpdates.hosts.length,
   })
 
   if (credentials.hosts.length === 0) {
@@ -542,6 +663,26 @@ async function collectMetrics(): Promise<string> {
   const xoMetricsOutput = xoMetrics.length > 0 ? formatToOpenMetrics(xoMetrics) : ''
   logger.debug('Formatted XO metrics', { count: xoMetrics.length })
 
+  // Format XOSTOR cluster metrics
+  const xostorMetrics = formatXostorClusterMetrics(xostorData)
+  const xostorMetricsOutput = xostorMetrics.length > 0 ? formatToOpenMetrics(xostorMetrics) : ''
+  logger.debug('Formatted XOSTOR metrics', { count: xostorMetrics.length })
+
+  // Format XOSTOR alarm metrics
+  const xostorAlarmsMetrics = formatXostorAlarmsMetrics(xostorAlarms)
+  const xostorAlarmsOutput = xostorAlarmsMetrics.length > 0 ? formatToOpenMetrics(xostorAlarmsMetrics) : ''
+  logger.debug('Formatted XOSTOR alarm metrics', { count: xostorAlarmsMetrics.length })
+
+  // Format XOSTOR SMART metrics
+  const xostorSmartMetrics = formatXostorSmartMetrics(xostorSmart)
+  const xostorSmartOutput = xostorSmartMetrics.length > 0 ? formatToOpenMetrics(xostorSmartMetrics) : ''
+  logger.debug('Formatted XOSTOR SMART metrics', { count: xostorSmartMetrics.length })
+
+  // Format XOSTOR pending-updates metrics
+  const xostorUpdatesMetrics = formatXostorUpdatesMetrics(xostorUpdates)
+  const xostorUpdatesOutput = xostorUpdatesMetrics.length > 0 ? formatToOpenMetrics(xostorUpdatesMetrics) : ''
+  logger.debug('Formatted XOSTOR update metrics', { count: xostorUpdatesMetrics.length })
+
   // Combine pool metrics with RRD metrics, SR metrics, host status metrics, uptime metrics, and XO metrics
   // Remove the # EOF from rrdMetrics if present (we'll add our own)
   const rrdMetricsWithoutEof = rrdMetrics.replace(/\n# EOF$/, '')
@@ -578,6 +719,22 @@ async function collectMetrics(): Promise<string> {
 
   if (xoMetricsOutput !== '') {
     allMetricsSections.push(xoMetricsOutput)
+  }
+
+  if (xostorMetricsOutput !== '') {
+    allMetricsSections.push(xostorMetricsOutput)
+  }
+
+  if (xostorAlarmsOutput !== '') {
+    allMetricsSections.push(xostorAlarmsOutput)
+  }
+
+  if (xostorSmartOutput !== '') {
+    allMetricsSections.push(xostorSmartOutput)
+  }
+
+  if (xostorUpdatesOutput !== '') {
+    allMetricsSections.push(xostorUpdatesOutput)
   }
 
   return allMetricsSections.join('\n') + '\n# EOF'

--- a/packages/xo-server-openmetrics/src/open-metric-server.mts
+++ b/packages/xo-server-openmetrics/src/open-metric-server.mts
@@ -103,7 +103,7 @@ interface LabelLookupData {
   vms: Record<string, VmLabelInfo>
   hosts: Record<string, HostLabelInfo>
   srs: Record<string, SrLabelInfo>
-  srSuffixToUuid: Record<string, string>
+  srTruncatedToUuid: Record<string, string>
   vdiUuidToSrUuid: Record<string, string>
 }
 

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.mts
@@ -7,10 +7,45 @@
 
 import { createLogger } from '@xen-orchestra/log'
 
-import type { HostStatusItem, LabelLookupData, SrDataItem, VdiDataItem, VmStatusItem, XoMetricsData } from './index.mjs'
+import type {
+  HostStatusItem,
+  LabelLookupData,
+  SrDataItem,
+  VdiDataItem,
+  VmStatusItem,
+  XoMetricsData,
+  XostorAlarmEntry,
+  XostorAlarmsItem,
+  XostorAlarmsPayload,
+  XostorClusterItem,
+  XostorPayload,
+  XostorSmartDevice,
+  XostorSmartHost,
+  XostorSmartPayload,
+  XostorUpdateItem,
+  XostorUpdatePackage,
+  XostorUpdatesPayload,
+} from './index.mjs'
 import type { ParsedMetric, ParsedRrdData } from './rrd-parser.mjs'
 
-export type { HostStatusItem, SrDataItem, VdiDataItem, VmStatusItem, XoMetricsData }
+export type {
+  HostStatusItem,
+  SrDataItem,
+  VdiDataItem,
+  VmStatusItem,
+  XoMetricsData,
+  XostorAlarmEntry,
+  XostorAlarmsItem,
+  XostorAlarmsPayload,
+  XostorClusterItem,
+  XostorPayload,
+  XostorSmartDevice,
+  XostorSmartHost,
+  XostorSmartPayload,
+  XostorUpdateItem,
+  XostorUpdatePackage,
+  XostorUpdatesPayload,
+}
 
 const logger = createLogger('xo:xo-server-openmetrics:formatter')
 
@@ -811,8 +846,13 @@ export function transformMetric(
           const srUuid = labelContext.labels.srSuffixToUuid[srSuffix]
           if (srUuid !== undefined) {
             const srInfo = labelContext.labels.srs[srUuid]
-            if (srInfo !== undefined && srInfo.name_label !== '') {
-              labels.sr_name = srInfo.name_label
+            if (srInfo !== undefined) {
+              if (srInfo.name_label !== '') {
+                labels.sr_name = srInfo.name_label
+              }
+              if (srInfo.SR_type !== '') {
+                labels.sr_type = srInfo.SR_type
+              }
             }
           }
         }
@@ -834,14 +874,19 @@ export function transformMetric(
             labels.vdi_name = vdiName
           }
 
-          // Resolve sr_name via device → VDI UUID → SR UUID → SR name
+          // Resolve sr_name and sr_type via device → VDI UUID → SR UUID → SR info
           const vdiUuid = vmInfo.vbdDeviceToVdiUuid[extractedLabels.device]
           if (vdiUuid !== undefined) {
             const srUuid = labelContext.labels.vdiUuidToSrUuid[vdiUuid]
             if (srUuid !== undefined) {
               const srInfo = labelContext.labels.srs[srUuid]
-              if (srInfo !== undefined && srInfo.name_label !== '') {
-                labels.sr_name = srInfo.name_label
+              if (srInfo !== undefined) {
+                if (srInfo.name_label !== '') {
+                  labels.sr_name = srInfo.name_label
+                }
+                if (srInfo.SR_type !== '') {
+                  labels.sr_type = srInfo.SR_type
+                }
               }
             }
           }
@@ -1001,6 +1046,9 @@ export function formatSrMetrics(srDataList: SrDataItem[]): FormattedMetric[] {
     if (sr.pool_name !== '') {
       baseLabels.pool_name = sr.pool_name
     }
+    if (sr.sr_type !== '') {
+      baseLabels.sr_type = sr.sr_type
+    }
 
     // For local SRs, add host information
     if (sr.host_id !== undefined) {
@@ -1071,6 +1119,9 @@ export function formatVdiMetrics(vdiDataList: VdiDataItem[]): FormattedMetric[] 
 
     if (vdi.pool_name !== '') {
       baseLabels.pool_name = vdi.pool_name
+    }
+    if (vdi.sr_type !== '') {
+      baseLabels.sr_type = vdi.sr_type
     }
 
     // Add VM labels if VDI is attached to a VM
@@ -1178,6 +1229,276 @@ export function formatVmStatusMetrics(vmStatusList: VmStatusItem[]): FormattedMe
       value: 1,
       timestamp,
     })
+  }
+
+  return metrics
+}
+
+/**
+ * Format XOSTOR cluster metrics derived from `linstor-manager.healthCheck`.
+ *
+ * Produces three metric families per detected LINSTOR-backed SR:
+ *  - `xcp_xostor_up` (gauge): 1 when healthCheck succeeded, 0 otherwise.
+ *    Acts as a collection-health signal so a silently-failing cluster shows
+ *    up on the dashboard instead of disappearing.
+ *  - `xcp_xostor_node_status` (gauge, value = 1): one entry per LINSTOR node,
+ *    with `role` (master|satellite) and `state` labels. Following the same
+ *    pattern as `xcp_host_status`, the actual state is carried by the label
+ *    rather than encoded as a numeric value.
+ *  - `xcp_xostor_resource_total` (gauge): total count of LINSTOR resources
+ *    in the cluster — Phase 1 analogue of the proposed OSD count.
+ */
+export function formatXostorClusterMetrics(payload: XostorPayload): FormattedMetric[] {
+  const metrics: FormattedMetric[] = []
+  if (payload.clusters.length === 0) {
+    return metrics
+  }
+
+  const timestamp = Math.floor(Date.now() / 1000)
+
+  for (const cluster of payload.clusters) {
+    const baseLabels: Record<string, string> = {
+      sr_uuid: cluster.sr_uuid,
+      pool_id: cluster.pool_id,
+    }
+    if (cluster.pool_name !== '') {
+      baseLabels.pool_name = cluster.pool_name
+    }
+
+    metrics.push({
+      name: `${METRIC_PREFIX}_xostor_up`,
+      help: 'XOSTOR cluster reachability (1 = healthCheck succeeded, 0 = collection failed)',
+      type: 'gauge',
+      labels: { ...baseLabels },
+      value: cluster.up ? 1 : 0,
+      timestamp,
+    })
+
+    for (const node of cluster.nodes) {
+      metrics.push({
+        name: `${METRIC_PREFIX}_xostor_node_status`,
+        help: 'XOSTOR cluster node status (always 1; current state is carried by the role and state labels)',
+        type: 'gauge',
+        labels: {
+          ...baseLabels,
+          node_name: node.node_name,
+          role: node.role,
+          state: node.state,
+        },
+        value: 1,
+        timestamp,
+      })
+    }
+
+    metrics.push({
+      name: `${METRIC_PREFIX}_xostor_resource_total`,
+      help: 'Total number of LINSTOR resources defined in the XOSTOR cluster',
+      type: 'gauge',
+      labels: { ...baseLabels },
+      value: cluster.resourceCount,
+      timestamp,
+    })
+
+    for (const [state, count] of Object.entries(cluster.replicaStates)) {
+      metrics.push({
+        name: `${METRIC_PREFIX}_xostor_resource_state_count`,
+        help: 'Number of LINSTOR resource replicas in each disk-state across the XOSTOR cluster',
+        type: 'gauge',
+        labels: { ...baseLabels, state },
+        value: count,
+        timestamp,
+      })
+    }
+  }
+
+  return metrics
+}
+
+/**
+ * Format XOSTOR active alarm metrics derived from XAPI messages.
+ *
+ * Two metric families per cluster:
+ *  - `xcp_xostor_alarms_up` (gauge): 1 when alarm collection succeeded, 0
+ *    otherwise. Mirrors the per-feature collection-status pattern used by
+ *    Phase 1's `xcp_xostor_up`.
+ *  - `xcp_xostor_alarms_count` (gauge): one series per
+ *    (cluster, alarm_name, target_type) carrying the number of matching
+ *    XAPI messages. Buckets with zero count are not emitted; their absence
+ *    means "no such alarm currently raised".
+ *
+ * Designed so PromQL alerting rules can express
+ * `sum by (sr_uuid) (xcp_xostor_alarms_count) > 0` without per-host knowledge.
+ */
+export function formatXostorAlarmsMetrics(payload: XostorAlarmsPayload): FormattedMetric[] {
+  const metrics: FormattedMetric[] = []
+  if (payload.clusters.length === 0) {
+    return metrics
+  }
+
+  const timestamp = Math.floor(Date.now() / 1000)
+
+  for (const cluster of payload.clusters) {
+    const baseLabels: Record<string, string> = {
+      sr_uuid: cluster.sr_uuid,
+      pool_id: cluster.pool_id,
+    }
+    if (cluster.pool_name !== '') {
+      baseLabels.pool_name = cluster.pool_name
+    }
+
+    metrics.push({
+      name: `${METRIC_PREFIX}_xostor_alarms_up`,
+      help: 'XOSTOR alarm collection success (1 = collected, 0 = collection failed)',
+      type: 'gauge',
+      labels: { ...baseLabels },
+      value: cluster.up ? 1 : 0,
+      timestamp,
+    })
+
+    for (const entry of cluster.entries) {
+      metrics.push({
+        name: `${METRIC_PREFIX}_xostor_alarms_count`,
+        help: 'Number of active XAPI alarm messages targeting a XOSTOR SR or one of its hosts',
+        type: 'gauge',
+        labels: {
+          ...baseLabels,
+          alarm_name: entry.alarm_name,
+          target_type: entry.target_type,
+        },
+        value: entry.count,
+        timestamp,
+      })
+    }
+  }
+
+  return metrics
+}
+
+/**
+ * Format XOSTOR per-host SMART health metrics derived from `smartctl.py`.
+ *
+ * Two metric families per XOSTOR host:
+ *  - `xcp_xostor_smart_up` (gauge): 1 when the plugin returned data, 0 when
+ *    the plugin call failed or `smartctl.py` is not installed on the host.
+ *    Always emitted so absence is unambiguous.
+ *  - `xcp_xostor_disk_smart_status` (gauge, value=1): one series per
+ *    (host, device) carrying the overall-health string as a `status` label.
+ *    Following the same pattern as `xcp_host_status` and
+ *    `xcp_xostor_node_status`, the actual state lives in a label rather
+ *    than the value.
+ *
+ * The host scope is "every host backing a XOSTOR PBD" — non-XOSTOR disks
+ * on these hosts are still relevant because a boot disk failure removes
+ * the node from the cluster.
+ */
+export function formatXostorSmartMetrics(payload: XostorSmartPayload): FormattedMetric[] {
+  const metrics: FormattedMetric[] = []
+  if (payload.hosts.length === 0) {
+    return metrics
+  }
+
+  const timestamp = Math.floor(Date.now() / 1000)
+
+  for (const host of payload.hosts) {
+    const baseLabels: Record<string, string> = {
+      sr_uuid: host.sr_uuid,
+      pool_id: host.pool_id,
+      host_uuid: host.host_uuid,
+    }
+    if (host.pool_name !== '') {
+      baseLabels.pool_name = host.pool_name
+    }
+    if (host.host_name !== '') {
+      baseLabels.host_name = host.host_name
+    }
+
+    metrics.push({
+      name: `${METRIC_PREFIX}_xostor_smart_up`,
+      help: 'XOSTOR SMART data collection success per host (1 = smartctl.py replied, 0 = plugin missing or call failed)',
+      type: 'gauge',
+      labels: { ...baseLabels },
+      value: host.up ? 1 : 0,
+      timestamp,
+    })
+
+    for (const device of host.devices) {
+      metrics.push({
+        name: `${METRIC_PREFIX}_xostor_disk_smart_status`,
+        help: 'SMART overall-health status per disk on a XOSTOR host (always 1; current status is carried by the status label)',
+        type: 'gauge',
+        labels: {
+          ...baseLabels,
+          device: device.device,
+          status: device.status,
+        },
+        value: 1,
+        timestamp,
+      })
+    }
+  }
+
+  return metrics
+}
+
+/**
+ * Format XOSTOR pending-update metrics derived from `updater.py check_update`.
+ *
+ * Two metric families per XOSTOR host:
+ *  - `xcp_xostor_updates_up` (gauge): 1 when the plugin returned data, 0
+ *    when the call failed or repos are unreachable (e.g. air-gapped hosts).
+ *  - `xcp_xostor_package_update_available` (gauge, value=1): one entry per
+ *    pending package update on a host. Emitted with a *presence* pattern
+ *    (no `0` lines) — absence means "no update pending AND collection
+ *    succeeded" (because `_up=1`). Duplicate package entries collapse to a
+ *    single series.
+ *
+ * No `severity` label is exposed: XCP-ng's `updater.py` payload does not
+ * carry one and emitting a constant placeholder would mislead operators.
+ */
+export function formatXostorUpdatesMetrics(payload: XostorUpdatesPayload): FormattedMetric[] {
+  const metrics: FormattedMetric[] = []
+  if (payload.hosts.length === 0) {
+    return metrics
+  }
+
+  const timestamp = Math.floor(Date.now() / 1000)
+
+  for (const host of payload.hosts) {
+    const baseLabels: Record<string, string> = {
+      sr_uuid: host.sr_uuid,
+      pool_id: host.pool_id,
+      host_uuid: host.host_uuid,
+    }
+    if (host.pool_name !== '') {
+      baseLabels.pool_name = host.pool_name
+    }
+    if (host.host_name !== '') {
+      baseLabels.host_name = host.host_name
+    }
+
+    metrics.push({
+      name: `${METRIC_PREFIX}_xostor_updates_up`,
+      help: 'XOSTOR update check success per host (1 = updater.py replied, 0 = call failed or repo unreachable)',
+      type: 'gauge',
+      labels: { ...baseLabels },
+      value: host.up ? 1 : 0,
+      timestamp,
+    })
+
+    const seenPackages = new Set<string>()
+    for (const entry of host.packages) {
+      if (seenPackages.has(entry.package)) continue
+      seenPackages.add(entry.package)
+
+      metrics.push({
+        name: `${METRIC_PREFIX}_xostor_package_update_available`,
+        help: 'Pending XOSTOR-related package update on a host (always 1; absent means no update pending)',
+        type: 'gauge',
+        labels: { ...baseLabels, package: entry.package },
+        value: 1,
+        timestamp,
+      })
+    }
   }
 
   return metrics

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.mts
@@ -843,7 +843,7 @@ export function transformMetric(
         if (extractedLabels.sr !== undefined) {
           const srSuffix = extractedLabels.sr
           // Try to find the full SR UUID from the suffix
-          const srUuid = labelContext.labels.srSuffixToUuid[srSuffix]
+          const srUuid = labelContext.labels.srTruncatedToUuid[srSuffix]
           if (srUuid !== undefined) {
             const srInfo = labelContext.labels.srs[srUuid]
             if (srInfo !== undefined) {

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
@@ -3146,11 +3146,13 @@ describe('indexSrUuidTruncations', () => {
   })
 
   it('should not overwrite existing entries (first match wins)', () => {
-    const index: Record<string, string> = { c787b75c: 'first-sr-uuid' }
+    const uuid = 'c787b75c-3e0d-70fa-d0c3-cbfd382d7e33'
+    const prefix = uuid.slice(0, 8)
+    const index: Record<string, string> = { [prefix]: 'first-sr-uuid' }
 
-    indexSrUuidTruncations('c787b75c-3e0d-70fa-d0c3-cbfd382d7e33', index)
+    indexSrUuidTruncations(uuid, index)
 
-    assert.equal(index['c787b75c'], 'first-sr-uuid')
+    assert.equal(index[prefix], 'first-sr-uuid')
   })
 
   it('should skip truncations longer than the UUID itself', () => {

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
@@ -26,6 +26,8 @@ import {
   type LabelContext,
 } from './openmetric-formatter.mjs'
 
+import { indexSrUuidTruncations } from './index.mjs'
+
 import type {
   HostStatusItem,
   SrDataItem,
@@ -770,7 +772,7 @@ describe('transformMetric with labelContext', () => {
           SR_type: 'lvm',
         },
       },
-      srSuffixToUuid: {
+      srTruncatedToUuid: {
         '1234567890': 'sr-uuid-full-1234567890',
       },
       vdiUuidToSrUuid: {
@@ -1001,6 +1003,35 @@ describe('transformMetric with labelContext', () => {
     assert.equal(result.labels.sr_type, undefined)
   })
 
+  it('should resolve sr_name and sr_type from a UUID prefix (XCP-ng RRD encoding)', () => {
+    // XCP-ng encodes the SR in RRD legends as the first 8 chars of the UUID.
+    // The label context must therefore index that prefix.
+    const fullUuid = 'c787b75c-3e0d-70fa-d0c3-cbfd382d7e33'
+    const prefix = fullUuid.slice(0, 8)
+    const ctx = createLabelContext()
+    ctx.labels.srs[fullUuid] = { name_label: 'XOSTOR NVME', SR_type: 'linstor' }
+    ctx.labels.srTruncatedToUuid[prefix] = fullUuid
+
+    const metric: ParsedMetric = {
+      legend: {
+        cf: 'AVERAGE',
+        objectType: 'host',
+        uuid: 'host-uuid-123',
+        metricName: `iops_read_${prefix}`,
+        rawLegend: `AVERAGE:host:host-uuid-123:iops_read_${prefix}`,
+      },
+      value: 42,
+      timestamp: 1700000000,
+    }
+
+    const result = transformMetric(metric, 'pool-456', ctx)
+
+    assert.ok(result)
+    assert.equal(result.labels.sr, prefix)
+    assert.equal(result.labels.sr_name, 'XOSTOR NVME')
+    assert.equal(result.labels.sr_type, 'linstor')
+  })
+
   it('should handle missing label context gracefully', () => {
     const metric: ParsedMetric = {
       legend: {
@@ -1149,7 +1180,7 @@ describe('formatAllPoolsToOpenMetrics with labelContext', () => {
         },
       },
       srs: {},
-      srSuffixToUuid: {},
+      srTruncatedToUuid: {},
       vdiUuidToSrUuid: {},
     },
   })
@@ -1414,7 +1445,7 @@ describe('CPU usage fallback', () => {
         },
         hosts: {},
         srs: {},
-        srSuffixToUuid: {},
+        srTruncatedToUuid: {},
         vdiUuidToSrUuid: {},
       },
     }
@@ -1672,7 +1703,7 @@ describe('formatHostUptimeMetrics', () => {
         },
       },
       srs: {},
-      srSuffixToUuid: {},
+      srTruncatedToUuid: {},
       vdiUuidToSrUuid: {},
     },
   })
@@ -1722,7 +1753,7 @@ describe('formatHostUptimeMetrics', () => {
         vms: {},
         hosts: {},
         srs: {},
-        srSuffixToUuid: {},
+        srTruncatedToUuid: {},
         vdiUuidToSrUuid: {},
       },
     }
@@ -1770,7 +1801,7 @@ describe('formatHostUptimeMetrics', () => {
           },
         },
         srs: {},
-        srSuffixToUuid: {},
+        srTruncatedToUuid: {},
         vdiUuidToSrUuid: {},
       },
     }
@@ -1810,7 +1841,7 @@ describe('formatHostUptimeMetrics', () => {
           },
         },
         srs: {},
-        srSuffixToUuid: {},
+        srTruncatedToUuid: {},
         vdiUuidToSrUuid: {},
       },
     }
@@ -1845,7 +1876,7 @@ describe('formatHostUptimeMetrics', () => {
           },
         },
         srs: {},
-        srSuffixToUuid: {},
+        srTruncatedToUuid: {},
         vdiUuidToSrUuid: {},
       },
     }
@@ -2291,7 +2322,7 @@ describe('formatVmUptimeMetrics', () => {
         },
       },
       srs: {},
-      srSuffixToUuid: {},
+      srTruncatedToUuid: {},
       vdiUuidToSrUuid: {},
     },
   })
@@ -2379,7 +2410,7 @@ describe('formatVmUptimeMetrics', () => {
           },
         },
         srs: {},
-        srSuffixToUuid: {},
+        srTruncatedToUuid: {},
         vdiUuidToSrUuid: {},
       },
     }
@@ -3089,5 +3120,46 @@ describe('formatXostorUpdatesMetrics', () => {
     assert.match(output, /# HELP xcp_xostor_package_update_available /)
     assert.match(output, /# TYPE xcp_xostor_package_update_available gauge/)
     assert.match(output, /package="linstor-controller"/)
+  })
+})
+
+// ============================================================================
+// indexSrUuidTruncations Tests
+// ============================================================================
+
+describe('indexSrUuidTruncations', () => {
+  it('should index both UUID prefix and suffix at all configured lengths', () => {
+    const uuid = 'c787b75c-3e0d-70fa-d0c3-cbfd382d7e33'
+    const index: Record<string, string> = {}
+
+    indexSrUuidTruncations(uuid, index)
+
+    // XCP-ng's typical 8-char prefix (the reason the bug existed)
+    assert.equal(index[uuid.slice(0, 8)], uuid)
+    // 8-char suffix (legacy / variant builds)
+    assert.equal(index[uuid.slice(-8)], uuid)
+    // 12, 16, 20 truncations also indexed at both ends
+    for (const len of [12, 16, 20]) {
+      assert.equal(index[uuid.slice(0, len)], uuid)
+      assert.equal(index[uuid.slice(-len)], uuid)
+    }
+  })
+
+  it('should not overwrite existing entries (first match wins)', () => {
+    const index: Record<string, string> = { c787b75c: 'first-sr-uuid' }
+
+    indexSrUuidTruncations('c787b75c-3e0d-70fa-d0c3-cbfd382d7e33', index)
+
+    assert.equal(index['c787b75c'], 'first-sr-uuid')
+  })
+
+  it('should skip truncations longer than the UUID itself', () => {
+    const shortUuid = 'abc1234'
+    const index: Record<string, string> = {}
+
+    indexSrUuidTruncations(shortUuid, index)
+
+    // 8/12/16/20 are all longer than the 7-char input
+    assert.equal(Object.keys(index).length, 0)
   })
 })

--- a/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
+++ b/packages/xo-server-openmetrics/src/openmetric-formatter.test.mts
@@ -14,14 +14,28 @@ import {
   formatAllPoolsToOpenMetrics,
   formatHostStatusMetrics,
   formatHostUptimeMetrics,
+  formatSrMetrics,
   formatVdiMetrics,
   formatVmStatusMetrics,
   formatVmUptimeMetrics,
+  formatXostorAlarmsMetrics,
+  formatXostorClusterMetrics,
+  formatXostorSmartMetrics,
+  formatXostorUpdatesMetrics,
   type FormattedMetric,
   type LabelContext,
 } from './openmetric-formatter.mjs'
 
-import type { HostStatusItem, VdiDataItem, VmStatusItem } from './index.mjs'
+import type {
+  HostStatusItem,
+  SrDataItem,
+  VdiDataItem,
+  VmStatusItem,
+  XostorAlarmsItem,
+  XostorClusterItem,
+  XostorSmartHost,
+  XostorUpdateItem,
+} from './index.mjs'
 
 import type { ParsedMetric, ParsedRrdData } from './rrd-parser.mjs'
 
@@ -753,6 +767,7 @@ describe('transformMetric with labelContext', () => {
       srs: {
         'sr-uuid-full-1234567890': {
           name_label: 'Local Storage',
+          SR_type: 'lvm',
         },
       },
       srSuffixToUuid: {
@@ -921,6 +936,69 @@ describe('transformMetric with labelContext', () => {
     assert.ok(result)
     assert.equal(result.labels.sr, '1234567890')
     assert.equal(result.labels.sr_name, 'Local Storage')
+  })
+
+  it('should add sr_type label for host SR-tagged metrics (iops/throughput/latency)', () => {
+    const ctx = createLabelContext()
+    ctx.labels.srs['sr-uuid-full-1234567890']!.SR_type = 'linstor'
+    const metric: ParsedMetric = {
+      legend: {
+        cf: 'AVERAGE',
+        objectType: 'host',
+        uuid: 'host-uuid-123',
+        metricName: 'iops_read_1234567890',
+        rawLegend: 'AVERAGE:host:host-uuid-123:iops_read_1234567890',
+      },
+      value: 100,
+      timestamp: 1700000000,
+    }
+
+    const result = transformMetric(metric, 'pool-456', ctx)
+
+    assert.ok(result)
+    assert.equal(result.labels.sr_type, 'linstor')
+  })
+
+  it('should add sr_type label for VBD VM disk metrics via VDI→SR mapping', () => {
+    const ctx = createLabelContext()
+    ctx.labels.srs['sr-uuid-full-1234567890']!.SR_type = 'linstor'
+    const metric: ParsedMetric = {
+      legend: {
+        cf: 'AVERAGE',
+        objectType: 'vm',
+        uuid: 'vm-uuid-789',
+        metricName: 'vbd_xvda_iops_read',
+        rawLegend: 'AVERAGE:vm:vm-uuid-789:vbd_xvda_iops_read',
+      },
+      value: 200,
+      timestamp: 1700000000,
+    }
+
+    const result = transformMetric(metric, 'pool-456', ctx)
+
+    assert.ok(result)
+    assert.equal(result.labels.sr_type, 'linstor')
+  })
+
+  it('should omit sr_type label when SR_type is empty', () => {
+    const ctx = createLabelContext()
+    ctx.labels.srs['sr-uuid-full-1234567890']!.SR_type = ''
+    const metric: ParsedMetric = {
+      legend: {
+        cf: 'AVERAGE',
+        objectType: 'host',
+        uuid: 'host-uuid-123',
+        metricName: 'iops_read_1234567890',
+        rawLegend: 'AVERAGE:host:host-uuid-123:iops_read_1234567890',
+      },
+      value: 100,
+      timestamp: 1700000000,
+    }
+
+    const result = transformMetric(metric, 'pool-456', ctx)
+
+    assert.ok(result)
+    assert.equal(result.labels.sr_type, undefined)
   })
 
   it('should handle missing label context gracefully', () => {
@@ -1780,6 +1858,66 @@ describe('formatHostUptimeMetrics', () => {
 })
 
 // ============================================================================
+// SR Metrics Tests
+// ============================================================================
+
+describe('formatSrMetrics', () => {
+  const createSrDataItem = (overrides: Partial<SrDataItem> = {}): SrDataItem => ({
+    uuid: 'sr-uuid-456',
+    name_label: 'Local Storage',
+    size: 1_000_000_000_000,
+    physical_usage: 250_000_000_000,
+    usage: 500_000_000_000,
+    pool_id: 'pool-789',
+    pool_name: 'Production Pool',
+    sr_type: 'lvm',
+    ...overrides,
+  })
+
+  it('should emit 3 metrics per SR with sr_type label when present', () => {
+    const metrics = formatSrMetrics([createSrDataItem({ sr_type: 'linstor' })])
+
+    assert.equal(metrics.length, 3)
+    for (const m of metrics) {
+      assert.equal(m.labels.sr_type, 'linstor')
+    }
+  })
+
+  it('should omit sr_type label when empty', () => {
+    const metrics = formatSrMetrics([createSrDataItem({ sr_type: '' })])
+
+    assert.equal(metrics.length, 3)
+    for (const m of metrics) {
+      assert.equal(m.labels.sr_type, undefined)
+    }
+  })
+
+  it('should distinguish multiple SRs by sr_type label', () => {
+    const metrics = formatSrMetrics([
+      createSrDataItem({ uuid: 'sr-a', sr_type: 'linstor' }),
+      createSrDataItem({ uuid: 'sr-b', sr_type: 'lvm' }),
+    ])
+
+    const typesByUuid = new Map<string, string>()
+    for (const m of metrics) {
+      const srUuid = m.labels.sr_uuid
+      const srType = m.labels.sr_type
+      if (srUuid !== undefined && srType !== undefined) {
+        typesByUuid.set(srUuid, srType)
+      }
+    }
+    assert.equal(typesByUuid.get('sr-a'), 'linstor')
+    assert.equal(typesByUuid.get('sr-b'), 'lvm')
+  })
+
+  it('should round-trip sr_type through formatToOpenMetrics', () => {
+    const metrics = formatSrMetrics([createSrDataItem({ sr_type: 'linstor' })])
+    const output = formatToOpenMetrics(metrics)
+    assert.match(output, /sr_type="linstor"/)
+  })
+})
+
+// ============================================================================
 // VDI Metrics Tests
 // ============================================================================
 
@@ -1791,6 +1929,7 @@ describe('formatVdiMetrics', () => {
     usage: 53687091200, // 50 GiB
     sr_uuid: 'sr-uuid-456',
     sr_name: 'Local Storage',
+    sr_type: 'lvm',
     pool_id: 'pool-789',
     pool_name: 'Production Pool',
     ...overrides,
@@ -1886,6 +2025,27 @@ describe('formatVdiMetrics', () => {
     const metrics = formatVdiMetrics(vdiData)
 
     assert.equal(metrics[0]!.labels.pool_name, undefined)
+  })
+
+  it('should propagate sr_type label when present', () => {
+    const vdiData: VdiDataItem[] = [createVdiDataItem({ sr_type: 'linstor' })]
+
+    const metrics = formatVdiMetrics(vdiData)
+
+    assert.equal(metrics.length, 2)
+    for (const m of metrics) {
+      assert.equal(m.labels.sr_type, 'linstor')
+    }
+  })
+
+  it('should omit sr_type label when empty', () => {
+    const vdiData: VdiDataItem[] = [createVdiDataItem({ sr_type: '' })]
+
+    const metrics = formatVdiMetrics(vdiData)
+
+    for (const m of metrics) {
+      assert.equal(m.labels.sr_type, undefined)
+    }
   })
 
   it('should produce valid OpenMetrics output', () => {
@@ -2278,5 +2438,656 @@ describe('formatVmUptimeMetrics', () => {
     const metrics = formatVmUptimeMetrics(labelContext)
 
     assert.equal(metrics.length, 0)
+  })
+})
+
+// ============================================================================
+// formatXostorClusterMetrics Tests
+// ============================================================================
+
+describe('formatXostorClusterMetrics', () => {
+  const makeCluster = (overrides: Partial<XostorClusterItem> = {}): XostorClusterItem => ({
+    sr_uuid: 'sr-xostor-1',
+    pool_id: 'pool-1',
+    pool_name: 'Production',
+    up: true,
+    nodes: [
+      { node_name: 'host-a', role: 'master', state: 'ONLINE' },
+      { node_name: 'host-b', role: 'satellite', state: 'ONLINE' },
+      { node_name: 'host-c', role: 'satellite', state: 'ONLINE' },
+    ],
+    resourceCount: 12,
+    replicaStates: {},
+    ...overrides,
+  })
+
+  it('should return empty array for empty input', () => {
+    const result = formatXostorClusterMetrics({ clusters: [] })
+    assert.deepEqual(result, [])
+  })
+
+  it('should emit xcp_xostor_up metric per cluster with value 1 on success', () => {
+    const result = formatXostorClusterMetrics({ clusters: [makeCluster()] })
+    const up = result.find(m => m.name === 'xcp_xostor_up')
+    assert.ok(up)
+    assert.equal(up.type, 'gauge')
+    assert.equal(up.value, 1)
+    assert.equal(up.labels.sr_uuid, 'sr-xostor-1')
+    assert.equal(up.labels.pool_id, 'pool-1')
+    assert.equal(up.labels.pool_name, 'Production')
+  })
+
+  it('should emit xcp_xostor_up with value 0 when collection failed', () => {
+    const result = formatXostorClusterMetrics({
+      clusters: [makeCluster({ up: false, nodes: [], resourceCount: 0 })],
+    })
+    const up = result.find(m => m.name === 'xcp_xostor_up')
+    assert.ok(up)
+    assert.equal(up.value, 0)
+  })
+
+  it('should emit one xcp_xostor_node_status per node with role and state labels', () => {
+    const result = formatXostorClusterMetrics({ clusters: [makeCluster()] })
+    const nodeMetrics = result.filter(m => m.name === 'xcp_xostor_node_status')
+
+    assert.equal(nodeMetrics.length, 3)
+    for (const m of nodeMetrics) {
+      assert.equal(m.type, 'gauge')
+      assert.equal(m.value, 1)
+      assert.equal(m.labels.sr_uuid, 'sr-xostor-1')
+      assert.equal(m.labels.pool_id, 'pool-1')
+      assert.equal(m.labels.pool_name, 'Production')
+      assert.ok(m.labels.node_name)
+      assert.ok(m.labels.role)
+      assert.ok(m.labels.state)
+    }
+
+    const masterMetric = nodeMetrics.find(m => m.labels.role === 'master')
+    assert.ok(masterMetric)
+    assert.equal(masterMetric.labels.node_name, 'host-a')
+
+    const satelliteMetrics = nodeMetrics.filter(m => m.labels.role === 'satellite')
+    assert.equal(satelliteMetrics.length, 2)
+  })
+
+  it('should emit xcp_xostor_resource_total gauge with count value', () => {
+    const result = formatXostorClusterMetrics({ clusters: [makeCluster({ resourceCount: 42 })] })
+    const total = result.find(m => m.name === 'xcp_xostor_resource_total')
+
+    assert.ok(total)
+    assert.equal(total.type, 'gauge')
+    assert.equal(total.value, 42)
+    assert.equal(total.labels.sr_uuid, 'sr-xostor-1')
+    assert.equal(total.labels.pool_id, 'pool-1')
+    assert.equal(total.labels.pool_name, 'Production')
+  })
+
+  it('should preserve offline node states (no filtering)', () => {
+    const result = formatXostorClusterMetrics({
+      clusters: [
+        makeCluster({
+          nodes: [
+            { node_name: 'host-a', role: 'master', state: 'ONLINE' },
+            { node_name: 'host-b', role: 'satellite', state: 'OFFLINE' },
+          ],
+        }),
+      ],
+    })
+
+    const nodeMetrics = result.filter(m => m.name === 'xcp_xostor_node_status')
+    assert.equal(nodeMetrics.length, 2)
+
+    const offline = nodeMetrics.find(m => m.labels.state === 'OFFLINE')
+    assert.ok(offline)
+    assert.equal(offline.value, 1)
+  })
+
+  it('should omit pool_name label when empty', () => {
+    const result = formatXostorClusterMetrics({ clusters: [makeCluster({ pool_name: '' })] })
+
+    for (const metric of result) {
+      assert.equal(metric.labels.pool_name, undefined)
+    }
+  })
+
+  it('should handle cluster with no nodes (partial data tolerated)', () => {
+    const result = formatXostorClusterMetrics({
+      clusters: [makeCluster({ nodes: [], resourceCount: 0 })],
+    })
+
+    const upMetric = result.find(m => m.name === 'xcp_xostor_up')
+    assert.ok(upMetric)
+    assert.equal(result.filter(m => m.name === 'xcp_xostor_node_status').length, 0)
+
+    const totalMetric = result.find(m => m.name === 'xcp_xostor_resource_total')
+    assert.ok(totalMetric)
+    assert.equal(totalMetric.value, 0)
+  })
+
+  it('should isolate clusters: each cluster emits its own set of metrics', () => {
+    const result = formatXostorClusterMetrics({
+      clusters: [
+        makeCluster({ sr_uuid: 'sr-a', pool_id: 'pool-a', resourceCount: 5 }),
+        makeCluster({ sr_uuid: 'sr-b', pool_id: 'pool-b', resourceCount: 7 }),
+      ],
+    })
+
+    const upMetrics = result.filter(m => m.name === 'xcp_xostor_up')
+    assert.equal(upMetrics.length, 2)
+    assert.ok(upMetrics.some(m => m.labels.sr_uuid === 'sr-a'))
+    assert.ok(upMetrics.some(m => m.labels.sr_uuid === 'sr-b'))
+
+    const resourceMetrics = result.filter(m => m.name === 'xcp_xostor_resource_total')
+    assert.equal(resourceMetrics.length, 2)
+    const valuesBySr = new Map(resourceMetrics.map(m => [m.labels.sr_uuid, m.value]))
+    assert.equal(valuesBySr.get('sr-a'), 5)
+    assert.equal(valuesBySr.get('sr-b'), 7)
+  })
+
+  it('should produce metrics that round-trip through formatToOpenMetrics', () => {
+    const metrics = formatXostorClusterMetrics({ clusters: [makeCluster()] })
+    const output = formatToOpenMetrics(metrics)
+
+    assert.match(output, /# HELP xcp_xostor_up /)
+    assert.match(output, /# TYPE xcp_xostor_up gauge/)
+    assert.match(output, /# HELP xcp_xostor_node_status /)
+    assert.match(output, /# TYPE xcp_xostor_node_status gauge/)
+    assert.match(output, /# HELP xcp_xostor_resource_total /)
+    assert.match(output, /# TYPE xcp_xostor_resource_total gauge/)
+    assert.match(output, /role="master"/)
+    assert.match(output, /role="satellite"/)
+  })
+
+  it('should emit no resource_state_count when replicaStates is empty', () => {
+    const result = formatXostorClusterMetrics({ clusters: [makeCluster({ replicaStates: {} })] })
+    const stateMetrics = result.filter(m => m.name === 'xcp_xostor_resource_state_count')
+    assert.equal(stateMetrics.length, 0)
+  })
+
+  it('should emit one resource_state_count per state with the bucket count as value', () => {
+    const result = formatXostorClusterMetrics({
+      clusters: [
+        makeCluster({
+          replicaStates: { UpToDate: 28, Inconsistent: 2 },
+        }),
+      ],
+    })
+
+    const stateMetrics = result.filter(m => m.name === 'xcp_xostor_resource_state_count')
+    assert.equal(stateMetrics.length, 2)
+    for (const m of stateMetrics) {
+      assert.equal(m.type, 'gauge')
+      assert.equal(m.labels.sr_uuid, 'sr-xostor-1')
+      assert.equal(m.labels.pool_id, 'pool-1')
+      assert.equal(m.labels.pool_name, 'Production')
+      assert.ok(m.labels.state)
+    }
+
+    const valuesByState = new Map(stateMetrics.map(m => [m.labels.state, m.value]))
+    assert.equal(valuesByState.get('UpToDate'), 28)
+    assert.equal(valuesByState.get('Inconsistent'), 2)
+  })
+
+  it('should preserve raw state names verbatim (no case normalization)', () => {
+    const result = formatXostorClusterMetrics({
+      clusters: [
+        makeCluster({
+          replicaStates: { UpToDate: 5, Outdated: 1, Diskless: 3, Unknown: 0 },
+        }),
+      ],
+    })
+
+    const states = new Set(result.filter(m => m.name === 'xcp_xostor_resource_state_count').map(m => m.labels.state))
+
+    assert.ok(states.has('UpToDate'))
+    assert.ok(states.has('Outdated'))
+    assert.ok(states.has('Diskless'))
+    assert.ok(states.has('Unknown'))
+  })
+
+  it('should omit pool_name on resource_state_count when pool_name empty', () => {
+    const result = formatXostorClusterMetrics({
+      clusters: [makeCluster({ pool_name: '', replicaStates: { UpToDate: 3 } })],
+    })
+
+    const stateMetric = result.find(m => m.name === 'xcp_xostor_resource_state_count')
+    assert.ok(stateMetric)
+    assert.equal(stateMetric.labels.pool_name, undefined)
+  })
+
+  it('should isolate replicaStates per cluster', () => {
+    const result = formatXostorClusterMetrics({
+      clusters: [
+        makeCluster({ sr_uuid: 'sr-a', replicaStates: { UpToDate: 9 } }),
+        makeCluster({ sr_uuid: 'sr-b', replicaStates: { UpToDate: 6, Inconsistent: 1 } }),
+      ],
+    })
+
+    const stateMetrics = result.filter(m => m.name === 'xcp_xostor_resource_state_count')
+    assert.equal(stateMetrics.length, 3)
+
+    const srAState = stateMetrics.find(m => m.labels.sr_uuid === 'sr-a')
+    assert.ok(srAState)
+    assert.equal(srAState.value, 9)
+
+    const srBInconsistent = stateMetrics.find(m => m.labels.sr_uuid === 'sr-b' && m.labels.state === 'Inconsistent')
+    assert.ok(srBInconsistent)
+    assert.equal(srBInconsistent.value, 1)
+  })
+})
+
+// ============================================================================
+// formatXostorAlarmsMetrics Tests
+// ============================================================================
+
+describe('formatXostorAlarmsMetrics', () => {
+  const makeCluster = (overrides: Partial<XostorAlarmsItem> = {}): XostorAlarmsItem => ({
+    sr_uuid: 'sr-xostor-1',
+    pool_id: 'pool-1',
+    pool_name: 'Production',
+    up: true,
+    entries: [],
+    ...overrides,
+  })
+
+  it('should return empty array for empty input', () => {
+    const result = formatXostorAlarmsMetrics({ clusters: [] })
+    assert.deepEqual(result, [])
+  })
+
+  it('should emit xcp_xostor_alarms_up per cluster with value 1 on success', () => {
+    const result = formatXostorAlarmsMetrics({ clusters: [makeCluster()] })
+    const up = result.find(m => m.name === 'xcp_xostor_alarms_up')
+
+    assert.ok(up)
+    assert.equal(up.type, 'gauge')
+    assert.equal(up.value, 1)
+    assert.equal(up.labels.sr_uuid, 'sr-xostor-1')
+    assert.equal(up.labels.pool_id, 'pool-1')
+    assert.equal(up.labels.pool_name, 'Production')
+  })
+
+  it('should emit xcp_xostor_alarms_up with value 0 when collection failed', () => {
+    const result = formatXostorAlarmsMetrics({ clusters: [makeCluster({ up: false })] })
+    const up = result.find(m => m.name === 'xcp_xostor_alarms_up')
+
+    assert.ok(up)
+    assert.equal(up.value, 0)
+  })
+
+  it('should emit one xcp_xostor_alarms_count per entry with count value', () => {
+    const result = formatXostorAlarmsMetrics({
+      clusters: [
+        makeCluster({
+          entries: [
+            { alarm_name: 'ALARM', target_type: 'sr', count: 3 },
+            { alarm_name: 'BOND_STATUS_CHANGED', target_type: 'host', count: 2 },
+          ],
+        }),
+      ],
+    })
+
+    const counts = result.filter(m => m.name === 'xcp_xostor_alarms_count')
+    assert.equal(counts.length, 2)
+
+    const sr = counts.find(m => m.labels.alarm_name === 'ALARM')
+    assert.ok(sr)
+    assert.equal(sr.value, 3)
+    assert.equal(sr.labels.target_type, 'sr')
+
+    const host = counts.find(m => m.labels.alarm_name === 'BOND_STATUS_CHANGED')
+    assert.ok(host)
+    assert.equal(host.value, 2)
+    assert.equal(host.labels.target_type, 'host')
+  })
+
+  it('should emit no alarms_count when entries is empty', () => {
+    const result = formatXostorAlarmsMetrics({ clusters: [makeCluster({ entries: [] })] })
+    const counts = result.filter(m => m.name === 'xcp_xostor_alarms_count')
+    assert.equal(counts.length, 0)
+
+    const up = result.find(m => m.name === 'xcp_xostor_alarms_up')
+    assert.ok(up)
+  })
+
+  it('should omit pool_name label when empty', () => {
+    const result = formatXostorAlarmsMetrics({
+      clusters: [
+        makeCluster({
+          pool_name: '',
+          entries: [{ alarm_name: 'ALARM', target_type: 'sr', count: 1 }],
+        }),
+      ],
+    })
+
+    for (const m of result) {
+      assert.equal(m.labels.pool_name, undefined)
+    }
+  })
+
+  it('should isolate alarms_count per cluster', () => {
+    const result = formatXostorAlarmsMetrics({
+      clusters: [
+        makeCluster({
+          sr_uuid: 'sr-a',
+          entries: [{ alarm_name: 'ALARM', target_type: 'sr', count: 5 }],
+        }),
+        makeCluster({
+          sr_uuid: 'sr-b',
+          entries: [{ alarm_name: 'MULTIPATH_PERIODIC_ALERT', target_type: 'host', count: 2 }],
+        }),
+      ],
+    })
+
+    const counts = result.filter(m => m.name === 'xcp_xostor_alarms_count')
+    assert.equal(counts.length, 2)
+
+    const a = counts.find(m => m.labels.sr_uuid === 'sr-a')
+    assert.ok(a)
+    assert.equal(a.value, 5)
+    assert.equal(a.labels.alarm_name, 'ALARM')
+
+    const b = counts.find(m => m.labels.sr_uuid === 'sr-b')
+    assert.ok(b)
+    assert.equal(b.value, 2)
+    assert.equal(b.labels.alarm_name, 'MULTIPATH_PERIODIC_ALERT')
+  })
+
+  it('should produce metrics that round-trip through formatToOpenMetrics', () => {
+    const result = formatXostorAlarmsMetrics({
+      clusters: [
+        makeCluster({
+          entries: [
+            { alarm_name: 'ALARM', target_type: 'sr', count: 1 },
+            { alarm_name: 'BOND_STATUS_CHANGED', target_type: 'host', count: 2 },
+          ],
+        }),
+      ],
+    })
+    const output = formatToOpenMetrics(result)
+
+    assert.match(output, /# HELP xcp_xostor_alarms_up /)
+    assert.match(output, /# TYPE xcp_xostor_alarms_up gauge/)
+    assert.match(output, /# HELP xcp_xostor_alarms_count /)
+    assert.match(output, /# TYPE xcp_xostor_alarms_count gauge/)
+    assert.match(output, /alarm_name="ALARM"/)
+    assert.match(output, /target_type="host"/)
+  })
+})
+
+// ============================================================================
+// formatXostorSmartMetrics Tests
+// ============================================================================
+
+describe('formatXostorSmartMetrics', () => {
+  const makeHost = (overrides: Partial<XostorSmartHost> = {}): XostorSmartHost => ({
+    sr_uuid: 'sr-xostor-1',
+    pool_id: 'pool-1',
+    pool_name: 'Production',
+    host_uuid: 'host-a-uuid',
+    host_name: 'host-a',
+    up: true,
+    devices: [
+      { device: 'sda', status: 'PASSED' },
+      { device: 'sdb', status: 'PASSED' },
+    ],
+    ...overrides,
+  })
+
+  it('should return empty array for empty input', () => {
+    const result = formatXostorSmartMetrics({ hosts: [] })
+    assert.deepEqual(result, [])
+  })
+
+  it('should emit xcp_xostor_smart_up per host with value 1 on success', () => {
+    const result = formatXostorSmartMetrics({ hosts: [makeHost()] })
+    const up = result.find(m => m.name === 'xcp_xostor_smart_up')
+
+    assert.ok(up)
+    assert.equal(up.type, 'gauge')
+    assert.equal(up.value, 1)
+    assert.equal(up.labels.sr_uuid, 'sr-xostor-1')
+    assert.equal(up.labels.pool_id, 'pool-1')
+    assert.equal(up.labels.pool_name, 'Production')
+    assert.equal(up.labels.host_uuid, 'host-a-uuid')
+    assert.equal(up.labels.host_name, 'host-a')
+  })
+
+  it('should emit xcp_xostor_smart_up with value 0 when plugin call failed', () => {
+    const result = formatXostorSmartMetrics({ hosts: [makeHost({ up: false, devices: [] })] })
+    const up = result.find(m => m.name === 'xcp_xostor_smart_up')
+
+    assert.ok(up)
+    assert.equal(up.value, 0)
+  })
+
+  it('should emit one xcp_xostor_disk_smart_status per device with value 1', () => {
+    const result = formatXostorSmartMetrics({ hosts: [makeHost()] })
+    const disks = result.filter(m => m.name === 'xcp_xostor_disk_smart_status')
+
+    assert.equal(disks.length, 2)
+    for (const m of disks) {
+      assert.equal(m.type, 'gauge')
+      assert.equal(m.value, 1)
+      assert.equal(m.labels.host_uuid, 'host-a-uuid')
+      assert.equal(m.labels.host_name, 'host-a')
+      assert.ok(m.labels.device)
+      assert.ok(m.labels.status)
+    }
+
+    const sda = disks.find(m => m.labels.device === 'sda')
+    assert.ok(sda)
+    assert.equal(sda.labels.status, 'PASSED')
+  })
+
+  it('should preserve mixed status strings verbatim (no normalization)', () => {
+    const result = formatXostorSmartMetrics({
+      hosts: [
+        makeHost({
+          devices: [
+            { device: 'sda', status: 'PASSED' },
+            { device: 'sdb', status: 'FAILED' },
+            { device: 'nvme0n1', status: 'UNKNOWN' },
+          ],
+        }),
+      ],
+    })
+
+    const statuses = new Set(result.filter(m => m.name === 'xcp_xostor_disk_smart_status').map(m => m.labels.status))
+    assert.ok(statuses.has('PASSED'))
+    assert.ok(statuses.has('FAILED'))
+    assert.ok(statuses.has('UNKNOWN'))
+  })
+
+  it('should emit only smart_up (no disk metrics) when devices is empty and up=true', () => {
+    const result = formatXostorSmartMetrics({ hosts: [makeHost({ devices: [] })] })
+
+    const up = result.find(m => m.name === 'xcp_xostor_smart_up')
+    assert.ok(up)
+    assert.equal(up.value, 1)
+
+    const disks = result.filter(m => m.name === 'xcp_xostor_disk_smart_status')
+    assert.equal(disks.length, 0)
+  })
+
+  it('should omit pool_name and host_name labels when empty', () => {
+    const result = formatXostorSmartMetrics({
+      hosts: [makeHost({ pool_name: '', host_name: '' })],
+    })
+
+    for (const m of result) {
+      assert.equal(m.labels.pool_name, undefined)
+      assert.equal(m.labels.host_name, undefined)
+    }
+  })
+
+  it('should isolate disks per host across multiple hosts', () => {
+    const result = formatXostorSmartMetrics({
+      hosts: [
+        makeHost({ host_uuid: 'host-a', devices: [{ device: 'sda', status: 'PASSED' }] }),
+        makeHost({ host_uuid: 'host-b', devices: [{ device: 'sdc', status: 'FAILED' }] }),
+      ],
+    })
+
+    const disks = result.filter(m => m.name === 'xcp_xostor_disk_smart_status')
+    assert.equal(disks.length, 2)
+
+    const a = disks.find(m => m.labels.host_uuid === 'host-a')
+    assert.ok(a)
+    assert.equal(a.labels.device, 'sda')
+
+    const b = disks.find(m => m.labels.host_uuid === 'host-b')
+    assert.ok(b)
+    assert.equal(b.labels.device, 'sdc')
+    assert.equal(b.labels.status, 'FAILED')
+  })
+
+  it('should produce metrics that round-trip through formatToOpenMetrics', () => {
+    const metrics = formatXostorSmartMetrics({ hosts: [makeHost()] })
+    const output = formatToOpenMetrics(metrics)
+
+    assert.match(output, /# HELP xcp_xostor_smart_up /)
+    assert.match(output, /# TYPE xcp_xostor_smart_up gauge/)
+    assert.match(output, /# HELP xcp_xostor_disk_smart_status /)
+    assert.match(output, /# TYPE xcp_xostor_disk_smart_status gauge/)
+    assert.match(output, /device="sda"/)
+    assert.match(output, /status="PASSED"/)
+  })
+})
+
+// ============================================================================
+// formatXostorUpdatesMetrics Tests
+// ============================================================================
+
+describe('formatXostorUpdatesMetrics', () => {
+  const makeHost = (overrides: Partial<XostorUpdateItem> = {}): XostorUpdateItem => ({
+    sr_uuid: 'sr-xostor-1',
+    pool_id: 'pool-1',
+    pool_name: 'Production',
+    host_uuid: 'host-a-uuid',
+    host_name: 'host-a',
+    up: true,
+    packages: [],
+    ...overrides,
+  })
+
+  it('should return empty array for empty input', () => {
+    const result = formatXostorUpdatesMetrics({ hosts: [] })
+    assert.deepEqual(result, [])
+  })
+
+  it('should emit xcp_xostor_updates_up per host with value 1 on success', () => {
+    const result = formatXostorUpdatesMetrics({ hosts: [makeHost()] })
+    const up = result.find(m => m.name === 'xcp_xostor_updates_up')
+
+    assert.ok(up)
+    assert.equal(up.type, 'gauge')
+    assert.equal(up.value, 1)
+    assert.equal(up.labels.sr_uuid, 'sr-xostor-1')
+    assert.equal(up.labels.pool_id, 'pool-1')
+    assert.equal(up.labels.pool_name, 'Production')
+    assert.equal(up.labels.host_uuid, 'host-a-uuid')
+    assert.equal(up.labels.host_name, 'host-a')
+  })
+
+  it('should emit xcp_xostor_updates_up with value 0 when collection failed', () => {
+    const result = formatXostorUpdatesMetrics({ hosts: [makeHost({ up: false })] })
+    const up = result.find(m => m.name === 'xcp_xostor_updates_up')
+
+    assert.ok(up)
+    assert.equal(up.value, 0)
+  })
+
+  it('should emit one xcp_xostor_package_update_available per pending package', () => {
+    const result = formatXostorUpdatesMetrics({
+      hosts: [
+        makeHost({
+          packages: [{ package: 'linstor-satellite' }, { package: 'linstor-controller' }],
+        }),
+      ],
+    })
+
+    const updates = result.filter(m => m.name === 'xcp_xostor_package_update_available')
+    assert.equal(updates.length, 2)
+    for (const m of updates) {
+      assert.equal(m.value, 1)
+      assert.equal(m.type, 'gauge')
+      assert.equal(m.labels.host_uuid, 'host-a-uuid')
+      assert.ok(m.labels.package)
+    }
+    const packages = new Set(updates.map(m => m.labels.package))
+    assert.ok(packages.has('linstor-satellite'))
+    assert.ok(packages.has('linstor-controller'))
+  })
+
+  it('should emit only updates_up (no package metrics) when packages is empty and up=true', () => {
+    const result = formatXostorUpdatesMetrics({ hosts: [makeHost({ packages: [] })] })
+
+    const up = result.find(m => m.name === 'xcp_xostor_updates_up')
+    assert.ok(up)
+    assert.equal(up.value, 1)
+
+    const updates = result.filter(m => m.name === 'xcp_xostor_package_update_available')
+    assert.equal(updates.length, 0)
+  })
+
+  it('should omit pool_name and host_name labels when empty', () => {
+    const result = formatXostorUpdatesMetrics({
+      hosts: [makeHost({ pool_name: '', host_name: '', packages: [{ package: 'linstor-satellite' }] })],
+    })
+
+    for (const m of result) {
+      assert.equal(m.labels.pool_name, undefined)
+      assert.equal(m.labels.host_name, undefined)
+    }
+  })
+
+  it('should isolate packages per host across multiple hosts', () => {
+    const result = formatXostorUpdatesMetrics({
+      hosts: [
+        makeHost({ host_uuid: 'host-a', packages: [{ package: 'linstor-satellite' }] }),
+        makeHost({ host_uuid: 'host-b', packages: [{ package: 'xcp-ng-linstor' }] }),
+      ],
+    })
+
+    const updates = result.filter(m => m.name === 'xcp_xostor_package_update_available')
+    assert.equal(updates.length, 2)
+
+    const a = updates.find(m => m.labels.host_uuid === 'host-a')
+    assert.ok(a)
+    assert.equal(a.labels.package, 'linstor-satellite')
+
+    const b = updates.find(m => m.labels.host_uuid === 'host-b')
+    assert.ok(b)
+    assert.equal(b.labels.package, 'xcp-ng-linstor')
+  })
+
+  it('should dedupe duplicate package entries per host', () => {
+    const result = formatXostorUpdatesMetrics({
+      hosts: [
+        makeHost({
+          packages: [
+            { package: 'linstor-satellite' },
+            { package: 'linstor-satellite' }, // dup, should be merged
+          ],
+        }),
+      ],
+    })
+
+    const updates = result.filter(m => m.name === 'xcp_xostor_package_update_available')
+    assert.equal(updates.length, 1)
+  })
+
+  it('should produce metrics that round-trip through formatToOpenMetrics', () => {
+    const metrics = formatXostorUpdatesMetrics({
+      hosts: [makeHost({ packages: [{ package: 'linstor-controller' }] })],
+    })
+    const output = formatToOpenMetrics(metrics)
+
+    assert.match(output, /# HELP xcp_xostor_updates_up /)
+    assert.match(output, /# TYPE xcp_xostor_updates_up gauge/)
+    assert.match(output, /# HELP xcp_xostor_package_update_available /)
+    assert.match(output, /# TYPE xcp_xostor_package_update_available gauge/)
+    assert.match(output, /package="linstor-controller"/)
   })
 })


### PR DESCRIPTION
### Description

Implements XO-2155. The OpenMetrics plugin now ships XOSTOR-specific metrics so operators can build a Grafana dashboard for XCP-ng Hyperconverged Infrastructure.

All metrics use the `xcp_xostor_*` prefix:

- Cluster status: `xcp_xostor_up`, `xcp_xostor_node_status` (master / satellite roles + raw state from `linstor-manager.healthCheck`), `xcp_xostor_resource_total`.
- Storage pool health: `xcp_xostor_resource_state_count` — replica counts per `disk-state` (UpToDate, Inconsistent, Outdated, Diskless, Unknown), aggregated per cluster.
- Performance filter: a new `sr_type` label on every SR-tagged metric (`xcp_host_disk_iops_*`, `xcp_host_disk_throughput_*`, latency, `xcp_sr_*`, `xcp_vdi_*`, `xcp_vm_disk_*`). Dashboards can filter `sr_type="linstor"` without changing existing queries.
- Active alarms: `xcp_xostor_alarms_count` aggregated by `alarm_name` (`ALARM`, `BOND_STATUS_CHANGED`, `MULTIPATH_PERIODIC_ALERT`) and `target_type` (sr / host).
- Disk SMART: `xcp_xostor_disk_smart_status` per (host, device) with the overall-health string in a `status` label, sourced from `smartctl.py`.
- Pending updates: `xcp_xostor_package_update_available` for `xcp-ng-linstor`, `linstor-satellite`, `linstor-controller`, `xcp-ng-release-linstor`, and `xcp-ng-xapi-plugins`.

Each collector caches at its own TTL (60 s for cluster and alarms, 5 min for SMART, 1 h for updates) and exposes an `xcp_xostor_<feature>_up` gauge so silent collection failures still show up on dashboards. A `TtlCache<T>` helper encapsulates the cache-plus-coalescing pattern shared by the three caching collectors.

186 unit tests, all green.

<img width="868" height="840" alt="Capture d’écran du 2026-05-18 09-24-41" src="https://github.com/user-attachments/assets/3278de99-ad62-41bd-b259-8d995369d5da" />

<img width="1920" height="2129" alt="FireShot Capture 013 - XOSTOR — XCP-ng Hyperconverged - Xen Orchestra - Dashboards - Grafana_ - localhost" src="https://github.com/user-attachments/assets/79fc7cd3-dd82-4301-8e2c-29a14759e126" />



Fixes XO-2155

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue (`Fixes XO-2155`)
  - [ ] If bug fix, add `Introduced by` — N/A (new feature)
- Changelog
  - [ ] Add CHANGELOG.unreleased.md entry (visible to XOA users running Prometheus/Grafana)
  - [ ] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [x] Not Draft

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
