### PR TITLE
fix: move try/catch inside initializations 

### DIFF
--- a/@xen-orchestra/backup-archive/src/RemoteDiskLineage.mts
+++ b/@xen-orchestra/backup-archive/src/RemoteDiskLineage.mts
@@ -69,7 +69,14 @@ export class RemoteDiskLineage {
    * Also detects interrupted merge state files.
    */
   async init(): Promise<void> {
-    const files = await this.#handler.list(this.#vdiDir, { prependDir: true })
+    let files: string[]
+    try {
+      files = await this.#handler.list(this.#vdiDir, { prependDir: true })
+    } catch (error) {
+      if (error?.code === 'NOT_SUPPORTED') throw error
+      this.#opts.logWarn('failed to list VDI directory', { vdiDir: this.#vdiDir, error })
+      return
+    }
 
     for (const filePath of files) {
       if (isDisk(filePath)) {

--- a/@xen-orchestra/backup-archive/src/VmIncrementalBackupArchive.integ.mjs
+++ b/@xen-orchestra/backup-archive/src/VmIncrementalBackupArchive.integ.mjs
@@ -686,3 +686,31 @@ test('check all types of aliases, corrupted, missing or not', async () => {
   assert.equal(data.length, 1)
   assert.equal(data[0], 'ok.vhd')
 })
+
+test('it preserves VDI directory when handler.list() throws during lineage init', async () => {
+  // Regression: when handler.list(vdiDir) threw (e.g. S3 404), the lineage
+  // was never added to #uniqueLineages, so cleanOrphanDiskDirs treated the directory
+  // as an orphan and deleted it with rmtree()
+  await generateVhd(`${basePath}/snapshot.vhd`)
+  await handler.writeFile(
+    `${rootPath}/metadata.json`,
+    JSON.stringify({ mode: 'delta', vhds: [`${relativePath}/snapshot.vhd`] })
+  )
+
+  const originalList = handler.list.bind(handler)
+  handler.list = async (path, opts) => {
+    if (typeof path === 'string' && path.includes(vdiId)) {
+      throw Object.assign(new Error('Simulated transient storage error'), { code: 'ENOENT' })
+    }
+    return originalList(path, opts)
+  }
+
+  try {
+    await VmBackupDirectory.cleanVm(handler, rootPath, { remove: true, logWarn: () => {}, logInfo: () => {} })
+  } finally {
+    handler.list = originalList
+  }
+
+  const remaining = await handler.list(basePath)
+  assert.ok(remaining.includes('snapshot.vhd'), 'VHD must survive when handler.list() throws during lineage init')
+})

--- a/@xen-orchestra/backup-archive/src/VmIncrementalBackupArchive.mts
+++ b/@xen-orchestra/backup-archive/src/VmIncrementalBackupArchive.mts
@@ -52,18 +52,18 @@ export class VmIncrementalBackupArchive implements VmBackupInterface {
 
   async init(): Promise<void> {
     // Build one RemoteDiskLineage per VDI directory derived from diskPaths
-    try {
-      for (const diskPath of this.diskPaths) {
-        const vdiDir = dirname(diskPath)
-        if (!this.diskLineages.has(vdiDir)) {
-          const lineage = new RemoteDiskLineage(this.handler, vdiDir, this.opts)
+    for (const diskPath of this.diskPaths) {
+      const vdiDir = dirname(diskPath)
+      if (!this.diskLineages.has(vdiDir)) {
+        const lineage = new RemoteDiskLineage(this.handler, vdiDir, this.opts)
+        this.diskLineages.set(vdiDir, lineage)
+        try {
           await lineage.init()
-          this.diskLineages.set(vdiDir, lineage)
+        } catch (error) {
+          if (error?.code === 'NOT_SUPPORTED') throw error
+          this.opts.logWarn('failed to scan VDI directory', { vdiDir, error })
         }
       }
-    } catch (error) {
-      if (error?.code === 'NOT_SUPPORTED') throw error
-      this.opts.logWarn('failed to scan VDI directories', { error })
     }
   }
 

--- a/@xen-orchestra/backup-archive/src/disks/index.mjs
+++ b/@xen-orchestra/backup-archive/src/disks/index.mjs
@@ -95,12 +95,8 @@ export async function cleanOrphanDiskDirs(
       if (!coveredDirs.has(vdiDir)) {
         logWarn('orphan VDI directory, not referenced by any backup', { path: vdiDir })
         if (remove) {
-          logInfo('deleting orphan VDI directory', { path: vdiDir })
-          try {
-            await handler.rmtree(vdiDir)
-          } catch (error) {
-            logWarn('failed to delete orphan VDI directory', { path: vdiDir, error })
-          }
+          logInfo('you could delete orphan VDI directory', { path: vdiDir })
+          // TODO: Readd rmtree() when codebase is ready
         }
       }
     }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
 - [Backup] fix transfer size only counting the last disk transferred (PR [#9900](https://github.com/vatesfr/xen-orchestra/pull/9900))
+- [Backup] fix backup cleanup removing too many files when listing fails (PR [#9925](https://github.com/vatesfr/xen-orchestra/pull/9925))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

Introduced by 100f11308a5a0dbf7e067317dc778241efdaab5c

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
