### PR TITLE
fix(backups): improve resume of backup merge failure

### DIFF
--- a/@xen-orchestra/backup-archive/src/RemoteDiskLineage.mts
+++ b/@xen-orchestra/backup-archive/src/RemoteDiskLineage.mts
@@ -21,6 +21,7 @@ import { limitConcurrency } from 'limit-concurrency-decorator'
 import assert from 'node:assert/strict'
 
 const defaultMergeLimiter = limitConcurrency(1)
+const MERGE_STATE_FILE_RE = /^\.(.+)\.merge\.json$/
 /**
  * Tracks the disk chain for a single VDI across all backup snapshots.
  * Owns merge and deletion decisions for its chain given which disks are still
@@ -84,11 +85,23 @@ export class RemoteDiskLineage {
       }
     }
 
+    const mergeParentPaths = new Set<string>()
+    for (const filePath of files) {
+      const match = MERGE_STATE_FILE_RE.exec(basename(filePath))
+      if (match !== null) {
+        mergeParentPaths.add(normalize(this.#vdiDir + '/' + match[1]))
+      }
+    }
+
     const uuidToPath = new Map<string, string>()
     for (const diskPath of this.#diskPaths) {
       let disk: RemoteDisk | undefined
       try {
-        disk = await openDisk({ handler: this.#handler, path: diskPath })
+        if (mergeParentPaths.has(diskPath)) {
+          disk = await openDisk({ handler: this.#handler, path: diskPath, force: true })
+        } else {
+          disk = await openDisk({ handler: this.#handler, path: diskPath })
+        }
       } catch (error) {
         if (error?.code === 'NOT_SUPPORTED' && this.#opts.merge) {
           throw error

--- a/@xen-orchestra/backup-archive/src/VmIncrementalBackupArchive.integ.mjs
+++ b/@xen-orchestra/backup-archive/src/VmIncrementalBackupArchive.integ.mjs
@@ -8,6 +8,8 @@ import { getHandler } from '@xen-orchestra/fs'
 import { pFromCallback } from 'promise-toolbox'
 // eslint-disable-next-line n/no-missing-import
 import { VmBackupDirectory } from '../dist/VmBackupDirectory.mjs'
+import { RemoteVhdDisk } from '../dist/disks/RemoteVhdDisk.mjs'
+import { MergeRemoteDisk } from '../dist/disks/MergeRemoteDisk.mjs'
 import { VHDFOOTER, VHDHEADER } from './tests.fixtures.mjs'
 import { VhdFile, Constants, VhdDirectory, VhdAbstract } from 'vhd-lib'
 import { dirname, basename } from 'node:path'
@@ -410,6 +412,73 @@ test('it merges a chain of multiple consecutive orphan ancestors in one pass', a
   assert.equal(remainingVhds.includes('grandchild.vhd'), true)
   assert.equal(remainingVhds.includes('ancestor.vhd'), false, 'ancestor should have been merged, not deleted directly')
   assert.equal(remainingVhds.includes('child.vhd'), false)
+})
+
+test('it resumes, through cleanVm, an interrupted merge whose ancestor lost its footer', async () => {
+  // Reproduces the production "footer1 !== footer2" failure end-to-end via the full cleanVm
+  // pipeline. ancestor (full) <- child (differencing, the active backup).
+  const ancestor = await generateVhd(`${basePath}/ancestor.vhd`, { blocks: [0, 1] })
+  await generateVhd(`${basePath}/child.vhd`, {
+    header: { parentUnicodeName: 'ancestor.vhd', parentUuid: ancestor.footer.uuid },
+    blocks: [2, 3, 4, 5],
+  })
+  await handler.writeFile(
+    `${rootPath}/metadata.json`,
+    JSON.stringify({ mode: 'delta', size: 12000, vhds: [`${relativePath}/child.vhd`] })
+  )
+
+  // Simulate a merge killed mid-transfer: write 2 of the 4 child blocks into the ancestor
+  // (which overwrites its end footer) then throw before mergeMetadata() rewrites the footer.
+  // This leaves the ancestor footerless AND a `.merge.json` state file — the exact post-crash
+  // state that makes cleanVm take the resume path.
+  const parent = new RemoteVhdDisk({ handler, path: `${basePath}/ancestor.vhd` })
+  const child = new RemoteVhdDisk({ handler, path: `${basePath}/child.vhd` })
+  await parent.init({ force: false })
+  await child.init({ force: false })
+  const merger = new MergeRemoteDisk(handler, { removeUnused: true, writeStateDelay: 0 })
+  let written = 0
+  const realWriteBlock = parent.writeBlock.bind(parent)
+  parent.writeBlock = async diskBlock => {
+    if (written === 2) {
+      throw new Error('simulated interruption')
+    }
+    written++
+    return realWriteBlock(diskBlock)
+  }
+  await assert.rejects(merger.merge(parent, child), /simulated interruption/)
+
+  assert.ok(
+    (await handler.list(basePath)).includes('.ancestor.vhd.merge.json'),
+    'an interrupted-merge state file should remain'
+  )
+
+  // Full pipeline: cleanVm must recognize the interrupted merge and resume it — opening the
+  // footerless ancestor through the chain without throwing "footer1 !== footer2".
+  await VmBackupDirectory.cleanVm(handler, rootPath, {
+    remove: true,
+    merge: true,
+    logInfo: () => {},
+    logWarn: () => {},
+  })
+
+  // The merge completed: the ancestor was consolidated into child.vhd and the state file is gone.
+  const remaining = await handler.list(basePath)
+  assert.equal(remaining.includes('.ancestor.vhd.merge.json'), false, 'state file removed after successful resume')
+  assert.equal(remaining.includes('ancestor.vhd'), false, 'ancestor consolidated into the merge target')
+  assert.equal(remaining.includes('child.vhd'), true, 'merge target remains')
+
+  // No blocks lost: the resumed merge wrote the blocks (4, 5) that were never written before
+  // the crash, so the consolidated disk holds the full set.
+  const merged = new RemoteVhdDisk({ handler, path: `${basePath}/child.vhd` })
+  await merged.init({ force: false })
+  try {
+    assert.deepEqual(merged.getBlockIndexes(), [0, 1, 2, 3, 4, 5], 'all blocks present after resumed merge')
+  } finally {
+    await merged.close()
+  }
+
+  // The backup is consistent, so its metadata is preserved.
+  assert.ok((await handler.list(rootPath)).includes('metadata.json'), 'metadata should be preserved')
 })
 
 test('it does not warn "missing target of alias" for aliases deleted by merge', async () => {

--- a/@xen-orchestra/backup-archive/src/disks/openDiskChain.mjs
+++ b/@xen-orchestra/backup-archive/src/disks/openDiskChain.mjs
@@ -33,12 +33,11 @@ async function _openDiskChain($defer, { handler, path, until, force = false }) {
   disks.push(disk)
   let foundRootDisk = until === undefined
   while (disk.isDifferencing()) {
-    disk = await disk.openParent()
-    if (disk.getPath() === until) {
+    if (disk.getParentPath() === until) {
       foundRootDisk = true
-      await disk.close()
       break
     }
+    disk = await disk.openParent()
     disks.unshift(disk)
   }
   if (!foundRootDisk) {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,8 @@
 
 [Treeview] fixed an issue where the selected item in the treeview would scroll to the top [Forum#12329](https://xcp-ng.org/forum/topic/12329) (PR [#10052](https://github.com/vatesfr/xen-orchestra/pull/10052))
 
+- [Backups] Improve resume of backup merge failure for VHD files (PR [#10053](https://github.com/vatesfr/xen-orchestra/pull/10053))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -33,6 +35,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backup-archive patch
 - @xen-orchestra/web patch
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

Introduced by #9765

When a backup merge fails on a VHD file, the footer might be missing. This caused a footer1 !== footer2 error and triggered a full backup while not deleting the previous chain and resulted in all further backup jobs to be displayed as failures even though the new backup chain was working properly.

The fix allows the cleanVm to resume the merge where it stops even if the VHD file footer is missing.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
