### PR TITLE
docs(xo): document VBD attach and note ISO mount is JSON-RPC only

### DIFF
--- a/docs/docs/xo5/restapi.md
+++ b/docs/docs/xo5/restapi.md
@@ -381,10 +381,9 @@ To attach an existing VDI to a VM, create a VBD through the `POST /vbds`
 endpoint. The VBD's `mode` (`RW` or `RO`) and `bootable` flag are set at creation.
 
 :::note
-Mounting or ejecting an ISO (CD-ROM) is not currently available through the, etc.
+Mounting or ejecting an ISO (CD-ROM) is not currently available through the
+REST API. Use the JSON-RPC API instead, for example via `xo-cli`:
 :::
-> REST API. Use the JSON-RPC API instead, for example via `xo-cli`:
->
 > ```sh
 > xo-cli vm.insertCd id=<vm-id> cd_id=<vdi-id> [force=<boolean>]
 > ```

--- a/docs/docs/xo5/restapi.md
+++ b/docs/docs/xo5/restapi.md
@@ -375,6 +375,18 @@ The following query parameters are supported to customize the created VDI:
 - `name_description`
 - `raw`: this parameter must be used if importing a raw export instead of a VHD
 
+## Attaching an existing VDI to a VM
+
+You attach an existing VDI to a VM by creating a VBD through the `POST /vbds`
+endpoint. The VBD's `mode` (`RW` or `RO`) and `bootable` flag are set at creation.
+
+> Note: mounting or ejecting an ISO (CD-ROM) is not currently available through the
+> REST API. Use the JSON-RPC API instead, for example via `xo-cli`:
+>
+> ```sh
+> xo-cli vm.insertCd id=<vm-id> cd_id=<vdi-id> [force=<boolean>]
+> ```
+
 ## Actions
 
 The field `params` contains the [JSON schema](https://json-schema.org/) for the parameters.

--- a/docs/docs/xo5/restapi.md
+++ b/docs/docs/xo5/restapi.md
@@ -377,10 +377,12 @@ The following query parameters are supported to customize the created VDI:
 
 ## Attaching an existing VDI to a VM
 
-You attach an existing VDI to a VM by creating a VBD through the `POST /vbds`
+To attach an existing VDI to a VM, create a VBD through the `POST /vbds`
 endpoint. The VBD's `mode` (`RW` or `RO`) and `bootable` flag are set at creation.
 
-> Note: mounting or ejecting an ISO (CD-ROM) is not currently available through the
+:::note
+Mounting or ejecting an ISO (CD-ROM) is not currently available through the, etc.
+:::
 > REST API. Use the JSON-RPC API instead, for example via `xo-cli`:
 >
 > ```sh


### PR DESCRIPTION
The REST API docs don't cover two things that came up on the forum (https://xcp-ng.org/forum/topic/11893): how to attach an existing VDI to a VM, and the fact that mounting/ejecting an ISO isn't available through REST yet. Someone automating deployments via the REST API went looking for both and couldn't find them.

This adds a short "Attaching an existing VDI to a VM" section to `xo5/restapi.md`:

- attaching an existing VDI is done by creating a VBD via `POST /vbds` (`mode` RW/RO, `bootable`);
- mounting/ejecting an ISO isn't available via REST; use the JSON-RPC API: `xo-cli vm.insertCd id=<id> cd_id=<id> [force=<boolean>]`.

Both points come from Danp's answers in that thread, where he confirmed with the dev team that the ISO-mount endpoint doesn't exist in the REST API. Flagged with the Doc & Knowledge team, who offered to review. Happy to adjust the wording or move the section.
