### PR TITLE
fix: attempt to add chunks instead of one map for qcow dataClustersIndex

### DIFF
--- a/@xen-orchestra/qcow2/src/disk/QcowDisk.mts
+++ b/@xen-orchestra/qcow2/src/disk/QcowDisk.mts
@@ -23,12 +23,55 @@ interface Qcow2Header {
   header_length: number
 }
 
+// V8's Map has a hard limit of ~16.7M entries (2^24 - 1), which is hit for ≥1TB QCOW2
+// disks with 64KB clusters. This class shards entries into chunks that stay under that limit.
+const CHUNK_SIZE = 8_000_000
+
+class ChunkedClusterIndex {
+  #chunks: Map<number, number>[] = []
+
+  set(blockIndex: number, clusterOffset: number): void {
+    const chunkIdx = Math.floor(blockIndex / CHUNK_SIZE)
+    let chunk = this.#chunks[chunkIdx]
+    if (chunk === undefined) {
+      chunk = new Map()
+      this.#chunks[chunkIdx] = chunk
+    }
+    chunk.set(blockIndex % CHUNK_SIZE, clusterOffset)
+  }
+
+  get(blockIndex: number): number | undefined {
+    return this.#chunks[Math.floor(blockIndex / CHUNK_SIZE)]?.get(blockIndex % CHUNK_SIZE)
+  }
+
+  has(blockIndex: number): boolean {
+    return this.#chunks[Math.floor(blockIndex / CHUNK_SIZE)]?.has(blockIndex % CHUNK_SIZE) ?? false
+  }
+
+  keys(): number[] {
+    const result: number[] = []
+    for (let i = 0; i < this.#chunks.length; i++) {
+      const chunk = this.#chunks[i]
+      if (chunk !== undefined) {
+        for (const localKey of chunk.keys()) {
+          result.push(i * CHUNK_SIZE + localKey)
+        }
+      }
+    }
+    return result
+  }
+
+  clear(): void {
+    this.#chunks = []
+  }
+}
+
 export abstract class QcowDisk extends RandomAccessDisk {
   #qcowHeader: Qcow2Header | undefined
   // in qcow land, the data are stored in clusters
-  #dataClustersIndex = new Map<number, number>()
+  #dataClustersIndex = new ChunkedClusterIndex()
 
-  get dataClustersIndex(): Map<number, number> {
+  get dataClustersIndex(): ChunkedClusterIndex {
     return this.#dataClustersIndex
   }
 
@@ -55,7 +98,7 @@ export abstract class QcowDisk extends RandomAccessDisk {
   abstract readBuffer(offset: number, length: number): Promise<Buffer>
 
   async readBlock(index: number): Promise<DiskBlock> {
-    const offset = this.dataClustersIndex.get(index)
+    const offset = this.#dataClustersIndex.get(index)
     if (offset === undefined) {
       throw new Error(`Can't read unallocated block, index:${index}`)
     }
@@ -123,7 +166,7 @@ export abstract class QcowDisk extends RandomAccessDisk {
   }
 
   getBlockIndexes(): Array<number> {
-    return [...this.#dataClustersIndex.keys()]
+    return this.#dataClustersIndex.keys()
   }
   hasBlock(index: number): boolean {
     return this.#dataClustersIndex.has(index)


### PR DESCRIPTION
### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
