### PR TITLE
feat(web-core): upgrade UiDropdownButton component to v9

### DIFF
--- a/@xen-orchestra/lite/src/components/host/HostHeader.vue
+++ b/@xen-orchestra/lite/src/components/host/HostHeader.vue
@@ -16,7 +16,7 @@
     <template #actions>
       <MenuList placement="bottom-end">
         <template #trigger="{ open }">
-          <UiDropdownButton @click="open($event)">{{ t('action:change-state') }}</UiDropdownButton>
+          <UiDropdownButton size="medium" @click="open($event)">{{ t('action:change-state') }}</UiDropdownButton>
         </template>
         <HostPowerStateActions :host />
       </MenuList>

--- a/@xen-orchestra/lite/src/components/pool/network/PoolNetworksTable.vue
+++ b/@xen-orchestra/lite/src/components/pool/network/PoolNetworksTable.vue
@@ -3,7 +3,7 @@
     <UiTitle>
       {{ t('networks') }}
       <template #action>
-        <UiDropdownButton v-tooltip="t('coming-soon!')" disabled>
+        <UiDropdownButton v-tooltip="t('coming-soon!')" size="medium" disabled>
           {{ t('new') }}
         </UiDropdownButton>
       </template>

--- a/@xen-orchestra/lite/src/components/pool/network/PoolNetworksTable.vue
+++ b/@xen-orchestra/lite/src/components/pool/network/PoolNetworksTable.vue
@@ -4,9 +4,6 @@
       {{ t('networks') }}
       <template #action>
         <slot name="title-actions" />
-        <UiDropdownButton v-tooltip="t('coming-soon!')" size="medium" disabled>
-          {{ t('new') }}
-        </UiDropdownButton>
       </template>
     </UiTitle>
     <div class="container">

--- a/@xen-orchestra/lite/src/components/pool/network/PoolNetworksTable.vue
+++ b/@xen-orchestra/lite/src/components/pool/network/PoolNetworksTable.vue
@@ -4,6 +4,9 @@
       {{ t('networks') }}
       <template #action>
         <slot name="title-actions" />
+        <UiDropdownButton v-tooltip="t('coming-soon!')" size="medium" disabled>
+          {{ t('new') }}
+        </UiDropdownButton>
       </template>
     </UiTitle>
     <div class="container">

--- a/@xen-orchestra/lite/src/components/vm/VmHeader.vue
+++ b/@xen-orchestra/lite/src/components/vm/VmHeader.vue
@@ -13,7 +13,7 @@
     <template #actions>
       <MenuList v-if="vm !== undefined" placement="bottom-start">
         <template #trigger="{ open }">
-          <UiDropdownButton @click="open($event)">{{ t('action:change-state') }}</UiDropdownButton>
+          <UiDropdownButton size="medium" @click="open($event)">{{ t('action:change-state') }}</UiDropdownButton>
         </template>
         <VmActionPowerStateItems :vm-refs="[vm.$ref]" />
       </MenuList>

--- a/@xen-orchestra/lite/src/pages/pool/[uuid]/network.vue
+++ b/@xen-orchestra/lite/src/pages/pool/[uuid]/network.vue
@@ -5,7 +5,7 @@
         <template #title-actions>
           <MenuList placement="bottom-end">
             <template #trigger="{ open }">
-              <UiDropdownButton @click="open($event)">{{ t('new') }}</UiDropdownButton>
+              <UiDropdownButton size="medium" @click="open($event)">{{ t('new') }}</UiDropdownButton>
             </template>
             <MenuItem>
               <UiLink class="new-network-link" :to="{ name: '/network/new' }" icon="fa:plus" size="medium">

--- a/@xen-orchestra/lite/src/stories/web-core/ui/dropdown-button/ui-dropdown-button.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/dropdown-button/ui-dropdown-button.story.vue
@@ -5,7 +5,7 @@
       iconProp(),
       prop('selected').bool().widget(),
       prop('disabled').bool().widget().ctx(),
