### PR TITLE
feat(backup): update footer and header at once

### DIFF
--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -490,7 +490,12 @@ export class RemoteAdapter {
       })
     } else {
       const stream = await toVhdStream(disk, { uuid, parentUuid, parentPath })
-      const size = await this.outputStream(path, stream, { validator, checksum: false })
+      const size = await this.outputStream(path, stream, {
+        validator,
+        // no checksum for VHDs, because they will be invalidated by
+        // merges and chains
+        checksum: false,
+      })
       await validator(path)
       return size
     }

--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -66,18 +66,40 @@ export class RemoteAdapter {
   // check if we will be allowed to merge a vhd created in this adapter
   // with the vhd at path `path`
   async isMergeableParent(packedParentUid, path) {
-    return await Disposable.use(VhdSynthetic.fromVhdChain(this.handler, path), vhd => {
-      // this baseUuid is not linked with this vhd
-      if (!vhd.footer.uuid.equals(packedParentUid)) {
-        return false
-      }
+    // [CHAIN-DEBUG] temporary logging to diagnose why chaining falls back to full transfers
+    try {
+      return await Disposable.use(VhdSynthetic.fromVhdChain(this.handler, path), vhd => {
+        // this baseUuid is not linked with this vhd
+        if (!vhd.footer.uuid.equals(packedParentUid)) {
+          warn('[CHAIN-DEBUG] isMergeableParent: footer uuid mismatch', {
+            path,
+            expectedParentUuid: packedParentUid.toString('hex'),
+            actualFooterUuid: vhd.footer.uuid.toString('hex'),
+          })
+          return false
+        }
 
-      // check if all the chain is composed of vhd directory
-      const isVhdDirectory = vhd.checkVhdsClass(VhdDirectory)
-      return isVhdDirectory
-        ? this.useVhdDirectory() && this.#getCompressionType() === vhd.compressionType
-        : !this.useVhdDirectory()
-    })
+        // check if all the chain is composed of vhd directory
+        const isVhdDirectory = vhd.checkVhdsClass(VhdDirectory)
+        const useVhdDirectory = this.useVhdDirectory()
+        const configuredCompression = this.#getCompressionType()
+        const mergeable = isVhdDirectory
+          ? useVhdDirectory && configuredCompression === vhd.compressionType
+          : !useVhdDirectory
+        warn('[CHAIN-DEBUG] isMergeableParent: uuid matched, checking storage class/compression', {
+          path,
+          isVhdDirectory,
+          useVhdDirectory,
+          configuredCompression,
+          vhdCompression: vhd.compressionType,
+          mergeable,
+        })
+        return mergeable
+      })
+    } catch (error) {
+      warn('[CHAIN-DEBUG] isMergeableParent: threw while reading the chain', { path, error })
+      throw error
+    }
   }
 
   async #removeVmBackupsFromCache(backups) {

--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -66,40 +66,18 @@ export class RemoteAdapter {
   // check if we will be allowed to merge a vhd created in this adapter
   // with the vhd at path `path`
   async isMergeableParent(packedParentUid, path) {
-    // [CHAIN-DEBUG] temporary logging to diagnose why chaining falls back to full transfers
-    try {
-      return await Disposable.use(VhdSynthetic.fromVhdChain(this.handler, path), vhd => {
-        // this baseUuid is not linked with this vhd
-        if (!vhd.footer.uuid.equals(packedParentUid)) {
-          warn('[CHAIN-DEBUG] isMergeableParent: footer uuid mismatch', {
-            path,
-            expectedParentUuid: packedParentUid.toString('hex'),
-            actualFooterUuid: vhd.footer.uuid.toString('hex'),
-          })
-          return false
-        }
+    return await Disposable.use(VhdSynthetic.fromVhdChain(this.handler, path), vhd => {
+      // this baseUuid is not linked with this vhd
+      if (!vhd.footer.uuid.equals(packedParentUid)) {
+        return false
+      }
 
-        // check if all the chain is composed of vhd directory
-        const isVhdDirectory = vhd.checkVhdsClass(VhdDirectory)
-        const useVhdDirectory = this.useVhdDirectory()
-        const configuredCompression = this.#getCompressionType()
-        const mergeable = isVhdDirectory
-          ? useVhdDirectory && configuredCompression === vhd.compressionType
-          : !useVhdDirectory
-        warn('[CHAIN-DEBUG] isMergeableParent: uuid matched, checking storage class/compression', {
-          path,
-          isVhdDirectory,
-          useVhdDirectory,
-          configuredCompression,
-          vhdCompression: vhd.compressionType,
-          mergeable,
-        })
-        return mergeable
-      })
-    } catch (error) {
-      warn('[CHAIN-DEBUG] isMergeableParent: threw while reading the chain', { path, error })
-      throw error
-    }
+      // check if all the chain is composed of vhd directory
+      const isVhdDirectory = vhd.checkVhdsClass(VhdDirectory)
+      return isVhdDirectory
+        ? this.useVhdDirectory() && this.#getCompressionType() === vhd.compressionType
+        : !this.useVhdDirectory()
+    })
   }
 
   async #removeVmBackupsFromCache(backups) {

--- a/@xen-orchestra/backups/RemoteAdapter.mjs
+++ b/@xen-orchestra/backups/RemoteAdapter.mjs
@@ -449,7 +449,7 @@ export class RemoteAdapter {
     return path
   }
 
-  async writeVhd(path, disk, { validator = noop, writeBlockConcurrency } = {}) {
+  async writeVhd(path, disk, { validator = noop, writeBlockConcurrency, uuid, parentUuid, parentPath } = {}) {
     const handler = this._handler
 
     if (this.useVhdDirectory()) {
@@ -461,10 +461,13 @@ export class RemoteAdapter {
           concurrency: writeBlockConcurrency,
           validator,
           compression: 'brotli',
+          uuid,
+          parentUuid,
+          parentPath,
         },
       })
     } else {
-      const stream = await toVhdStream(disk)
+      const stream = await toVhdStream(disk, { uuid, parentUuid, parentPath })
       const size = await this.outputStream(path, stream, { validator, checksum: false })
       await validator(path)
       return size

--- a/@xen-orchestra/backups/_runners/_vmRunners/IncrementalRemote.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/IncrementalRemote.mjs
@@ -106,16 +106,6 @@ class IncrementalRemoteVmBackupRunner extends AbstractRemote {
           }),
         'writer.transfer()'
       )
-      // this will update parent name with the needed alias
-      await this._callWriters(
-        writer =>
-          writer.updateUuidAndChain({
-            isVhdDifferencing,
-            timestamp: metadata.timestamp,
-            vdis: incrementalExport.vdis,
-          }),
-        'writer.updateUuidAndChain()'
-      )
 
       await this._callWriters(writer => writer.cleanup(), 'writer.cleanup()')
       // for healthcheck

--- a/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
@@ -80,15 +80,6 @@ export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends Abstr
         }),
       'writer.transfer()'
     )
