### PR TITLE
feat(xva): import disk using generators

### DIFF
--- a/@xen-orchestra/xva/_constants.mjs
+++ b/@xen-orchestra/xva/_constants.mjs
@@ -1,0 +1,1 @@
+export const XVA_DISK_CHUNK_LENGTH = 1024 * 1024

--- a/@xen-orchestra/xva/_writeChunkInXva.mjs
+++ b/@xen-orchestra/xva/_writeChunkInXva.mjs
@@ -1,0 +1,17 @@
+import { fromCallback } from 'promise-toolbox'
+import { xxhash64 } from 'hash-wasm'
+import { XVA_DISK_CHUNK_LENGTH } from './_constants.mjs'
+
+async function addEntry(pack, name, buffer) {
+  await fromCallback.call(pack, pack.entry, { name }, buffer)
+}
+
+export async function writeChunk(pack, data, name) {
+  if (data.length < XVA_DISK_CHUNK_LENGTH) {
+    data = Buffer.concat([data, Buffer.alloc(XVA_DISK_CHUNK_LENGTH - data.length, 0)])
+  }
+  await addEntry(pack, name, data)
+  // weirdly, ocaml and xxhash return the bytes in reverse order to each other
+  const hash = (await xxhash64(data)).toString('hex').toUpperCase()
+  await addEntry(pack, `${name}.xxhash`, Buffer.from(hash, 'utf8'))
+}

--- a/@xen-orchestra/xva/_writeChunkInXva.mjs
+++ b/@xen-orchestra/xva/_writeChunkInXva.mjs
@@ -11,7 +11,6 @@ export async function writeChunk(pack, data, name) {
     data = Buffer.concat([data, Buffer.alloc(XVA_DISK_CHUNK_LENGTH - data.length, 0)])
   }
   await addEntry(pack, name, data)
-  // weirdly, ocaml and xxhash return the bytes in reverse order to each other
   const hash = (await xxhash64(data)).toString('hex').toUpperCase()
   await addEntry(pack, `${name}.xxhash`, Buffer.from(hash, 'utf8'))
 }

--- a/@xen-orchestra/xva/_writeDisk.mjs
+++ b/@xen-orchestra/xva/_writeDisk.mjs
@@ -1,22 +1,7 @@
 import { DiskLargerBlock, DiskSmallerBlock } from '@xen-orchestra/disk-transform'
-import { fromCallback } from 'promise-toolbox'
 import { formatBlockPath } from './_formatBlockPath.mjs'
-import { xxhash64 } from 'hash-wasm'
-
-export const XVA_DISK_CHUNK_LENGTH = 1024 * 1024
-async function addEntry(pack, name, buffer) {
-  await fromCallback.call(pack, pack.entry, { name }, buffer)
-}
-
-async function writeBlock(pack, data, name) {
-  if (data.length < XVA_DISK_CHUNK_LENGTH) {
-    data = Buffer.concat([data, Buffer.alloc(XVA_DISK_CHUNK_LENGTH - data.length, 0)])
-  }
-  await addEntry(pack, name, data)
-  // weirdly, ocaml and xxhash return the bytes in reverse order to each other
-  const hash = (await xxhash64(data)).toString('hex').toUpperCase()
-  await addEntry(pack, `${name}.xxhash`, Buffer.from(hash, 'utf8'))
-}
+import { writeChunk } from './_writeChunkInXva.mjs'
+import { XVA_DISK_CHUNK_LENGTH } from './_constants.mjs'
 
 export default async function addDisk(pack, disk, basePath) {
   let diskXvaChunk
@@ -42,7 +27,7 @@ export default async function addDisk(pack, disk, basePath) {
       mustWriteBlock = mustWriteBlock || !block.data.equals(empty)
     }
     if (mustWriteBlock) {
-      await writeBlock(pack, block.data, formatBlockPath(basePath, counter))
+      await writeChunk(pack, block.data, formatBlockPath(basePath, counter))
     }
   }
 }

--- a/@xen-orchestra/xva/_writeDisk.mjs
+++ b/@xen-orchestra/xva/_writeDisk.mjs
@@ -1,7 +1,23 @@
 import { DiskLargerBlock, DiskSmallerBlock } from '@xen-orchestra/disk-transform'
+import { fromCallback } from 'promise-toolbox'
 import { formatBlockPath } from './_formatBlockPath.mjs'
