### PR TITLE
fix(xo-server): store rrd as Float32 instead of string

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,8 @@
 
 > Users must be able to say: "Nice enhancement, I'm eager to test it"
 
+- [vm stats] Reduce the memory consumptionof the rrd stats (PR [#9909](https://github.com/vatesfr/xen-orchestra/pull/9909))
+
 ### Bug fixes
 
 > Users must be able to say: "I had this issue, happy to know it's fixed"
@@ -37,5 +39,6 @@
 
 - @xen-orchestra/backup-archive patch
 - @xen-orchestra/web patch
+- xo-server patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@
 
 > Users must be able to say: "Nice enhancement, I'm eager to test it"
 
-- [vm stats] Reduce the memory consumptionof the rrd stats (PR [#9909](https://github.com/vatesfr/xen-orchestra/pull/9909))
+- [vm stats] Reduce the memory consumption of the rrd stats (PR [#10039](https://github.com/vatesfr/xen-orchestra/pull/10039))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xapi-stats.mjs
+++ b/packages/xo-server/src/xapi-stats.mjs
@@ -61,6 +61,20 @@ function parseNumber(value) {
   return isNaN(value) ? null : value
 }
 
+// Like parseNumber but keeps NaN as-is instead of returning null, so missing values
+// can be stored in a typed array (where null would be coerced to 0). They are turned
+// back into null when read, see computeValues.
+function parseRrdValue(value) {
+  if (typeof value === 'string') {
+    const asNumber = +value
+    if (isNaN(asNumber) && value !== 'NaN') {
+      throw new Error('cannot parse number: ' + value)
+    }
+    return asNumber
+  }
+  return value
+}
+
 async function getServerTimestamp(xapi, hostRef) {
   return parseDateTime(await xapi.call('host.get_servertime', hostRef))
 }
@@ -70,16 +84,17 @@ async function getServerTimestamp(xapi, hostRef) {
 // -------------------------------------------------------------------
 
 /**
- * @param {{t: string, values: string[]}[]} dataRow
+ * @param {{t: string, values: Float32Array}[]} dataRow
  * @param {number} legendIndex
  * @param {(value: number) => number} [transformValue]
  * @returns {(number | null)[]}
  */
 const computeValues = (dataRow, legendIndex, transformValue = identity) =>
   dataRow.map(({ values }) => {
-    const value = parseNumber(values[legendIndex])
+    const value = values[legendIndex]
 
-    if (value === null) {
+    // missing/NaN values are stored as NaN (see parseRrdValue) and exposed as null
+    if (Number.isNaN(value)) {
       return null
     }
 
@@ -404,12 +419,28 @@ export default class XapiStats {
       })
       .then(response => response.body.text())
       .then(data => {
+        let json
         try {
           // starting from XAPI 23.31, the response is valid JSON
-          return JSON.parse(data)
+          json = JSON.parse(data)
         } catch (_) {
-          return JSON5.parse(data)
+          json = JSON5.parse(data)
         }
+
+        const rows = json.data
+        if (Array.isArray(rows)) {
+          for (let i = 0; i < rows.length; i++) {
+            const row = rows[i]
+            const { values } = row
+            const floats = new Float32Array(values.length)
+            for (let j = 0; j < values.length; j++) {
+              floats[j] = parseRrdValue(values[j])
+            }
+            row.values = floats
+          }
+        }
+
+        return json
       })
       .catch(err => {
         delete this.#hostCache[hostUuid][step]

--- a/packages/xo-server/src/xapi-stats.mjs
+++ b/packages/xo-server/src/xapi-stats.mjs
@@ -365,7 +365,7 @@ const STATS = {
     vbdIowait: {
       test: /^vbd_xvd(.)_iowait$/,
       getPath: matches => ['vbdIowait', matches[1]],
-      transofrmValue: value => value * 1e2,
+      transformValue: value => value * 1e2,
     },
     vbdInflight: {
       test: /^vbd_xvd(.)_inflight$/,


### PR DESCRIPTION
Store each row's values as a compact Float32Array instead of an array of strings: this cache can retain dozens of MB of these, and a Float32Array uses 4 bytes/value vs ~40+ for a heap string (64-bit precision is unnecessary for RRD metrics). Missing/NaN values are kept as NaN and turned back into null when read, see computeValues.

a string use 1 byte per char,  + 16 byte header for the string header

at worst , XO stores 120 values per metric per granularity , typically 50MB per host . After this change we are under 5MB

stats are still working : 
<img width="1653" height="721" alt="image" src="https://github.com/user-attachments/assets/a09c26ef-9136-40b7-b437-ee66a95485b0" />

<img width="1648" height="366" alt="image" src="https://github.com/user-attachments/assets/cbfb986f-e563-42c1-ad13-5c1cad202e4c" />


### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
