### PR TITLE
feat(disk-cli): add option to show chain info, size, and improve peformances

### DIFF
--- a/@xen-orchestra/backup-archive/src/disks/openDiskChain.mjs
+++ b/@xen-orchestra/backup-archive/src/disks/openDiskChain.mjs
@@ -15,9 +15,10 @@ import { RemoteVhdDiskChain } from './RemoteVhdDiskChain.mjs'
  * @param {string} params.path
  * @param {string | undefined} params.until
  * @param {boolean} [params.force]
+ * @param {boolean} [params.ignoreBlockIndexes] - skip reading the block allocation table of each disk (cheaper, but blocks can't be read)
  * @returns {Promise<RemoteDisk>}
  */
-async function _openDiskChain($defer, { handler, path, until, force = false }) {
+async function _openDiskChain($defer, { handler, path, until, force = false, ignoreBlockIndexes = false }) {
   /**
    * @type {RemoteVhdDisk}
    */
@@ -29,7 +30,7 @@ async function _openDiskChain($defer, { handler, path, until, force = false }) {
   $defer.onFailure(() => Promise.all(disks.map(disk => disk.close())))
   disk = new RemoteVhdDisk({ handler, path })
 
-  await disk.init({ force })
+  await disk.init({ force, ignoreBlockIndexes })
   disks.push(disk)
   let foundRootDisk = until === undefined
   while (disk.isDifferencing()) {
@@ -37,7 +38,10 @@ async function _openDiskChain($defer, { handler, path, until, force = false }) {
       foundRootDisk = true
       break
     }
-    disk = await disk.openParent()
+    // Instantiate + init the parent directly (instead of openParent()) so the
+    // block allocation table read can be skipped when ignoreBlockIndexes is set.
+    disk = /** @type {RemoteVhdDisk} */ (disk.instantiateParent())
+    await disk.init({ force, ignoreBlockIndexes })
     disks.unshift(disk)
   }
   if (!foundRootDisk) {
@@ -48,6 +52,6 @@ async function _openDiskChain($defer, { handler, path, until, force = false }) {
 }
 
 /**
- * @type {(params: { handler: RemoteHandlerAbstract, path: string, until?: string, force?: boolean }) => Promise<RemoteDisk>}
+ * @type {(params: { handler: RemoteHandlerAbstract, path: string, until?: string, force?: boolean, ignoreBlockIndexes?: boolean }) => Promise<RemoteDisk>}
  */
 export const openDiskChain = defer(_openDiskChain)

--- a/@xen-orchestra/disk-cli/.USAGE.md
+++ b/@xen-orchestra/disk-cli/.USAGE.md
@@ -3,8 +3,8 @@ $ xo-disk-cli --help
 Usage: xo-disk-cli <command> <handler-url> <path> [options]
 
 Commands:
-  info       Show disk info (virtual size, uid, parent uid, block size); pass --chain to show the full parent chain
-  list       List all disks at a path and display their properties in a table
+  info       Show disk info (virtual size, uid, parent uid, block size); --chain shows the full parent chain, --size adds the size on disk
+  list       List all disks at a path and display their properties in a table; --size adds the size on disk
   transform  Convert a disk to another format and write to stdout (raw | vhd | qcow2)
 ```
 
@@ -15,7 +15,7 @@ Commands:
 Display metadata for a single disk file.
 
 ```
-xo-disk-cli info <handler-url> <disk-path> [--chain]
+xo-disk-cli info <handler-url> <disk-path> [--chain] [--size]
 ```
 
 Output includes: UID, parent UID (for differencing disks), virtual size, and block size.
@@ -29,8 +29,23 @@ Disk info: /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/snapshot.vhd
   Block size:   2.00 MiB (2097152 bytes)
 ```
 
+By default the disk is opened without reading its block allocation table, which
+is cheap but does not allow computing the size on disk. Pass `--size` to read
+the block allocation table and print the size on disk as an extra line:
+
+```
+$ xo-disk-cli info file:///mnt/backups /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/snapshot.vhd --size
+Disk info: /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/snapshot.vhd
+  UID:          <uuid>
+  Parent UID:   <parent-uuid>
+  Virtual size: 8.00 GiB (8589934592 bytes)
+  Block size:   2.00 MiB (2097152 bytes)
+  Size on disk: 128.00 MiB (134217728 bytes)
+```
+
 With `--chain`, the disk's full parent chain is opened and each disk is printed
-from the root (base) disk down to the given leaf disk:
+from the root (base) disk down to the given leaf disk. `--chain` and `--size`
+can be combined:
 
 ```
 $ xo-disk-cli info file:///mnt/backups /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/snapshot.vhd --chain
@@ -54,11 +69,26 @@ Disk info: /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/snapshot.vhd
 List all disk files found at a directory path and display their properties in a table. Disks are sorted so that each child appears directly after its parent. When a disk's parent is the row immediately above, the parent UID column shows `↑` for quick chain health assessment.
 
 ```
-xo-disk-cli list <handler-url> <dir-path>
+xo-disk-cli list <handler-url> <dir-path> [--size]
 ```
+
+By default disks are opened without reading their block allocation table (cheap),
+so the "Size on disk" column is omitted:
 
 ```
 $ xo-disk-cli list file:///mnt/backups /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/
+┌──────────────┬──────────────────────────────────────┬──────────────┬─────────────┬──────────────────────────────────────┐
+│ File         │ UID                                  │ Virtual size │ Differencing │ Parent UID                           │
+├──────────────┼──────────────────────────────────────┼──────────────┼─────────────┼──────────────────────────────────────┤
+│ base.vhd     │ xxxxxxxx-...                         │ 8.00 GiB     │ no          │ (none)                               │
+│ snapshot.vhd │ yyyyyyyy-...                         │ 8.00 GiB     │ yes         │ ↑                                    │
+└──────────────┴──────────────────────────────────────┴──────────────┴─────────────┴──────────────────────────────────────┘
+```
+
+Pass `--size` to read each disk's block allocation table and add the "Size on disk" column:
+
+```
+$ xo-disk-cli list file:///mnt/backups /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/ --size
 ┌──────────────┬──────────────────────────────────────┬─────────────┬──────────────┬─────────────┬──────────────────────────────────────┐
 │ File         │ UID                                  │ Size on disk│ Virtual size │ Differencing │ Parent UID                           │
 ├──────────────┼──────────────────────────────────────┼─────────────┼──────────────┼─────────────┼──────────────────────────────────────┤

--- a/@xen-orchestra/disk-cli/.USAGE.md
+++ b/@xen-orchestra/disk-cli/.USAGE.md
@@ -3,7 +3,7 @@ $ xo-disk-cli --help
 Usage: xo-disk-cli <command> <handler-url> <path> [options]
 
 Commands:
-  info       Show disk info (virtual size, uid, parent uid, block size)
+  info       Show disk info (virtual size, uid, parent uid, block size); pass --chain to show the full parent chain
   list       List all disks at a path and display their properties in a table
   transform  Convert a disk to another format and write to stdout (raw | vhd | qcow2)
 ```
@@ -15,7 +15,7 @@ Commands:
 Display metadata for a single disk file.
 
 ```
-xo-disk-cli info <handler-url> <disk-path>
+xo-disk-cli info <handler-url> <disk-path> [--chain]
 ```
 
 Output includes: UID, parent UID (for differencing disks), virtual size, and block size.
@@ -25,6 +25,26 @@ $ xo-disk-cli info file:///mnt/backups /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/
 Disk info: /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/snapshot.vhd
   UID:          <uuid>
   Parent UID:   <parent-uuid>
+  Virtual size: 8.00 GiB (8589934592 bytes)
+  Block size:   2.00 MiB (2097152 bytes)
+```
+
+With `--chain`, the disk's full parent chain is opened and each disk is printed
+from the root (base) disk down to the given leaf disk:
+
+```
+$ xo-disk-cli info file:///mnt/backups /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/snapshot.vhd --chain
+Disk chain: /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/snapshot.vhd (2 disks, root → leaf)
+
+Disk info: /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/base.vhd
+  UID:          <base-uuid>
+  Parent UID:   (none)
+  Virtual size: 8.00 GiB (8589934592 bytes)
+  Block size:   2.00 MiB (2097152 bytes)
+
+Disk info: /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/snapshot.vhd
+  UID:          <uuid>
+  Parent UID:   <base-uuid>
   Virtual size: 8.00 GiB (8589934592 bytes)
   Block size:   2.00 MiB (2097152 bytes)
 ```

--- a/@xen-orchestra/disk-cli/README.md
+++ b/@xen-orchestra/disk-cli/README.md
@@ -21,7 +21,7 @@ $ xo-disk-cli --help
 Usage: xo-disk-cli <command> <handler-url> <path> [options]
 
 Commands:
-  info       Show disk info (virtual size, uid, parent uid, block size)
+  info       Show disk info (virtual size, uid, parent uid, block size); pass --chain to show the full parent chain
   list       List all disks at a path and display their properties in a table
   transform  Convert a disk to another format and write to stdout (raw | vhd | qcow2)
 ```
@@ -33,7 +33,7 @@ Commands:
 Display metadata for a single disk file.
 
 ```
-xo-disk-cli info <handler-url> <disk-path>
+xo-disk-cli info <handler-url> <disk-path> [--chain]
 ```
 
 Output includes: UID, parent UID (for differencing disks), virtual size, and block size.
@@ -43,6 +43,26 @@ $ xo-disk-cli info file:///mnt/backups /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/
 Disk info: /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/snapshot.vhd
   UID:          <uuid>
   Parent UID:   <parent-uuid>
+  Virtual size: 8.00 GiB (8589934592 bytes)
+  Block size:   2.00 MiB (2097152 bytes)
+```
+
+With `--chain`, the disk's full parent chain is opened and each disk is printed
+from the root (base) disk down to the given leaf disk:
+
+```
+$ xo-disk-cli info file:///mnt/backups /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/snapshot.vhd --chain
+Disk chain: /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/snapshot.vhd (2 disks, root → leaf)
+
+Disk info: /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/base.vhd
+  UID:          <base-uuid>
+  Parent UID:   (none)
+  Virtual size: 8.00 GiB (8589934592 bytes)
+  Block size:   2.00 MiB (2097152 bytes)
+
+Disk info: /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/snapshot.vhd
+  UID:          <uuid>
+  Parent UID:   <base-uuid>
   Virtual size: 8.00 GiB (8589934592 bytes)
   Block size:   2.00 MiB (2097152 bytes)
 ```

--- a/@xen-orchestra/disk-cli/README.md
+++ b/@xen-orchestra/disk-cli/README.md
@@ -21,8 +21,8 @@ $ xo-disk-cli --help
 Usage: xo-disk-cli <command> <handler-url> <path> [options]
 
 Commands:
-  info       Show disk info (virtual size, uid, parent uid, block size); pass --chain to show the full parent chain
-  list       List all disks at a path and display their properties in a table
+  info       Show disk info (virtual size, uid, parent uid, block size); --chain shows the full parent chain, --size adds the size on disk
+  list       List all disks at a path and display their properties in a table; --size adds the size on disk
   transform  Convert a disk to another format and write to stdout (raw | vhd | qcow2)
 ```
 
@@ -33,7 +33,7 @@ Commands:
 Display metadata for a single disk file.
 
 ```
-xo-disk-cli info <handler-url> <disk-path> [--chain]
+xo-disk-cli info <handler-url> <disk-path> [--chain] [--size]
 ```
 
 Output includes: UID, parent UID (for differencing disks), virtual size, and block size.
@@ -47,8 +47,23 @@ Disk info: /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/snapshot.vhd
   Block size:   2.00 MiB (2097152 bytes)
 ```
 
+By default the disk is opened without reading its block allocation table, which
+is cheap but does not allow computing the size on disk. Pass `--size` to read
+the block allocation table and print the size on disk as an extra line:
+
+```
+$ xo-disk-cli info file:///mnt/backups /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/snapshot.vhd --size
+Disk info: /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/snapshot.vhd
+  UID:          <uuid>
+  Parent UID:   <parent-uuid>
+  Virtual size: 8.00 GiB (8589934592 bytes)
+  Block size:   2.00 MiB (2097152 bytes)
+  Size on disk: 128.00 MiB (134217728 bytes)
+```
+
 With `--chain`, the disk's full parent chain is opened and each disk is printed
-from the root (base) disk down to the given leaf disk:
+from the root (base) disk down to the given leaf disk. `--chain` and `--size`
+can be combined:
 
 ```
 $ xo-disk-cli info file:///mnt/backups /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/snapshot.vhd --chain
@@ -72,11 +87,26 @@ Disk info: /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/snapshot.vhd
 List all disk files found at a directory path and display their properties in a table. Disks are sorted so that each child appears directly after its parent. When a disk's parent is the row immediately above, the parent UID column shows `↑` for quick chain health assessment.
 
 ```
-xo-disk-cli list <handler-url> <dir-path>
+xo-disk-cli list <handler-url> <dir-path> [--size]
 ```
+
+By default disks are opened without reading their block allocation table (cheap),
+so the "Size on disk" column is omitted:
 
 ```
 $ xo-disk-cli list file:///mnt/backups /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/
+┌──────────────┬──────────────────────────────────────┬──────────────┬─────────────┬──────────────────────────────────────┐
+│ File         │ UID                                  │ Virtual size │ Differencing │ Parent UID                           │
+├──────────────┼──────────────────────────────────────┼──────────────┼─────────────┼──────────────────────────────────────┤
+│ base.vhd     │ xxxxxxxx-...                         │ 8.00 GiB     │ no          │ (none)                               │
+│ snapshot.vhd │ yyyyyyyy-...                         │ 8.00 GiB     │ yes         │ ↑                                    │
+└──────────────┴──────────────────────────────────────┴──────────────┴─────────────┴──────────────────────────────────────┘
+```
+
+Pass `--size` to read each disk's block allocation table and add the "Size on disk" column:
+
+```
+$ xo-disk-cli list file:///mnt/backups /xo-vm-backups/<vm-uuid>/vdis/<vdi-uuid>/ --size
 ┌──────────────┬──────────────────────────────────────┬─────────────┬──────────────┬─────────────┬──────────────────────────────────────┐
 │ File         │ UID                                  │ Size on disk│ Virtual size │ Differencing │ Parent UID                           │
 ├──────────────┼──────────────────────────────────────┼─────────────┼──────────────┼─────────────┼──────────────────────────────────────┤

--- a/@xen-orchestra/disk-cli/src/commands/info.mts
+++ b/@xen-orchestra/disk-cli/src/commands/info.mts
@@ -1,22 +1,53 @@
 import Disposable from 'promise-toolbox/Disposable'
-import { getSyncedHandler } from '@xen-orchestra/fs'
-import { openDisposableDisk, RemoteDisk } from '@xen-orchestra/backup-archive/disks'
+import { getSyncedHandler, type RemoteHandler } from '@xen-orchestra/fs'
+import { openDisposableDisk, openDiskChain, RemoteDisk, DiskDisposable } from '@xen-orchestra/backup-archive/disks'
 import { formatBytes } from '../utils.mjs'
 
-export async function infoCommand(handlerUrl: string, diskPath: string, _extraArgs: string[]): Promise<void> {
-  await Disposable.use(getSyncedHandler({ url: handlerUrl }), async handler => {
-    await Disposable.use(openDisposableDisk({ handler, path: diskPath }), async (disk: RemoteDisk) => {
-      const isDifferencing = disk.isDifferencing()
-      const virtualSize = disk.getVirtualSize()
-      const blockSize = disk.getBlockSize()
-      const uid = disk.getUuid()
-      const parentUid = isDifferencing ? disk.getParentUuid() : null
+function printDiskInfo(label: string, disk: RemoteDisk): void {
+  const isDifferencing = disk.isDifferencing()
+  const virtualSize = disk.getVirtualSize()
+  const blockSize = disk.getBlockSize()
+  const uid = disk.getUuid()
+  const parentUid = isDifferencing ? disk.getParentUuid() : null
 
-      console.log(`Disk info: ${diskPath}`)
-      console.log(`  UID:          ${uid}`)
-      console.log(`  Parent UID:   ${parentUid ?? '(none)'}`)
-      console.log(`  Virtual size: ${formatBytes(virtualSize)} (${virtualSize} bytes)`)
-      console.log(`  Block size:   ${formatBytes(blockSize)} (${blockSize} bytes)`)
-    })
+  console.log(`Disk info: ${label}`)
+  console.log(`  UID:          ${uid}`)
+  console.log(`  Parent UID:   ${parentUid ?? '(none)'}`)
+  console.log(`  Virtual size: ${formatBytes(virtualSize)} (${virtualSize} bytes)`)
+  console.log(`  Block size:   ${formatBytes(blockSize)} (${blockSize} bytes)`)
+}
+
+// Opens the full chain (root → leaf) as a disposable, reusing the same chain
+// walker as the `transform` command.
+async function openDisposableChain(handler: RemoteHandler, path: string): Promise<DiskDisposable> {
+  const chain = await openDiskChain({ handler, path })
+  return { value: chain, dispose: () => chain.close() }
+}
+
+export async function infoCommand(handlerUrl: string, diskPath: string, extraArgs: string[]): Promise<void> {
+  const showChain = extraArgs.includes('--chain')
+
+  await Disposable.use(getSyncedHandler({ url: handlerUrl }), async handler => {
+    if (!showChain) {
+      await Disposable.use(openDisposableDisk({ handler, path: diskPath }), (disk: RemoteDisk) => {
+        printDiskInfo(diskPath, disk)
+      })
+      return
+    }
+
+    // Resolve the full lineage first; the chain is only used to enumerate the
+    // paths, so it is closed before re-opening each disk to print its details.
+    const paths = await Disposable.use(openDisposableChain(handler, diskPath), chain => chain.getPaths())
+
+    console.log(`Disk chain: ${diskPath} (${paths.length} disk${paths.length === 1 ? '' : 's'}, root → leaf)\n`)
+
+    for (const [index, path] of paths.entries()) {
+      await Disposable.use(openDisposableDisk({ handler, path }), (disk: RemoteDisk) => {
+        printDiskInfo(path, disk)
+      })
+      if (index < paths.length - 1) {
+        console.log()
+      }
+    }
   })
 }

--- a/@xen-orchestra/disk-cli/src/commands/info.mts
+++ b/@xen-orchestra/disk-cli/src/commands/info.mts
@@ -3,48 +3,79 @@ import { getSyncedHandler, type RemoteHandler } from '@xen-orchestra/fs'
 import { openDisposableDisk, openDiskChain, RemoteDisk, DiskDisposable } from '@xen-orchestra/backup-archive/disks'
 import { formatBytes } from '../utils.mjs'
 
-function printDiskInfo(label: string, disk: RemoteDisk): void {
-  const isDifferencing = disk.isDifferencing()
-  const virtualSize = disk.getVirtualSize()
-  const blockSize = disk.getBlockSize()
-  const uid = disk.getUuid()
-  const parentUid = isDifferencing ? disk.getParentUuid() : null
+type DiskInfoLine = {
+  path: string
+  uid: string
+  parentUid: string | null
+  virtualSize: number
+  blockSize: number
+  // Only computed with --size; requires reading the block allocation table.
+  sizeOnDisk?: number
+}
 
-  console.log(`Disk info: ${label}`)
-  console.log(`  UID:          ${uid}`)
-  console.log(`  Parent UID:   ${parentUid ?? '(none)'}`)
-  console.log(`  Virtual size: ${formatBytes(virtualSize)} (${virtualSize} bytes)`)
-  console.log(`  Block size:   ${formatBytes(blockSize)} (${blockSize} bytes)`)
+function readDiskInfo(disk: RemoteDisk, path: string, showSize: boolean): DiskInfoLine {
+  const isDifferencing = disk.isDifferencing()
+  return {
+    path,
+    uid: disk.getUuid(),
+    parentUid: isDifferencing ? disk.getParentUuid() : null,
+    virtualSize: disk.getVirtualSize(),
+    blockSize: disk.getBlockSize(),
+    sizeOnDisk: showSize ? disk.getSizeOnDisk() : undefined,
+  }
+}
+
+function printDiskInfo(info: DiskInfoLine): void {
+  console.log(`Disk info: ${info.path}`)
+  console.log(`  UID:          ${info.uid}`)
+  console.log(`  Parent UID:   ${info.parentUid ?? '(none)'}`)
+  console.log(`  Virtual size: ${formatBytes(info.virtualSize)} (${info.virtualSize} bytes)`)
+  console.log(`  Block size:   ${formatBytes(info.blockSize)} (${info.blockSize} bytes)`)
+  if (info.sizeOnDisk !== undefined) {
+    console.log(`  Size on disk: ${formatBytes(info.sizeOnDisk)} (${info.sizeOnDisk} bytes)`)
+  }
 }
 
 // Opens the full chain (root → leaf) as a disposable, reusing the same chain
 // walker as the `transform` command.
-async function openDisposableChain(handler: RemoteHandler, path: string): Promise<DiskDisposable> {
-  const chain = await openDiskChain({ handler, path })
+async function openDisposableChain(
+  handler: RemoteHandler,
+  path: string,
+  ignoreBlockIndexes: boolean
+): Promise<DiskDisposable> {
+  const chain = await openDiskChain({ handler, path, ignoreBlockIndexes })
   return { value: chain, dispose: () => chain.close() }
 }
 
 export async function infoCommand(handlerUrl: string, diskPath: string, extraArgs: string[]): Promise<void> {
   const showChain = extraArgs.includes('--chain')
+  const showSize = extraArgs.includes('--size')
+  // Reading the block allocation table is costly, so only do it when the size on
+  // disk is requested; every other field comes from the footer/header.
+  const ignoreBlockIndexes = !showSize
 
   await Disposable.use(getSyncedHandler({ url: handlerUrl }), async handler => {
     if (!showChain) {
-      await Disposable.use(openDisposableDisk({ handler, path: diskPath }), (disk: RemoteDisk) => {
-        printDiskInfo(diskPath, disk)
-      })
+      const info = await Disposable.use(
+        openDisposableDisk({ handler, path: diskPath, ignoreBlockIndexes }),
+        (disk: RemoteDisk) => readDiskInfo(disk, diskPath, showSize)
+      )
+      printDiskInfo(info)
       return
     }
 
-    // Resolve the full lineage first; the chain is only used to enumerate the
-    // paths, so it is closed before re-opening each disk to print its details.
-    const paths = await Disposable.use(openDisposableChain(handler, diskPath), chain => chain.getPaths())
+    // Resolve the full lineage (root → leaf), then print each disk's info.
+    const paths = await Disposable.use(openDisposableChain(handler, diskPath, ignoreBlockIndexes), chain =>
+      chain.getPaths()
+    )
 
     console.log(`Disk chain: ${diskPath} (${paths.length} disk${paths.length === 1 ? '' : 's'}, root → leaf)\n`)
 
     for (const [index, path] of paths.entries()) {
-      await Disposable.use(openDisposableDisk({ handler, path }), (disk: RemoteDisk) => {
-        printDiskInfo(path, disk)
-      })
+      const info = await Disposable.use(openDisposableDisk({ handler, path, ignoreBlockIndexes }), (disk: RemoteDisk) =>
+        readDiskInfo(disk, path, showSize)
+      )
+      printDiskInfo(info)
       if (index < paths.length - 1) {
         console.log()
       }

--- a/@xen-orchestra/disk-cli/src/commands/list.mts
+++ b/@xen-orchestra/disk-cli/src/commands/list.mts
@@ -3,13 +3,18 @@ import { getSyncedHandler } from '@xen-orchestra/fs'
 import { isDisk, openDisposableDisk, RemoteDisk } from '@xen-orchestra/backup-archive/disks'
 import { formatBytes, renderTable } from '../utils.mjs'
 import { asyncEach } from '@vates/async-each'
-const HEADERS = ['File', 'UID', 'Size on disk', 'Virtual size', 'Differencing', 'Parent UID']
+
+// The "Size on disk" column is only shown with --size: computing it requires
+// reading the block allocation table of every disk, which is costly.
+function buildHeaders(showSize: boolean): string[] {
+  return ['File', 'UID', ...(showSize ? ['Size on disk'] : []), 'Virtual size', 'Differencing', 'Parent UID']
+}
 
 export type OkDiskInfo = {
   ok: true
   filename: string
   uid: string
-  sizeOnDisk: string
+  sizeOnDisk?: string
   virtualSize: string
   differencing: boolean
   parentUid: string | null
@@ -54,9 +59,10 @@ export function sortDisks(disks: DiskInfo[]): DiskInfo[] {
   return [...sorted, ...errDisks]
 }
 
-export function toTableRow(disk: DiskInfo, prevDisk: DiskInfo | undefined): string[] {
+export function toTableRow(disk: DiskInfo, prevDisk: DiskInfo | undefined, showSize: boolean): string[] {
   if (!disk.ok) {
-    return [disk.filename, `(error: ${disk.error})`, '-', '-', '-', '-']
+    // filename + error message, then a placeholder for every remaining column.
+    return [disk.filename, `(error: ${disk.error})`, ...Array(showSize ? 4 : 3).fill('-')]
   }
 
   const parentIsAbove = disk.differencing && prevDisk?.ok && prevDisk.uid === disk.parentUid
@@ -64,14 +70,16 @@ export function toTableRow(disk: DiskInfo, prevDisk: DiskInfo | undefined): stri
   return [
     disk.filename,
     disk.uid,
-    disk.sizeOnDisk,
+    ...(showSize ? [disk.sizeOnDisk ?? '-'] : []),
     disk.virtualSize,
     disk.differencing ? 'yes' : 'no',
     disk.differencing ? (parentIsAbove ? '↑' : (disk.parentUid ?? '')) : '(none)',
   ]
 }
 
-export async function listCommand(handlerUrl: string, dirPath: string, _extraArgs: string[]): Promise<void> {
+export async function listCommand(handlerUrl: string, dirPath: string, extraArgs: string[]): Promise<void> {
+  const showSize = extraArgs.includes('--size')
+
   await Disposable.use(getSyncedHandler({ url: handlerUrl }), async handler => {
     const entries = await handler.list(dirPath, { prependDir: true })
     const diskPaths = entries.filter(entry => isDisk(entry))
@@ -88,14 +96,14 @@ export async function listCommand(handlerUrl: string, dirPath: string, _extraArg
         const filename = diskPath.slice(diskPath.lastIndexOf('/') + 1)
         try {
           const disk = await Disposable.use(
-            openDisposableDisk({ handler, path: diskPath }),
+            openDisposableDisk({ handler, path: diskPath, ignoreBlockIndexes: !showSize }),
             async (disk: RemoteDisk) => {
               const differencing = disk.isDifferencing()
               return {
                 ok: true as const,
                 filename,
                 uid: disk.getUuid(),
-                sizeOnDisk: formatBytes(disk.getSizeOnDisk()),
+                sizeOnDisk: showSize ? formatBytes(disk.getSizeOnDisk()) : undefined,
                 virtualSize: formatBytes(disk.getVirtualSize()),
                 differencing,
                 parentUid: differencing ? disk.getParentUuid() : null,
@@ -111,7 +119,7 @@ export async function listCommand(handlerUrl: string, dirPath: string, _extraArg
     )
 
     const sorted = sortDisks(disks)
-    const rows = sorted.map((disk, i) => toTableRow(disk, sorted[i - 1]))
-    console.log(renderTable(HEADERS, rows))
+    const rows = sorted.map((disk, i) => toTableRow(disk, sorted[i - 1], showSize))
+    console.log(renderTable(buildHeaders(showSize), rows))
   })
 }

--- a/@xen-orchestra/disk-cli/src/declarations.d.ts
+++ b/@xen-orchestra/disk-cli/src/declarations.d.ts
@@ -52,6 +52,7 @@ declare module '@xen-orchestra/backup-archive/disks' {
   export interface RemoteDisk extends RandomAccessDisk {
     getSizeOnDisk(): number
     getPath(): string
+    getPaths(): string[]
     getUuid(): string
     getParentUuid(): string
     getMaxBlockCount(): number
@@ -66,9 +67,6 @@ declare module '@xen-orchestra/backup-archive/disks' {
 
   export function openDisposableDisk(params: { handler: RemoteHandler; path: string }): Promise<DiskDisposable>
 
-  export function openDiskChain(params: {
-    handler: RemoteHandler
-    path: string
-    until?: string
-  }): Promise<RandomAccessDisk>
+  // Returns a RemoteVhdDiskChain, which is a RemoteDisk exposing getPaths() over the whole lineage.
+  export function openDiskChain(params: { handler: RemoteHandler; path: string; until?: string }): Promise<RemoteDisk>
 }

--- a/@xen-orchestra/disk-cli/src/declarations.d.ts
+++ b/@xen-orchestra/disk-cli/src/declarations.d.ts
@@ -42,6 +42,7 @@ declare module '@xen-orchestra/backup-archive/disks/openDiskChain.mjs' {
     handler: RemoteHandler
     path: string
     until?: string
+    ignoreBlockIndexes?: boolean
   }): Promise<RandomAccessDisk>
 }
 
@@ -55,6 +56,7 @@ declare module '@xen-orchestra/backup-archive/disks' {
     getPaths(): string[]
     getUuid(): string
     getParentUuid(): string
+    getParentPath(): string
     getMaxBlockCount(): number
   }
 
@@ -65,8 +67,18 @@ declare module '@xen-orchestra/backup-archive/disks' {
 
   export function isDisk(path: string): boolean
 
-  export function openDisposableDisk(params: { handler: RemoteHandler; path: string }): Promise<DiskDisposable>
+  export function openDisposableDisk(params: {
+    handler: RemoteHandler
+    path: string
+    force?: boolean
+    ignoreBlockIndexes?: boolean
+  }): Promise<DiskDisposable>
 
   // Returns a RemoteVhdDiskChain, which is a RemoteDisk exposing getPaths() over the whole lineage.
-  export function openDiskChain(params: { handler: RemoteHandler; path: string; until?: string }): Promise<RemoteDisk>
+  export function openDiskChain(params: {
+    handler: RemoteHandler
+    path: string
+    until?: string
+    ignoreBlockIndexes?: boolean
+  }): Promise<RemoteDisk>
 }

--- a/@xen-orchestra/disk-cli/src/index.mts
+++ b/@xen-orchestra/disk-cli/src/index.mts
@@ -14,7 +14,7 @@ const COMMANDS: Record<string, CommandFn> = {
 
 function showHelp(exitCode: number): never {
   const commandDescriptions: Record<string, string> = {
-    info: 'Show disk info (virtual size, uid, parent uid, block size)',
+    info: 'Show disk info (virtual size, uid, parent uid, block size); pass --chain to show the full parent chain',
     list: 'List all disks at a path and display their properties in a table',
     transform: 'Convert a disk to another format and write to stdout (raw | vhd | qcow2)',
   }
@@ -30,6 +30,7 @@ ${commandList}
 
 Examples:
   xo-disk-cli info      file:///mnt/backups /xo-vm-backups/uuid/disk.alias.vhd
+  xo-disk-cli info      file:///mnt/backups /xo-vm-backups/uuid/disk.alias.vhd --chain
   xo-disk-cli list      file:///mnt/backups /xo-vm-backups/uuid/
   xo-disk-cli transform file:///mnt/backups /xo-vm-backups/uuid/disk.vhd raw > disk.img
   xo-disk-cli transform file:///mnt/backups /xo-vm-backups/uuid/disk.vhd qcow2 > disk.qcow2

--- a/@xen-orchestra/disk-cli/src/index.mts
+++ b/@xen-orchestra/disk-cli/src/index.mts
@@ -14,8 +14,8 @@ const COMMANDS: Record<string, CommandFn> = {
 
 function showHelp(exitCode: number): never {
   const commandDescriptions: Record<string, string> = {
-    info: 'Show disk info (virtual size, uid, parent uid, block size); pass --chain to show the full parent chain',
-    list: 'List all disks at a path and display their properties in a table',
+    info: 'Show disk info (virtual size, uid, parent uid, block size); --chain shows the full parent chain, --size adds the size on disk',
+    list: 'List all disks at a path and display their properties in a table; --size adds the size on disk',
     transform: 'Convert a disk to another format and write to stdout (raw | vhd | qcow2)',
   }
 
@@ -30,8 +30,9 @@ ${commandList}
 
 Examples:
   xo-disk-cli info      file:///mnt/backups /xo-vm-backups/uuid/disk.alias.vhd
-  xo-disk-cli info      file:///mnt/backups /xo-vm-backups/uuid/disk.alias.vhd --chain
+  xo-disk-cli info      file:///mnt/backups /xo-vm-backups/uuid/disk.alias.vhd --chain --size
   xo-disk-cli list      file:///mnt/backups /xo-vm-backups/uuid/
+  xo-disk-cli list      file:///mnt/backups /xo-vm-backups/uuid/ --size
   xo-disk-cli transform file:///mnt/backups /xo-vm-backups/uuid/disk.vhd raw > disk.img
   xo-disk-cli transform file:///mnt/backups /xo-vm-backups/uuid/disk.vhd qcow2 > disk.qcow2
 `)

--- a/@xen-orchestra/disk-cli/src/test/commands/info.test.mts
+++ b/@xen-orchestra/disk-cli/src/test/commands/info.test.mts
@@ -18,6 +18,7 @@ import assert from 'node:assert/strict'
 
 const handlerDispose = mock.fn(() => Promise.resolve())
 const diskDispose = mock.fn(() => Promise.resolve())
+const chainClose = mock.fn(() => Promise.resolve())
 
 const baseDisk = {
   isDifferencing: () => false,
@@ -29,6 +30,12 @@ const baseDisk = {
 
 // Reassigned per-test to inject different disk behaviours.
 let currentDisk: typeof baseDisk = { ...baseDisk }
+
+// Paths returned by the chain (root → leaf); reassigned per-test.
+let chainPaths: string[] = ['/vdis/root.vhd', '/vdis/leaf.vhd']
+
+// Chain returned by openDiskChain — only getPaths() and close() are used by `info`.
+const openDiskChainSpy = mock.fn(() => Promise.resolve({ getPaths: () => chainPaths, close: chainClose }))
 
 // ---------------------------------------------------------------------------
 // Module mocks — registered once. openDisk reads `currentDisk` at call-time
@@ -44,6 +51,7 @@ mock.module('@xen-orchestra/fs', {
 mock.module('@xen-orchestra/backup-archive/disks', {
   namedExports: {
     openDisposableDisk: () => Promise.resolve({ value: currentDisk, dispose: diskDispose }),
+    openDiskChain: openDiskChainSpy,
   },
 })
 
@@ -59,7 +67,10 @@ describe('info command', () => {
   beforeEach(() => {
     handlerDispose.mock.resetCalls()
     diskDispose.mock.resetCalls()
+    chainClose.mock.resetCalls()
+    openDiskChainSpy.mock.resetCalls()
     currentDisk = { ...baseDisk }
+    chainPaths = ['/vdis/root.vhd', '/vdis/leaf.vhd']
   })
 
   test('disposes handler and disk on success', async () => {
@@ -88,5 +99,31 @@ describe('info command', () => {
       },
     }
     await assert.rejects(() => infoCommand('file:///test', '/vdis/disk.vhd', []), /corrupt header/)
+  })
+
+  test('without --chain, openDiskChain is never called', async () => {
+    await infoCommand('file:///test', '/vdis/disk.vhd', [])
+    assert.strictEqual(openDiskChainSpy.mock.callCount(), 0, 'openDiskChain must not be called without --chain')
+  })
+
+  test('--chain: opens the chain, opens each disk in it, and disposes everything', async () => {
+    await infoCommand('file:///test', '/vdis/leaf.vhd', ['--chain'])
+    assert.strictEqual(openDiskChainSpy.mock.callCount(), 1, 'openDiskChain must be called once')
+    assert.strictEqual(chainClose.mock.callCount(), 1, 'chain must be closed after enumerating paths')
+    // One openDisposableDisk (and thus one dispose) per disk in the chain.
+    assert.strictEqual(diskDispose.mock.callCount(), chainPaths.length, 'each chain disk must be opened and disposed')
+    assert.strictEqual(handlerDispose.mock.callCount(), 1, 'handler must be disposed once')
+  })
+
+  test('--chain: chain is closed even when opening a disk in it throws', async () => {
+    currentDisk = {
+      ...baseDisk,
+      getUuid: () => {
+        throw new Error('corrupt header')
+      },
+    }
+    await assert.rejects(() => infoCommand('file:///test', '/vdis/leaf.vhd', ['--chain']), /corrupt header/)
+    assert.strictEqual(chainClose.mock.callCount(), 1, 'chain must be closed even on error')
+    assert.strictEqual(handlerDispose.mock.callCount(), 1, 'handler must be disposed even on error')
   })
 })

--- a/@xen-orchestra/disk-cli/src/test/commands/info.test.mts
+++ b/@xen-orchestra/disk-cli/src/test/commands/info.test.mts
@@ -4,16 +4,19 @@
  * Focus:
  *  - Handler and disk are always disposed, even when disk methods throw.
  *  - Errors from broken disks are propagated (not swallowed).
+ *  - By default disks are opened with ignoreBlockIndexes: true (cheap); --size
+ *    opens with ignoreBlockIndexes: false and prints the size on disk.
+ *  - --chain opens the whole lineage and prints each disk.
  *
- * Design: mock.module() is called once at the top level. The mock for openDisk
- * reads `currentDisk` at call-time via closure, so individual tests can inject
- * failure scenarios simply by reassigning the variable before calling the command.
+ * Design: mock.module() is called once at the top level. The mocks read mutable
+ * closure variables at call-time so individual tests can inject scenarios simply
+ * by reassigning a variable before calling the command.
  */
 import { describe, test, mock, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 
 // ---------------------------------------------------------------------------
-// Spies — created once and reused; reset in beforeEach.
+// Spies & mutable state — created once and reused; reset in beforeEach.
 // ---------------------------------------------------------------------------
 
 const handlerDispose = mock.fn(() => Promise.resolve())
@@ -24,6 +27,7 @@ const baseDisk = {
   isDifferencing: () => false,
   getVirtualSize: () => 1024 * 1024 * 1024,
   getBlockSize: () => 2 * 1024 * 1024,
+  getSizeOnDisk: () => 128 * 1024 * 1024,
   getUuid: () => 'aaaa-bbbb',
   getParentUuid: () => 'pppp-qqqq',
 }
@@ -34,12 +38,17 @@ let currentDisk: typeof baseDisk = { ...baseDisk }
 // Paths returned by the chain (root → leaf); reassigned per-test.
 let chainPaths: string[] = ['/vdis/root.vhd', '/vdis/leaf.vhd']
 
-// Chain returned by openDiskChain — only getPaths() and close() are used by `info`.
-const openDiskChainSpy = mock.fn(() => Promise.resolve({ getPaths: () => chainPaths, close: chainClose }))
+// Records the options each openDisposableDisk call received.
+const openDiskParams: Array<{ path: string; ignoreBlockIndexes?: boolean }> = []
+const openChainParams: Array<{ path: string; ignoreBlockIndexes?: boolean }> = []
+
+const openDiskChainSpy = mock.fn((params: { path: string; ignoreBlockIndexes?: boolean }) => {
+  openChainParams.push(params)
+  return Promise.resolve({ getPaths: () => chainPaths, close: chainClose })
+})
 
 // ---------------------------------------------------------------------------
-// Module mocks — registered once. openDisk reads `currentDisk` at call-time
-// so tests only need to reassign the variable, not re-mock the module.
+// Module mocks — registered once. Implementations read mutable state at call-time.
 // ---------------------------------------------------------------------------
 
 mock.module('@xen-orchestra/fs', {
@@ -50,14 +59,30 @@ mock.module('@xen-orchestra/fs', {
 
 mock.module('@xen-orchestra/backup-archive/disks', {
   namedExports: {
-    openDisposableDisk: () => Promise.resolve({ value: currentDisk, dispose: diskDispose }),
+    openDisposableDisk: (params: { path: string; ignoreBlockIndexes?: boolean }) => {
+      openDiskParams.push(params)
+      return Promise.resolve({ value: currentDisk, dispose: diskDispose })
+    },
     openDiskChain: openDiskChainSpy,
   },
 })
 
 // Import the module under test AFTER mocks are registered so it receives the
-// mocked implementations. The same infoCommand reference is reused for all tests.
+// mocked implementations.
 const { infoCommand } = await import('../../commands/info.mjs')
+
+// Capture console.log output without polluting test output.
+async function captureLog(fn: () => Promise<void>): Promise<string> {
+  const lines: string[] = []
+  const orig = console.log
+  console.log = (...args: unknown[]) => lines.push(args.map(String).join(' '))
+  try {
+    await fn()
+  } finally {
+    console.log = orig
+  }
+  return lines.join('\n')
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -69,12 +94,14 @@ describe('info command', () => {
     diskDispose.mock.resetCalls()
     chainClose.mock.resetCalls()
     openDiskChainSpy.mock.resetCalls()
+    openDiskParams.length = 0
+    openChainParams.length = 0
     currentDisk = { ...baseDisk }
     chainPaths = ['/vdis/root.vhd', '/vdis/leaf.vhd']
   })
 
   test('disposes handler and disk on success', async () => {
-    await infoCommand('file:///test', '/vdis/disk.vhd', [])
+    await captureLog(() => infoCommand('file:///test', '/vdis/disk.vhd', []))
     assert.strictEqual(handlerDispose.mock.callCount(), 1, 'handler must be disposed once')
     assert.strictEqual(diskDispose.mock.callCount(), 1, 'disk must be disposed once')
   })
@@ -101,18 +128,51 @@ describe('info command', () => {
     await assert.rejects(() => infoCommand('file:///test', '/vdis/disk.vhd', []), /corrupt header/)
   })
 
+  test('by default opens the disk with ignoreBlockIndexes: true and hides size on disk', async () => {
+    const output = await captureLog(() => infoCommand('file:///test', '/vdis/disk.vhd', []))
+    assert.strictEqual(openDiskParams.length, 1)
+    assert.strictEqual(openDiskParams[0].ignoreBlockIndexes, true, 'block indexes must be skipped by default')
+    assert.ok(!output.includes('Size on disk'), 'size on disk must not be printed without --size')
+  })
+
+  test('--size opens the disk with ignoreBlockIndexes: false and prints size on disk', async () => {
+    const output = await captureLog(() => infoCommand('file:///test', '/vdis/disk.vhd', ['--size']))
+    assert.strictEqual(openDiskParams[0].ignoreBlockIndexes, false, 'block indexes must be read with --size')
+    assert.ok(output.includes('Size on disk'), 'size on disk must be printed with --size')
+  })
+
   test('without --chain, openDiskChain is never called', async () => {
-    await infoCommand('file:///test', '/vdis/disk.vhd', [])
+    await captureLog(() => infoCommand('file:///test', '/vdis/disk.vhd', []))
     assert.strictEqual(openDiskChainSpy.mock.callCount(), 0, 'openDiskChain must not be called without --chain')
   })
 
   test('--chain: opens the chain, opens each disk in it, and disposes everything', async () => {
-    await infoCommand('file:///test', '/vdis/leaf.vhd', ['--chain'])
+    await captureLog(() => infoCommand('file:///test', '/vdis/leaf.vhd', ['--chain']))
     assert.strictEqual(openDiskChainSpy.mock.callCount(), 1, 'openDiskChain must be called once')
     assert.strictEqual(chainClose.mock.callCount(), 1, 'chain must be closed after enumerating paths')
     // One openDisposableDisk (and thus one dispose) per disk in the chain.
     assert.strictEqual(diskDispose.mock.callCount(), chainPaths.length, 'each chain disk must be opened and disposed')
     assert.strictEqual(handlerDispose.mock.callCount(), 1, 'handler must be disposed once')
+  })
+
+  test('--chain defaults to ignoreBlockIndexes: true for both the chain and each disk', async () => {
+    await captureLog(() => infoCommand('file:///test', '/vdis/leaf.vhd', ['--chain']))
+    assert.strictEqual(openChainParams[0].ignoreBlockIndexes, true, 'chain walk must skip block indexes by default')
+    assert.ok(
+      openDiskParams.every(p => p.ignoreBlockIndexes === true),
+      'each chain disk must be opened with ignoreBlockIndexes: true'
+    )
+  })
+
+  test('--chain --size reads block indexes and prints size on disk for each disk', async () => {
+    const output = await captureLog(() => infoCommand('file:///test', '/vdis/leaf.vhd', ['--chain', '--size']))
+    assert.strictEqual(openChainParams[0].ignoreBlockIndexes, false, 'chain walk must read block indexes with --size')
+    assert.ok(
+      openDiskParams.every(p => p.ignoreBlockIndexes === false),
+      'each chain disk must be opened with ignoreBlockIndexes: false'
+    )
+    const sizeLines = output.split('\n').filter(l => l.includes('Size on disk'))
+    assert.strictEqual(sizeLines.length, chainPaths.length, 'size on disk must be printed for each disk')
   })
 
   test('--chain: chain is closed even when opening a disk in it throws', async () => {

--- a/@xen-orchestra/disk-cli/src/test/commands/list.test.mts
+++ b/@xen-orchestra/disk-cli/src/test/commands/list.test.mts
@@ -27,6 +27,9 @@ const baseDisk = {
   getParentUuid: () => null as unknown as string,
 }
 
+// Records the options each openDisposableDisk call received.
+const openDiskParams: Array<{ path: string; ignoreBlockIndexes?: boolean }> = []
+
 // Reassigned per-test to control what handler.list() returns (or throws).
 let currentListImpl: () => Promise<string[]> = async () => []
 
@@ -52,8 +55,9 @@ mock.module('@xen-orchestra/fs', {
 mock.module('@xen-orchestra/backup-archive/disks', {
   namedExports: {
     isDisk: (p: string) => p.endsWith('.vhd'),
-    openDisposableDisk: ({ path }: { path: string }) => {
-      if (brokenPaths.has(path)) throw new Error('disk header corrupted')
+    openDisposableDisk: (params: { path: string; ignoreBlockIndexes?: boolean }) => {
+      openDiskParams.push(params)
+      if (brokenPaths.has(params.path)) throw new Error('disk header corrupted')
       return Promise.resolve({ value: { ...baseDisk }, dispose: diskDispose })
     },
   },
@@ -86,6 +90,7 @@ describe('list command', () => {
     handlerDispose.mock.resetCalls()
     diskDispose.mock.resetCalls()
     brokenPaths.clear()
+    openDiskParams.length = 0
     currentListImpl = async () => ['/dir/disk.vhd']
   })
 
@@ -121,5 +126,23 @@ describe('list command', () => {
     currentListImpl = async () => []
     const output = await captureLog(() => listCommand('file:///test', '/dir', []))
     assert.ok(output.includes('No disks found'))
+  })
+
+  test('by default opens disks with ignoreBlockIndexes: true and hides the size column', async () => {
+    const output = await captureLog(() => listCommand('file:///test', '/dir', []))
+    assert.ok(
+      openDiskParams.every(p => p.ignoreBlockIndexes === true),
+      'disks must be opened with ignoreBlockIndexes: true by default'
+    )
+    assert.ok(!output.includes('Size on disk'), 'the size column must be hidden without --size')
+  })
+
+  test('--size opens disks with ignoreBlockIndexes: false and shows the size column', async () => {
+    const output = await captureLog(() => listCommand('file:///test', '/dir', ['--size']))
+    assert.ok(
+      openDiskParams.every(p => p.ignoreBlockIndexes === false),
+      'disks must be opened with ignoreBlockIndexes: false with --size'
+    )
+    assert.ok(output.includes('Size on disk'), 'the size column must appear with --size')
   })
 })

--- a/@xen-orchestra/disk-cli/src/test/sortDisks.test.mts
+++ b/@xen-orchestra/disk-cli/src/test/sortDisks.test.mts
@@ -2,6 +2,10 @@ import { describe, test } from 'node:test'
 import assert from 'node:assert/strict'
 import { sortDisks, toTableRow, type DiskInfo } from '../commands/list.mjs'
 
+// These tests assert on the full-width row (with the "Size on disk" column), so
+// they always exercise toTableRow with showSize = true.
+const toTableRowWithSize = (disk: DiskInfo, prevDisk: DiskInfo | undefined) => toTableRow(disk, prevDisk, true)
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -106,43 +110,43 @@ describe('sortDisks', () => {
 
 describe('toTableRow', () => {
   test('base disk shows "(none)" in parent uid column', () => {
-    const row = toTableRow(ok('a'), undefined)
+    const row = toTableRowWithSize(ok('a'), undefined)
     assert.strictEqual(row[5], '(none)')
   })
 
   test('differencing disk with no previous disk shows parentUid', () => {
-    const row = toTableRow(ok('b', 'a'), undefined)
+    const row = toTableRowWithSize(ok('b', 'a'), undefined)
     assert.strictEqual(row[5], 'a')
   })
 
   test('differencing disk whose parent is not the previous row shows parentUid', () => {
-    const row = toTableRow(ok('b', 'a'), ok('x'))
+    const row = toTableRowWithSize(ok('b', 'a'), ok('x'))
     assert.strictEqual(row[5], 'a')
   })
 
   test('differencing disk whose parent is immediately above shows ↑', () => {
-    const row = toTableRow(ok('b', 'a'), ok('a'))
+    const row = toTableRowWithSize(ok('b', 'a'), ok('a'))
     assert.strictEqual(row[5], '↑')
   })
 
   test('error disk shows error message in second column', () => {
-    const row = toTableRow(err('bad.vhd'), undefined)
+    const row = toTableRowWithSize(err('bad.vhd'), undefined)
     assert.ok(row[1].includes('error'))
     assert.ok(row[1].includes('disk header corrupted'))
   })
 
   test('differencing column shows "yes" for differencing disk', () => {
-    assert.strictEqual(toTableRow(ok('b', 'a'), undefined)[4], 'yes')
+    assert.strictEqual(toTableRowWithSize(ok('b', 'a'), undefined)[4], 'yes')
   })
 
   test('differencing column shows "no" for base disk', () => {
-    assert.strictEqual(toTableRow(ok('a'), undefined)[4], 'no')
+    assert.strictEqual(toTableRowWithSize(ok('a'), undefined)[4], 'no')
   })
 
   test('parent with multiple children: at least one child shows parent UID instead of ↑', () => {
     const sorted = sortDisks([ok('c2', 'a'), ok('a'), ok('c1', 'a')])
 
-    const rows = sorted.map((disk, i) => toTableRow(disk, sorted[i - 1]))
+    const rows = sorted.map((disk, i) => toTableRowWithSize(disk, sorted[i - 1]))
 
     // Find rows for the two children
     const childRows = rows.filter((_row, i) => {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -62,7 +62,8 @@
 <!--packages-start-->
 
 - @vates/types minor
-- @xen-orchestra/backup-archive patch
+- @xen-orchestra/backup-archive minor
+- @xen-orchestra/disk-cli minor
 - @xen-orchestra/disk-transform patch
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web patch


### PR DESCRIPTION
### Description

Extend disk-cli's info/list commands to inspect a disk's full parent lineage and optionally report its actual size on disk  while avoiding the cost of reading each VHD's block allocation table (BAT) unless that size is actually requested.

* info gains a `--chain` flag that walks the disk's full lineage (root → leaf) via openDiskChain and prints info for every disk in the chain, not just the target one. Adds getPaths() to RemoteDisk/RemoteVhdDiskChain and widens openDiskChain's return type declaration from RandomAccessDisk to RemoteDisk.
*  Adds an `ignoreBlockIndexes` option to `openDiskChain` that skips reading each disk's BAT while walking the chain (cheaper, but blocks can't be read afterward). Parent disks are now instantiated via i`nstantiateParent()` + explicit `init({ force, ignoreBlockIndexes })` instead of `openParent()`, so the flag can be threaded through.
* Wires `ignoreBlockIndexes` through info and list: BAT is now skipped by default and only read when `--size` is passed (since `getSizeOnDisk()` needs it). info `--size` adds a "Size on disk" line (also combinable with `--chain`); `list --size` adds a "Size on disk" column. Without `--size`, both commands run cheaper by skipping the BAT read entirely. 

Test and usage/README updates included.



### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
