### PR TITLE
fix(xo-server/rpu): retry check_update while updater plugin is busy

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,7 +33,7 @@
 - [XO6] Fix negative "other" value in backup repository dashboard (PR [#10044](https://github.com/vatesfr/xen-orchestra/pull/10044))
 - [Backups] Fix missing transfer size (PR [#10106](https://github.com/vatesfr/xen-orchestra/pull/10106))
 - [Host/dashboard] Switch CPU and RAM panels order to match Pool dashboard layout (PR [#10059](https://github.com/vatesfr/xen-orchestra/pull/10059))
-
+- [RPU] Fix `The updater plugin is busy` error making the update fail right after the "Updating LINSTOR packages" step (PR [#10115](https://github.com/vatesfr/xen-orchestra/pull/10115))
 
 ### Packages to release
 

--- a/packages/xo-server/src/xapi/mixins/patching.mjs
+++ b/packages/xo-server/src/xapi/mixins/patching.mjs
@@ -9,6 +9,7 @@ import { asyncEach } from '@vates/async-each'
 import { createLogger } from '@xen-orchestra/log'
 import { decorateObject } from '@vates/decorate-with'
 import { defer as deferrable } from 'golike-defer'
+import { pRetry } from 'promise-toolbox'
 import { Task } from '@xen-orchestra/mixins/Tasks.mjs'
 
 import ensureArray from '../../_ensureArray.mjs'
@@ -52,6 +53,9 @@ const log = createLogger('xo:xapi')
 const _isXcp = host => host.software_version.product_brand === 'XCP-ng'
 const _isXs = host => host.software_version.product_brand === 'XenServer'
 const _isXsWithCdnUpdates = host => _isXs(host) && semver.gt(host.software_version.product_version, '8.3.0')
+
+export const isUpdaterBusyError = error =>
+  error?.code === '-1' && typeof error.params?.[0] === 'string' && /plugin is busy/i.test(error.params[0])
 
 const LISTING_DEBOUNCE_TIME_MS = 60000
 
@@ -163,7 +167,20 @@ const methods = {
   // list all yum updates available for a XCP-ng host
   // (hostObject) → { uuid: patchObject }
   async _listXcpUpdates(host) {
-    const result = JSON.parse(await this.call('host.call_plugin', host.$ref, 'updater.py', 'check_update', {}))
+    const result = JSON.parse(
+      await pRetry(() => this.call('host.call_plugin', host.$ref, 'updater.py', 'check_update', {}), {
+        delay: 2000,
+        tries: 10,
+        when: isUpdaterBusyError,
+        onRetry() {
+          log.warn('updater plugin busy, retrying check_update', {
+            attempt: this.attemptNumber,
+            delay: this.delay,
+            host: host.uuid,
+          })
+        },
+      })
+    )
 
     if (result.error != null) {
       throw new Error(result.error)


### PR DESCRIPTION
### Description

Fixes https://project.vates.tech/vates-global/browse/XO-2730/

Introduced by 782a93cdf (#8455)

On a pool with a LINSTOR SR, `rollingPoolUpdate()` first updates the LINSTOR packages, which calls `updater.py update` on every host, then immediately runs the "Listing missing patches" step, which calls `updater.py check_update` on the same hosts. The updater lock on a host can still be held for a few seconds after its `update` call returned, so `check_update` fails with the generic plugin error `-1` (`The updater plugin is busy (current operation: update)`) and this single error aborts the whole RPU before any host was updated. The rejection is then cached for up to 60 seconds by the `listMissingPatches` debounce, so restarting the RPU right away fails too.

`_listXcpUpdates()` now retries `check_update` every 2 seconds (up to 10 attempts, ~18 seconds total) as long as the error is the updater busy error (current message and legacy `The plugin is busy.`). Any other error is still thrown immediately, and if the updater is genuinely stuck after the last attempt, the last busy error is thrown as before. Each retry logs a warning:

```
WARN updater plugin busy, retrying check_update { attempt: 0, delay: 2000, host: "e64e353e-..." }
```

```mermaid
sequenceDiagram
    participant RPU as xo-server (rollingPoolUpdate)
    participant Updater as updater.py (on each host)

    Note over RPU,Updater: step "Updating LINSTOR packages"
    RPU->>Updater: update (xcp-ng-xapi-plugins, xcp-ng-linstor, ...)
    Updater-->>RPU: OK, but the lock may be held a few more seconds

    Note over RPU,Updater: step "Listing missing patches"
    RPU->>Updater: check_update
    Updater-->>RPU: error -1 "The updater plugin is busy (current operation: update)"

    alt before this PR
        Note over RPU: error propagates, the whole RPU is aborted
    else after this PR
        loop up to 10 attempts, 2s apart (~18s)
            RPU->>Updater: check_update (retry)
        end
        Updater-->>RPU: missing patches list
        Note over RPU: RPU continues normally
    end
```

#### Before / after

| Situation | Before | After |
| --- | --- | --- |
| `check_update` right after the LINSTOR step, lock still held | whole RPU aborts, no host updated; the rejection stays cached for up to 60s (debounce), so an immediate restart fails too | retried every 2s (up to 10 attempts), the RPU carries on as soon as the lock is released, one warning log per retry |
| updater still busy after ~18s (genuinely stuck) | RPU aborts | same, the last busy error is thrown and the RPU fails |
| any other error (`HOST_OFFLINE`, ...) | RPU aborts immediately | unchanged, no retry |

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
