### PR TITLE
fix(xapi/host): fix async use in a sync block for smart reboot

### DIFF
--- a/@xen-orchestra/xapi/host.mjs
+++ b/@xen-orchestra/xapi/host.mjs
@@ -48,14 +48,16 @@ class Host {
 
     // check the VMs with PCI passthrough
     const vms = await asyncMap(residentVmRefs, ref => this.getRecord('VM', ref))
-    const vmsNotSuspendable = vms.filter(async vm => {
+    const vmsNotSuspendable = []
+
+    await asyncEach(vms, async vm => {
       try {
         await this.call('VM.assert_operation_valid', vm.$ref, 'suspend')
-        return false
       } catch (err) {
-        return true
+        vmsNotSuspendable.push(vm)
       }
     })
+
     const vmsNotSuspendableRefs = new Set(vmsNotSuspendable.map(vm => vm.$ref))
 
     const vmsWithSuspendBlocked = await asyncMap(residentVmRefs, ref => this.getRecord('VM', ref)).filter(

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,6 +30,7 @@
 - [XO6] Fix the VM's VDI tab, which sometimes displays an error (PR [#10156](https://github.com/vatesfr/xen-orchestra/pull/10156))
 - [XO6] Reduce the number of HTTP requests when navigating between pages (PR [#10156](https://github.com/vatesfr/xen-orchestra/pull/10156))
 - [Backups] Don't hide errors during transfers (PR [#10183](https://github.com/vatesfr/xen-orchestra/pull/10183))
+- [Smart reboot] Fix `suspendBlocked` error when no issue to suspend resident VMs (PR []())
 
 ### Packages to release
 
@@ -54,6 +55,7 @@
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+- @xen-orchestra/xapi patch
 - xo-server minor
 - xo-server-openmetrics minor
 - xo-web minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,7 +30,7 @@
 - [XO6] Fix the VM's VDI tab, which sometimes displays an error (PR [#10156](https://github.com/vatesfr/xen-orchestra/pull/10156))
 - [XO6] Reduce the number of HTTP requests when navigating between pages (PR [#10156](https://github.com/vatesfr/xen-orchestra/pull/10156))
 - [Backups] Don't hide errors during transfers (PR [#10183](https://github.com/vatesfr/xen-orchestra/pull/10183))
-- [Smart reboot] Fix `suspendBlocked` error when no issue to suspend resident VMs (PR []())
+- [Smart reboot] Fix `suspendBlocked` error when no issue to suspend resident VMs (PR [#10180](https://github.com/vatesfr/xen-orchestra/pull/10180))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

Array.filter, doesn't support async operation.
Introduced by 42ca53f80c5219ebbd49d0cb3fc0b0f1f370e2f9

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
