### PR TITLE
fix(disk-transform): erronous offset in DiskLargerBlock when copying data

### DIFF
--- a/@xen-orchestra/backup-archive/package.json
+++ b/@xen-orchestra/backup-archive/package.json
@@ -38,6 +38,7 @@
     "build": "yarn run clean && tsc",
     "dev": "tsc --watch",
     "postversion": "npm publish --access public",
+    "test": "yarn run clean && tsc && node --test **/*.test.mjs",
     "test-integration": "yarn run clean && tsc && node --test **/*.integ.mjs",
     "clean": "rimraf dist/"
   },

--- a/@xen-orchestra/backup-archive/src/VmBackup.types.mts
+++ b/@xen-orchestra/backup-archive/src/VmBackup.types.mts
@@ -10,6 +10,11 @@ export interface PartialBackupMetadata {
   jobId: string
   scheduleId: string
   timestamp: number
+  // 'true' when written by code including the non-NBD qcow2 corruption fix and its force-full
+  // gate; its absence marks a potentially-corrupt older backup and makes the gate re-probe.
+  // Preserved (never stamped) across merges here.
+  // @todo remove this code and the logic associated on 2027 01 01
+  includeNonNbdQcow2Fix?: boolean
 }
 export const DEFAULT_MERGE_CONCURRENCY = 1
 export const DEFAULT_REMOVE_CONCURRENCY = 4

--- a/@xen-orchestra/backup-archive/src/disks/RemoteVhdDiskChain.mjs
+++ b/@xen-orchestra/backup-archive/src/disks/RemoteVhdDiskChain.mjs
@@ -312,4 +312,12 @@ export class RemoteVhdDiskChain extends RemoteDisk {
   async clean(opts = {}) {
     throw new Error(`Can't clean a disk chain`)
   }
+
+  /**
+   *
+   * @returns {RemoteVhdDisk|undefined}
+   */
+  getRootDisk() {
+    return this.#disks[0]
+  }
 }

--- a/@xen-orchestra/backups/_otherConfig.mjs
+++ b/@xen-orchestra/backups/_otherConfig.mjs
@@ -33,6 +33,13 @@ export const VM_UUID = 'xo:backup:vm'
 // allows direction-agnostic discovery of common base VDIs (e.g. for failback/reverse replication)
 export const CONTENT_KEY = 'xo:backup:contentKey'
 
+// in `other_config` of a replicated VM and its VDIs
+// set to the string 'true' on every write done by code that includes the non-NBD qcow2
+// corruption fix (fix(disk-transform): erroneous DiskLargerBlock copy offset). Its absence
+// on a qcow2 full means the replica may be silently corrupt and its chain must be re-based
+// with a clean full. Named after the specific fix so future fixes get their own flag.
+export const INCLUDE_NON_NBD_QCOW2_FIX = 'xo:backup:includeNonNbdQcow2Fix'
+
 async function listVdiRefs(xapi, vmRef) {
   return xapi.VM_getDisks(vmRef)
 }