-      prop('size').enum('small', 'medium').widget().default('medium'),
+      prop('size').enum('small', 'medium').preset('medium').widget().required(),
       slot(),
       setting('defaultSlotContent').preset('Dropdown title').widget(text()).help('Content for default slot'),
     ]"

--- a/@xen-orchestra/lite/src/stories/web-core/ui/dropdown-button/ui-dropdown-button.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/dropdown-button/ui-dropdown-button.story.vue
@@ -10,7 +10,7 @@
       setting('defaultSlotContent').preset('Dropdown title').widget(text()).help('Content for default slot'),
     ]"
   >
-    <UiDropdownButton v-bind="properties">{{ settings.defaultSlotContent }}</UiDropdownButton>
+    <UiDropdownButton v-bind="properties" :size="properties.size">{{ settings.defaultSlotContent }}</UiDropdownButton>
   </ComponentStory>
 </template>
 

--- a/@xen-orchestra/lite/src/stories/web-core/ui/dropdown-button/ui-dropdown-button.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/dropdown-button/ui-dropdown-button.story.vue
@@ -5,6 +5,7 @@
       iconProp(),
       prop('selected').bool().widget(),
       prop('disabled').bool().widget().ctx(),
+      prop('size').enum('small', 'medium').widget().default('medium'),
       slot(),
       setting('defaultSlotContent').preset('Dropdown title').widget(text()).help('Content for default slot'),
     ]"

--- a/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
@@ -63,7 +63,7 @@ const className = computed(() => toVariants({ size }))
   }
 
   &.selected:not(:disabled) {
-    border: 2px solid var(--color-brand-item-base);
+    border: 0.2rem solid var(--color-brand-item-base);
     color: var(--color-brand-txt-base);
   }
 

--- a/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
@@ -1,11 +1,11 @@
 <!-- v5 -->
 <template>
   <button :class="{ selected }" :disabled="isDisabled" class="ui-dropdown-item" type="button">
-    <VtsIcon :name="icon" size="medium" />
-    <span class="typo-action-button label">
+    <VtsIcon :name="icon" :size="size ?? 'medium'" />
+    <span class="label" :class="size == 'small' ? 'typo-action-button-small' : 'typo-action-button'">
       <slot />
     </span>
-    <VtsIcon name="fa:angle-down" size="medium" />
+    <VtsIcon name="fa:angle-down" :size="size ?? 'medium'" />
   </button>
 </template>
 
@@ -18,6 +18,7 @@ const { disabled, selected, icon } = defineProps<{
   disabled?: boolean
   selected?: boolean
   icon?: IconName
+  size?: 'small' | 'medium'
 }>()
 
 const isDisabled = useDisabled(() => disabled)

--- a/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
@@ -1,11 +1,11 @@
 <!-- v8 -->
 <template>
   <button :class="[className, { selected }]" :disabled="isDisabled" class="ui-dropdown-item" type="button">
-    <VtsIcon :name="icon" :size="size" />
+    <VtsIcon :name="icon" :size />
     <span :class="size === 'small' ? 'typo-action-button-small' : 'typo-action-button'">
       <slot />
     </span>
-    <VtsIcon name="fa:angle-down" :size="size" />
+    <VtsIcon name="fa:angle-down" :size />
   </button>
 </template>
 
@@ -16,16 +16,11 @@ import type { IconName } from '@core/icons'
 import { toVariants } from '@core/utils/to-variants.util'
 import { computed } from 'vue'
 
