### PR TITLE
fix(xo-server): automatically reconnect to XenServer after connection

### DIFF
--- a/packages/xo-server/src/_xenServerAutoReconnect.mjs
+++ b/packages/xo-server/src/_xenServerAutoReconnect.mjs
@@ -1,0 +1,61 @@
+import { fibonacci } from 'iterable-backoff'
+
+// hard cap between two attempts: quick first retries, then steady 1/min
+export const MAX_DELAY = 60e3
+
+// Reconnection loop for a server in the `enabled but disconnected` state,
+// which nothing else in xo-server ever retries: a failed explicit connect
+// (boot, user action, host eject) or an unexpected XAPI disconnection tears
+// the Xapi instance down and, without this loop, the server would stay
+// disconnected until a manual reconnection.
+//
+// Deps are injected to keep this testable without a full app:
+// - connect(id): attempt the connection, throws on failure
+// - delay(ms): wait before the next attempt
+// - getServer(id): server record ({ enabled }), throws if the server was deleted
+// - getStatus(id): 'disconnected' | 'connecting' | 'connected'
+// - isFatal(error): optional, true for permanent errors not worth retrying
+// - isGone(error): optional, true when a getServer error means the server was deleted
+//
+// Resolves with the reason why the loop stopped, never rejects.
+export async function autoReconnect(
+  id,
+  { connect, delay, getServer, getStatus, isFatal = () => false, isGone = () => true, log }
+) {
+  for (const ms of fibonacci()
+    .toMs()
+    .map(ms => Math.min(ms, MAX_DELAY))) {
+    await delay(ms)
+
+    let server
+    try {
+      server = await getServer(id)
+    } catch (error) {
+      if (isGone(error)) {
+        return 'server deleted'
+      }
+      // transient failure (e.g. database hiccup): keep the loop alive
+      log.debug('auto-reconnect could not read the server', { serverId: id, error })
+      continue
+    }
+    if (!server.enabled) {
+      return 'server disabled'
+    }
+    if (getStatus(id) !== 'disconnected') {
+      return 'already connected'
+    }
+
+    try {
+      await connect(id)
+      return 'connected'
+    } catch (error) {
+      // retrying would hammer the host with invalid credentials, or never
+      // succeed for permanent errors (e.g. pool already connected)
+      if (error?.code === 'SESSION_AUTHENTICATION_FAILED' || isFatal(error)) {
+        log.warn('auto-reconnect aborted: permanent error', { serverId: id, error })
+        return 'permanent error'
+      }
+      log.debug('auto-reconnect attempt failed', { serverId: id, error })
+    }
+  }
+}

