### PR TITLE
feat(qa-test): user url instead of fs

### DIFF
--- a/@xen-orchestra/qa-test/.USAGE.md
+++ b/@xen-orchestra/qa-test/.USAGE.md
@@ -30,27 +30,26 @@ cp .env.example .env
 
 All variables are required. The test suite fails immediately if any are missing.
 
-| Variable                 | Description                                                                | Example                  |
-| ------------------------ | -------------------------------------------------------------------------- | ------------------------ |
-| `HOSTNAME`               | XO instance URL                                                            | `http://10.1.4.216:9000` |
-| `USERNAME`               | XO user                                                                    | `admin@admin.net`        |
-| `PASSWORD`               | XO password                                                                | `admin`                  |
-| `REFERENCE_VM_ID`        | UUID of the VM to clone for tests                                          | `61c24db9-262d-...`      |
-| `SR_ID`                  | UUID of the Storage Repository                                             | `8aa2fb4a-143e-...`      |
-| `VM_PREFIX`              | Test VM name prefix                                                        | `TST`                    |
-| `BACKUP_REPOSITORY_NAME` | Backup repository name in XO                                               | `Test backup QA`         |
-| `BACKUP_REPOSITORY_PATH` | Test backup path on the XO server (must contain `test`, `qa`, or `tmp/xo`) | `/tmp/xo-test-backups`   |
-| `BACKUP_PATH`            | Production backup path used for repository creation (not cleaned up)       | `/var/lib/xo/backups`    |
-| `VHD_EXPORT_PATH`        | VHD/XVA export directory (must contain `test`, `qa`, or `tmp/`)            | `/tmp/xo-test-exports`   |
+| Variable                 | Description                                                                                                                                                                                | Example                       |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------- |
+| `HOSTNAME`               | XO instance URL                                                                                                                                                                            | `http://10.1.4.216:9000`      |
+| `USERNAME`               | XO user                                                                                                                                                                                    | `admin@admin.net`             |
+| `PASSWORD`               | XO password                                                                                                                                                                                | `admin`                       |
+| `REFERENCE_VM_ID`        | UUID of the VM to clone for tests                                                                                                                                                          | `61c24db9-262d-...`           |
+| `SR_ID`                  | UUID of the Storage Repository                                                                                                                                                             | `8aa2fb4a-143e-...`           |
+| `VM_PREFIX`              | Test VM name prefix                                                                                                                                                                        | `TST`                         |
+| `BACKUP_REPOSITORY_NAME` | Backup repository name in XO                                                                                                                                                               | `Test backup QA`              |
+| `BACKUP_REPOSITORY_URL`  | `@xen-orchestra/fs` URL for the test backup remote. For `file://` remotes the path must contain `test`, `qa`, or `tmp/xo`. Any supported backend works (`s3://`, `nfs://`, `azure://`, …). | `file:///tmp/xo-test-backups` |
+| `VHD_EXPORT_PATH`        | VHD/XVA export directory (must contain `test`, `qa`, or `tmp/`)                                                                                                                            | `/tmp/xo-test-exports`        |
 
-The following are required only for mirror backup tests (`qa:backup:mirror`):
+The following are required only for mirror backup tests (`qa:mirror`):
 
-| Variable                             | Description                                                      | Example               |
-| ------------------------------------ | ---------------------------------------------------------------- | --------------------- |
-| `MIRROR_DESTINATION_REPOSITORY_NAME` | Mirror destination repository name                               | `Test mirror QA`      |
-| `MIRROR_DESTINATION_REPOSITORY_PATH` | Mirror destination path (must contain `test`, `qa`, or `tmp/xo`) | `/tmp/xo-test-mirror` |
+| Variable                             | Description                                                                                              | Example                      |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `MIRROR_DESTINATION_REPOSITORY_NAME` | Mirror destination repository name                                                                       | `Test mirror QA`             |
+| `MIRROR_DESTINATION_REPOSITORY_URL`  | `@xen-orchestra/fs` URL for the mirror destination. Same backend flexibility as `BACKUP_REPOSITORY_URL`. | `file:///tmp/xo-test-mirror` |
 
