### PR TITLE
feat(xo-server): delay load balancer re-enable after RPU

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,6 +32,7 @@
 - [Rolling Pool Update/Reboot] Re-check that each host can still be evacuated right before evacuating it, to fail early with an explicit error (PR [#10097](https://github.com/vatesfr/xen-orchestra/pull/10097))
 - [XO6/VM] Add "New VM" button on Host view (PR [#10048](https://github.com/vatesfr/xen-orchestra/pull/10048))
 - [xo-server] expose more metrics when doing a memory dump (PR [#10041](https://github.com/vatesfr/xen-orchestra/pull/10041))
+- [RPU] Re-enable the load balancer after a configurable safe delay (30 minutes by default) when a rolling pool update ends (PR [#10111](https://github.com/vatesfr/xen-orchestra/pull/10111))
 
 ### Bug fixes
 

--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -37,6 +37,9 @@ verboseApiLogsOnErrors = false
 # if no events could be fetched during this delay, the server will be marked as disconnected
 xapiMarkDisconnectedDelay = '5 minutes'
 
+# Delay before re-enabling the load balancer after a rolling pool update
+loadBalancerReEnableDelay = '30 minutes'
+
 # Observability of rolling pool updates/reboots (RPU/RPR).
 #
 # Each run writes two files in the traces directory:

--- a/packages/xo-server/docs/rolling-pool-update-reboot.md
+++ b/packages/xo-server/docs/rolling-pool-update-reboot.md
@@ -119,3 +119,10 @@ task.start({ name: 'Rolling pool update', poolId: string, poolName: string })
 │  └─ task.end
 └─ task.end
 ```
+
+If the load balancer was loaded before the rolling pool update, its cooldown and re-enablement are reported as a separate root task. This task starts during cleanup after either success or failure, so its delay does not extend the rolling pool update task. If rolling pool updates overlap or another starts during the cooldown, the load balancer stays disabled and a fresh cooldown starts after the last update ends.
+
+```
+task.start({ name: 'Waiting before re-enabling the load balancer', objectId: string, poolId: string, poolName: string })
+└─ task.end
+```

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -6,6 +6,8 @@ import { BaseError } from 'make-error'
 import { createLogger } from '@xen-orchestra/log'
 import { createPredicate } from 'value-matcher'
 import { decorateClass } from '@vates/decorate-with'
+import { deduped } from '@vates/disposable/deduped.js'
+import { synchronized } from 'decorator-synchronized'
 import { defer } from 'golike-defer'
 import { extractIdsFromSimplePattern } from '@xen-orchestra/backups/extractIdsFromSimplePattern.mjs'
 import { fibonacci } from 'iterable-backoff'
@@ -14,6 +16,7 @@ import { noSuchObject, incorrectState } from 'xo-common/api-errors.js'
 import { parseDuration } from '@vates/parse-duration'
 import { pDelay, ignoreErrors } from 'promise-toolbox'
 import { Task } from '@vates/task'
+import Disposable from 'promise-toolbox/Disposable'
 
 import * as XenStore from '../_XenStore.mjs'
 import Xapi from '../xapi/index.mjs'
@@ -37,6 +40,8 @@ class PoolAlreadyConnected extends BaseError {
 }
 
 const log = createLogger('xo:xo-mixins:xen-servers')
+const MAX_TIMER_DELAY = 2 ** 31 - 1
+const synchronizedLoadBalancerOperation = synchronized()(operation => operation())
 
 // Server is disconnected:
 // - _xapis[server.id] is undefined
@@ -818,6 +823,65 @@ export default class XenServers {
       ::ignoreErrors()
   }
 
+  _getRollingPoolUpdateLoadBalancerSuspension() {
+    const app = this._app
+    const state = { shouldReEnable: false }
+    return new Disposable(
+      () =>
+        state.shouldReEnable &&
+        synchronizedLoadBalancerOperation(async () => {
+          if (!(await app.getOptionalPlugin('load-balancer'))?.loaded) {
+            await app.loadPlugin('load-balancer')
+          }
+        }),
+      state
+    )
+  }
+
+  _releaseRollingPoolUpdateLoadBalancer(suspension, pool) {
+    const { reEnableDelay, shouldReEnable } = suspension.value
+    if (!shouldReEnable) {
+      return suspension.dispose()
+    }
+
+    const poolId = pool.id
+    const task = this._app.tasks.create({
+      name: 'Waiting before re-enabling the load balancer',
+      objectId: poolId,
+      poolId,
+      poolName: pool.name_label,
+    })
+    task
+      .run(async () => {
+        await pDelay(reEnableDelay).unref()
+        await suspension.dispose()
+      })
+      .catch(error => {
+        log.warn('failed to re-enable the load balancer after a rolling pool update', { error, poolId })
+      })
+  }
+
+  async _suspendRollingPoolUpdateLoadBalancer($defer, pool) {
+    const app = this._app
+    const suspension = this._getRollingPoolUpdateLoadBalancerSuspension()
+    const state = suspension.value
+    $defer(() => this._releaseRollingPoolUpdateLoadBalancer(suspension, pool))
+
+    await synchronizedLoadBalancerOperation(async () => {
+      if ((await app.getOptionalPlugin('load-balancer'))?.loaded) {
+        const reEnableDelay = app.config.getDuration('loadBalancerReEnableDelay')
+        if (!Number.isSafeInteger(reEnableDelay) || reEnableDelay < 0 || reEnableDelay > MAX_TIMER_DELAY) {
+          throw new RangeError(
+            `loadBalancerReEnableDelay must be an integer between 0 and ${MAX_TIMER_DELAY} milliseconds`
+          )
+        }
+        state.reEnableDelay = reEnableDelay
+        state.shouldReEnable = true
+        await app.unloadPlugin('load-balancer')
+      }
+    })
+  }
+
   async rollingPoolUpdate($defer, pool, { rebootVm, parentTask } = {}) {
     const app = this._app
     await app.checkFeatureAuthorization('ROLLING_POOL_UPDATE')
@@ -862,10 +926,7 @@ export default class XenServers {
     )
 
     // Disable load balancer
-    if ((await app.getOptionalPlugin('load-balancer'))?.loaded) {
-      await app.unloadPlugin('load-balancer')
-      $defer(() => app.loadPlugin('load-balancer'))
-    }
+    await this._suspendRollingPoolUpdateLoadBalancer($defer, pool)
 
     const xapi = this.getXapi(pool)
     if (await xapi.getField('pool', pool._xapiRef, 'wlb_enabled')) {
@@ -900,5 +961,11 @@ export default class XenServers {
 }
 
 decorateClass(XenServers, {
+  _getRollingPoolUpdateLoadBalancerSuspension: [
+    deduped,
+    function () {
+      return [this]
+    },
+  ],
   rollingPoolUpdate: defer,
 })

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -41,6 +41,7 @@ class PoolAlreadyConnected extends BaseError {
 
 const log = createLogger('xo:xo-mixins:xen-servers')
 const MAX_TIMER_DELAY = 2 ** 31 - 1
+const DEFAULT_LOAD_BALANCER_RE_ENABLE_DELAY = 30 * 60 * 1000 // 30 minutes, same as config.toml
 const synchronizedLoadBalancerOperation = synchronized()(operation => operation())
 
 // Server is disconnected:
@@ -823,7 +824,7 @@ export default class XenServers {
       ::ignoreErrors()
   }
 
-  _getRollingPoolUpdateLoadBalancerSuspension() {
+  _getRpuLoadBalancerSuspension() {
     const app = this._app
     const state = { shouldReEnable: false }
     return new Disposable(
@@ -845,7 +846,7 @@ export default class XenServers {
     )
   }
 
-  _releaseRollingPoolUpdateLoadBalancer(suspension, pool) {
+  _releaseRpuLoadBalancer(suspension, pool) {
     const { reEnableDelay, shouldReEnable } = suspension.value
     if (!shouldReEnable) {
       return suspension.dispose()
@@ -868,20 +869,28 @@ export default class XenServers {
       })
   }
 
-  async _suspendRollingPoolUpdateLoadBalancer($defer, pool) {
+  async _suspendRpuLoadBalancer($defer, pool) {
     const app = this._app
-    const suspension = this._getRollingPoolUpdateLoadBalancerSuspension()
+    const suspension = this._getRpuLoadBalancerSuspension()
     const state = suspension.value
-    $defer(() => this._releaseRollingPoolUpdateLoadBalancer(suspension, pool))
+    $defer(() => this._releaseRpuLoadBalancer(suspension, pool))
 
     await synchronizedLoadBalancerOperation(async () => {
       const plugin = await app.getOptionalPlugin('load-balancer')
       if (plugin?.loaded) {
-        const reEnableDelay = app.config.getDuration('loadBalancerReEnableDelay')
-        if (!Number.isSafeInteger(reEnableDelay) || reEnableDelay < 0 || reEnableDelay > MAX_TIMER_DELAY) {
-          throw new RangeError(
-            `loadBalancerReEnableDelay must be an integer between 0 and ${MAX_TIMER_DELAY} milliseconds`
-          )
+        let reEnableDelay
+        try {
+          reEnableDelay = app.config.getDuration('loadBalancerReEnableDelay')
+          if (!Number.isSafeInteger(reEnableDelay) || reEnableDelay < 0 || reEnableDelay > MAX_TIMER_DELAY) {
+            throw new RangeError(
+              `loadBalancerReEnableDelay must be an integer between 0 and ${MAX_TIMER_DELAY} milliseconds`
+            )
+          }
+        } catch (error) {
+          log.warn(`invalid loadBalancerReEnableDelay, using default (${DEFAULT_LOAD_BALANCER_RE_ENABLE_DELAY} ms)`, {
+            error,
+          })
+          reEnableDelay = DEFAULT_LOAD_BALANCER_RE_ENABLE_DELAY
         }
         state.autoload = plugin.autoload
         state.reEnableDelay = reEnableDelay
@@ -935,7 +944,7 @@ export default class XenServers {
     )
 
     // Disable load balancer
-    await this._suspendRollingPoolUpdateLoadBalancer($defer, pool)
+    await this._suspendRpuLoadBalancer($defer, pool)
 
     const xapi = this.getXapi(pool)
     if (await xapi.getField('pool', pool._xapiRef, 'wlb_enabled')) {
@@ -970,7 +979,7 @@ export default class XenServers {
 }
 
 decorateClass(XenServers, {
-  _getRollingPoolUpdateLoadBalancerSuspension: [
+  _getRpuLoadBalancerSuspension: [
     deduped,
     function () {
       return [this]

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -830,9 +830,16 @@ export default class XenServers {
       () =>
         state.shouldReEnable &&
         synchronizedLoadBalancerOperation(async () => {
-          if (!(await app.getOptionalPlugin('load-balancer'))?.loaded) {
-            await app.loadPlugin('load-balancer')
+          const plugin = await app.getOptionalPlugin('load-balancer')
+          if (plugin?.loaded) {
+            return
           }
+          if (state.autoload && plugin?.autoload === false) {
+            throw new Error(
+              'not re-enabling the load balancer plugin because its autoload has been disabled during the suspension'
+            )
+          }
+          await app.loadPlugin('load-balancer')
         }),
       state
     )
@@ -868,13 +875,15 @@ export default class XenServers {
     $defer(() => this._releaseRollingPoolUpdateLoadBalancer(suspension, pool))
 
     await synchronizedLoadBalancerOperation(async () => {
-      if ((await app.getOptionalPlugin('load-balancer'))?.loaded) {
+      const plugin = await app.getOptionalPlugin('load-balancer')
+      if (plugin?.loaded) {
         const reEnableDelay = app.config.getDuration('loadBalancerReEnableDelay')
         if (!Number.isSafeInteger(reEnableDelay) || reEnableDelay < 0 || reEnableDelay > MAX_TIMER_DELAY) {
           throw new RangeError(
             `loadBalancerReEnableDelay must be an integer between 0 and ${MAX_TIMER_DELAY} milliseconds`
           )
         }
+        state.autoload = plugin.autoload
         state.reEnableDelay = reEnableDelay
         state.shouldReEnable = true
         await app.unloadPlugin('load-balancer')


### PR DESCRIPTION
### Description

When the load balancer is loaded, keep it disabled after a rolling pool update and re-enable it after a configurable cooldown (`30 minutes` by default).

The cooldown runs in a separate task, so it does not extend the RPU task. Overlapping RPUs share the suspension, preventing one update from re-enabling the load balancer while another update or cooldown is still running.

Invalid delays are rejected before the load balancer is unloaded.

See https://project.vates.tech/vates-global/browse/XO-2706/

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.

