### PR TITLE
feat(xo-server/rpu): assert each host can be evacuated right before its evacuation

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@
 - [XO6/VM] Group VM power actions in a new "Change state" submenu and isolate the Delete action (PR [#10036](https://github.com/vatesfr/xen-orchestra/pull/10036))
 - [OpenMetrics] Add an estimated per-VM power consumption metric (`xcp_vm_power_consumption_watts`), splitting each host's IPMI power across its running VMs proportionally to CPU load (PR [#10031](https://github.com/vatesfr/xen-orchestra/pull/10031))
 - [XO6/VM] Add possibility to export a VM (PR [#9989](https://github.com/vatesfr/xen-orchestra/pull/9989))
+- [Rolling Pool Update/Reboot] Re-check that each host can still be evacuated right before evacuating it, to fail early with an explicit error (PR [#10097](https://github.com/vatesfr/xen-orchestra/pull/10097))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/xapi/mixins/pool.mjs
+++ b/packages/xo-server/src/xapi/mixins/pool.mjs
@@ -64,7 +64,9 @@ const methods = {
       }
     }
 
-    await Promise.all(hosts.map(host => host.$call('assert_can_evacuate')))
+    await Promise.all(
+      hosts.filter(host => !ignoreHost || !ignoreHost(host)).map(host => host.$call('assert_can_evacuate'))
+    )
 
     // Steps in the RPR : Evacuate hosts, reboot hosts, migrate VMs back, and potentially updateHosts (beforeEvacuateVms and beforeRebootHost)
     const nSteps = 3 + Number(beforeEvacuateVms !== undefined) + Number(beforeRebootHost !== undefined)
@@ -127,6 +129,12 @@ const methods = {
             await this._waitObjectState(metricsRef, metrics => metrics.live)
 
             const getServerTime = async () => parseDateTime(await this.call('host.get_servertime', host.$ref)) * 1e3
+
+            // the pool state may have changed since the initial check, e.g. while evacuating the previous hosts
+            await Task.run({ properties: { name: `Check evacuation precondition`, hostId, hostName } }, async () => {
+              await host.$call('assert_can_evacuate')
+            })
+
             await Task.run({ properties: { name: `Evacuate`, hostId, hostName } }, async () => {
               await this.clearHost(host)
             })


### PR DESCRIPTION
### Description

During a Rolling Pool Update/Reboot, hosts are evacuated and rebooted sequentially (master first), but `assert_can_evacuate` was only called **once, before the first host**. Between host #1 and host #N the pool state may change (VMs started, memory pressure moved by previous evacuations, …): the failure was then only detected by the actual `host.evacuate`, **after** `host.disable` — late error, host left disabled to re-enable, message buried in the retry logic.

This PR re-validates evacuability of **each host right before evacuating it**, as a visible `Check evacuation precondition` subtask:

- fails **early**, before any side effect (`host.disable` not called yet, host stays enabled)
- surfaces the **native XAPI error** (`CANNOT_EVACUATE_HOST(VM_LACKS_FEATURE, …)`, `HOST_NOT_ENOUGH_FREE_MEMORY`, …) directly in the task tree
- placed **after** the `metrics.live` wait to avoid transient false positives right after the master reboot

Opportunistic fix included: the **initial** `assert_can_evacuate` check now skips hosts excluded by `ignoreHost` — an RPU no longer aborts upfront because of a host that was never going to be touched (e.g. no missing patches).

Note: `assert_can_evacuate` is advisory (TOCTOU) — it does not replace the existing error handling of the real evacuate, it precedes it. Abort-on-failure keeps the exact semantics of any throw in the loop (HA re-enabled via `$defer`).

https://project.vates.tech/vates-global/browse/XO-2705/

```mermaid
flowchart TD
    A["Rolling Pool Update / Reboot"] --> B["Initial check: assert_can_evacuate<br/>on all hosts — now skips ignored hosts"]
    B -- "failure" --> Z["Abort — nothing touched"]
    B -- "success" --> C["For each host (master first)"]
    C --> D["Wait for host metrics to be live"]
    D --> E["🆕 Subtask: Check evacuation precondition<br/>assert_can_evacuate on current host"]
    E -- "failure<br/>(pool state changed mid-RPU)" --> F["Abort BEFORE host.disable:<br/>host stays enabled,<br/>native XAPI error in the task tree"]
    E -- "success" --> G["Evacuate (host.disable + host.evacuate)"]
    G --> H["Install patches (RPU only)"]
    H --> I["Reboot + wait for host to be up"]
    I -- "next host" --> C
    C -- "all hosts done" --> J["Migrate VMs back"]

    style E fill:#1f6feb,color:#fff
    style F fill:#da3633,color:#fff
```

### QA (nested XCP-ng 8.2 pool, 2 hosts)

**Failure path** — RPR launched, then a tool-less HVM VM started on the slave *while the master was rebooting* (i.e. after the initial check passed):

```
REST API: rolling pool reboot [failure]
  Restarting hosts [failure]
    Restarting host <master> [success]
      Check evacuation precondition [success]   ← new subtask, happy path
      Evacuate → Restart → Waiting for host to be up [success]
    Restarting host <slave> [failure]
      Check evacuation precondition [failure]   ← early abort
        CANNOT_EVACUATE_HOST(VM_LACKS_FEATURE, OpaqueRef:…)
      (no Evacuate, no host.disable)
```

Slave still `enabled: true` after the abort ✅ — the full XAPI error (code, params, call) is in the subtask result ✅.

**Nominal path** — clean RPR on the same pool: both hosts pass their precondition subtask, full reboot cycle, task `success`.

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [ ] Reference the relevant issue (`See …` — internal ticket "[RPU] assert_can_evacuate must be called for all hosts at start and each")
- Changelog
  - [x] Changelog entries (Enhancements)
  - [x] "Packages to release" updated (`xo-server minor`)
- PR
  - [x] No UI changes (task subtask appears automatically in the task tree)
  - [x] Tested on a nested 2-host pool (failure + nominal paths)