-> **Safety**: paths used for automatic cleanup must contain `test`, `qa`, or `tmp/xo` to prevent accidental deletion of production data.
+> **Safety**: for `file://` remotes the path component of the URL must contain `test`, `qa`, or `tmp/xo` to prevent accidental deletion of production data. Non-local remotes (`s3://`, `nfs://`, …) skip this local-path check — cleanup is delegated to the XO API.
 
 ## Logging
 

--- a/@xen-orchestra/qa-test/.env.example
+++ b/@xen-orchestra/qa-test/.env.example
@@ -13,10 +13,12 @@ REFERENCE_VM_ID=  # Required: UUID of the reference VM to clone for tests
 SR_ID=  # Required: UUID of the Storage Repository for health checks
 BACKUP_REPOSITORY_NAME=Test backup QA
 
-# Test Backup Paths
-# IMPORTANT: Only test-scoped paths are allowed for automatic cleanup
-# Paths must contain 'test', 'qa', or 'tmp/xo' to prevent production data deletion
-BACKUP_REPOSITORY_PATH=/tmp/xo-test-backups
+# Test Backup URLs (@xen-orchestra/fs format)
+# IMPORTANT: Only test-scoped paths are allowed for automatic cleanup of file:// remotes.
+# The path component of the URL must contain 'test', 'qa', or 'tmp/xo'.
+# Any @xen-orchestra/fs-compatible URL is accepted (file://, s3://, nfs://, azure://, …)
+# use " around the url to handle # escaping
+BACKUP_REPOSITORY_URL="file:///tmp/xo-test-backups"
 
 # ===========================================
 # MIRROR BACKUP TEST CONFIGURATION
@@ -24,8 +26,9 @@ BACKUP_REPOSITORY_PATH=/tmp/xo-test-backups
 
 # Destination repository for mirror backup tests
 # Source is BACKUP_REPOSITORY_NAME above
+# use " around the url to handle # escaping
 MIRROR_DESTINATION_REPOSITORY_NAME=Test mirror QA
-MIRROR_DESTINATION_REPOSITORY_PATH=/tmp/xo-test-mirror
+MIRROR_DESTINATION_REPOSITORY_URL="file:///tmp/xo-test-mirror"
 
 # ===========================================
 # REPLICATION TEST CONFIGURATION

--- a/@xen-orchestra/qa-test/README.md
+++ b/@xen-orchestra/qa-test/README.md
@@ -38,27 +38,26 @@ cp .env.example .env
 
 All variables are required. The test suite fails immediately if any are missing.
 
-| Variable                 | Description                                                                | Example                  |
-| ------------------------ | -------------------------------------------------------------------------- | ------------------------ |
-| `HOSTNAME`               | XO instance URL                                                            | `http://10.1.4.216:9000` |
-| `USERNAME`               | XO user                                                                    | `admin@admin.net`        |
-| `PASSWORD`               | XO password                                                                | `admin`                  |
-| `REFERENCE_VM_ID`        | UUID of the VM to clone for tests                                          | `61c24db9-262d-...`      |
-| `SR_ID`                  | UUID of the Storage Repository                                             | `8aa2fb4a-143e-...`      |
-| `VM_PREFIX`              | Test VM name prefix                                                        | `TST`                    |
-| `BACKUP_REPOSITORY_NAME` | Backup repository name in XO                                               | `Test backup QA`         |
-| `BACKUP_REPOSITORY_PATH` | Test backup path on the XO server (must contain `test`, `qa`, or `tmp/xo`) | `/tmp/xo-test-backups`   |
-| `BACKUP_PATH`            | Production backup path used for repository creation (not cleaned up)       | `/var/lib/xo/backups`    |
-| `VHD_EXPORT_PATH`        | VHD/XVA export directory (must contain `test`, `qa`, or `tmp/`)            | `/tmp/xo-test-exports`   |
+| Variable                  | Description                                                                                                    | Example                            |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| `HOSTNAME`                | XO instance URL                                                                                                | `http://10.1.4.216:9000`           |
+| `USERNAME`                | XO user                                                                                                        | `admin@admin.net`                  |
+| `PASSWORD`                | XO password                                                                                                    | `admin`                            |
+| `REFERENCE_VM_ID`         | UUID of the VM to clone for tests                                                                              | `61c24db9-262d-...`                |
+| `SR_ID`                   | UUID of the Storage Repository                                                                                 | `8aa2fb4a-143e-...`                |
+| `VM_PREFIX`               | Test VM name prefix                                                                                            | `TST`                              |
+| `BACKUP_REPOSITORY_NAME`  | Backup repository name in XO                                                                                   | `Test backup QA`                   |
+| `BACKUP_REPOSITORY_URL`   | `@xen-orchestra/fs` URL for the test backup remote. For `file://` remotes the path must contain `test`, `qa`, or `tmp/xo`. Any supported backend works (`s3://`, `nfs://`, `azure://`, …). | `file:///tmp/xo-test-backups` |
+| `VHD_EXPORT_PATH`         | VHD/XVA export directory (must contain `test`, `qa`, or `tmp/`)                                               | `/tmp/xo-test-exports`             |
 
