### PR TITLE
Fix: throttled stream length and encrypted XVA warning

### DIFF
--- a/@xen-orchestra/backup-archive/src/VmFullBackupArchive.mts
+++ b/@xen-orchestra/backup-archive/src/VmFullBackupArchive.mts
@@ -43,11 +43,18 @@ const isValidTar = async (handler: RemoteHandlerAbstract, size: number, fd: File
   return buf.every(byte => byte === 0)
 }
 
-export async function isValidXva(handler: RemoteHandlerAbstract, filePath: string): Promise<boolean> {
+export async function isValidXva(
+  handler: RemoteHandlerAbstract,
+  filePath: string,
+  metadataSize?: number
+): Promise<boolean> {
   // size is longer when encrypted + reading part of an encrypted file is not implemented
   if (handler.isEncrypted) {
-    return true
+    const size = await handler.getSizeOnDisk(filePath)
+    return size > 20
   }
+
+  let isValid = true
 
   const fd = await handler.openFile(filePath, 'r')
   try {
@@ -56,13 +63,19 @@ export async function isValidXva(handler: RemoteHandlerAbstract, filePath: strin
       // neither a valid gzip nor tar
       return false
     }
+    let validSize = true
+    if (metadataSize !== undefined) {
+      validSize = metadataSize === size
+    }
 
-    return (await isCompressedFile(handler, fd))
+    const validDisk = (await isCompressedFile(handler, fd))
       ? true // compressed files cannot be validated at this time
       : await isValidTar(handler, size, fd)
+    isValid = validSize && validDisk
   } finally {
     handler.closeFile(fd).catch(noop)
   }
+  return isValid
 }
 
 const noop = (): void => {}
@@ -101,28 +114,22 @@ export class VmFullBackupArchive implements VmBackupInterface {
    */
   async check(): Promise<CheckResult> {
     if (this.isValid === undefined) {
-      let fileSize = 0
-      let validDisk = false
-      let validSize = true
       try {
-        fileSize = await this.handler.getSize(this.xvaPath)
-        validDisk = await isValidXva(this.handler, this.xvaPath)
+        this.isValid = await isValidXva(this.handler, this.xvaPath, this.metadata.size)
       } catch (error) {
-        validDisk = false
+        this.isValid = false
         if (error?.code === 'ENOENT') {
           this.missingDisk = true
         }
         this.opts.logWarn('Issue while checking XVA', { error })
       }
-      try {
-        await this.handler.getSize(`${this.xvaPath}.checksum`)
-      } catch (error) {
-        this.opts.logWarn('Checksum file not valid, not blocking', { error })
+      if (!this.handler.isEncrypted) {
+        try {
+          await this.handler.getSize(`${this.xvaPath}.checksum`)
+        } catch (error) {
+          this.opts.logWarn('Checksum file not valid, not blocking', { error })
+        }
       }
-      if (this.metadata.size !== undefined) {
-        validSize = this.metadata.size === fileSize
-      }
-      this.isValid = fileSize > 0 && validSize && validDisk
     }
     if (!this.isValid) {
       if (this.missingDisk) {

--- a/@xen-orchestra/backups/_runners/_createStreamThrottle.mjs
+++ b/@xen-orchestra/backups/_runners/_createStreamThrottle.mjs
@@ -10,6 +10,9 @@ export default function createStreamThrottle(rate) {
   }
   const group = new ThrottleGroup({ rate })
   return function throttleStream(stream) {
-    return pipeline(stream, group.createThrottle(), noop)
+    const throttled = pipeline(stream, group.createThrottle(), noop)
+    throttled.length = stream.length
+    throttled.maxStreamLength = stream.maxStreamLength
+    return throttled
   }
 }

--- a/@xen-orchestra/backups/_runners/_createStreamThrottle.test.mjs
+++ b/@xen-orchestra/backups/_runners/_createStreamThrottle.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { Readable } from 'node:stream'
+
+import createStreamThrottle from './_createStreamThrottle.mjs'
+
+const makeStream = (chunks, props = {}) => {
+  const stream = Readable.from(chunks)
+  Object.assign(stream, props)
+  return stream
+}
+
+const readAll = async stream => {
+  const chunks = []
+  for await (const chunk of stream) {
+    chunks.push(chunk)
+  }
+  return Buffer.concat(chunks.map(c => (typeof c === 'string' ? Buffer.from(c) : c))).toString()
+}
+
+describe('createStreamThrottle', () => {
+  it('rate=0 returns identity, stream data and props intact', async () => {
+    const throttleStream = createStreamThrottle(0)
+    const stream = makeStream(['hello world'], { length: 11, maxStreamLength: 20 })
+    const throttled = throttleStream(stream)
+    assert.strictEqual(throttled, stream)
+    assert.strictEqual(throttled.length, 11)
+    assert.strictEqual(throttled.maxStreamLength, 20)
+    assert.strictEqual(await readAll(throttled), 'hello world')
+  })
+
+  it('rate>0 passes data through and preserves length and maxStreamLength', async () => {
+    const throttleStream = createStreamThrottle(1024 * 1024)
+    const stream = makeStream(['hello world'], { length: 11, maxStreamLength: 20 })
+    const throttled = throttleStream(stream)
+    assert.strictEqual(throttled.length, 11)
+    assert.strictEqual(throttled.maxStreamLength, 20)
+    assert.strictEqual(await readAll(throttled), 'hello world')
+  })
+
+  it('rate>0 handles undefined length and maxStreamLength', async () => {
+    const throttleStream = createStreamThrottle(1024 * 1024)
+    const stream = makeStream(['hello world'])
+    const throttled = throttleStream(stream)
+    assert.strictEqual(throttled.length, undefined)
+    assert.strictEqual(throttled.maxStreamLength, undefined)
+    assert.strictEqual(await readAll(throttled), 'hello world')
+  })
+
+  // regression: maxStreamLength was lost after throttling, causing S3 to ignore it and cap at 50GB
+  it('rate>0 preserves maxStreamLength so S3 can compute correct partSize', async () => {
+    const throttleStream = createStreamThrottle(1024 * 1024)
+    const stream = makeStream(['hello world'], { maxStreamLength: 11 })
+    const throttled = throttleStream(stream)
+    assert.strictEqual(throttled.maxStreamLength, 11)
+    assert.strictEqual(await readAll(throttled), 'hello world')
+  })
+})

--- a/@xen-orchestra/fs/src/types/fs.mts
+++ b/@xen-orchestra/fs/src/types/fs.mts
@@ -157,7 +157,7 @@ export abstract class RemoteHandlerAbstract {
   abstract getInfo(): Promise<RemoteInfoResult>
 
   abstract getSize(file: FileDescriptor): Promise<number>
-  abstract getSizeOnDisk(file: FileArg): Promise<number>
+  abstract getSizeOnDisk(file: FileDescriptor): Promise<number>
   abstract lock(path: string): Promise<LockDisposer>
   abstract test(): Promise<TestResult>
   abstract isImmutable(): boolean

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 
 - [Backups] fix alignment issue in full mirror with disk > 50GB from non encrypted to encrypted remote (PR [#10061](https://github.com/vatesfr/xen-orchestra/pull/10061))
 - [Backups] Add length to throttled stream during transfer size (PR [#10079](https://github.com/vatesfr/xen-orchestra/pull/10079))
+- [Backups] Remove warning "Issue while checking XVA" when Backup Repository is encrypted (PR [#10079](https://github.com/vatesfr/xen-orchestra/pull/10079))
 
 ### Packages to release
 
@@ -34,6 +35,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backup-archive patch
 - @xen-orchestra/backups patch
 - @xen-orchestra/fs patch
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
 - [Backups] fix alignment issue in full mirror with disk > 50GB from non encrypted to encrypted remote (PR [#10061](https://github.com/vatesfr/xen-orchestra/pull/10061))
+- [Backups] Add length to throttled stream during transfer size (PR [#10079](https://github.com/vatesfr/xen-orchestra/pull/10079))
 
 ### Packages to release
 
@@ -33,6 +34,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/backups patch
 - @xen-orchestra/fs patch
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

Attempt to fix the root issue in this thread: https://xcp-ng.org/forum/topic/12328/error-mirroring-full-backups-to-backblaze-b2

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
