### PR TITLE
docs(xo): refactor navbar navigation to create a unified documentation ecosystem

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -241,10 +241,9 @@ export default {
       title: 'Xen Orchestra Documentation',
       logo: { alt: 'Xen Orchestra logo', src: 'img/logo.png', href: '/' },
       items: [
-        { href: 'https://xen-orchestra.com', label: 'Home', position: 'right' },
-        { href: 'https://xen-orchestra.com/blog/', label: 'Blog', position: 'right' },
-        { href: '/', label: 'Documentation', position: 'right' },
-        { href: 'https://github.com/vatesfr/xen-orchestra', label: 'GitHub', position: 'right' },
+        { to: 'https://docs.vates.tech/', label: 'Vates VMS', position: 'right', target: '_self'},
+        { to: 'https://docs.xcp-ng.org/', label: 'XCP-ng', position: 'right', target: '_self'},
+        { href: '/', label: 'Xen Orchestra', position: 'right' },
       ],
     },
     footer: {

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -253,6 +253,10 @@ export default {
           title: 'Learn',
           items: [
             {
+              label: 'About Xen Orchestra',
+              href: 'https://xen-orchestra.com/#!/xo-home',
+            },
+            {
               label: 'Introduction',
               href: '/',
             },

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -44,13 +44,13 @@ export default {
       collapsible: true,
       collapsed: false,
       items:[
-        /* These categories are hidden until they no longer only contain blank pages
         {
           type: 'category',
           label: 'What\'s new in XO6',
           type: 'link',
-          to: 'https://xen-orchestra.com/blog/',
+          href: 'https://xen-orchestra.com/blog/',
         },
+        /* These categories are hidden until they no longer only contain blank pages
         {
           type: 'category',
           label: 'Getting started',

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -48,12 +48,8 @@ export default {
         {
           type: 'category',
           label: 'What\'s new in XO6',
-          collapsible: true,
-          collapsed: true,
-          items:[
-            'xo6/whatsnew',
-            'xo6/xo6vsxo5',
-          ],
+          type: 'link',
+          to: 'https://xen-orchestra.com/blog/',
         },
         {
           type: 'category',

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -29,6 +29,11 @@
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 
+/* Make all text links inside the navbar bold */
+.navbar__item {
+  font-weight: bold;
+}
+
 [data-theme='dark'] .DocSearch {
   --docsearch-text-color: var(--ifm-font-color-base);
   --docsearch-muted-color: var(--ifm-color-secondary-darkest);


### PR DESCRIPTION
📝 **Summary**

This pull request streamlines the navbar (or header) in the XO documentation, to offer a more coherent and cohesive browsing experience for our readers, across our three documentation sites.

- The navbar has been cleaned up. We're removing the GitHub link, which was redundant as it already appears in the footer.
- The "Blog" link has been moved from the navbar to the "What's new in XO 6" section in the sidebar.
- We've introduced direct, highly visible links to our two sister documentation platforms ([XCP-ng](https://docs.xcp-ng.org/) and [Vates VMS](https://docs.vates.tech/)) in the navbar.
- The "Documentation" link has been renamed "Xen Orchestra", so it appears the same when the nav bars will be updated in the XCP-ng and Vates VMS docs.
- The "Home" link in the nav bar has been moved to the footer and renamed "About Xen Orchestra".

The goal of this overhaul is to replicate this exact same layout across all three of our documentation sites. Having an identical, mirrored header on every platform will create a unified brand experience. Readers will be able to switch between ecosystems smoothly and navigate our documentation platform without friction.


🔍 **Preview of the changes**

**Before:**

<img width="854" height="263" alt="before" src="https://github.com/user-attachments/assets/494f6075-4c67-4e65-8c26-975cce70ccf3" />

<img width="938" height="223" alt="Capture d&#39;écran 2026-07-03 102438" src="https://github.com/user-attachments/assets/9ac648ed-829c-44f4-b666-98aee5688510" />


**After:**

<img width="852" height="210" alt="after" src="https://github.com/user-attachments/assets/5b1947e1-0fb6-4fc1-a155-05e06455e7f0" />

<img width="989" height="431" alt="Capture d&#39;écran 2026-07-03 102300" src="https://github.com/user-attachments/assets/6729c8dc-96dc-4304-baf3-e401b0bc8098" />




