### PR TITLE
fix(rest-api): fix vm dashboard replica detection

### DIFF
--- a/@xen-orchestra/rest-api/src/vms/vm.service.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.service.mts
@@ -294,27 +294,28 @@ export class VmService {
 
   #getLastReplication(id: XoVm['id']): VmDashboard['backupsInfo']['replication'] {
     const vm = this.#restApi.getObject<XoVm>(id, 'VM')
-    const replicatedVms = this.#restApi.getObjectsByType<XoVm>('VM', {
-      filter: obj => obj.other['xo:backup:vm'] === vm.id,
+    const snapshotReplicas = this.#restApi.getObjectsByType<XoVmSnapshot>('VM-snapshot', {
+      filter: obj => obj.other['xo:backup:vm'] === vm.id && obj.$snapshot_of !== vm.id,
     })
 
     let lastTimestamp: number | undefined
-    let lastReplica: XoVm | undefined
-    for (const id in replicatedVms) {
-      const replica = replicatedVms[id as XoVm['id']]
-      const timestamp = parseDateTime(replica.other['xo:backup:datetime'])
+    let lastReplicaId: XoVm['id'] | undefined
+    for (const id in snapshotReplicas) {
+      const snapshot = snapshotReplicas[id as XoVmSnapshot['id']]
+      const timestamp = parseDateTime(snapshot.other['xo:backup:datetime'])
 
       if (lastTimestamp === undefined || lastTimestamp < timestamp) {
         lastTimestamp = timestamp
-        lastReplica = replica
+        lastReplicaId = snapshot.$snapshot_of
       }
     }
 
-    if (lastReplica === undefined) {
+    if (lastReplicaId === undefined) {
       return {}
     }
 
-    const vdis = this.getVmVdis(id, 'VM')
+    const replica = this.#restApi.getObject<XoVm>(lastReplicaId, 'VM')
+    const vdis = this.getVmVdis(replica.id, 'VM')
     let sr: XoSr['id'] | undefined = undefined
     for (const vdi of vdis) {
       if (sr === undefined) {
@@ -330,7 +331,7 @@ export class VmService {
     }
 
     return {
-      id: lastReplica.id,
+      id: replica.id,
       timestamp: lastTimestamp! * 1000,
       sr,
     }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -74,7 +74,7 @@
 - [REST API] `GET /vms/:id.:format`, `GET /vm-templates/:id.:format`, `GET /vm-snapshots/:id.:format` now correctly support explicit compress query param (`zstd` | `gzip`). Still support `true` | `false` as deprecated value (PR [#9960](https://github.com/vatesfr/xen-orchestra/pull/9960))
 - [Backup/Restore] Fix file-level restore of VMs whose disks use LVM (e.g. the default Ubuntu install layout): logical volumes are now listed and can be restored, including when restoring several copies of the same VM at once — previously failed with `unknown filesystem type 'LVM2_member'` (PR [#9776](https://github.com/vatesfr/xen-orchestra/pull/9776))
 - [Backup/Restore] Fix file-level restore hanging when downloading large folders, and high memory use when downloading a folder as a zip (PR [#9776](https://github.com/vatesfr/xen-orchestra/pull/9776))
-- [REST API/VM/dashboard] Fix detection of the last VM replication
+- [REST API/VM/dashboard] Fix detection of the last VM replication (PR [#9991](https://github.com/vatesfr/xen-orchestra/pull/9991))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -74,6 +74,7 @@
 - [REST API] `GET /vms/:id.:format`, `GET /vm-templates/:id.:format`, `GET /vm-snapshots/:id.:format` now correctly support explicit compress query param (`zstd` | `gzip`). Still support `true` | `false` as deprecated value (PR [#9960](https://github.com/vatesfr/xen-orchestra/pull/9960))
 - [Backup/Restore] Fix file-level restore of VMs whose disks use LVM (e.g. the default Ubuntu install layout): logical volumes are now listed and can be restored, including when restoring several copies of the same VM at once — previously failed with `unknown filesystem type 'LVM2_member'` (PR [#9776](https://github.com/vatesfr/xen-orchestra/pull/9776))
 - [Backup/Restore] Fix file-level restore hanging when downloading large folders, and high memory use when downloading a folder as a zip (PR [#9776](https://github.com/vatesfr/xen-orchestra/pull/9776))
+- [REST API/VM/dashboard] Fix detection of the last VM replication
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

introduced by 680b8108860146d277a8675c4605375774d6e333

See https://github.com/vatesfr/xen-orchestra/pull/9806/changes#diff-6f2227ada6bc2da3fd324691bb30b604b7c61a2cdbeebcad7969a8233cd4f0c4R394


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
