### PR TITLE
docs(mcp): require Xen Orchestra 6.5 or later

### DIFF
--- a/@xen-orchestra/mcp/.USAGE.md
+++ b/@xen-orchestra/mcp/.USAGE.md
@@ -65,8 +65,10 @@ See the [full documentation](https://docs.xen-orchestra.com/mcp) for configurati
 ### Prerequisites
 
 - **Node.js** >= 20
-- **Xen Orchestra** instance with [REST API](https://docs.xen-orchestra.com/restapi) enabled
+- **Xen Orchestra** 6.5 or later, with the [REST API](https://docs.xen-orchestra.com/restapi) enabled
 - An **AI assistant** that supports MCP (Claude Desktop, Claude Code, etc.)
+
+> **Note:** this MCP server requires **Xen Orchestra 6.5 or later**. On an older XO it stops at startup with an error such as `Unable to verify MCP status (HTTP 404)` — upgrade your Xen Orchestra to use it.
 
 ### Configuration
 

--- a/@xen-orchestra/mcp/README.md
+++ b/@xen-orchestra/mcp/README.md
@@ -83,8 +83,10 @@ See the [full documentation](https://docs.xen-orchestra.com/mcp) for configurati
 ### Prerequisites
 
 - **Node.js** >= 20
-- **Xen Orchestra** instance with [REST API](https://docs.xen-orchestra.com/restapi) enabled
+- **Xen Orchestra** 6.5 or later, with the [REST API](https://docs.xen-orchestra.com/restapi) enabled
 - An **AI assistant** that supports MCP (Claude Desktop, Claude Code, etc.)
+
+> **Note:** this MCP server requires **Xen Orchestra 6.5 or later**. On an older XO it stops at startup with an error such as `Unable to verify MCP status (HTTP 404)` — upgrade your Xen Orchestra to use it.
 
 ### Configuration
 

--- a/docs/docs/xo5/mcp.md
+++ b/docs/docs/xo5/mcp.md
@@ -22,8 +22,12 @@ All operations are **read-only by default**, ensuring safe interaction with your
 ### Prerequisites
 
 - **Node.js** 20 or later
-- A **Xen Orchestra** instance with [REST API](restapi.md) enabled
+- A **Xen Orchestra** instance, version **6.5 or later**, with [REST API](restapi.md) enabled
 - An **AI assistant** that supports MCP (Claude Desktop, Claude Code, etc.)
+
+:::warning Xen Orchestra 6.5 or later required
+The MCP server requires **Xen Orchestra 6.5 or later**. On an older XO it stops at startup with an error such as `Unable to verify MCP status (HTTP 404)`. Upgrade your Xen Orchestra to use it.
+:::
 
 ### Install the MCP server
 
@@ -396,4 +400,8 @@ If your AI assistant injects `HTTPS_PROXY` into the MCP process and your XOA liv
 
 :::note MCP disabled by admin
 The xo-server administrator has set `[mcp] enabled = false` in the server config. The binary won't start until that flag is removed or set back to `true`. See [Disabling MCP globally](#disabling-mcp-globally) for the server-side details.
+:::
+
+:::note Unable to verify MCP status (HTTP 404)
+Your Xen Orchestra is older than **6.5**. Upgrade XO to 6.5 or later to use the MCP server — see [Prerequisites](#prerequisites).
 :::

--- a/docs/docs/xo5/mcp.md
+++ b/docs/docs/xo5/mcp.md
@@ -25,7 +25,7 @@ All operations are **read-only by default**, ensuring safe interaction with your
 - A **Xen Orchestra** instance, version **6.5 or later**, with [REST API](restapi.md) enabled
 - An **AI assistant** that supports MCP (Claude Desktop, Claude Code, etc.)
 
-:::warning Xen Orchestra 6.5 or later required
+:::warning
 The MCP server requires **Xen Orchestra 6.5 or later**. On an older XO it stops at startup with an error such as `Unable to verify MCP status (HTTP 404)`. Upgrade your Xen Orchestra to use it.
 :::
 
@@ -402,6 +402,7 @@ If your AI assistant injects `HTTPS_PROXY` into the MCP process and your XOA liv
 The xo-server administrator has set `[mcp] enabled = false` in the server config. The binary won't start until that flag is removed or set back to `true`. See [Disabling MCP globally](#disabling-mcp-globally) for the server-side details.
 :::
 
-:::note Unable to verify MCP status (HTTP 404)
-Your Xen Orchestra is older than **6.5**. Upgrade XO to 6.5 or later to use the MCP server — see [Prerequisites](#prerequisites).
+:::note
+**Unable to verify MCP status (HTTP 404)**
+Your Xen Orchestra is older than **6.5**. Upgrade XO to 6.5 or later to use the MCP server, see [Prerequisites](#prerequisites).
 :::


### PR DESCRIPTION
### Description

Documents that `@xen-orchestra/mcp` requires **Xen Orchestra 6.5 or later**.

Since `1.4.0`, the MCP binary probes `/rest/v0/mcp/status` at startup to honor the
server-side kill-switch (introduced in XO 6.5, PR #9860). That endpoint does not
exist on older XO, so the binary aborts with `Unable to verify MCP status (HTTP 404)`.
Users on XO < 6.5 hit this with no explanation of the version requirement.

This PR makes the requirement explicit:

- `@xen-orchestra/mcp/.USAGE.md` — Prerequisites now state "Xen Orchestra 6.5 or
  later" plus a note explaining the `HTTP 404` error and pointing to an XO upgrade.
- `@xen-orchestra/mcp/README.md` — regenerated from `.USAGE.md` via
  `scripts/normalize-packages.js` (not edited by hand).
- `docs/docs/xo5/mcp.md` — same prerequisite, a `:::warning` callout, and a new
  Troubleshooting entry for `Unable to verify MCP status (HTTP 404)`.

The wording deliberately points users toward upgrading XO rather than pinning an
older MCP release.

See https://github.com/vatesfr/xen-orchestra/pull/9860 (kill-switch, shipped in XO 6.5.0).

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue (`See #9860`)
  - [ ] If bug fix, add `Introduced by` — n/a, documentation only
- Changelog
  - [ ] If visible by XOA users, add changelog entry — n/a, documentation only
  - [x] Update "Packages to release" in `CHANGELOG.unreleased.md` — `@xen-orchestra/mcp patch` (README regenerated)
- PR
  - [ ] If UI changes, add screenshots — n/a
  - [ ] If not finished or not tested, open as _Draft_ — ready for review


### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