-The following are required only for mirror backup tests (`qa:backup:mirror`):
+The following are required only for mirror backup tests (`qa:mirror`):
 
-| Variable                             | Description                                                      | Example               |
-| ------------------------------------ | ---------------------------------------------------------------- | --------------------- |
-| `MIRROR_DESTINATION_REPOSITORY_NAME` | Mirror destination repository name                               | `Test mirror QA`      |
-| `MIRROR_DESTINATION_REPOSITORY_PATH` | Mirror destination path (must contain `test`, `qa`, or `tmp/xo`) | `/tmp/xo-test-mirror` |
+| Variable                              | Description                                                                                                   | Example                             |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `MIRROR_DESTINATION_REPOSITORY_NAME`  | Mirror destination repository name                                                                            | `Test mirror QA`                    |
+| `MIRROR_DESTINATION_REPOSITORY_URL`   | `@xen-orchestra/fs` URL for the mirror destination. Same backend flexibility as `BACKUP_REPOSITORY_URL`.     | `file:///tmp/xo-test-mirror`        |
 
-> **Safety**: paths used for automatic cleanup must contain `test`, `qa`, or `tmp/xo` to prevent accidental deletion of production data.
+> **Safety**: for `file://` remotes the path component of the URL must contain `test`, `qa`, or `tmp/xo` to prevent accidental deletion of production data. Non-local remotes (`s3://`, `nfs://`, …) skip this local-path check — cleanup is delegated to the XO API.
 
 ## Logging
 

