### PR TITLE
feat(overlay): allow manually aborting overlays

### DIFF
--- a/@xen-orchestra/lite/src/main.ts
+++ b/@xen-orchestra/lite/src/main.ts
@@ -1,5 +1,7 @@
 import App from '@/App.vue'
 import i18n from '@core/i18n'
+import { useOverlayStore } from '@core/packages/overlay/use-overlay-store.ts'
+import { noop } from '@vueuse/core'
 import { createPinia } from 'pinia'
 import { createApp } from 'vue'
 import { createRouter, createWebHashHistory } from 'vue-router'
@@ -10,6 +12,13 @@ const router = createRouter({
   history: createWebHashHistory(),
   routes,
 })
+
+router
+  .isReady()
+  .catch(noop)
+  .then(() => {
+    router.afterEach(() => useOverlayStore().abortAll())
+  })
 
 const app = createApp(App)
 

--- a/@xen-orchestra/web-core/lib/components/overlay/VtsOverlayList.vue
+++ b/@xen-orchestra/web-core/lib/components/overlay/VtsOverlayList.vue
@@ -28,7 +28,7 @@ const overlayStore = useOverlayStore()
   .backdrop {
     position: fixed;
     inset: 0;
-    z-index: 1011;
+    z-index: 1015;
     background-color: var(--color-opacity-primary);
     pointer-events: none;
 
@@ -46,7 +46,7 @@ const overlayStore = useOverlayStore()
   .overlays {
     position: fixed;
     inset: 0;
-    z-index: 1012;
+    z-index: 1016;
 
     /* The container only positions the stacked modals; each modal catches its own
        clicks, so an empty container must let clicks through. */

--- a/@xen-orchestra/web-core/lib/packages/overlay/README.md
+++ b/@xen-orchestra/web-core/lib/packages/overlay/README.md
@@ -163,12 +163,13 @@ An event that is _not_ declared in `useOverlay` can also be handled at open time
 
 ## Aborted overlays
 
-An overlay can be torn down without a user decision:
+An overlay is not tied to the lifecycle of the component that opened it: it stays open until the user makes a decision, or until it is aborted. An overlay can be aborted in three ways:
 
-- the component that created it (where `useOverlay` was called) is unmounted (its scope is disposed),
-- or `open()` is called again on the same `useOverlay` instance while the overlay is still open (the previous one is replaced).
+- `open()` is called again on the same `useOverlay` instance while the overlay is still open (the previous one is replaced),
+- the `abort()` function returned by `useOverlay` is called,
+- or the store's `abortAll()` is called (see below).
 
-In both cases the promise resolves with `OVERLAY_ABORT_EVENT` (a symbol) as its `event`, and no handler runs:
+In all cases the promise resolves with `OVERLAY_ABORT_EVENT` (a symbol) as its `event`, and no handler runs:
 
 ```ts
 const response = await open()
@@ -179,6 +180,10 @@ if (response.event === OVERLAY_ABORT_EVENT) {
 ```
 
 The `OVERLAY_ABORT_EVENT` case is always part of the response union, so exhaustive `event` checks will remind you it exists.
+
+Aborting an overlay whose decision is already being resolved is a no-op: the promise resolves with the actual response.
+
+An overlay can also be aborted while one of its handlers is still awaiting (for example, navigating away while a save is in progress). In that case the overlay closes right away with `OVERLAY_ABORT_EVENT`. The handler's async work keeps running — it cannot be cancelled — but the value it eventually returns is ignored, and the caller sees an abort.
 
 ## Busy and disabled triggers
 
@@ -283,3 +288,13 @@ Opened overlays live in a Pinia store (`useOverlayStore`). The app must render t
 ```
 
 Styling and animations are up to you. The store also exposes `isCurrent(key)` to style stacked overlays (e.g. dim the ones below the topmost), and each `overlay` carries its current `status`.
+
+Since overlays are not tied to the component that opened them, dismissing them on navigation is the app's decision. If that's the behavior you want, wire it once on the router:
+
+```ts
+router.isReady().then(() => {
+  router.afterEach(() => useOverlayStore().abortAll())
+})
+```
+
+Register the guard only once the router is ready: the initial navigation also triggers `afterEach`, which would abort any overlay opened while the app was starting up.

--- a/@xen-orchestra/web-core/lib/packages/overlay/create-event-handler.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/create-event-handler.ts
@@ -1,7 +1,6 @@
 import { isThenable } from '@core/packages/overlay/is-thenable.ts'
 import { KEEP_OVERLAY_OPEN } from '@core/packages/overlay/symbols.ts'
-import type { Overlay, OverlayEventHandler, OverlayResponse } from '@core/packages/overlay/types.ts'
-import { nextTick } from 'vue'
+import type { Overlay, OverlayEventHandler, OverlayResponse, OverlayStatus } from '@core/packages/overlay/types.ts'
 
 export function createEventHandler({
   overlay,
@@ -12,7 +11,7 @@ export function createEventHandler({
   overlay: Overlay
   definitionEvents: Record<string, true | OverlayEventHandler>
   openEvents: Record<string, OverlayEventHandler>
-  settle: (response: OverlayResponse<PropertyKey, unknown>) => void
+  settle: (response: OverlayResponse<PropertyKey, unknown>) => Promise<void>
 }) {
   const shouldStop = (payload: unknown) => payload === KEEP_OVERLAY_OPEN || overlay.status === 'settled'
 
@@ -32,7 +31,7 @@ export function createEventHandler({
     }
 
     try {
-      overlay.status = 'locked'
+      overlay.status = 'locked' as OverlayStatus
 
       // The definition handler receives the raw emit arguments, then the open
       // handler receives the payload it produced. An event handled at open
@@ -62,13 +61,7 @@ export function createEventHandler({
         }
       }
 
-      overlay.status = 'settled'
-
-      // The leave transition freezes the DOM in its last painted state,
-      // so paint a non-busy frame before removing the overlay
-      await nextTick()
-
-      settle({ event: eventName, payload })
+      await settle({ event: eventName, payload })
     } finally {
       if (overlay.status !== 'settled') {
         overlay.status = 'idle'

--- a/@xen-orchestra/web-core/lib/packages/overlay/types.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/types.ts
@@ -62,6 +62,7 @@ export interface Overlay {
   props: Record<string, unknown>
   status: OverlayStatus
   lastTrigger: symbol | undefined
+  abort: () => void
 }
 
 export type ExtractEventName<TName> = TName extends `onVnode${string}`

--- a/@xen-orchestra/web-core/lib/packages/overlay/use-overlay-store.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/use-overlay-store.ts
@@ -15,6 +15,10 @@ export const useOverlayStore = defineStore('overlay', () => {
     }
   }
 
+  function abortAll() {
+    registry.value.forEach(overlay => overlay.abort())
+  }
+
   function isCurrent(key: symbol): boolean {
     return Array.from(registry.value.keys()).at(-1) === key
   }
@@ -27,6 +31,7 @@ export const useOverlayStore = defineStore('overlay', () => {
     overlays: computed(() => Array.from(registry.value.values())),
     register,
     unregister,
+    abortAll,
     isCurrent,
     get,
   }

--- a/@xen-orchestra/web-core/lib/packages/overlay/use-overlay.ts
+++ b/@xen-orchestra/web-core/lib/packages/overlay/use-overlay.ts
@@ -13,7 +13,7 @@ import type {
 } from '@core/packages/overlay/types.ts'
 import { useOverlayStore } from '@core/packages/overlay/use-overlay-store.ts'
 import { reactiveComputed } from '@vueuse/core'
-import { defineAsyncComponent, markRaw, onScopeDispose, reactive, type AsyncComponentLoader, type Component } from 'vue'
+import { defineAsyncComponent, markRaw, nextTick, reactive, type AsyncComponentLoader, type Component } from 'vue'
 import type { ComponentProps } from 'vue-component-type-helpers'
 
 export function useOverlay<TComponent extends Component, const TEvents extends OverlayEvents<TComponent>>({
@@ -29,9 +29,11 @@ export function useOverlay<TComponent extends Component, const TEvents extends O
 
   const component = defineAsyncComponent(componentLoader)
 
-  let abortCurrent: (() => void) | undefined
+  let currentOverlay: Overlay | undefined
 
-  onScopeDispose(() => abortCurrent?.(), true)
+  function abort() {
+    currentOverlay?.abort()
+  }
 
   function open<TOpenEvents extends OpenEvents<TComponent, TEvents>>(
     ...args: MaybeOptionalArgs<
@@ -45,8 +47,7 @@ export function useOverlay<TComponent extends Component, const TEvents extends O
   ) {
     const { events: openEvents, props } = args[0] ?? {}
 
-    // Reopening while the previous overlay is still open replaces it
-    abortCurrent?.()
+    abort()
 
     return new Promise<ExtractOverlayResponse<TComponent, TEvents, TOpenEvents>>(resolve => {
       const definitionEvents = events as Record<string, true | OverlayEventHandler>
@@ -60,16 +61,30 @@ export function useOverlay<TComponent extends Component, const TEvents extends O
         props: {},
         status: 'idle',
         lastTrigger: undefined,
+        abort: () => settle({ event: OVERLAY_ABORT_EVENT, payload: undefined }),
       })
 
-      function settle(response: ExtractOverlayResponse<TComponent, TEvents, TOpenEvents>) {
-        overlay.status = 'settled'
-        abortCurrent = undefined
-        resolve(response)
-        overlayStore.unregister(overlay)
-      }
+      currentOverlay = overlay
 
-      abortCurrent = () => settle({ event: OVERLAY_ABORT_EVENT, payload: undefined })
+      async function settle(response: ExtractOverlayResponse<TComponent, TEvents, TOpenEvents>) {
+        if (overlay.status === 'settled') {
+          return
+        }
+
+        overlay.status = 'settled'
+
+        // The `leave` transition freezes the DOM in its last painted state,
+        // so paint a non-busy frame before removing the overlay
+        await nextTick()
+
+        resolve(response)
+
+        overlayStore.unregister(overlay)
+
+        if (currentOverlay === overlay) {
+          currentOverlay = undefined
+        }
+      }
 
       const handleEvent = createEventHandler({
         overlay,
@@ -95,5 +110,5 @@ export function useOverlay<TComponent extends Component, const TEvents extends O
     })
   }
 
-  return { open }
+  return { open, abort }
 }

--- a/@xen-orchestra/web/src/main.ts
+++ b/@xen-orchestra/web/src/main.ts
@@ -1,5 +1,6 @@
 import { formValidationConfig } from '@/plugins/form-validation.config.ts'
 import i18n from '@core/i18n'
+import { useOverlayStore } from '@core/packages/overlay/use-overlay-store.ts'
 import { RegleVuePlugin } from '@regle/core'
 import type { XoUser } from '@vates/types'
 import { useFetch } from '@vueuse/core'
@@ -52,6 +53,8 @@ async function init() {
   } catch (error) {
     console.error('Initial navigation failed', error)
   }
+
+  router.afterEach(() => useOverlayStore().abortAll())
 
   app.mount('#app')
 }


### PR DESCRIPTION
### Description

Replace the auto-abort-on-unmount behavior with explicit control: `useOverlay` now returns an `abort()` function alongside `open()`, and the overlay store exposes `abortAll()`. Overlays are no longer tied to the lifecycle of the component that opened them — they stay open until the user settles them or they are explicitly aborted.

`abortAll()` is wired on router navigation in the web and lite apps, so open overlays are dismissed when the route changes. `settle()` is now guarded so aborting an already-settled overlay is a no-op, and the `nextTick` paint frame moved into `settle()` to cover the abort path too.

```ts
const { open, abort } = useOverlay({
  component: () => import('@/components/vm/VmDeleteModal.vue'),
  events: { onConfirm: true },
})

const response = await open({ props: { vm } })

// From anywhere holding the composable, dismiss the current overlay:
abort()

// Or dismiss every open overlay (e.g. on navigation):
useOverlayStore().abortAll()
```

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
