### PR TITLE
feat(xo6): warn and link to doc when traffic rules are not in the expected format

### DIFF
--- a/@vates/types/src/common.mts
+++ b/@vates/types/src/common.mts
@@ -744,6 +744,8 @@ export type XapiPoolStats = Record<XoHost['id'], XapiHostStats | { error: Record
 export type TrafficRuleProtocol = (typeof TRAFFIC_RULE_PROTOCOLS)[number]
 
 export const SDN_CONTROLLER_OF_RULES_KEY = 'xo:sdn-controller:of-rules'
+export const SDN_CONTROLLER_OF_METHOD_KEY = 'xo:sdn-controller:of-method'
+export const SDN_CONTROLLER_OF_FORMAT_KEY = 'xo:sdn-controller:of-format'
 export const TRAFFIC_RULE_PROTOCOLS = ['ARP', 'ICMP', 'IP', 'TCP', 'UDP'] as const
 export const TRAFFIC_RULE_PROTOCOLS_WITH_PORT: readonly TrafficRuleProtocol[] = ['TCP', 'UDP']
 

--- a/@xen-orchestra/web-core/lib/locales/en.json
+++ b/@xen-orchestra/web-core/lib/locales/en.json
@@ -1022,6 +1022,8 @@
   "traffic-rule": "Traffic rule",
   "traffic-rule-delete-warning": "This action is irreversible. The selected traffic rule will be permanently deleted.",
   "traffic-rules": "Traffic rules",
+  "traffic-rules:format-warning": "Configuration error: Traffic rules are not in the expected format. Please {check-doc} on how to migrate them.",
+  "traffic-rules:format-warning:check-doc": "check the latest documentation",
   "traffic-rules:info-message": "Traffic rules order is being implemented. Behaviour may be hazardous.",
   "traffic-rules:no-traffic-rules-detected": "No traffic rules detected",
   "transfer-size": "Transfer size",

--- a/@xen-orchestra/web-core/lib/locales/fr.json
+++ b/@xen-orchestra/web-core/lib/locales/fr.json
@@ -1022,6 +1022,8 @@
   "traffic-rule": "Règle de trafic",
   "traffic-rule-delete-warning": "Cette action est irréversible. La règle de trafic sélectionnée sera définitivement supprimée.",
   "traffic-rules": "Règles de trafic",
+  "traffic-rules:format-warning": "Erreur de configuration : les règles de trafic ne sont pas au format attendu. Veuillez {check-doc} la plus récente pour savoir comment les migrer.",
+  "traffic-rules:format-warning:check-doc": "consulter la documentation",
   "traffic-rules:info-message": "Les règles de trafic sont en cours d'application. Certains comportements peuvent être hasardeux.",
   "traffic-rules:no-traffic-rules-detected": "Aucune règle de trafic détectée",
   "transfer-size": "Taille transférée",

--- a/@xen-orchestra/web/src/modules/traffic-rules/components/TrafficRulesTable.vue
+++ b/@xen-orchestra/web/src/modules/traffic-rules/components/TrafficRulesTable.vue
@@ -7,6 +7,15 @@
       </template>
     </UiTitle>
     <UiAlert accent="info">{{ t('traffic-rules:info-message') }}</UiAlert>
+    <UiAlert v-if="showRulesFormatWarning" accent="warning">
+      <I18nT keypath="traffic-rules:format-warning">
+        <template #check-doc>
+          <UiLink size="small" href="https://docs.xen-orchestra.com/xo5/sdn_controller#migration-path">
+            {{ t('traffic-rules:format-warning:check-doc') }}
+          </UiLink>
+        </template>
+      </I18nT>
+    </UiAlert>
     <VtsQueryBuilder v-model="filter" :schema />
     <div class="container">
       <VtsTable :state :pagination-bindings sticky="right">
@@ -30,6 +39,7 @@
 </template>
 
 <script setup lang="ts">
+import type { FrontXoPool } from '@/modules/pool/remote-resources/use-xo-pool-collection.ts'
 import { useDirectionLabels } from '@/modules/traffic-rules/composables/direction-labels.composable.ts'
 import { useTrafficRuleTarget } from '@/modules/traffic-rules/composables/traffic-rule-target.composable.ts'
 import { useTrafficRuleDeleteModal } from '@/modules/traffic-rules/composables/use-traffic-rule-delete-modal.composable.ts'
@@ -38,6 +48,7 @@ import VtsQueryBuilder from '@core/components/query-builder/VtsQueryBuilder.vue'
 import VtsRow from '@core/components/table/VtsRow.vue'
 import VtsTable from '@core/components/table/VtsTable.vue'
 import UiAlert from '@core/components/ui/alert/UiAlert.vue'
+import UiLink from '@core/components/ui/link/UiLink.vue'
 import UiTitle from '@core/components/ui/title/UiTitle.vue'
 import { usePagination } from '@core/composables/pagination.composable.ts'
 import { useRouteQuery } from '@core/composables/route-query.composable.ts'
@@ -48,16 +59,19 @@ import { useTrafficRulesColumns } from '@core/tables/column-sets/traffic-rules-c
 import { useBooleanSchema } from '@core/utils/query-builder/use-boolean-schema.ts'
 import { useNumberSchema } from '@core/utils/query-builder/use-number-schema.ts'
 import { useStringSchema } from '@core/utils/query-builder/use-string-schema.ts'
-import type { TrafficRule } from '@vates/types'
+import { type TrafficRule, SDN_CONTROLLER_OF_METHOD_KEY, SDN_CONTROLLER_OF_FORMAT_KEY } from '@vates/types'
+
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const {
   rules: rawRules,
+  pool,
   busy,
   error,
 } = defineProps<{
   rules: TrafficRule[]
+  pool?: FrontXoPool
   busy?: boolean
   error?: boolean
 }>()
@@ -73,6 +87,12 @@ const selectedRuleId = useRouteQuery('id')
 const getTarget = useTrafficRuleTarget()
 
 const getDirectionLabels = useDirectionLabels()
+
+const showRulesFormatWarning = computed(() => {
+  const ofMethod = pool?.otherConfig[SDN_CONTROLLER_OF_METHOD_KEY]
+  const ofFormat = pool?.otherConfig[SDN_CONTROLLER_OF_FORMAT_KEY]
+  return ofMethod !== undefined && ofFormat !== undefined && ofMethod !== ofFormat
+})
 
 const enrichedRules = computed(() =>
   rawRules.map((rule, index) => {

--- a/@xen-orchestra/web/src/pages/pool/[id]/security.vue
+++ b/@xen-orchestra/web/src/pages/pool/[id]/security.vue
@@ -2,7 +2,7 @@
   <div class="security" :class="{ mobile: uiStore.isSmall }">
     <UiCard class="container">
       <VtsStateHero v-if="!isReady" format="page" type="busy" size="medium" />
-      <TrafficRulesTable v-else :rules="trafficRules">
+      <TrafficRulesTable v-else :rules="trafficRules" :pool>
         <template #title-action>
           <UiLink :to="{ name: '/traffic-rule/new', query: { poolid: pool.id } }" icon="fa:plus" size="medium">
             {{ t('new') }}

--- a/@xen-orchestra/web/src/pages/vif/[id]/traffic-rules.vue
+++ b/@xen-orchestra/web/src/pages/vif/[id]/traffic-rules.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="traffic-rules" :class="{ mobile: uiStore.isSmall }">
     <UiCard class="container">
-      <TrafficRulesTable :rules="trafficRules">
+      <TrafficRulesTable :rules="trafficRules" :pool>
         <template #title-action>
           <UiLink :to="{ name: '/traffic-rule/new', query: { vifid: vif.id } }" icon="fa:plus" size="medium">
             {{ t('new') }}
@@ -19,6 +19,7 @@
 </template>
 
 <script setup lang="ts">
+import { useXoPoolCollection } from '@/modules/pool/remote-resources/use-xo-pool-collection.ts'
 import TrafficRulesSidePanel from '@/modules/traffic-rules/components/list/panel/TrafficRulesSidePanel.vue'
 import TrafficRulesTable from '@/modules/traffic-rules/components/TrafficRulesTable.vue'
 import { useTrafficRules } from '@/modules/traffic-rules/composables/traffic-rules.composable.ts'
@@ -36,6 +37,9 @@ const { vif } = defineProps<{ vif: FrontXoVif }>()
 const uiStore = useUiStore()
 
 const { t } = useI18n()
+
+const { useGetPoolById } = useXoPoolCollection()
+const pool = useGetPoolById(() => vif.$pool)
 
 const { trafficRules } = useTrafficRules(() => [vif], [])
 


### PR DESCRIPTION
### Description

**Traffic rules: Add notification for users who changed SDN Controller mode**

:warning: Merge together with (or after) #9999 and #10000 :warning: 

- show a warning and link to the documentation when SDN controller's method and format are different

### Screenshots

| Light | Dark |
|---|---|
| <img width="896" height="738" alt="Screenshot from 2026-06-23 15-48-37" src="https://github.com/user-attachments/assets/9ae209a7-c615-4594-90ad-867903ccd853" /> | <img width="896" height="738" alt="Screenshot from 2026-06-23 15-48-34" src="https://github.com/user-attachments/assets/330eccd1-be2f-4ee7-a88c-0497b41d5f9a" /> |