### PR TITLE
feat(xo-server): add esxi.importDisk

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@
 - [XO6] After deleting a VM or VIF, users are now redirected to the parent list instead of seeing a 404 page (PR [#9984](https://github.com/vatesfr/xen-orchestra/pull/9984))
 - [Web stack] Updated side panels (PR [#9836](https://github.com/vatesfr/xen-orchestra/pull/9836))
 - [Plugin/LDAP] Add failover URIs (PR [#9961](https://github.com/vatesfr/xen-orchestra/pull/9961))
-- [V2V] Add `esxi.importDisk` API endpoint to import a single ESXi disk into an SR as a standalone VDI ( [PR#XXXX] (XXXX))
+- [V2V] Add `esxi.importDisk` API endpoint to import a single ESXi disk into an SR as a standalone VDI ( [PR#10024] (https://github.com/vatesfr/xen-orchestra/pull/10024))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@
 - [XO6] After deleting a VM or VIF, users are now redirected to the parent list instead of seeing a 404 page (PR [#9984](https://github.com/vatesfr/xen-orchestra/pull/9984))
 - [Web stack] Updated side panels (PR [#9836](https://github.com/vatesfr/xen-orchestra/pull/9836))
 - [Plugin/LDAP] Add failover URIs (PR [#9961](https://github.com/vatesfr/xen-orchestra/pull/9961))
+- [V2V] Add `esxi.importDisk` API endpoint to import a single ESXi disk into an SR as a standalone VDI ( [PR#XXXX] (XXXX))
 
 ### Bug fixes
 
@@ -41,5 +42,6 @@
 - @xen-orchestra/backups patch
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+- xo-server minor
 
 <!--packages-end-->

--- a/packages/xo-server/src/api/esxi.mjs
+++ b/packages/xo-server/src/api/esxi.mjs
@@ -190,3 +190,19 @@ exportDisk.params = {
   disk: { type: 'string', optional: true },
 }
 exportDisk.permission = 'admin'
+
+export async function importDisk({ disk, format, host, password, sslVerify, sr, user, vm }) {
+  return this.importEsxiDiskToSr({ disk, format, host, user, password, sslVerify, sr, vm })
+}
+
+importDisk.params = {
+  disk: { type: 'string' },
+  format: { type: 'string', optional: true },
+  host: { type: 'string' },
+  password: { type: 'string' },
+  sr: { type: 'string' },
+  sslVerify: { type: 'boolean', optional: true },
+  user: { type: 'string' },
+  vm: { type: 'string' },
+}
+importDisk.permission = 'admin'

--- a/packages/xo-server/src/xo-mixins/vmware/index.mjs
+++ b/packages/xo-server/src/xo-mixins/vmware/index.mjs
@@ -6,6 +6,7 @@ import asyncMapSettled from '@xen-orchestra/async-map/legacy.js'
 import { createLogger } from '@xen-orchestra/log'
 import Esxi from '@xen-orchestra/vmware-explorer/esxi.mjs'
 import { checkVddkDependencies } from '@xen-orchestra/vmware-explorer/checks.mjs'
+import { VDI_FORMAT_VHD } from '@xen-orchestra/xapi'
 import OTHER_CONFIG_TEMPLATE from '../../xapi/other-config-template.mjs'
 import { importDisksFromDatastore, importStream } from './importDisksfromDatastore.mjs'
 import { buildDiskChainByNode } from './buildChainByNode.mjs'
@@ -266,6 +267,7 @@ export default class MigrateVm {
     const disk = chain.pop()
     const stream = new PassThrough()
     importStream({ esxi, disk, vmId, format }, source => {
+      stream.length = source.length
       source.pipe(stream)
       return new Promise((resolve, reject) => {
         finished(source, { writable: false }, error => {
@@ -280,5 +282,23 @@ export default class MigrateVm {
       throw error
     })
     return stream
+  }
+
+  async importEsxiDiskToSr({
+    disk,
+    format = VDI_FORMAT_VHD,
+    host,
+    user,
+    password,
+    sslVerify = true,
+    sr: srId,
+    vm: vmId,
+  }) {
+    const sr = this._app.getXapiObject(srId)
+    const stream = await this.exportEsxiDisk({ disk, format, host, user, password, vm: vmId })
+    // sr.$importVdi: VHD infers virtual_size via peekFooterFromStream;
+    // QCOW2 uses stream.length (forwarded above)
+    const vdiRef = await sr.$importVdi(stream, { format, name_label: `[ESXI] ${vmId} / ${disk}` })
+    return sr.$xapi.getObject(vdiRef).uuid
   }
 }

--- a/packages/xo-server/src/xo-mixins/vmware/index.mjs
+++ b/packages/xo-server/src/xo-mixins/vmware/index.mjs
@@ -296,8 +296,6 @@ export default class MigrateVm {
   }) {
     const sr = this._app.getXapiObject(srId)
     const stream = await this.exportEsxiDisk({ disk, format, host, user, password, vm: vmId })
-    // sr.$importVdi: VHD infers virtual_size via peekFooterFromStream;
-    // QCOW2 uses stream.length (forwarded above)
     const vdiRef = await sr.$importVdi(stream, { format, name_label: `[ESXI] ${vmId} / ${disk}` })
     return sr.$xapi.getObject(vdiRef).uuid
   }


### PR DESCRIPTION
### Description

[XO-2563]

tried with xo-cli esxi.importDisk   host=10.10.xx user=xxx password=xxx  vm=8 disk=ide0:0 sr=xxx
Result : 
<img width="1643" height="237" alt="b9d7bd8b-3cd6-4973-a640-14579b163e14" src="https://github.com/user-attachments/assets/51b5423b-a38f-4c27-8b5f-23c5fc75b654" />

### Checklist


- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