@@ -90,6 +97,7 @@ export function resetVmOtherConfig(xapi, vmRef) {
       [DATETIME]: null,
       [DELTA_CHAIN_LENGTH]: null,
       [EXPORTED_SUCCESSFULLY]: null,
+      [INCLUDE_NON_NBD_QCOW2_FIX]: null,
       [JOB_ID]: null,
       [SCHEDULE_ID]: null,
       [VM_UUID]: null,
@@ -120,6 +128,10 @@ export async function setVmOtherConfig(xapi, vmRef, { timestamp, jobId, schedule
     xapi.setFieldEntries(type, ref, 'other_config', {
       [REPLICATED_TO_SR_UUID]: srUuid,
       [DATETIME]: formatDateTime(timestamp),
+      // stamped on every write: its presence marks the object as produced by code
+      // that includes the non-NBD qcow2 corruption fix, so a chain rooted in a pre-fix
+      // qcow2 full (missing this flag) can be detected and re-based with a clean full
+      [INCLUDE_NON_NBD_QCOW2_FIX]: 'true',
       [JOB_ID]: jobId,
       [SCHEDULE_ID]: scheduleId,
       [VM_UUID]: vmUuid,

--- a/@xen-orchestra/backups/_runners/_vmRunners/IncrementalRemote.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/IncrementalRemote.mjs
@@ -99,6 +99,7 @@ class IncrementalRemoteVmBackupRunner extends AbstractRemote {
         writer =>
           writer.transfer({
             deltaExport: forkDeltaExport(incrementalExport, writer.constructor.name),
+            includeNonNbdQcow2Fix: metadata.includeNonNbdQcow2Fix,
             isVhdDifferencing,
             timestamp: metadata.timestamp,
             vm: metadata.vm,

--- a/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
@@ -73,7 +73,9 @@ export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends Abstr
       writer =>
         writer.transfer({
           deltaExport: forkDeltaExport(deltaExport, writer.constructor.name),
-          // freshly exported from XAPI by fixed code → disk data is known-good
+          // freshly exported from XAPI by code that has the fix and the force-full gate
+          // (writer.checkBaseVdis ran before this transfer), so the chain is verified/forced
+          // clean; the tip's flag lets the next run skip re-probing
           includeNonNbdQcow2Fix: true,
           isVhdDifferencing,
           timestamp,

--- a/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/IncrementalXapi.mjs
@@ -73,6 +73,8 @@ export const IncrementalXapi = class IncrementalXapiVmBackupRunner extends Abstr
       writer =>
         writer.transfer({
           deltaExport: forkDeltaExport(deltaExport, writer.constructor.name),
+          // freshly exported from XAPI by fixed code → disk data is known-good
+          includeNonNbdQcow2Fix: true,
           isVhdDifferencing,
           timestamp,
           vm,

--- a/@xen-orchestra/backups/_runners/_writers/AggregatedIncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/AggregatedIncrementalRemoteWriter.mjs
@@ -50,8 +50,15 @@ export class AggregatedIncrementalRemoteWriter extends AbstractAggregatedRemoteW
     await Promise.all(this.writers.map(writer => writer.prepare({ isFull })))
   }
   // write only on the main writer
-  transfer({ isVhdDifferencing, timestamp, deltaExport, vm, vmSnapshot }) {
-    return this.mainWriter.transfer({ isVhdDifferencing, timestamp, deltaExport, vm, vmSnapshot })
+  transfer({ includeNonNbdQcow2Fix, isVhdDifferencing, timestamp, deltaExport, vm, vmSnapshot }) {
+    return this.mainWriter.transfer({
+      includeNonNbdQcow2Fix,
+      isVhdDifferencing,
+      timestamp,
+      deltaExport,
+      vm,
+      vmSnapshot,
+    })
   }
 
   // remove the backups and remove the entries

--- a/@xen-orchestra/backups/_runners/_writers/AggregatedIncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/AggregatedIncrementalRemoteWriter.mjs
@@ -22,7 +22,7 @@ export class AggregatedIncrementalRemoteWriter extends AbstractAggregatedRemoteW
     }
     // update the parameter with our best candidate
     // that can be an empty map
-    baseUuidToSrcVdi.forEach(key => {
+    baseUuidToSrcVdi.forEach((_, key) => {
       if (!selectedCopy.has(key)) {
         baseUuidToSrcVdi.delete(key)
       }

--- a/@xen-orchestra/backups/_runners/_writers/AggregatedIncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/AggregatedIncrementalRemoteWriter.mjs
@@ -50,15 +50,8 @@ export class AggregatedIncrementalRemoteWriter extends AbstractAggregatedRemoteW
     await Promise.all(this.writers.map(writer => writer.prepare({ isFull })))
   }
   // write only on the main writer
-  transfer({ includeNonNbdQcow2Fix, isVhdDifferencing, timestamp, deltaExport, vm, vmSnapshot }) {
-    return this.mainWriter.transfer({
-      includeNonNbdQcow2Fix,
-      isVhdDifferencing,
-      timestamp,
-      deltaExport,
-      vm,
-      vmSnapshot,
-    })
+  transfer(args) {
+    return this.mainWriter.transfer(args)
   }
 
   // remove the backups and remove the entries

--- a/@xen-orchestra/backups/_runners/_writers/AggregatedIncrementalXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/AggregatedIncrementalXapiWriter.mjs
@@ -25,7 +25,7 @@ export class AggregatedIncrementalXapiWriter extends AbstractAggregatedXapiWrite
     }
     // update the parameter with our best candidate
     // that can be an empty map
-    baseUuidToSrcVdi.forEach(key => {
+    baseUuidToSrcVdi.forEach((_, key) => {
       if (!selectedCopy.has(key)) {
         baseUuidToSrcVdi.delete(key)
       }

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
@@ -16,6 +16,8 @@ import { MixinRemoteWriter } from './_MixinRemoteWriter.mjs'
 import { AbstractIncrementalWriter } from './_AbstractIncrementalWriter.mjs'
 import { checkVhd } from './_checkVhd.mjs'
 import { packUuid } from './_packUuid.mjs'
+import { openDiskChain } from '@xen-orchestra/backup-archive/disks'
+import { VDI_FORMAT_QCOW2 } from '@xen-orchestra/xapi'
 
 const { warn } = createLogger('xo:backups:DeltaBackupWriter')
 
@@ -61,10 +63,93 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
       if (parentDestPath === undefined) {
         baseUuidToSrcVdi.delete(baseUuid)
       } else {
-        this.#parentVdiPaths[vhdDir] = parentDestPath
-        this.#parentUuids[vhdDir] = parentUuid
+        try {
+          // A delta is only chained onto a qcow2 base when NBD is enabled; without NBD a qcow2
+          // export falls back to a full, so there is no suspect base to worry about.
+          if (this._settings.preferNbd && !(await this.#isBaseChainable(parentDestPath))) {
+            Task.warning('forcing a full: qcow2 base predates the non-NBD qcow2 fix and looks corrupt', {
+              parentDestPath,
+            })
+            baseUuidToSrcVdi.delete(baseUuid)
+            return
+          }
+          this.#parentVdiPaths[vhdDir] = parentDestPath
+          this.#parentUuids[vhdDir] = parentUuid
+        } catch (error) {
+          warn('checkBaseVdis: unexpected error, forcing a full', { error, parentDestPath })
+          baseUuidToSrcVdi.delete(baseUuid)
+        }
       }
     })
+  }
+
+  // Decide whether it is safe to chain a delta onto `parentDestPath` (the chain tip).
+  // A qcow2 full exported before the DiskLargerBlock 20260724 fix can be silently corrupt (block 0
+  // valid, following allocated blocks all zero); chaining a delta onto it would extend a
+  // broken chain, so we detect that case and let the caller fall back to a full.
+  async #isBaseChainable(parentDestPath) {
+    // parentDestPath is the chain tip = most-recent backup; its filename is stable under
+    // merges (merges rename the OLDER disks), so unlike the root it maps reliably to its
+    // metadata json.
+    const parentDate = basename(parentDestPath).replace(/\.(alias\.)?vhd$/, '')
+    let metadata
+    try {
+      metadata = await this._adapter.readVmBackupMetadata(`${this._vmBackupDir}/${parentDate}.json`)
+    } catch (error) {
+      warn('checkBaseVdis: cannot read parent metadata, will probe', { error, parentDestPath })
+    }
+    if (metadata?.includeNonNbdQcow2Fix === true) {
+      // written by code that has the fix and this gate, so its chain was already
+      // verified/forced clean — no disk open needed
+      // we can't have includeNonNbdQcow2Fix = false since it  would have restarted a clean chain
+      return true
+    }
+    const isQcow2 =
+      metadata === undefined ||
+      Object.values(metadata.vdis ?? {}).some(vdi => vdi?.sm_config?.['image-format'] === VDI_FORMAT_QCOW2)
+    if (!isQcow2) {
+      // only qcow2 exports can carry this corruption
+      return true
+    }
+    return this.#baseHasData(parentDestPath)
+  }
+
+  // Probe the first data blocks of the chain root for the DiskLargerBlock corruption
+  // signature. Returns false only when enough allocated blocks past the first are all zero.
+  async #baseHasData(parentDestPath) {
+    const { handler } = this._adapter
+    // open the chain (with block allocation tables) and probe its root full. This only runs
+    // once per chain — afterwards the includeNonNbdQcow2Fix flag on the tip skips it — so
+    // reading the deltas' BATs here is negligible and lets us reuse the root disk directly.
+    const chain = await openDiskChain({ handler, path: parentDestPath })
+    try {
+      const root = chain.getRootDisk()
+      if (root === undefined) {
+        throw new Error(`can't resolve root of chain ${parentDestPath}`)
+      }
+      const empty = Buffer.alloc(root.getBlockSize(), 0)
+      const MAX_EMPTY = 10
+      let nbEmpty = 0
+      for (let i = 1; i < root.getMaxBlockCount(); i++) {
+        if (!root.hasBlock(i)) {
+          continue
+        }
+        const { data } = await root.readBlock(i)
+        if (!data.equals(empty)) {
+          // real data → not the corruption signature
+          return true
+        }
+        if (++nbEmpty > MAX_EMPTY) {
+          // enough allocated-but-zero blocks → looks corrupt
+          return false
+        }
+      }
+      // too few allocated blocks past the first to conclude (also covers sparse/tiny disks)
+      // a full should not be too costly
+      return false
+    } finally {
+      await chain.close()
+    }
   }
 
   async beforeBackup() {

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
@@ -139,7 +139,7 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
     }
   }
 
-  async _transfer($defer, { isVhdDifferencing, timestamp, deltaExport, vm, vmSnapshot }) {
+  async _transfer($defer, { includeNonNbdQcow2Fix, isVhdDifferencing, timestamp, deltaExport, vm, vmSnapshot }) {
     const adapter = this._adapter
     const job = this._job
     const scheduleId = this._schedule.id
@@ -168,6 +168,11 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
     }
 
     metadataContent = {
+      // marks whether the disk data is known-good w.r.t. the non-NBD qcow2 corruption bug.
+      // A fresh XAPI export by fixed code passes `true`; the mirror runner propagates the
+      // source backup's value (copying corrupt source data must NOT become "fixed"). Its
+      // absence flags a potentially-corrupt older disk (used by cleanVm and the force-full gate).
+      includeNonNbdQcow2Fix,
       isVhdDifferencing,
       jobId,
       mode: job.mode,

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalRemoteWriter.mjs
@@ -18,6 +18,7 @@ import { checkVhd } from './_checkVhd.mjs'
 import { packUuid } from './_packUuid.mjs'
 import { openDiskChain } from '@xen-orchestra/backup-archive/disks'
 import { VDI_FORMAT_QCOW2 } from '@xen-orchestra/xapi'
+import { diskHasData } from './_diskHasData.mjs'
 
 const { warn } = createLogger('xo:backups:DeltaBackupWriter')
 
@@ -127,26 +128,8 @@ export class IncrementalRemoteWriter extends MixinRemoteWriter(AbstractIncrement
       if (root === undefined) {
         throw new Error(`can't resolve root of chain ${parentDestPath}`)
       }
-      const empty = Buffer.alloc(root.getBlockSize(), 0)
-      const MAX_EMPTY = 10
-      let nbEmpty = 0
-      for (let i = 1; i < root.getMaxBlockCount(); i++) {
-        if (!root.hasBlock(i)) {
-          continue
-        }
-        const { data } = await root.readBlock(i)
-        if (!data.equals(empty)) {
-          // real data → not the corruption signature
-          return true
-        }
-        if (++nbEmpty > MAX_EMPTY) {
-          // enough allocated-but-zero blocks → looks corrupt
-          return false
-        }
-      }
-      // too few allocated blocks past the first to conclude (also covers sparse/tiny disks)
-      // a full should not be too costly
-      return false
+
+      return await diskHasData(root)
     } finally {
       await chain.close()
     }

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
@@ -20,6 +20,7 @@ import {
   DATETIME,
   VM_UUID,
   CONTENT_KEY,
+  INCLUDE_NON_NBD_QCOW2_FIX,
   resetVmOtherConfig,
 } from '../../_otherConfig.mjs'
 import { formatFilenameDate } from '../../_filenameDate.mjs'
@@ -27,8 +28,9 @@ import { XapiDiskSource } from '@xen-orchestra/xapi'
 import { asyncEach } from '@vates/async-each'
 import { createLogger } from '@xen-orchestra/log'
 import { VM_POWER_STATE } from '@vates/types'
+import { diskHasData } from './_diskHasData.mjs'
 
-const { debug } = createLogger('xo:backups:IncrementalXapiWriter')
+const { debug, warn } = createLogger('xo:backups:IncrementalXapiWriter')
 
 export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWriter) {
   // Map of source VDI UUID (COPY_OF) → validated active VDI on the target SR.
@@ -93,6 +95,45 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
         )
       }
       if (target !== undefined) {
+        // A delta is only chained onto a qcow2 base when NBD is enabled; without NBD a qcow2
+        // export falls back to a full, so there is no suspect base.
+        if (this._settings.preferNbd) {
+          // Every copy written by fixed code carries the flag, so the marker on the most recent
+          // link is enough: if it is there, this chain was already verified (or re-based) by a
+          // run that had the fix, and older links need no re-check.
+          const suspect = target.other_config[INCLUDE_NON_NBD_QCOW2_FIX] !== 'true'
+          if (suspect) {
+            const chain = this.#diskReplicaSnapshots(target)
+            // probe the OLDEST link (least-masked view of the corruption — a later delta could
+            // have overwritten the corrupt blocks and hidden the damage on a more recent snapshot).
+            // Re-replicating a full is expensive, so only force one when it actually looks corrupt.
+            let base = target
+            assert.notStrictEqual(base.other_config[DATETIME], undefined)
+            for (const vdi of chain) {
+              const datetime = vdi.other_config[DATETIME]
+              assert.notStrictEqual(datetime, undefined)
+              if (datetime < base.other_config[DATETIME]) {
+                base = vdi
+              }
+            }
+            let chainable
+            try {
+              chainable = await this.#baseVdiHasData(base.$ref)
+            } catch (error) {
+              // can't read the base to decide → don't chain onto it
+              warn('checkBaseVdis: error probing replicated base, forcing a full', { error, baseVdi: base.uuid })
+              chainable = false
+            }
+            if (!chainable) {
+              Task.warning('forcing a full: replicated qcow2 chain predates the non-NBD qcow2 fix and looks corrupt', {
+                baseVdi: base.uuid,
+              })
+              // drop it so neither the snapshot nor the legacy fallback reuses it → full
+              baseUuidToSrcVdi.delete(baseUuid)
+              continue
+            }
+          }
+        }
         snapshotCandidates.set(baseUuid, target)
       }
     }
@@ -133,6 +174,42 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
       }
     }
   }
+
+  // All replica snapshots of a given disk share the same active target VDI ($snapshot_of). Return
+  // them (same job+vm) so the caller can inspect the whole chain: any link missing the fix marker
+  // makes the chain suspect, and the oldest link (by DATETIME) is the least-masked base to probe.
+  // Scoped by $snapshot_of, so history before a CR VM recreation (which resets it) is not included.
+  #diskReplicaSnapshots(target) {
+    const activeUuid = target.$snapshot_of?.uuid
+    const snapshots = []
+    for (const vdi of this._sr.$VDIs) {
+      if (
+        vdi?.managed &&
+        vdi?.is_a_snapshot &&
+        vdi.$snapshot_of?.uuid === activeUuid &&
+        vdi.other_config[JOB_ID] === this._job.id &&
+        vdi.other_config[VM_UUID] === this._vmUuid
+      ) {
+        snapshots.push(vdi)
+      }
+    }
+    return snapshots
+  }
+
+  // Probe a replicated base VDI for the DiskLargerBlock corruption signature (block 0 valid,
+  // following allocated blocks all zero). Uses an export (not NBD): block flow is guaranteed
+  // to be in index order, so block 0 comes first and inspecting the first few blocks is enough.
+  // Returns false only when no allocated non-zero block is found among the first ones.
+  async #baseVdiHasData(vdiRef) {
+    const source = new XapiDiskSource({ xapi: this._sr.$xapi, vdiRef, preferNbd: false })
+    try {
+      await source.init()
+      return await diskHasData(source)
+    } finally {
+      await source.close()
+    }
+  }
+
   /**
    * 6.3+ snapshot-based validation: for each snapshot candidate, check whether
    * the active VDI has diverged from the snapshot. Returns a baseVdisBySourceUuid

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
@@ -1,3 +1,4 @@
+import assert from 'node:assert'
 import humanFormat from 'human-format'
 
 import { asyncMapSettled } from '@xen-orchestra/async-map'
@@ -417,6 +418,10 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
       if (baseDeltaVdiUuid !== undefined) {
         // reuse the validated mapping built by checkBaseVdis
         vdi.baseVdi = this.#baseVdisBySourceUuid.get(baseDeltaVdiUuid)
+        // BASE_DELTA_VDI is set, so the export is differencing. Without a base to clone,
+        // importIncrementalVm would create a blank VDI and write only the changed blocks
+        // into it, silently producing a corrupt replica: fail the job instead.
+        assert.notStrictEqual(vdi.baseVdi, undefined, `no validated target base for ${baseDeltaVdiUuid}`)
       } else {
         // first replication of this disk (full, no base)
         vdi.baseVdi = undefined

--- a/@xen-orchestra/backups/_runners/_writers/_diskHasData.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/_diskHasData.mjs
@@ -1,0 +1,26 @@
+// Probe a disk for the DiskLargerBlock corruption signature (block 0 valid,
+// following allocated blocks all zero). Uses an export (not NBD): block flow is guaranteed
+// to be in index order, so block 0 comes first and inspecting the first few blocks is enough.
+
+// Returns false only when no allocated non-zero block is found among the first ones.
+export async function diskHasData(source) {
+  const empty = Buffer.alloc(source.getBlockSize(), 0)
+  const MAX_EMPTY = 10
+  let nbEmpty = 0
+  // diskBlocks() closes the source when the iteration ends or is broken out of
+  for await (const { index, data } of source.diskBlocks()) {
+    if (index === 0) {
+      // block 0 stays valid even in the corruption signature — skip it
+      continue
+    }
+    if (!data.equals(empty)) {
+      // an allocated block holds real data → not corrupt
+      return true
+    }
+    if (++nbEmpty >= MAX_EMPTY) {
+      break
+    }
+  }
+  // no allocated non-zero block among the first ones → looks corrupt (or empty; a full is cheap then)
+  return false
+}

--- a/@xen-orchestra/disk-transform/src/DiskLargerBlock.mts
+++ b/@xen-orchestra/disk-transform/src/DiskLargerBlock.mts
@@ -67,22 +67,24 @@ export class DiskLargerBlock extends RandomAccessDisk {
 
   getBlockIndexes(): Array<number> {
     const maxBlock = Math.ceil(this.getVirtualSize() / this.getBlockSize())
-    const blockRatio = this.getBlockSize() / this.source.getBlockSize()
     const indexes = []
     for (let i = 0; i < maxBlock; i++) {
-      for (let j = 0; j < blockRatio; j++) {
-        if (this.source.hasBlock(i * blockRatio + j)) {
-          indexes.push(i)
-          break
-        }
+      if (this.hasBlock(i)) {
+        indexes.push(i)
       }
     }
     return indexes
   }
 
   getBlockIndexesCount(): number {
-    let blockRatio = this.getBlockSize() / this.source.getBlockSize()
-    return this.#source.getBlockIndexesCount() / blockRatio
+    let count = 0
+    const maxBlock = Math.ceil(this.getVirtualSize() / this.getBlockSize())
+    for (let i = 0; i < maxBlock; i++) {
+      if (this.hasBlock(i)) {
+        count++
+      }
+    }
+    return count
   }
 
   hasBlock(index: number): boolean {

--- a/@xen-orchestra/disk-transform/src/DiskLargerBlock.mts
+++ b/@xen-orchestra/disk-transform/src/DiskLargerBlock.mts
@@ -31,6 +31,9 @@ export class DiskLargerBlock extends RandomAccessDisk {
     throw new Error('Method not implemented.')
   }
   async readBlock(index: number): Promise<DiskBlock> {
+    if (!this.hasBlock(index)) {
+      throw new Error(`Block ${index} not present in this disk`)
+    }
     // @todo handle partial block at the end
     const source = this.source
     const destinationBlockData = Buffer.alloc(this.getBlockSize(), 0)

--- a/@xen-orchestra/disk-transform/src/DiskLargerBlock.mts
+++ b/@xen-orchestra/disk-transform/src/DiskLargerBlock.mts
@@ -33,9 +33,10 @@ export class DiskLargerBlock extends RandomAccessDisk {
   async readBlock(index: number): Promise<DiskBlock> {
     // @todo handle partial block at the end
     const source = this.source
-    const destinationBlock = Buffer.alloc(this.getBlockSize(), 0)
+    const destinationBlockData = Buffer.alloc(this.getBlockSize(), 0)
     const blockRatio = this.#blockSize / source.getBlockSize()
-    for (let i = index * blockRatio; i < (index + 1) * blockRatio; i++) {
+    const firstSourceBlockIndex = index * blockRatio
+    for (let i = firstSourceBlockIndex; i < firstSourceBlockIndex + blockRatio; i++) {
       let data: Buffer | undefined
       if (source.hasBlock(i)) {
         data = (await source.readBlock(i)).data
@@ -51,12 +52,12 @@ export class DiskLargerBlock extends RandomAccessDisk {
         }
       }
       if (data !== undefined) {
-        data.copy(destinationBlock, i * source.getBlockSize())
+        data.copy(destinationBlockData, (i - firstSourceBlockIndex) * source.getBlockSize())
       }
     }
     return {
       index,
-      data: destinationBlock,
+      data: destinationBlockData,
     }
   }
 

--- a/@xen-orchestra/disk-transform/src/DiskLargerBlock.test.mts
+++ b/@xen-orchestra/disk-transform/src/DiskLargerBlock.test.mts
@@ -118,6 +118,29 @@ test('readBlock with simple block mapping', async () => {
   assert(result.data.subarray(512).equals(block2))
 })
 
+test('readBlock at index > 0 places source data at block-relative offsets', async () => {
+  // Regression test: a large block after index 0 must be assembled from its own
+  // source blocks at offsets relative to the start of that large block.
+  // With distinct, non-zero patterns this catches the case where copy() targets an
+  // absolute (disk-wide) offset and silently produces a zeroed block.
+  const blockC = createPatternBuffer(512, 'C')
+  const blockD = createPatternBuffer(512, 'D')
+  const source = new MockDisk(512, 4096, [
+    [2, blockC],
+    [3, blockD],
+  ])
+  await source.init()
+
+  const disk = new DiskLargerBlock(source, 1024) // blockRatio = 2, so large block 1 = source blocks 2 & 3
+  await disk.init()
+
+  const result = await disk.readBlock(1)
+  assert.strictEqual(result.index, 1)
+  assert.strictEqual(result.data.length, 1024)
+  assert(result.data.subarray(0, 512).equals(blockC))
+  assert(result.data.subarray(512).equals(blockD))
+})
+
 test('hasBlock behavior', async () => {
   const source = new MockDisk(512, 2048, [
     [0, Buffer.alloc(512)],

--- a/@xen-orchestra/disk-transform/src/DiskLargerBlock.test.mts
+++ b/@xen-orchestra/disk-transform/src/DiskLargerBlock.test.mts
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert, { strictEqual } from 'node:assert'
 import { test } from 'node:test'
 import { DiskLargerBlock } from './DiskLargerBlock.mjs'
 import { RandomAccessDisk, DiskBlock, Disk } from './Disk.mjs'
@@ -45,7 +45,7 @@ class MockDisk extends RandomAccessDisk {
     this.closed = true
   }
   isDifferencing(): boolean {
-    return this.isDiff
+    return this.parentDisk !== null || this.isDiff
   }
   instantiateParent(): RandomAccessDisk {
     if (!this.parentDisk) throw new Error('No parent disk available')
@@ -275,4 +275,30 @@ test('generator', async () => {
   for await (const block of disk.diskBlocks()) {
     assert.strictEqual(block.data.length, 1024)
   }
+})
+
+test('readblock missing block throws', async () => {
+  const parentBlock = createPatternBuffer(512, 'PARENT')
+  const childBlock = createPatternBuffer(512, 'CHILD')
+  const sourceParent = new MockDisk(512, 2048, [
+    [0, parentBlock],
+    [1, parentBlock],
+    [2, parentBlock],
+    [3, parentBlock],
+  ])
+  await sourceParent.init()
+  const source = new MockDisk(512, 2048, [[2, childBlock]])
+  source.parentDisk = sourceParent
+  await source.init()
+
+  const disk = new DiskLargerBlock(source, 1024)
+  await disk.init()
+  assert.strictEqual(disk.getBlockIndexesCount(), 1)
+  for await (const block of disk.diskBlocks()) {
+    assert.strictEqual(block.index, 1)
+    assert.ok(block.data.slice(0, 512).equals(childBlock), 'missing child data ')
+    assert.ok(block.data.slice(512, 1024).equals(parentBlock), 'missing parent data')
+  }
+
+  await assert.rejects(() => disk.readBlock(0))
 })

--- a/@xen-orchestra/disk-transform/src/DiskLargerBlock.test.mts
+++ b/@xen-orchestra/disk-transform/src/DiskLargerBlock.test.mts
@@ -237,6 +237,34 @@ test('close propagation', async () => {
   await disk.close()
   assert.strictEqual(source.closed, true)
 })
+test('getBlockIndexesCount', async () => {
+  const block = createPatternBuffer(512, 'BLOCK')
+  let source = new MockDisk(512, 4096, [
+    [2, block],
+    [3, block],
+  ])
+  await source.init()
+
+  let disk = new DiskLargerBlock(source, 1024)
+  await disk.init()
+  assert.strictEqual(disk.getBlockIndexesCount(), 1)
+  assert.strictEqual(disk.getBlockIndexesCount(), disk.getBlockIndexes().length)
+
+  await disk.close()
+
+  source = new MockDisk(512, 4096, [
+    [0, block],
+    [3, block],
+  ])
+  await source.init()
+
+  disk = new DiskLargerBlock(source, 1024)
+  await disk.init()
+  assert.strictEqual(disk.getBlockIndexesCount(), 2)
+  assert.strictEqual(disk.getBlockIndexesCount(), disk.getBlockIndexes().length)
+
+  await disk.close()
+})
 
 test('generator', async () => {
   const source = new MockDisk(512, 1024)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 - [Backups] Fix qcow2 transfer without NBD (PR [#10164](https://github.com/vatesfr/xen-orchestra/pull/10164))
 - [Backups] Force a full backup if any suspect is detected on qcow2 without nbd (PR [#10164](https://github.com/vatesfr/xen-orchestra/pull/10164))
+- [Backups] Force a full feplication if any suspect is detected on qcow2 without nbd (PR [#10164](https://github.com/vatesfr/xen-orchestra/pull/10164))
 - [Backups] Fix aggregated backup failing instead of falling back to a full backup (PR [#10164](https://github.com/vatesfr/xen-orchestra/pull/10164))
 
 ### Packages to release

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,9 @@
 ### Bug fixes
 
 > Users must be able to say: "I had this issue, happy to know it's fixed"
+- [Backups] Fix qcow2 transfer without NBD (PR [#10164](https://github.com/vatesfr/xen-orchestra/pull/10164))
+
+
 
 ### Packages to release
 
@@ -30,5 +33,5 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
-
+- @xen-orchestra/disk-transform patch
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,8 +15,8 @@
 
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 - [Backups] Fix qcow2 transfer without NBD (PR [#10164](https://github.com/vatesfr/xen-orchestra/pull/10164))
-
-
+- [Backups] Force a full backup if any suspect is detected on qcow2 without nbd (PR [#10164](https://github.com/vatesfr/xen-orchestra/pull/10164))
+- [Backups] Fix aggregated backup failing instead of falling back to a full backup (PR [#10164](https://github.com/vatesfr/xen-orchestra/pull/10164))
 
 ### Packages to release
 
@@ -33,5 +33,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+- @xen-orchestra/backup-archive patch
+- @xen-orchestra/backups patch
 - @xen-orchestra/disk-transform patch
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,7 @@
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 - [Backups] Fix qcow2 transfer without NBD (PR [#10164](https://github.com/vatesfr/xen-orchestra/pull/10164))
 - [Backups] Force a full backup if any suspect is detected on qcow2 without nbd (PR [#10164](https://github.com/vatesfr/xen-orchestra/pull/10164))
-- [Backups] Force a full feplication if any suspect is detected on qcow2 without nbd (PR [#10164](https://github.com/vatesfr/xen-orchestra/pull/10164))
+- [Backups] Force a full replication if any suspect is detected on qcow2 without nbd (PR [#10164](https://github.com/vatesfr/xen-orchestra/pull/10164))
 - [Backups] Fix aggregated backup failing instead of falling back to a full backup (PR [#10164](https://github.com/vatesfr/xen-orchestra/pull/10164))
 
 ### Packages to release

--- a/docs/docs/xo5/backups.md
+++ b/docs/docs/xo5/backups.md
@@ -289,8 +289,9 @@ Supported remote types:
 
 - The initial "/" or "\\" is automatically added.
 - For disks larger than **2 TB**, store backups on **block-based remotes**.
-- For **qcow2** disks, use **NBD** mode for backups.
-  :::
+- For **qcow2** disks, enable [NBD](https://docs.xen-orchestra.com/incremental_backups#nbd-enabled-backups) for incremental backups — without it, each run falls back to a full backup.
+
+:::
 
 ### NFS
 
@@ -339,7 +340,8 @@ Xen Orchestra supports Amazon S3 storage and other S3-compatible providers, so y
 
 - Not all S3-compatible providers adhere perfectly to Amazon S3 standards. Make sure to test your setup before trusting it with critical backups.
 - Losing your encryption key means your backups will be permanently inaccessible. If you enable encryption, make sure your key is stored securely, and outside of the backed up infrastructure, as there's no way to recover your data without it.
-  :::
+
+:::
 
 ![](../assets/XO-Amazon-S3-remote.png)
 
@@ -422,7 +424,8 @@ You can also restore specific files and directories inside a VM. It works with a
   - [Data Deduplication](https://learn.microsoft.com/en-us/windows-server/storage/data-deduplication/overview)
   - [Logical Disk Manager](https://en.wikipedia.org/wiki/Logical_Disk_Manager) (LDM)
   - [Resilient File System](https://learn.microsoft.com/en-us/windows-server/storage/refs/refs-overview) (ReFS)
-    :::
+
+:::
 
 ### Restore a file
 
@@ -510,7 +513,8 @@ Concurrency is a parameter that let you define how many VMs your backup job will
 :::tip
 
 - Default concurrency value is 2 if left empty.
-  :::
+
+:::
 
 Let's say you want to backup 50 VMs (each with 1x disk) at 3:00 AM. There are **2 different strategies**:
 
@@ -612,7 +616,8 @@ Xen Orchestra supports the **Grandfather-Father-Son (GFS)** backup retention str
 - **What GFS isn't:**\
   GFS in Xen Orchestra stands for Grandfather-Father-Son. It's a backup strategy, and is not related to the file system called GFS2 (or Global File System 2), supported by XenServer.
 - GFS retention is defined per schedule. For example, if a backup has two schedules, two independent GFS backups will be created. This is why we recommend using a single schedule for any job utilizing GFS long-term retention.
-  :::
+
+:::
 
 #### Enabling GFS Retention
 

--- a/docs/docs/xo5/incremental_backups.md
+++ b/docs/docs/xo5/incremental_backups.md
@@ -88,6 +88,12 @@ After the job is completed, you can verify whether NBD was used for the transfer
 
 ![](../assets/nbd-backup-log.png)
 
+:::warning
+**Incremental backups of qcow2 disks require NBD.** qcow2 disks are used for VDIs larger than 2 TiB and on storage repositories that store their disks in the qcow2 format.
+
+Enabling **Use NBD to transfer disk** in the job's Advanced settings is not sufficient on its own. NBD must also be enabled on at least one network of **every** pool involved, and XOA (or the proxy running the backup) must be able to reach those networks. If a default backup network is set, NBD must be enabled on it. If these conditions are not met, the job **falls back with a warning** to a non-NBD transfer: no qcow2 delta can be produced, so each run transfers a full backup instead. Always confirm NBD was actually used in the backup log after the first run.
+:::
+
 To learn more about the evolution of this feature across various XO releases, check out our blog posts for versions [5.76](https://xen-orchestra.com/blog/xen-orchestra-5-76/), [5.81](https://xen-orchestra.com/blog/xen-orchestra-5-81/), [5.82](https://xen-orchestra.com/blog/xen-orchestra-5-82/), and [5.86](https://xen-orchestra.com/blog/xen-orchestra-5-86/).
 
 ## Understanding large deltas
@@ -108,9 +114,9 @@ Sometimes, you might notice that incremental backups are surprisingly large, alm
 - Look out for cron jobs, log rotations, or background tasks that might be active during backup times.
 - Ensure your VM has enough memory to prevent excessive paging.
 - Create a separated disk with `[NOBAK]` in its name to handle temporary files. This disk won't be transferred.
-    To know more on excluding disks from backup jobs, check out the [Exclude disks](https://docs.xen-orchestra.com/backups#exclude-disks) section.
+  To know more on excluding disks from backup jobs, check out the [Exclude disks](https://docs.xen-orchestra.com/backups#exclude-disks) section.
 - For disks larger than **2 TB**, store backups on a remote in **block mode**.
-- For **qcow2** disks, use **NBD** mode for backups.
+- For **qcow2** disks, [enable NBD](#nbd-enabled-backups) — without it, each incremental run falls back to a full backup.
 
 ### Known issues
 
@@ -121,4 +127,5 @@ To prevent this:
 
 1. Migrate the disk to another storage. This will reset the disk state.
 2. Disable **purge snapshot data** on the backup.
+
 :::


### PR DESCRIPTION
the offset must be relative to the start of THIS large block, not to the start of the disk — otherwise every large block after index 0 lands past the end of destinationBlock and copy() silently writes nothing (zeroed block).

affect qcow2 incremental backup with NBD disable

NBD + qcow2 and Vhd backups don't go through this code path

review by commit : 
* fix the root issue
* update the documentation 
* mark the fixed backup and replication
* mini fix to allow for reopenning a disk 
* get the root of a chain
* force a full backup if the base disk is potentially impacted
* force a full replication if the root disk is potentially impacted


### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
