### PR TITLE
feat(xo6): add possibility to export VM

### DIFF
--- a/@xen-orchestra/web-core/lib/locales/en.json
+++ b/@xen-orchestra/web-core/lib/locales/en.json
@@ -776,6 +776,7 @@
   "other": "Other",
   "other-properties": "Other properties",
   "other-settings": "Other settings",
+  "ova": "OVA",
   "page-not-found": "This page is not to be found…",
   "page-please-wait": "Hold tight, astronaut! The page is getting ready to take off.{newline}We're just aligning the thrusters and calibrating the systems. It won't be long now, stay tuned!",
   "pagination:all": "@:all",
@@ -1201,6 +1202,7 @@
   "xoa-password-confirm-different": "XOA password confirmation is different",
   "xoa-ssh-account": "XOA SSH account",
   "xoa-ssh-password-confirm-different": "SSH password confirmation is different",
+  "xva": "XVA",
   "you-are-currently-on": "You are currently on: {0}",
   "zstd": "ZSTD"
 }

--- a/@xen-orchestra/web-core/lib/locales/fr.json
+++ b/@xen-orchestra/web-core/lib/locales/fr.json
@@ -776,6 +776,7 @@
   "other": "Autre",
   "other-properties": "Autres propriétés",
   "other-settings": "Autres paramètres",
+  "ova": "OVA",
   "page-not-found": "Cette page est introuvable…",
   "page-please-wait": "Accrochez-vous, astronaute ! La page est sur le point de décoller.{newline}Nous alignons les propulseurs et calibrons les systèmes. Plus que quelques instants, restez à l'écoute !",
   "pagination:all": "Tous",
@@ -1201,6 +1202,7 @@
   "xoa-password-confirm-different": "La confirmation du mot de passe XOA est différente",
   "xoa-ssh-account": "Compte SSH de la XOA",
   "xoa-ssh-password-confirm-different": "La confirmation du mot de passe SSH est différente",
+  "xva": "XVA",
   "you-are-currently-on": "Vous êtes actuellement sur : {0}",
   "zstd": "ZSTD"
 }

--- a/@xen-orchestra/web/src/modules/vm/components/actions/VmMoreActions.vue
+++ b/@xen-orchestra/web/src/modules/vm/components/actions/VmMoreActions.vue
@@ -14,12 +14,14 @@
     {{ t('action:export') }}
   </MenuItem>
   <MenuSeparator />
+  <VmExportButton :vm />
   <VmDeleteButton :vm />
 </template>
 
 <script lang="ts" setup>
 import VmDeleteButton from '@/modules/vm/components/actions/delete/VmDeleteButton.vue'
 import VmDuplicateButton from '@/modules/vm/components/actions/duplicate/VmDuplicateButton.vue'
+import VmExportButton from '@/modules/vm/components/actions/export/VmExportButton.vue'
 import VmSnapshotButton from '@/modules/vm/components/actions/snapshot/VmSnapshotButton.vue'
 import VmPowerStateActions from '@/modules/vm/components/actions/VmPowerStateActions.vue'
 import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection.ts'

--- a/@xen-orchestra/web/src/modules/vm/components/actions/export/VmExportButton.vue
+++ b/@xen-orchestra/web/src/modules/vm/components/actions/export/VmExportButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <MenuItem icon="action:download" @click="openDrawer">
+  <MenuItem icon="action:download" @click="openDrawer()">
     {{ t('action:export') }}
   </MenuItem>
 </template>
@@ -8,8 +8,6 @@
 import { useVmExportDrawer } from '@/modules/vm/composables/use-vm-export-drawer.composable'
 import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection'
 import MenuItem from '@core/components/menu/MenuItem.vue'
