### PR TITLE
fix(encryption): fix 401 issue caused by key deletion before set

### DIFF
--- a/packages/xo-server/src/collection/redis.mjs
+++ b/packages/xo-server/src/collection/redis.mjs
@@ -227,7 +227,6 @@ export default class Redis extends Collection {
           serialized = await this.#crypto.encrypt(serialized)
         }
 
-        await redis.del(key)
         await redis.set(key, serialized)
 
         // Update indexes.


### PR DESCRIPTION
### Description

Introduced by 6f68b04

When adding an entry to redis, the pre-encryption code used `redis.del` then `redis.set`, awaited in the same promise array which worked fine as no other redis request could be processed in between.

This promise array was lost when refactoring the code for encryption and thus, when a lot of queries are sent in a short amount of time (cache refresh of the v6 dashboard for example), queries could run between the `redis.del` and `redis.set` leading to not found tokens and 401 responses.

Simply removing the `redis.del` fixes the issue because `redis.set` unconditionally overwrites any existing value atomically.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
