### PR TITLE
fix(encryption): fix orphaned entry issue

### DIFF
--- a/@xen-orchestra/web/src/route-map.d.ts
+++ b/@xen-orchestra/web/src/route-map.d.ts
@@ -8,11 +8,11 @@
 // Make sure to add this file to your tsconfig.json file as an "includes" or "files" entry.
 
 import type {
+  RouteRecordInfo,
   ParamValue,
   ParamValueOneOrMore,
   ParamValueZeroOrMore,
   ParamValueZeroOrOne,
-  RouteRecordInfo,
 } from 'vue-router'
 import type { _ExtractParamParserType } from 'vue-router/experimental'
 

--- a/@xen-orchestra/web/src/route-map.d.ts
+++ b/@xen-orchestra/web/src/route-map.d.ts
@@ -8,11 +8,11 @@
 // Make sure to add this file to your tsconfig.json file as an "includes" or "files" entry.
 
 import type {
-  RouteRecordInfo,
   ParamValue,
   ParamValueOneOrMore,
   ParamValueZeroOrMore,
   ParamValueZeroOrOne,
+  RouteRecordInfo,
 } from 'vue-router'
 import type { _ExtractParamParserType } from 'vue-router/experimental'
 

--- a/packages/xo-server/src/collection/redis.mjs
+++ b/packages/xo-server/src/collection/redis.mjs
@@ -191,22 +191,24 @@ export default class Redis extends Collection {
           }
 
           const previous = await this.#get(`${prefix}:${id}`)
-          await this._beforeUpdate(model, this._unserialize(previous) ?? previous)
+          if (previous !== undefined) {
+            await this._beforeUpdate(model, this._unserialize(previous) ?? previous)
 
-          // remove the previous values from indexes
-          if (indexes.length !== 0) {
-            await asyncMapSettled(indexes, async index => {
-              let value = previous[index]
-              if (value !== undefined) {
-                if (this.#crypto && !this.#crypto.isDegraded()) {
-                  value = await this.#crypto.hmacIndex(String(value).toLowerCase())
-                } else {
-                  value = String(value).toLowerCase()
+            // remove the previous values from indexes
+            if (indexes.length !== 0) {
+              await asyncMapSettled(indexes, async index => {
+                let value = previous[index]
+                if (value !== undefined) {
+                  if (this.#crypto && !this.#crypto.isDegraded()) {
+                    value = await this.#crypto.hmacIndex(String(value).toLowerCase())
+                  } else {
+                    value = String(value).toLowerCase()
+                  }
+
+                  return redis.sRem(`${prefix}_${index}:${value}`, id)
                 }
-
-                return redis.sRem(`${prefix}_${index}:${value}`, id)
-              }
-            })
+              })
+            }
           }
         }
 

--- a/packages/xo-server/src/collection/redis.mjs
+++ b/packages/xo-server/src/collection/redis.mjs
@@ -9,6 +9,8 @@ import map from 'lodash/map.js'
 import omit from 'lodash/omit.js'
 import { v4 as generateUuid } from 'uuid'
 
+import { createLogger } from '@xen-orchestra/log'
+
 import Collection, { ModelAlreadyExists } from '../collection.mjs'
 
 /** @typedef {import('../xo-mixins/crypto-credentials.mjs').default} CryptoCredentials */
@@ -34,6 +36,8 @@ import Collection, { ModelAlreadyExists } from '../collection.mjs'
 // TODO: Remote events.
 
 const VERSION = '20170905'
+
+const log = createLogger('xo:redis')
 
 export default class Redis extends Collection {
   /** @type {CryptoCredentials | undefined} */
@@ -209,6 +213,8 @@ export default class Redis extends Collection {
                 }
               })
             }
+          } else {
+            log.warn(`The id ${prefix}:${id} had no attached entries.`)
           }
         }
 


### PR DESCRIPTION
### Description

When a Redis entry has an ID but no corresponding data key, undefined was returned which caused errors when new data was added.

Error case was the configuration of a plugin failing to save. 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
