### PR TITLE
feat(web-core): add hide-permanently package

### DIFF
--- a/@xen-orchestra/web-core/lib/packages/hide-permanently/README.md
+++ b/@xen-orchestra/web-core/lib/packages/hide-permanently/README.md
@@ -1,0 +1,60 @@
+# Hide Permanently
+
+A composable to permanently hide an element (e.g. an informational alert) once the user dismisses it.
+
+Hidden IDs are stored in Local Storage (`permanently-hidden-items` key), so the element stays hidden across page reloads and sessions.
+
+## Registering IDs
+
+Each hideable element is identified by a unique ID, to prevent collisions.
+
+The application must register IDs by augmenting the `PermanentlyHideableItems` interface in a `.d.ts` file:
+
+```ts
+declare module '@xen-orchestra/web-core/packages/hide-permanently/types.ts' {
+  interface PermanentlyHideableItems {
+    'my-first-id': true
+    'my-second-id': true
+  }
+}
+
+export {}
+```
+
+## `useHidePermanently`
+
+```ts
+const { isVisible: isUserInfoVisible, hidePermanently: hideUserInfoPermanently } = useHidePermanently(id)
+
+// or, with array destructuring:
+const [isUserInfoVisible, hideUserInfoPermanently] = useHidePermanently(id)
+```
+
+### Arguments
+
+| Argument | Type                    | Required | Description                       |
+| -------- | ----------------------- | :------: | --------------------------------- |
+| `id`     | `PermanentlyHideableId` |    ✓     | The registered ID of the element. |
+
+### Returns
+
+| Property          | Type                   | Description                                           |
+| ----------------- | ---------------------- | ----------------------------------------------------- |
+| `isVisible`       | `ComputedRef<boolean>` | Whether the element is visible (i.e. not hidden yet). |
+| `hidePermanently` | `() => void`           | Hides the element permanently.                        |
+
+## Example
+
+```vue
+<template>
+  <div v-if="isHelpTextVisible">
+    Some dismissible help text
+
+    <button type="button" @click="hideHelpTextPermanently()">Don't show again</button>
+  </div>
+</template>
+
+<script lang="ts" setup>
+const [isHelpTextVisible, hideHelpTextPermanently] = useHidePermanently('my-first-id')
+</script>
+```

--- a/@xen-orchestra/web-core/lib/packages/hide-permanently/types.ts
+++ b/@xen-orchestra/web-core/lib/packages/hide-permanently/types.ts
@@ -1,0 +1,3 @@
+export interface PermanentlyHideableItems {}
+
+export type PermanentlyHideableId = keyof PermanentlyHideableItems & string

--- a/@xen-orchestra/web-core/lib/packages/hide-permanently/use-hide-permanently.ts
+++ b/@xen-orchestra/web-core/lib/packages/hide-permanently/use-hide-permanently.ts
@@ -1,0 +1,15 @@
+import type { PermanentlyHideableId } from '@core/packages/hide-permanently/types.ts'
+import { makeDestructurable, useLocalStorage } from '@vueuse/core'
+import { computed } from 'vue'
+
+export function useHidePermanently(id: PermanentlyHideableId) {
+  const hiddenItems = useLocalStorage('permanently-hidden-items', new Set<PermanentlyHideableId>())
+
+  const isVisible = computed(() => !hiddenItems.value.has(id))
+
+  function hidePermanently() {
+    hiddenItems.value.add(id)
+  }
+
+  return makeDestructurable({ isVisible, hidePermanently } as const, [isVisible, hidePermanently] as const)
+}


### PR DESCRIPTION
### Description

Add a `hide-permanently` package to `web-core`, providing a `useHidePermanently` composable to permanently dismiss an element (e.g. an informational alert).

### Planned usage

This package will back the dismissible information blocks on the RBAC management pages (Users, Groups, Roles). Each block stays visible until the user reads it and closes it with the cross; we then persist that it has been read in Local Storage so it is not shown again on subsequent visits.

Hidden IDs are persisted in Local Storage (`permanently-hidden-items` key), so the element stays hidden across reloads and sessions. Applications register their IDs via module augmentation of the `PermanentlyHideableItems` interface, making usage type-safe and preventing ID collisions.

The composable is destructurable both as an object and as an array.

```ts
// app.d.ts
declare module '@xen-orchestra/web-core/packages/hide-permanently/types.ts' {
  interface PermanentlyHideableItems {
    'my-help-text': true
  }
}

export {}
```

```vue
<template>
  <div v-if="isHelpTextVisible">
    Some dismissible help text

    <button type="button" @click="hideHelpTextPermanently()">Don't show again</button>
  </div>
</template>

<script lang="ts" setup>
const [isHelpTextVisible, hideHelpTextPermanently] = useHidePermanently('my-help-text')
</script>
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.

