### PR TITLE
fix(xo-server-sdn-controller): apply/clean network rules on VIF update

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,6 +29,8 @@
 - **XO 5**:
   - [Jobs] fix array values being incorrectly handled (used for instance on job.runSequence) (PR [#9928](https://github.com/vatesfr/xen-orchestra/pull/9928))
 
+- xo-server-sdn-controller: apply/clean network rules on VIF update (PR [#9933](https://github.com/vatesfr/xen-orchestra/pull/9933))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -48,6 +50,7 @@
 - @vates/types minor
 - @xen-orchestra/acl minor
 - @xen-orchestra/rest-api minor
+- xo-server-sdn-controller patch
 - xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -1459,7 +1459,12 @@ class SDNController extends EventEmitter {
           await vif.$xapi.watchTask(key).catch(noop)
           vif = await vif.$xapi.barrier(vif.$ref)
           await this._applyVifOfRules(vif)
+          await this._applyNetworkOfRules(vif.$network)
         } else if (value === 'unplug' || value === 'unplug_force') {
+          // refresh NetworkOfRules by cleaning/applying
+          await this._cleanNetworkOfRules(vif.$network)
+          await this._applyNetworkOfRules(vif.$network)
+
           await this._cleanVifOfRules(vif)
           await vif.$xapi.watchTask(key).catch(noop)
         }


### PR DESCRIPTION
### Description

when a VIF is unplugged, network rules applied to the VIF aren't properly removed.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
