### PR TITLE
docs(backups): say that purge snapshot data still purges without NBD

### DIFF
--- a/docs/docs/xo5/incremental_backups.md
+++ b/docs/docs/xo5/incremental_backups.md
@@ -125,11 +125,7 @@ To prevent this:
 
 :::warning
 **Purge snapshot data** only takes effect when the backup is actually transferred over NBD.
-Enabling NBD on the backup job is a preference, not a guarantee: if NBD is not enabled on the
-network used to transfer the backups, the job uses the regular export path, the snapshot data
-is purged anyway, and every subsequent run is transferred as a full backup.
+Enabling NBD on the backup job is a preference, not a guarantee: if NBD is not enabled on the network used to transfer the backups, the job uses the regular export path, the snapshot data is purged anyway, and every subsequent run is transferred as a full backup.
 
-If your backups keep falling back to full, check the backup log to see whether NBD was actually
-used for the run, and that NBD is enabled on the transfer network (see
-[NBD-enabled Backups](#nbd-enabled-backups)), before trying the two steps above.
+If your backups keep falling back to full, check the backup log to see whether NBD was actually used for the run, and that NBD is enabled on the transfer network (see [NBD-enabled Backups](#nbd-enabled-backups)), before trying the two steps above.
 :::

--- a/docs/docs/xo5/incremental_backups.md
+++ b/docs/docs/xo5/incremental_backups.md
@@ -122,3 +122,14 @@ To prevent this:
 1. Migrate the disk to another storage. This will reset the disk state.
 2. Disable **purge snapshot data** on the backup.
 :::
+
+:::warning
+**Purge snapshot data** only takes effect when the backup is actually transferred over NBD.
+Enabling NBD on the backup job is a preference, not a guarantee: if NBD is not enabled on the
+network used to transfer the backups, the job uses the regular export path, the snapshot data
+is purged anyway, and every subsequent run is transferred as a full backup.
+
+If your backups keep falling back to full, check the backup log to see whether NBD was actually
+used for the run, and that NBD is enabled on the transfer network (see
+[NBD-enabled Backups](#nbd-enabled-backups)), before trying the two steps above.
+:::

--- a/docs/docs/xo5/incremental_backups.md
+++ b/docs/docs/xo5/incremental_backups.md
@@ -181,6 +181,8 @@ To prevent this:
 1. Migrate the disk to another storage. This will reset the disk state.
 2. Disable **purge snapshot data** on the backup.
 
+Neither step helps if NBD was never enabled on the transfer network. The purge is gated on the job's **Use NBD to transfer disk** preference, not on whether the transfer actually used NBD, so the snapshot data is destroyed even when the export falls back to the regular path, and every later run is full. Confirm in the backup log which path the run took.
+
 :::
 
 ## Understanding large deltas


### PR DESCRIPTION
### Description

The **Purge snapshot data (CBT)** section lists two fixes when every run transfers a full backup: migrate the disk, or disable purge. Neither one helps if NBD was never enabled on the transfer network.

`_AbstractXapi.mjs#_removeSnapshotData()` gates the purge on the job's `preferNbd` setting, not on whether the transfer actually used NBD. So the snapshot data gets destroyed even when the export falls back to the regular path, and every later run is full. The function's own comment says so:

> preferNbd is not a guarantee that the backup used NBD, depending on the network configuration, in that case next runs will be full, but there is not an easy way to prevent that

One paragraph, inside the existing warning.

It came up on the forum: https://xcp-ng.org/forum/topic/12347. The reporter tried both documented fixes and got nowhere before working it out himself.

I've rebased and cut this down since #10212 landed. That revamp already says NBD is required, that enabling it on the job isn't sufficient on its own, and that the backup log is where you confirm which path a run took. My original version repeated all three. What was left is the bit above: the purge happens anyway.

Documentation only, no behaviour change. I'm going from reading the runner rather than from working on it, so happy to reword if the framing is off.
