### PR TITLE
fix(xo-server): disable auto power on during rolling pool update/reboot

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,7 +36,7 @@
 - [Backups] Fix missing transfer size (PR [#10106](https://github.com/vatesfr/xen-orchestra/pull/10106))
 - [Host/dashboard] Switch CPU and RAM panels order to match Pool dashboard layout (PR [#10059](https://github.com/vatesfr/xen-orchestra/pull/10059))
 - [Plugins/Perf-alert] Update URL generation to support V6 routing (PR [#10054](https://github.com/vatesfr/xen-orchestra/pull/10054))
-
+- [Rolling Pool Update/Reboot] Temporarily disable VMs auto power on during the run: unexpected VM starts on rebooted hosts could break the remaining host evacuations (`HOST_NOT_ENOUGH_FREE_MEMORY`) (PR [#10104](https://github.com/vatesfr/xen-orchestra/pull/10104))
 
 ### Packages to release
 

--- a/packages/xo-server/src/xapi/mixins/pool.mjs
+++ b/packages/xo-server/src/xapi/mixins/pool.mjs
@@ -1,4 +1,5 @@
 import { cancelable, timeout } from 'promise-toolbox'
+import { createLogger } from '@xen-orchestra/log'
 import { decorateObject } from '@vates/decorate-with'
 import { defer as deferrable } from 'golike-defer'
 import { incorrectState } from 'xo-common/api-errors.js'
@@ -8,6 +9,8 @@ import { Task } from '@xen-orchestra/mixins/Tasks.mjs'
 import filter from 'lodash/filter.js'
 import groupBy from 'lodash/groupBy.js'
 import mapValues from 'lodash/mapValues.js'
+
+const log = createLogger('xo:xapi')
 
 const PATH_DB_DUMP = '/pool/xmldbdump'
 
@@ -38,6 +41,12 @@ const methods = {
       const haConfig = this.pool.ha_configuration
       await this.call('pool.disable_ha')
       $defer(() => this.call('pool.enable_ha', haSrs, haConfig))
+    }
+
+    if (this.pool.other_config.auto_poweron === 'true') {
+      log.info(`temporarily disabling auto power on during the rolling reboot of pool ${this.pool.uuid}`)
+      await this.pool.update_other_config('auto_poweron', 'false')
+      $defer(() => this.pool.update_other_config('auto_poweron', 'true'))
     }
 
     const hosts = filter(this.objects.all, { $type: 'host' })
@@ -272,5 +281,5 @@ const methods = {
 export default decorateObject(methods, {
   exportPoolMetadata: cancelable,
   importPoolMetadata: cancelable,
-  rollingPoolReboot: deferrable,
+  rollingPoolReboot: deferrable.onError(log.warn),
 })


### PR DESCRIPTION
### Description

During a rolling pool update/reboot, every host reboot triggers XCP-ng's
`xapi-autostart-vms` script (`xapi-domains.service`). When
`pool.other_config:auto_poweron=true`, that script starts every halted VM flagged
auto_poweron, pool-wide, a few seconds after the host is back up. Errors are swallowed
(`|| true`) and never retried. Two problems follow, both reproduced on a nested 8.2
pool and cross-checked in `xensource.log`:

- The VM lands on the freshly emptied host, right before the remaining evacuations. A
  run that passed the initial `assert_can_evacuate` can still fail mid-run with
  `CANNOT_EVACUATE_HOST(HOST_NOT_ENOUGH_FREE_MEMORY)`. Likely what hit
  https://xcp-ng.org/forum/topic/12348.
- The reverse: the start attempt itself can fail with `NO_HOSTS_AVAILABLE` while hosts
  are disabled/rebooting or their storage isn't ready yet. Customers relying on auto
  power on can find VMs still halted after a "successful" RPU.

The RPU already disables HA (#6057) and the load balancer (#6089) for the duration of
the run; auto power on was the remaining automatic actor. This PR applies the same
treatment in `rollingPoolReboot` (shared by RPR and RPU): turn the pool-level flag off
at the start, restore it in a `$defer` so it runs on success and failure. Deferred
restore failures (HA included) now go through the app logger via
`deferrable.onError(log.warn)`, same pattern as `setHostMultipathing`, instead of a
bare `console.error`.

Introduced by 18abd0384 (#5430): the original rolling pool update never neutralized
auto_poweron, and d6abdb246 (#7242) carried the omission into `rollingPoolReboot`.

https://project.vates.tech/vates-global/browse/XO-2748/

```mermaid
sequenceDiagram
    participant XO as XO rollingPoolReboot
    participant Pool as Pool other_config
    participant Host as Host N
    participant Script as xapi-autostart-vms

    rect rgb(230, 245, 230)
    Note over XO,Pool: this PR
    XO->>Pool: auto_poweron = 'false'
    end
    loop each host, master first
        XO->>Host: evacuate + reboot
        Host->>Script: runs at boot
        Script->>Pool: pool-list other-config auto_poweron=true
        Pool-->>Script: no match
        Note over Script: before this PR: pool-wide vm-start here.<br/>Halted VMs took memory needed by the<br/>next evacuations, or failed with a<br/>silent NO_HOSTS_AVAILABLE
        XO->>Host: wait enabled + metrics live
    end
    XO->>XO: migrate VMs back
    rect rgb(230, 245, 230)
    Note over XO,Pool: this PR, $defer (success and failure)
    XO->>Pool: restore auto_poweron = 'true'
    end
```

### Test

Nested XCP-ng 8.2 pool, halted Alpine VM flagged auto_poweron, pool flag set.

- Before the fix (2026-07-09 QA): start attempts at both host boots of an RPR. Master
  boot: `Async.VM.start` failed silently with `NO_HOSTS_AVAILABLE`. Slave boot:
  `VM_STARTED` 1 s after the end of the run. Isolated host reboots: VM starts 6 s
  after the host is back enabled, both with and without host affinity.
- After the fix: re-run the same scenario. Expected: no `vm-start` line in
  `xensource.log` during the run, flag back to `true` at the end, VM still halted,
  `xo:xapi` info line "temporarily disabling auto power on" in the journal.

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [x] Reference the relevant issue (See https://xcp-ng.org/forum/topic/12348)
  - [x] If bug fix, add `Introduced by` (18abd0384, #5430)
- Changelog
  - [x] Changelog entry added (Bug fixes)
  - [x] "Packages to release" updated (`xo-server patch`)
- PR
  - [x] No UI changes, no screenshots needed
  - [x] Open as Draft until the lab re-run above is done
