### PR TITLE
fix(CI): do not log "ENOENT" when unlink fails after check

### DIFF
--- a/packages/vhd-lib/tests/utils.js
+++ b/packages/vhd-lib/tests/utils.js
@@ -32,7 +32,9 @@ async function checkFile(vhdName) {
     try {
       await fsPromise.unlink(target)
     } catch (err) {
-      console.warn(err)
+      if (err.code !== 'ENOENT') {
+        console.warn(err)
+      }
     }
   }
 }

--- a/packages/vhd-lib/tests/utils.js
+++ b/packages/vhd-lib/tests/utils.js
@@ -73,7 +73,7 @@ exports.recoverRawContent = async function recoverRawContent(vhdName, rawName, o
 
 // @ todo how can I call vhd-cli copy from here
 async function convertToVhdDirectory(rawFileName, vhdFileName, path) {
-  fs.mkdirp(path)
+  await fs.mkdirp(path)
 
   const srcVhd = await fs.open(vhdFileName, 'r')
 
@@ -110,7 +110,7 @@ async function convertToVhdDirectory(rawFileName, vhdFileName, path) {
 exports.convertToVhdDirectory = convertToVhdDirectory
 
 exports.createRandomVhdDirectory = async function createRandomVhdDirectory(path, sizeMB) {
-  fs.mkdirp(path)
+  await fs.mkdirp(path)
   const rawFileName = `${path}/temp.raw`
   await createRandomFile(rawFileName, sizeMB)
   const vhdFileName = `${path}/temp.vhd`


### PR DESCRIPTION
### Description

Sometimes, CI fails because of this error:
```
# Error: ENOENT: no such file or directory, unlink '/tmp/tmp-6346-RBK7q3sLOi5L/vhdFile.vhd.qcow2'
#     at async Object.unlink (node:internal/fs/promises:1065:10)
#     at async checkFile (/home/runner/work/xen-orchestra/xen-orchestra/packages/vhd-lib/tests/utils.js:33:7)
#     at async /home/runner/work/xen-orchestra/xen-orchestra/packages/vhd-lib/tests/utils.integ.js:40:36
#     at async waitForActual (node:assert:644:5)
#     at async Function.rejects (node:assert:767:25)
#     at async TestContext.<anonymous> (/home/runner/work/xen-orchestra/xen-orchestra/packages/vhd-lib/tests/utils.integ.js:40:3)
#     at async Test.run (node:internal/test_runner/test:1054:7)
#     at async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3) {
#   errno: -2,
#   code: 'ENOENT',
#   syscall: 'unlink',
#   path: '/tmp/tmp-6346-RBK7q3sLOi5L/vhdFile.vhd.qcow2'
# }
```
It is not a real error but console.warn displaying the name "Error" which make the whole CI fail. Here I exclude ENOENT from being displayed but keep other errors visible. 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
