### PR TITLE
feat(xo-server-sdn-controller): traffic-rules: check the configuration matches the rules format

### DIFF
--- a/packages/xo-server-sdn-controller/src/index.js
+++ b/packages/xo-server-sdn-controller/src/index.js
@@ -800,6 +800,37 @@ class SDNController extends EventEmitter {
       const pools = Object.values(xapi.objects.indexes.type.pool ?? {})
       for (const pool of pools) {
         pool.update_other_config('xo:sdn-controller:of-method', of_method)
+
+        // Migration path from 'channel' to 'xapi-plugin'
+        // set of-format if not present
+        const of_format = pool.other_config['xo:sdn-controller:of-format']
+        if (of_format === undefined) {
+          // default to the current configuration
+          pool.update_other_config('xo:sdn-controller:of-format', of_method)
+        } else if (of_format !== of_method) {
+          // check if we have any of-rules used
+          let used = false
+          for (const vif of vifs) {
+            if (vif.other_config['xo:sdn-controller:of-rules'] !== undefined) {
+              // found one rule
+              used = true
+            }
+          }
+          if (!used) {
+            // no of-rules used, so the database is fine as it
+            pool.update_other_config('xo:sdn-controller:of-format', of_method)
+          } else {
+            // some of-rules are used, and the format doesn't match !
+            log.error(
+              `Configuration error: traffic-rules are not in the expected format (config=${of_method}, xapi=${of_format})`,
+              {
+                pool: pool.name_label || pool.$master.name_label,
+                uuid: pool.uuid,
+              }
+            )
+            // XXX report the error to user
+          }
+        }
       }
     } catch (error) {
       log.error('Error while handling xapi connection', {


### PR DESCRIPTION
### Description

XCPNG-3260

Report an error if we detect that the runtime configuration doesn't match the of-rules format stored in xapi database.

The admin is expected to ran migration script by hand to fix it. see #9999

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