-import { IK_CLOSE_MENU } from '@core/utils/injection-keys.util'
-import { inject } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const { vm } = defineProps<{
@@ -18,12 +16,5 @@ const { vm } = defineProps<{
 
 const { t } = useI18n()
 
-const closeMenu = inject(IK_CLOSE_MENU, undefined)
-
-const { openDrawer: open } = useVmExportDrawer(() => vm)
-
-function openDrawer() {
-  open()
-  closeMenu?.()
-}
+const { openDrawer } = useVmExportDrawer(() => vm)
 </script>

--- a/@xen-orchestra/web/src/modules/vm/components/actions/export/VmExportButton.vue
+++ b/@xen-orchestra/web/src/modules/vm/components/actions/export/VmExportButton.vue
@@ -1,0 +1,29 @@
+<template>
+  <MenuItem icon="action:download" @click="openDrawer">
+    {{ t('action:export') }}
+  </MenuItem>
+</template>
+
+<script lang="ts" setup>
+import { useVmExportDrawer } from '@/modules/vm/composables/use-vm-export-drawer.composable'
+import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection'
+import MenuItem from '@core/components/menu/MenuItem.vue'
+import { IK_CLOSE_MENU } from '@core/utils/injection-keys.util'
+import { inject } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { vm } = defineProps<{
+  vm: FrontXoVm
+}>()
+
+const { t } = useI18n()
+
+const closeMenu = inject(IK_CLOSE_MENU, undefined)
+
+const { openDrawer: open } = useVmExportDrawer(() => vm)
+
+function openDrawer() {
+  open()
+  closeMenu?.()
+}
+</script>

--- a/@xen-orchestra/web/src/modules/vm/components/drawer/VmExportDrawer.vue
+++ b/@xen-orchestra/web/src/modules/vm/components/drawer/VmExportDrawer.vue
@@ -46,6 +46,7 @@
 </template>
 
 <script lang="ts" setup>
+import type { VmExportCompression, VmExportType } from '@/modules/vm/jobs/xo-vm-export.job'
 import VtsDrawer from '@core/components/drawer/VtsDrawer.vue'
 import VtsDrawerCancelButton from '@core/components/drawer/VtsDrawerCancelButton.vue'
 import VtsDrawerConfirmButton from '@core/components/drawer/VtsDrawerConfirmButton.vue'
@@ -55,8 +56,8 @@ import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 export type VmExportFormValues = {
-  type: 'xva' | 'ova'
-  compression: 'none' | 'gzip' | 'zstd'
+  type: VmExportType
+  compression: VmExportCompression
 }
 
 const emit = defineEmits<{
@@ -66,8 +67,8 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
-const type = ref<string>('xva')
-const compression = ref<string>('none')
+const type = ref<VmExportType>('xva')
+const compression = ref<VmExportCompression>('none')
 
 watch(type, newType => {
   if (newType === 'ova') {
@@ -77,8 +78,8 @@ watch(type, newType => {
 
 function handleConfirm() {
   emit('confirm', {
-    type: type.value as VmExportFormValues['type'],
-    compression: compression.value as VmExportFormValues['compression'],
+    type: type.value,
+    compression: compression.value,
   })
 }
 </script>

--- a/@xen-orchestra/web/src/modules/vm/components/drawer/VmExportDrawer.vue
+++ b/@xen-orchestra/web/src/modules/vm/components/drawer/VmExportDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsDrawer dismissible is-open @dismiss="emit('cancel')">
+  <VtsDrawer dismissible @dismiss="emit('cancel')">
     <template #title>
       {{ t('action:export-n-vms', 1) }}
     </template>
@@ -12,10 +12,8 @@
         <div class="field">
           <UiLabel accent="neutral" required>{{ t('type') }}</UiLabel>
           <div class="radio-group">
-            <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
-            <UiRadioButton v-model="type" accent="brand" value="xva">XVA</UiRadioButton>
-            <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
-            <UiRadioButton v-model="type" accent="brand" value="ova">OVA</UiRadioButton>
+            <UiRadioButton v-model="type" accent="brand" value="xva"> {{ t('xva') }} </UiRadioButton>
+            <UiRadioButton v-model="type" accent="brand" value="ova"> {{ t('ova') }} </UiRadioButton>
           </div>
         </div>
 
@@ -28,10 +26,8 @@
               <UiRadioButton v-model="compression" accent="brand" value="none">
                 {{ t('disabled') }}
               </UiRadioButton>
-              <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
-              <UiRadioButton v-model="compression" accent="brand" value="gzip">GZIP</UiRadioButton>
-              <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
-              <UiRadioButton v-model="compression" accent="brand" value="zstd">ZSTD</UiRadioButton>
+              <UiRadioButton v-model="compression" accent="brand" value="gzip"> {{ t('gzip') }}</UiRadioButton>
+              <UiRadioButton v-model="compression" accent="brand" value="zstd"> {{ t('zstd') }}</UiRadioButton>
             </div>
           </div>
         </template>

--- a/@xen-orchestra/web/src/modules/vm/components/drawer/VmExportDrawer.vue
+++ b/@xen-orchestra/web/src/modules/vm/components/drawer/VmExportDrawer.vue
@@ -1,0 +1,115 @@
+<template>
+  <VtsDrawer dismissible is-open @dismiss="emit('cancel')">
+    <template #title>
+      {{ t('action:export-n-vms', 1) }}
+    </template>
+
+    <template #content>
+      <div class="form">
+        <p class="section-title">{{ t('general-information') }}</p>
+
+        <!-- Type -->
+        <div class="field">
+          <UiLabel accent="neutral" required>{{ t('type') }}</UiLabel>
+          <div class="radio-group">
+            <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
+            <UiRadioButton v-model="type" accent="brand" value="xva">XVA</UiRadioButton>
+            <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
+            <UiRadioButton v-model="type" accent="brand" value="ova">OVA</UiRadioButton>
+          </div>
+        </div>
+
+        <!-- Compression: only available for XVA -->
+        <template v-if="type === 'xva'">
+          <p class="section-title">{{ t('options') }}</p>
+          <div class="field">
+            <UiLabel accent="neutral" required>{{ t('compression') }}</UiLabel>
+            <div class="radio-group">
+              <UiRadioButton v-model="compression" accent="brand" value="none">
+                {{ t('disabled') }}
+              </UiRadioButton>
+              <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
+              <UiRadioButton v-model="compression" accent="brand" value="gzip">GZIP</UiRadioButton>
+              <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
+              <UiRadioButton v-model="compression" accent="brand" value="zstd">ZSTD</UiRadioButton>
+            </div>
+          </div>
+        </template>
+      </div>
+    </template>
+
+    <template #buttons>
+      <VtsDrawerCancelButton />
+      <VtsDrawerConfirmButton :on-click="handleConfirm">{{ t('action:export') }}</VtsDrawerConfirmButton>
+    </template>
+  </VtsDrawer>
+</template>
+
+<script lang="ts" setup>
+import VtsDrawer from '@core/components/drawer/VtsDrawer.vue'
+import VtsDrawerCancelButton from '@core/components/drawer/VtsDrawerCancelButton.vue'
+import VtsDrawerConfirmButton from '@core/components/drawer/VtsDrawerConfirmButton.vue'
+import UiLabel from '@core/components/ui/label/UiLabel.vue'
+import UiRadioButton from '@core/components/ui/radio-button/UiRadioButton.vue'
+import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+export type VmExportFormValues = {
+  type: 'xva' | 'ova'
+  compression: 'none' | 'gzip' | 'zstd'
+}
+
+const emit = defineEmits<{
+  confirm: [values: VmExportFormValues]
+  cancel: []
+}>()
+
+const { t } = useI18n()
+
+const type = ref<string>('xva')
+const compression = ref<string>('none')
+
+watch(type, newType => {
+  if (newType === 'ova') {
+    compression.value = 'none'
+  }
+})
+
+function handleConfirm() {
+  emit('confirm', {
+    type: type.value as VmExportFormValues['type'],
+    compression: compression.value as VmExportFormValues['compression'],
+  })
+}
+</script>
+
+<style lang="postcss" scoped>
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+  width: 100%;
+  text-align: left;
+}
+
+.section-title {
+  font-weight: 600;
+  color: var(--color-brand-txt-base);
+  border-bottom: 0.1rem solid var(--color-brand-txt-base);
+  padding-bottom: 0.8rem;
+  width: 100%;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.radio-group {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 1.6rem;
+}
+</style>

--- a/@xen-orchestra/web/src/modules/vm/composables/use-vm-export-drawer.composable.ts
+++ b/@xen-orchestra/web/src/modules/vm/composables/use-vm-export-drawer.composable.ts
@@ -11,22 +11,23 @@ export function useVmExportDrawer(rawVm: MaybeRefOrGetter<FrontXoVm>) {
   const exportType = ref<VmExportType>('xva')
   const exportCompression = ref<VmExportCompression>('none')
 
-  const { run, isRunning, errorMessage, canRun } = useXoVmExportJob(() => vm.value, exportType, exportCompression)
+  const { run } = useXoVmExportJob(() => vm.value, exportType, exportCompression)
 
   const openDrawer = useDrawer(() => ({
     component: import('@/modules/vm/components/drawer/VmExportDrawer.vue'),
     onConfirm: async (values: VmExportFormValues) => {
-      exportType.value = values.type
-      exportCompression.value = values.compression
+      try {
+        exportType.value = values.type
+        exportCompression.value = values.compression
 
-      await run()
+        await run()
+      } catch (error) {
+        console.error('Error when exporting VM:', error)
+      }
     },
   }))
 
   return {
     openDrawer,
-    canRun,
-    isRunning,
-    errorMessage,
   }
 }

--- a/@xen-orchestra/web/src/modules/vm/composables/use-vm-export-drawer.composable.ts
+++ b/@xen-orchestra/web/src/modules/vm/composables/use-vm-export-drawer.composable.ts
@@ -18,11 +18,8 @@ export function useVmExportDrawer(rawVm: MaybeRefOrGetter<FrontXoVm>) {
     onConfirm: async (values: VmExportFormValues) => {
       exportType.value = values.type
       exportCompression.value = values.compression
-      try {
-        await run()
-      } catch (error) {
-        console.error('Error when exporting VM:', error)
-      }
+
+      await run()
     },
   }))
 

--- a/@xen-orchestra/web/src/modules/vm/composables/use-vm-export-drawer.composable.ts
+++ b/@xen-orchestra/web/src/modules/vm/composables/use-vm-export-drawer.composable.ts
@@ -1,0 +1,35 @@
+import type { VmExportFormValues } from '@/modules/vm/components/drawer/VmExportDrawer.vue'
+import { useXoVmExportJob, type VmExportCompression, type VmExportType } from '@/modules/vm/jobs/xo-vm-export.job'
+import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection'
+import { useDrawer } from '@core/packages/drawer/use-drawer'
+import { toComputed } from '@core/utils/to-computed.util'
+import { ref, type MaybeRefOrGetter } from 'vue'
+
+export function useVmExportDrawer(rawVm: MaybeRefOrGetter<FrontXoVm>) {
+  const vm = toComputed(rawVm)
+
+  const exportType = ref<VmExportType>('xva')
+  const exportCompression = ref<VmExportCompression>('none')
+
+  const { run, isRunning, errorMessage, canRun } = useXoVmExportJob(() => vm.value, exportType, exportCompression)
+
+  const openDrawer = useDrawer(() => ({
+    component: import('@/modules/vm/components/drawer/VmExportDrawer.vue'),
+    onConfirm: async (values: VmExportFormValues) => {
+      exportType.value = values.type
+      exportCompression.value = values.compression
+      try {
+        await run()
+      } catch (error) {
+        console.error('Error when exporting VM:', error)
+      }
+    },
+  }))
+
+  return {
+    openDrawer,
+    canRun,
+    isRunning,
+    errorMessage,
+  }
+}

--- a/@xen-orchestra/web/src/modules/vm/jobs/xo-vm-export.job.ts
+++ b/@xen-orchestra/web/src/modules/vm/jobs/xo-vm-export.job.ts
@@ -24,7 +24,7 @@ export const useXoVmExportJob = defineJob('vm.export', [xoVmArg, xoVmExportTypeA
     async run(vm: FrontXoVm, type: VmExportType, compression: VmExportCompression) {
       const params = new URLSearchParams()
 
-      if (compression !== 'none') {
+      if (type === 'xva' && compression !== 'none') {
         params.set('compress', compression)
       }
 
@@ -34,11 +34,14 @@ export const useXoVmExportJob = defineJob('vm.export', [xoVmArg, xoVmExportTypeA
       const anchor = document.createElement('a')
       anchor.href = url
       anchor.download = ''
-      document.body.appendChild(anchor)
-      anchor.click()
-      document.body.removeChild(anchor)
-    },
 
+      try {
+        document.body.appendChild(anchor)
+        anchor.click()
+      } finally {
+        document.body.removeChild(anchor)
+      }
+    },
     validate(_isRunning: boolean, vm?: FrontXoVm) {
       if (!vm) {
         throw new JobError(t('job:vm-export:missing-vm'))

--- a/@xen-orchestra/web/src/modules/vm/jobs/xo-vm-export.job.ts
+++ b/@xen-orchestra/web/src/modules/vm/jobs/xo-vm-export.job.ts
@@ -2,6 +2,7 @@ import { xoVmArg } from '@/modules/vm/jobs/xo-vm-args'
 import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection'
 import { BASE_URL } from '@/shared/utils/fetch.util'
 import { defineJob, defineJobArg, JobError } from '@core/packages/job'
+import { downloadFile } from '@core/utils/download-file.utils.ts'
 import { useI18n } from 'vue-i18n'
 
 export type VmExportType = 'xva' | 'ova'
@@ -30,17 +31,9 @@ export const useXoVmExportJob = defineJob('vm.export', [xoVmArg, xoVmExportTypeA
 
       const query = params.size > 0 ? `?${params.toString()}` : ''
       const url = `${BASE_URL}/vms/${vm.id}.${type}${query}`
+      const fileName = `${vm.id}.${type}`
 
-      const anchor = document.createElement('a')
-      anchor.href = url
-      anchor.download = ''
-
-      try {
-        document.body.appendChild(anchor)
-        anchor.click()
-      } finally {
-        document.body.removeChild(anchor)
-      }
+      downloadFile(url, fileName)
     },
     validate(_isRunning: boolean, vm?: FrontXoVm) {
       if (!vm) {

--- a/@xen-orchestra/web/src/modules/vm/jobs/xo-vm-export.job.ts
+++ b/@xen-orchestra/web/src/modules/vm/jobs/xo-vm-export.job.ts
@@ -1,0 +1,48 @@
+import { xoVmArg } from '@/modules/vm/jobs/xo-vm-args'
+import type { FrontXoVm } from '@/modules/vm/remote-resources/use-xo-vm-collection'
+import { BASE_URL } from '@/shared/utils/fetch.util'
+import { defineJob, defineJobArg, JobError } from '@core/packages/job'
+import { useI18n } from 'vue-i18n'
+
+export type VmExportType = 'xva' | 'ova'
+export type VmExportCompression = 'none' | 'gzip' | 'zstd'
+
+const xoVmExportTypeArg = defineJobArg<VmExportType>({
+  identify: type => type,
+  toArray: false,
+})
+
+const xoVmExportCompressionArg = defineJobArg<VmExportCompression>({
+  identify: compression => compression,
+  toArray: false,
+})
+
+export const useXoVmExportJob = defineJob('vm.export', [xoVmArg, xoVmExportTypeArg, xoVmExportCompressionArg], () => {
+  const { t } = useI18n()
+
+  return {
+    async run(vm: FrontXoVm, type: VmExportType, compression: VmExportCompression) {
+      const params = new URLSearchParams()
+
+      if (compression !== 'none') {
+        params.set('compress', compression)
+      }
+
+      const query = params.size > 0 ? `?${params.toString()}` : ''
+      const url = `${BASE_URL}/vms/${vm.id}.${type}${query}`
+
+      const anchor = document.createElement('a')
+      anchor.href = url
+      anchor.download = ''
+      document.body.appendChild(anchor)
+      anchor.click()
+      document.body.removeChild(anchor)
+    },
+
+    validate(_isRunning: boolean, vm?: FrontXoVm) {
+      if (!vm) {
+        throw new JobError(t('job:vm-export:missing-vm'))
+      }
+    },
+  }
+})

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@
 - [RPU] Trace rolling pool updates/reboots to disk to allow diagnosis even after xo-server restarts (PR [#10078](https://github.com/vatesfr/xen-orchestra/pull/10078))
 - [XO6/VM] Group VM power actions in a new "Change state" submenu and isolate the Delete action (PR [#10036](https://github.com/vatesfr/xen-orchestra/pull/10036))
 - [OpenMetrics] Add an estimated per-VM power consumption metric (`xcp_vm_power_consumption_watts`), splitting each host's IPMI power across its running VMs proportionally to CPU load (PR [#10031](https://github.com/vatesfr/xen-orchestra/pull/10031))
+- [XO6/VM] Add possibility to export a VM (PR [#9989](https://github.com/vatesfr/xen-orchestra/pull/9989))
 
 ### Bug fixes
 


### PR DESCRIPTION
### Description

Implement the export vm content action in XO6 VMs view with corresponding UI control.

**Changes:**
- Add VmExportButton component in the VM actions menu (between Snapshot and Delete)
- Add VmExportDrawer component with:
  - Radio selection for export type (XVA / OVA)
  - Radio selection for compression (Disabled / GZIP / ZSTD), hidden when OVA is selected
- Add useVmExportDrawer composable using useDrawer for proper drawer mounting outside the menu context
- Add useXoVmExportJob job that builds the REST API URL (/rest/v0/vms/<uuid>.xva|ova) with optional compress query parameter and triggers a browser download

**How it works:**
Clicking the Export action opens a drawer where the user selects the format and compression. On confirm, the job builds the appropriate REST endpoint URL and triggers a native browser download.

**REST API:**
- XVA: GET /rest/v0/vms/<uuid>.xva[?compress=gzip|zstd]
- OVA: GET /rest/v0/vms/<uuid>.ova

<img width="1835" height="1017" alt="Capture d’écran du 2026-06-29 10-30-01" src="https://github.com/user-attachments/assets/c4469b46-ab2e-41d2-b76c-1000087bfa61" />
<img width="1835" height="1017" alt="Capture d’écran du 2026-06-29 10-30-05" src="https://github.com/user-attachments/assets/d3c27668-ff41-43d9-b2da-60de5111844b" />
<img width="1835" height="1017" alt="Capture d’écran du 2026-06-29 10-30-08" src="https://github.com/user-attachments/assets/2e3e9fb5-27cf-48aa-bc71-ab6eef7757aa" />
<img width="1835" height="1017" alt="Capture d’écran du 2026-06-29 10-29-39" src="https://github.com/user-attachments/assets/a03507b7-f40f-4a2c-9ee2-fa3024ce0c87" />
<img width="1835" height="1017" alt="Capture d’écran du 2026-06-29 10-29-43" src="https://github.com/user-attachments/assets/755072da-5d24-4dc0-8a02-e3f1376d444f" />
<img width="1835" height="1017" alt="Capture d’écran du 2026-06-29 10-29-48" src="https://github.com/user-attachments/assets/7215ad24-42f1-4531-af4f-73311c892284" />

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue (`See https://project.vates.tech/vates-global/browse/XO-2553/`)
  - If bug fix, add `Introduced by`
- Changelog
  - [x] If visible by XOA users, add changelog entry
  - [x] Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - [x] If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
