### PR TITLE
fix(backups): retry VDI_destroy after cleanup

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
@@ -7,6 +7,7 @@ import { asyncEach } from '@vates/async-each'
 import { decorateMethodsWith } from '@vates/decorate-with'
 import { defer } from 'golike-defer'
 import { Task } from '@vates/task'
+import { pRetry } from 'promise-toolbox'
 
 import { getOldEntries } from '../../_getOldEntries.mjs'
 import { Abstract } from './_Abstract.mjs'
@@ -469,7 +470,11 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
         } else {
           return asyncMap(
             vdis.map(async ({ $ref }) => {
-              await xapi.VDI_destroy($ref)
+              await pRetry(() => xapi.VDI_destroy($ref), {
+                when: err => err.code === 'VDI_IN_USE',
+                retries: 5,
+                delay: 2000,
+              })
             })
           )
         }


### PR DESCRIPTION
### Description
There is a race condition between two separate processes after copying VDI.

From the xensource.log of a user


17:30:17  xapi: "Copying VDI complete." => vhd-tool done, HTTP body fully sent
17:30:17  xapi: VBD.unplug for 2afecab3 task created =>xapi starts its own cleanup (line 62432)
17:30:18  xapi: VDI.deactivate still in progress => cleanup not done yet
17:30:18  XO:   VDI.destroy for 09157b75 => VDI_IN_USE => XO already calling destroy (line 62480)
17:30:23  XO:   VDI.destroy retry => SUCCESS =>VBD finally done by now
XO reads stream EOF at ~17:30:17 => _copy() resolves => _removeUnusedSnapshots() => VDI_destroy. That all takes ~1 second. But xapi's VBD.unplug also starts at 17:30:17 and takes ~1 second. They overlap.

There's no await in XO code that waits for xapi's VBD cleanup because pTaskResult (the promise that resolves when the xapi task fully completes, including VBD.unplug) is attached to response.task but exportContent discards it by extracting only .body.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