--- a/@xen-orchestra/qa-test/client/cleanupClient.js
+++ b/@xen-orchestra/qa-test/client/cleanupClient.js
@@ -7,29 +7,41 @@ import { BACKUP_JOB_NAME_PREFIX, getRequiredEnv } from '../utils/index.js'
 const log = createLogger('cleanup')
 
 /**
- * Allowed paths for automatic backup cleanup.
+ * Allowed paths for automatic backup cleanup of file:// remotes.
  * SECURITY: Only test-scoped paths containing 'test', 'qa', or 'tmp/xo'.
+ * Non-file:// remotes return an empty list (cleanup is delegated to XO API).
  *
- * Computed lazily so that `process.env.BACKUP_REPOSITORY_PATH` is read at call
+ * Computed lazily so that `process.env.BACKUP_REPOSITORY_URL` is read at call
  * time rather than module-load time — otherwise ESM import hoisting would make
  * it evaluate before any in-code env loading runs.
  *
  * @returns {Array<string>}
  */
 const getAllowedCleanupPaths = () => {
-  const repoPath = process.env.BACKUP_REPOSITORY_PATH
+  const repoUrl = process.env.BACKUP_REPOSITORY_URL
+
+  // Non-local remotes have no local path to safety-check
+  if (!repoUrl?.startsWith('file://')) return []
+
+  let repoPath
+  try {
+    repoPath = new URL(repoUrl).pathname
+  } catch {
+    log.warn('Rejected cleanup URL: invalid URL', { repoUrl })
+    return []
+  }
 
   // SECURITY: Reject paths containing path traversal sequences
-  if (repoPath?.includes('..')) {
+  if (repoPath.includes('..')) {
     log.warn('Rejected cleanup path: contains path traversal', { repoPath })
     return []
   }
 
-  const normalized = repoPath ? path.resolve(repoPath).toLowerCase() : ''
+  const normalized = path.resolve(repoPath).toLowerCase()
   const isTestPath = ['test', 'qa', 'tmp/xo'].some(marker => normalized.includes(marker))
 
   if (!isTestPath) {
-    if (repoPath) log.warn('Rejected cleanup path: not a test path', { repoPath })
+    log.warn('Rejected cleanup path: not a test path', { repoPath })
     return []
   }
 

--- a/@xen-orchestra/qa-test/client/requests/abstract.js
+++ b/@xen-orchestra/qa-test/client/requests/abstract.js
@@ -429,11 +429,13 @@ export class AbstractRequest {
         duration,
       }
     } catch (error) {
-      // Clean up partial file on error
+      // Clean up partial file on error (ignore ENOENT — file was never created if the HTTP request failed)
       try {
         await fs.unlink(outputPath)
       } catch (cleanupError) {
-        log.warn('Cleanup failed for partial download', { outputPath, error: cleanupError.message })
+        if (cleanupError.code !== 'ENOENT') {
+          log.warn('Cleanup failed for partial download', { outputPath, error: cleanupError.message })
+        }
       }
 
       if (error.code) {

--- a/@xen-orchestra/qa-test/client/requests/misc.js
+++ b/@xen-orchestra/qa-test/client/requests/misc.js
@@ -27,21 +27,21 @@ export class BackupRepositoryRequest extends AbstractRequest {
    *
    * @param {string} name - Name for the backup repository
    * @param {Object} options - Creation options
-   * @param {string} [options.path] - File path for the backup repository. If not provided, uses BACKUP_PATH environment variable (required when omitted).
+   * @param {string} [options.url] - @xen-orchestra/fs-compatible URL for the repository (e.g. file:///tmp/backups, s3://bucket/path). If not provided, uses BACKUP_REPOSITORY_URL environment variable.
    * @returns {Promise<string>} Created backup repository ID
    * @throws {Error} If creation fails
    */
   async create(name, options = {}) {
     this._ensureConnected()
 
-    const path = options.path || getRequiredEnv('BACKUP_PATH')
-    log.debug('Creating backup repository', { name, path })
+    const url = options.url ?? getRequiredEnv('BACKUP_REPOSITORY_URL')
+    log.debug('Creating backup repository', { name, url })
 
     // Backup repository creation may not be available via REST API, use WebSocket directly
     try {
       const backupRepositoryResult = await this.dispatchClient.xoClient.call('remote.create', {
         name,
-        url: `file://${path}`,
+        url,
       })
 
       const backupRepositoryId = backupRepositoryResult?.id || backupRepositoryResult

--- a/@xen-orchestra/qa-test/package.json
+++ b/@xen-orchestra/qa-test/package.json
@@ -20,6 +20,7 @@
     "node": ">=18"
   },
   "dependencies": {
+    "@xen-orchestra/fs": "*",
     "@xen-orchestra/log": "^0.7.2",
     "xo-lib": "^0.11.2"
   },

--- a/@xen-orchestra/qa-test/tests/backup-mirror.test.js
+++ b/@xen-orchestra/qa-test/tests/backup-mirror.test.js
@@ -22,7 +22,7 @@ const SOURCE_REPOSITORY_NAME = getRequiredEnv('BACKUP_REPOSITORY_NAME')
 
 /** Destination backup repository — mirror target */
 const MIRROR_DESTINATION_REPOSITORY_NAME = getRequiredEnv('MIRROR_DESTINATION_REPOSITORY_NAME')
-const MIRROR_DESTINATION_REPOSITORY_PATH = getRequiredEnv('MIRROR_DESTINATION_REPOSITORY_PATH')
+const MIRROR_DESTINATION_REPOSITORY_URL = getRequiredEnv('MIRROR_DESTINATION_REPOSITORY_URL')
 
 describe('Mirror Backup - Full Remote', () => {
   /** @type {import('../client/dispatchClient.js').DispatchClient} */
@@ -155,7 +155,7 @@ describe('Mirror Backup - Full Remote', () => {
 
     if (!sourceRepository) {
       const id = await dispatchClient.backupRepository.create(SOURCE_REPOSITORY_NAME, {
-        path: getRequiredEnv('BACKUP_REPOSITORY_PATH'),
+        url: getRequiredEnv('BACKUP_REPOSITORY_URL'),
       })
       sourceRepository = await dispatchClient.backupRepository.get({ id })
       if (!sourceRepository) {
@@ -171,7 +171,7 @@ describe('Mirror Backup - Full Remote', () => {
 
     if (!destRepository) {
       const id = await dispatchClient.backupRepository.create(MIRROR_DESTINATION_REPOSITORY_NAME, {
-        path: MIRROR_DESTINATION_REPOSITORY_PATH,
+        url: MIRROR_DESTINATION_REPOSITORY_URL,
       })
       destRepository = await dispatchClient.backupRepository.get({ id })
       if (!destRepository) {

--- a/@xen-orchestra/qa-test/tests/backup-replication-combined.test.js
+++ b/@xen-orchestra/qa-test/tests/backup-replication-combined.test.js
@@ -122,7 +122,7 @@ describe('Backup + Replication Combined Tests', () => {
       log.warn('Backup repository not found, creating it for tests')
 
       const backupRepositoryId = await dispatchClient.backupRepository.create(BACKUP_REPOSITORY_NAME, {
-        path: getRequiredEnv('BACKUP_REPOSITORY_PATH'),
+        url: getRequiredEnv('BACKUP_REPOSITORY_URL'),
       })
 
       // eslint-disable-next-line require-atomic-updates -- sequential code in before() hook, no race condition

--- a/@xen-orchestra/qa-test/tests/backup.nbd.test.js
+++ b/@xen-orchestra/qa-test/tests/backup.nbd.test.js
@@ -53,7 +53,7 @@ describe('NBD Incremental Backup Tests', () => {
       // Create the backup repository for testing
       try {
         const backupRepositoryId = await dispatchClient.backupRepository.create(backupRepositoryName, {
-          path: getRequiredEnv('BACKUP_REPOSITORY_PATH'),
+          url: getRequiredEnv('BACKUP_REPOSITORY_URL'),
         })
 
         // Fetch the canonical repository object from the API

--- a/@xen-orchestra/qa-test/tests/backup.test.js
+++ b/@xen-orchestra/qa-test/tests/backup.test.js
@@ -55,7 +55,7 @@ describe('Backup basic tests', () => {
       // Create the backup repository for testing
       try {
         const backupRepositoryId = await dispatchClient.backupRepository.create(backupRepositoryName, {
-          path: getRequiredEnv('BACKUP_REPOSITORY_PATH'),
+          url: getRequiredEnv('BACKUP_REPOSITORY_URL'),
         })
 
         // Fetch the canonical repository object from the API

--- a/@xen-orchestra/qa-test/tests/setup.js
+++ b/@xen-orchestra/qa-test/tests/setup.js
@@ -1,8 +1,10 @@
 import '../logSetup.js'
 import { createLogger } from '@xen-orchestra/log'
+import { getSyncedHandler } from '@xen-orchestra/fs'
 import { DispatchClient } from '../client/dispatchClient.js'
 import { createResourceTracker } from '../utils/resourceTracker.js'
 import { getRequiredEnv } from '../utils/index.js'
+import { assertRepositoryMatchesConfig } from '../utils/backupUtils.js'
 
 const log = createLogger('setup')
 
@@ -69,13 +71,24 @@ export const setup = async () => {
 
     // Create or get backup repository
     const backupRepositoryName = getRequiredEnv('BACKUP_REPOSITORY_NAME')
+    const repoUrl = getRequiredEnv('BACKUP_REPOSITORY_URL')
+
+    // For file:// remotes: ensure the local directory exists before XO tries to use it.
+    // Other backends (s3://, nfs://, …) are managed by XO — their connectivity is
+    // validated when the backup job actually runs.
+    if (repoUrl.startsWith('file://')) {
+      const { dispose } = await getSyncedHandler({ url: repoUrl })
+      await dispose()
+    }
+
     let backupRepository = await dispatchClient.backupRepository.get({ name: backupRepositoryName })
 
     if (backupRepository) {
       log.debug('Using existing backup repository', { name: backupRepositoryName })
+      assertRepositoryMatchesConfig(backupRepository, repoUrl)
     } else {
       const backupRepositoryId = await dispatchClient.backupRepository.create(backupRepositoryName, {
-        path: getRequiredEnv('BACKUP_REPOSITORY_PATH'),
+        url: repoUrl,
       })
 
       backupRepository = await dispatchClient.backupRepository.get({ id: backupRepositoryId })
@@ -114,12 +127,16 @@ export const setup = async () => {
 export const teardown = async (dispatchClient, tracker) => {
   log.debug('Starting test teardown')
 
-  try {
-    await performCleanup(dispatchClient, tracker)
-    log.debug('Teardown completed')
-  } catch (error) {
-    log.warn('Teardown failed', { error })
-  } finally {
+  if (tracker !== undefined) {
+    try {
+      await performCleanup(dispatchClient, tracker)
+      log.debug('Teardown completed')
+    } catch (error) {
+      log.warn('Teardown failed', { error })
+    }
+  }
+
+  if (dispatchClient !== undefined) {
     try {
       await dispatchClient.close()
     } catch (error) {

--- a/@xen-orchestra/qa-test/utils/backupUtils.js
+++ b/@xen-orchestra/qa-test/utils/backupUtils.js
@@ -29,22 +29,29 @@ export const assertRepositoryEmpty = async (dispatchClient, repository) => {
 }
 
 /**
- * Asserts that a backup repository's URL matches the path declared in the .env.
+ * Asserts that a backup repository's URL matches the URL declared in the .env.
  *
  * The QA suite identifies repositories by name (e.g. `BACKUP_REPOSITORY_NAME`)
- * but it is the file path that determines where data physically lands. If a
- * repository with the expected name already exists on the XO server but points
- * at a different location, tests would silently operate on the wrong directory.
- * This check fails fast so that the operator can either delete the misconfigured
- * remote in XO or update the .env to match it.
+ * but it is the URL that determines where data physically lands. If a repository
+ * with the expected name already exists on the XO server but points at a different
+ * location, tests would silently operate on the wrong remote. This check fails fast
+ * so that the operator can either delete the misconfigured remote in XO or update
+ * the .env to match it.
+ *
+ * Passwords are stripped before comparison: XO obfuscates stored remote passwords,
+ * so comparing credentials would always fail for existing remotes.
  *
  * @param {{id: string, name: string, url: string}} repository - Repository as returned by the REST API
- * @param {string} expectedPath - Filesystem path expected by the test (typically from `.env`)
- * @throws {Error} If `repository.url` is not exactly `file://${expectedPath}`
+ * @param {string} expectedUrl - Full @xen-orchestra/fs URL expected by the test (from `BACKUP_REPOSITORY_URL`)
+ * @throws {Error} If `repository.url` does not match `expectedUrl` (ignoring password)
  */
-export const assertRepositoryMatchesConfig = (repository, expectedPath) => {
-  const expectedUrl = `file://${expectedPath}`
-  if (repository.url !== expectedUrl) {
+export const assertRepositoryMatchesConfig = (repository, expectedUrl) => {
+  // Strip password from scheme://user:password@host URLs before comparing.
+  // XO returns stored URLs with an obfuscated password, so credential comparison
+  // would always fail for an already-existing remote.
+  const stripPassword = url => url.replace(/(:\/\/[^:@/]+):([^@]+)@/, '$1:***@')
+
+  if (stripPassword(repository.url) !== stripPassword(expectedUrl)) {
     throw new Error(
       `Backup repository "${repository.name}" (${repository.id}) has url "${repository.url}", ` +
         `but the .env requires "${expectedUrl}". ` +


### PR DESCRIPTION
### Description
this enable the test to run using  from and to shared storage ( nfs/samba/s3/azure)

the local path is only used for export tests

tested with a remote garage (object storage) provider, full suite is passing 


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