--- a/packages/xo-server/src/_xenServerAutoReconnect.test.mjs
+++ b/packages/xo-server/src/_xenServerAutoReconnect.test.mjs
@@ -1,0 +1,149 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { autoReconnect, MAX_DELAY } from './_xenServerAutoReconnect.mjs'
+
+const noopLog = { debug: () => {}, warn: () => {} }
+
+function makeDeps(overrides) {
+  return {
+    connect: async () => {},
+    delay: () => Promise.resolve(),
+    getServer: async () => ({ enabled: true }),
+    getStatus: () => 'disconnected',
+    log: noopLog,
+    ...overrides,
+  }
+}
+
+describe('autoReconnect', () => {
+  it('reconnects after transient failures', async () => {
+    let attempts = 0
+    const outcome = await autoReconnect(
+      's1',
+      makeDeps({
+        connect: async () => {
+          if (++attempts < 3) {
+            throw new Error('EHOSTUNREACH')
+          }
+        },
+      })
+    )
+    assert.equal(outcome, 'connected')
+    assert.equal(attempts, 3)
+  })
+
+  it('stops when the server is disabled', async () => {
+    const outcome = await autoReconnect('s1', makeDeps({ getServer: async () => ({ enabled: false }) }))
+    assert.equal(outcome, 'server disabled')
+  })
+
+  it('stops when the server was deleted', async () => {
+    const outcome = await autoReconnect(
+      's1',
+      makeDeps({
+        getServer: async () => {
+          throw new Error('no such object')
+        },
+        isGone: error => error.message === 'no such object',
+      })
+    )
+    assert.equal(outcome, 'server deleted')
+  })
+
+  it('survives transient getServer failures when isGone says the server still exists', async () => {
+    let reads = 0
+    let attempts = 0
+    const outcome = await autoReconnect(
+      's1',
+      makeDeps({
+        getServer: async () => {
+          if (++reads === 1) {
+            throw new Error('database hiccup')
+          }
+          return { enabled: true }
+        },
+        isGone: () => false,
+        connect: async () => {
+          ++attempts
+        },
+      })
+    )
+    assert.equal(outcome, 'connected')
+    assert.equal(reads, 2)
+    assert.equal(attempts, 1)
+  })
+
+  it('stops when the server was reconnected by other means', async () => {
+    let connectCalled = false
+    const outcome = await autoReconnect(
+      's1',
+      makeDeps({
+        getStatus: () => 'connected',
+        connect: async () => {
+          connectCalled = true
+        },
+      })
+    )
+    assert.equal(outcome, 'already connected')
+    assert.equal(connectCalled, false)
+  })
+
+  it('gives up immediately on authentication failure', async () => {
+    let attempts = 0
+    const outcome = await autoReconnect(
+      's1',
+      makeDeps({
+        connect: async () => {
+          ++attempts
+          const error = new Error('authentication failed')
+          error.code = 'SESSION_AUTHENTICATION_FAILED'
+          throw error
+        },
+      })
+    )
+    assert.equal(outcome, 'permanent error')
+    assert.equal(attempts, 1)
+  })
+
+  it('gives up immediately on errors reported fatal by isFatal', async () => {
+    let attempts = 0
+    const outcome = await autoReconnect(
+      's1',
+      makeDeps({
+        connect: async () => {
+          ++attempts
+          throw new Error('pool already connected')
+        },
+        isFatal: error => error.message === 'pool already connected',
+      })
+    )
+    assert.equal(outcome, 'permanent error')
+    assert.equal(attempts, 1)
+  })
+
+  it('starts fast and caps delays at MAX_DELAY', async () => {
+    const delays = []
+    let attempts = 0
+    const outcome = await autoReconnect(
+      's1',
+      makeDeps({
+        delay: async ms => {
+          delays.push(ms)
+        },
+        connect: async () => {
+          if (++attempts < 15) {
+            throw new Error('still down')
+          }
+        },
+      })
+    )
+    assert.equal(outcome, 'connected')
+    assert.ok(delays[0] <= 2e3, `first delay should be short, got ${delays[0]}`)
+    assert.ok(
+      delays.every(ms => ms <= MAX_DELAY),
+      'delays must be capped'
+    )
+    assert.equal(Math.max(...delays), MAX_DELAY)
+  })
+})

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -18,6 +18,7 @@ import * as XenStore from '../_XenStore.mjs'
 import Xapi from '../xapi/index.mjs'
 import xapiObjectToXo from '../xapi-object-to-xo.mjs'
 import XapiStats from '../xapi-stats.mjs'
+import { autoReconnect } from '../_xenServerAutoReconnect.mjs'
 import { camelToSnakeCase, forEach, isEmpty, popProperty } from '../utils.mjs'
 import { Servers } from '../models/server.mjs'
 
