### PR TITLE
feat(web-core): add promise-based overlay system

### DIFF
--- a/@xen-orchestra/web-core/lib/components/overlay/VtsOverlayButton.vue
+++ b/@xen-orchestra/web-core/lib/components/overlay/VtsOverlayButton.vue
@@ -7,7 +7,7 @@
 <script lang="ts" setup>
 import UiButton, { type ButtonVariant } from '@core/components/ui/button/UiButton.vue'
 import { useMapper } from '@core/packages/mapper'
-import { useOverlayTrigger } from '@core/packages/overlay/use-overlay-trigger'
+import { useOverlayTrigger } from '@core/packages/overlay/use-overlay-trigger.ts'
 import { IK_OVERLAY_ACCENT } from '@core/utils/injection-keys.util.ts'
 import { inject } from 'vue'
 

--- a/@xen-orchestra/web-core/lib/components/overlay/VtsOverlayButton.vue
+++ b/@xen-orchestra/web-core/lib/components/overlay/VtsOverlayButton.vue
@@ -1,0 +1,35 @@
+<template>
+  <UiButton :accent="buttonAccent" :busy="isBusy" :disabled="isDisabled" :variant size="medium" @click="trigger">
+    <slot />
+  </UiButton>
+</template>
+
+<script lang="ts" setup>
+import UiButton, { type ButtonVariant } from '@core/components/ui/button/UiButton.vue'
+import { useMapper } from '@core/packages/mapper'
+import { useOverlayTrigger } from '@core/packages/overlay/use-overlay-trigger'
+import { IK_OVERLAY_ACCENT } from '@core/utils/injection-keys.util.ts'
+import { inject } from 'vue'
+
+defineProps<{
+  variant: ButtonVariant
+}>()
+
+defineSlots<{
+  default(): any
+}>()
+
+const { isBusy, isDisabled, trigger } = useOverlayTrigger()
+
+const overlayAccent = inject(IK_OVERLAY_ACCENT, undefined)
+
+const buttonAccent = useMapper(
+  () => overlayAccent?.value,
+  {
+    info: 'brand',
+    warning: 'warning',
+    danger: 'danger',
+  },
+  'info'
+)
+</script>

--- a/@xen-orchestra/web-core/lib/components/overlay/VtsOverlayCancelButton.vue
+++ b/@xen-orchestra/web-core/lib/components/overlay/VtsOverlayCancelButton.vue
@@ -1,0 +1,16 @@
+<template>
+  <VtsOverlayButton variant="secondary">
+    <slot>{{ t('cancel') }}</slot>
+  </VtsOverlayButton>
+</template>
+
+<script lang="ts" setup>
+import VtsOverlayButton from '@core/components/overlay/VtsOverlayButton.vue'
+import { useI18n } from 'vue-i18n'
+
+defineSlots<{
+  default?(): any
+}>()
+
+const { t } = useI18n()
+</script>

--- a/@xen-orchestra/web-core/lib/components/overlay/VtsOverlayConfirmButton.vue
+++ b/@xen-orchestra/web-core/lib/components/overlay/VtsOverlayConfirmButton.vue
@@ -1,0 +1,25 @@
+<template>
+  <VtsOverlayButton
+    variant="primary"
+    :type="onClick ? 'button' : 'submit'"
+    v-on="onClick ? { click: () => emit('click') } : {}"
+  >
+    <slot />
+  </VtsOverlayButton>
+</template>
+
+<script lang="ts" setup>
+import VtsOverlayButton from '@core/components/overlay/VtsOverlayButton.vue'
+
+const { onClick } = defineProps<{
+  onClick?: () => void
+}>()
+
+const emit = defineEmits<{
+  click: []
+}>()
+
+defineSlots<{
+  default(): any
+}>()
+</script>

--- a/@xen-orchestra/web-core/lib/components/overlay/VtsOverlayList.vue
+++ b/@xen-orchestra/web-core/lib/components/overlay/VtsOverlayList.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="vts-overlay-list">
+    <Transition name="fade">
+      <div v-if="overlayStore.overlays.length > 0" class="backdrop" />
+    </Transition>
+
+    <TransitionGroup tag="div" name="overlay" class="overlays">
+      <OverlayComponent
+        v-for="overlay of overlayStore.overlays"
+        :key="overlay.key"
+        class="overlay"
+        :overlay
+        :class="{ dimmed: !overlayStore.isCurrent(overlay.key) }"
+      />
+    </TransitionGroup>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import OverlayComponent from '@core/packages/overlay/OverlayComponent.vue'
+import { useOverlayStore } from '@core/packages/overlay/use-overlay-store.ts'
+
+const overlayStore = useOverlayStore()
+</script>
+
+<style lang="postcss" scoped>
+.vts-overlay-list {
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 1011;
+    background-color: var(--color-opacity-primary);
+    pointer-events: none;
+
+    &.fade-enter-active,
+    &.fade-leave-active {
+      transition: opacity 0.3s ease;
+    }
+
+    &.fade-enter-from,
+    &.fade-leave-to {
+      opacity: 0;
+    }
+  }
+
+  .overlays {
+    position: fixed;
+    inset: 0;
+    z-index: 1012;
+
+    /* The container only positions the stacked modals; each modal catches its own
+       clicks, so an empty container must let clicks through. */
+    pointer-events: none;
+
+    .overlay {
+      pointer-events: auto;
+      transition:
+        opacity 0.3s ease,
+        transform 0.3s ease,
+        filter 0.3s ease;
+
+      &.dimmed {
+        filter: brightness(0.8);
+      }
+
+      &.overlay-enter-from.ui-modal,
+      &.overlay-leave-to.ui-modal {
+        opacity: 0;
+      }
+
+      &.overlay-enter-from.ui-drawer,
+      &.overlay-leave-to.ui-drawer {
+        transform: translateX(100%);
+
+        &:dir(rtl) {
+          transform: translateX(-100%);
+        }
+      }
+    }
+  }
+}
+</style>

