### PR TITLE
fix(@xen-orchestra/proxy): invalid parameter in listVmBackups

### DIFF
--- a/@xen-orchestra/proxy/app/mixins/backups.mjs
+++ b/@xen-orchestra/proxy/app/mixins/backups.mjs
@@ -315,6 +315,7 @@ export default class Backups {
                 type: 'object',
                 additionalProperties: { type: 'object' },
               },
+              vmId: { type: 'string', optional: true },
             },
           },
         ],

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,6 +37,7 @@
 - [XO-Server] Force stop when in dev mode (PR [#9994](https://github.com/vatesfr/xen-orchestra/pull/9994))
 - [XO-Server] Log a xo-server waiting for a soft stop in background (PR [#9994](https://github.com/vatesfr/xen-orchestra/pull/9994))
 - [Backup-repository] Properly unmount and cut connection on stop/disconnect/forget (PR [#9994](https://github.com/vatesfr/xen-orchestra/pull/9994))
+- [xo-proxy] Fix invalid parameters error message in listVmBackups (XS update for example) (PR [#10035](https://github.com/vatesfr/xen-orchestra/pull/10035))
 
 ### Packages to release
 
@@ -55,6 +56,7 @@
 <!--packages-start-->
 
 - @xen-orchestra/backups patch
+- @xen-orchestra/proxy patch
 - @xen-orchestra/vmware-explorer minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor


### PR DESCRIPTION
### Description

introduced by https://github.com/vatesfr/xen-orchestra/pull/9143

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