-const {
-  disabled,
-  selected,
-  icon,
-  size = 'medium',
-} = defineProps<{
+const { disabled, selected, icon, size } = defineProps<{
+  size: 'small' | 'medium'
   disabled?: boolean
   selected?: boolean
   icon?: IconName
-  size?: 'small' | 'medium'
 }>()
 
 const isDisabled = useDisabled(() => disabled)
@@ -59,19 +54,17 @@ const className = computed(() => toVariants({ size }))
 
   &:hover {
     border-color: var(--color-brand-item-hover);
-    background-color: var(--color-brand-background-hover);
     color: var(--color-brand-txt-hover);
   }
 
   &:active {
     border-color: var(--color-brand-item-active);
-    background-color: var(--color-brand-background-active);
     color: var(--color-brand-txt-active);
   }
 
   &.selected:not(:disabled) {
-    background-color: var(--color-brand-background-selected);
-    outline: 0.1rem solid var(--color-brand-item-base);
+    border: 2px solid var(--color-brand-item-base);
+    color: var(--color-brand-txt-base);
   }
 
   &:focus-visible {

--- a/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
@@ -5,7 +5,7 @@
     <span class="label" :class="size == 'small' ? 'typo-action-button-small' : 'typo-action-button'">
       <slot />
     </span>
-    <VtsIcon name="fa:angle-down" :size="size ?? 'medium'" />
+    <VtsIcon name="table:angle-down" :size="size ?? 'medium'" />
   </button>
 </template>
 

--- a/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
@@ -1,4 +1,4 @@
-<!-- v5 -->
+<!-- v8 -->
 <template>
   <button :class="{ selected }" :disabled="isDisabled" class="ui-dropdown-item" type="button">
     <VtsIcon :name="icon" :size="size ?? 'medium'" />
@@ -32,27 +32,39 @@ const isDisabled = useDisabled(() => disabled)
   padding-inline: 1.6rem;
   gap: 0.8rem;
   background: var(--color-neutral-background-primary);
-  border: 0.1rem solid var(--color-brand-txt-base);
+  border: 0.1rem solid var(--color-brand-item-base);
   border-radius: 9rem;
   cursor: pointer;
   position: relative;
   color: var(--color-brand-txt-base);
 
+  :deep(.icon-path) {
+    color: var(--color-brand-txt-base);
+  }
+
   &:hover {
-    border-color: var(--color-brand-txt-hover);
+    border-color: var(--color-brand-item-hover);
     background-color: var(--color-brand-background-hover);
     color: var(--color-brand-txt-hover);
+
+    :deep(.icon-path) {
+      color: var(--color-brand-txt-hover);
+    }
   }
 
   &:active {
-    border-color: var(--color-brand-txt-active);
+    border-color: var(--color-brand-item-active);
     background-color: var(--color-brand-background-active);
     color: var(--color-brand-txt-active);
+
+    :deep(.icon-path) {
+      color: var(--color-brand-txt-active);
+    }
   }
 
   &.selected:not(:disabled) {
     background-color: var(--color-brand-background-selected);
-    outline: 0.1rem solid var(--color-brand-txt-base);
+    outline: 0.1rem solid var(--color-brand-item-base);
   }
 
   &:focus-visible {
@@ -72,6 +84,10 @@ const isDisabled = useDisabled(() => disabled)
     border-color: var(--color-neutral-txt-secondary);
     background-color: var(--color-neutral-background-disabled);
     color: var(--color-neutral-txt-secondary);
+
+    :deep(.icon-path) {
+      color: var(--color-neutral-txt-secondary);
+    }
   }
 }
 </style>

--- a/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
@@ -1,11 +1,11 @@
 <!-- v8 -->
 <template>
-  <button :class="{ selected }" :disabled="isDisabled" class="ui-dropdown-item" type="button">
-    <VtsIcon :name="icon" :size="size ?? 'medium'" />
-    <span class="label" :class="size == 'small' ? 'typo-action-button-small' : 'typo-action-button'">
+  <button :class="[className, { selected }]" :disabled="isDisabled" class="ui-dropdown-item" type="button">
+    <VtsIcon :name="icon" :size="size" />
+    <span :class="size === 'small' ? 'typo-action-button-small' : 'typo-action-button'">
       <slot />
     </span>
-    <VtsIcon name="table:angle-down" :size="size ?? 'medium'" />
+    <VtsIcon name="fa:angle-down" :size="size" />
   </button>
 </template>
 
@@ -13,8 +13,15 @@
 import VtsIcon from '@core/components/icon/VtsIcon.vue'
 import { useDisabled } from '@core/composables/disabled.composable'
 import type { IconName } from '@core/icons'
+import { toVariants } from '@core/utils/to-variants.util'
+import { computed } from 'vue'
 
-const { disabled, selected, icon } = defineProps<{
+const {
+  disabled,
+  selected,
+  icon,
+  size = 'medium',
+} = defineProps<{
   disabled?: boolean
   selected?: boolean
   icon?: IconName
@@ -22,6 +29,8 @@ const { disabled, selected, icon } = defineProps<{
 }>()
 
 const isDisabled = useDisabled(() => disabled)
+
+const className = computed(() => toVariants({ size }))
 </script>
 
 <style lang="postcss" scoped>
@@ -38,28 +47,26 @@ const isDisabled = useDisabled(() => disabled)
   position: relative;
   color: var(--color-brand-txt-base);
 
-  :deep(.icon-path) {
-    color: var(--color-brand-txt-base);
+  &.size--small {
+    padding-block: 0.8rem;
+    padding-inline: 1.2rem;
+  }
+
+  &.size--medium {
+    padding-block: 1.2rem;
+    padding-inline: 1.6rem;
   }
 
   &:hover {
     border-color: var(--color-brand-item-hover);
     background-color: var(--color-brand-background-hover);
     color: var(--color-brand-txt-hover);
-
-    :deep(.icon-path) {
-      color: var(--color-brand-txt-hover);
-    }
   }
 
   &:active {
     border-color: var(--color-brand-item-active);
     background-color: var(--color-brand-background-active);
     color: var(--color-brand-txt-active);
-
-    :deep(.icon-path) {
-      color: var(--color-brand-txt-active);
-    }
   }
 
   &.selected:not(:disabled) {
@@ -84,10 +91,6 @@ const isDisabled = useDisabled(() => disabled)
     border-color: var(--color-neutral-txt-secondary);
     background-color: var(--color-neutral-background-disabled);
     color: var(--color-neutral-txt-secondary);
-
-    :deep(.icon-path) {
-      color: var(--color-neutral-txt-secondary);
-    }
   }
 }
 </style>

--- a/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
@@ -62,7 +62,7 @@ const className = computed(() => toVariants({ size }))
   }
 
   &.selected:not(:disabled) {
-    border: 0.2rem solid var(--color-brand-item-base);
+    outline: 0.2rem solid var(--color-brand-item-base);
     color: var(--color-brand-txt-base);
   }
 

--- a/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
@@ -13,7 +13,7 @@
 import VtsIcon from '@core/components/icon/VtsIcon.vue'
 import { useDisabled } from '@core/composables/disabled.composable.ts'
 import type { IconName } from '@core/icons'
-import { toVariants } from '@core/utils/to-variants.util'
+import { toVariants } from '@core/utils/to-variants.util.ts'
 import { computed } from 'vue'
 
 const { disabled, selected, icon, size } = defineProps<{

--- a/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
@@ -33,8 +33,6 @@ const className = computed(() => toVariants({ size }))
 .ui-dropdown-item {
   display: inline-flex;
   align-items: center;
-  padding-block: 1.2rem;
-  padding-inline: 1.6rem;
   gap: 0.8rem;
   background: var(--color-neutral-background-primary);
   border: 0.1rem solid var(--color-brand-item-base);

--- a/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
@@ -1,11 +1,11 @@
 <!-- v8 -->
 <template>
-  <button :class="{ selected }" :disabled="isDisabled" class="ui-dropdown-item" type="button">
-    <VtsIcon :name="icon" :size="size ?? 'medium'" />
-    <span class="label" :class="size == 'small' ? 'typo-action-button-small' : 'typo-action-button'">
+  <button :class="[className, { selected }]" :disabled="isDisabled" class="ui-dropdown-item" type="button">
+    <VtsIcon :name="icon" :size="size" />
+    <span :class="size === 'small' ? 'typo-action-button-small' : 'typo-action-button'">
       <slot />
     </span>
-    <VtsIcon name="table:angle-down" :size="size ?? 'medium'" />
+    <VtsIcon name="fa:angle-down" :size="size" />
   </button>
 </template>
 
@@ -13,8 +13,15 @@
 import VtsIcon from '@core/components/icon/VtsIcon.vue'
 import { useDisabled } from '@core/composables/disabled.composable.ts'
 import type { IconName } from '@core/icons'
+import { toVariants } from '@core/utils/to-variants.util'
+import { computed } from 'vue'
 
-const { disabled, selected, icon } = defineProps<{
+const {
+  disabled,
+  selected,
+  icon,
+  size = 'medium',
+} = defineProps<{
   disabled?: boolean
   selected?: boolean
   icon?: IconName
@@ -22,6 +29,8 @@ const { disabled, selected, icon } = defineProps<{
 }>()
 
 const isDisabled = useDisabled(() => disabled)
+
+const className = computed(() => toVariants({ size }))
 </script>
 
 <style lang="postcss" scoped>
@@ -38,28 +47,26 @@ const isDisabled = useDisabled(() => disabled)
   position: relative;
   color: var(--color-brand-txt-base);
 
-  :deep(.icon-path) {
-    color: var(--color-brand-txt-base);
+  &.size--small {
+    padding-block: 0.8rem;
+    padding-inline: 1.2rem;
+  }
+
+  &.size--medium {
+    padding-block: 1.2rem;
+    padding-inline: 1.6rem;
   }
 
   &:hover {
     border-color: var(--color-brand-item-hover);
     background-color: var(--color-brand-background-hover);
     color: var(--color-brand-txt-hover);
-
-    :deep(.icon-path) {
-      color: var(--color-brand-txt-hover);
-    }
   }
 
   &:active {
     border-color: var(--color-brand-item-active);
     background-color: var(--color-brand-background-active);
     color: var(--color-brand-txt-active);
-
-    :deep(.icon-path) {
-      color: var(--color-brand-txt-active);
-    }
   }
 
   &.selected:not(:disabled) {
@@ -84,10 +91,6 @@ const isDisabled = useDisabled(() => disabled)
     border-color: var(--color-neutral-txt-secondary);
     background-color: var(--color-neutral-background-disabled);
     color: var(--color-neutral-txt-secondary);
-
-    :deep(.icon-path) {
-      color: var(--color-neutral-txt-secondary);
-    }
   }
 }
 </style>

--- a/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/dropdown-button/UiDropdownButton.vue
@@ -11,13 +11,14 @@
 
 <script lang="ts" setup>
 import VtsIcon from '@core/components/icon/VtsIcon.vue'
+import type { ButtonSize } from '@core/components/ui/button/UiButton.vue'
 import { useDisabled } from '@core/composables/disabled.composable.ts'
 import type { IconName } from '@core/icons'
 import { toVariants } from '@core/utils/to-variants.util.ts'
 import { computed } from 'vue'
 
 const { disabled, selected, icon, size } = defineProps<{
-  size: 'small' | 'medium'
+  size: ButtonSize
   disabled?: boolean
   selected?: boolean
   icon?: IconName

--- a/@xen-orchestra/web/src/modules/host/components/HostHeader.vue
+++ b/@xen-orchestra/web/src/modules/host/components/HostHeader.vue
@@ -22,7 +22,7 @@
       </UiLink>
       <MenuList v-if="!uiStore.isSmall" placement="bottom-end">
         <template #trigger="{ open }">
-          <UiDropdownButton @click="open($event)">{{ t('action:change-state') }}</UiDropdownButton>
+          <UiDropdownButton size="medium" @click="open($event)">{{ t('action:change-state') }}</UiDropdownButton>
         </template>
         <HostPowerStateActions :host />
       </MenuList>

--- a/@xen-orchestra/web/src/modules/third-parties/components/ThirdParties.vue
+++ b/@xen-orchestra/web/src/modules/third-parties/components/ThirdParties.vue
@@ -1,7 +1,7 @@
 <template>
   <MenuList placement="bottom-end">
     <template #trigger="{ open }">
-      <UiDropdownButton @click="open($event)">{{ t('third-parties') }}</UiDropdownButton>
+      <UiDropdownButton size="small" @click="open($event)">{{ t('third-parties') }}</UiDropdownButton>
     </template>
     <VtsDropdownTitle>
       <EasyVirtLogo class="logo" />{{ t('provider-solutions', { provider: 'EasyVirt' }) }}

--- a/@xen-orchestra/web/src/modules/vm/components/VmHeader.vue
+++ b/@xen-orchestra/web/src/modules/vm/components/VmHeader.vue
@@ -19,7 +19,7 @@
       </UiLink>
       <MenuList placement="bottom-end">
         <template #trigger="{ open }">
-          <UiDropdownButton @click="open($event)">{{ t('action:change-state') }}</UiDropdownButton>
+          <UiDropdownButton size="medium" @click="open($event)">{{ t('action:change-state') }}</UiDropdownButton>
         </template>
         <VmPowerStateActions :vm />
       </MenuList>

--- a/@xen-orchestra/web/src/modules/vm/components/VmHeader.vue
+++ b/@xen-orchestra/web/src/modules/vm/components/VmHeader.vue
@@ -16,7 +16,7 @@
       </UiLink>
       <MenuList placement="bottom-start">
         <template #trigger="{ open }">
-          <UiDropdownButton @click="open($event)">{{ t('action:change-state') }}</UiDropdownButton>
+          <UiDropdownButton size="medium" @click="open($event)">{{ t('action:change-state') }}</UiDropdownButton>
         </template>
         <VmPowerStateActions :vm />
       </MenuList>

--- a/@xen-orchestra/web/src/modules/vm/components/list/panel/VmSidePanel.vue
+++ b/@xen-orchestra/web/src/modules/vm/components/list/panel/VmSidePanel.vue
@@ -3,7 +3,7 @@
     <template v-if="vm" #actions>
       <MenuList placement="bottom-start">
         <template #trigger="{ open }">
-          <UiDropdownButton @click="open($event)">{{ t('action:change-state') }}</UiDropdownButton>
+          <UiDropdownButton size="medium" @click="open($event)">{{ t('action:change-state') }}</UiDropdownButton>
         </template>
         <VmPowerStateActions :vm />
       </MenuList>

--- a/@xen-orchestra/web/src/pages/pool/[id]/networks.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/networks.vue
@@ -5,7 +5,7 @@
         <template #title-actions>
           <MenuList placement="bottom-end">
             <template #trigger="{ open }">
-              <UiDropdownButton @click="open($event)">{{ t('new') }}</UiDropdownButton>
+              <UiDropdownButton size="medium" @click="open($event)">{{ t('new') }}</UiDropdownButton>
             </template>
             <MenuItem>
               <UiLink

--- a/@xen-orchestra/web/src/pages/vm/[id]/vdis.vue
+++ b/@xen-orchestra/web/src/pages/vm/[id]/vdis.vue
@@ -5,7 +5,9 @@
         <template #title-actions>
           <MenuList placement="bottom-end">
             <template #trigger="{ open }">
-              <UiDropdownButton icon="action:add" @click="open($event)">{{ t('action:add') }}</UiDropdownButton>
+              <UiDropdownButton size="medium" icon="action:add" @click="open($event)">
+                {{ t('action:add') }}
+              </UiDropdownButton>
             </template>
             <MenuItem>
               <UiLink

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 - [V2V] Add `esxi.importDisk` API endpoint to import a single ESXi disk into an SR as a standalone VDI ( [PR#10024] (https://github.com/vatesfr/xen-orchestra/pull/10024))
 - [XO5/V2V] Show if the transfer will be a full or a delta one when doing 2 steps V2V transfer (PR [#10014](https://github.com/vatesfr/xen-orchestra/pull/10014))
 - [V2V] Create a CDROM on destination if source has one (PR [#10014](https://github.com/vatesfr/xen-orchestra/pull/10014))
+- [web] Update size of `third party apps` button (PR [#9850](https://github.com/vatesfr/xen-orchestra/pull/9850))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@
 - [REST API] VDI can now be exported in qcow2 format, and the VHD export uses NBD when available. Both formats work whatever the format the disk is stored in. Every export format, raw included, now provides the size of the download (PR [#10350](https://github.com/vatesfr/xen-orchestra/pull/10350))
 - [REST API] SSE now supports Non XAPI objects (user, group, acl-privilege, acl-role, proxy, server, backup-repository, backup-job, schedule) (PR [#10278](https://github.com/vatesfr/xen-orchestra/pull/10278))
 - [REST API/SDN Controller, Audit] Traffic rule and audit record routes are now documented in the Swagger/OpenAPI spec (PR [#9895](https://github.com/vatesfr/xen-orchestra/pull/9895))
+- [Dropdown Button] `UiDropdownButton` now supports multiple sizes (PR [#9850](https://github.com/vatesfr/xen-orchestra/pull/9850))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,7 +20,7 @@
 - [REST API] VDI can now be exported in qcow2 format, and the VHD export uses NBD when available. Both formats work whatever the format the disk is stored in. Every export format, raw included, now provides the size of the download (PR [#10350](https://github.com/vatesfr/xen-orchestra/pull/10350))
 - [REST API] SSE now supports Non XAPI objects (user, group, acl-privilege, acl-role, proxy, server, backup-repository, backup-job, schedule) (PR [#10278](https://github.com/vatesfr/xen-orchestra/pull/10278))
 - [REST API/SDN Controller, Audit] Traffic rule and audit record routes are now documented in the Swagger/OpenAPI spec (PR [#9895](https://github.com/vatesfr/xen-orchestra/pull/9895))
-- [Dropdown Button] `UiDropdownButton` now supports multiple sizes (PR [#9850](https://github.com/vatesfr/xen-orchestra/pull/9850))
+- [XO6] Add a small size for dropdown buttons (PR [#9850](https://github.com/vatesfr/xen-orchestra/pull/9850))
 
 ### Bug fixes
 


### PR DESCRIPTION
### Description

🔗 [XO-1884](https://project.vates.tech/vates-global/browse/XO-1884/)

Upgrade `UiDropdownButton` from v5 to v9:

- Add a required `size` prop (`small` / `medium`)
- Update border/background colors

### Light screenshots

||Small|Medium|
|---|---|---|
| idle | <img width="222" height="85" alt="Capture d’écran du 2026-09-03 15-40-48" src="https://github.com/user-attachments/assets/115ad928-4136-49a2-9ad8-0c0032856d31" /> | <img width="252" height="76" alt="Capture d’écran du 2026-09-03 15-31-54" src="https://github.com/user-attachments/assets/170bf88b-0660-445d-95d8-7aa6067b794b" /> |
| hover | <img width="222" height="85" alt="Capture d’écran du 2026-09-03 15-40-54" src="https://github.com/user-attachments/assets/6b9c68cf-a93c-48c0-85ad-590250685354" /> | <img width="252" height="76" alt="Capture d’écran du 2026-09-03 15-32-49" src="https://github.com/user-attachments/assets/a5de72c7-f700-448a-9bd2-726470c69413" /> |
| focus-visible | <img width="222" height="85" alt="Capture d’écran du 2026-09-03 15-41-02" src="https://github.com/user-attachments/assets/cd2f933f-081b-41b9-9a4e-57cf3e5c7399" /> | <img width="252" height="76" alt="Capture d’écran du 2026-09-03 15-33-00" src="https://github.com/user-attachments/assets/fc13d0b3-67df-4cc6-becd-85ea1758d53d" /> |
| active | <img width="222" height="85" alt="Capture d’écran du 2026-09-03 15-41-07" src="https://github.com/user-attachments/assets/b8cf6824-d4ea-4fe8-9845-0ab42ad249de" /> | <img width="252" height="76" alt="Capture d’écran du 2026-09-03 15-34-14" src="https://github.com/user-attachments/assets/e0d68663-0779-448f-bcf0-2e577b0f67cf" /> |
| selected | <img width="222" height="85" alt="Capture d’écran du 2026-09-03 15-41-19" src="https://github.com/user-attachments/assets/2e7ce7f5-27b1-4fbf-b55c-77427d2db924" /> | <img width="252" height="76" alt="Capture d’écran du 2026-09-03 15-34-25" src="https://github.com/user-attachments/assets/dca4c14b-6506-4e8e-ab57-21180e71d51c" /> |
| disabled | <img width="222" height="85" alt="Capture d’écran du 2026-09-03 15-41-26" src="https://github.com/user-attachments/assets/f3c8bc88-53b1-4d97-af70-2a8f555342a0" /> | <img width="252" height="76" alt="Capture d’écran du 2026-09-03 15-34-30" src="https://github.com/user-attachments/assets/52f11471-7147-4bbe-aa0a-3711b0fdae5d" /> |

### Dark screenshots

||Small|Medium|
|---|---|---|
| idle | <img width="222" height="85" alt="Capture d’écran du 2026-09-03 15-39-33" src="https://github.com/user-attachments/assets/4d15aa90-2fc7-42a4-9b48-1f6b7ed79cb0" /> | <img width="253" height="85" alt="Capture d’écran du 2026-09-03 15-35-14" src="https://github.com/user-attachments/assets/f7d59297-21da-4362-adb3-6a20f10fe704" /> |
| hover | <img width="222" height="85" alt="Capture d’écran du 2026-09-03 15-39-42" src="https://github.com/user-attachments/assets/7365f6eb-662f-4389-92db-bd2421e54fe9" /> | <img width="253" height="85" alt="Capture d’écran du 2026-09-03 15-35-19" src="https://github.com/user-attachments/assets/0055ef85-489b-43d0-87b0-340cd7ffaf76" />|
| focus-visible | <img width="222" height="85" alt="Capture d’écran du 2026-09-03 15-40-03" src="https://github.com/user-attachments/assets/4a14ad43-606a-4f18-be3c-c924240325a7" /> | <img width="253" height="85" alt="Capture d’écran du 2026-09-03 15-35-26" src="https://github.com/user-attachments/assets/d09ace05-a713-494f-a44f-8b3a2a020334" /> |
| active | <img width="222" height="85" alt="Capture d’écran du 2026-09-03 15-40-15" src="https://github.com/user-attachments/assets/7bca092f-9804-410a-8302-e87724a09a13" /> | <img width="250" height="90" alt="Capture d’écran du 2026-09-03 15-48-34" src="https://github.com/user-attachments/assets/ff87242e-f382-49fe-9dfd-ba149c66e51d" /> |
| selected | <img width="222" height="85" alt="Capture d’écran du 2026-09-03 15-40-20" src="https://github.com/user-attachments/assets/f082b183-b2c5-4049-b49c-5da7a108a482" /> | <img width="253" height="85" alt="Capture d’écran du 2026-09-03 15-35-52" src="https://github.com/user-attachments/assets/7b8d7f5d-9dd4-49ae-b717-2e8ad1c680a1" /> |
| disabled | <img width="222" height="85" alt="Capture d’écran du 2026-09-03 15-40-24" src="https://github.com/user-attachments/assets/66d5afc2-28a3-4a72-980e-8fb6739ed73d" /> | <img width="253" height="85" alt="Capture d’écran du 2026-09-03 15-35-58" src="https://github.com/user-attachments/assets/8e7111c6-90c4-468c-bd6d-c6842c380bf5" /> |

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