--- a/@xen-orchestra/web-core/lib/packages/overlay/OverlayComponent.vue
+++ b/@xen-orchestra/web-core/lib/packages/overlay/OverlayComponent.vue
@@ -1,0 +1,22 @@
+<template>
+  <component :is="overlay.component" v-bind="overlay.props" />
+</template>
+
+<script lang="ts" setup>
+import { IK_OVERLAY_KEY } from '@core/packages/overlay/injection-keys'
+import type { Overlay } from '@core/packages/overlay/types'
+import { computed, provide } from 'vue'
+
+const { overlay } = defineProps<{
+  overlay: Overlay
+}>()
+
+defineSlots<{
+  default(): true
+}>()
+
+provide(
+  IK_OVERLAY_KEY,
+  computed(() => overlay.key)
+)
+</script>

--- a/@xen-orchestra/web-core/lib/packages/overlay/OverlayComponent.vue
+++ b/@xen-orchestra/web-core/lib/packages/overlay/OverlayComponent.vue
@@ -3,16 +3,12 @@
 </template>
 
 <script lang="ts" setup>
-import { IK_OVERLAY_KEY } from '@core/packages/overlay/injection-keys'
-import type { Overlay } from '@core/packages/overlay/types'
+import { IK_OVERLAY_KEY } from '@core/packages/overlay/injection-keys.ts'
+import type { Overlay } from '@core/packages/overlay/types.ts'
 import { computed, provide } from 'vue'
 
 const { overlay } = defineProps<{
   overlay: Overlay
-}>()
-
-defineSlots<{
-  default(): true
 }>()
 
 provide(

--- a/@xen-orchestra/web-core/lib/packages/overlay/README.md
+++ b/@xen-orchestra/web-core/lib/packages/overlay/README.md
@@ -1,0 +1,285 @@
+# Overlay
+
+Promise-based overlays (modals, drawers…) for Vue.
+
+You define an overlay from any component, open it, and `await` the user's decision.
+
+`useOverlay` takes a component-loader and the list of its events you want to handle. Events are identified by their handler prop name (`onYes` for a `yes` emit), and the keys are type-checked against the component's actual emits. In the following example, the overlay will automatically close when `ConfirmModal` emits `yes` or `no`:
+
+```ts
+const { open } = useOverlay({
+  component: () => import('path/to/ConfirmModal.vue'),
+  events: {
+    onYes: true,
+    onNo: true,
+  },
+})
+
+async function showConfirmation() {
+  const { event } = await open()
+
+  // At this point, the user has made a decision and the overlay is closed
+
+  if (event === 'onYes') {
+    // The user confirmed
+  }
+}
+```
+
+The promise resolves with `{ event, payload }` (see below) when the user makes a decision, and the overlay closes automatically.
+
+`true` is a shorthand for "when this event is emitted, close the overlay". The response payload is then `undefined`.
+
+## Passing props
+
+If the component has props, pass them to `open()`. They are fully type-checked, and `open()` won't compile without them if any prop is required:
+
+```ts
+const { open } = useOverlay({
+  component: () => import('path/to/VmConfirmModal.vue'),
+  events: {
+    onConfirm: true,
+    onCancel: true,
+  },
+})
+
+async function showConfirmation() {
+  const { event } = await open({
+    props: {
+      message: 'Are you sure you want to do this?',
+    },
+  })
+}
+```
+
+Props are passed as-is and captured when the overlay opens. To keep an overlay in sync with live data, pass a `reactive()` object containing computeds — or better, use `reactiveComputed` from VueUse:
+
+```ts
+const props = reactiveComputed(() => ({
+  message: `${selectedItems.value.length} items will be deleted`,
+}))
+
+async function showDeleteConfirmation() {
+  const { event } = await open({ props })
+}
+```
+
+## Custom handlers and payloads
+
+Instead of `true`, an event can have a handler. It receives the event's emit arguments, and whatever it returns (awaited) becomes the response payload:
+
+```ts
+const { open: openRenameModal } = useOverlay({
+  component: () => import('path/to/RenameModal.vue'),
+  events: {
+    onSubmit: (newName: string) => newName.trim(),
+    onCancel: true,
+  },
+})
+
+async function renameItem() {
+  const response = await openRenameModal()
+
+  if (response.event === 'onSubmit') {
+    response.payload // ← string (trimmed newName)
+  }
+}
+```
+
+The response is a discriminated union: narrowing on `response.event` narrows the type of `response.payload` accordingly.
+
+Handlers can be async. The overlay stays open (and is marked as busy, see below) while the handler runs, then closes when it resolves:
+
+```ts
+events: {
+  onSubmit: async (newName: string) => {
+    await api.rename(newName)
+  },
+  onCancel: true,
+}
+```
+
+While a handler is running, any further event is ignored: a double-click, or a click on Cancel during a save, does nothing.
+
+## Keeping the overlay open with `KEEP_OVERLAY_OPEN`
+
+Sometimes handling an event should _not_ close the overlay — a validation failure, a failed API call. Return `KEEP_OVERLAY_OPEN` for that:
+
+```ts
+const { open } = useOverlay({
+  component: () => import('path/to/RenameModal.vue'),
+  events: {
+    onSubmit: async (newName: string) => {
+      try {
+        await api.rename(newName)
+      } catch {
+        notify('Failed to rename')
+
+        return KEEP_OVERLAY_OPEN
+      }
+    },
+    onCancel: true,
+  },
+})
+```
+
+The overlay stays open, the promise stays pending, and the user can try again. `KEEP_OVERLAY_OPEN` is automatically excluded from the payload type.
+
+## Per-call handlers
+
+`open()` also accepts `events`. A per-call handler for an event that already has a `useOverlay` handler runs _after_ it: the per-call handler receives the payload the `useOverlay` handler produced, and returns the final payload (or `KEEP_OVERLAY_OPEN`):
+
+```ts
+const { open } = useOverlay({
+  component: () => import('path/to/RenameModal.vue'),
+  events: {
+    onSubmit: (newName: string) => newName.trim(),
+    onCancel: true,
+  },
+})
+
+async function renameItem(id: string) {
+  await open({
+    events: {
+      onSubmit: async newName => {
+        const success = await api.rename(id, newName)
+
+        if (!success) {
+          notify('Failed to rename')
+
+          return KEEP_OVERLAY_OPEN
+        }
+
+        return newName
+      },
+    },
+  })
+}
+```
+
+This is what makes composition work: the composable defining the overlay handles the generic part (extracting and cleaning the value), while each call site decides what to do with it.
+
+An event that is _not_ declared in `useOverlay` can also be handled at open time. Its handler then receives the raw emit arguments directly, and the event is added to the response union for that call.
+
+## Aborted overlays
+
+An overlay can be torn down without a user decision:
+
+- the component that created it (where `useOverlay` was called) is unmounted (its scope is disposed),
+- or `open()` is called again on the same `useOverlay` instance while the overlay is still open (the previous one is replaced).
+
+In both cases the promise resolves with `OVERLAY_ABORT_EVENT` (a symbol) as its `event`, and no handler runs:
+
+```ts
+const response = await open()
+
+if (response.event === OVERLAY_ABORT_EVENT) {
+  return
+}
+```
+
+The `OVERLAY_ABORT_EVENT` case is always part of the response union, so exhaustive `event` checks will remind you it exists.
+
+## Busy and disabled triggers
+
+Inside the overlay component, use `useOverlayTrigger()` to wire the controls that emit events (buttons, typically) to the overlay's state:
+
+```html
+<template>
+  <SomeModal @confirm="emit('submit')">
+    <div class="content">
+      <slot />
+    </div>
+    <div class="buttons">
+      <button type="submit" :disabled="isDisabled" @click="trigger">
+        <span v-if="isBusy">Saving...</span>
+        <span v-else>Save</span>
+      </button>
+    </div>
+  </SomeModal>
+</template>
+
+<script lang="ts" setup>
+  const emit = defineEmits<{
+    submit: []
+  }>()
+
+  const { isBusy, isDisabled, trigger } = useOverlayTrigger()
+</script>
+```
+
+- `isDisabled` is `true` while the overlay is handling an event — use it to disable every control.
+- `isBusy` is `true` while an async handler is running _and_ this trigger initiated it — use it to show a spinner on the right control only. For that, call `trigger()` when the control is activated, so the trigger identifies itself before the event is handled.
+
+Each `useOverlayTrigger()` call creates a distinct trigger, so two buttons never show a spinner at the same time. It works from any component rendered inside an overlay, at any depth, and is inert when the component is not rendered in an overlay.
+
+## Escape key
+
+`useOverlayEscape(handler)` calls the handler when Escape is pressed, but only while the calling component is the current (topmost) overlay and is not already handling an event. The handler is expected to emit the component's own close event, so that Escape goes through the exact same pipeline as a pointer interaction:
+
+```ts
+useOverlayEscape(() => emit('dismiss'))
+```
+
+Like `useOverlayTrigger()`, it works from any component rendered inside an overlay, and does nothing when the component is not rendered in an overlay.
+
+## Composition: building your own composable
+
+`useOverlay` is designed to be wrapped in small, domain-specific composables:
+
+```ts
+// use-user-delete-modal.ts
+export function useUserDeleteModal() {
+  return useOverlay({
+    component: () => import('path/to/UserDeleteModal.vue'),
+    events: {
+      onConfirm: true,
+      onCancel: true,
+    },
+  })
+}
+
+// use-user-delete.ts
+export function useUserDelete() {
+  const { open } = useUserDeleteModal()
+
+  async function deleteUser(user: User) {
+    await open({
+      events: {
+        onConfirm: () => api.deleteUser(user.id),
+      },
+      props: { name: user.name },
+    })
+  }
+
+  return { deleteUser }
+}
+```
+
+Call sites stay trivial:
+
+```html
+<template>
+  <button @click="deleteUser(user)">Delete</button>
+</template>
+
+<script lang="ts" setup>
+  const { deleteUser } = useUserDelete()
+</script>
+```
+
+## Rendering the overlays
+
+Opened overlays live in a Pinia store (`useOverlayStore`). The app must render them once, near the root, with `OverlayComponent`:
+
+```html
+<template>
+  <OverlayComponent v-for="overlay of overlayStore.overlays" :key="overlay.key" :overlay />
+</template>
+
+<script lang="ts" setup>
+  const overlayStore = useOverlayStore()
+</script>
+```
+
+Styling and animations are up to you. The store also exposes `isCurrent(key)` to style stacked overlays (e.g. dim the ones below the topmost), and each `overlay` carries its current `status`.

--- a/@xen-orchestra/web-core/lib/packages/overlay/create-event-handler.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/create-event-handler.ts
@@ -1,0 +1,80 @@
+import { isThenable } from '@core/packages/overlay/is-thenable'
+import { KEEP_OVERLAY_OPEN } from '@core/packages/overlay/symbols'
+import type { Overlay, OverlayEventHandler, OverlayResponse } from '@core/packages/overlay/types'
+import { nextTick } from 'vue'
+
+export function createEventHandler({
+  overlay,
+  definitionEvents,
+  openEvents,
+  settle,
+}: {
+  overlay: Overlay
+  definitionEvents: Record<string, true | OverlayEventHandler>
+  openEvents: Record<string, OverlayEventHandler>
+  settle: (response: OverlayResponse<PropertyKey, unknown>) => void
+}) {
+  const shouldStop = (payload: unknown) => payload === KEEP_OVERLAY_OPEN || overlay.status === 'settled'
+
+  const runHandler = async (handler: OverlayEventHandler, handlerArgs: unknown[]) => {
+    const result = handler(...handlerArgs)
+
+    if (isThenable(result)) {
+      overlay.status = 'busy'
+    }
+
+    return await result
+  }
+
+  return async function handleEvent(eventName: string, emitArgs: unknown[]) {
+    if (overlay.status !== 'idle') {
+      return
+    }
+
+    try {
+      overlay.status = 'locked'
+
+      // The definition handler receives the raw emit arguments, then the open
+      // handler receives the payload it produced. An event handled at open
+      // time only receives the raw emit arguments directly.
+      let handlerArgs = emitArgs
+      let payload: unknown
+
+      const definitionHandler = definitionEvents[eventName]
+
+      if (definitionHandler !== undefined) {
+        payload = definitionHandler === true ? undefined : await runHandler(definitionHandler, handlerArgs)
+
+        if (shouldStop(payload)) {
+          return
+        }
+
+        handlerArgs = [payload]
+      }
+
+      const openHandler = openEvents[eventName]
+
+      if (openHandler !== undefined) {
+        payload = await runHandler(openHandler, handlerArgs)
+
+        if (shouldStop(payload)) {
+          return
+        }
+      }
+
+      overlay.status = 'settled'
+
+      // The leave transition freezes the DOM in its last painted state,
+      // so paint a non-busy frame before removing the overlay
+      await nextTick()
+
+      settle({ event: eventName, payload })
+    } finally {
+      if (overlay.status !== 'settled') {
+        overlay.status = 'idle'
+      }
+
+      overlay.lastTrigger = undefined
+    }
+  }
+}

--- a/@xen-orchestra/web-core/lib/packages/overlay/create-event-handler.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/create-event-handler.ts
@@ -1,6 +1,6 @@
-import { isThenable } from '@core/packages/overlay/is-thenable'
-import { KEEP_OVERLAY_OPEN } from '@core/packages/overlay/symbols'
-import type { Overlay, OverlayEventHandler, OverlayResponse } from '@core/packages/overlay/types'
+import { isThenable } from '@core/packages/overlay/is-thenable.ts'
+import { KEEP_OVERLAY_OPEN } from '@core/packages/overlay/symbols.ts'
+import type { Overlay, OverlayEventHandler, OverlayResponse } from '@core/packages/overlay/types.ts'
 import { nextTick } from 'vue'
 
 export function createEventHandler({

--- a/@xen-orchestra/web-core/lib/packages/overlay/injection-keys.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/injection-keys.ts
@@ -1,0 +1,3 @@
+import type { ComputedRef, InjectionKey } from 'vue'
+
+export const IK_OVERLAY_KEY = Symbol('IK_OVERLAY_KEY') as InjectionKey<ComputedRef<symbol>>

--- a/@xen-orchestra/web-core/lib/packages/overlay/is-thenable.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/is-thenable.ts
@@ -1,0 +1,3 @@
+export function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return typeof (value as PromiseLike<unknown> | undefined)?.then === 'function'
+}

--- a/@xen-orchestra/web-core/lib/packages/overlay/symbols.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/symbols.ts
@@ -1,0 +1,5 @@
+/** Returned from an event handler to keep the overlay open (e.g. after a validation failure) */
+export const KEEP_OVERLAY_OPEN = Symbol('keep overlay open')
+
+/** `event` of the response resolved when an overlay is torn down without a user decision (e.g. the opener's scope was disposed) */
+export const OVERLAY_ABORT_EVENT = Symbol('overlay aborted')

--- a/@xen-orchestra/web-core/lib/packages/overlay/types.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/types.ts
@@ -1,4 +1,4 @@
-import type { KEEP_OVERLAY_OPEN, OVERLAY_ABORT_EVENT } from '@core/packages/overlay/symbols'
+import type { KEEP_OVERLAY_OPEN, OVERLAY_ABORT_EVENT } from '@core/packages/overlay/symbols.ts'
 import type { Component } from 'vue'
 import type { ComponentProps } from 'vue-component-type-helpers'
 

--- a/@xen-orchestra/web-core/lib/packages/overlay/types.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/types.ts
@@ -1,0 +1,94 @@
+import type { KEEP_OVERLAY_OPEN, OVERLAY_ABORT_EVENT } from '@core/packages/overlay/symbols'
+import type { Component } from 'vue'
+import type { ComponentProps } from 'vue-component-type-helpers'
+
+export type Prettify<T> = T extends infer R ? { [K in keyof R]: R[K] } & NonNullable<unknown> : never
+
+export type OverlayEvents<TComponent extends Component> = {
+  [TKey in ComponentEmitName<TComponent>]?:
+    | true
+    | ((...args: ExtractHandlerArgs<ComponentProps<TComponent>[TKey]>) => unknown)
+}
+
+// Generic inference skips excess property checks, so unknown event keys are
+// forced to `never` to be rejected at the call site
+export type ForbidExtraEvents<TComponent extends Component, TEvents> = Record<
+  Exclude<keyof TEvents, ComponentEmitName<TComponent>>,
+  never
+>
+
+export type OpenEvents<TComponent extends Component, TEvents extends OverlayEvents<TComponent>> = {
+  [TKey in ComponentEmitName<TComponent>]?: TKey extends keyof TEvents
+    ? (payload: ExtractHandlerPayload<TEvents[TKey]>) => unknown
+    : ComponentProps<TComponent>[TKey]
+}
+
+export type ResolvedPayload<TValue> = Exclude<Awaited<TValue>, typeof KEEP_OVERLAY_OPEN>
+
+export type ExtractHandlerPayload<THandler> = THandler extends (...args: never) => infer TReturn
+  ? ResolvedPayload<TReturn>
+  : THandler extends true
+    ? undefined
+    : never
+
+export type ExtractOverlayResponse<
+  TComponent extends Component,
+  TEvents extends OverlayEvents<TComponent>,
+  TOpenEvents extends OpenEvents<TComponent, TEvents>,
+> =
+  | Prettify<
+      {
+        [TKey in RequiredKeys<TOpenEvents>]: OverlayResponse<
+          TKey,
+          ExtractHandlerPayload<TOpenEvents[TKey & keyof TOpenEvents]>
+        >
+      }[RequiredKeys<TOpenEvents>]
+    >
+  | Prettify<
+      {
+        [TKey in Exclude<keyof TEvents, RequiredKeys<TOpenEvents>>]: OverlayResponse<
+          TKey,
+          ExtractHandlerPayload<TEvents[TKey]>
+        >
+      }[Exclude<keyof TEvents, RequiredKeys<TOpenEvents>>]
+    >
+  | OverlayResponse<typeof OVERLAY_ABORT_EVENT, undefined>
+
+export type OverlayStatus = 'idle' | 'locked' | 'busy' | 'settled'
+
+export interface Overlay {
+  key: symbol
+  component: Component
+  props: Record<string, unknown>
+  status: OverlayStatus
+  lastTrigger: symbol | undefined
+}
+
+export type ExtractEventName<TName> = TName extends `onVnode${string}`
+  ? never
+  : TName extends `on${Capitalize<string>}`
+    ? TName
+    : never
+
+export type ExtractHandlerArgs<THandler> = THandler extends (...args: infer TArgs) => unknown ? TArgs : never
+
+export type ComponentEmitName<TComponent extends Component> = ExtractEventName<
+  keyof Required<ComponentProps<TComponent>>
+>
+
+export type RequiredKeys<TObject> = {
+  [TKey in keyof TObject]-?: NonNullable<unknown> extends Pick<TObject, TKey> ? never : TKey
+}[keyof TObject]
+
+export type OverlayEventHandler = (...args: unknown[]) => unknown
+
+export interface OverlayResponse<TEvent extends PropertyKey, TPayload> {
+  event: TEvent
+  payload: TPayload
+}
+
+export type MaybeOptionalArgs<TObject extends object> =
+  Partial<TObject> extends TObject ? [arg?: TObject] : [arg: TObject]
+
+export type MaybeOptionalKey<TKey extends PropertyKey, TObject extends object> =
+  Partial<TObject> extends TObject ? { [P in TKey]?: TObject } : { [P in TKey]: TObject }

--- a/@xen-orchestra/web-core/lib/packages/overlay/use-overlay-escape.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/use-overlay-escape.ts
@@ -1,5 +1,5 @@
-import { IK_OVERLAY_KEY } from '@core/packages/overlay/injection-keys'
-import { useOverlayStore } from '@core/packages/overlay/use-overlay-store'
+import { IK_OVERLAY_KEY } from '@core/packages/overlay/injection-keys.ts'
+import { useOverlayStore } from '@core/packages/overlay/use-overlay-store.ts'
 import { onKeyStroke } from '@vueuse/core'
 import { inject } from 'vue'
 

--- a/@xen-orchestra/web-core/lib/packages/overlay/use-overlay-escape.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/use-overlay-escape.ts
@@ -1,0 +1,34 @@
+import { IK_OVERLAY_KEY } from '@core/packages/overlay/injection-keys'
+import { useOverlayStore } from '@core/packages/overlay/use-overlay-store'
+import { onKeyStroke } from '@vueuse/core'
+import { inject } from 'vue'
+
+/**
+ * Calls the handler when Escape is pressed while the calling component is the
+ * current (topmost) overlay and is not busy. The handler is expected to emit
+ * the component's own close event, so that Escape goes through the exact same
+ * pipeline as a pointer interaction.
+ */
+export function useOverlayEscape(handler: () => void) {
+  const overlayKey = inject(IK_OVERLAY_KEY, undefined)
+
+  if (overlayKey === undefined) {
+    return
+  }
+
+  const overlayStore = useOverlayStore()
+
+  onKeyStroke('Escape', () => {
+    if (!overlayStore.isCurrent(overlayKey.value)) {
+      return
+    }
+
+    const overlay = overlayStore.get(overlayKey.value)
+
+    if (overlay?.status !== 'idle') {
+      return
+    }
+
+    handler()
+  })
+}

--- a/@xen-orchestra/web-core/lib/packages/overlay/use-overlay-store.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/use-overlay-store.ts
@@ -1,0 +1,33 @@
+import type { Overlay } from '@core/packages/overlay/types'
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+export const useOverlayStore = defineStore('overlay', () => {
+  const registry = ref(new Map<symbol, Overlay>())
+
+  function register(overlay: Overlay) {
+    registry.value.set(overlay.key, overlay)
+  }
+
+  function unregister(overlay: Overlay) {
+    if (registry.value.get(overlay.key) === overlay) {
+      registry.value.delete(overlay.key)
+    }
+  }
+
+  function isCurrent(key: symbol): boolean {
+    return Array.from(registry.value.keys()).at(-1) === key
+  }
+
+  function get(key: symbol): Overlay | undefined {
+    return registry.value.get(key)
+  }
+
+  return {
+    overlays: computed(() => Array.from(registry.value.values())),
+    register,
+    unregister,
+    isCurrent,
+    get,
+  }
+})

--- a/@xen-orchestra/web-core/lib/packages/overlay/use-overlay-store.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/use-overlay-store.ts
@@ -1,4 +1,4 @@
-import type { Overlay } from '@core/packages/overlay/types'
+import type { Overlay } from '@core/packages/overlay/types.ts'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 

--- a/@xen-orchestra/web-core/lib/packages/overlay/use-overlay-trigger.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/use-overlay-trigger.ts
@@ -1,0 +1,33 @@
+import { IK_OVERLAY_KEY } from '@core/packages/overlay/injection-keys'
+import { useOverlayStore } from '@core/packages/overlay/use-overlay-store'
+import { computed, inject } from 'vue'
+
+export function useOverlayTrigger() {
+  const overlayKey = inject(IK_OVERLAY_KEY, undefined)
+
+  const triggerKey = Symbol('overlay trigger')
+
+  const overlayStore = useOverlayStore()
+
+  const overlay = computed(() => {
+    if (overlayKey === undefined) {
+      return undefined
+    }
+
+    return overlayStore.get(overlayKey.value)
+  })
+
+  const status = computed(() => overlay.value?.status ?? 'idle')
+
+  const isBusy = computed(() => overlay.value?.lastTrigger === triggerKey && status.value === 'busy')
+
+  const isDisabled = computed(() => status.value !== 'idle')
+
+  function trigger() {
+    if (overlay.value) {
+      overlay.value.lastTrigger = triggerKey
+    }
+  }
+
+  return { isBusy, isDisabled, trigger }
+}

--- a/@xen-orchestra/web-core/lib/packages/overlay/use-overlay-trigger.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/use-overlay-trigger.ts
@@ -1,5 +1,5 @@
-import { IK_OVERLAY_KEY } from '@core/packages/overlay/injection-keys'
-import { useOverlayStore } from '@core/packages/overlay/use-overlay-store'
+import { IK_OVERLAY_KEY } from '@core/packages/overlay/injection-keys.ts'
+import { useOverlayStore } from '@core/packages/overlay/use-overlay-store.ts'
 import { computed, inject } from 'vue'
 
 export function useOverlayTrigger() {

--- a/@xen-orchestra/web-core/lib/packages/overlay/use-overlay.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/use-overlay.ts
@@ -1,5 +1,5 @@
-import { createEventHandler } from '@core/packages/overlay/create-event-handler'
-import { OVERLAY_ABORT_EVENT } from '@core/packages/overlay/symbols'
+import { createEventHandler } from '@core/packages/overlay/create-event-handler.ts'
+import { OVERLAY_ABORT_EVENT } from '@core/packages/overlay/symbols.ts'
 import type {
   ExtractOverlayResponse,
   ForbidExtraEvents,
@@ -10,8 +10,8 @@ import type {
   OverlayEventHandler,
   OverlayEvents,
   Prettify,
-} from '@core/packages/overlay/types'
-import { useOverlayStore } from '@core/packages/overlay/use-overlay-store'
+} from '@core/packages/overlay/types.ts'
+import { useOverlayStore } from '@core/packages/overlay/use-overlay-store.ts'
 import { reactiveComputed } from '@vueuse/core'
 import { defineAsyncComponent, markRaw, onScopeDispose, reactive, type AsyncComponentLoader, type Component } from 'vue'
 import type { ComponentProps } from 'vue-component-type-helpers'

--- a/@xen-orchestra/web-core/lib/packages/overlay/use-overlay.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/use-overlay.ts
@@ -1,0 +1,99 @@
+import { createEventHandler } from '@core/packages/overlay/create-event-handler'
+import { OVERLAY_ABORT_EVENT } from '@core/packages/overlay/symbols'
+import type {
+  ExtractOverlayResponse,
+  ForbidExtraEvents,
+  MaybeOptionalArgs,
+  MaybeOptionalKey,
+  OpenEvents,
+  Overlay,
+  OverlayEventHandler,
+  OverlayEvents,
+  Prettify,
+} from '@core/packages/overlay/types'
+import { useOverlayStore } from '@core/packages/overlay/use-overlay-store'
+import { reactiveComputed } from '@vueuse/core'
+import { defineAsyncComponent, markRaw, onScopeDispose, reactive, type AsyncComponentLoader, type Component } from 'vue'
+import type { ComponentProps } from 'vue-component-type-helpers'
+
+export function useOverlay<TComponent extends Component, const TEvents extends OverlayEvents<TComponent>>({
+  component: componentLoader,
+  events,
+}: {
+  component: AsyncComponentLoader<TComponent>
+  events: TEvents & NoInfer<ForbidExtraEvents<TComponent, TEvents>>
+}) {
+  const overlayStore = useOverlayStore()
+
+  const key = Symbol('new-overlay')
+
+  const component = defineAsyncComponent(componentLoader)
+
+  let abortCurrent: (() => void) | undefined
+
+  onScopeDispose(() => abortCurrent?.(), true)
+
+  function open<TOpenEvents extends OpenEvents<TComponent, TEvents>>(
+    ...args: MaybeOptionalArgs<
+      Prettify<
+        { events?: TOpenEvents & NoInfer<ForbidExtraEvents<TComponent, TOpenEvents>> } & MaybeOptionalKey<
+          'props',
+          ComponentProps<TComponent>
+        >
+      >
+    >
+  ) {
+    const { events: openEvents, props } = args[0] ?? {}
+
+    // Reopening while the previous overlay is still open replaces it
+    abortCurrent?.()
+
+    return new Promise<ExtractOverlayResponse<TComponent, TEvents, TOpenEvents>>(resolve => {
+      const definitionEvents = events as Record<string, true | OverlayEventHandler>
+      const perOpenEvents = (openEvents ?? {}) as Record<string, OverlayEventHandler>
+
+      // A new object per `open()` call, so that a pending async handler of a
+      // replaced overlay cannot interfere with the one currently displayed
+      const overlay = reactive<Overlay>({
+        key,
+        component: markRaw(component),
+        props: {},
+        status: 'idle',
+        lastTrigger: undefined,
+      })
+
+      function settle(response: ExtractOverlayResponse<TComponent, TEvents, TOpenEvents>) {
+        overlay.status = 'settled'
+        abortCurrent = undefined
+        resolve(response)
+        overlayStore.unregister(overlay)
+      }
+
+      abortCurrent = () => settle({ event: OVERLAY_ABORT_EVENT, payload: undefined })
+
+      const handleEvent = createEventHandler({
+        overlay,
+        definitionEvents,
+        openEvents: perOpenEvents,
+        settle: response => settle(response as ExtractOverlayResponse<TComponent, TEvents, TOpenEvents>),
+      })
+
+      // Merge all props + events. If an event is provided in both, the `events`
+      // handler runs first, then the `openEvents` one, if needed.
+      const eventProps: Record<string, OverlayEventHandler> = {}
+
+      const eventNames = new Set([...Object.keys(definitionEvents), ...Object.keys(perOpenEvents)])
+
+      eventNames.forEach(eventName => {
+        eventProps[eventName] = (...emitArgs: unknown[]) => handleEvent(eventName, emitArgs)
+      })
+
+      // `reactiveComputed` keeps the merged props live when a reactive `props` object is passed
+      overlay.props = reactiveComputed(() => ({ ...(props as Record<string, unknown> | undefined), ...eventProps }))
+
+      overlayStore.register(overlay)
+    })
+  }
+
+  return { open }
+}

--- a/@xen-orchestra/web-core/lib/utils/injection-keys.util.ts
+++ b/@xen-orchestra/web-core/lib/utils/injection-keys.util.ts
@@ -24,3 +24,5 @@ export const IK_DISABLED = Symbol('IK_DISABLED') as InjectionKey<ComputedRef<boo
 export const IK_INPUT_WRAPPER_CONTROLLER = Symbol('IK_INPUT_WRAPPER_CONTROLLER') as InjectionKey<InputWrapperController>
 
 export const IK_MODAL_ACCENT = Symbol('IK_MODAL_ACCENT') as InjectionKey<ComputedRef<ModalAccent>>
+
+export const IK_OVERLAY_ACCENT = Symbol('IK_OVERLAY_ACCENT') as InjectionKey<ComputedRef<ModalAccent>>

--- a/@xen-orchestra/web-core/lib/utils/injection-keys.util.ts
+++ b/@xen-orchestra/web-core/lib/utils/injection-keys.util.ts
@@ -1,6 +1,6 @@
 import type { InputWrapperController } from '@core/components/input-wrapper/VtsInputWrapper.vue'
 import type { ModalAccent } from '@core/components/ui/modal/UiModal.vue'
-import type { ValueFormatter } from '@core/types/chart'
+import type { ValueFormatter } from '@core/types/chart.ts'
 import type { ComputedRef, InjectionKey, Ref } from 'vue'
 
 export const IK_CHART_VALUE_FORMATTER = Symbol('IK_CHART_VALUE_FORMATTER') as InjectionKey<ComputedRef<ValueFormatter>>

--- a/@xen-orchestra/web-core/package.json
+++ b/@xen-orchestra/web-core/package.json
@@ -34,6 +34,7 @@
     "ndjson-readablestream": "^1.3.0",
     "placement.js": "^1.0.0-beta.5",
     "simple-icons": "^14.14.0",
+    "vue-component-type-helpers": "~3.3.7",
     "vue-echarts": "^6.6.8",
     "vue-virtual-scroller": "^2.0.0-beta.8"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -19698,6 +19698,11 @@ vscode-uri@^3.0.8:
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.1.0.tgz#dd09ec5a66a38b5c3fffc774015713496d14e09c"
   integrity sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==
 
+vue-component-type-helpers@~3.3.7:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/vue-component-type-helpers/-/vue-component-type-helpers-3.3.7.tgz#98f2a53901c3883a674bbc063f74c51a97eb7057"
+  integrity sha512-Skkhw9agYSgsWqv7bxSOGJZa9SaiJbZVGdXuFWnrzKaQYHnw9qbjD630rw6RyMqDbp54nfLCLw5SZA55if7JLg==
+
 vue-demi@>=0.13.0:
   version "0.14.10"
   resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.10.tgz#afc78de3d6f9e11bf78c55e8510ee12814522f04"


### PR DESCRIPTION
### Description

`web-core` currently ships two packages, `packages/modal` and `packages/drawer`, that are almost line-for-line duplicates: same promise-based opener, same store, same config/response types — only the names differ. Every fix or improvement had to be made twice, and the two copies had already started to drift (e.g. error handling and route-change behavior differ between them).

Also, since each system has its own store and its own list component, when a drawer opens a modal, the modal is mounted below the drawer and is thus unusable.

This PR introduces a single **`packages/overlay`** system designed to replace both: a modal or a drawer is just a component rendered as an overlay, the open/await/close mechanics are identical. Migration of existing modals and drawers (and removal of the two old packages) will come in follow-up PRs.

#### Features

- **One `useOverlay()` composable** for any overlay type (modal, drawer, …): pass a component and the events you want to handle, get back `open()` and `abort()`.
- **Promise-based**: `open()` resolves with a `{ event, payload }` discriminated union once the user has made a decision — narrowing on `event` narrows `payload`.
- **Fully type-checked**: events are identified by their handler prop name (`onConfirm` for a `confirm` emit) and validated against the component's actual emits; `open()` requires the component's props (type-checked as well).
- **Event handlers**: each event maps either to `true` ("just close the overlay when this event is emitted") or to a custom (sync or async) handler; the handler receives the emit arguments and its return value becomes the typed payload. While an async handler runs, the overlay stays open and is marked busy.
- **`KEEP_OVERLAY_OPEN`**: a handler can return this symbol to keep the overlay open (validation failure, failed API call…) — the promise stays pending and the user can retry.
- **Per-call handlers**: `open()` accepts its own `events`, running after the `useOverlay` ones — the composable handles the generic part, each call site decides what to do with the result.
- **Automatic aborts**: the overlay is torn down (promise resolves with `OVERLAY_ABORT_EVENT`, no handler runs) when the creating scope is disposed, when `open()` is called again, or when `abort()` is called.
- **Helper composables**: `useOverlayTrigger()` (per-control `isBusy` / `isDisabled` state, so only the button that initiated an async handler shows a spinner) and `useOverlayEscape()` (Escape handling, only for the topmost, non-busy overlay — routed through the component's own close event).
- **One rendering point**: opened overlays live in a single Pinia store (`useOverlayStore`); the app renders them once with `VtsOverlayList`, which owns the shared backdrop, enter/leave transitions (fade for modals, slide for drawers) and dims every overlay below the topmost. Modals and drawers stack chronologically — a modal opened from a drawer appears on top of it.
- **UI building blocks**: `VtsOverlayList`, `VtsOverlayButton`, `VtsOverlayConfirmButton`, `VtsOverlayCancelButton`.
- Full documentation in `packages/overlay/README.md`.

#### Examples

Simple confirmation:

```ts
const { open } = useOverlay({
  component: ConfirmModal,
  events: {
    onYes: true,
    onNo: true,
  },
})

async function deleteVm() {
  const { event } = await open({
    props: { message: 'Are you sure you want to delete this VM?' },
  })

  if (event === 'onYes') {
    // The user confirmed, and the overlay is already closed
  }
}
```

Typed payload from an event handler:

```ts
const { open } = useOverlay({
  component: RenameModal,
  events: {
    onSubmit: (newName: string) => newName.trim(),
    onCancel: true,
  },
})

async function renameItem() {
  const response = await open()

  if (response.event === 'onSubmit') {
    response.payload // ← string (trimmed name)
  }
}
```


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
