### PR TITLE
Fix: issue when merge is resuming but parent path has no footer

### DIFF
--- a/@xen-orchestra/backup-archive/src/RemoteDiskLineage.mts
+++ b/@xen-orchestra/backup-archive/src/RemoteDiskLineage.mts
@@ -21,6 +21,7 @@ import { limitConcurrency } from 'limit-concurrency-decorator'
 import assert from 'node:assert/strict'
 
 const defaultMergeLimiter = limitConcurrency(1)
+const MERGE_STATE_FILE_RE = /^\.(.+)\.merge\.json$/
 /**
  * Tracks the disk chain for a single VDI across all backup snapshots.
  * Owns merge and deletion decisions for its chain given which disks are still
@@ -84,11 +85,23 @@ export class RemoteDiskLineage {
       }
     }
 
+    const mergeParentPaths = new Set<string>()
+    for (const filePath of files) {
+      const match = MERGE_STATE_FILE_RE.exec(basename(filePath))
+      if (match !== null) {
+        mergeParentPaths.add(normalize(this.#vdiDir + '/' + match[1]))
+      }
+    }
+
     const uuidToPath = new Map<string, string>()
     for (const diskPath of this.#diskPaths) {
       let disk: RemoteDisk | undefined
       try {
-        disk = await openDisk({ handler: this.#handler, path: diskPath })
+        if (mergeParentPaths.has(diskPath)) {
+          disk = await openDisk({ handler: this.#handler, path: diskPath, force: true })
+        } else {
+          disk = await openDisk({ handler: this.#handler, path: diskPath })
+        }
       } catch (error) {
         if (error?.code === 'NOT_SUPPORTED' && this.#opts.merge) {
           throw error
@@ -234,6 +247,11 @@ export class RemoteDiskLineage {
         return undefined
       }
       visited.add(diskPath)
+
+      // if (this.#brokenDiskPaths.has(diskPath)) {
+      //   toDelete.add(diskPath)
+      //   return undefined
+      // }
 
       if (!orphanDisks.has(diskPath)) {
         // Active disk, anchor of the merge chain

--- a/@xen-orchestra/backup-archive/src/VmIncrementalBackupArchive.integ.mjs
+++ b/@xen-orchestra/backup-archive/src/VmIncrementalBackupArchive.integ.mjs
@@ -759,3 +759,59 @@ test('it preserves VDI directory when handler.list() throws during lineage init'
   const remaining = await handler.list(basePath)
   assert.ok(remaining.includes('snapshot.vhd'), 'VHD must survive when handler.list() throws during lineage init')
 })
+
+test('it resumes an interrupted merge when the parent VHD has a missing footer', async () => {
+  // regression: truncated footer on merge parent caused propagateBroken to flag the active
+  // child as broken => backup incorrectly seen as incomplete => metadata deleted on next clean
+
+  await handler.writeFile(
+    `${rootPath}/metadata.json`,
+    JSON.stringify({ mode: 'delta', vhds: [`${relativePath}/child.vhd`] })
+  )
+
+  const parent = await generateVhd(`${basePath}/parent.vhd`, { blocks: [0, 1] })
+  await generateVhd(`${basePath}/child.vhd`, {
+    header: { parentUnicodeName: 'parent.vhd', parentUuid: parent.footer.uuid },
+    blocks: [2, 3],
+  })
+
+  // Simulate interrupted merge: truncate the footer (last 512 bytes) of parent.vhd
+  const parentFsPath = `${tempDir}/${basePath}/parent.vhd`
+  const { size } = await fs.stat(parentFsPath)
+  await fs.truncate(parentFsPath, size - 512)
+
+  await handler.writeFile(
+    `${basePath}/.parent.vhd.merge.json`,
+    JSON.stringify({
+      parent: { uuid: '0' },
+      child: { uuid: '0' },
+      chain: ['parent.vhd', 'child.vhd'],
+      currentBlock: 0,
+      mergedDataSize: 0,
+      step: 'mergeBlocks',
+      diskSize: 0,
+    })
+  )
+
+  const warnings = []
+  await VmBackupDirectory.cleanVm(handler, rootPath, {
+    remove: true,
+    merge: true,
+    logWarn: (msg, data) => warnings.push({ msg, data }),
+    logInfo: () => {},
+  })
+
+  assert.ok(!warnings.some(w => w.msg === 'failed to open disk'))
+  assert.ok(!warnings.some(w => w.msg === 'disk broken: parent missing or broken'))
+
+  // metadata must survive, backup is valid, not incorrectly flagged as incomplete
+  assert.ok(
+    (await handler.list(rootPath)).includes('metadata.json'),
+    'metadata.json must not be deleted for a valid backup'
+  )
+
+  const files = await handler.list(basePath)
+  assert.ok(files.includes('child.vhd'), 'child.vhd must survive as merge target')
+  assert.ok(!files.includes('parent.vhd'), 'parent.vhd must be removed after merge')
+  assert.ok(!files.some(f => f.endsWith('.merge.json')), 'merge state file must be removed after successful resume')
+})

--- a/@xen-orchestra/backup-archive/src/disks/openDiskChain.mjs
+++ b/@xen-orchestra/backup-archive/src/disks/openDiskChain.mjs
@@ -33,12 +33,11 @@ async function _openDiskChain($defer, { handler, path, until, force = false }) {
   disks.push(disk)
   let foundRootDisk = until === undefined
   while (disk.isDifferencing()) {
-    disk = await disk.openParent()
-    if (disk.getPath() === until) {
+    if (disk.getParentPath() === until) {
       foundRootDisk = true
-      await disk.close()
       break
     }
+    disk = await disk.openParent()
     disks.unshift(disk)
   }
   if (!foundRootDisk) {


### PR DESCRIPTION
### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
