### PR TITLE
chore(husky): warn before committing dev routes in route-map.d.ts

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,21 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# Check for dev routes in route-map.d.ts
+ROUTE_MAP="@xen-orchestra/web/src/route-map.d.ts"
+if git diff --cached --name-only | grep -qF "$ROUTE_MAP"; then
+  if git diff --cached -- "$ROUTE_MAP" | grep -qE "^\+.*(/dev/|src/pages/dev/)"; then
+    echo ""
+    echo "Warning: route-map.d.ts contains staged dev routes (/dev/*)."
+    echo "These are development-only routes and should not be committed."
+    printf "Commit anyway? [y/N] "
+    read REPLY </dev/tty
+    case "$REPLY" in
+      [yY][eE][sS]|[yY]) ;;
+      *) echo "Aborted. Use --no-verify to bypass this check."; exit 1 ;;
+    esac
+    echo ""
+  fi
+fi
+
 npx lint-staged


### PR DESCRIPTION
### Description

Warns before committing dev routes to route-map.d.ts and lets the user abort

<img width="542" height="123" alt="Capture d’écran 2026-07-01 à 12 18 14" src="https://github.com/user-attachments/assets/3aaecffb-8786-4480-b214-119e9ed780c4" />

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
