### PR TITLE
fix(xo6): route-map incorrectly formatted by Prettier on commit

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,4 @@
 **/*.hbs
 
 # Generated files
-/@xen-orchestra/web/typed-router.d.ts
+/@xen-orchestra/web/src/route-map.d.ts

--- a/@xen-orchestra/web/src/route-map.d.ts
+++ b/@xen-orchestra/web/src/route-map.d.ts
@@ -14,11 +14,14 @@ import type {
   ParamValueZeroOrMore,
   ParamValueZeroOrOne,
 } from 'vue-router'
-import type { _ExtractParamParserType } from 'vue-router/experimental'
+import type {
+  _ExtractParamParserType,
+} from 'vue-router/experimental'
 
 declare module 'vue-router' {
   interface TypesConfig {
-    ParamParsers: never
+    ParamParsers:
+      | never
   }
 }
 
@@ -32,62 +35,100 @@ declare module 'vue-router/auto-routes' {
       '/',
       Record<never, never>,
       Record<never, never>,
-      '/(site)/backups' | '/(site)/dashboard' | '/(site)/hosts' | '/(site)/pools' | '/(site)/tasks' | '/(site)/vms'
-    >
-    '/(site)/backups': RouteRecordInfo<'/(site)/backups', '/backups', Record<never, never>, Record<never, never>, never>
+      | '/(site)/backups'
+      | '/(site)/dashboard'
+      | '/(site)/hosts'
+      | '/(site)/pools'
+      | '/(site)/tasks'
+      | '/(site)/vms'
+    >,
+    '/(site)/backups': RouteRecordInfo<
+      '/(site)/backups',
+      '/backups',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/(site)/dashboard': RouteRecordInfo<
       '/(site)/dashboard',
       '/dashboard',
       Record<never, never>,
       Record<never, never>,
-      never
-    >
-    '/(site)/hosts': RouteRecordInfo<'/(site)/hosts', '/hosts', Record<never, never>, Record<never, never>, never>
-    '/(site)/pools': RouteRecordInfo<'/(site)/pools', '/pools', Record<never, never>, Record<never, never>, never>
-    '/(site)/tasks': RouteRecordInfo<'/(site)/tasks', '/tasks', Record<never, never>, Record<never, never>, never>
-    '/(site)/vms': RouteRecordInfo<'/(site)/vms', '/vms', Record<never, never>, Record<never, never>, never>
+      | never
+    >,
+    '/(site)/hosts': RouteRecordInfo<
+      '/(site)/hosts',
+      '/hosts',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
+    '/(site)/pools': RouteRecordInfo<
+      '/(site)/pools',
+      '/pools',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
+    '/(site)/tasks': RouteRecordInfo<
+      '/(site)/tasks',
+      '/tasks',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
+    '/(site)/vms': RouteRecordInfo<
+      '/(site)/vms',
+      '/vms',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/[...path]': RouteRecordInfo<
       '/[...path]',
       '/:path(.*)',
       { path: ParamValue<true> },
       { path: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/backup/[id]': RouteRecordInfo<
       '/backup/[id]',
       '/backup/:id',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      '/backup/[id]/backed-up-vms' | '/backup/[id]/configuration' | '/backup/[id]/runs' | '/backup/[id]/targets'
-    >
+      | '/backup/[id]/backed-up-vms'
+      | '/backup/[id]/configuration'
+      | '/backup/[id]/runs'
+      | '/backup/[id]/targets'
+    >,
     '/backup/[id]/backed-up-vms': RouteRecordInfo<
       '/backup/[id]/backed-up-vms',
       '/backup/:id/backed-up-vms',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/backup/[id]/configuration': RouteRecordInfo<
       '/backup/[id]/configuration',
       '/backup/:id/configuration',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/backup/[id]/runs': RouteRecordInfo<
       '/backup/[id]/runs',
       '/backup/:id/runs',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/backup/[id]/targets': RouteRecordInfo<
       '/backup/[id]/targets',
       '/backup/:id/targets',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/host/[id]': RouteRecordInfo<
       '/host/[id]',
       '/host/:id',
@@ -100,71 +141,77 @@ declare module 'vue-router/auto-routes' {
       | '/host/[id]/system'
       | '/host/[id]/tasks'
       | '/host/[id]/vms'
-    >
+    >,
     '/host/[id]/console': RouteRecordInfo<
       '/host/[id]/console',
       '/host/:id/console',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/host/[id]/dashboard': RouteRecordInfo<
       '/host/[id]/dashboard',
       '/host/:id/dashboard',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/host/[id]/networks': RouteRecordInfo<
       '/host/[id]/networks',
       '/host/:id/networks',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/host/[id]/storage': RouteRecordInfo<
       '/host/[id]/storage',
       '/host/:id/storage',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/host/[id]/system': RouteRecordInfo<
       '/host/[id]/system',
       '/host/:id/system',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/host/[id]/tasks': RouteRecordInfo<
       '/host/[id]/tasks',
       '/host/:id/tasks',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/host/[id]/vms': RouteRecordInfo<
       '/host/[id]/vms',
       '/host/:id/vms',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
-    '/network/new': RouteRecordInfo<'/network/new', '/network/new', Record<never, never>, Record<never, never>, never>
+      | never
+    >,
+    '/network/new': RouteRecordInfo<
+      '/network/new',
+      '/network/new',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/network/new-bonded': RouteRecordInfo<
       '/network/new-bonded',
       '/network/new-bonded',
       Record<never, never>,
       Record<never, never>,
-      never
-    >
+      | never
+    >,
     '/network/new-internal': RouteRecordInfo<
       '/network/new-internal',
       '/network/new-internal',
       Record<never, never>,
       Record<never, never>,
-      never
-    >
+      | never
+    >,
     '/pool/[id]': RouteRecordInfo<
       '/pool/[id]',
       '/pool/:id',
@@ -178,71 +225,77 @@ declare module 'vue-router/auto-routes' {
       | '/pool/[id]/system'
       | '/pool/[id]/tasks'
       | '/pool/[id]/vms'
-    >
+    >,
     '/pool/[id]/dashboard': RouteRecordInfo<
       '/pool/[id]/dashboard',
       '/pool/:id/dashboard',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/pool/[id]/hosts': RouteRecordInfo<
       '/pool/[id]/hosts',
       '/pool/:id/hosts',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/pool/[id]/networks': RouteRecordInfo<
       '/pool/[id]/networks',
       '/pool/:id/networks',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/pool/[id]/security': RouteRecordInfo<
       '/pool/[id]/security',
       '/pool/:id/security',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/pool/[id]/storage': RouteRecordInfo<
       '/pool/[id]/storage',
       '/pool/:id/storage',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/pool/[id]/system': RouteRecordInfo<
       '/pool/[id]/system',
       '/pool/:id/system',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/pool/[id]/tasks': RouteRecordInfo<
       '/pool/[id]/tasks',
       '/pool/:id/tasks',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/pool/[id]/vms': RouteRecordInfo<
       '/pool/[id]/vms',
       '/pool/:id/vms',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/pool/connect': RouteRecordInfo<
       '/pool/connect',
       '/pool/connect',
       Record<never, never>,
       Record<never, never>,
-      never
-    >
-    '/settings': RouteRecordInfo<'/settings', '/settings', Record<never, never>, Record<never, never>, never>
+      | never
+    >,
+    '/settings': RouteRecordInfo<
+      '/settings',
+      '/settings',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/vm/[id]': RouteRecordInfo<
       '/vm/[id]',
       '/vm/:id',
@@ -256,64 +309,70 @@ declare module 'vue-router/auto-routes' {
       | '/vm/[id]/system'
       | '/vm/[id]/tasks'
       | '/vm/[id]/vdis'
-    >
+    >,
     '/vm/[id]/backups': RouteRecordInfo<
       '/vm/[id]/backups',
       '/vm/:id/backups',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/vm/[id]/console': RouteRecordInfo<
       '/vm/[id]/console',
       '/vm/:id/console',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/vm/[id]/dashboard': RouteRecordInfo<
       '/vm/[id]/dashboard',
       '/vm/:id/dashboard',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/vm/[id]/networks': RouteRecordInfo<
       '/vm/[id]/networks',
       '/vm/:id/networks',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/vm/[id]/snapshots': RouteRecordInfo<
       '/vm/[id]/snapshots',
       '/vm/:id/snapshots',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/vm/[id]/system': RouteRecordInfo<
       '/vm/[id]/system',
       '/vm/:id/system',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/vm/[id]/tasks': RouteRecordInfo<
       '/vm/[id]/tasks',
       '/vm/:id/tasks',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
+      | never
+    >,
     '/vm/[id]/vdis': RouteRecordInfo<
       '/vm/[id]/vdis',
       '/vm/:id/vdis',
       { id: ParamValue<true> },
       { id: ParamValue<false> },
-      never
-    >
-    '/vm/new': RouteRecordInfo<'/vm/new', '/vm/new', Record<never, never>, Record<never, never>, never>
+      | never
+    >,
+    '/vm/new': RouteRecordInfo<
+      '/vm/new',
+      '/vm/new',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
   }
 
   /**
@@ -336,35 +395,50 @@ declare module 'vue-router/auto-routes' {
         | '/(site)/pools'
         | '/(site)/tasks'
         | '/(site)/vms'
-      views: 'default'
+      views:
+        | 'default'
     }
     'src/pages/(site)/backups.vue': {
-      routes: '/(site)/backups'
-      views: never
+      routes:
+        | '/(site)/backups'
+      views:
+        | never
     }
     'src/pages/(site)/dashboard.vue': {
-      routes: '/(site)/dashboard'
-      views: never
+      routes:
+        | '/(site)/dashboard'
+      views:
+        | never
     }
     'src/pages/(site)/hosts.vue': {
-      routes: '/(site)/hosts'
-      views: never
+      routes:
+        | '/(site)/hosts'
+      views:
+        | never
     }
     'src/pages/(site)/pools.vue': {
-      routes: '/(site)/pools'
-      views: never
+      routes:
+        | '/(site)/pools'
+      views:
+        | never
     }
     'src/pages/(site)/tasks.vue': {
-      routes: '/(site)/tasks'
-      views: never
+      routes:
+        | '/(site)/tasks'
+      views:
+        | never
     }
     'src/pages/(site)/vms.vue': {
-      routes: '/(site)/vms'
-      views: never
+      routes:
+        | '/(site)/vms'
+      views:
+        | never
     }
     'src/pages/[...path].vue': {
-      routes: '/[...path]'
-      views: never
+      routes:
+        | '/[...path]'
+      views:
+        | never
     }
     'src/pages/backup/[id].vue': {
       routes:
@@ -373,23 +447,32 @@ declare module 'vue-router/auto-routes' {
         | '/backup/[id]/configuration'
         | '/backup/[id]/runs'
         | '/backup/[id]/targets'
-      views: 'default'
+      views:
+        | 'default'
     }
     'src/pages/backup/[id]/backed-up-vms.vue': {
-      routes: '/backup/[id]/backed-up-vms'
-      views: never
+      routes:
+        | '/backup/[id]/backed-up-vms'
+      views:
+        | never
     }
     'src/pages/backup/[id]/configuration.vue': {
-      routes: '/backup/[id]/configuration'
-      views: never
+      routes:
+        | '/backup/[id]/configuration'
+      views:
+        | never
     }
     'src/pages/backup/[id]/runs.vue': {
-      routes: '/backup/[id]/runs'
-      views: never
+      routes:
+        | '/backup/[id]/runs'
+      views:
+        | never
     }
     'src/pages/backup/[id]/targets.vue': {
-      routes: '/backup/[id]/targets'
-      views: never
+      routes:
+        | '/backup/[id]/targets'
+      views:
+        | never
     }
     'src/pages/host/[id].vue': {
       routes:
@@ -401,47 +484,68 @@ declare module 'vue-router/auto-routes' {
         | '/host/[id]/system'
         | '/host/[id]/tasks'
         | '/host/[id]/vms'
-      views: 'default'
+      views:
+        | 'default'
     }
     'src/pages/host/[id]/console.vue': {
-      routes: '/host/[id]/console'
-      views: never
+      routes:
+        | '/host/[id]/console'
+      views:
+        | never
     }
     'src/pages/host/[id]/dashboard.vue': {
-      routes: '/host/[id]/dashboard'
-      views: never
+      routes:
+        | '/host/[id]/dashboard'
+      views:
+        | never
     }
     'src/pages/host/[id]/networks.vue': {
-      routes: '/host/[id]/networks'
-      views: never
+      routes:
+        | '/host/[id]/networks'
+      views:
+        | never
     }
     'src/pages/host/[id]/storage.vue': {
-      routes: '/host/[id]/storage'
-      views: never
+      routes:
+        | '/host/[id]/storage'
+      views:
+        | never
     }
     'src/pages/host/[id]/system.vue': {
-      routes: '/host/[id]/system'
-      views: never
+      routes:
+        | '/host/[id]/system'
+      views:
+        | never
     }
     'src/pages/host/[id]/tasks.vue': {
-      routes: '/host/[id]/tasks'
-      views: never
+      routes:
+        | '/host/[id]/tasks'
+      views:
+        | never
     }
     'src/pages/host/[id]/vms.vue': {
-      routes: '/host/[id]/vms'
-      views: never
+      routes:
+        | '/host/[id]/vms'
+      views:
+        | never
     }
     'src/pages/network/new.vue': {
-      routes: '/network/new'
-      views: never
+      routes:
+        | '/network/new'
+      views:
+        | never
     }
     'src/pages/network/new-bonded.vue': {
-      routes: '/network/new-bonded'
-      views: never
+      routes:
+        | '/network/new-bonded'
+      views:
+        | never
     }
     'src/pages/network/new-internal.vue': {
-      routes: '/network/new-internal'
-      views: never
+      routes:
+        | '/network/new-internal'
+      views:
+        | never
     }
     'src/pages/pool/[id].vue': {
       routes:
@@ -454,47 +558,68 @@ declare module 'vue-router/auto-routes' {
         | '/pool/[id]/system'
         | '/pool/[id]/tasks'
         | '/pool/[id]/vms'
-      views: 'default'
+      views:
+        | 'default'
     }
     'src/pages/pool/[id]/dashboard.vue': {
-      routes: '/pool/[id]/dashboard'
-      views: never
+      routes:
+        | '/pool/[id]/dashboard'
+      views:
+        | never
     }
     'src/pages/pool/[id]/hosts.vue': {
-      routes: '/pool/[id]/hosts'
-      views: never
+      routes:
+        | '/pool/[id]/hosts'
+      views:
+        | never
     }
     'src/pages/pool/[id]/networks.vue': {
-      routes: '/pool/[id]/networks'
-      views: never
+      routes:
+        | '/pool/[id]/networks'
+      views:
+        | never
     }
     'src/pages/pool/[id]/security.vue': {
-      routes: '/pool/[id]/security'
-      views: never
+      routes:
+        | '/pool/[id]/security'
+      views:
+        | never
     }
     'src/pages/pool/[id]/storage.vue': {
-      routes: '/pool/[id]/storage'
-      views: never
+      routes:
+        | '/pool/[id]/storage'
+      views:
+        | never
     }
     'src/pages/pool/[id]/system.vue': {
-      routes: '/pool/[id]/system'
-      views: never
+      routes:
+        | '/pool/[id]/system'
+      views:
+        | never
     }
     'src/pages/pool/[id]/tasks.vue': {
-      routes: '/pool/[id]/tasks'
-      views: never
+      routes:
+        | '/pool/[id]/tasks'
+      views:
+        | never
     }
     'src/pages/pool/[id]/vms.vue': {
-      routes: '/pool/[id]/vms'
-      views: never
+      routes:
+        | '/pool/[id]/vms'
+      views:
+        | never
     }
     'src/pages/pool/connect.vue': {
-      routes: '/pool/connect'
-      views: never
+      routes:
+        | '/pool/connect'
+      views:
+        | never
     }
     'src/pages/settings.vue': {
-      routes: '/settings'
-      views: never
+      routes:
+        | '/settings'
+      views:
+        | never
     }
     'src/pages/vm/[id].vue': {
       routes:
@@ -507,43 +632,62 @@ declare module 'vue-router/auto-routes' {
         | '/vm/[id]/system'
         | '/vm/[id]/tasks'
         | '/vm/[id]/vdis'
-      views: 'default'
+      views:
+        | 'default'
     }
     'src/pages/vm/[id]/backups.vue': {
-      routes: '/vm/[id]/backups'
-      views: never
+      routes:
+        | '/vm/[id]/backups'
+      views:
+        | never
     }
     'src/pages/vm/[id]/console.vue': {
-      routes: '/vm/[id]/console'
-      views: never
+      routes:
+        | '/vm/[id]/console'
+      views:
+        | never
     }
     'src/pages/vm/[id]/dashboard.vue': {
-      routes: '/vm/[id]/dashboard'
-      views: never
+      routes:
+        | '/vm/[id]/dashboard'
+      views:
+        | never
     }
     'src/pages/vm/[id]/networks.vue': {
-      routes: '/vm/[id]/networks'
-      views: never
+      routes:
+        | '/vm/[id]/networks'
+      views:
+        | never
     }
     'src/pages/vm/[id]/snapshots.vue': {
-      routes: '/vm/[id]/snapshots'
-      views: never
+      routes:
+        | '/vm/[id]/snapshots'
+      views:
+        | never
     }
     'src/pages/vm/[id]/system.vue': {
-      routes: '/vm/[id]/system'
-      views: never
+      routes:
+        | '/vm/[id]/system'
+      views:
+        | never
     }
     'src/pages/vm/[id]/tasks.vue': {
-      routes: '/vm/[id]/tasks'
-      views: never
+      routes:
+        | '/vm/[id]/tasks'
+      views:
+        | never
     }
     'src/pages/vm/[id]/vdis.vue': {
-      routes: '/vm/[id]/vdis'
-      views: never
+      routes:
+        | '/vm/[id]/vdis'
+      views:
+        | never
     }
     'src/pages/vm/new.vue': {
-      routes: '/vm/new'
-      views: never
+      routes:
+        | '/vm/new'
+      views:
+        | never
     }
   }
 
@@ -554,7 +698,9 @@ declare module 'vue-router/auto-routes' {
    * @internal
    */
   export type _RouteNamesForFilePath<FilePath extends string> =
-    _RouteFileInfoMap extends Record<FilePath, infer Info> ? Info['routes'] : keyof RouteNamedMap
+    _RouteFileInfoMap extends Record<FilePath, infer Info>
+      ? Info['routes']
+      : keyof RouteNamedMap
 }
 
 export {}

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,5 +34,6 @@
 <!--packages-start-->
 
 - @xen-orchestra/rest-api patch
+- @xen-orchestra/web patch
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

**Introduced by 8c00cce**

The new `route-map.d.ts` auto-generated file was not excluded from the pre-commit hook linting, causing changes on every build / dev server start.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
