### PR TITLE
chore(deps): hoist pinia, vite and vue-router to root devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,15 @@
     "husky": "^8.0.2",
     "lint-staged": "^15.0.2",
     "lodash": "^4.18.0",
+    "pinia": "^3.0.1",
     "prettier": "^3.0.1",
     "promise-toolbox": "^0.21.0",
     "semver": "^7.3.6",
     "sorted-object": "^2.0.1",
     "turbo": "^2.0.3",
-    "vue-eslint-parser": "^9.4.3"
+    "vite": "^8.0.0",
+    "vue-eslint-parser": "^9.4.3",
+    "vue-router": "5.0.6"
   },
   "engines": {
     "node": ">=14",


### PR DESCRIPTION
### Description

Yarn 1 duplicates same-version packages into workspaces, which causes `@xen-orchestra/lite`
to resolve two copies of `vue-router` and `pinia` at runtime (leading to order-dependent
router errors). Declaring them as root devDependencies ensures a single hoisted instance
and survives a fresh install, unlike hand-deleting the duplicated copies.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.