@@ -46,6 +47,8 @@ const log = createLogger('xo:xo-mixins:xen-servers')
 export default class XenServers {
   constructor(app, { safeMode }) {
     this._objectConflicts = { __proto__: null } // TODO: clean when a server is disconnected.
+    this._connectingXenServers = new Set()
+    this._reconnectingXenServers = new Set()
     this._serverIdsByPool = { __proto__: null }
     this._stats = new XapiStats()
     this._xapis = { __proto__: null }
@@ -190,6 +193,12 @@ export default class XenServers {
     if (hasChanged) {
       await this._servers.update(server)
     }
+
+    // an enabled server must not stay disconnected without retries, e.g. after
+    // the user fixed its credentials or address
+    if (server.enabled && !this._connectingXenServers.has(id) && this._getXenServerStatus(id) === 'disconnected') {
+      this._autoReconnectXenServer(id)
+    }
   }
 
   async getXenServerWithCredentials(id) {
@@ -323,18 +332,63 @@ export default class XenServers {
     })
   }
 
-  async connectXenServer(id) {
+  // starts a reconnection loop for a server left `enabled` but without a
+  // Xapi instance, a state nothing else retries (see _xenServerAutoReconnect.mjs)
+  _autoReconnectXenServer(id) {
+    const reconnecting = this._reconnectingXenServers
+    if (reconnecting.has(id)) {
+      return
+    }
+    reconnecting.add(id)
+
+    autoReconnect(id, {
+      // `enable: false`: the loop must never overwrite a concurrent disable
+      connect: id => this.connectXenServer(id, { enable: false }),
+      delay: pDelay,
+      getServer: id => this.getXenServer(id),
+      getStatus: id => this._getXenServerStatus(id),
+      isFatal: error => error instanceof PoolAlreadyConnected,
+      isGone: error => noSuchObject.is(error),
+      log,
+    })
+      .then(outcome => {
+        log.info('auto-reconnect stopped', { serverId: id, outcome })
+      })
+      .catch(error => {
+        log.error('auto-reconnect crashed', { serverId: id, error })
+      })
+      .finally(() => {
+        reconnecting.delete(id)
+      })
+  }
+
+  async connectXenServer(id, { enable = true } = {}) {
     const server = await this.getXenServerWithCredentials(id)
     const serverStatus = this._getXenServerStatus(id)
-    if (serverStatus !== 'disconnected') {
+    // `_connectingXenServers` also guards against a concurrent connection
+    // attempt for the same server, which would overwrite `_xapis[id]` and leak
+    // a live connection
+    const connecting = this._connectingXenServers.has(id)
+    if (serverStatus !== 'disconnected' || connecting) {
       throw incorrectState({
-        actual: serverStatus,
+        actual: connecting ? 'connecting' : serverStatus,
         expected: 'disconnected',
         object: server.id,
         property: 'status',
       })
     }
-    await this.updateXenServer(id, { enabled: true })
+    this._connectingXenServers.add(id)
+    try {
+      await this._connectXenServer(id, server, { enable })
+    } finally {
+      this._connectingXenServers.delete(id)
+    }
+  }
+
+  async _connectXenServer(id, server, { enable }) {
+    if (enable) {
+      await this.updateXenServer(id, { enabled: true })
+    }
 
     const { config } = this._app
 
@@ -532,12 +586,27 @@ export default class XenServers {
         delete this._xapis[server.id]
         delete this._serverIdsByPool[poolId]
         this._app.emit('server:disconnected', { server, xapi })
+
+        // deliberate disconnections set `enabled` to false beforehand, in
+        // which case the loop stops on its own
+        this._autoReconnectXenServer(server.id)
       })
       this._app.emit('server:connected', { server, xapi })
     } catch (error) {
       delete this._xapis[server.id]
       xapi.disconnect()::ignoreErrors()
-      this.updateXenServer(id, { error })::ignoreErrors()
+
+      // avoid a database write per auto-reconnect attempt when the error did not change
+      const previousError = server.error
+      if (previousError?.code !== error?.code || previousError?.message !== error?.message) {
+        this.updateXenServer(id, { error })::ignoreErrors()
+      }
+
+      // permanent errors: retrying is pointless, do not start the loop
+      if (!(error instanceof PoolAlreadyConnected) && error?.code !== 'SESSION_AUTHENTICATION_FAILED') {
+        this._autoReconnectXenServer(id)
+      }
+
       throw error
     }
   }


### PR DESCRIPTION
### Description

A server left `enabled` but without a Xapi instance was never retried by anything in
xo-server. Three paths lead to that state:

- a failed explicit connect: xo-server boots while a pool is down, a user clicks
  "connect" during an outage, or the host-eject path exhausts its 5 attempts;
- a `SESSION_INVALID` teardown after a pool master restart (`_sessionCall` calls
  `disconnect()`, and nothing listens to `server:disconnected`);
- fixing a server's credentials/address while it is disconnected (`server.set` never
  triggers a connection).

Once there, the server stays `disconnected` forever, showing an error that can be
minutes or hours old. Support ends up chasing false "pool is dead" reports, typically
right after a rolling pool update, which is exactly when hosts reboot by design.

https://project.vates.tech/vates-global/browse/XO-2733/

**Reproduced and validated on a nested lab (2026-07-07):**

| Scenario | Before this PR | With this PR |
| --- | --- | --- |
| Master reboots, nobody touches XO | recovers in ~60 s (event loop survives, no bug) | unchanged |
| One failed connect while the master is down | stuck `disconnected` 12+ min after XAPI was back (chronometer stopped there; would be forever), error stale the whole time | **automatic reconnection 17 s after XAPI answered**; displayed error refreshed at every attempt during the outage (`UND_ERR_CONNECT_TIMEOUT` → `EHOSTUNREACH` → `ECONNRESET`) |

Journal proof of the fix in action:

```
xo:xo-mixins:xen-servers INFO auto-reconnect stopped {
  serverId: '97836437-4814-4f7e-9cbb-d0235f7249fe',
  outcome: 'connected'
}
```

**The fix** (`_xenServerAutoReconnect.mjs` + wiring in `xo-mixins/xen-servers.mjs`):

- a reconnection loop starts whenever a server ends up `enabled` + `disconnected`:
  failed connect, unexpected disconnection, or server edit (`updateXenServer`);
- fibonacci backoff capped at 60 s (1 s, 1 s, 2 s, … 60 s), unlimited;
- stops on: success, server disabled, server deleted, or permanent error
  (`SESSION_AUTHENTICATION_FAILED`, `PoolAlreadyConnected`);
- one loop max per server; the loop never overwrites a concurrent user disable
  (`connectXenServer(id, { enable: false })`);
- the persisted `server.error` is refreshed on every attempt (no more stale errors),
  deduplicated to avoid one Redis write per attempt;
- bonus hardening: concurrent `connectXenServer()` calls for the same server are now
  rejected (`incorrectState`) instead of racing and corrupting `_xapis` (pre-existing
  bug, made more likely by the automated caller).

Not covered on purpose: the xen-api `SESSION_INVALID` → `disconnect()` behaviour is
left as is (the loop makes that teardown recoverable, changing the client would
impact every consumer).

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
