### PR TITLE
fix(docs): wrap {master, satellite} in backticks on xo5/advanced page

### DIFF
--- a/docs/docs/xo5/advanced.md
+++ b/docs/docs/xo5/advanced.md
@@ -526,7 +526,7 @@ These metrics describe LINSTOR-backed XOSTOR clusters and only appear when the X
 | Metric                                | Type  | Description                                                                                              |
 | ------------------------------------- | ----- | -------------------------------------------------------------------------------------------------------- |
 | `xcp_xostor_up`                       | gauge | Cluster reachability (1 = `linstor-manager.healthCheck` succeeded, 0 = collection failed)                |
-| `xcp_xostor_node_status`              | gauge | One series per LINSTOR node (always 1; `role` ∈ {master, satellite} and raw `state` are labels)          |
+| `xcp_xostor_node_status`              | gauge | One series per LINSTOR node (always 1; `role` ∈ `{master, satellite}` and raw `state` are labels)        |
 | `xcp_xostor_resource_total`           | gauge | Total number of LINSTOR resources defined in the cluster                                                 |
 | `xcp_xostor_resource_state_count`     | gauge | Replica count per `disk-state` (UpToDate, Inconsistent, Outdated, Diskless, Unknown), summed per cluster |
 | `xcp_xostor_alarms_up`                | gauge | Alarm-collection status (1 = collected, 0 = collection failed)                                           |


### PR DESCRIPTION
### Description

Fix the `/xo5/advanced` documentation page that failed to build with `ReferenceError: master is not defined`.

Docusaurus 3 uses MDX v3, which parses `{master, satellite}` in the XOSTOR metrics table as a JSX expression and tries to evaluate the undefined identifier `master`, breaking static site generation for the whole `en` locale. Wrapping the value in backticks (`` `{master, satellite}` ``) renders it as inline code so MDX no longer evaluates it.

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue: fixes the broken build of https://docs.xen-orchestra.com/xo5/advanced
  - [x] If bug fix, add `Introduced by`: introduced by fc4d34b35 (feat(openmetrics): expose XOSTOR metrics for Grafana dashboards, #9849)
- Changelog
  - [ ] If visible by XOA users, add changelog entry — _N/A, docs-only fix (not shipped in XOA)_
  - [ ] Update "Packages to release" in `CHANGELOG.unreleased.md` — _N/A_
- PR
  - [ ] If UI changes, add screenshots — _N/A, no UI change_
  - [ ] If not finished or not tested, open as _Draft_ — _ready_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
