### PR TITLE
fix(backups): uncaught VM error

### DIFF
--- a/@xen-orchestra/backups/_runners/VmsXapi.mjs
+++ b/@xen-orchestra/backups/_runners/VmsXapi.mjs
@@ -101,10 +101,14 @@ export const VmsXapi = class VmsXapiBackupRunner extends Abstract {
 
         const handleVm = vmUuid => {
           const getVmTask = () => {
-            if (taskByVmId[vmUuid] === undefined) {
+            const started = taskByVmId[vmUuid] !== undefined
+            if (!started) {
               taskByVmId[vmUuid] = new Task(taskStart)
             }
-            return taskByVmId[vmUuid]
+            return {
+              task: taskByVmId[vmUuid],
+              started,
+            }
           }
           const vmBackupFailed = async (error, task) => {
             if (isLastRun) {
@@ -135,7 +139,7 @@ export const VmsXapi = class VmsXapiBackupRunner extends Abstract {
                   taskStart.properties.name_label = vm.name_label
                 }
 
-                const task = getVmTask()
+                const { task } = getVmTask()
                 // error has to be caught in the task to prevent its failure, but handled outside the task to execute another task.run()
                 let taskError
                 return task
@@ -174,12 +178,19 @@ export const VmsXapi = class VmsXapiBackupRunner extends Abstract {
                       task.success(result)
                     } else {
                       // ending the task with error or not ending the task
-                      vmBackupFailed(taskError, task)
+                      return vmBackupFailed(taskError, task)
                     }
                   })
                   .catch(noop) // errors are handled by logs
               }),
-            error => vmBackupFailed(error, getVmTask())
+            error => {
+              const { task: vmTask, started } = getVmTask()
+              if (!started) {
+                // the task is not started (except if it's a retry), and an unstarted task can't be failed
+                vmTask.start()
+              }
+              return vmBackupFailed(error, vmTask)
+            }
           )
         }
         const { concurrency } = settings

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
 - [Site/Dashboard] Rename `no job` to `no active job` in the `VMs protection` card (PR [#10013](https://github.com/vatesfr/xen-orchestra/pull/10013))
+- [Backups] Fix failed VM not appearing in the logs (PR [#10021](https://github.com/vatesfr/xen-orchestra/pull/10021))
 
 ### Packages to release
 
@@ -33,6 +34,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
 - @xen-orchestra/web patch
 - @xen-orchestra/web-core patch
 


### PR DESCRIPTION
### Description

Some error cases on VM job (e.g. missing VM) would prevent the subtask of that VM from being created, and the error was seen at the parent level task.

This made the task appear as a failure with only successful VM, suggesting the failure was just a visual bug, when some VM backups were actually missing.

Introduced by fbba05bbde4514c63b2ddd97b5304de1210030e5
See https://help.vates.tech/#ticket/zoom/59309
[XO-2611](https://project.vates.tech/vates-global/browse/XO-2611/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
