### PR TITLE
feat: aggregate errors in backup runners

### DIFF
--- a/@xen-orchestra/backups/_runners/VmsRemote.mjs
+++ b/@xen-orchestra/backups/_runners/VmsRemote.mjs
@@ -71,6 +71,7 @@ export const VmsRemote = class RemoteVmsBackupRunner extends Abstract {
         const queue = new Set(vmsUuids)
         const taskByVmId = {}
         const nTriesByVmId = {}
+        const vmErrors = []
 
         const handleVm = vmUuid => {
           if (nTriesByVmId[vmUuid] === undefined) {
@@ -126,6 +127,7 @@ export const VmsRemote = class RemoteVmsBackupRunner extends Abstract {
                       return task.success(result)
                     }
                     if (isLastRun) {
+                      vmErrors.push(taskError)
                       return task.failure(taskError)
                     }
                     // don't end the task
@@ -148,6 +150,8 @@ export const VmsRemote = class RemoteVmsBackupRunner extends Abstract {
 
           await asyncMapSettled(vmIds, _handleVm)
         }
+
+        this._throwVmErrors(vmErrors)
       }
     )
   }

--- a/@xen-orchestra/backups/_runners/VmsXapi.mjs
+++ b/@xen-orchestra/backups/_runners/VmsXapi.mjs
@@ -98,6 +98,7 @@ export const VmsXapi = class VmsXapiBackupRunner extends Abstract {
         const queue = new Set(vmIds)
         const taskByVmId = {}
         const nTriesByVmId = {}
+        const vmErrors = []
 
         const handleVm = vmUuid => {
           const getVmTask = () => {
@@ -175,11 +176,19 @@ export const VmsXapi = class VmsXapiBackupRunner extends Abstract {
                     } else {
                       // ending the task with error or not ending the task
                       vmBackupFailed(taskError, task)
+                      if (isLastRun) {
+                        vmErrors.push(taskError)
+                      }
                     }
                   })
                   .catch(noop) // errors are handled by logs
               }),
-            error => vmBackupFailed(error, getVmTask())
+            error => {
+              vmBackupFailed(error, getVmTask())
+              if (isLastRun) {
+                vmErrors.push(error)
+              }
+            }
           )
         }
         const { concurrency } = settings
@@ -191,6 +200,8 @@ export const VmsXapi = class VmsXapiBackupRunner extends Abstract {
 
           await asyncMapSettled(vmIds, _handleVm)
         }
+
+        this._throwVmErrors(vmErrors)
       }
     )
   }

--- a/@xen-orchestra/backups/_runners/_Abstract.mjs
+++ b/@xen-orchestra/backups/_runners/_Abstract.mjs
@@ -11,7 +11,22 @@ export const DEFAULT_SETTINGS = {
   reportWhen: 'failure',
 }
 
+export class AggregateError extends Error {
+  constructor(errors, message) {
+    super(message)
+    this.errors = errors
+  }
+}
+
 export const Abstract = class AbstractRunner {
+  _throwVmErrors(errors) {
+    if (errors.length === 1) {
+      throw errors[0]
+    } else if (errors.length > 1) {
+      throw new AggregateError(errors, `${errors.length} VMs failed`)
+    }
+  }
+
   constructor({ config, getAdapter, getConnectedRecord, job, schedule }) {
     this._config = config
     this._getRecord = getConnectedRecord


### PR DESCRIPTION
### Description

Some errors are sometimes swallowed inside try/catch. This is an attempt to have them in the logs
In draft because I don't know if it a good way to do it

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
