### PR TITLE
feat(complex-matcher): implement deep resolution matcher

### DIFF
--- a/@vates/types/src/xo-app.mts
+++ b/@vates/types/src/xo-app.mts
@@ -372,6 +372,7 @@ export type XoApp = {
   ): Promise<XoBackupRepository>
   getAllXapis(): Record<string, Xapi>
   getObjects(opts?: { filter?: Record<string, unknown>; limit?: number }): Record<string, XapiXoRecord>
+  getAnyObject(id: string): Promise<object | undefined>
   getLicenses(params?: { productType?: LicenseProductType }): Promise<License[]>
   bindLicense(params: { licenseId: string; boundObjectId: string }): Promise<License>
   unbindLicense(params: {

--- a/@vates/types/src/xo-app.mts
+++ b/@vates/types/src/xo-app.mts
@@ -373,7 +373,7 @@ export type XoApp = {
   ): Promise<XoBackupRepository>
   getAllXapis(): Record<string, Xapi>
   getObjects(opts?: { filter?: Record<string, unknown>; limit?: number }): Record<string, XapiXoRecord>
-  getAnyObject(id: string): Promise<XoRecord>
+  getAnyObject(id: XoRecord['id']): Promise<XoRecord>
   getLicenses(params?: { productType?: LicenseProductType }): Promise<License[]>
   bindLicense(params: { licenseId: string; boundObjectId: string }): Promise<License>
   unbindLicense(params: {

--- a/@vates/types/src/xo-app.mts
+++ b/@vates/types/src/xo-app.mts
@@ -12,6 +12,7 @@ import type {
   XoPool,
   XoPoolBackupArchive,
   XoProxy,
+  XoRecord,
   XoSchedule,
   XoServer,
   XoTask,
@@ -372,7 +373,7 @@ export type XoApp = {
   ): Promise<XoBackupRepository>
   getAllXapis(): Record<string, Xapi>
   getObjects(opts?: { filter?: Record<string, unknown>; limit?: number }): Record<string, XapiXoRecord>
-  getAnyObject(id: string): Promise<object | undefined>
+  getAnyObject(id: string): Promise<XoRecord>
   getLicenses(params?: { productType?: LicenseProductType }): Promise<License[]>
   bindLicense(params: { licenseId: string; boundObjectId: string }): Promise<License>
   unbindLicense(params: {

--- a/@xen-orchestra/acl/src/class/privilege.mts
+++ b/@xen-orchestra/acl/src/class/privilege.mts
@@ -10,7 +10,7 @@ export type TPrivilege<T extends SupportedResource> = XoAclPrivilege<SupportedAc
 
 export class Privilege<T extends SupportedResource> {
   #action: TPrivilege<T>['action']
-  #selector?: (object: object) => boolean
+  #selector?: CM.Node
   #resource: TPrivilege<T>['resource']
   #effect: TPrivilege<T>['effect']
 
@@ -28,7 +28,7 @@ export class Privilege<T extends SupportedResource> {
     Privilege.checkActionIsValid(resource, action)
 
     this.#action = action
-    this.#selector = selector !== undefined ? CM.parse(selector).createPredicate() : undefined
+    this.#selector = selector !== undefined ? CM.parse(selector) : undefined
     this.#resource = resource
     this.#effect = effect
   }
@@ -67,27 +67,30 @@ export class Privilege<T extends SupportedResource> {
     throw new Error(`Unable to verify if ${this.#action} match ${action} `)
   }
 
-  #matchSelector(object: object) {
+  #matchSelector(object: object, resolver?: (id: string) => object | undefined) {
     if (this.#selector === undefined) {
       return true
     }
 
-    return this.#selector(object)
+    return this.#selector.createPredicate(resolver)(object)
   }
 
   #matchResource(resource: string): resource is SupportedResource {
     return resource === this.#resource
   }
 
-  match<Resource extends SupportedResource = T>(constraint: {
-    action: SupportedActions<Resource>
-    resource: Resource
-    object: object
-  }): boolean {
+  match<Resource extends SupportedResource = T>(
+    constraint: {
+      action: SupportedActions<Resource>
+      resource: Resource
+      object: object
+    },
+    resolver?: (id: string) => object | undefined
+  ): boolean {
     return (
       this.#matchResource(constraint.resource) &&
       this.#matchAction(constraint.action) &&
-      this.#matchSelector(constraint.object)
+      this.#matchSelector(constraint.object, resolver)
     )
   }
 

--- a/@xen-orchestra/acl/src/class/privilege.mts
+++ b/@xen-orchestra/acl/src/class/privilege.mts
@@ -10,25 +10,28 @@ export type TPrivilege<T extends SupportedResource> = XoAclPrivilege<SupportedAc
 
 export class Privilege<T extends SupportedResource> {
   #action: TPrivilege<T>['action']
-  #selector?: CM.Node
+  #selector?: (object: object) => boolean
   #resource: TPrivilege<T>['resource']
   #effect: TPrivilege<T>['effect']
 
-  constructor({
-    action,
-    selector,
-    resource,
-    effect,
-  }: {
-    action: TPrivilege<T>['action']
-    selector?: TPrivilege<T>['selector']
-    resource: TPrivilege<T>['resource']
-    effect: TPrivilege<T>['effect']
-  }) {
+  constructor(
+    {
+      action,
+      selector,
+      resource,
+      effect,
+    }: {
+      action: TPrivilege<T>['action']
+      selector?: TPrivilege<T>['selector']
+      resource: TPrivilege<T>['resource']
+      effect: TPrivilege<T>['effect']
+    },
+    resolver?: (id: string) => object | undefined
+  ) {
     Privilege.checkActionIsValid(resource, action)
 
     this.#action = action
-    this.#selector = selector !== undefined ? CM.parse(selector) : undefined
+    this.#selector = selector !== undefined ? CM.parse(selector).createPredicate(resolver) : undefined
     this.#resource = resource
     this.#effect = effect
   }
@@ -67,30 +70,27 @@ export class Privilege<T extends SupportedResource> {
     throw new Error(`Unable to verify if ${this.#action} match ${action} `)
   }
 
-  #matchSelector(object: object, resolver?: (id: string) => object | undefined) {
+  #matchSelector(object: object) {
     if (this.#selector === undefined) {
       return true
     }
 
-    return this.#selector.createPredicate(resolver)(object)
+    return this.#selector(object)
   }
 
   #matchResource(resource: string): resource is SupportedResource {
     return resource === this.#resource
   }
 
-  match<Resource extends SupportedResource = T>(
-    constraint: {
-      action: SupportedActions<Resource>
-      resource: Resource
-      object: object
-    },
-    resolver?: (id: string) => object | undefined
-  ): boolean {
+  match<Resource extends SupportedResource = T>(constraint: {
+    action: SupportedActions<Resource>
+    resource: Resource
+    object: object
+  }): boolean {
     return (
       this.#matchResource(constraint.resource) &&
       this.#matchAction(constraint.action) &&
-      this.#matchSelector(constraint.object, resolver)
+      this.#matchSelector(constraint.object)
     )
   }
 

--- a/@xen-orchestra/acl/src/index.mts
+++ b/@xen-orchestra/acl/src/index.mts
@@ -64,10 +64,10 @@ export function hasPrivilegeOn<T extends SupportedResource>(
   }
 
   for (const userPrivilege of userPrivileges) {
-    const privilege = new CPrivilege(userPrivilege as Privilege<typeof userPrivilege.resource>)
+    const privilege = new CPrivilege(userPrivilege as Privilege<typeof userPrivilege.resource>, resolver)
 
     for (const [object, effects] of effectsByObject.entries()) {
-      if (!privilege.match({ action, resource, object }, resolver)) {
+      if (!privilege.match({ action, resource, object })) {
         continue
       }
       effects.push(privilege.effect)

--- a/@xen-orchestra/acl/src/index.mts
+++ b/@xen-orchestra/acl/src/index.mts
@@ -27,19 +27,22 @@ export type AnyPrivilegeOnParam = {
   }
 }[SupportedResource]
 
-export function hasPrivilegeOn<T extends SupportedResource>({
-  user,
-  action,
-  resource,
-  objects,
-  userPrivileges,
-}: {
-  user: XoUser
-  resource: T
-  action: SupportedActions<T>
-  objects: object | object[]
-  userPrivileges: AnyPrivilege[]
-}) {
+export function hasPrivilegeOn<T extends SupportedResource>(
+  {
+    user,
+    action,
+    resource,
+    objects,
+    userPrivileges,
+  }: {
+    user: XoUser
+    resource: T
+    action: SupportedActions<T>
+    objects: object | object[]
+    userPrivileges: AnyPrivilege[]
+  },
+  resolver?: (id: string) => object | undefined
+) {
   // Function that will be called outside of the module
   // We cannot be sure types are respected
   assert.strictEqual(typeof user?.permission, 'string')
@@ -64,7 +67,7 @@ export function hasPrivilegeOn<T extends SupportedResource>({
     const privilege = new CPrivilege(userPrivilege as Privilege<typeof userPrivilege.resource>)
 
     for (const [object, effects] of effectsByObject.entries()) {
-      if (!privilege.match({ action, resource, object })) {
+      if (!privilege.match({ action, resource, object }, resolver)) {
         continue
       }
       effects.push(privilege.effect)
@@ -81,17 +84,24 @@ export function hasPrivilegeOn<T extends SupportedResource>({
   return true
 }
 
-export function getMissingPrivileges(params: AnyPrivilegeOnParam[], userPrivileges: AnyPrivilege[]) {
+export function getMissingPrivileges(
+  params: AnyPrivilegeOnParam[],
+  userPrivileges: AnyPrivilege[],
+  resolver?: (id: string) => object | undefined
+) {
   return params
     .filter(
       param =>
-        !hasPrivilegeOn({
-          user: param.user,
-          resource: param.resource,
-          action: param.action as SupportedActions<typeof param.resource>,
-          objects: param.objects,
-          userPrivileges,
-        })
+        !hasPrivilegeOn(
+          {
+            user: param.user,
+            resource: param.resource,
+            action: param.action as SupportedActions<typeof param.resource>,
+            objects: param.objects,
+            userPrivileges,
+          },
+          resolver
+        )
     )
     .map(({ action, objects, resource }) => {
       let objectIds: unknown[] | undefined
@@ -122,18 +132,25 @@ export function getMissingPrivileges(params: AnyPrivilegeOnParam[], userPrivileg
     })
 }
 
-export function hasPrivileges(params: AnyPrivilegeOnParam[], userPrivileges: AnyPrivilege[]) {
-  return getMissingPrivileges(params, userPrivileges).length === 0
+export function hasPrivileges(
+  params: AnyPrivilegeOnParam[],
+  userPrivileges: AnyPrivilege[],
+  resolver?: (id: string) => object | undefined
+) {
+  return getMissingPrivileges(params, userPrivileges, resolver).length === 0
 }
 
-export function filterObjectsWithPrivilege<Resource extends SupportedResource, Object extends object>(param: {
-  user: XoUser
-  resource: Resource
-  action: SupportedActions<Resource>
-  objects: Object[]
-  userPrivileges: AnyPrivilege[]
-}) {
-  return param.objects.filter(obj => hasPrivilegeOn({ ...param, objects: obj }))
+export function filterObjectsWithPrivilege<Resource extends SupportedResource, Object extends object>(
+  param: {
+    user: XoUser
+    resource: Resource
+    action: SupportedActions<Resource>
+    objects: Object[]
+    userPrivileges: AnyPrivilege[]
+  },
+  resolver?: (id: string) => object | undefined
+) {
+  return param.objects.filter(obj => hasPrivilegeOn({ ...param, objects: obj }, resolver))
 }
 
 // Utils

--- a/@xen-orchestra/acl/src/tests/acl.test.mts
+++ b/@xen-orchestra/acl/src/tests/acl.test.mts
@@ -91,6 +91,9 @@ suite('ACL V2 behavior', async () => {
   const templateDeny = { id: 'template-deny-id', $pool: '2' }
   const vdis = [{ $SR: '2' }, { $SR: '2' }]
   const vdisMultipleSrs = [{ $SR: '1' }, { $SR: '2' }]
+  const vdisOnTaggedSr = [{ $SR: '4' }]
+  const vdisOnUntaggedSr = [{ $SR: '5' }]
+  const srs = { '4': { tags: ['tag'] } }
   const vifs = [{ $network: '1' }]
   const iso = { id: 'iso-vdi-id', $SR: '3' }
   const hostAffinity = { id: 'affinity-host-id', $pool: '1' }
@@ -118,6 +121,14 @@ suite('ACL V2 behavior', async () => {
     action: 'create',
     resource: 'vdi',
     selector: '$SR:2',
+    effect: 'allow',
+    roleId,
+  } satisfies TPrivilege<'vdi'>
+  const vdiCreateResolve = {
+    id: privilegeId,
+    action: 'create',
+    resource: 'vdi',
+    selector: '$SR:[resolve]:tags:tag',
     effect: 'allow',
     roleId,
   } satisfies TPrivilege<'vdi'>
@@ -170,6 +181,11 @@ suite('ACL V2 behavior', async () => {
     isoVdiUse,
     hostVm,
   ]
+
+  const resolvePrivileges = [vdiCreateResolve]
+
+  // === Resolvers
+  const srTagResolver = (id: string) => srs[id]
 
   // === Test ===
   suite('hasPrivilegeOn behavior', () => {
@@ -255,6 +271,35 @@ suite('ACL V2 behavior', async () => {
           objects: [almaVm, alpineVm],
           userPrivileges: allPrivileges,
         }),
+        false
+      )
+    })
+
+    test('should allow create on vdi whose SR has tag', () => {
+      assert.strictEqual(
+        hasPrivilegeOn(
+          {
+            user,
+            action: 'create',
+            resource: 'vdi',
+            objects: vdisOnTaggedSr,
+            userPrivileges: resolvePrivileges,
+          },
+          srTagResolver
+        ),
+        true
+      )
+      assert.strictEqual(
+        hasPrivilegeOn(
+          {
+            user,
+            action: 'create',
+            resource: 'vdi',
+            objects: vdisOnUntaggedSr,
+            userPrivileges: resolvePrivileges,
+          },
+          srTagResolver
+        ),
         false
       )
     })

--- a/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
@@ -40,6 +40,14 @@ export abstract class BaseController<T extends RestXoRecord, IsSync extends bool
   restApi: RestApi
   readonly type: BaseControllerType<T>
 
+  objectResolver = (id: string) => {
+    try {
+      return this.restApi.getObject(id as XapiXoRecord['id'])
+    } catch {
+      return undefined
+    }
+  }
+
   constructor(type: BaseControllerType<T>, restApi: RestApi) {
     super()
     this.type = type
@@ -65,14 +73,6 @@ export abstract class BaseController<T extends RestXoRecord, IsSync extends bool
         : []
     ) as AnyPrivilege[]
 
-    const resolver = (id: string) => {
-      try {
-        return this.restApi.getObject(id as XapiXoRecord['id'])
-      } catch {
-        return undefined
-      }
-    }
-
     let limit = opts?.limit ?? Infinity
     for (const object of objects) {
       if (limit === 0) {
@@ -81,7 +81,7 @@ export abstract class BaseController<T extends RestXoRecord, IsSync extends bool
 
       if (
         opts?.privilege !== undefined &&
-        !hasPrivilegeOn({ user, userPrivileges, objects: object, ...opts.privilege }, resolver)
+        !hasPrivilegeOn({ user, userPrivileges, objects: object, ...opts.privilege }, this.objectResolver)
       ) {
         continue
       }
@@ -123,7 +123,8 @@ export abstract class BaseController<T extends RestXoRecord, IsSync extends bool
 
     let userFilter: (task: XoTask) => boolean = () => true
     if (filter !== undefined) {
-      userFilter = typeof filter === 'string' ? safeParseComplexMatcher(filter).createPredicate() : filter
+      userFilter =
+        typeof filter === 'string' ? safeParseComplexMatcher(filter).createPredicate(this.objectResolver) : filter
     }
 
     for await (const task of this.restApi.tasks.list({ filter: objectFilter })) {

--- a/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
@@ -23,6 +23,7 @@ import type { MaybePromise, SendObjects, WithHref } from '../helpers/helper.type
 import type { Response as ExResponse } from 'express'
 import { invalidParameters } from 'xo-common/api-errors.js'
 import { NDJSON_CONTENT_TYPE, safeParseComplexMatcher } from '../helpers/utils.helper.mjs'
+import * as CM from 'complex-matcher'
 
 const noop = () => {}
 
@@ -65,6 +66,20 @@ export abstract class BaseController<T extends RestXoRecord, IsSync extends bool
         : []
     ) as AnyPrivilege[]
 
+    const nodes: CM.Node[] = []
+    userPrivileges.forEach(userPrivilege => {
+      if (userPrivilege.selector) {
+        nodes.push(CM.parse(userPrivilege.selector))
+      }
+    })
+
+    let resolver: (id: string) => object | undefined
+    if (nodes.length > 0) {
+      resolver = await this.restApi.buildResolver(objects, new CM.And(nodes))
+    } else {
+      resolver = this.restApi.resolver
+    }
+
     let limit = opts?.limit ?? Infinity
     for (const object of objects) {
       if (limit === 0) {
@@ -73,7 +88,7 @@ export abstract class BaseController<T extends RestXoRecord, IsSync extends bool
 
       if (
         opts?.privilege !== undefined &&
-        !hasPrivilegeOn({ user, userPrivileges, objects: object, ...opts.privilege }, this.restApi.resolver)
+        !hasPrivilegeOn({ user, userPrivileges, objects: object, ...opts.privilege }, resolver)
       ) {
         continue
       }
@@ -115,8 +130,8 @@ export abstract class BaseController<T extends RestXoRecord, IsSync extends bool
 
     let userFilter: (task: XoTask) => boolean = () => true
     if (filter !== undefined) {
-      userFilter =
-        typeof filter === 'string' ? safeParseComplexMatcher(filter).createPredicate(this.restApi.resolver) : filter
+      const parsedFilter = safeParseComplexMatcher(filter)
+      userFilter = parsedFilter.createPredicate(await this.restApi.buildResolver(object, parsedFilter))
     }
 
     for await (const task of this.restApi.tasks.list({ filter: objectFilter })) {

--- a/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
@@ -40,14 +40,6 @@ export abstract class BaseController<T extends RestXoRecord, IsSync extends bool
   restApi: RestApi
   readonly type: BaseControllerType<T>
 
-  objectResolver = (id: string) => {
-    try {
-      return this.restApi.getObject(id as XapiXoRecord['id'])
-    } catch {
-      return undefined
-    }
-  }
-
   constructor(type: BaseControllerType<T>, restApi: RestApi) {
     super()
     this.type = type
@@ -81,7 +73,7 @@ export abstract class BaseController<T extends RestXoRecord, IsSync extends bool
 
       if (
         opts?.privilege !== undefined &&
-        !hasPrivilegeOn({ user, userPrivileges, objects: object, ...opts.privilege }, this.objectResolver)
+        !hasPrivilegeOn({ user, userPrivileges, objects: object, ...opts.privilege }, this.restApi.resolver)
       ) {
         continue
       }
@@ -124,7 +116,7 @@ export abstract class BaseController<T extends RestXoRecord, IsSync extends bool
     let userFilter: (task: XoTask) => boolean = () => true
     if (filter !== undefined) {
       userFilter =
-        typeof filter === 'string' ? safeParseComplexMatcher(filter).createPredicate(this.objectResolver) : filter
+        typeof filter === 'string' ? safeParseComplexMatcher(filter).createPredicate(this.restApi.resolver) : filter
     }
 
     for await (const task of this.restApi.tasks.list({ filter: objectFilter })) {

--- a/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
@@ -65,6 +65,14 @@ export abstract class BaseController<T extends RestXoRecord, IsSync extends bool
         : []
     ) as AnyPrivilege[]
 
+    const resolver = (id: string) => {
+      try {
+        return this.restApi.getObject(id as XapiXoRecord['id'])
+      } catch {
+        return undefined
+      }
+    }
+
     let limit = opts?.limit ?? Infinity
     for (const object of objects) {
       if (limit === 0) {
@@ -73,7 +81,7 @@ export abstract class BaseController<T extends RestXoRecord, IsSync extends bool
 
       if (
         opts?.privilege !== undefined &&
-        !hasPrivilegeOn({ user, userPrivileges, objects: object, ...opts.privilege })
+        !hasPrivilegeOn({ user, userPrivileges, objects: object, ...opts.privilege }, resolver)
       ) {
         continue
       }

--- a/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
@@ -128,16 +128,20 @@ export abstract class BaseController<T extends RestXoRecord, IsSync extends bool
     const objectFilter = (task: XoTask) =>
       task.properties.objectId === object.id || task.properties.params?.id === object.id
 
+    const objectTasks: XoTask[] = []
+    for await (const task of this.restApi.tasks.list({ filter: objectFilter })) {
+      objectTasks.push(task)
+    }
+
     let userFilter: (task: XoTask) => boolean = () => true
     if (filter !== undefined) {
       const parsedFilter = safeParseComplexMatcher(filter)
-      userFilter = parsedFilter.createPredicate(await this.restApi.buildResolver(object, parsedFilter))
+      userFilter = parsedFilter.createPredicate(await this.restApi.buildResolver(objectTasks, parsedFilter))
     }
 
-    for await (const task of this.restApi.tasks.list({ filter: objectFilter })) {
-      if (limit === 0) {
-        break
-      }
+    for (const task of objectTasks) {
+      if (limit === 0) break
+
       if (userFilter(task)) {
         tasks[task.id] = task
         limit--

--- a/@xen-orchestra/rest-api/src/abstract-classes/listener.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/listener.mts
@@ -153,36 +153,50 @@ export abstract class Listener<Type extends XoListenerType | undefined = undefin
       ;[resource] = resourceXapiType as [keyof typeof XAPI_TYPE_BY_ACL_RESOURCE, XapiXoRecord['type']]
     }
 
+    const resolver = (id: string) => {
+      try {
+        return restApi.getObject(id as XapiXoRecord['id'])
+      } catch {
+        return undefined
+      }
+    }
+
     switch (event) {
       case 'add':
         if (object === undefined) {
           return
         }
 
-        if (!hasPrivilegeOn({ user, userPrivileges, action: 'read', objects: object, resource })) {
+        if (!hasPrivilegeOn({ user, userPrivileges, action: 'read', objects: object, resource }, resolver)) {
           return
         }
         return 'add'
       case 'update': {
         const canSeeObject =
           object !== undefined &&
-          hasPrivilegeOn({
-            user,
-            userPrivileges,
-            action: 'read',
-            objects: object,
-            resource,
-          })
+          hasPrivilegeOn(
+            {
+              user,
+              userPrivileges,
+              action: 'read',
+              objects: object,
+              resource,
+            },
+            resolver
+          )
 
         const canSeePreviousObject =
           previousObject !== undefined &&
-          hasPrivilegeOn({
-            user,
-            userPrivileges,
-            action: 'read',
-            objects: previousObject,
-            resource,
-          })
+          hasPrivilegeOn(
+            {
+              user,
+              userPrivileges,
+              action: 'read',
+              objects: previousObject,
+              resource,
+            },
+            resolver
+          )
 
         if (canSeeObject && canSeePreviousObject) {
           return 'update'
@@ -200,13 +214,16 @@ export abstract class Listener<Type extends XoListenerType | undefined = undefin
       }
       case 'remove':
         if (
-          !hasPrivilegeOn({
-            user,
-            userPrivileges,
-            action: 'read',
-            objects: object ?? previousObject!,
-            resource,
-          })
+          !hasPrivilegeOn(
+            {
+              user,
+              userPrivileges,
+              action: 'read',
+              objects: object ?? previousObject!,
+              resource,
+            },
+            resolver
+          )
         ) {
           return
         }

--- a/@xen-orchestra/rest-api/src/abstract-classes/listener.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/listener.mts
@@ -153,21 +153,13 @@ export abstract class Listener<Type extends XoListenerType | undefined = undefin
       ;[resource] = resourceXapiType as [keyof typeof XAPI_TYPE_BY_ACL_RESOURCE, XapiXoRecord['type']]
     }
 
-    const resolver = (id: string) => {
-      try {
-        return restApi.getObject(id as XapiXoRecord['id'])
-      } catch {
-        return undefined
-      }
-    }
-
     switch (event) {
       case 'add':
         if (object === undefined) {
           return
         }
 
-        if (!hasPrivilegeOn({ user, userPrivileges, action: 'read', objects: object, resource }, resolver)) {
+        if (!hasPrivilegeOn({ user, userPrivileges, action: 'read', objects: object, resource }, restApi.resolver)) {
           return
         }
         return 'add'
@@ -182,7 +174,7 @@ export abstract class Listener<Type extends XoListenerType | undefined = undefin
               objects: object,
               resource,
             },
-            resolver
+            restApi.resolver
           )
 
         const canSeePreviousObject =
@@ -195,7 +187,7 @@ export abstract class Listener<Type extends XoListenerType | undefined = undefin
               objects: previousObject,
               resource,
             },
-            resolver
+            restApi.resolver
           )
 
         if (canSeeObject && canSeePreviousObject) {
@@ -222,7 +214,7 @@ export abstract class Listener<Type extends XoListenerType | undefined = undefin
               objects: object ?? previousObject!,
               resource,
             },
-            resolver
+            restApi.resolver
           )
         ) {
           return

--- a/@xen-orchestra/rest-api/src/abstract-classes/xo-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/xo-controller.mts
@@ -5,6 +5,7 @@ import { BaseController, type BaseControllerType } from './base-controller.mjs'
 
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { limitAndFilterArray } from '../helpers/utils.helper.mjs'
+import * as CM from 'complex-matcher'
 
 export abstract class XoController<
   T extends NonXapiXoRecord<SupportedActionsByResource, SupportedResource> | AnyPrivilege,
@@ -21,7 +22,14 @@ export abstract class XoController<
   ): Promise<Record<T['id'], T>> {
     let objects = await this.getAllCollectionObjects(opts)
 
-    objects = limitAndFilterArray(objects, opts, this.restApi.resolver)
+    let resolver: (id: string) => object | undefined
+    if (opts.filter) {
+      resolver = await this.restApi.buildResolver(objects, CM.parse(opts.filter))
+    } else {
+      resolver = this.restApi.resolver
+    }
+
+    objects = limitAndFilterArray(objects, opts, resolver)
 
     const objectById = {} as Record<T['id'], T>
 

--- a/@xen-orchestra/rest-api/src/abstract-classes/xo-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/xo-controller.mts
@@ -21,7 +21,7 @@ export abstract class XoController<
   ): Promise<Record<T['id'], T>> {
     let objects = await this.getAllCollectionObjects(opts)
 
-    objects = limitAndFilterArray(objects, opts)
+    objects = limitAndFilterArray(objects, opts, this.objectResolver)
 
     const objectById = {} as Record<T['id'], T>
 

--- a/@xen-orchestra/rest-api/src/abstract-classes/xo-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/xo-controller.mts
@@ -21,7 +21,7 @@ export abstract class XoController<
   ): Promise<Record<T['id'], T>> {
     let objects = await this.getAllCollectionObjects(opts)
 
-    objects = limitAndFilterArray(objects, opts, this.objectResolver)
+    objects = limitAndFilterArray(objects, opts, this.restApi.resolver)
 
     const objectById = {} as Record<T['id'], T>
 

--- a/@xen-orchestra/rest-api/src/abstract-classes/xo-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/xo-controller.mts
@@ -4,7 +4,7 @@ import type { AnyPrivilege, SupportedActionsByResource, SupportedResource } from
 import { BaseController, type BaseControllerType } from './base-controller.mjs'
 
 import { RestApi } from '../rest-api/rest-api.mjs'
-import { limitAndFilterArray } from '../helpers/utils.helper.mjs'
+import { limitAndFilterArray, safeParseComplexMatcher } from '../helpers/utils.helper.mjs'
 import * as CM from 'complex-matcher'
 
 export abstract class XoController<
@@ -24,7 +24,7 @@ export abstract class XoController<
 
     let resolver: (id: string) => object | undefined
     if (opts.filter) {
-      resolver = await this.restApi.buildResolver(objects, CM.parse(opts.filter))
+      resolver = await this.restApi.buildResolver(objects, safeParseComplexMatcher(opts.filter))
     } else {
       resolver = this.restApi.resolver
     }

--- a/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
@@ -20,7 +20,7 @@ import {
 } from 'tsoa'
 import { provide } from 'inversify-binding-decorators'
 import { type Request as ExRequest, json } from 'express'
-import type { XoAclRole, XoGroup, XoUser } from '@vates/types'
+import type { XapiXoRecord, XoAclRole, XoGroup, XoUser } from '@vates/types'
 
 import { acl, actionsFromBody } from '../middlewares/acl.middleware.mjs'
 import { aclPrivilegeIds, partialAclPrivileges } from '../open-api/oa-examples/acl-privilege.oa-example.mjs'
@@ -290,7 +290,7 @@ export class AclRoleController extends XoController<XoAclRole> {
     @Query() limit?: number
   ): SendObjects<Partial<Unbrand<AnyPrivilege>>> {
     const privileges = (await this.restApi.xoApp.getAclV2RolePrivileges(id as XoAclRole['id'])) as AnyPrivilege[]
-    return this.sendObjects(limitAndFilterArray(privileges, { filter }), req, {
+    return this.sendObjects(limitAndFilterArray(privileges, { filter }, this.objectResolver), req, {
       path: 'acl-privileges',
       limit,
       privilege: { resource: 'acl-privilege', action: 'read' },

--- a/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
@@ -290,7 +290,7 @@ export class AclRoleController extends XoController<XoAclRole> {
     @Query() limit?: number
   ): SendObjects<Partial<Unbrand<AnyPrivilege>>> {
     const privileges = (await this.restApi.xoApp.getAclV2RolePrivileges(id as XoAclRole['id'])) as AnyPrivilege[]
-    return this.sendObjects(limitAndFilterArray(privileges, { filter }, this.objectResolver), req, {
+    return this.sendObjects(limitAndFilterArray(privileges, { filter }, this.restApi.resolver), req, {
       path: 'acl-privileges',
       limit,
       privilege: { resource: 'acl-privilege', action: 'read' },

--- a/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
+++ b/@xen-orchestra/rest-api/src/acl-roles/acl-role.controller.mts
@@ -20,7 +20,7 @@ import {
 } from 'tsoa'
 import { provide } from 'inversify-binding-decorators'
 import { type Request as ExRequest, json } from 'express'
-import type { XapiXoRecord, XoAclRole, XoGroup, XoUser } from '@vates/types'
+import type { XoAclRole, XoGroup, XoUser } from '@vates/types'
 
 import { acl, actionsFromBody } from '../middlewares/acl.middleware.mjs'
 import { aclPrivilegeIds, partialAclPrivileges } from '../open-api/oa-examples/acl-privilege.oa-example.mjs'

--- a/@xen-orchestra/rest-api/src/alarms/alarm.service.mts
+++ b/@xen-orchestra/rest-api/src/alarms/alarm.service.mts
@@ -61,7 +61,15 @@ export class AlarmService {
 
     let userFilter: (obj: XoAlarm) => boolean = () => true
     if (filter !== undefined) {
-      userFilter = typeof filter === 'string' ? safeParseComplexMatcher(filter).createPredicate() : filter
+      const objectResolver = (id: string) => {
+        try {
+          return this.#restApi.getObject(id as XapiXoRecord['id'])
+        } catch {
+          return undefined
+        }
+      }
+
+      userFilter = typeof filter === 'string' ? safeParseComplexMatcher(filter).createPredicate(objectResolver) : filter
     }
     const alarms: Record<XoAlarm['id'], XoAlarm> = {}
     for (const id in rawAlarms) {

--- a/@xen-orchestra/rest-api/src/alarms/alarm.service.mts
+++ b/@xen-orchestra/rest-api/src/alarms/alarm.service.mts
@@ -61,15 +61,8 @@ export class AlarmService {
 
     let userFilter: (obj: XoAlarm) => boolean = () => true
     if (filter !== undefined) {
-      const objectResolver = (id: string) => {
-        try {
-          return this.#restApi.getObject(id as XapiXoRecord['id'])
-        } catch {
-          return undefined
-        }
-      }
-
-      userFilter = typeof filter === 'string' ? safeParseComplexMatcher(filter).createPredicate(objectResolver) : filter
+      userFilter =
+        typeof filter === 'string' ? safeParseComplexMatcher(filter).createPredicate(this.#restApi.resolver) : filter
     }
     const alarms: Record<XoAlarm['id'], XoAlarm> = {}
     for (const id in rawAlarms) {

--- a/@xen-orchestra/rest-api/src/backup-jobs/backup-job.controller.mts
+++ b/@xen-orchestra/rest-api/src/backup-jobs/backup-job.controller.mts
@@ -5,6 +5,7 @@ import {
   XoMirrorBackupJob,
   AnyXoLog,
   XoBackupLog,
+  XapiXoRecord,
 } from '@vates/types'
 import { createLogger } from '@xen-orchestra/log'
 import { inject } from 'inversify'
@@ -219,7 +220,7 @@ export class DeprecatedBackupController extends XoController<AnyXoBackupJob> {
     @Query() limit?: number
   ): SendObjects<Partial<UnbrandXoVmBackupJob>> {
     const vmBackupJobs = await this.restApi.xoApp.getAllJobs('backup')
-    return this.sendObjects(limitAndFilterArray(vmBackupJobs, { filter }), req, {
+    return this.sendObjects(limitAndFilterArray(vmBackupJobs, { filter }, this.objectResolver), req, {
       path: 'backup-jobs',
       limit,
       privilege: { action: 'read', resource: 'backup-job' },
@@ -273,7 +274,7 @@ export class DeprecatedBackupController extends XoController<AnyXoBackupJob> {
     @Query() limit?: number
   ): SendObjects<Partial<UnbrandXoMetadataBackupJob>> {
     const metadataBackupJobs = await this.restApi.xoApp.getAllJobs('metadataBackup')
-    return this.sendObjects(limitAndFilterArray(metadataBackupJobs, { filter }), req, {
+    return this.sendObjects(limitAndFilterArray(metadataBackupJobs, { filter }, this.objectResolver), req, {
       path: 'backup-jobs',
       limit,
       privilege: { action: 'read', resource: 'backup-job' },
@@ -317,7 +318,7 @@ export class DeprecatedBackupController extends XoController<AnyXoBackupJob> {
     @Query() limit?: number
   ): SendObjects<Partial<UnbrandXoMirrorBackupJob>> {
     const mirrorBackupJobs = await this.restApi.xoApp.getAllJobs('mirrorBackup')
-    return this.sendObjects(limitAndFilterArray(mirrorBackupJobs, { filter }), req, {
+    return this.sendObjects(limitAndFilterArray(mirrorBackupJobs, { filter }, this.objectResolver), req, {
       path: 'backup-jobs',
       limit,
       privilege: { action: 'read', resource: 'backup-job' },
@@ -360,7 +361,8 @@ export class DeprecatedBackupController extends XoController<AnyXoBackupJob> {
     @Query() filter?: string,
     @Query() limit?: number
   ): SendObjects<Partial<Unbrand<XoBackupLog>>> {
-    const userFilter = filter === undefined ? () => true : safeParseComplexMatcher(filter).createPredicate()
+    const userFilter =
+      filter === undefined ? () => true : safeParseComplexMatcher(filter).createPredicate(this.objectResolver)
 
     const predicate = (log: AnyXoLog) => {
       if (!this.#backupLogService.isBackupLog(log)) {

--- a/@xen-orchestra/rest-api/src/backup-jobs/backup-job.controller.mts
+++ b/@xen-orchestra/rest-api/src/backup-jobs/backup-job.controller.mts
@@ -5,7 +5,6 @@ import {
   XoMirrorBackupJob,
   AnyXoLog,
   XoBackupLog,
-  XapiXoRecord,
 } from '@vates/types'
 import { createLogger } from '@xen-orchestra/log'
 import { inject } from 'inversify'
@@ -220,7 +219,7 @@ export class DeprecatedBackupController extends XoController<AnyXoBackupJob> {
     @Query() limit?: number
   ): SendObjects<Partial<UnbrandXoVmBackupJob>> {
     const vmBackupJobs = await this.restApi.xoApp.getAllJobs('backup')
-    return this.sendObjects(limitAndFilterArray(vmBackupJobs, { filter }, this.objectResolver), req, {
+    return this.sendObjects(limitAndFilterArray(vmBackupJobs, { filter }, this.restApi.resolver), req, {
       path: 'backup-jobs',
       limit,
       privilege: { action: 'read', resource: 'backup-job' },
@@ -274,7 +273,7 @@ export class DeprecatedBackupController extends XoController<AnyXoBackupJob> {
     @Query() limit?: number
   ): SendObjects<Partial<UnbrandXoMetadataBackupJob>> {
     const metadataBackupJobs = await this.restApi.xoApp.getAllJobs('metadataBackup')
-    return this.sendObjects(limitAndFilterArray(metadataBackupJobs, { filter }, this.objectResolver), req, {
+    return this.sendObjects(limitAndFilterArray(metadataBackupJobs, { filter }, this.restApi.resolver), req, {
       path: 'backup-jobs',
       limit,
       privilege: { action: 'read', resource: 'backup-job' },
@@ -318,7 +317,7 @@ export class DeprecatedBackupController extends XoController<AnyXoBackupJob> {
     @Query() limit?: number
   ): SendObjects<Partial<UnbrandXoMirrorBackupJob>> {
     const mirrorBackupJobs = await this.restApi.xoApp.getAllJobs('mirrorBackup')
-    return this.sendObjects(limitAndFilterArray(mirrorBackupJobs, { filter }, this.objectResolver), req, {
+    return this.sendObjects(limitAndFilterArray(mirrorBackupJobs, { filter }, this.restApi.resolver), req, {
       path: 'backup-jobs',
       limit,
       privilege: { action: 'read', resource: 'backup-job' },
@@ -362,7 +361,7 @@ export class DeprecatedBackupController extends XoController<AnyXoBackupJob> {
     @Query() limit?: number
   ): SendObjects<Partial<Unbrand<XoBackupLog>>> {
     const userFilter =
-      filter === undefined ? () => true : safeParseComplexMatcher(filter).createPredicate(this.objectResolver)
+      filter === undefined ? () => true : safeParseComplexMatcher(filter).createPredicate(this.restApi.resolver)
 
     const predicate = (log: AnyXoLog) => {
       if (!this.#backupLogService.isBackupLog(log)) {

--- a/@xen-orchestra/rest-api/src/groups/group.controller.mts
+++ b/@xen-orchestra/rest-api/src/groups/group.controller.mts
@@ -288,7 +288,7 @@ export class GroupController extends XoController<XoGroup> {
   ): SendObjects<Partial<Unbrand<XoUser>>> {
     const group = await this.getObject(id as XoGroup['id'])
     const users = await Promise.all(group.users.map(id => this.#userService.getUser(id)))
-    return this.sendObjects(limitAndFilterArray(users, { filter }), req, {
+    return this.sendObjects(limitAndFilterArray(users, { filter }, this.objectResolver), req, {
       path: 'users',
       limit,
       privilege: { action: 'read', resource: 'user' },

--- a/@xen-orchestra/rest-api/src/groups/group.controller.mts
+++ b/@xen-orchestra/rest-api/src/groups/group.controller.mts
@@ -288,7 +288,7 @@ export class GroupController extends XoController<XoGroup> {
   ): SendObjects<Partial<Unbrand<XoUser>>> {
     const group = await this.getObject(id as XoGroup['id'])
     const users = await Promise.all(group.users.map(id => this.#userService.getUser(id)))
-    return this.sendObjects(limitAndFilterArray(users, { filter }, this.objectResolver), req, {
+    return this.sendObjects(limitAndFilterArray(users, { filter }, this.restApi.resolver), req, {
       path: 'users',
       limit,
       privilege: { action: 'read', resource: 'user' },

--- a/@xen-orchestra/rest-api/src/helpers/utils.helper.mts
+++ b/@xen-orchestra/rest-api/src/helpers/utils.helper.mts
@@ -140,10 +140,11 @@ export function safeParseComplexMatcher(string: string) {
 
 export function limitAndFilterArray<T>(
   array: T[],
-  { filter, limit = Infinity }: { filter?: string | ((obj: T) => boolean); limit?: number } = {}
+  { filter, limit = Infinity }: { filter?: string | ((obj: T) => boolean); limit?: number } = {},
+  resolver?: (id: string) => object | undefined
 ): T[] {
   if (filter !== undefined) {
-    const predicate = typeof filter === 'string' ? safeParseComplexMatcher(filter).createPredicate() : filter
+    const predicate = typeof filter === 'string' ? safeParseComplexMatcher(filter).createPredicate(resolver) : filter
     array = array.filter(predicate)
   }
 

--- a/@xen-orchestra/rest-api/src/messages/message.controller.mts
+++ b/@xen-orchestra/rest-api/src/messages/message.controller.mts
@@ -52,7 +52,7 @@ export class MessageController extends XapiXoController<XoMessage> {
   > {
     let userfilter: (obj: XoMessage) => boolean = () => true
     if (filter !== undefined) {
-      userfilter = safeParseComplexMatcher(filter).createPredicate(this.objectResolver)
+      userfilter = safeParseComplexMatcher(filter).createPredicate(this.restApi.resolver)
     }
     const messagePredicate = (obj: XoMessage) => !alarmPredicate(obj) && userfilter(obj)
 

--- a/@xen-orchestra/rest-api/src/messages/message.controller.mts
+++ b/@xen-orchestra/rest-api/src/messages/message.controller.mts
@@ -52,7 +52,7 @@ export class MessageController extends XapiXoController<XoMessage> {
   > {
     let userfilter: (obj: XoMessage) => boolean = () => true
     if (filter !== undefined) {
-      userfilter = safeParseComplexMatcher(filter).createPredicate()
+      userfilter = safeParseComplexMatcher(filter).createPredicate(this.objectResolver)
     }
     const messagePredicate = (obj: XoMessage) => !alarmPredicate(obj) && userfilter(obj)
 

--- a/@xen-orchestra/rest-api/src/middlewares/acl.middleware.mts
+++ b/@xen-orchestra/rest-api/src/middlewares/acl.middleware.mts
@@ -296,15 +296,7 @@ export function acl(acls: AclEntry | AclEntry[]) {
       return next(error)
     }
 
-    const resolver = (id: string) => {
-      try {
-        return restApi.getObject(id as XapiXoRecord['id'])
-      } catch {
-        return undefined
-      }
-    }
-
-    const missingPrivileges = getMissingPrivileges(missingPrivilegeParams, userPrivileges, resolver)
+    const missingPrivileges = getMissingPrivileges(missingPrivilegeParams, userPrivileges, restApi.resolver)
     if (missingPrivileges.length > 0) {
       return next(
         new ApiError('not enough privileges', 403, {

--- a/@xen-orchestra/rest-api/src/middlewares/acl.middleware.mts
+++ b/@xen-orchestra/rest-api/src/middlewares/acl.middleware.mts
@@ -14,6 +14,7 @@ import { iocContainer } from '../ioc/ioc.mjs'
 import type { Branded, NonXapiXoRecord, XoApp, XapiXoRecord, XoRecord, XoAclBasePrivilege } from '@vates/types'
 import { ServiceIdentifier, ValidateError } from 'tsoa'
 import { ApiError } from '../helpers/error.helper.mjs'
+import * as CM from 'complex-matcher'
 
 export const ACL_MIDDLEWARE_NAME = '_aclMiddleware'
 
@@ -296,7 +297,28 @@ export function acl(acls: AclEntry | AclEntry[]) {
       return next(error)
     }
 
-    const missingPrivileges = getMissingPrivileges(missingPrivilegeParams, userPrivileges, restApi.resolver)
+    const objects: object[] = []
+    missingPrivilegeParams.forEach(missingPrivilegeParam => {
+      Array.isArray(missingPrivilegeParam.objects)
+        ? objects.push(...missingPrivilegeParam.objects)
+        : objects.push(missingPrivilegeParam.objects)
+    })
+
+    const nodes: CM.Node[] = []
+    userPrivileges.forEach(userPrivilege => {
+      if (userPrivilege.selector) {
+        nodes.push(CM.parse(userPrivilege.selector))
+      }
+    })
+
+    let resolver: (id: string) => object | undefined
+    if (nodes.length > 0) {
+      resolver = await restApi.buildResolver(objects, new CM.And(nodes))
+    } else {
+      resolver = restApi.resolver
+    }
+
+    const missingPrivileges = getMissingPrivileges(missingPrivilegeParams, userPrivileges, resolver)
     if (missingPrivileges.length > 0) {
       return next(
         new ApiError('not enough privileges', 403, {

--- a/@xen-orchestra/rest-api/src/middlewares/acl.middleware.mts
+++ b/@xen-orchestra/rest-api/src/middlewares/acl.middleware.mts
@@ -296,7 +296,15 @@ export function acl(acls: AclEntry | AclEntry[]) {
       return next(error)
     }
 
-    const missingPrivileges = getMissingPrivileges(missingPrivilegeParams, userPrivileges)
+    const resolver = (id: string) => {
+      try {
+        return restApi.getObject(id as XapiXoRecord['id'])
+      } catch {
+        return undefined
+      }
+    }
+
+    const missingPrivileges = getMissingPrivileges(missingPrivilegeParams, userPrivileges, resolver)
     if (missingPrivileges.length > 0) {
       return next(
         new ApiError('not enough privileges', 403, {

--- a/@xen-orchestra/rest-api/src/middlewares/acl.middleware.mts
+++ b/@xen-orchestra/rest-api/src/middlewares/acl.middleware.mts
@@ -299,9 +299,11 @@ export function acl(acls: AclEntry | AclEntry[]) {
 
     const objects: object[] = []
     missingPrivilegeParams.forEach(missingPrivilegeParam => {
-      Array.isArray(missingPrivilegeParam.objects)
-        ? objects.push(...missingPrivilegeParam.objects)
-        : objects.push(missingPrivilegeParam.objects)
+      if (Array.isArray(missingPrivilegeParam.objects)) {
+        objects.push(...missingPrivilegeParam.objects)
+      } else {
+        objects.push(missingPrivilegeParam.objects)
+      }
     })
 
     const nodes: CM.Node[] = []

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
@@ -50,20 +50,20 @@ export class RestApi {
     return this.#xoApp.getObject(id, type)
   }
 
+  resolver = (id: string): object | undefined => {
+    try {
+      return this.#xoApp.getObject(id as XapiXoRecord['id'])
+    } catch {
+      return undefined
+    }
+  }
+
   getObjectsByType<T extends XapiXoRecord>(
     type: T['type'],
     { filter, ...opts }: { filter?: string | ((obj: T) => boolean); limit?: number } = {}
   ): Record<T['id'], T> {
     if (filter !== undefined && typeof filter === 'string') {
-      const objectResolver = (id: string) => {
-        try {
-          return this.getObject(id as XapiXoRecord['id'])
-        } catch {
-          return undefined
-        }
-      }
-
-      filter = safeParseComplexMatcher(filter).createPredicate(objectResolver)
+      filter = safeParseComplexMatcher(filter).createPredicate(this.resolver)
     }
     return this.#xoApp.getObjectsByType(type, { filter, ...opts }) ?? ({} as Record<T['id'], T>)
   }

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
@@ -1,6 +1,7 @@
 import { createLogger } from '@xen-orchestra/log'
 import { invalidCredentials } from 'xo-common/api-errors.js'
 import type { XapiXoRecord, XoApp, XoUser } from '@vates/types'
+import * as CM from 'complex-matcher'
 
 import type { Container } from 'inversify'
 import { safeParseComplexMatcher } from '../helpers/utils.helper.mjs'
@@ -56,6 +57,51 @@ export class RestApi {
     } catch {
       return undefined
     }
+  }
+
+  async buildResolver(objects: object | object[], filterNode: CM.Node): Promise<(id: string) => object | undefined> {
+    let objectArray: object[]
+    if (!Array.isArray(objects)) {
+      objectArray = [objects]
+    } else {
+      objectArray = objects
+    }
+
+    const anyObjects: Map<string, object> = new Map()
+    const process = async (objectsToProcess: object[], node: CM.Node) => {
+      const fields = CM.getResolveFields(node)
+
+      for (const field of fields) {
+        const objectIds: string[] = []
+        for (const object of objectsToProcess) {
+          const ids = object[field.name]
+          if (ids !== undefined) {
+            for (const id of Array.isArray(ids) ? ids : [ids]) {
+              if (!anyObjects.has(id) && !objectIds.includes(id)) {
+                objectIds.push(id)
+              }
+            }
+          }
+        }
+
+        const fetchedObjects: object[] = []
+        for (const objectId of objectIds) {
+          const fetchedObject = await this.#xoApp.getAnyObject(objectId)
+          if (fetchedObject !== undefined) {
+            anyObjects.set(objectId, fetchedObject)
+            fetchedObjects.push(fetchedObject)
+          }
+        }
+
+        if (fetchedObjects.length > 0) {
+          await process(fetchedObjects, field.resolveNode.child)
+        }
+      }
+    }
+
+    await process(objectArray, filterNode)
+
+    return (id: string) => anyObjects.get(id) ?? this.resolver(id)
   }
 
   getObjectsByType<T extends XapiXoRecord>(

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
@@ -55,7 +55,15 @@ export class RestApi {
     { filter, ...opts }: { filter?: string | ((obj: T) => boolean); limit?: number } = {}
   ): Record<T['id'], T> {
     if (filter !== undefined && typeof filter === 'string') {
-      filter = safeParseComplexMatcher(filter).createPredicate()
+      const objectResolver = (id: string) => {
+        try {
+          return this.getObject(id as XapiXoRecord['id'])
+        } catch {
+          return undefined
+        }
+      }
+
+      filter = safeParseComplexMatcher(filter).createPredicate(objectResolver)
     }
     return this.#xoApp.getObjectsByType(type, { filter, ...opts }) ?? ({} as Record<T['id'], T>)
   }

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
@@ -1,6 +1,6 @@
 import { createLogger } from '@xen-orchestra/log'
 import { invalidCredentials, noSuchObject } from 'xo-common/api-errors.js'
-import type { XapiXoRecord, XoApp, XoUser } from '@vates/types'
+import type { XapiXoRecord, XoApp, XoRecord, XoUser } from '@vates/types'
 import * as CM from 'complex-matcher'
 
 import type { Container } from 'inversify'
@@ -72,9 +72,9 @@ export class RestApi {
       const fields = CM.getResolveFields(node)
 
       for (const field of fields) {
-        const objectIds: string[] = []
-        for (const object of objectsToProcess) {
-          const ids = object[field.name]
+        const objectIds: XoRecord['id'][] = []
+        for (const objectToProcess of objectsToProcess) {
+          const ids = field.path.reduce((object, path) => object?.[path], objectToProcess)
           if (ids !== undefined) {
             for (const id of Array.isArray(ids) ? ids : [ids]) {
               if (!anyObjects.has(id) && !objectIds.includes(id)) {

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.mts
@@ -1,5 +1,5 @@
 import { createLogger } from '@xen-orchestra/log'
-import { invalidCredentials } from 'xo-common/api-errors.js'
+import { invalidCredentials, noSuchObject } from 'xo-common/api-errors.js'
 import type { XapiXoRecord, XoApp, XoUser } from '@vates/types'
 import * as CM from 'complex-matcher'
 
@@ -86,7 +86,15 @@ export class RestApi {
 
         const fetchedObjects: object[] = []
         for (const objectId of objectIds) {
-          const fetchedObject = await this.#xoApp.getAnyObject(objectId)
+          let fetchedObject
+          try {
+            fetchedObject = await this.#xoApp.getAnyObject(objectId)
+          } catch (error) {
+            if (!noSuchObject.is(error)) {
+              throw error
+            }
+          }
+
           if (fetchedObject !== undefined) {
             anyObjects.set(objectId, fetchedObject)
             fetchedObjects.push(fetchedObject)

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.test.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.test.mts
@@ -1,0 +1,48 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { noSuchObject } from 'xo-common/api-errors.js'
+import * as CM from 'complex-matcher'
+import { RestApi } from './rest-api.mjs'
+
+const makeRestApi = xoApp => new RestApi(xoApp as any, undefined as any)
+
+describe('RestApi#buildResolver', () => {
+  const store = {
+    vm1: { $SR: 'sr1' },
+    sr1: { tags: ['prod'] },
+  }
+  const makeApp = (over = {}) => ({
+    getObject: id => store[id], // used by this.resolver fallback
+    getAnyObject: async id => {
+      const o = store[id]
+      if (o === undefined) throw noSuchObject(id)
+      return o
+    },
+    ...over,
+  })
+
+  it('resolves a single referenced id', async () => {
+    const api = makeRestApi(makeApp())
+    const node = CM.parse('$SR:[resolve]:tags:prod')
+    const resolver = await api.buildResolver({ $SR: 'sr1' }, node)
+    assert.deepEqual(resolver('sr1'), { tags: ['prod'] })
+  })
+
+  it('skips an unresolvable id (noSuchObject) instead of throwing', async () => {
+    const api = makeRestApi(makeApp())
+    const node = CM.parse('$SR:[resolve]:tags:prod')
+    await assert.doesNotReject(() => api.buildResolver({ $SR: 'missing' }, node))
+  })
+
+  it('propagates a genuine (non-noSuchObject) error', async () => {
+    const api = makeRestApi(
+      makeApp({
+        getAnyObject: async () => {
+          throw new Error('db down')
+        },
+      })
+    )
+    const node = CM.parse('$SR:[resolve]:tags:prod')
+    await assert.rejects(() => api.buildResolver({ $SR: 'sr1' }, node), /db down/)
+  })
+})

--- a/@xen-orchestra/rest-api/src/rest-api/rest-api.test.mts
+++ b/@xen-orchestra/rest-api/src/rest-api/rest-api.test.mts
@@ -11,10 +11,11 @@ describe('RestApi#buildResolver', () => {
     vm1: { $SR: 'sr1' },
     sr1: { tags: ['prod'] },
   }
+  const anyStore = { ...store, user1: { email: 'test@test.com' } }
   const makeApp = (over = {}) => ({
     getObject: id => store[id], // used by this.resolver fallback
     getAnyObject: async id => {
-      const o = store[id]
+      const o = anyStore[id]
       if (o === undefined) throw noSuchObject(id)
       return o
     },
@@ -44,5 +45,12 @@ describe('RestApi#buildResolver', () => {
     )
     const node = CM.parse('$SR:[resolve]:tags:prod')
     await assert.rejects(() => api.buildResolver({ $SR: 'sr1' }, node), /db down/)
+  })
+
+  it('resolves a nested referenced id via getAnyObject prefetch', async () => {
+    const api = makeRestApi(makeApp())
+    const node = CM.parse('properties:userId:[resolve]:email:"test@test.com"')
+    const resolver = await api.buildResolver({ properties: { userId: 'user1' } }, node)
+    assert.deepEqual(resolver('user1'), { email: 'test@test.com' })
   })
 })

--- a/@xen-orchestra/rest-api/src/tasks/task.controller.mts
+++ b/@xen-orchestra/rest-api/src/tasks/task.controller.mts
@@ -93,7 +93,8 @@ export class TaskController extends XoController<XoTask> {
         throw new ApiError('watch=true requires ndjson=true', 400)
       }
 
-      const userFilter = filter === undefined ? undefined : safeParseComplexMatcher(filter).createPredicate()
+      const userFilter =
+        filter === undefined ? undefined : safeParseComplexMatcher(filter).createPredicate(this.objectResolver)
       const stream = new Transform({
         objectMode: true,
         transform([event, object], encoding, callback) {

--- a/@xen-orchestra/rest-api/src/tasks/task.controller.mts
+++ b/@xen-orchestra/rest-api/src/tasks/task.controller.mts
@@ -1,5 +1,5 @@
 import type { Request as ExRequest } from 'express'
-import type { XoTask } from '@vates/types'
+import type { XapiXoRecord, XoTask } from '@vates/types'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
 import {
   Delete,
@@ -112,6 +112,14 @@ export class TaskController extends XoController<XoTask> {
         req.destroy()
       })
 
+      const resolver = (id: string) => {
+        try {
+          return this.restApi.getObject(id as XapiXoRecord['id'])
+        } catch {
+          return undefined
+        }
+      }
+
       const userId = this.restApi.getCurrentUser().id
       const update = async (task: XoTask) => {
         const user = await this.restApi.xoApp.getUser(userId)
@@ -121,7 +129,7 @@ export class TaskController extends XoController<XoTask> {
             : ((await this.restApi.xoApp.getAclV2UserPrivileges(user.id)) as AnyPrivilege[])
 
         if (
-          hasPrivilegeOn({ user, userPrivileges, action: 'read', resource: 'task', objects: task }) &&
+          hasPrivilegeOn({ user, userPrivileges, action: 'read', resource: 'task', objects: task }, resolver) &&
           (userFilter === undefined || userFilter(task))
         ) {
           stream.write(['update', task])
@@ -135,7 +143,7 @@ export class TaskController extends XoController<XoTask> {
             : ((await this.restApi.xoApp.getAclV2UserPrivileges(user.id)) as AnyPrivilege[])
 
         if (
-          hasPrivilegeOn({ user, userPrivileges, action: 'read', resource: 'task', objects: task }) &&
+          hasPrivilegeOn({ user, userPrivileges, action: 'read', resource: 'task', objects: task }, resolver) &&
           (userFilter === undefined || userFilter(task))
         ) {
           stream.write(['remove', { id: task.id }])
@@ -203,9 +211,17 @@ export class TaskController extends XoController<XoTask> {
     const userPrivileges =
       user.permission === 'admin' ? [] : ((await this.restApi.xoApp.getAclV2UserPrivileges(user.id)) as AnyPrivilege[])
 
+    const resolver = (id: string) => {
+      try {
+        return this.restApi.getObject(id as XapiXoRecord['id'])
+      } catch {
+        return undefined
+      }
+    }
+
     const deletePromises: Promise<void>[] = []
     for await (const task of this.restApi.tasks.list()) {
-      if (hasPrivilegeOn({ user, userPrivileges, resource: 'task', action: 'delete', objects: task })) {
+      if (hasPrivilegeOn({ user, userPrivileges, resource: 'task', action: 'delete', objects: task }, resolver)) {
         deletePromises.push(this.restApi.tasks.deleteLog(task.id))
       }
     }

--- a/@xen-orchestra/rest-api/src/tasks/task.controller.mts
+++ b/@xen-orchestra/rest-api/src/tasks/task.controller.mts
@@ -94,7 +94,7 @@ export class TaskController extends XoController<XoTask> {
       }
 
       const userFilter =
-        filter === undefined ? undefined : safeParseComplexMatcher(filter).createPredicate(this.objectResolver)
+        filter === undefined ? undefined : safeParseComplexMatcher(filter).createPredicate(this.restApi.resolver)
       const stream = new Transform({
         objectMode: true,
         transform([event, object], encoding, callback) {
@@ -113,14 +113,6 @@ export class TaskController extends XoController<XoTask> {
         req.destroy()
       })
 
-      const resolver = (id: string) => {
-        try {
-          return this.restApi.getObject(id as XapiXoRecord['id'])
-        } catch {
-          return undefined
-        }
-      }
-
       const userId = this.restApi.getCurrentUser().id
       const update = async (task: XoTask) => {
         const user = await this.restApi.xoApp.getUser(userId)
@@ -130,7 +122,10 @@ export class TaskController extends XoController<XoTask> {
             : ((await this.restApi.xoApp.getAclV2UserPrivileges(user.id)) as AnyPrivilege[])
 
         if (
-          hasPrivilegeOn({ user, userPrivileges, action: 'read', resource: 'task', objects: task }, resolver) &&
+          hasPrivilegeOn(
+            { user, userPrivileges, action: 'read', resource: 'task', objects: task },
+            this.restApi.resolver
+          ) &&
           (userFilter === undefined || userFilter(task))
         ) {
           stream.write(['update', task])
@@ -144,7 +139,10 @@ export class TaskController extends XoController<XoTask> {
             : ((await this.restApi.xoApp.getAclV2UserPrivileges(user.id)) as AnyPrivilege[])
 
         if (
-          hasPrivilegeOn({ user, userPrivileges, action: 'read', resource: 'task', objects: task }, resolver) &&
+          hasPrivilegeOn(
+            { user, userPrivileges, action: 'read', resource: 'task', objects: task },
+            this.restApi.resolver
+          ) &&
           (userFilter === undefined || userFilter(task))
         ) {
           stream.write(['remove', { id: task.id }])
@@ -212,17 +210,14 @@ export class TaskController extends XoController<XoTask> {
     const userPrivileges =
       user.permission === 'admin' ? [] : ((await this.restApi.xoApp.getAclV2UserPrivileges(user.id)) as AnyPrivilege[])
 
-    const resolver = (id: string) => {
-      try {
-        return this.restApi.getObject(id as XapiXoRecord['id'])
-      } catch {
-        return undefined
-      }
-    }
-
     const deletePromises: Promise<void>[] = []
     for await (const task of this.restApi.tasks.list()) {
-      if (hasPrivilegeOn({ user, userPrivileges, resource: 'task', action: 'delete', objects: task }, resolver)) {
+      if (
+        hasPrivilegeOn(
+          { user, userPrivileges, resource: 'task', action: 'delete', objects: task },
+          this.restApi.resolver
+        )
+      ) {
         deletePromises.push(this.restApi.tasks.deleteLog(task.id))
       }
     }

--- a/@xen-orchestra/rest-api/src/tasks/task.controller.mts
+++ b/@xen-orchestra/rest-api/src/tasks/task.controller.mts
@@ -1,5 +1,5 @@
 import type { Request as ExRequest } from 'express'
-import type { XapiXoRecord, XoTask } from '@vates/types'
+import type { XoTask } from '@vates/types'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
 import {
   Delete,

--- a/@xen-orchestra/rest-api/src/users/user.controller.mts
+++ b/@xen-orchestra/rest-api/src/users/user.controller.mts
@@ -260,7 +260,7 @@ export class UserController extends XoController<XoUser> {
     const user = await this.getObject(id as XoUser['id'])
     const groups = await Promise.all(user.groups.map(group => this.restApi.xoApp.getGroup(group)))
 
-    return this.sendObjects(limitAndFilterArray(groups, { filter }), req, {
+    return this.sendObjects(limitAndFilterArray(groups, { filter }, this.objectResolver), req, {
       path: 'groups',
       limit,
       privilege: { action: 'read', resource: 'group' },
@@ -295,7 +295,7 @@ export class UserController extends XoController<XoUser> {
 
     const tokens = await this.restApi.xoApp.getAuthenticationTokensForUser(user.id)
 
-    return limitAndFilterArray(tokens, { filter, limit })
+    return limitAndFilterArray(tokens, { filter, limit }, this.objectResolver)
   }
 
   /**
@@ -434,7 +434,7 @@ export class UserController extends XoController<XoUser> {
 
     const userPrivileges = (await this.restApi.xoApp.getAclV2UserPrivileges(user.id)) as AnyPrivilege[]
 
-    return this.sendObjects(limitAndFilterArray(userPrivileges, { filter }), req, {
+    return this.sendObjects(limitAndFilterArray(userPrivileges, { filter }, this.objectResolver), req, {
       path: 'acl-privileges',
       limit,
       privilege: currentUser.id === user.id ? undefined : { action: 'read', resource: 'acl-privilege' },

--- a/@xen-orchestra/rest-api/src/users/user.controller.mts
+++ b/@xen-orchestra/rest-api/src/users/user.controller.mts
@@ -260,7 +260,7 @@ export class UserController extends XoController<XoUser> {
     const user = await this.getObject(id as XoUser['id'])
     const groups = await Promise.all(user.groups.map(group => this.restApi.xoApp.getGroup(group)))
 
-    return this.sendObjects(limitAndFilterArray(groups, { filter }, this.objectResolver), req, {
+    return this.sendObjects(limitAndFilterArray(groups, { filter }, this.restApi.resolver), req, {
       path: 'groups',
       limit,
       privilege: { action: 'read', resource: 'group' },
@@ -295,7 +295,7 @@ export class UserController extends XoController<XoUser> {
 
     const tokens = await this.restApi.xoApp.getAuthenticationTokensForUser(user.id)
 
-    return limitAndFilterArray(tokens, { filter, limit }, this.objectResolver)
+    return limitAndFilterArray(tokens, { filter, limit }, this.restApi.resolver)
   }
 
   /**
@@ -434,7 +434,7 @@ export class UserController extends XoController<XoUser> {
 
     const userPrivileges = (await this.restApi.xoApp.getAclV2UserPrivileges(user.id)) as AnyPrivilege[]
 
-    return this.sendObjects(limitAndFilterArray(userPrivileges, { filter }, this.objectResolver), req, {
+    return this.sendObjects(limitAndFilterArray(userPrivileges, { filter }, this.restApi.resolver), req, {
       path: 'acl-privileges',
       limit,
       privilege: currentUser.id === user.id ? undefined : { action: 'read', resource: 'acl-privilege' },

--- a/@xen-orchestra/rest-api/src/vm-controller/vm-controller.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-controller/vm-controller.controller.mts
@@ -169,7 +169,7 @@ export class VmControllerController extends XapiXoController<XoVmController> {
     @Query() limit?: number
   ): SendObjects<Partial<Unbrand<XoVdi>>> {
     const vdis = this.#vmService.getVmVdis(id as XoVmController['id'], 'VM-controller')
-    return this.sendObjects(limitAndFilterArray(vdis, { filter }, this.objectResolver), req, {
+    return this.sendObjects(limitAndFilterArray(vdis, { filter }, this.restApi.resolver), req, {
       path: obj => obj.type.toLowerCase() + 's',
       limit,
       privilege: { action: 'read', resource: 'vdi' },

--- a/@xen-orchestra/rest-api/src/vm-controller/vm-controller.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-controller/vm-controller.controller.mts
@@ -169,7 +169,7 @@ export class VmControllerController extends XapiXoController<XoVmController> {
     @Query() limit?: number
   ): SendObjects<Partial<Unbrand<XoVdi>>> {
     const vdis = this.#vmService.getVmVdis(id as XoVmController['id'], 'VM-controller')
-    return this.sendObjects(limitAndFilterArray(vdis, { filter }), req, {
+    return this.sendObjects(limitAndFilterArray(vdis, { filter }, this.objectResolver), req, {
       path: obj => obj.type.toLowerCase() + 's',
       limit,
       privilege: { action: 'read', resource: 'vdi' },

--- a/@xen-orchestra/rest-api/src/vm-snapshots/vm-snapshot.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-snapshots/vm-snapshot.controller.mts
@@ -222,7 +222,7 @@ export class VmSnapshotController extends XapiXoController<XoVmSnapshot> {
     @Query() limit?: number
   ): SendObjects<Partial<Unbrand<XoVdiSnapshot>>> {
     const vdis = this.#vmService.getVmVdis(id as XoVmSnapshot['id'], 'VM-snapshot')
-    return this.sendObjects(limitAndFilterArray(vdis, { filter }, this.objectResolver), req, {
+    return this.sendObjects(limitAndFilterArray(vdis, { filter }, this.restApi.resolver), req, {
       path: obj => obj.type.toLowerCase() + 's',
       limit,
       privilege: { action: 'read', resource: 'vdi' },

--- a/@xen-orchestra/rest-api/src/vm-snapshots/vm-snapshot.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-snapshots/vm-snapshot.controller.mts
@@ -222,7 +222,7 @@ export class VmSnapshotController extends XapiXoController<XoVmSnapshot> {
     @Query() limit?: number
   ): SendObjects<Partial<Unbrand<XoVdiSnapshot>>> {
     const vdis = this.#vmService.getVmVdis(id as XoVmSnapshot['id'], 'VM-snapshot')
-    return this.sendObjects(limitAndFilterArray(vdis, { filter }), req, {
+    return this.sendObjects(limitAndFilterArray(vdis, { filter }, this.objectResolver), req, {
       path: obj => obj.type.toLowerCase() + 's',
       limit,
       privilege: { action: 'read', resource: 'vdi' },

--- a/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
@@ -223,7 +223,7 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
     @Query() limit?: number
   ): SendObjects<Partial<Unbrand<XoVdi>>> {
     const vdis = this.#vmService.getVmVdis(id as XoVmTemplate['id'], 'VM-template')
-    return this.sendObjects(limitAndFilterArray(vdis, { filter }, this.objectResolver), req, {
+    return this.sendObjects(limitAndFilterArray(vdis, { filter }, this.restApi.resolver), req, {
       path: obj => obj.type.toLowerCase() + 's',
       limit,
       privilege: { action: 'read', resource: 'vdi' },

--- a/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
+++ b/@xen-orchestra/rest-api/src/vm-templates/vm-template.controller.mts
@@ -223,7 +223,7 @@ export class VmTemplateController extends XapiXoController<XoVmTemplate> {
     @Query() limit?: number
   ): SendObjects<Partial<Unbrand<XoVdi>>> {
     const vdis = this.#vmService.getVmVdis(id as XoVmTemplate['id'], 'VM-template')
-    return this.sendObjects(limitAndFilterArray(vdis, { filter }), req, {
+    return this.sendObjects(limitAndFilterArray(vdis, { filter }, this.objectResolver), req, {
       path: obj => obj.type.toLowerCase() + 's',
       limit,
       privilege: { action: 'read', resource: 'vdi' },

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -873,7 +873,7 @@ export class VmController extends XapiXoController<XoVm> {
     @Query() limit?: number
   ): SendObjects<Partial<Unbrand<XoVdi>>> {
     const vdis = this.#vmService.getVmVdis(id as XoVm['id'], 'VM')
-    return this.sendObjects(limitAndFilterArray(vdis, { filter }, this.objectResolver), req, {
+    return this.sendObjects(limitAndFilterArray(vdis, { filter }, this.restApi.resolver), req, {
       path: obj => obj.type.toLowerCase() + 's',
       limit,
       privilege: { action: 'read', resource: 'vdi' },
@@ -914,7 +914,7 @@ export class VmController extends XapiXoController<XoVm> {
       }
     }
 
-    return this.sendObjects(limitAndFilterArray(vmBackupJobs, { filter }, this.objectResolver), req, {
+    return this.sendObjects(limitAndFilterArray(vmBackupJobs, { filter }, this.restApi.resolver), req, {
       path: '/backup-jobs',
       limit,
       privilege: { action: 'read', resource: 'backup-job' },

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -873,7 +873,7 @@ export class VmController extends XapiXoController<XoVm> {
     @Query() limit?: number
   ): SendObjects<Partial<Unbrand<XoVdi>>> {
     const vdis = this.#vmService.getVmVdis(id as XoVm['id'], 'VM')
-    return this.sendObjects(limitAndFilterArray(vdis, { filter }), req, {
+    return this.sendObjects(limitAndFilterArray(vdis, { filter }, this.objectResolver), req, {
       path: obj => obj.type.toLowerCase() + 's',
       limit,
       privilege: { action: 'read', resource: 'vdi' },
@@ -914,7 +914,7 @@ export class VmController extends XapiXoController<XoVm> {
       }
     }
 
-    return this.sendObjects(limitAndFilterArray(vmBackupJobs, { filter }), req, {
+    return this.sendObjects(limitAndFilterArray(vmBackupJobs, { filter }, this.objectResolver), req, {
       path: '/backup-jobs',
       limit,
       privilege: { action: 'read', resource: 'backup-job' },

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -60,6 +60,7 @@
 - [Netbox] Add option to ignore [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918) private IPs during synchronization. Thanks [@sboyd-m](https://github.com/sboyd-m)! (PR [#6306](https://github.com/vatesfr/xen-orchestra/pull/6306))
 - [SR] Storage repositories can now be connected from the Pool/Host Storage tab (PR [#9877](https://github.com/vatesfr/xen-orchestra/pull/9877))
 - [Core] Remove all icons from table headers (PR [#9943](https://github.com/vatesfr/xen-orchestra/pull/9943)
+- [Complex-matcher] Implemented [resolve] and [resolve:all] nodes for deep resolution (PR [#9911](https://github.com/vatesfr/xen-orchestra/pull/9911))
 
 - [Dependabot] Update packages and sync package.json with yarn.lock (PR [#9969](https://github.com/vatesfr/xen-orchestra/pull/9969))
   - update shell-quote to 1.8.4:
@@ -118,6 +119,7 @@
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
 - @xen-orchestra/xapi minor
+- complex-matcher minor
 - xo-common minor
 - xo-server minor
 - xo-server-ipmi-sensors patch

--- a/packages/complex-matcher/index.d.ts
+++ b/packages/complex-matcher/index.d.ts
@@ -86,4 +86,6 @@ export function getPropertyClausesStrings(node: Node): {
   [key: string]: string[]
 }
 
+export function getResolveFields(node: Node): { name: string; resolveNode: Resolve }[]
+
 export function setPropertyClause(node: Node | undefined, name: string, child: Node | string): Node

--- a/packages/complex-matcher/index.d.ts
+++ b/packages/complex-matcher/index.d.ts
@@ -75,8 +75,9 @@ export class TruthyProperty extends BaseNode {
 }
 
 export class Resolve extends BaseNode {
-  constructor(child: BaseNode)
+  constructor(child: BaseNode, mode: 'some' | 'every' = 'some')
   child: BaseNode
+  mode: 'some' | 'every'
 }
 
 export function parse(input: string): Node

--- a/packages/complex-matcher/index.d.ts
+++ b/packages/complex-matcher/index.d.ts
@@ -1,8 +1,8 @@
 export type ComparisonOperator = '>' | '>=' | '<' | '<='
 
 declare class BaseNode {
-  createPredicate(): (value: any) => boolean
-  match(value: any): boolean
+  createPredicate(resolver?: (id: string) => object | undefined): (value: any) => boolean
+  match(value: any, resolver?: (id: string) => object | undefined): boolean
   toString(isNested?: boolean): string
 }
 
@@ -72,6 +72,11 @@ export { StringNode as String }
 export class TruthyProperty extends BaseNode {
   constructor(name: string)
   name: string
+}
+
+export class Resolve extends BaseNode {
+  constructor(child: BaseNode)
+  child: BaseNode
 }
 
 export function parse(input: string): Node

--- a/packages/complex-matcher/index.d.ts
+++ b/packages/complex-matcher/index.d.ts
@@ -86,6 +86,6 @@ export function getPropertyClausesStrings(node: Node): {
   [key: string]: string[]
 }
 
-export function getResolveFields(node: Node): { name: string; resolveNode: Resolve }[]
+export function getResolveFields(node: Node): { path: [string]; resolveNode: Resolve }[]
 
 export function setPropertyClause(node: Node | undefined, name: string, child: Node | string): Node

--- a/packages/complex-matcher/index.fixtures.js
+++ b/packages/complex-matcher/index.fixtures.js
@@ -2,7 +2,8 @@
 
 const CM = require('./')
 
-exports.pattern = 'foo !"\\\\ \\"" name:|(wonderwoman batman) hasCape? age:32 chi*go /^foo\\/bar\\./i'
+exports.pattern =
+  'foo !"\\\\ \\"" name:|(wonderwoman batman) hasCape? age:32 chi*go /^foo\\/bar\\./i object:[resolve]:tags:tag'
 
 exports.ast = new CM.And([
   new CM.String('foo'),
@@ -12,4 +13,5 @@ exports.ast = new CM.And([
   new CM.Property('age', new CM.NumberOrStringNode('32')),
   new CM.GlobPattern('chi*go'),
   new CM.RegExp('^foo/bar\\.', 'i'),
+  new CM.Property('object', new CM.Resolve(new CM.Property('tags', new CM.String('tag')))),
 ])

--- a/packages/complex-matcher/index.js
+++ b/packages/complex-matcher/index.js
@@ -315,10 +315,11 @@ class TruthyProperty extends Node {
 exports.TruthyProperty = TruthyProperty
 
 class Resolve extends Node {
-  constructor(child) {
+  constructor(child, mode = 'some') {
     super()
 
     this.child = child
+    this.mode = mode
   }
 
   match(value, resolver) {
@@ -331,10 +332,19 @@ class Resolve extends Node {
     }
 
     if (Array.isArray(value)) {
-      return value.some(id => {
-        const obj = resolver(id)
-        return obj != null && this.child.match(obj, resolver)
-      })
+      if (this.mode === 'some') {
+        return value.some(id => {
+          const obj = resolver(id)
+          return obj != null && this.child.match(obj, resolver)
+        })
+      } else if (this.mode === 'every') {
+        return value.every(id => {
+          const obj = resolver(id)
+          return obj != null && this.child.match(obj, resolver)
+        })
+      }
+
+      throw new Error(`${this.mode} mode not supported by resolve`)
     }
 
     const obj = resolver(value)
@@ -342,7 +352,12 @@ class Resolve extends Node {
   }
 
   toString() {
-    return `[resolve]:${this.child.toString(true)}`
+    if (this.mode === 'some') {
+      return `[resolve]:${this.child.toString(true)}`
+    } else if (this.mode === 'every') {
+      return `[resolve:all]:${this.child.toString(true)}`
+    }
+    throw new Error(`${this.mode} mode not supported by resolve`)
   }
 }
 exports.Resolve = Resolve
@@ -566,7 +581,8 @@ const parser = P.grammar({
       P.seq(P.regex(/[<>]=?/), r.rawString).map(([op, val]) => {
         return new Comparison(op, +val)
       }),
-      P.seq(P.text('[resolve]'), P.text(':'), r.ws, r.term).map(_ => new Resolve(_[3])),
+      P.seq(P.text('[resolve]'), P.text(':'), r.ws, r.term).map(_ => new Resolve(_[3], 'some')),
+      P.seq(P.text('[resolve:all]'), P.text(':'), r.ws, r.term).map(_ => new Resolve(_[3], 'every')),
       P.seq(r.property, r.ws, P.text(':'), r.ws, r.term).map(_ => new Property(_[0], _[4])),
       P.seq(r.property, P.text('?')).map(_ => new TruthyProperty(_[0])),
       r.value

--- a/packages/complex-matcher/index.js
+++ b/packages/complex-matcher/index.js
@@ -27,8 +27,8 @@ const isRawString = string => {
 // -------------------------------------------------------------------
 
 class Node {
-  createPredicate() {
-    return value => this.match(value)
+  createPredicate(resolver) {
+    return value => this.match(value, resolver)
   }
 }
 
@@ -55,8 +55,8 @@ class And extends Node {
     this.children = children
   }
 
-  match(value) {
-    return this.children.every(child => child.match(value))
+  match(value, resolver) {
+    return this.children.every(child => child.match(value, resolver))
   }
 
   toString(isNested) {
@@ -105,8 +105,8 @@ class Or extends Node {
     this.children = children
   }
 
-  match(value) {
-    return this.children.some(child => child.match(value))
+  match(value, resolver) {
+    return this.children.some(child => child.match(value, resolver))
   }
 
   toString() {
@@ -122,8 +122,8 @@ class Not extends Node {
     this.child = child
   }
 
-  match(value) {
-    return !this.child.match(value)
+  match(value, resolver) {
+    return !this.child.match(value, resolver)
   }
 
   toString() {
@@ -188,8 +188,8 @@ class Property extends Node {
     this.child = child
   }
 
-  match(value) {
-    return value != null && this.child.match(value[this.name])
+  match(value, resolver) {
+    return value != null && this.child.match(value[this.name], resolver)
   }
 
   toString() {
@@ -313,6 +313,39 @@ class TruthyProperty extends Node {
   }
 }
 exports.TruthyProperty = TruthyProperty
+
+class Resolve extends Node {
+  constructor(child) {
+    super()
+
+    this.child = child
+  }
+
+  match(value, resolver) {
+    if (resolver === undefined) {
+      throw new Error('[resolve] requires a resolver')
+    }
+
+    if (value == null) {
+      return false
+    }
+
+    if (Array.isArray(value)) {
+      return value.some(id => {
+        const obj = resolver(id)
+        return obj != null && this.child.match(obj, resolver)
+      })
+    }
+
+    const obj = resolver(value)
+    return obj != null && this.child.match(obj, resolver)
+  }
+
+  toString() {
+    return `[resolve]:${this.child.toString(true)}`
+  }
+}
+exports.Resolve = Resolve
 
 // -------------------------------------------------------------------
 
@@ -533,6 +566,7 @@ const parser = P.grammar({
       P.seq(P.regex(/[<>]=?/), r.rawString).map(([op, val]) => {
         return new Comparison(op, +val)
       }),
+      P.seq(P.text('[resolve]'), P.text(':'), r.ws, r.term).map(_ => new Resolve(_[3])),
       P.seq(r.property, r.ws, P.text(':'), r.ws, r.term).map(_ => new Property(_[0], _[4])),
       P.seq(r.property, P.text('?')).map(_ => new TruthyProperty(_[0])),
       r.value

--- a/packages/complex-matcher/index.js
+++ b/packages/complex-matcher/index.js
@@ -672,6 +672,24 @@ exports.getPropertyClausesStrings = function getPropertyClausesStrings(node) {
 
 // -------------------------------------------------------------------
 
+exports.getResolveFields = function getResolveFields(node) {
+  const result = []
+
+  if (node instanceof Property) {
+    if (node.child instanceof Resolve) {
+      result.push({ name: node.name, resolveNode: node.child })
+    }
+  } else if (node instanceof And || node instanceof Or) {
+    node.children.forEach(childNode => {
+      result.push(...getResolveFields(childNode))
+    })
+  } else if (node instanceof Not) {
+    result.push(...getResolveFields(node.child))
+  }
+
+  return result
+}
+
 exports.setPropertyClause = function setPropertyClause(node, name, child) {
   const property = child && new Property(name, typeof child === 'string' ? new StringNode(child) : child)
 

--- a/packages/complex-matcher/index.js
+++ b/packages/complex-matcher/index.js
@@ -672,19 +672,21 @@ exports.getPropertyClausesStrings = function getPropertyClausesStrings(node) {
 
 // -------------------------------------------------------------------
 
-exports.getResolveFields = function getResolveFields(node) {
+exports.getResolveFields = function getResolveFields(node, prefix = []) {
   const result = []
 
   if (node instanceof Property) {
     if (node.child instanceof Resolve) {
-      result.push({ name: node.name, resolveNode: node.child })
+      result.push({ path: [...prefix, node.name], resolveNode: node.child })
+    } else {
+      result.push(...getResolveFields(node.child, [...prefix, node.name]))
     }
   } else if (node instanceof And || node instanceof Or) {
     node.children.forEach(childNode => {
-      result.push(...getResolveFields(childNode))
+      result.push(...getResolveFields(childNode, prefix))
     })
   } else if (node instanceof Not) {
-    result.push(...getResolveFields(node.child))
+    result.push(...getResolveFields(node.child, prefix))
   }
 
   return result

--- a/packages/complex-matcher/index.test.js
+++ b/packages/complex-matcher/index.test.js
@@ -132,7 +132,7 @@ it('toString', () => {
 describe('resolve', () => {
   const target = { objects: 'object' }
   const targetArray = { objects: ['object'] }
-  const store = { object: { tags: ['tag'] } }
+  const store = { object: { tags: ['tag'], nested: 'nested-object' }, 'nested-object': { tags: ['nested-tag'] } }
   const notFoundStore = { 'not-object': { tags: ['tag'] } }
 
   it('match a single ID', () => {
@@ -143,12 +143,20 @@ describe('resolve', () => {
     assert(parse('objects:[resolve]:tags:tag').createPredicate(id => store[id])(targetArray))
   })
 
-  it('returns false when resolved object does not match', () => {
+  it('match with recursive resolution', () => {
+    assert(parse('objects:[resolve]:nested:[resolve]:tags:nested-tag').createPredicate(id => store[id])(target))
+  })
+
+  it("doesn't match when resolved object does not satisfy the predicate", () => {
     assert(!parse('objects:[resolve]:tags:not-found-tag').createPredicate(id => store[id])(target))
   })
 
-  it('returns false when resolved object not found', () => {
+  it("doesn't match when resolved object not found", () => {
     assert(!parse('objects:[resolve]:tags:tag').createPredicate(id => notFoundStore[id])(target))
+  })
+
+  it("doesn't match recursively when resolved object does not satisfy the predicate", () => {
+    assert(!parse('objects:[resolve]:nested:[resolve]:tags:not-found-tag').createPredicate(id => store[id])(target))
   })
 
   it('throws when no resolver is provided', () => {

--- a/packages/complex-matcher/index.test.js
+++ b/packages/complex-matcher/index.test.js
@@ -169,3 +169,25 @@ describe('resolve', () => {
     assert.equal(parse('objects:[resolve]:tags:tag').toString(), 'objects:[resolve]:tags:tag')
   })
 })
+
+describe('resolve:all', () => {
+  const allMatch = { objects: ['object-1', 'object-2'] }
+  const someMatch = { objects: ['object-1', 'object-3'] }
+  const store = {
+    'object-1': { tags: ['tag'] },
+    'object-2': { tags: ['tag'] },
+    'object-3': { tags: ['other'] },
+  }
+
+  it('matches when all resolved objects satisfy the predicate', () => {
+    assert(parse('objects:[resolve:all]:tags:tag').createPredicate(id => store[id])(allMatch))
+  })
+
+  it("doesn't match when only some resolved objects satisfy the predicate", () => {
+    assert(!parse('objects:[resolve:all]:tags:tag').createPredicate(id => store[id])(someMatch))
+  })
+
+  it('toString round-trips correctly', () => {
+    assert.equal(parse('objects:[resolve:all]:tags:tag').toString(), 'objects:[resolve:all]:tags:tag')
+  })
+})

--- a/packages/complex-matcher/index.test.js
+++ b/packages/complex-matcher/index.test.js
@@ -7,12 +7,14 @@ const { ast, pattern } = require('./index.fixtures')
 const {
   getPropertyClausesStrings,
   Comparison,
+  getResolveFields,
   GlobPattern,
   Null,
   NumberNode,
   NumberOrStringNode,
   parse,
   Property,
+  Resolve,
   setPropertyClause,
   StringNode,
 } = require('./')
@@ -100,6 +102,50 @@ describe('Number', () => {
 describe('NumberOrStringNode', () => {
   it('match a string', () => {
     assert.equal(new NumberOrStringNode('123').match([{ foo: '123' }]), true)
+  })
+})
+
+describe('getResolveFields', () => {
+  it('returns field name and resolve node for a single property', () => {
+    const resolveFields = getResolveFields(parse('object:[resolve]:tags:tag'))
+    assert.equal(resolveFields[0].name, 'object')
+    assert(resolveFields[0].resolveNode instanceof Resolve)
+  })
+
+  it('returns empty array when no [resolve] is present', () => {
+    const resolveFields = getResolveFields(parse('tags:tag'))
+    assert.equal(resolveFields.length, 0)
+  })
+
+  it('returns all field names and resolve nodes for an And node', () => {
+    const resolveFields = getResolveFields(parse('object1:[resolve]:tags:tag object2:[resolve]:tags:tag'))
+    assert.equal(resolveFields[0].name, 'object1')
+    assert(resolveFields[0].resolveNode instanceof Resolve)
+    assert.equal(resolveFields[1].name, 'object2')
+    assert(resolveFields[1].resolveNode instanceof Resolve)
+  })
+
+  it('only returns properties with [resolve] in a mixed And node', () => {
+    const resolveFields2 = getResolveFields(parse('object3:[resolve]:tags:tag tags:tag'))
+    assert.equal(resolveFields2.length, 1)
+    assert.equal(resolveFields2[0].name, 'object3')
+    assert(resolveFields2[0].resolveNode instanceof Resolve)
+  })
+
+  it('returns all field names and resolve nodes for an Or node', () => {
+    const resolveFields = getResolveFields(parse('|(object1:[resolve]:tags:tag object2:[resolve]:tags:tag)'))
+    assert.equal(resolveFields.length, 2)
+    assert.equal(resolveFields[0].name, 'object1')
+    assert(resolveFields[0].resolveNode instanceof Resolve)
+    assert.equal(resolveFields[1].name, 'object2')
+    assert(resolveFields[1].resolveNode instanceof Resolve)
+  })
+
+  it('returns field names and resolve nodes inside a Not node', () => {
+    const resolveFields = getResolveFields(parse('!(object:[resolve]:tags:tag)'))
+    assert.equal(resolveFields.length, 1)
+    assert.equal(resolveFields[0].name, 'object')
+    assert(resolveFields[0].resolveNode instanceof Resolve)
   })
 })
 

--- a/packages/complex-matcher/index.test.js
+++ b/packages/complex-matcher/index.test.js
@@ -128,3 +128,36 @@ describe('setPropertyClause', () => {
 it('toString', () => {
   assert.equal(ast.toString(), pattern)
 })
+
+describe('resolve', () => {
+  const target = { objects: 'object' }
+  const targetArray = { objects: ['object'] }
+  const store = { object: { tags: ['tag'] } }
+  const notFoundStore = { 'not-object': { tags: ['tag'] } }
+
+  it('match a single ID', () => {
+    assert(parse('objects:[resolve]:tags:tag').createPredicate(id => store[id])(target))
+  })
+
+  it('match an array of IDs', () => {
+    assert(parse('objects:[resolve]:tags:tag').createPredicate(id => store[id])(targetArray))
+  })
+
+  it('returns false when resolved object does not match', () => {
+    assert(!parse('objects:[resolve]:tags:not-found-tag').createPredicate(id => store[id])(target))
+  })
+
+  it('returns false when resolved object not found', () => {
+    assert(!parse('objects:[resolve]:tags:tag').createPredicate(id => notFoundStore[id])(target))
+  })
+
+  it('throws when no resolver is provided', () => {
+    assert.throws(() => parse('objects:[resolve]:tags:tag').createPredicate()(target), {
+      message: '[resolve] requires a resolver',
+    })
+  })
+
+  it('toString round-trips correctly', () => {
+    assert.equal(parse('objects:[resolve]:tags:tag').toString(), 'objects:[resolve]:tags:tag')
+  })
+})

--- a/packages/complex-matcher/index.test.js
+++ b/packages/complex-matcher/index.test.js
@@ -108,7 +108,7 @@ describe('NumberOrStringNode', () => {
 describe('getResolveFields', () => {
   it('returns field name and resolve node for a single property', () => {
     const resolveFields = getResolveFields(parse('object:[resolve]:tags:tag'))
-    assert.equal(resolveFields[0].name, 'object')
+    assert.deepEqual(resolveFields[0].path, ['object'])
     assert(resolveFields[0].resolveNode instanceof Resolve)
   })
 
@@ -119,33 +119,53 @@ describe('getResolveFields', () => {
 
   it('returns all field names and resolve nodes for an And node', () => {
     const resolveFields = getResolveFields(parse('object1:[resolve]:tags:tag object2:[resolve]:tags:tag'))
-    assert.equal(resolveFields[0].name, 'object1')
+    assert.deepEqual(resolveFields[0].path, ['object1'])
     assert(resolveFields[0].resolveNode instanceof Resolve)
-    assert.equal(resolveFields[1].name, 'object2')
+    assert.deepEqual(resolveFields[1].path, ['object2'])
     assert(resolveFields[1].resolveNode instanceof Resolve)
   })
 
   it('only returns properties with [resolve] in a mixed And node', () => {
     const resolveFields2 = getResolveFields(parse('object3:[resolve]:tags:tag tags:tag'))
     assert.equal(resolveFields2.length, 1)
-    assert.equal(resolveFields2[0].name, 'object3')
+    assert.deepEqual(resolveFields2[0].path, ['object3'])
     assert(resolveFields2[0].resolveNode instanceof Resolve)
   })
 
   it('returns all field names and resolve nodes for an Or node', () => {
     const resolveFields = getResolveFields(parse('|(object1:[resolve]:tags:tag object2:[resolve]:tags:tag)'))
     assert.equal(resolveFields.length, 2)
-    assert.equal(resolveFields[0].name, 'object1')
+    assert.deepEqual(resolveFields[0].path, ['object1'])
     assert(resolveFields[0].resolveNode instanceof Resolve)
-    assert.equal(resolveFields[1].name, 'object2')
+    assert.deepEqual(resolveFields[1].path, ['object2'])
     assert(resolveFields[1].resolveNode instanceof Resolve)
   })
 
   it('returns field names and resolve nodes inside a Not node', () => {
     const resolveFields = getResolveFields(parse('!(object:[resolve]:tags:tag)'))
     assert.equal(resolveFields.length, 1)
-    assert.equal(resolveFields[0].name, 'object')
+    assert.deepEqual(resolveFields[0].path, ['object'])
     assert(resolveFields[0].resolveNode instanceof Resolve)
+  })
+
+  it('returns the full path and resolve node for a nested property', () => {
+    const resolveFields = getResolveFields(parse('properties:userId:[resolve]:tags:tag'))
+    assert.equal(resolveFields.length, 1)
+    assert.deepEqual(resolveFields[0].path, ['properties', 'userId'])
+    assert(resolveFields[0].resolveNode instanceof Resolve)
+  })
+
+  it('prefixes paths for resolves inside a grouped property', () => {
+    const resolveFields = getResolveFields(parse('object1:(object2:[resolve]:tags:tag object3:[resolve]:tags:tag)'))
+    assert.equal(resolveFields.length, 2)
+    assert.deepEqual(resolveFields[0].path, ['object1', 'object2'])
+    assert.deepEqual(resolveFields[1].path, ['object1', 'object3'])
+  })
+
+  it('ignores non-resolve terms in a group', () => {
+    const resolveFields = getResolveFields(parse('object1:(object2:[resolve]:tags:tag property)'))
+    assert.equal(resolveFields.length, 1)
+    assert.deepEqual(resolveFields[0].path, ['object1', 'object2'])
   })
 })
 

--- a/packages/xo-server/src/xo.mjs
+++ b/packages/xo-server/src/xo.mjs
@@ -98,6 +98,52 @@ export default class Xo extends EventEmitter {
     return obj
   }
 
+  async getAnyObject(id) {
+    let result
+
+    try {
+      result = this.getObject(id)
+    } catch {}
+    if (result !== undefined) return result
+
+    try {
+      result = await this.getUser(id)
+    } catch {}
+    if (result !== undefined) return result
+
+    try {
+      result = await this.getGroup(id)
+    } catch {}
+    if (result !== undefined) return result
+
+    try {
+      result = await this.getProxy(id)
+    } catch {}
+    if (result !== undefined) return result
+
+    try {
+      result = await this.getSchedule(id)
+    } catch {}
+    if (result !== undefined) return result
+
+    try {
+      result = await this.getJob(id)
+    } catch {}
+    if (result !== undefined) return result
+
+    try {
+      result = await this.getAclV2Role(id)
+    } catch {}
+    if (result !== undefined) return result
+
+    try {
+      result = await this.getAclV2Privilege(id)
+    } catch {}
+    if (result !== undefined) return result
+
+    return result
+  }
+
   hasObject(key, type) {
     try {
       return this.getObject(key, type) !== undefined

--- a/packages/xo-server/src/xo.mjs
+++ b/packages/xo-server/src/xo.mjs
@@ -99,49 +99,33 @@ export default class Xo extends EventEmitter {
   }
 
   async getAnyObject(id) {
-    let result
+    const getters = [
+      Promise.resolve().then(() => this.getObject(id)),
+      this.getUser(id),
+      this.getGroup(id),
+      this.getProxy(id),
+      this.getSchedule(id),
+      this.getJob(id),
+      this.getAclV2Role(id),
+      this.getAclV2Privilege(id),
+    ]
 
-    try {
-      result = this.getObject(id)
-    } catch {}
-    if (result !== undefined) return result
-
-    try {
-      result = await this.getUser(id)
-    } catch {}
-    if (result !== undefined) return result
-
-    try {
-      result = await this.getGroup(id)
-    } catch {}
-    if (result !== undefined) return result
-
-    try {
-      result = await this.getProxy(id)
-    } catch {}
-    if (result !== undefined) return result
-
-    try {
-      result = await this.getSchedule(id)
-    } catch {}
-    if (result !== undefined) return result
-
-    try {
-      result = await this.getJob(id)
-    } catch {}
-    if (result !== undefined) return result
-
-    try {
-      result = await this.getAclV2Role(id)
-    } catch {}
-    if (result !== undefined) return result
-
-    try {
-      result = await this.getAclV2Privilege(id)
-    } catch {}
-    if (result !== undefined) return result
-
-    return result
+    // Promise.any requires Node >=15 but engines is >=14.18, so invert
+    // Promise.all: settle on the first fulfilled getter, and throw
+    // noSuchObject only when every getter rejects.
+    return Promise.all(
+      getters.map(promise =>
+        promise.then(
+          value => Promise.reject(value),
+          error => error
+        )
+      )
+    ).then(
+      () => {
+        throw noSuchObject(id)
+      },
+      value => value
+    )
   }
 
   hasObject(key, type) {

--- a/packages/xo-server/src/xo.mjs
+++ b/packages/xo-server/src/xo.mjs
@@ -110,9 +110,6 @@ export default class Xo extends EventEmitter {
       this.getAclV2Privilege(id),
     ]
 
-    // Promise.any requires Node >=15 but engines is >=14.18, so invert
-    // Promise.all: settle on the first fulfilled getter, and throw
-    // noSuchObject only when every getter rejects.
     return Promise.all(
       getters.map(promise =>
         promise.then(


### PR DESCRIPTION
Fixes #2104

### Description

([XO-2293](https://project.vates.tech/vates-global/browse/XO-2293/))

Implement deep resolution matcher to complex-matcher.

By using `[resolve]` after an object, the complex-matcher will get all the objects of the preceding type and match them against the rest of the match string.

Ex: `VM:[resolve]:tags:test-tag` will return true on the VM objects with the "test-tag" tag.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