-    await this._callWriters(
-      writer =>
-        writer.updateUuidAndChain({
-          isVhdDifferencing,
-          timestamp,
-          vdis: deltaExport.vdis,
-        }),
-      'writer.updateUuidAndChain()'
-    )
 
     if (isFull) {
       await setVmDeltaChainLength(this._xapi, exportedVm.$ref, 0)

--- a/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
@@ -20,7 +20,7 @@ import { AggregatedIncrementalRemoteWriter } from '../_writers/AggregatedIncreme
 import { AggregatedIncrementalXapiWriter } from '../_writers/AggregatedIncrementalXapiWriter.mjs'
 import { TaskProgressHandler } from './_TaskProgressHandler.mjs'
 
-const { debug, warn } = createLogger('xo:backups:IncrementalXapiVmBackup')
+const { debug } = createLogger('xo:backups:IncrementalXapiVmBackup')
 
 export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends AbstractXapi {
   _getWriters() {
@@ -227,11 +227,7 @@ export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends Abstr
     }
 
     if (presentBaseVdis.size === 0) {
-      // [CHAIN-DEBUG] no base survived => whole VM backup will be full
-      warn('[CHAIN-DEBUG] _selectBaseVm: no base VM found (=> full backup)', {
-        exportedSnapshotGroups: grouped.length,
-        baseCandidatesCount: baseUuidToSrcVdiUuid.size,
-      })
+      debug('no base VM found')
       return
     }
 
@@ -239,8 +235,7 @@ export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends Abstr
     // especially on replication when we alwayr update the same VM
     const fullInterval = this._settings.fullInterval
     if (fullInterval !== 0 && fullInterval <= deltaChainLength + 1) {
-      // [CHAIN-DEBUG] scheduled full because the configured fullInterval was reached
-      warn('[CHAIN-DEBUG] _selectBaseVm: fullInterval reached, forcing full backup', {
+      debug('not using base VM because fullInterval reached', {
         fullInterval,
         deltaChainLength,
         eq: fullInterval < deltaChainLength + 1,
@@ -248,17 +243,6 @@ export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends Abstr
       })
       return
     }
-
-    // [CHAIN-DEBUG] temporary logging to diagnose why chaining falls back to full transfers
-    warn('[CHAIN-DEBUG] _selectBaseVm: base selection summary', {
-      exportedSnapshotGroups: grouped.length,
-      lastExportedVdisCount: lastExportedVdis.length,
-      // survivors after every writer's checkBaseVdis() confirmed a mergeable parent
-      presentBaseVdisCount: presentBaseVdis.size,
-      baseCandidatesCount: baseUuidToSrcVdiUuid.size,
-      deltaChainLength,
-      fullInterval: this._settings.fullInterval,
-    })
 
     baseUuidToSrcVdiUuid.forEach((srcVdiUuid, baseUuid) => {
       if (presentBaseVdis.has(baseUuid)) {
@@ -268,8 +252,7 @@ export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends Abstr
         })
         this._baseVdis[srcVdiUuid] = lastExportedVdis.find(vdi => vdi.uuid === baseUuid)
       } else {
-        // [CHAIN-DEBUG] this base VDI was dropped by a writer's checkBaseVdis => full for this vdi
-        warn('[CHAIN-DEBUG] _selectBaseVm: base VDI dropped by writer (=> full for this vdi)', {
+        debug('missing base VDI', {
           base: baseUuid,
           vdi: srcVdiUuid,
         })

--- a/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
@@ -20,7 +20,7 @@ import { AggregatedIncrementalRemoteWriter } from '../_writers/AggregatedIncreme
 import { AggregatedIncrementalXapiWriter } from '../_writers/AggregatedIncrementalXapiWriter.mjs'
 import { TaskProgressHandler } from './_TaskProgressHandler.mjs'
 
-const { debug } = createLogger('xo:backups:IncrementalXapiVmBackup')
+const { debug, warn } = createLogger('xo:backups:IncrementalXapiVmBackup')
 
 export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends AbstractXapi {
   _getWriters() {
@@ -227,7 +227,11 @@ export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends Abstr
     }
 
     if (presentBaseVdis.size === 0) {
-      debug('no base VM found')
+      // [CHAIN-DEBUG] no base survived => whole VM backup will be full
+      warn('[CHAIN-DEBUG] _selectBaseVm: no base VM found (=> full backup)', {
+        exportedSnapshotGroups: grouped.length,
+        baseCandidatesCount: baseUuidToSrcVdiUuid.size,
+      })
       return
     }
 
@@ -235,7 +239,8 @@ export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends Abstr
     // especially on replication when we alwayr update the same VM
     const fullInterval = this._settings.fullInterval
     if (fullInterval !== 0 && fullInterval <= deltaChainLength + 1) {
-      debug('not using base VM because fullInterval reached', {
+      // [CHAIN-DEBUG] scheduled full because the configured fullInterval was reached
+      warn('[CHAIN-DEBUG] _selectBaseVm: fullInterval reached, forcing full backup', {
         fullInterval,
         deltaChainLength,
         eq: fullInterval < deltaChainLength + 1,
@@ -243,6 +248,17 @@ export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends Abstr
       })
       return
     }
+
+    // [CHAIN-DEBUG] temporary logging to diagnose why chaining falls back to full transfers
+    warn('[CHAIN-DEBUG] _selectBaseVm: base selection summary', {
+      exportedSnapshotGroups: grouped.length,
+      lastExportedVdisCount: lastExportedVdis.length,
+      // survivors after every writer's checkBaseVdis() confirmed a mergeable parent
+      presentBaseVdisCount: presentBaseVdis.size,
+      baseCandidatesCount: baseUuidToSrcVdiUuid.size,
+      deltaChainLength,
+      fullInterval: this._settings.fullInterval,
+    })
 
     baseUuidToSrcVdiUuid.forEach((srcVdiUuid, baseUuid) => {
       if (presentBaseVdis.has(baseUuid)) {
@@ -252,7 +268,8 @@ export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends Abstr
         })
         this._baseVdis[srcVdiUuid] = lastExportedVdis.find(vdi => vdi.uuid === baseUuid)
       } else {
-        debug('missing base VDI', {
+        // [CHAIN-DEBUG] this base VDI was dropped by a writer's checkBaseVdis => full for this vdi
+        warn('[CHAIN-DEBUG] _selectBaseVm: base VDI dropped by writer (=> full for this vdi)', {
           base: baseUuid,
           vdi: srcVdiUuid,
         })

--- a/@xen-orchestra/backups/_runners/_writers/AggregatedIncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/AggregatedIncrementalRemoteWriter.mjs
@@ -54,11 +54,6 @@ export class AggregatedIncrementalRemoteWriter extends AbstractAggregatedRemoteW
     return this.mainWriter.transfer({ isVhdDifferencing, timestamp, deltaExport, vm, vmSnapshot })
   }
 
-  // chain only on the main writer
-  updateUuidAndChain({ isVhdDifferencing, vdis }) {
-    return this.mainWriter.updateUuidAndChain({ isVhdDifferencing, vdis })
-  }
-
   // remove the backups and remove the entries
   async cleanup() {
     if (!this.props.settings.deleteFirst) {

--- a/@xen-orchestra/backups/_runners/_writers/AggregatedIncrementalXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/AggregatedIncrementalXapiWriter.mjs
@@ -59,11 +59,6 @@ export class AggregatedIncrementalXapiWriter extends AbstractAggregatedXapiWrite
     return this.mainWriter.transfer(args)
   }
 
-  // chain only on the main writer
-  updateUuidAndChain(args) {
-    return this.mainWriter.updateUuidAndChain(args)
-  }
-
   // remove the backups and remove the entries
   async cleanup() {
     debug('cleanup')

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
@@ -2,11 +2,12 @@ import assert from 'node:assert'
 import mapValues from 'lodash/mapValues.js'
 import { asyncEach } from '@vates/async-each'
 import { asyncMap } from '@xen-orchestra/async-map'
-import { chainVhd, openVhd } from 'vhd-lib'
+import { openVhd } from 'vhd-lib'
 import { createLogger } from '@xen-orchestra/log'
 import { decorateClass } from '@vates/decorate-with'
 import { defer } from 'golike-defer'
 import { dirname, basename } from 'node:path'
+import { relativeFromFile } from '@xen-orchestra/fs/path'
 import { Task } from '@vates/task'
 
 import { formatFilenameDate } from '../../_filenameDate.mjs'
@@ -22,7 +23,6 @@ const { warn } = createLogger('xo:backups:DeltaBackupWriter')
 
 export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrementalWriter) {
   #parentVdiPaths
-  #vhds
   async checkBaseVdis(baseUuidToSrcVdi) {
     this.#parentVdiPaths = {}
     const { handler } = this._adapter
@@ -126,48 +126,6 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
     }
   }
 
-  async updateUuidAndChain({ isVhdDifferencing, vdis }) {
-    assert.notStrictEqual(
-      this.#vhds,
-      undefined,
-      '_transfer must be called before updateUuidAndChain for incremental backups'
-    )
-
-    const parentVdiPaths = this.#parentVdiPaths
-    const { handler } = this._adapter
-    const vhds = this.#vhds
-    await asyncEach(Object.entries(vdis), async ([id, vdi]) => {
-      const isDifferencing = isVhdDifferencing[id]
-      const path = `${this._vmBackupDir}/${vhds[id]}`
-      if (isDifferencing) {
-        assert.notStrictEqual(
-          parentVdiPaths,
-          undefined,
-          'checkbasevdi must be called before updateUuidAndChain for incremental backups'
-        )
-        const parentPath = parentVdiPaths[dirname(path)]
-        // we are in a incremental backup
-        // we already computed the chain in checkBaseVdis
-        assert.notStrictEqual(parentPath, undefined, 'A differential VHD must have a parent')
-        // forbid any kind of loop
-        assert.ok(basename(parentPath) < basename(path), `vhd must be sorted to be chained`)
-        // re-chainVhd is mandatory
-        // since the parent may be a alias or not
-        // and the child may be the other
-        await chainVhd(handler, parentPath, handler, path)
-      }
-
-      // set the correct UUID in the VHD if needed
-      await Disposable.use(openVhd(handler, path), async vhd => {
-        if (!vhd.footer.uuid.equals(packUuid(vdi.uuid))) {
-          vhd.footer.uuid = packUuid(vdi.uuid)
-          await vhd.readBlockAllocationTable() // required by writeFooter()
-          await vhd.writeFooter()
-        }
-      })
-    })
-  }
-
   async _deleteOldEntries() {
     const adapter = this._adapter
     const oldEntries = this._oldEntries
@@ -186,10 +144,8 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
     const jobId = job.id
     const handler = adapter.handler
 
-    const basename = formatFilenameDate(timestamp)
-    // update this.#vhds before eventually skipping transfer, so that
-    // updateUuidAndChain has all the mandatory data
-    const vhds = (this.#vhds = mapValues(
+    const filenameDate = formatFilenameDate(timestamp)
+    const vhds = mapValues(
       deltaExport.vdis,
       vdi =>
         `vdis/${jobId}/${
@@ -198,8 +154,8 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
               // don't do delta for it
               vdi.uuid
             : vdi.$snapshot_of$uuid
-        }/${adapter.getVhdFileName(basename)}`
-    ))
+        }/${adapter.getVhdFileName(filenameDate)}`
+    )
 
     let metadataContent = await this._isAlreadyTransferred(timestamp)
     if (metadataContent !== undefined) {
@@ -229,12 +185,27 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
         Object.entries(deltaExport.disks),
         async ([diskRef, disk]) => {
           const path = `${this._vmBackupDir}/${vhds[diskRef]}`
+          const vdi = deltaExport.vdis[diskRef]
+
+          let parentUuid, parentPath
+          if (isVhdDifferencing[diskRef]) {
+            const parentDestPath = this.#parentVdiPaths[dirname(path)]
+            assert.notStrictEqual(parentDestPath, undefined, 'A differential VHD must have a parent')
+            // forbid any kind of loop
+            assert.ok(basename(parentDestPath) < basename(path), `vhd must be sorted to be chained`)
+            parentPath = relativeFromFile(path, parentDestPath)
+            parentUuid = await Disposable.use(openVhd(handler, parentDestPath), parentVhd => parentVhd.footer.uuid)
+          }
+
           const transferred = await adapter.writeVhd(path, disk, {
             // no checksum for VHDs, because they will be invalidated by
             // merges and chains
             checksum: false,
             validator: tmpPath => checkVhd(handler, tmpPath),
             writeBlockConcurrency: this._config.writeBlockConcurrency,
+            uuid: packUuid(vdi.uuid),
+            parentUuid,
+            parentPath,
           })
           size += transferred
         },

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
@@ -231,9 +231,6 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
           })
 
           const transferred = await adapter.writeVhd(path, disk, {
-            // no checksum for VHDs, because they will be invalidated by
-            // merges and chains
-            checksum: false,
             validator: tmpPath => checkVhd(handler, tmpPath),
             writeBlockConcurrency: this._config.writeBlockConcurrency,
             uuid: packUuid(vdi.uuid),

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
@@ -21,10 +21,10 @@ const { warn } = createLogger('xo:backups:DeltaBackupWriter')
 
 export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrementalWriter) {
   #parentVdiPaths
-  #parentUUids
+  #parentUuids
   async checkBaseVdis(baseUuidToSrcVdi) {
     this.#parentVdiPaths = {}
-    this.#parentUUids = {}
+    this.#parentUuids = {}
     const { handler } = this._adapter
     const adapter = this._adapter
 
@@ -62,7 +62,7 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
         baseUuidToSrcVdi.delete(baseUuid)
       } else {
         this.#parentVdiPaths[vhdDir] = parentDestPath
-        this.#parentUUids[vhdDir] = parentUuid
+        this.#parentUuids[vhdDir] = parentUuid
       }
     })
   }
@@ -193,7 +193,7 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
           let parentUuid, parentPath
           if (isVhdDifferencing[diskRef]) {
             const parentDestPath = this.#parentVdiPaths[dirname(path)]
-            parentUuid = this.#parentUUids[dirname(path)]
+            parentUuid = this.#parentUuids[dirname(path)]
             assert.notStrictEqual(parentDestPath, undefined, 'A differential VHD must have a parent')
             // forbid any kind of loop
             assert.ok(basename(parentDestPath) < basename(path), `vhd must be sorted to be chained`)

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
@@ -40,14 +40,6 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
           ignoreMissing: true,
           prependDir: true,
         })
-        // [CHAIN-DEBUG] temporary logging to diagnose why chaining falls back to full transfers
-        warn('[CHAIN-DEBUG] checkBaseVdis: candidate vhds for base', {
-          baseUuid,
-          srcVdiUuid,
-          vhdDir,
-          candidateCount: vhds.length,
-          candidates: vhds.map(_ => basename(_)),
-        })
         const packedBaseUuid = packUuid(baseUuid)
         // the last one is probably the right one
 
@@ -67,20 +59,8 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
       }
       // no usable parent => the runner will have to decide to fall back to a full or stop backup
       if (parentDestPath === undefined) {
-        // [CHAIN-DEBUG] no mergeable parent found → this base is dropped and the disk will be a full transfer
-        warn('[CHAIN-DEBUG] checkBaseVdis: NO mergeable parent found, dropping base (=> full transfer)', {
-          baseUuid,
-          srcVdiUuid,
-          vhdDir,
-        })
         baseUuidToSrcVdi.delete(baseUuid)
       } else {
-        // [CHAIN-DEBUG] mergeable parent found → disk will be a differencing/incremental transfer
-        warn('[CHAIN-DEBUG] checkBaseVdis: mergeable parent found', {
-          baseUuid,
-          srcVdiUuid,
-          parentDestPath,
-        })
         this.#parentVdiPaths[vhdDir] = parentDestPath
         this.#parentUuids[vhdDir] = parentUuid
       }
@@ -219,16 +199,6 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
             assert.ok(basename(parentDestPath) < basename(path), `vhd must be sorted to be chained`)
             parentPath = relativeFromFile(path, parentDestPath)
           }
-
-          // [CHAIN-DEBUG] temporary logging to diagnose why chaining falls back to full transfers
-          warn('[CHAIN-DEBUG] _transfer: writing vhd', {
-            path: basename(path),
-            isDifferencing: !!isVhdDifferencing[diskRef],
-            // this uuid must match the base uuid looked up on the NEXT backup
-            footerUuid: packUuid(vdi.uuid).toString('hex'),
-            parentUuid: parentUuid?.toString('hex'),
-            parentPath,
-          })
 
           const transferred = await adapter.writeVhd(path, disk, {
             validator: tmpPath => checkVhd(handler, tmpPath),

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
@@ -40,6 +40,14 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
           ignoreMissing: true,
           prependDir: true,
         })
+        // [CHAIN-DEBUG] temporary logging to diagnose why chaining falls back to full transfers
+        warn('[CHAIN-DEBUG] checkBaseVdis: candidate vhds for base', {
+          baseUuid,
+          srcVdiUuid,
+          vhdDir,
+          candidateCount: vhds.length,
+          candidates: vhds.map(_ => basename(_)),
+        })
         const packedBaseUuid = packUuid(baseUuid)
         // the last one is probably the right one
 
@@ -59,8 +67,20 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
       }
       // no usable parent => the runner will have to decide to fall back to a full or stop backup
       if (parentDestPath === undefined) {
+        // [CHAIN-DEBUG] no mergeable parent found → this base is dropped and the disk will be a full transfer
+        warn('[CHAIN-DEBUG] checkBaseVdis: NO mergeable parent found, dropping base (=> full transfer)', {
+          baseUuid,
+          srcVdiUuid,
+          vhdDir,
+        })
         baseUuidToSrcVdi.delete(baseUuid)
       } else {
+        // [CHAIN-DEBUG] mergeable parent found → disk will be a differencing/incremental transfer
+        warn('[CHAIN-DEBUG] checkBaseVdis: mergeable parent found', {
+          baseUuid,
+          srcVdiUuid,
+          parentDestPath,
+        })
         this.#parentVdiPaths[vhdDir] = parentDestPath
         this.#parentUuids[vhdDir] = parentUuid
       }
@@ -199,6 +219,16 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
             assert.ok(basename(parentDestPath) < basename(path), `vhd must be sorted to be chained`)
             parentPath = relativeFromFile(path, parentDestPath)
           }
+
+          // [CHAIN-DEBUG] temporary logging to diagnose why chaining falls back to full transfers
+          warn('[CHAIN-DEBUG] _transfer: writing vhd', {
+            path: basename(path),
+            isDifferencing: !!isVhdDifferencing[diskRef],
+            // this uuid must match the base uuid looked up on the NEXT backup
+            footerUuid: packUuid(vdi.uuid).toString('hex'),
+            parentUuid: parentUuid?.toString('hex'),
+            parentPath,
+          })
 
           const transferred = await adapter.writeVhd(path, disk, {
             // no checksum for VHDs, because they will be invalidated by

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
@@ -2,7 +2,6 @@ import assert from 'node:assert'
 import mapValues from 'lodash/mapValues.js'
 import { asyncEach } from '@vates/async-each'
 import { asyncMap } from '@xen-orchestra/async-map'
-import { openVhd } from 'vhd-lib'
 import { createLogger } from '@xen-orchestra/log'
 import { decorateClass } from '@vates/decorate-with'
 import { defer } from 'golike-defer'
@@ -17,14 +16,15 @@ import { MixinRemoteWriter } from './_MixinRemoteWriter.mjs'
 import { AbstractIncrementalWriter } from './_AbstractIncrementalWriter.mjs'
 import { checkVhd } from './_checkVhd.mjs'
 import { packUuid } from './_packUuid.mjs'
-import { Disposable } from 'promise-toolbox'
 
 const { warn } = createLogger('xo:backups:DeltaBackupWriter')
 
 export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrementalWriter) {
   #parentVdiPaths
+  #parentUUids
   async checkBaseVdis(baseUuidToSrcVdi) {
     this.#parentVdiPaths = {}
+    this.#parentUUids = {}
     const { handler } = this._adapter
     const adapter = this._adapter
 
@@ -32,6 +32,7 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
 
     await asyncMap(baseUuidToSrcVdi, async ([baseUuid, srcVdiUuid]) => {
       let parentDestPath
+      let parentUuid
       const vhdDir = `${vdisDir}/${srcVdiUuid}`
       try {
         const vhds = await handler.list(vhdDir, {
@@ -47,6 +48,7 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
           try {
             if (await adapter.isMergeableParent(packedBaseUuid, path)) {
               parentDestPath = path
+              parentUuid = packedBaseUuid
             }
           } catch (error) {
             warn('checkBaseVdis', { error })
@@ -60,6 +62,7 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
         baseUuidToSrcVdi.delete(baseUuid)
       } else {
         this.#parentVdiPaths[vhdDir] = parentDestPath
+        this.#parentUUids[vhdDir] = parentUuid
       }
     })
   }
@@ -190,11 +193,11 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
           let parentUuid, parentPath
           if (isVhdDifferencing[diskRef]) {
             const parentDestPath = this.#parentVdiPaths[dirname(path)]
+            parentUuid = this.#parentUUids[dirname(path)]
             assert.notStrictEqual(parentDestPath, undefined, 'A differential VHD must have a parent')
             // forbid any kind of loop
             assert.ok(basename(parentDestPath) < basename(path), `vhd must be sorted to be chained`)
             parentPath = relativeFromFile(path, parentDestPath)
-            parentUuid = await Disposable.use(openVhd(handler, parentDestPath), parentVhd => parentVhd.footer.uuid)
           }
 
           const transferred = await adapter.writeVhd(path, disk, {

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
@@ -235,9 +235,6 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
     return { baseVdisBySourceUuid, targetVmRef }
   }
 
-  updateUuidAndChain() {
-    // nothing to do, the chaining is not modified in this case
-  }
   prepare({ isFull }) {
     // create the task related to this export and ensure all methods are called in this context
     const task = new Task({

--- a/@xen-orchestra/backups/_runners/_writers/_AbstractIncrementalWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/_AbstractIncrementalWriter.mjs
@@ -5,10 +5,6 @@ export class AbstractIncrementalWriter extends AbstractWriter {
     throw new Error('Not implemented')
   }
 
-  updateUuidAndChain() {
-    throw new Error('Not implemented')
-  }
-
   cleanup() {
     throw new Error('Not implemented')
   }

--- a/@xen-orchestra/backups/docs/VM backups/README.md
+++ b/@xen-orchestra/backups/docs/VM backups/README.md
@@ -230,7 +230,6 @@ Settings are described in [`@xen-orchestra/backups/\_runners/VmsXapi.mjs``](http
     - `checkBaseVdis(baseUuidToSrcVdi, baseVm)`
     - `prepare({ isFull })`
     - `transfer({ timestamp, deltaExport, sizeContainers })`
-    - `updateUuidAndChain({ isVhdDifferencing, vdis })`
     - `cleanup()`
     - `healthCheck()` // is not executed if no health check sr or tag doesn't match
   - **Full**

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -52,6 +52,7 @@
 - [Rolling Pool Update/Reboot] Temporarily disable VMs auto power on during the run: unexpected VM starts on rebooted hosts could break the remaining host evacuations (`HOST_NOT_ENOUGH_FREE_MEMORY`) (PR [#10104](https://github.com/vatesfr/xen-orchestra/pull/10104))
 - [Backups] Fix failed status on successful retry [Forum#12366](https://xcp-ng.org/forum/topic/12366) (PR [#10129](https://github.com/vatesfr/xen-orchestra/pull/10129))
 - [Host] Successful evacuation signature fallbacks on older XAPI versions are no longer logged as warnings (PR [#10131](https://github.com/vatesfr/xen-orchestra/pull/10131))
+- [Backups] write the complete disk metadata at once to improve compatibility with immutable backup repository (PR [#10104](https://github.com/vatesfr/xen-orchestra/pull/10104))
 
 ### Packages to release
 

--- a/packages/vhd-lib/disk-consumer/DiskConsumerVhdDirectory.mjs
+++ b/packages/vhd-lib/disk-consumer/DiskConsumerVhdDirectory.mjs
@@ -20,6 +20,9 @@ import assert from 'node:assert'
  * @property {string} compression
  * @property {number} concurrency
  * @property {string} flags
+ * @property {Buffer?} uuid
+ * @property {Buffer?} parentUuid
+ * @property {string?} parentPath
  * @property {(path: string) => Promise<void>} validator
  */
 
@@ -44,7 +47,7 @@ export class DiskConsumerVhdDirectory extends BaseVhd {
    * @returns {Promise<number>}
    */
   async write(signal) {
-    const { handler, path, compression, flags, validator, concurrency } = this.#target
+    const { handler, path, compression, flags, validator, concurrency, uuid, parentUuid, parentPath } = this.#target
     const SUFFIX = '.alias.vhd'
     assert.ok(path.endsWith(SUFFIX), `filename must be an alias , got ${path}`)
     const base = basename(path).slice(0, -SUFFIX.length)
@@ -57,7 +60,16 @@ export class DiskConsumerVhdDirectory extends BaseVhd {
       await handler.mktree(dataPath)
       const vhd = new VhdDirectory(handler, dataPath, { flags, compression })
       vhd.footer = unpackFooter(this.computeVhdFooter())
+      if (uuid) {
+        vhd.footer.uuid = uuid
+      }
       vhd.header = unpackHeader(this.computeVhdHeader())
+      if (parentUuid) {
+        vhd.header.parentUuid = parentUuid
+      }
+      if (parentPath) {
+        vhd.header.parentUnicodeName = parentPath
+      }
       /**
        * @type {import('@xen-orchestra/disk-transform').DiskBlock | null}
        */

--- a/packages/vhd-lib/disk-consumer/DiskConsumerVhdDirectory.mjs
+++ b/packages/vhd-lib/disk-consumer/DiskConsumerVhdDirectory.mjs
@@ -12,11 +12,6 @@ import { VhdDirectory, VhdAbstract } from 'vhd-lib'
 import { unpackFooter, unpackHeader } from 'vhd-lib/Vhd/_utils.js'
 import { DEFAULT_BLOCK_SIZE } from '../_constants.js'
 import assert from 'node:assert'
-import { createLogger } from '@xen-orchestra/log'
-
-// [CHAIN-DEBUG] temporary: diagnose why the footer uuid isn't persisted on immutable remotes.
-// If NONE of these lines appear in the logs, the deployed vhd-lib is stale (pre-fix copy).
-const { warn } = createLogger('xo:vhd-lib:disk-consumer')
 
 /**
  * @typedef {Object} VhdRemoteTarget
@@ -53,15 +48,6 @@ export class DiskConsumerVhdDirectory extends BaseVhd {
    */
   async write(signal) {
     const { handler, path, compression, flags, validator, concurrency, uuid, parentUuid, parentPath } = this.#target
-    // [CHAIN-DEBUG] probe 1: proves the fixed vhd-lib is actually running, and whether uuid arrived.
-    // Absent from logs => deployed vhd-lib is the pre-fix copy (half-deploy).
-    warn('[CHAIN-DEBUG] disk-consumer.write: received target', {
-      path,
-      hasUuid: uuid !== undefined,
-      uuid: uuid?.toString('hex'),
-      parentUuid: parentUuid?.toString('hex'),
-      parentPath,
-    })
     const SUFFIX = '.alias.vhd'
     assert.ok(path.endsWith(SUFFIX), `filename must be an alias , got ${path}`)
     const base = basename(path).slice(0, -SUFFIX.length)
@@ -84,14 +70,6 @@ export class DiskConsumerVhdDirectory extends BaseVhd {
       if (parentPath) {
         vhd.header.parentUnicodeName = parentPath
       }
-      // [CHAIN-DEBUG] probe 2: the in-memory footer/header right before the single write.
-      warn('[CHAIN-DEBUG] disk-consumer.write: in-memory footer/header before write', {
-        dataPath,
-        footerUuid: vhd.footer.uuid?.toString('hex'),
-        footerDiskType: vhd.footer.diskType,
-        headerParentUuid: vhd.header.parentUuid?.toString('hex'),
-        headerParentName: vhd.header.parentUnicodeName,
-      })
       /**
        * @type {import('@xen-orchestra/disk-transform').DiskBlock | null}
        */
@@ -119,21 +97,6 @@ export class DiskConsumerVhdDirectory extends BaseVhd {
       await Promise.all([vhd.writeFooter(), vhd.writeHeader(), vhd.writeBlockAllocationTable()])
       await validator(dataPath)
       await VhdAbstract.createAlias(handler, path, dataPath)
-      // [CHAIN-DEBUG] probe 3 (decisive): re-read the footer/header straight back from the remote —
-      // the exact bytes isMergeableParent will read on the next backup. If persistedFooterUuid differs
-      // from probe 2's footerUuid, the write did NOT persist the uuid on this remote (object-lock write bug).
-      try {
-        const check = new VhdDirectory(handler, dataPath, { flags: 'r' })
-        await check.readHeaderAndFooter()
-        warn('[CHAIN-DEBUG] disk-consumer.write: persisted footer/header re-read after write', {
-          dataPath,
-          persistedFooterUuid: check.footer.uuid?.toString('hex'),
-          persistedParentUuid: check.header.parentUuid?.toString('hex'),
-          persistedParentName: check.header.parentUnicodeName,
-        })
-      } catch (error) {
-        warn('[CHAIN-DEBUG] disk-consumer.write: persisted footer/header re-read FAILED', { dataPath, error })
-      }
       // this will return VHD metadata size + block size, even for disk bigger than bigger than 2TB
       return vhd.streamSize()
     } catch (err) {

--- a/packages/vhd-lib/disk-consumer/DiskConsumerVhdDirectory.mjs
+++ b/packages/vhd-lib/disk-consumer/DiskConsumerVhdDirectory.mjs
@@ -12,6 +12,11 @@ import { VhdDirectory, VhdAbstract } from 'vhd-lib'
 import { unpackFooter, unpackHeader } from 'vhd-lib/Vhd/_utils.js'
 import { DEFAULT_BLOCK_SIZE } from '../_constants.js'
 import assert from 'node:assert'
+import { createLogger } from '@xen-orchestra/log'
+
+// [CHAIN-DEBUG] temporary: diagnose why the footer uuid isn't persisted on immutable remotes.
+// If NONE of these lines appear in the logs, the deployed vhd-lib is stale (pre-fix copy).
+const { warn } = createLogger('xo:vhd-lib:disk-consumer')
 
 /**
  * @typedef {Object} VhdRemoteTarget
@@ -48,6 +53,15 @@ export class DiskConsumerVhdDirectory extends BaseVhd {
    */
   async write(signal) {
     const { handler, path, compression, flags, validator, concurrency, uuid, parentUuid, parentPath } = this.#target
+    // [CHAIN-DEBUG] probe 1: proves the fixed vhd-lib is actually running, and whether uuid arrived.
+    // Absent from logs => deployed vhd-lib is the pre-fix copy (half-deploy).
+    warn('[CHAIN-DEBUG] disk-consumer.write: received target', {
+      path,
+      hasUuid: uuid !== undefined,
+      uuid: uuid?.toString('hex'),
+      parentUuid: parentUuid?.toString('hex'),
+      parentPath,
+    })
     const SUFFIX = '.alias.vhd'
     assert.ok(path.endsWith(SUFFIX), `filename must be an alias , got ${path}`)
     const base = basename(path).slice(0, -SUFFIX.length)
@@ -70,6 +84,14 @@ export class DiskConsumerVhdDirectory extends BaseVhd {
       if (parentPath) {
         vhd.header.parentUnicodeName = parentPath
       }
+      // [CHAIN-DEBUG] probe 2: the in-memory footer/header right before the single write.
+      warn('[CHAIN-DEBUG] disk-consumer.write: in-memory footer/header before write', {
+        dataPath,
+        footerUuid: vhd.footer.uuid?.toString('hex'),
+        footerDiskType: vhd.footer.diskType,
+        headerParentUuid: vhd.header.parentUuid?.toString('hex'),
+        headerParentName: vhd.header.parentUnicodeName,
+      })
       /**
        * @type {import('@xen-orchestra/disk-transform').DiskBlock | null}
        */
@@ -97,6 +119,21 @@ export class DiskConsumerVhdDirectory extends BaseVhd {
       await Promise.all([vhd.writeFooter(), vhd.writeHeader(), vhd.writeBlockAllocationTable()])
       await validator(dataPath)
       await VhdAbstract.createAlias(handler, path, dataPath)
+      // [CHAIN-DEBUG] probe 3 (decisive): re-read the footer/header straight back from the remote —
+      // the exact bytes isMergeableParent will read on the next backup. If persistedFooterUuid differs
+      // from probe 2's footerUuid, the write did NOT persist the uuid on this remote (object-lock write bug).
+      try {
+        const check = new VhdDirectory(handler, dataPath, { flags: 'r' })
+        await check.readHeaderAndFooter()
+        warn('[CHAIN-DEBUG] disk-consumer.write: persisted footer/header re-read after write', {
+          dataPath,
+          persistedFooterUuid: check.footer.uuid?.toString('hex'),
+          persistedParentUuid: check.header.parentUuid?.toString('hex'),
+          persistedParentName: check.header.parentUnicodeName,
+        })
+      } catch (error) {
+        warn('[CHAIN-DEBUG] disk-consumer.write: persisted footer/header re-read FAILED', { dataPath, error })
+      }
       // this will return VHD metadata size + block size, even for disk bigger than bigger than 2TB
       return vhd.streamSize()
     } catch (err) {

--- a/packages/vhd-lib/disk-consumer/DiskConsumerVhdStream.mjs
+++ b/packages/vhd-lib/disk-consumer/DiskConsumerVhdStream.mjs
@@ -1,22 +1,62 @@
 import { Readable } from 'stream'
 import { BaseVhd, FULL_BLOCK_BITMAP } from './BaseVhd.mjs'
 import { DEFAULT_BLOCK_SIZE } from '../_constants.js'
+import { unpackFooter, unpackHeader } from 'vhd-lib/Vhd/_utils.js'
+import { fuFooter, fuHeader, checksumStruct } from 'vhd-lib/_structs.js'
 
 /**
  * @typedef {Readable & { length: number }} VhdStream
  */
 
 /**
+ * @typedef {Object} VhdStreamTarget
+ * @property {Buffer?} uuid
+ * @property {Buffer?} parentUuid
+ * @property {string?} parentPath
+ */
+
+/**
  * @extends {BaseVhd}
  */
 export class DiskConsumerVhdStream extends BaseVhd {
+  /** @type {VhdStreamTarget} */
+  #target
+
+  /**
+   * @param {import('@xen-orchestra/disk-transform').Disk} source
+   * @param {VhdStreamTarget} [target]
+   */
+  constructor(source, target = {}) {
+    super(source)
+    this.#target = target
+  }
+
   /**
    * @param {AbortSignal} [signal]
    * @returns {VhdStream}
    */
   async toStream(signal) {
-    const footer = this.computeVhdFooter()
-    const header = this.computeVhdHeader()
+    const { uuid, parentUuid, parentPath } = this.#target
+
+    // footer/header are yielded as raw bytes below (no separate writeFooter()/writeHeader()
+    // step to repack them later), so any post-creation change must be repacked here
+    const footerObj = unpackFooter(this.computeVhdFooter())
+    if (uuid) {
+      footerObj.uuid = uuid
+    }
+    const footer = fuFooter.pack(footerObj)
+    checksumStruct(footer, fuFooter)
+
+    const headerObj = unpackHeader(this.computeVhdHeader())
+    if (parentUuid) {
+      headerObj.parentUuid = parentUuid
+    }
+    if (parentPath) {
+      headerObj.parentUnicodeName = parentPath
+    }
+    const header = fuHeader.pack(headerObj)
+    checksumStruct(header, fuHeader)
+
     const { bat, fileSize } = this.computeVhdBatAndFileSize() // the bat contains the calculated position of the futures blocks
     const uid = 'to stream ' + Math.random()
     const blockGenerator = this.source.diskBlocks(uid)

--- a/packages/vhd-lib/disk-consumer/index.mjs
+++ b/packages/vhd-lib/disk-consumer/index.mjs
@@ -10,6 +10,9 @@
  * @property {string} compression
  * @property {number} concurrency
  * @property {string} flags
+ * @property {Buffer?} uuid
+ * @property {Buffer?} parentUuid
+ * @property {string?} parentPath
  * @property {(path: string) => Promise<void>} validator
  *
  */
@@ -20,11 +23,11 @@ import { DiskConsumerVhdDirectory } from './DiskConsumerVhdDirectory.mjs'
 /**
  *
  * @param {Disk} disk
- * @param {{ signal?: AbortSignal }} [options]
+ * @param {{ signal?: AbortSignal, uuid?: Buffer, parentUuid?: Buffer, parentPath?: string }} [options]
  * @returns {Promise<Readable>}
  */
-export async function toVhdStream(disk, { signal } = {}) {
-  const consumer = new DiskConsumerVhdStream(disk)
+export async function toVhdStream(disk, { signal, uuid, parentUuid, parentPath } = {}) {
+  const consumer = new DiskConsumerVhdStream(disk, { uuid, parentUuid, parentPath })
   return consumer.toStream(signal)
 }
 


### PR DESCRIPTION
### Description

the current code is currently writing the backup to the remote, and then update its chaining to the parent and uuid

this can cause issue with immutable remote without versioning. 

This PR is updating the data into the inmemory disk , before writing it to the backup repository, and remove all the updateuuidcandchain calls 


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
