### PR TITLE
fix: allow merges even if one fails

### DIFF
--- a/@xen-orchestra/backup-archive/src/RemoteDiskLineage.mts
+++ b/@xen-orchestra/backup-archive/src/RemoteDiskLineage.mts
@@ -328,21 +328,29 @@ export class RemoteDiskLineage {
     if (merge) {
       const limitedMergeChain = defaultMergeLimiter(this.#mergeChain.bind(this))
       const doMerge = async () => {
-        await asyncEach(
-          toMerge,
-          async ({ chain, isResuming }) => {
-            const { finalDiskSize, mergeTargetPath } = await limitedMergeChain([...chain], isResuming)
-            mergedSizes.set(mergeTargetPath, (mergedSizes.get(mergeTargetPath) ?? 0) + finalDiskSize)
-            // parentPath alias deleted by parentDisk.rename(mergeTargetPath)
-            // intermediates deleted by childDisk.unlink() when removeUnused=true
-            // Unregister so #cleanOrphanDataFiles does not read already-deleted aliases
-            // and produce false "missing target of alias" warnings.
-            for (const deletedPath of chain.slice(0, -1)) {
-              this.#unregisterDisk(deletedPath)
-            }
-          },
-          { concurrency: this.#opts.mergeConcurrency ?? DEFAULT_MERGE_CONCURRENCY }
-        )
+        try {
+          await asyncEach(
+            toMerge,
+            async ({ chain, isResuming }) => {
+              const { finalDiskSize, mergeTargetPath } = await limitedMergeChain([...chain], isResuming)
+              mergedSizes.set(mergeTargetPath, (mergedSizes.get(mergeTargetPath) ?? 0) + finalDiskSize)
+              // parentPath alias deleted by parentDisk.rename(mergeTargetPath)
+              // intermediates deleted by childDisk.unlink() when removeUnused=true
+              // Unregister so #cleanOrphanDataFiles does not read already-deleted aliases
+              // and produce false "missing target of alias" warnings.
+              for (const deletedPath of chain.slice(0, -1)) {
+                this.#unregisterDisk(deletedPath)
+              }
+            },
+            // one chain failing (e.g. still immutability-locked) must not prevent other
+            // independent chains of this lineage from merging in the same clean() call
+            { concurrency: this.#opts.mergeConcurrency ?? DEFAULT_MERGE_CONCURRENCY, stopOnError: false }
+          )
+        } catch (error) {
+          for (const chainError of error.errors ?? [error]) {
+            this.#opts.logWarn('failed to merge disk chain', { error: chainError })
+          }
+        }
       }
       if (toMerge.length !== 0) {
         await Task.run({ properties: { name: 'merge' } }, doMerge)

--- a/@xen-orchestra/backup-archive/src/RemoteDiskLineage.mts
+++ b/@xen-orchestra/backup-archive/src/RemoteDiskLineage.mts
@@ -328,10 +328,10 @@ export class RemoteDiskLineage {
     if (merge) {
       const limitedMergeChain = defaultMergeLimiter(this.#mergeChain.bind(this))
       const doMerge = async () => {
-        try {
-          await asyncEach(
-            toMerge,
-            async ({ chain, isResuming }) => {
+        await asyncEach(
+          toMerge,
+          async ({ chain, isResuming }) => {
+            try {
               const { finalDiskSize, mergeTargetPath } = await limitedMergeChain([...chain], isResuming)
               mergedSizes.set(mergeTargetPath, (mergedSizes.get(mergeTargetPath) ?? 0) + finalDiskSize)
               // parentPath alias deleted by parentDisk.rename(mergeTargetPath)
@@ -341,16 +341,14 @@ export class RemoteDiskLineage {
               for (const deletedPath of chain.slice(0, -1)) {
                 this.#unregisterDisk(deletedPath)
               }
-            },
-            // one chain failing (e.g. still immutability-locked) must not prevent other
-            // independent chains of this lineage from merging in the same clean() call
-            { concurrency: this.#opts.mergeConcurrency ?? DEFAULT_MERGE_CONCURRENCY, stopOnError: false }
-          )
-        } catch (error) {
-          for (const chainError of error.errors ?? [error]) {
-            this.#opts.logWarn('failed to merge disk chain', { error: chainError })
-          }
-        }
+            } catch (error) {
+              // A broken chain (e.g. corrupted parent) must not abort merging of other,
+              // unrelated chains, nor skip #cleanOrphanDataFiles/remove below.
+              this.#opts.logWarn('failed to merge disk chain', { chain, error })
+            }
+          },
+          { concurrency: this.#opts.mergeConcurrency ?? DEFAULT_MERGE_CONCURRENCY }
+        )
       }
       if (toMerge.length !== 0) {
         await Task.run({ properties: { name: 'merge' } }, doMerge)

--- a/@xen-orchestra/backup-archive/src/VmBackupDirectory.mts
+++ b/@xen-orchestra/backup-archive/src/VmBackupDirectory.mts
@@ -145,22 +145,30 @@ export class VmBackupDirectory implements VmBackupInterface {
 
     // Merge/delete orphan disks in VDI directories covered by archives; collect merged sizes per disk path
     const allMergedSizes = new Map<string, number>()
-    await asyncEach(
-      Array.from(this.#uniqueLineages!.entries()),
-      async ([_vdiDir, lineage]) => {
-        const { mergedSizes, removedFiles, merge: hasPendingMerge } = await lineage.clean({ remove, merge })
-        if (removedFiles.length > 0) {
-          cacheNeedsRegen = true
-        }
-        if (hasPendingMerge) {
-          someLineageMergedOrShouldBe = true
-        }
-        for (const [diskPath, size] of mergedSizes || []) {
-          allMergedSizes.set(diskPath, (allMergedSizes.get(diskPath) ?? 0) + size)
-        }
-      },
-      { concurrency: DEFAULT_MERGE_CONCURRENCY }
-    )
+    try {
+      await asyncEach(
+        Array.from(this.#uniqueLineages!.entries()),
+        async ([_vdiDir, lineage]) => {
+          const { mergedSizes, removedFiles, merge: hasPendingMerge } = await lineage.clean({ remove, merge })
+          if (removedFiles.length > 0) {
+            cacheNeedsRegen = true
+          }
+          if (hasPendingMerge) {
+            someLineageMergedOrShouldBe = true
+          }
+          for (const [diskPath, size] of mergedSizes || []) {
+            allMergedSizes.set(diskPath, (allMergedSizes.get(diskPath) ?? 0) + size)
+          }
+        },
+        // one VDI lineage failing to clean must not prevent other, independent VDI
+        // lineages of this VM from being merged/cleaned in the same cleanVm() call
+        { concurrency: DEFAULT_MERGE_CONCURRENCY, stopOnError: false }
+      )
+    } catch (error) {
+      for (const lineageError of error.errors ?? [error]) {
+        this.opts.logWarn('failed to clean VDI lineage', { error: lineageError })
+      }
+    }
 
     // Delete VDI directories not referenced by any archive
     const coveredDirs = new Set(this.#uniqueLineages!.keys())

--- a/@xen-orchestra/backup-archive/src/VmBackupDirectory.mts
+++ b/@xen-orchestra/backup-archive/src/VmBackupDirectory.mts
@@ -145,10 +145,10 @@ export class VmBackupDirectory implements VmBackupInterface {
 
     // Merge/delete orphan disks in VDI directories covered by archives; collect merged sizes per disk path
     const allMergedSizes = new Map<string, number>()
-    try {
-      await asyncEach(
-        Array.from(this.#uniqueLineages!.entries()),
-        async ([_vdiDir, lineage]) => {
+    await asyncEach(
+      Array.from(this.#uniqueLineages!.entries()),
+      async ([vdiDir, lineage]) => {
+        try {
           const { mergedSizes, removedFiles, merge: hasPendingMerge } = await lineage.clean({ remove, merge })
           if (removedFiles.length > 0) {
             cacheNeedsRegen = true
@@ -159,16 +159,14 @@ export class VmBackupDirectory implements VmBackupInterface {
           for (const [diskPath, size] of mergedSizes || []) {
             allMergedSizes.set(diskPath, (allMergedSizes.get(diskPath) ?? 0) + size)
           }
-        },
-        // one VDI lineage failing to clean must not prevent other, independent VDI
-        // lineages of this VM from being merged/cleaned in the same cleanVm() call
-        { concurrency: DEFAULT_MERGE_CONCURRENCY, stopOnError: false }
-      )
-    } catch (error) {
-      for (const lineageError of error.errors ?? [error]) {
-        this.opts.logWarn('failed to clean VDI lineage', { error: lineageError })
-      }
-    }
+        } catch (error) {
+          // One broken/unmergeable VDI lineage must not abort cleanup (prune dirs, archive
+          // metadata clean, cache regen, root-orphan removal) for the rest of this VM.
+          this.opts.logWarn('failed to clean VDI lineage', { vdiDir, error })
+        }
+      },
+      { concurrency: DEFAULT_MERGE_CONCURRENCY }
+    )
 
     // Delete VDI directories not referenced by any archive
     const coveredDirs = new Set(this.#uniqueLineages!.keys())

--- a/@xen-orchestra/backup-archive/src/VmIncrementalBackupArchive.integ.mjs
+++ b/@xen-orchestra/backup-archive/src/VmIncrementalBackupArchive.integ.mjs
@@ -766,6 +766,67 @@ test('it cleans orphan merge states ', async () => {
   assert.deepEqual(await handler.list(basePath), [])
 })
 
+test('a broken merge in one VDI lineage must not block cleanup of a healthy sibling lineage', async () => {
+  // Regression guard: RemoteDiskLineage.clean()'s merge loop and VmBackupDirectory.clean()'s
+  // per-lineage loop used to let an error from #mergeChain (e.g. a real "footer1 !== footer2"
+  // corruption) escape uncaught, aborting the ENTIRE cleanVm call — skipping prune/cache-regen/
+  // orphan-removal for every other, healthy VDI directory of the same VM.
+
+  // --- lineage 1 (basePath): footer-corrupted orphan ancestor with an active child ---
+  const ancestor = await generateVhd(`${basePath}/ancestor.vhd`, { blocks: [0, 1] })
+  await generateVhd(`${basePath}/child.vhd`, {
+    header: { parentUnicodeName: 'ancestor.vhd', parentUuid: ancestor.footer.uuid },
+    blocks: [2, 3],
+  })
+  // Corrupt only the trailing (end-of-file) footer copy; leading footer/header stay intact.
+  // A stray, unparseable `.merge.json` makes RemoteDiskLineage.init() open this disk with
+  // force:true (checkSecondFooter skipped), so the corruption survives the initial scan and
+  // the ancestor is legitimately scheduled to merge into the active child — reproducing the
+  // production crash inside #mergeChain's later, non-resuming (force:false) reopen.
+  const size = await handler.getSize(`${basePath}/ancestor.vhd`)
+  await handler.write(`${basePath}/ancestor.vhd`, Buffer.alloc(512, 0xff), size - 512)
+  await handler.writeFile(`${basePath}/.ancestor.vhd.merge.json`, '')
+
+  await handler.writeFile(
+    `${rootPath}/metadata1.json`,
+    JSON.stringify({ mode: 'delta', vhds: [`${relativePath}/child.vhd`] })
+  )
+
+  // --- lineage 2 (basePath2): healthy orphan + active child, must still merge normally ---
+  const orphan2 = await generateVhd(`${basePath2}/orphan2.vhd`)
+  await generateVhd(`${basePath2}/child2.vhd`, {
+    header: { parentUnicodeName: 'orphan2.vhd', parentUuid: orphan2.footer.uuid },
+  })
+  await handler.writeFile(
+    `${rootPath}/metadata2.json`,
+    JSON.stringify({ mode: 'delta', vhds: [`${relativePath2}/child2.vhd`] })
+  )
+
+  const warned = []
+  const logWarn = message => warned.push(message)
+
+  // Must resolve, not reject: before the fix, the corrupted ancestor's merge attempt threw
+  // uncaught and this call rejected instead.
+  await VmBackupDirectory.cleanVm(handler, rootPath, { remove: true, merge: true, logInfo: () => {}, logWarn })
+
+  assert.ok(warned.includes('failed to merge disk chain'), 'broken chain merge failure should be logged, not thrown')
+
+  // lineage 1: merge failed, nothing touched — both disks remain as-is
+  const remaining1 = await handler.list(basePath)
+  assert.ok(remaining1.includes('ancestor.vhd'), 'corrupted ancestor left untouched after failed merge')
+  assert.ok(remaining1.includes('child.vhd'), 'active child left untouched after failed merge')
+
+  // lineage 2: unaffected sibling still merges normally in the same cleanVm call
+  const remaining2 = await handler.list(basePath2)
+  assert.ok(!remaining2.includes('orphan2.vhd'), 'healthy sibling lineage must still merge its own orphan')
+  assert.ok(remaining2.includes('child2.vhd'), 'healthy sibling merge target survives')
+
+  // both metadata files preserved: this VM's cleanup pipeline (cache regen, etc.) completed
+  const rootFiles = await handler.list(rootPath)
+  assert.ok(rootFiles.includes('metadata1.json'))
+  assert.ok(rootFiles.includes('metadata2.json'))
+})
+
 test('check all types of aliases, corrupted, missing or not', async () => {
   // valid alias pointing to an existing data file
   await handler.mkdir(`${basePath}/data`)

--- a/@xen-orchestra/backup-archive/src/VmIncrementalBackupArchive.integ.mjs
+++ b/@xen-orchestra/backup-archive/src/VmIncrementalBackupArchive.integ.mjs
@@ -828,3 +828,118 @@ test('it preserves VDI directory when handler.list() throws during lineage init'
   const remaining = await handler.list(basePath)
   assert.ok(remaining.includes('snapshot.vhd'), 'VHD must survive when handler.list() throws during lineage init')
 })
+
+test('regression: a locked (immutable) VDI chain blocks merging of an unrelated, fully mutable VDI chain', async () => {
+  // Two independent VDI directories for the same VM. basePath's chain is still
+  // immutability-locked (simulated: rename() EPERMs, as it would on a chattr +i remote).
+  // basePath2's chain is fully mutable and has nothing to do with basePath's lock.
+  //
+  // Current behavior: RemoteDiskLineage/MergeRemoteDisk never catch EPERM, and the
+  // asyncEach loops driving both the per-VDI merge (RemoteDiskLineage.mts) and the
+  // cross-VDI merge (VmBackupDirectory.mts, DEFAULT_MERGE_CONCURRENCY = 1, so VDIs are
+  // processed strictly in order) default to stopOnError. So one locked chain aborts
+  // merging of every VDI processed after it in the same cleanVm() call, even though
+  // they're fully independent and fully mergeable.
+  const orphan1 = await generateVhd(`${basePath}/orphan.vhd`, { blocks: [0, 1] })
+  await generateVhd(`${basePath}/child.vhd`, {
+    header: { parentUnicodeName: 'orphan.vhd', parentUuid: orphan1.footer.uuid },
+    blocks: [2, 3],
+  })
+
+  const orphan2 = await generateVhd(`${basePath2}/orphan.vhd`, { blocks: [0, 1] })
+  await generateVhd(`${basePath2}/child.vhd`, {
+    header: { parentUnicodeName: 'orphan.vhd', parentUuid: orphan2.footer.uuid },
+    blocks: [2, 3],
+  })
+
+  await handler.writeFile(
+    `${rootPath}/metadata.json`,
+    JSON.stringify({
+      mode: 'delta',
+      vhds: [`${relativePath}/child.vhd`, `${relativePath2}/child.vhd`],
+    })
+  )
+
+  const originalRename = handler.rename.bind(handler)
+  handler.rename = async (oldPath, newPath) => {
+    if (typeof newPath === 'string' && newPath.includes(vdiId) && newPath.endsWith('child.vhd')) {
+      throw Object.assign(new Error('simulated immutability lock'), { code: 'EPERM', errno: -1, syscall: 'rename' })
+    }
+    return originalRename(oldPath, newPath)
+  }
+
+  try {
+    await VmBackupDirectory.cleanVm(handler, rootPath, {
+      remove: true,
+      merge: true,
+      logWarn: () => {},
+      logInfo: () => {},
+    })
+  } finally {
+    handler.rename = originalRename
+  }
+
+  // basePath2's chain is fully mutable and independent of basePath's lock — it must merge
+  // regardless of basePath being stuck.
+  assert.deepEqual(
+    (await handler.list(basePath2)).filter(f => f.endsWith('.vhd')),
+    ['child.vhd']
+  )
+})
+
+test('it performs two independent merges within a single chain in one cleanVm() call', async () => {
+  // Chain of 5, oldest -> newest: v1 <- v2 <- v3 <- v4 <- v5
+  // v2, v4 and v5 are each an active/retained backup (their own metadata.json).
+  // v1 and v3 are superseded orphans. This should produce exactly two separate
+  // merges in one cleanVm(): (v1 -> v2) and (v3 -> v4) — v5 needs no merge.
+  //
+  // Merge target naming: the parent (older) is always renamed away, the target
+  // (newer/active side of the pair) keeps its name and survives with the merged
+  // data. So after merging (v1,v2) survivor is v2, after merging (v3,v4) survivor
+  // is v4. Expected files on disk at the end: v2.vhd, v4.vhd, v5.vhd.
+  const v1 = await generateVhd(`${basePath}/v1.vhd`)
+  const v2 = await generateVhd(`${basePath}/v2.vhd`, {
+    header: { parentUnicodeName: 'v1.vhd', parentUuid: v1.footer.uuid },
+  })
+  const v3 = await generateVhd(`${basePath}/v3.vhd`, {
+    header: { parentUnicodeName: 'v2.vhd', parentUuid: v2.footer.uuid },
+  })
+  const v4 = await generateVhd(`${basePath}/v4.vhd`, {
+    header: { parentUnicodeName: 'v3.vhd', parentUuid: v3.footer.uuid },
+  })
+  await generateVhd(`${basePath}/v5.vhd`, {
+    header: { parentUnicodeName: 'v4.vhd', parentUuid: v4.footer.uuid },
+  })
+
+  await handler.writeFile(
+    `${rootPath}/metadata2.json`,
+    JSON.stringify({ mode: 'delta', vhds: [`${relativePath}/v2.vhd`] })
+  )
+  await handler.writeFile(
+    `${rootPath}/metadata4.json`,
+    JSON.stringify({ mode: 'delta', vhds: [`${relativePath}/v4.vhd`] })
+  )
+  await handler.writeFile(
+    `${rootPath}/metadata5.json`,
+    JSON.stringify({ mode: 'delta', vhds: [`${relativePath}/v5.vhd`] })
+  )
+
+  const mergeChains = []
+  const logInfo = (message, opts) => {
+    if (message === 'merging disk chain') mergeChains.push(opts.chain.map(p => basename(p)))
+  }
+  await VmBackupDirectory.cleanVm(handler, rootPath, { remove: true, merge: true, logInfo, logWarn: () => {} })
+
+  assert.equal(mergeChains.length, 2, 'exactly two independent merges should occur')
+  assert.deepEqual(
+    mergeChains.sort(),
+    [
+      ['v1.vhd', 'v2.vhd'],
+      ['v3.vhd', 'v4.vhd'],
+    ],
+    'merges must be (v1,v2) and (v3,v4), not one big v1..v5 span'
+  )
+
+  const remaining = (await handler.list(basePath)).filter(f => f.endsWith('.vhd')).sort()
+  assert.deepEqual(remaining, ['v2.vhd', 'v4.vhd', 'v5.vhd'])
+})


### PR DESCRIPTION
### Description

When a merge fails on a lineage, all the other steps (merges, removal, etc) fail too. We need to protect this to avoid a always growing remote.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
