### PR TITLE
doc(RBAC) : added details on POST privilege example

### DIFF
--- a/docs/docs/xo6/acl-v2.md
+++ b/docs/docs/xo6/acl-v2.md
@@ -165,12 +165,12 @@ Actions are written using the exact string you pass in a privilege. A parent act
 
 > Alice needs to start and stop VMs in her test environment, but must not touch anything in production.
 
-Create a `QA Operator` role with these privileges:
+Create a `QA Operator` role with these privileges: POST /acl-privileges
 
 ```json
-{ "resource": "vm", "action": "read",     "effect": "allow", "selector": "tags:qa" }
-{ "resource": "vm", "action": "start",    "effect": "allow", "selector": "tags:qa" }
-{ "resource": "vm", "action": "shutdown", "effect": "allow", "selector": "tags:qa" }
+{ "resource": "vm", "action": "read",     "effect": "allow", "selector": "tags:qa" "roleId": "169020fd-4d5e-45fc-a26c-23153df00dcf"}
+{ "resource": "vm", "action": "start",    "effect": "allow", "selector": "tags:qa" "roleId": "169020fd-4d5e-45fc-a26c-23153df00dcf"}
+{ "resource": "vm", "action": "shutdown", "effect": "allow", "selector": "tags:qa" "roleId": "169020fd-4d5e-45fc-a26c-23153df00dcf"}
 ```
 
 Attach the role to Alice. She can now manage QA VMs only. Any attempt on a VM without the `qa` tag is blocked with a 403.


### PR DESCRIPTION
### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
