### PR TITLE
docs(xo6): hide categories that dont contain any actual pages

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -44,6 +44,7 @@ export default {
       collapsible: true,
       collapsed: false,
       items:[
+        /* These categories are hidden until they no longer only contain blank pages
         {
           type: 'category',
           label: 'What\'s new in XO6',
@@ -90,6 +91,7 @@ export default {
             'xo6/backups',
           ],
         },
+        */
         {
           type: 'category',
           label: 'Security',


### PR DESCRIPTION
We recently [added new sections for the XO6 category](https://github.com/vatesfr/xen-orchestra/pull/9972) in the XO documentation. These pages were meant to be placeholders while the content was being written. To avoid confusing readers with empty pages that only have titles, this PR hides the sections from the sidebar until the actual content is ready.