### PR TITLE
fix(qa-test): metadata test can run so fast there is a datetime collision

### DIFF
--- a/@xen-orchestra/qa-test/client/requests/backup.js
+++ b/@xen-orchestra/qa-test/client/requests/backup.js
@@ -391,7 +391,7 @@ export class BackupRequest extends AbstractRequest {
 
     log.debug('Running metadata backup job', { jobId, scheduleId })
 
-    const runStartTime = Date.now() - 5000
+    const runStartTime = Date.now()
 
     try {
       await this.dispatchClient.xoClient.call('metadataBackup.runJob', {

--- a/@xen-orchestra/qa-test/tests/metadata-backup.test.js
+++ b/@xen-orchestra/qa-test/tests/metadata-backup.test.js
@@ -5,7 +5,7 @@ import { createLogger } from '@xen-orchestra/log'
 
 import { DispatchClient } from '../client/dispatchClient.js'
 import { createResourceTracker } from '../utils/resourceTracker.js'
-import { generateBackupJobName, getDefaultSchedule, getRequiredEnv, getScheduleKey } from '../utils/index.js'
+import { delay, generateBackupJobName, getDefaultSchedule, getRequiredEnv, getScheduleKey } from '../utils/index.js'
 import { assertBackupSuccess } from '../utils/backupUtils.js'
 
 const log = createLogger('qa:backup:metadata')
@@ -179,6 +179,12 @@ describe('Metadata backup tests', () => {
 
     it('each run should succeed with pool metadata and XO config tasks', async () => {
       for (let runIndex = 1; runIndex <= 3; runIndex++) {
+        // Backup dirs are named with second-precision timestamps; wait 2 s so each
+        // run gets a unique directory and retention logic sees 3 distinct entries.
+        if (runIndex > 1) {
+          await delay(2000)
+        }
+
         log.debug(`Running metadata backup job (${runIndex}/3)`, { jobId, scheduleKey })
 
         const result = await dispatchClient.backup.runMetadataJobAndGetLog(jobId, scheduleKey)


### PR DESCRIPTION
### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
