### PR TITLE
fix(backups): add warn with debug for snapshot pileup issue

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
@@ -213,6 +213,35 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
           vmUuid: vm.uuid,
         })
         await setVmSnapshotContentKeys(xapi, snapshotRef)
+
+        // Verify that setVmOtherConfig actually tagged every disk we expected.
+        // If the snapshot exposes fewer 'Disk' VBDs than the live VM has, the
+        // tagging call silently skipped some VDIs and the resulting snapshot
+        // will be invisible to retention/cleanup on the next run.
+        const liveDisks = await xapi.VM_getDisks(vm.$ref)
+        const snapshotDisks = await xapi.VM_getDisks(snapshotRef)
+        if (liveDisks.length !== snapshotDisks.length) {
+          const snapshotVbdRefs = await xapi.getField('VM', snapshotRef, 'VBDs')
+          const snapshotVbds = await xapi.getRecords('VBD', snapshotVbdRefs)
+          warn('inconsistent snapshot tagging detected', {
+            vmUuid: vm.uuid,
+            vmName: vm.name_label,
+            snapshotRef,
+            jobId: this._jobId,
+            timestamp: this.timestamp,
+            expectedDiskCount: liveDisks.length,
+            actualDiskCount: snapshotDisks.length,
+            liveDisks,
+            snapshotDisks,
+            snapshotVbds: snapshotVbds.map(vbd => ({
+              uuid: vbd.uuid,
+              type: vbd.type,
+              VDI: vbd.VDI,
+              currently_attached: vbd.currently_attached,
+            })),
+          })
+        }
+
         const snapshot = await xapi.getRecord('VM', snapshotRef)
         await snapshot.set_name_label(this._getSnapshotNameLabel(vm))
         // reload data to ensure it is up to date with the new name label

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -38,6 +38,7 @@
 <!--packages-start-->
 
 - @xen-orchestra/backup-archive patch
+- @xen-orchestra/backups patch
 - @xen-orchestra/web patch
 - xo-server patch
 


### PR DESCRIPTION
### Description

Adds logs for a snapshot pileup issue that supposedly comes from the vdi-snapshots not having the appropriate other_config data.

No changelog feels appropriate

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
