### PR TITLE
docs: make a more logical doc structure for xo6

### DIFF
--- a/docs/docs/xo6/backups.md
+++ b/docs/docs/xo6/backups.md
@@ -1,0 +1,1 @@
+# Backups

--- a/docs/docs/xo6/coreconcepts.md
+++ b/docs/docs/xo6/coreconcepts.md
@@ -1,0 +1,1 @@
+# Core concepts

--- a/docs/docs/xo6/gettingstarted.md
+++ b/docs/docs/xo6/gettingstarted.md
@@ -1,0 +1,1 @@
+# Getting started

--- a/docs/docs/xo6/management.md
+++ b/docs/docs/xo6/management.md
@@ -1,0 +1,1 @@
+# Management

--- a/docs/docs/xo6/whatsnew.md
+++ b/docs/docs/xo6/whatsnew.md
@@ -1,0 +1,4 @@
+---
+id: whatsnew
+title: What's new
+---

--- a/docs/docs/xo6/xo6vsxo5.md
+++ b/docs/docs/xo6/xo6vsxo5.md
@@ -1,0 +1,4 @@
+---
+id: xo6vsxo5
+title: XO 6 vs. XO 5
+---

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -46,12 +46,74 @@ export default {
       items:[
         {
           type: 'category',
+          label: 'What\'s new in XO6',
+          collapsible: true,
+          collapsed: true,
+          items:[
+            'xo6/whatsnew',
+            'xo6/xo6vsxo5',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Getting started',
+          collapsible: true,
+          collapsed: true,
+          items:[
+            'xo6/gettingstarted',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Core concepts',
+          collapsible: true,
+          collapsed: true,
+          items:[
+            'xo6/coreconcepts',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Management',
+          collapsible: true,
+          collapsed: true,
+          items:[
+            'xo6/management',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Backups',
+          collapsible: true,
+          collapsed: true,
+          items:[
+            'xo6/backups',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Security',
+          collapsible: true,
+          collapsed: true,
+          items:[
+            {
+          type: 'category',
+          label: 'User management',
+          collapsible: true,
+          collapsed: true,
+          items:[
+            'xo6/acl-v2',
+          ],
+        },
+          ],
+        },
+        {
+          type: 'category',
           label: 'Support',
           collapsible: true,
           collapsed: true,
           items: [
             'xo6/intro_support',
-            'xo6/acl-v2',
             'xo6/purchase',
             'xo6/community'
       ],


### PR DESCRIPTION
This pull request creates a new, refreshed tree structure for the **XO6** documentation, which we intend
to be more helpful for readers and XO6 users.
New sections are created:

- What's new in XO6
- Getting started
- Core concepts
- Management
- Backups
- Security

These sections will be completed later, with subsection and new documentation pages, specifically for XO 6. Additionally, the [ACLv2/RBAC page](https://docs.xen-orchestra.com/xo6/acl-v2) has been moved from the **Support** section to the **Security** section.

No modifications have been made to the **XO5** section.

Preview of the changes:

<img width="1930" height="1703" alt="Capture d&#39;écran 2026-06-11 103611" src="https://github.com/user-attachments/assets/add716f8-976f-40ab-93f0-498efcf940a5" />

