### PR TITLE
fix(xo6): use warning accent and icon for pool disconnect modal

### DIFF
--- a/@xen-orchestra/web-core/lib/components/modal/VtsDisconnectModal.vue
+++ b/@xen-orchestra/web-core/lib/components/modal/VtsDisconnectModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <VtsModal accent="info" icon="status:info-picto">
+  <VtsModal accent="warning" icon="status:warning-picto">
     <template #title>
       <I18nT keypath="confirm-disconnect" scope="global" tag="div">
         <span class="n-disconnect">{{ title }}</span>
@@ -34,6 +34,6 @@ const { t } = useI18n()
 
 <style lang="postcss" scoped>
 .n-disconnect {
-  color: var(--color-info-item-base);
+  color: var(--color-warning-txt-base);
 }
 </style>

--- a/@xen-orchestra/web-core/lib/locales/en.json
+++ b/@xen-orchestra/web-core/lib/locales/en.json
@@ -819,7 +819,7 @@
   "pool-connection-ip-info": "Provide the primary host’s address of the pool you want to connect to.",
   "pool-connection-success": "You have successfully connected to the pool. You can now find it in your treeview and start managing your hosts and VMs.",
   "pool-cpu-usage": "Pool CPU Usage",
-  "pool-disconnect-info": "You will no longer be able to manage this pool from XO. You can reconnect it later.",
+  "pool-disconnect-info": "The pool will no longer be manageable from XO. You can reconnect it later.",
   "pool-management": "Pool management",
   "pool-ram-usage": "Pool RAM Usage",
   "pool:status:connected": "@:status:connected",

--- a/@xen-orchestra/web-core/lib/locales/fr.json
+++ b/@xen-orchestra/web-core/lib/locales/fr.json
@@ -819,7 +819,7 @@
   "pool-connection-ip-info": "Entrez l’adresse de l’hôte primaire du pool auquel vous souhaitez vous connecter.",
   "pool-connection-success": "Vous êtes connecté au pool. Vous pouvez désormais le retrouver dans votre arborescence et commencer à gérer vos hôtes et vos machines virtuelles.",
   "pool-cpu-usage": "Utilisation CPU du Pool",
-  "pool-disconnect-info": "Vous ne pourrez plus gérer ce pool depuis XO. Vous pourrez le reconnecter ultérieurement.",
+  "pool-disconnect-info": "Le pool ne pourra plus être géré depuis XO. Vous pourrez le reconnecter ultérieurement.",
   "pool-management": "Gestion du Pool",
   "pool-ram-usage": "Utilisation RAM du Pool",
   "pool:status:connected": "@:status:connected",

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -63,6 +63,7 @@
 - [Host] Successful evacuation signature fallbacks on older XAPI versions are no longer logged as warnings (PR [#10131](https://github.com/vatesfr/xen-orchestra/pull/10131))
 - [Backups] write the complete disk metadata at once to improve compatibility with immutable backup repository (PR [#10104](https://github.com/vatesfr/xen-orchestra/pull/10104))
 - [XO6/Host] Wrap the Network name in the PIF side panel (PR [#10155](https://github.com/vatesfr/xen-orchestra/pull/10155))
+- [XO6/Pool] Use warning accent and icon in the disconnect pool confirmation modal (PR [#10160](https://github.com/vatesfr/xen-orchestra/pull/10160))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

Switch pool disconnect modal colors from info to warning

<img width="669" height="285" alt="Capture d’écran 2026-07-23 à 16 16 52" src="https://github.com/user-attachments/assets/094040ea-faaf-4b4d-8657-002e41435493" />
<img width="667" height="284" alt="Capture d’écran 2026-07-23 à 16 16 55" src="https://github.com/user-attachments/assets/7a973b38-a8a9-470b-a86d-d89299e0a99b" />


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