+import { xxhash64 } from 'hash-wasm'
 
 export const XVA_DISK_CHUNK_LENGTH = 1024 * 1024
+async function addEntry(pack, name, buffer) {
+  await fromCallback.call(pack, pack.entry, { name }, buffer)
+}
+
+async function writeBlock(pack, data, name) {
+  if (data.length < XVA_DISK_CHUNK_LENGTH) {
+    data = Buffer.concat([data, Buffer.alloc(XVA_DISK_CHUNK_LENGTH - data.length, 0)])
+  }
+  await addEntry(pack, name, data)
+  // weirdly, ocaml and xxhash return the bytes in reverse order to each other
+  const hash = (await xxhash64(data)).toString('hex').toUpperCase()
+  await addEntry(pack, `${name}.xxhash`, Buffer.from(hash, 'utf8'))
+}
+
 export default async function addDisk(pack, disk, basePath) {
   let diskXvaChunk
   if (disk.getBlockSize() < XVA_DISK_CHUNK_LENGTH) {
@@ -15,17 +31,17 @@ export default async function addDisk(pack, disk, basePath) {
   const nbBlocks = Math.ceil(diskXvaChunk.getVirtualSize() / diskXvaChunk.getBlockSize())
 
   for (let counter = 0; counter < nbBlocks; counter++) {
-    let writeBlock = false
+    let mustWriteBlock = false
     let block
     if (counter === 0 || counter === nbBlocks - 1) {
-      writeBlock = true // first and last block must be present in xva disks
+      mustWriteBlock = true // first and last block must be present in xva disks
     }
-    if (writeBlock || diskXvaChunk.hasBlock(counter)) {
+    if (mustWriteBlock || diskXvaChunk.hasBlock(counter)) {
       block = await diskXvaChunk.readBlock(counter)
       // ignore empty chunks that are not first or last
-      writeBlock = writeBlock || !block.data.equals(empty)
+      mustWriteBlock = mustWriteBlock || !block.data.equals(empty)
     }
-    if (writeBlock) {
+    if (mustWriteBlock) {
       await writeBlock(pack, block.data, formatBlockPath(basePath, counter))
     }
   }

--- a/@xen-orchestra/xva/_writeDisk.mjs
+++ b/@xen-orchestra/xva/_writeDisk.mjs
@@ -1,57 +1,32 @@
+import { DiskLargerBlock, DiskSmallerBlock } from '@xen-orchestra/disk-transform'
 import { formatBlockPath } from './_formatBlockPath.mjs'
-import { fromCallback } from 'promise-toolbox'
-import { readChunkStrict } from '@vates/read-chunk'
-import { xxhash64 } from 'hash-wasm'
 
 export const XVA_DISK_CHUNK_LENGTH = 1024 * 1024
-
-async function addEntry(pack, name, buffer) {
-  await fromCallback.call(pack, pack.entry, { name }, buffer)
-}
-
-async function writeBlock(pack, data, name) {
-  if (data.length < XVA_DISK_CHUNK_LENGTH) {
-    data = Buffer.concat([data, Buffer.alloc(XVA_DISK_CHUNK_LENGTH - data.length, 0)])
+export default async function addDisk(pack, disk, basePath) {
+  let diskXvaChunk
+  if (disk.getBlockSize() < XVA_DISK_CHUNK_LENGTH) {
+    diskXvaChunk = new DiskLargerBlock(disk, XVA_DISK_CHUNK_LENGTH)
+  } else if (disk.getBlockSize() > XVA_DISK_CHUNK_LENGTH) {
+    diskXvaChunk = new DiskSmallerBlock(disk, XVA_DISK_CHUNK_LENGTH)
+  } else {
+    diskXvaChunk = disk
   }
-  await addEntry(pack, name, data)
-  // weirdly, ocaml and xxhash return the bytes in reverse order to each other
-  const hash = (await xxhash64(data)).toString('hex').toUpperCase()
-  await addEntry(pack, `${name}.xxhash`, Buffer.from(hash, 'utf8'))
-}
-
-export default async function addDisk(pack, vhd, basePath) {
-  let counter = 0
-  let written
-  let lastBlockWrittenAt = Date.now()
-  const MAX_INTERVAL_BETWEEN_BLOCKS = 60 * 1000
   const empty = Buffer.alloc(XVA_DISK_CHUNK_LENGTH, 0)
-  const stream = await vhd.rawContent()
-  let lastBlockLength
-  const diskSize = vhd.footer.currentSize
-  let remaining = diskSize
-  while (remaining > 0) {
-    lastBlockLength = Math.min(XVA_DISK_CHUNK_LENGTH, remaining)
-    const data = await readChunkStrict(stream, lastBlockLength)
-    remaining -= lastBlockLength
-    if (
-      // write first block
-      counter === 0 ||
-      // write all non empty blocks
-      !data.equals(empty) ||
-      // write one block from time to time to ensure there is no timeout
-      // occurring while passing empty blocks
-      Date.now() - lastBlockWrittenAt > MAX_INTERVAL_BETWEEN_BLOCKS
-    ) {
-      written = true
-      await writeBlock(pack, data, formatBlockPath(basePath, counter))
-      lastBlockWrittenAt = Date.now()
-    } else {
-      written = false
+  const nbBlocks = Math.ceil(diskXvaChunk.getVirtualSize() / diskXvaChunk.getBlockSize())
+
+  for (let counter = 0; counter < nbBlocks; counter++) {
+    let writeBlock = false
+    let block
+    if (counter === 0 || counter === nbBlocks - 1) {
+      writeBlock = true // first and last block must be present in xva disks
     }
-    counter++
-  }
-  if (!written) {
-    // last block must be present
-    await writeBlock(pack, empty, formatBlockPath(basePath, counter - 1))
+    if (writeBlock || diskXvaChunk.hasBlock(counter)) {
+      block = await diskXvaChunk.readBlock(counter)
+      // ignore empty chunks that are not first or last
+      writeBlock = writeBlock || !block.data.equals(empty)
+    }
+    if (writeBlock) {
+      await writeBlock(pack, block.data, formatBlockPath(basePath, counter))
+    }
   }
 }

--- a/@xen-orchestra/xva/_writeDisk.mjs
+++ b/@xen-orchestra/xva/_writeDisk.mjs
@@ -27,7 +27,6 @@ export default async function addDisk(pack, disk, basePath) {
     // occurring while passing empty blocks
     if (Date.now() - lastBlockWrittenAt > MAX_INTERVAL_BETWEEN_BLOCKS) {
       mustWriteBlock = true
-      lastBlockWrittenAt = Date.now()
     }
     if (mustWriteBlock || diskXvaChunk.hasBlock(counter)) {
       block = await diskXvaChunk.readBlock(counter)
@@ -36,6 +35,7 @@ export default async function addDisk(pack, disk, basePath) {
     }
     if (mustWriteBlock) {
       await writeChunk(pack, block.data, formatBlockPath(basePath, counter))
+      lastBlockWrittenAt = Date.now()
     }
   }
 }

--- a/@xen-orchestra/xva/_writeDisk.mjs
+++ b/@xen-orchestra/xva/_writeDisk.mjs
@@ -5,6 +5,8 @@ import { XVA_DISK_CHUNK_LENGTH } from './_constants.mjs'
 
 export default async function addDisk(pack, disk, basePath) {
   let diskXvaChunk
+  let lastBlockWrittenAt = Date.now()
+  const MAX_INTERVAL_BETWEEN_BLOCKS = 60 * 1000
   if (disk.getBlockSize() < XVA_DISK_CHUNK_LENGTH) {
     diskXvaChunk = new DiskLargerBlock(disk, XVA_DISK_CHUNK_LENGTH)
   } else if (disk.getBlockSize() > XVA_DISK_CHUNK_LENGTH) {
@@ -20,6 +22,12 @@ export default async function addDisk(pack, disk, basePath) {
     let block
     if (counter === 0 || counter === nbBlocks - 1) {
       mustWriteBlock = true // first and last block must be present in xva disks
+    }
+    // write one block from time to time to ensure there is no timeout
+    // occurring while passing empty blocks
+    if (Date.now() - lastBlockWrittenAt > MAX_INTERVAL_BETWEEN_BLOCKS) {
+      mustWriteBlock = true
+      lastBlockWrittenAt = Date.now()
     }
     if (mustWriteBlock || diskXvaChunk.hasBlock(counter)) {
       block = await diskXvaChunk.readBlock(counter)

--- a/@xen-orchestra/xva/_writeDiskStream.mjs
+++ b/@xen-orchestra/xva/_writeDiskStream.mjs
@@ -1,0 +1,57 @@
+import { formatBlockPath } from './_formatBlockPath.mjs'
+import { fromCallback } from 'promise-toolbox'
+import { readChunkStrict } from '@vates/read-chunk'
+import { xxhash64 } from 'hash-wasm'
+
+export const XVA_DISK_CHUNK_LENGTH = 1024 * 1024
+
+async function addEntry(pack, name, buffer) {
+  await fromCallback.call(pack, pack.entry, { name }, buffer)
+}
+
+async function writeBlock(pack, data, name) {
+  if (data.length < XVA_DISK_CHUNK_LENGTH) {
+    data = Buffer.concat([data, Buffer.alloc(XVA_DISK_CHUNK_LENGTH - data.length, 0)])
+  }
+  await addEntry(pack, name, data)
+  // weirdly, ocaml and xxhash return the bytes in reverse order to each other
+  const hash = (await xxhash64(data)).toString('hex').toUpperCase()
+  await addEntry(pack, `${name}.xxhash`, Buffer.from(hash, 'utf8'))
+}
+
+export default async function addDisk(pack, vhd, basePath) {
+  let counter = 0
+  let written
+  let lastBlockWrittenAt = Date.now()
+  const MAX_INTERVAL_BETWEEN_BLOCKS = 60 * 1000
+  const empty = Buffer.alloc(XVA_DISK_CHUNK_LENGTH, 0)
+  const stream = await vhd.rawContent()
+  let lastBlockLength
+  const diskSize = vhd.footer.currentSize
+  let remaining = diskSize
+  while (remaining > 0) {
+    lastBlockLength = Math.min(XVA_DISK_CHUNK_LENGTH, remaining)
+    const data = await readChunkStrict(stream, lastBlockLength)
+    remaining -= lastBlockLength
+    if (
+      // write first block
+      counter === 0 ||
+      // write all non empty blocks
+      !data.equals(empty) ||
+      // write one block from time to time to ensure there is no timeout
+      // occurring while passing empty blocks
+      Date.now() - lastBlockWrittenAt > MAX_INTERVAL_BETWEEN_BLOCKS
+    ) {
+      written = true
+      await writeBlock(pack, data, formatBlockPath(basePath, counter))
+      lastBlockWrittenAt = Date.now()
+    } else {
+      written = false
+    }
+    counter++
+  }
+  if (!written) {
+    // last block must be present
+    await writeBlock(pack, empty, formatBlockPath(basePath, counter - 1))
+  }
+}

--- a/@xen-orchestra/xva/_writeDiskStream.mjs
+++ b/@xen-orchestra/xva/_writeDiskStream.mjs
@@ -1,23 +1,7 @@
 import { formatBlockPath } from './_formatBlockPath.mjs'
-import { fromCallback } from 'promise-toolbox'
 import { readChunkStrict } from '@vates/read-chunk'
-import { xxhash64 } from 'hash-wasm'
-
-export const XVA_DISK_CHUNK_LENGTH = 1024 * 1024
-
-async function addEntry(pack, name, buffer) {
-  await fromCallback.call(pack, pack.entry, { name }, buffer)
-}
-
-async function writeBlock(pack, data, name) {
-  if (data.length < XVA_DISK_CHUNK_LENGTH) {
-    data = Buffer.concat([data, Buffer.alloc(XVA_DISK_CHUNK_LENGTH - data.length, 0)])
-  }
-  await addEntry(pack, name, data)
-  // weirdly, ocaml and xxhash return the bytes in reverse order to each other
-  const hash = (await xxhash64(data)).toString('hex').toUpperCase()
-  await addEntry(pack, `${name}.xxhash`, Buffer.from(hash, 'utf8'))
-}
+import { writeChunk } from './_writeChunkInXva.mjs'
+import { XVA_DISK_CHUNK_LENGTH } from './_constants.mjs'
 
 export default async function addDisk(pack, vhd, basePath) {
   let counter = 0
@@ -43,7 +27,7 @@ export default async function addDisk(pack, vhd, basePath) {
       Date.now() - lastBlockWrittenAt > MAX_INTERVAL_BETWEEN_BLOCKS
     ) {
       written = true
-      await writeBlock(pack, data, formatBlockPath(basePath, counter))
+      await writeChunk(pack, data, formatBlockPath(basePath, counter))
       lastBlockWrittenAt = Date.now()
     } else {
       written = false
@@ -52,6 +36,6 @@ export default async function addDisk(pack, vhd, basePath) {
   }
   if (!written) {
     // last block must be present
-    await writeBlock(pack, empty, formatBlockPath(basePath, counter - 1))
+    await writeChunk(pack, empty, formatBlockPath(basePath, counter - 1))
   }
 }

--- a/@xen-orchestra/xva/_writeOvaXml.mjs
+++ b/@xen-orchestra/xva/_writeOvaXml.mjs
@@ -10,10 +10,11 @@ import { DEFAULT_VIF } from './templates/vif.mjs'
 import { DEFAULT_VM } from './templates/vm.mjs'
 import toOvaXml from './_toOvaXml.mjs'
 import { XVA_DISK_CHUNK_LENGTH } from './_constants.mjs'
+import fs from 'node:fs/promises'
 
 export default async function writeOvaXml(
   pack,
-  { memory, networks, nCpus, firmware, vdis, vhds, ...vmSnapshot },
+  { memory, networks, nCpus, firmware, vdis, vhds, disks, ...vmSnapshot },
   { sr, network }
 ) {
   let refId = 0
@@ -76,10 +77,15 @@ export default async function writeOvaXml(
   )
 
   data.objects.push(srObj)
-  assert.strictEqual(vhds.length, vdis.length)
-  for (let index = 0; index < vhds.length; index++) {
+  // `disks` (RandomAccessDisk) and `vhds` (legacy stream) are both written to the
+  // XVA the same way here: one VDI + one VBD per backing disk. They only differ in
+  // how their blocks are streamed later (see importVm.mjs). `vdis` holds the VDI
+  // metadata and must be ordered to match `[...vhds, ...disks]`.
+  const backingDisks = [...(vhds ?? []), ...(disks ?? [])]
+  assert.strictEqual(backingDisks.length, vdis.length)
+  for (let index = 0; index < backingDisks.length; index++) {
     const userdevice = index + 1
-    const vhd = vhds[index]
+    const disk = backingDisks[index]
     const alignedSize = Math.ceil(vdis[index].virtual_size / XVA_DISK_CHUNK_LENGTH) * XVA_DISK_CHUNK_LENGTH
     const vdi = defaultsDeep(
       {
@@ -97,7 +103,7 @@ export default async function writeOvaXml(
 
     data.objects.push(vdi)
     srObj.snapshot.VDIs.push(vdi.id)
-    vhd.ref = vdi.id
+    disk.ref = vdi.id
 
     const vbd = defaultsDeep(
       {
@@ -151,6 +157,8 @@ export default async function writeOvaXml(
       networkObj.snapshot.vifs.push(vif.id)
     }
   }
+
   const xml = toOvaXml(data)
+  await fs.writeFile('/tmp/xml', xml)
   await fromCallback.call(pack, pack.entry, { name: `ova.xml` }, xml)
 }

--- a/@xen-orchestra/xva/_writeOvaXml.mjs
+++ b/@xen-orchestra/xva/_writeOvaXml.mjs
@@ -9,7 +9,7 @@ import { DEFAULT_VDI } from './templates/vdi.mjs'
 import { DEFAULT_VIF } from './templates/vif.mjs'
 import { DEFAULT_VM } from './templates/vm.mjs'
 import toOvaXml from './_toOvaXml.mjs'
-import { XVA_DISK_CHUNK_LENGTH } from './_writeDiskStream.mjs'
+import { XVA_DISK_CHUNK_LENGTH } from './_constants.mjs'
 
 export default async function writeOvaXml(
   pack,

--- a/@xen-orchestra/xva/_writeOvaXml.mjs
+++ b/@xen-orchestra/xva/_writeOvaXml.mjs
@@ -9,7 +9,7 @@ import { DEFAULT_VDI } from './templates/vdi.mjs'
 import { DEFAULT_VIF } from './templates/vif.mjs'
 import { DEFAULT_VM } from './templates/vm.mjs'
 import toOvaXml from './_toOvaXml.mjs'
-import { XVA_DISK_CHUNK_LENGTH } from './_writeDisk.mjs'
+import { XVA_DISK_CHUNK_LENGTH } from './_writeDiskStream.mjs'
 
 export default async function writeOvaXml(
   pack,

--- a/@xen-orchestra/xva/importDisk.mjs
+++ b/@xen-orchestra/xva/importDisk.mjs
@@ -15,18 +15,21 @@ export async function importVdi(vdi, disk, xapi, sr) {
     xapi,
     sr
   )
-  // wait for the VM to be loaded if necessary
-  xapi.getObject(vmRef, undefined) ?? (await xapi.waitObject(vmRef))
+  try {
+    // wait for the VM to be loaded if necessary
+    xapi.getObject(vmRef, undefined) ?? (await xapi.waitObject(vmRef))
 
-  const vbdRefs = await xapi.getField('VM', vmRef, 'VBDs')
-  // get the disk
-  const disks = { __proto__: null }
-  ;(await xapi.getRecords('VBD', vbdRefs)).forEach(vbd => {
-    if (vbd.type === 'Disk' && isNotEmptyRef(vbd.VDI)) {
-      disks[vbd.VDI] = true
-    }
-  })
-  // destroy the VM and VBD
-  await xapi.call('VM.destroy', vmRef)
-  return await xapi.getRecord('VDI', Object.keys(disks)[0])
+    const vbdRefs = await xapi.getField('VM', vmRef, 'VBDs')
+    // get the disk
+    const disks = { __proto__: null }
+    ;(await xapi.getRecords('VBD', vbdRefs)).forEach(vbd => {
+      if (vbd.type === 'Disk' && isNotEmptyRef(vbd.VDI)) {
+        disks[vbd.VDI] = true
+      }
+    })
+    return await xapi.getRecord('VDI', Object.keys(disks)[0])
+  } finally {
+    // destroy what is remaining of the VM
+    await xapi.call('VM.destroy', vmRef)
+  }
 }

--- a/@xen-orchestra/xva/importDisk.mjs
+++ b/@xen-orchestra/xva/importDisk.mjs
@@ -1,0 +1,32 @@
+import { isNotEmptyRef } from './_isNotEmptyRef.mjs'
+import { importVm } from './importVm.mjs'
+
+export async function importVdi(vdi, disk, xapi, sr) {
+  // create a fake VM
+  const vmRef = await importVm(
+    {
+      name_label: `[xva-disk-import]${vdi.name_label}`,
+      memory: 1024 * 1024 * 32,
+      nCpus: 1,
+      firmware: 'bios',
+      vdis: [vdi],
+      disks: [disk],
+    },
+    xapi,
+    sr
+  )
+  // wait for the VM to be loaded if necessary
+  xapi.getObject(vmRef, undefined) ?? (await xapi.waitObject(vmRef))
+
+  const vbdRefs = await xapi.getField('VM', vmRef, 'VBDs')
+  // get the disk
+  const disks = { __proto__: null }
+  ;(await xapi.getRecords('VBD', vbdRefs)).forEach(vbd => {
+    if (vbd.type === 'Disk' && isNotEmptyRef(vbd.VDI)) {
+      disks[vbd.VDI] = true
+    }
+  })
+  // destroy the VM and VBD
+  await xapi.call('VM.destroy', vmRef)
+  return await xapi.getRecord('VDI', Object.keys(disks)[0])
+}

--- a/@xen-orchestra/xva/importDisk.mjs
+++ b/@xen-orchestra/xva/importDisk.mjs
@@ -1,8 +1,9 @@
 import { isNotEmptyRef } from './_isNotEmptyRef.mjs'
 import { importVm } from './importVm.mjs'
 
-export async function importVdi(vdi, disk, xapi, sr) {
+export async function importDisk(vdi, disk, sr) {
   // create a fake VM
+  const xapi = sr.$xapi
   const vmRef = await importVm(
     {
       name_label: `[xva-disk-import]${vdi.name_label}`,
@@ -12,7 +13,6 @@ export async function importVdi(vdi, disk, xapi, sr) {
       vdis: [vdi],
       disks: [disk],
     },
-    xapi,
     sr
   )
   try {

--- a/@xen-orchestra/xva/importVdi.mjs
+++ b/@xen-orchestra/xva/importVdi.mjs
@@ -12,7 +12,6 @@ export async function importVdi(vdi, vhd, xapi, sr) {
       vdis: [vdi],
       vhds: [vhd],
     },
-    xapi,
     sr
   )
   // wait for the VM to be loaded if necessary

--- a/@xen-orchestra/xva/importVm.mjs
+++ b/@xen-orchestra/xva/importVm.mjs
@@ -4,8 +4,9 @@ import writeOvaXml from './_writeOvaXml.mjs'
 import writeDiskStream from './_writeDiskStream.mjs'
 import writeDisk from './_writeDisk.mjs'
 
-export async function importVm(vm, xapi, sr, network) {
+export async function importVm(vm, sr, network) {
   const pack = tar.pack()
+  const xapi = sr.$xapi
   const taskRef = await xapi.task_create('VM import')
   const query = {
     sr_id: sr.$ref,

--- a/@xen-orchestra/xva/importVm.mjs
+++ b/@xen-orchestra/xva/importVm.mjs
@@ -1,6 +1,7 @@
 import tar from 'tar-stream'
 
 import writeOvaXml from './_writeOvaXml.mjs'
+import writeDiskStream from './_writeDiskStream.mjs'
 import writeDisk from './_writeDisk.mjs'
 
 export async function importVm(vm, xapi, sr, network) {
@@ -19,7 +20,10 @@ export async function importVm(vm, xapi, sr, network) {
 
   await writeOvaXml(pack, vm, { sr, network })
   for (const vhd of vm.vhds) {
-    await writeDisk(pack, vhd, vhd.ref)
+    await writeDiskStream(pack, vhd, vhd.ref)
+  }
+  for (const disk of vm.disks) {
+    await writeDisk(pack, disk, disk.ref)
   }
   pack.finalize()
   const str = await promise

--- a/@xen-orchestra/xva/importVm.mjs
+++ b/@xen-orchestra/xva/importVm.mjs
@@ -19,10 +19,10 @@ export async function importVm(vm, xapi, sr, network) {
     .catch(err => console.error(err))
 
   await writeOvaXml(pack, vm, { sr, network })
-  for (const vhd of vm.vhds) {
+  for (const vhd of vm.vhds ?? []) {
     await writeDiskStream(pack, vhd, vhd.ref)
   }
-  for (const disk of vm.disks) {
+  for (const disk of vm.disks ?? []) {
     await writeDisk(pack, disk, disk.ref)
   }
   pack.finalize()

--- a/@xen-orchestra/xva/package.json
+++ b/@xen-orchestra/xva/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@vates/read-chunk": "^1.2.1",
+    "@xen-orchestra/disk-transform": "^1.3.0",
     "hash-wasm": "^4.11.0",
     "lodash.defaultsdeep": "^4.6.1",
     "promise-toolbox": "^0.21.0",

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -122,6 +122,7 @@
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
 - @xen-orchestra/xapi minor
+- @xen-orchestra/xva minor
 - xo-common minor
 - xo-server minor
 - xo-server-ipmi-sensors patch

--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -32,7 +32,7 @@ guessVhdSizeOnImport = true
 # This is disabled by default for performance (lots of data) and
 # security concerns (avoiding sensitive data in the logs) but can
 # be turned for investigation by the administrator.
-verboseApiLogsOnErrors = false
+verboseApiLogsOnErrors = true
 
 # if no events could be fetched during this delay, the server will be marked as disconnected
 xapiMarkDisconnectedDelay = '5 minutes'

--- a/packages/xo-server/src/xo-mixins/vmware/importDisksfromDatastore.mjs
+++ b/packages/xo-server/src/xo-mixins/vmware/importDisksfromDatastore.mjs
@@ -5,15 +5,24 @@ import { toVhdStream } from 'vhd-lib/disk-consumer/index.mjs'
 import { NbdDisk } from '@vates/nbd-client/NbdDisk.mjs'
 import { createLogger } from '@xen-orchestra/log'
 import { toQcow2Stream } from '@xen-orchestra/qcow2'
+import { importDisk } from '@xen-orchestra/xva/importDisk.mjs'
 
 const { warn } = createLogger('xo:importdiskfromdatastore')
 
-export async function importStream({ esxi, dataMap, disk, vmId, format }, consumerCallback) {
-  const signal = Task.abortSignal
-  const { datastore: datastoreName, diskPath } = disk
 
+ 
+async function instantiateSource({esxi, dataMap,disk, vmId}){
+  const signal = Task.abortSignal
   let vmdk
   let stream
+  const { datastore: datastoreName, diskPath } = disk
+
+  async function close(){
+    await vmdk?.close().catch(err => warn('error while closing source vmdk', err))
+    await esxi
+      .killNbdServer(vmId, `[${datastoreName}] ${diskPath}`)
+      .catch(err => warn('error while stopping nbdkit server', err))
+  }
   try {
     // we read the data from the full chain to ensure we don't have partial blocks ( blocks with 0 when clusters are in parent only)
     const { nbdInfos } = await esxi.spawnNbdKitProcess(vmId, `[${datastoreName}] ${diskPath}`)
@@ -23,6 +32,29 @@ export async function importStream({ esxi, dataMap, disk, vmId, format }, consum
     await vmdk.init()
     signal?.throwIfAborted()
     vmdk = new ReadAhead(vmdk)
+    return {vmdk, close}
+  }catch(error){
+    await close()
+    throw error
+  }
+}
+
+async function importXvaDisk({esxi, dataMap, disk, vmId, vdiMetadata, sr }){
+  const {vmdk, close} = await instantiateSource({esxi, dataMap,disk, vmId})
+
+  try{
+    return await  importDisk({vdi: vdiMetadata}, vmdk, sr )
+  }finally{
+    await close()
+  }
+
+}
+
+export async function importStream({ esxi, dataMap, disk, vmId, format }, consumerCallback) {
+  const signal = Task.abortSignal
+  const {vmdk, close} = await(instantiateSource({esxi,dataMap,disk, vmId}))
+  let stream
+  try {
 
     if (format === VDI_FORMAT_QCOW2) {
       stream = await toQcow2Stream(vmdk, { signal })
@@ -37,10 +69,7 @@ export async function importStream({ esxi, dataMap, disk, vmId, format }, consum
     Task.warning(err)
     throw err
   } finally {
-    await vmdk?.close().catch(err => warn('error while closing source vmdk', err))
-    await esxi
-      .killNbdServer(vmId, `[${datastoreName}] ${diskPath}`)
-      .catch(err => warn('error while stopping nbdkit server', err))
+    await close()
   }
 }
 
@@ -97,30 +126,18 @@ async function importDiskChain({ esxi, sr, vm, chainByNode, userdevice, vmId }) 
     Task.info(`no reference disk found, fall back a full import`)
   }
   try {
-    if (!existingVdi) {
+    let transfered
+    if (!existingVdi) { 
       Task.info(`create a new VDI for ${diskPath}`)
-      const alignedSize = Math.ceil(capacity / blockSize) * blockSize
-      const delta = alignedSize - capacity
-      if (delta > 0) {
-        Task.info(`aligning disk size from ${capacity} to ${alignedSize} (adding ${delta} bytes at the end)`)
-      }
 
       const vdiMetadata = {
         name_description: descriptionLabel,
         name_label: '[ESXI]' + nameLabel,
         SR: sr.$ref,
-        virtual_size: alignedSize,
+        virtual_size: capacity,
       }
-      const vdiRef = await sr.$xapi.VDI_create(vdiMetadata)
-      existingVdi = sr.$xapi.getObject(vdiRef, undefined) ?? (await sr.$xapi.waitObject(vdiRef))
-
-      Task.info(
-        `vdi created  `,
-        diskPath,
-        'will create vbd',
-        userdevice,
-        `xvd${String.fromCharCode('a'.charCodeAt(0) + userdevice)}`
-      )
+      transferred = await importXvaDisk({esxi, dataMap, disk: activeDisk, vmId, vdiMetadata, sr})
+      Task.info(`import of ${diskPath} base content done`, { datastoreName, diskPath, sourceVmId: vmId })
       await sr.$xapi.VBD_create({
         VDI: vdiRef,
         VM: vm.$ref,
@@ -128,11 +145,11 @@ async function importDiskChain({ esxi, sr, vm, chainByNode, userdevice, vmId }) 
         userdevice: String(userdevice < 3 ? userdevice : userdevice + 1),
       })
       Task.info(`vbd created `, diskPath)
+    } else {
+      transfered = await importStream({ esxi, dataMap, disk: activeDisk, vmId, format }, async stream => {
+        await existingVdi.$importContent(stream, { format })
+      })
     }
-
-    const transfered = await importStream({ esxi, dataMap, disk: activeDisk, vmId, format }, async stream => {
-      await existingVdi.$importContent(stream, { format })
-    })
 
     Task.info(`import of ${diskPath} content done`, { datastoreName, diskPath, sourceVmId: vmId })
     const duration = Math.round((Date.now() - start) / 1000)


### PR DESCRIPTION
### Description


XVA import is the only import format that allow us to filter the empty block as they come. It support disk up to 99999999 chunk of 1MB (99.9 TB) as long as we have the data sorted

This PR is creating a fake xva import per disk, using a RandomAccessDisk generator (Disk have no guarantee of order)  , then on success detach the disk and attach it to the target VM 

It is doing some refactoring to mutualize the constants and methods

The base of the code has been used for ~2year to import raw disks from esxi 

No feature in changelog, it will comes when we plug it into the import system

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
