### PR TITLE
fix(immutable-backup): in depth cleanup on start 

### DIFF
--- a/@xen-orchestra/immutable-backups/.USAGE.md
+++ b/@xen-orchestra/immutable-backups/.USAGE.md
@@ -38,8 +38,7 @@ immutabilityDuration = "7d"
 
 ## CLI commands
 
-- **`xo-immutable-remote`**: Start the watching daemon. Must be kept running to protect new backups reliably.
-- **`xo-lift-remote-immutability`**: Manually trigger a lifting pass. If `liftEvery` is set in the config, the process continues running and repeats the check on that interval.
+- **`xo-immutable-remote`**: Start the watching daemon. Must be kept running to protect new backups reliably. It lifts expired immutability on startup, then every `liftEvery`.
 
 ## How protection works
 
@@ -84,6 +83,8 @@ On each `liftEvery` tick (and once immediately on startup), the service walks th
 
 The expiry reference is the **datetime in the filename**, not the file's `mtime`. XO periodically rewrites metadata `.json` files (cache refresh, reconciliation), which would otherwise reset `mtime` and defer expiry indefinitely.
 
+A lift pass runs immediately when the service starts, then on every `liftEvery` tick.
+
 On the **first lift run after startup**, all backup files are scanned unconditionally (full scan). This catches orphaned immutable files left by a previous partial or interrupted lock. Subsequent runs use a fast-path: only backups whose `.json` sentinel is currently immutable are processed.
 
 ## Troubleshooting
@@ -124,7 +125,7 @@ Change the setting. The next lift cycle will use the new duration; files already
 
 ### Reducing the immutability duration
 
-Change the setting, then run `xo-lift-remote-immutability` to apply immediately, or wait for the next scheduled `liftEvery` cycle.
+Change the setting, then restart `xo-immutable-remote` to apply immediately, or wait for the next scheduled `liftEvery` cycle.
 
 ### Why are my incremental backups not marked as protected in XO?
 

--- a/@xen-orchestra/immutable-backups/.USAGE.md
+++ b/@xen-orchestra/immutable-backups/.USAGE.md
@@ -83,9 +83,9 @@ On each `liftEvery` tick (and once immediately on startup), the service walks th
 
 The expiry reference is the **datetime in the filename**, not the file's `mtime`. XO periodically rewrites metadata `.json` files (cache refresh, reconciliation), which would otherwise reset `mtime` and defer expiry indefinitely.
 
-A lift pass runs immediately when the service starts, then on every `liftEvery` tick.
-
 On the **first lift run after startup**, all backup files are scanned unconditionally (full scan). This catches orphaned immutable files left by a previous partial or interrupted lock. Subsequent runs use a fast-path: only backups whose `.json` sentinel is currently immutable are processed.
+
+The first run also walks the disk directories (`xo-vm-backups/<vmUUID>/vdis/<jobId>/<vdiId>/`) directly and lifts any expired disk found there, still using the datetime in its own filename. Both the locking and the regular lifting name a backup's disks from its `<datetime>.json`, so a disk stops being reachable that way once XO's retention has deleted that json — or once a merge has renamed the disk, since the surviving `data/<datetime>.vhd` then carries the datetime of the older backup its blocks came from. Such a disk would otherwise stay immutable forever, and an immutable disk prevents XO from ever merging or deleting the backups of that VDI.
 
 ## Troubleshooting
 
@@ -114,8 +114,10 @@ If one or a few VM had an issue and need manual cleanup, you can manually lift t
 4. As root on the file server, run:
    ```bash
    chattr +i /path/to/remote/on/fileserver/xo-vm-backups/<vm uuid>/*.json
-   chattr +i -R /path/to/remote/on/fileserver/xo-vm-backups/<vm uuid>/vdis/
+   chattr +i -R /path/to/remote/on/fileserver/xo-vm-backups/<vm uuid>/vdis/*/*/*.vhd
+   chattr +i -R /path/to/remote/on/fileserver/xo-vm-backups/<vm uuid>/vdis/*/*/data/*.vhd
    ```
+   Lock the disks, **not** the directories that hold them: `chattr +i -R …/vdis/` also locks `vdis`, the job and VDI directories and `data`, and an immutable directory rejects the files of the next backup, so every later run of that VM would fail. Depending on whether the remote uses VHD directories, one of the two commands above may report that it matched nothing.
 
 Note that this VM will be mutable between step 2 and 4, it's up to you to document and test the backup after.
 

--- a/@xen-orchestra/immutable-backups/README.md
+++ b/@xen-orchestra/immutable-backups/README.md
@@ -99,9 +99,9 @@ On each `liftEvery` tick (and once immediately on startup), the service walks th
 
 The expiry reference is the **datetime in the filename**, not the file's `mtime`. XO periodically rewrites metadata `.json` files (cache refresh, reconciliation), which would otherwise reset `mtime` and defer expiry indefinitely.
 
-A lift pass runs immediately when the service starts, then on every `liftEvery` tick.
-
 On the **first lift run after startup**, all backup files are scanned unconditionally (full scan). This catches orphaned immutable files left by a previous partial or interrupted lock. Subsequent runs use a fast-path: only backups whose `.json` sentinel is currently immutable are processed.
+
+The first run also walks the disk directories (`xo-vm-backups/<vmUUID>/vdis/<jobId>/<vdiId>/`) directly and lifts any expired disk found there, still using the datetime in its own filename. Both the locking and the regular lifting name a backup's disks from its `<datetime>.json`, so a disk stops being reachable that way once XO's retention has deleted that json — or once a merge has renamed the disk, since the surviving `data/<datetime>.vhd` then carries the datetime of the older backup its blocks came from. Such a disk would otherwise stay immutable forever, and an immutable disk prevents XO from ever merging or deleting the backups of that VDI.
 
 ## Troubleshooting
 
@@ -130,8 +130,10 @@ If one or a few VM had an issue and need manual cleanup, you can manually lift t
 4. As root on the file server, run:
    ```bash
    chattr +i /path/to/remote/on/fileserver/xo-vm-backups/<vm uuid>/*.json
-   chattr +i -R /path/to/remote/on/fileserver/xo-vm-backups/<vm uuid>/vdis/
+   chattr +i -R /path/to/remote/on/fileserver/xo-vm-backups/<vm uuid>/vdis/*/*/*.vhd
+   chattr +i -R /path/to/remote/on/fileserver/xo-vm-backups/<vm uuid>/vdis/*/*/data/*.vhd
    ```
+   Lock the disks, **not** the directories that hold them: `chattr +i -R …/vdis/` also locks `vdis`, the job and VDI directories and `data`, and an immutable directory rejects the files of the next backup, so every later run of that VM would fail. Depending on whether the remote uses VHD directories, one of the two commands above may report that it matched nothing.
 
 Note that this VM will be mutable between step 2 and 4, it's up to you to document and test the backup after.
 

--- a/@xen-orchestra/immutable-backups/README.md
+++ b/@xen-orchestra/immutable-backups/README.md
@@ -54,8 +54,7 @@ immutabilityDuration = "7d"
 
 ## CLI commands
 
-- **`xo-immutable-remote`**: Start the watching daemon. Must be kept running to protect new backups reliably.
-- **`xo-lift-remote-immutability`**: Manually trigger a lifting pass. If `liftEvery` is set in the config, the process continues running and repeats the check on that interval.
+- **`xo-immutable-remote`**: Start the watching daemon. Must be kept running to protect new backups reliably. It lifts expired immutability on startup, then every `liftEvery`.
 
 ## How protection works
 
@@ -100,6 +99,8 @@ On each `liftEvery` tick (and once immediately on startup), the service walks th
 
 The expiry reference is the **datetime in the filename**, not the file's `mtime`. XO periodically rewrites metadata `.json` files (cache refresh, reconciliation), which would otherwise reset `mtime` and defer expiry indefinitely.
 
+A lift pass runs immediately when the service starts, then on every `liftEvery` tick.
+
 On the **first lift run after startup**, all backup files are scanned unconditionally (full scan). This catches orphaned immutable files left by a previous partial or interrupted lock. Subsequent runs use a fast-path: only backups whose `.json` sentinel is currently immutable are processed.
 
 ## Troubleshooting
@@ -116,7 +117,7 @@ Restart `xo-immutable-remote`. The first lift run after startup always performs 
    chattr -i -R /path/to/remote/on/fileserver/
    ```
 
-### Make one VM mutable again temporarly
+### Make one VM temporarily mutable again
 
 If one or a few VM had an issue and need manual cleanup, you can manually lift the immutability for one VM.
 
@@ -125,14 +126,14 @@ If one or a few VM had an issue and need manual cleanup, you can manually lift t
    ```bash
    chattr -i -R /path/to/remote/on/fileserver/xo-vm-backups/<vm uuid>
    ```
-3. run the backup job, it will fix what is reparable and purge the non recoverable backups
+3. Run the backup job, it will fix what is repairable and purge the non recoverable backups
 4. As root on the file server, run:
    ```bash
    chattr +i /path/to/remote/on/fileserver/xo-vm-backups/<vm uuid>/*.json
    chattr +i -R /path/to/remote/on/fileserver/xo-vm-backups/<vm uuid>/vdis/
    ```
 
-Note that this VM will be mutable between step 2 and 4, it's up to you to document and test the backup after
+Note that this VM will be mutable between step 2 and 4, it's up to you to document and test the backup after.
 
 ### Increasing the immutability duration
 
@@ -140,7 +141,7 @@ Change the setting. The next lift cycle will use the new duration; files already
 
 ### Reducing the immutability duration
 
-Change the setting, then run `xo-lift-remote-immutability` to apply immediately, or wait for the next scheduled `liftEvery` cycle.
+Change the setting, then restart `xo-immutable-remote` to apply immediately, or wait for the next scheduled `liftEvery` cycle.
 
 ### Why are my incremental backups not marked as protected in XO?
 

--- a/@xen-orchestra/immutable-backups/src/directory.mts
+++ b/@xen-orchestra/immutable-backups/src/directory.mts
@@ -8,17 +8,18 @@ export async function makeImmutable(dirPath: string): Promise<void> {
 // chattr processes all paths even when some are missing (it does not abort on the first
 // error), so every existing path is correctly lifted.
 //
-// Per-path "while trying to stat" messages (ENOENT) are silently ignored regardless of
-// locale — these are always expected for optional paths (.xva, .alias.vhd, …) that are
-// absent in delta backups.  chattr localises the error description but "while trying to
-// stat" is always emitted in English, so we match on that suffix only.
+// Per-path "while trying to stat" messages (ENOENT) are silently ignored — these are always
+// expected for optional paths (.xva, .alias.vhd, …) that are absent in delta backups.  chattr
+// translates that whole message, so it is run under `LC_ALL=C`: without it, every batch
+// containing an optional missing path fails on a localised system, which means no backup ever
+// gets locked there.
 //
 // Any other error (e.g. EAGAIN on NFS when the file is still open, permission denied) is
 // retried up to 3 times with a 1 s delay before being re-thrown.
 async function execChattrWithMissingFiles(args: string[]): Promise<void> {
   for (let attempt = 0; ; attempt++) {
     try {
-      await execa('chattr', args)
+      await execa('chattr', args, { env: { LC_ALL: 'C' } })
       return
     } catch (err) {
       const stderr = (err as ExecaError).stderr ?? ''

--- a/@xen-orchestra/immutable-backups/src/liftProtection.integ.mts
+++ b/@xen-orchestra/immutable-backups/src/liftProtection.integ.mts
@@ -1,0 +1,177 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { tmpdir } from 'node:os'
+import { rimraf } from 'rimraf'
+import execa from 'execa'
+
+import * as Directory from './directory.mjs'
+import { liftRemoteImmutability } from './liftProtection.mjs'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
+
+const VM_UUID = 'aaaaaaaa-0000-0000-0000-000000000001'
+const JOB_UUID = 'bbbbbbbb-0000-0000-0000-000000000001'
+const VDI_UUID = 'cccccccc-0000-0000-0000-000000000001'
+
+/** Well past any reasonable immutabilityDuration. */
+const EXPIRED_DATE = '20240115T120000Z'
+/** Inside the window: the expiry reference is the datetime in the name, not the file's dates. */
+const RECENT_DATE = new Date().toISOString().replace(/[-:.]/g, '').slice(0, 15) + 'Z'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Recursively lift all immutable flags inside `root`, then delete the tree.
+// Must be run as root since chattr requires elevated privileges.
+async function cleanupRoot(root: string): Promise<void> {
+  try {
+    await execa('chattr', ['-i', '-R', root])
+  } catch (_err) {}
+  await rimraf(root)
+}
+
+async function makeRoot(): Promise<string> {
+  return await fs.mkdtemp(path.join(tmpdir(), 'immut-lift-test-'))
+}
+
+function vmDirOf(root: string): string {
+  return path.join(root, 'xo-vm-backups', VM_UUID)
+}
+
+function vdiDirOf(root: string): string {
+  return path.join(vmDirOf(root), 'vdis', JOB_UUID, VDI_UUID)
+}
+
+// Creates `vdis/<jobId>/<vdiId>/<datetime>.alias.vhd` plus the VHD directory it points at, the way
+// XO lays them out, and returns both paths along with one block file inside the VHD directory.
+async function writeDisk(root: string, datetime: string) {
+  const vdiDir = vdiDirOf(root)
+  const dataDir = path.join(vdiDir, 'data')
+  const vhdDir = path.join(dataDir, `${datetime}.vhd`)
+  const blockFile = path.join(vhdDir, 'blocks', '0', '0')
+
+  await fs.mkdir(path.dirname(blockFile), { recursive: true })
+  await fs.writeFile(blockFile, 'block')
+  await fs.writeFile(path.join(vhdDir, 'footer'), 'footer')
+
+  const alias = path.join(vdiDir, `${datetime}.alias.vhd`)
+  await fs.writeFile(alias, path.relative(vdiDir, vhdDir))
+
+  return { alias, vhdDir, blockFile }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('liftProtection/liftRemoteImmutability', async () => {
+  it('lifts expired disks that no metadata json names any more', async () => {
+    const root = await makeRoot()
+    try {
+      // Retention deletes the json first and leaves the disks to the next cleanVm, so nothing names
+      // them: this is the state the sentinel-driven pass cannot reach.
+      const { alias, vhdDir, blockFile } = await writeDisk(root, EXPIRED_DATE)
+      await Directory.makeImmutableBatch([alias, vhdDir])
+
+      assert.strictEqual(await Directory.isImmutable(alias), true, 'alias should start immutable')
+      assert.strictEqual(await Directory.isImmutable(vhdDir), true, 'VHD directory should start immutable')
+
+      await liftRemoteImmutability(root, ONE_DAY_MS, true)
+
+      assert.strictEqual(await Directory.isImmutable(alias), false, 'alias should be lifted')
+      assert.strictEqual(await Directory.isImmutable(vhdDir), false, 'VHD directory should be lifted')
+      // A VHD directory is useless to XO unless its blocks are writable too: the merge moves block
+      // files out of it.
+      assert.strictEqual(await Directory.isImmutable(blockFile), false, 'blocks should be lifted too')
+
+      // and the files are really usable again
+      await fs.unlink(blockFile)
+      await fs.unlink(alias)
+    } finally {
+      await cleanupRoot(root)
+    }
+  })
+
+  it('keeps disks inside the immutability window locked', async () => {
+    const root = await makeRoot()
+    try {
+      const { alias, vhdDir, blockFile } = await writeDisk(root, RECENT_DATE)
+      await Directory.makeImmutableBatch([alias, vhdDir])
+
+      await liftRemoteImmutability(root, ONE_DAY_MS, true)
+
+      assert.strictEqual(await Directory.isImmutable(alias), true, 'recent alias must stay immutable')
+      assert.strictEqual(await Directory.isImmutable(vhdDir), true, 'recent VHD directory must stay immutable')
+      assert.strictEqual(await Directory.isImmutable(blockFile), true, 'recent blocks must stay immutable')
+
+      await assert.rejects(fs.unlink(alias), { code: 'EPERM' })
+    } finally {
+      await cleanupRoot(root)
+    }
+  })
+
+  it('does not sweep the disk directories outside of a full scan', async () => {
+    const root = await makeRoot()
+    try {
+      const { alias, vhdDir } = await writeDisk(root, EXPIRED_DATE)
+      await Directory.makeImmutableBatch([alias, vhdDir])
+
+      await liftRemoteImmutability(root, ONE_DAY_MS, false)
+
+      assert.strictEqual(await Directory.isImmutable(alias), true, 'alias should be untouched')
+      assert.strictEqual(await Directory.isImmutable(vhdDir), true, 'VHD directory should be untouched')
+    } finally {
+      await cleanupRoot(root)
+    }
+  })
+
+  it('lifts a disk whose name does not match the datetime of the backup referencing it', async () => {
+    const root = await makeRoot()
+    try {
+      // Shape left by a merge: the alias of the recent backup points at the VHD directory of the
+      // older one, whose blocks it now holds.
+      const { vhdDir, blockFile } = await writeDisk(root, EXPIRED_DATE)
+      const alias = path.join(vdiDirOf(root), `${RECENT_DATE}.alias.vhd`)
+      await fs.writeFile(alias, path.relative(vdiDirOf(root), vhdDir))
+      await fs.unlink(path.join(vdiDirOf(root), `${EXPIRED_DATE}.alias.vhd`))
+      await Directory.makeImmutableBatch([alias, vhdDir])
+
+      await liftRemoteImmutability(root, ONE_DAY_MS, true)
+
+      // The VHD directory carries an expired datetime, so it is released and stays mergeable — the
+      // reason mtime cannot be the reference: every merge would push it forward and it would never
+      // expire.
+      assert.strictEqual(await Directory.isImmutable(vhdDir), false, 'merged VHD directory should be lifted')
+      assert.strictEqual(await Directory.isImmutable(blockFile), false, 'its blocks should be lifted')
+      assert.strictEqual(await Directory.isImmutable(alias), true, 'the recent alias keeps its lock')
+    } finally {
+      await cleanupRoot(root)
+    }
+  })
+
+  it('still lifts through the metadata json when it is present', async () => {
+    const root = await makeRoot()
+    try {
+      const { alias, vhdDir } = await writeDisk(root, EXPIRED_DATE)
+      const json = path.join(vmDirOf(root), `${EXPIRED_DATE}.json`)
+      await fs.writeFile(json, '{}')
+      await Directory.makeImmutableBatch([json, alias, vhdDir])
+
+      // not a full scan: the fast path applies, and the json is immutable so it is picked up
+      await liftRemoteImmutability(root, ONE_DAY_MS, false)
+
+      assert.strictEqual(await Directory.isImmutable(json), false, 'json should be lifted')
+      assert.strictEqual(await Directory.isImmutable(alias), false, 'alias should be lifted')
+      assert.strictEqual(await Directory.isImmutable(vhdDir), false, 'VHD directory should be lifted')
+    } finally {
+      await cleanupRoot(root)
+    }
+  })
+})

--- a/@xen-orchestra/immutable-backups/src/liftProtection.mts
+++ b/@xen-orchestra/immutable-backups/src/liftProtection.mts
@@ -118,6 +118,68 @@ async function liftExpiredVmBackups(root: string, immutabilityDuration: number, 
   })
 }
 
+// `liftExpiredVmBackups` names the files of a backup from the datetime of its `<datetime>.json`,
+// like the watcher does when locking them. A disk can outlive that name:
+//
+// - retention deletes the metadata json first and leaves the disks to the next `cleanVm`, so
+//   nothing names them any more;
+// - a merge renames a disk, and the surviving `data/<datetime>.vhd` keeps the name of the older
+//   backup its blocks came from.
+//
+// Such a disk would stay immutable forever — a full scan does not help, it only bypasses the
+// `isImmutable` fast-path — and an immutable disk blocks every future merge and deletion in its VDI
+// directory. So walk the VDI directories themselves and lift what is expired, using the datetime in
+// each entry's own name, which is the reference the other passes use too.
+//
+// Only runs on the first pass after startup: it recovers states that should not happen, and looking
+// hourly would not make it more effective.
+async function liftExpiredOrphanDisks(root: string, immutabilityDuration: number): Promise<void> {
+  const threshold = Date.now() - immutabilityDuration
+  const vmDirs = await listDirs(join(root, 'xo-vm-backups'))
+  debug('scanning VDI directories for expired disks', { count: vmDirs.length })
+  await asyncEach(vmDirs, async vmDir => {
+    // disks live under `vdis/<jobId>/<vdiId>/`, so two levels of directories to walk first
+    const jobDirs = await listDirs(join(vmDir, 'vdis'))
+    const vdiDirs = (await Promise.all(jobDirs.map(jobDir => listDirs(jobDir)))).flat()
+
+    await asyncEach(vdiDirs, async vdiDir => {
+      try {
+        // `<datetime>.vhd` (flat VHD or alias) and `<datetime>.alias.vhd`
+        const entries = await fsp.readdir(vdiDir, { withFileTypes: true })
+        const candidates = entries.map(entry => join(vdiDir, entry.name))
+
+        // `data/<datetime>.vhd` VHD directories. They are locked recursively, but the attribute is
+        // set on the directory itself too, so its own entry is enough to decide — no need to look
+        // at the blocks inside.
+        if (entries.some(entry => entry.name === 'data' && entry.isDirectory())) {
+          const dataDir = join(vdiDir, 'data')
+          candidates.push(...(await fsp.readdir(dataDir)).map(name => join(dataDir, name)))
+        }
+
+        const expired: string[] = []
+        for (const path of candidates) {
+          // Entries without a datetime — `data` itself, merge state files — are left alone: there
+          // is nothing to compare them to.
+          const datetime = extractDatetime(basename(path))
+          if (datetime === undefined) continue
+          const backupTimestamp = parseDatetime(datetime)
+          if (backupTimestamp === undefined || backupTimestamp > threshold) continue
+          expired.push(path)
+        }
+
+        if (expired.length === 0) return
+        debug('lifting expired disks', { vdiDir, count: expired.length })
+        // Recursive: a VHD directory must be released together with its blocks, and `-R` is a no-op
+        // on the flat VHDs and aliases sharing the batch.
+        await Directory.liftImmutabilityBatch(expired)
+      } catch (err) {
+        // `cleanVm` may be merging or deleting these files at the same time
+        if (err.code !== 'ENOENT') warn('error lifting expired disks', { err, vdiDir })
+      }
+    })
+  })
+}
+
 // Walk `xo-config-backups/<scheduleId>/<datetime>/metadata.json` files and
 // lift immutability on any backup directory whose metadata mtime is expired.
 async function liftExpiredConfigBackups(root: string, immutabilityDuration: number, fullScan: boolean): Promise<void> {
@@ -180,6 +242,12 @@ export async function liftRemoteImmutability(
     liftExpiredConfigBackups(root, immutabilityDuration, fullScan),
     liftExpiredPoolBackups(root, immutabilityDuration, fullScan),
   ])
+
+  // after the passes above: every disk still named by a metadata json has been handled, so this one
+  // only has the leftovers to look at
+  if (fullScan) {
+    await liftExpiredOrphanDisks(root, immutabilityDuration)
+  }
 }
 
 // Lift immutability on all expired backups across every configured remote.

--- a/@xen-orchestra/immutable-backups/src/protectRemotes.mts
+++ b/@xen-orchestra/immutable-backups/src/protectRemotes.mts
@@ -13,6 +13,7 @@ for (const [remoteId, remote] of Object.entries(remotes)) {
 }
 
 info('setup watcher for immutability lifting')
+await liftImmutability(remotes).catch(error => warn('error while lifting immutability', error))
 setInterval(async () => {
   await liftImmutability(remotes).catch(error => warn('error while lifting immutability', error))
 }, liftEvery)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 - [Immutable backups] Backups are protected again on file servers whose system language is not English: immutability was silently not applied at all on those (PR [#10182](https://github.com/vatesfr/xen-orchestra/pull/10182))
+- [Immutable backups] Release disks that stayed immutable forever after their metadata was deleted by the retention, or after a merge renamed them, which prevented any further merge or deletion of that disk's backups (PR [#10182](https://github.com/vatesfr/xen-orchestra/pull/10182))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 ### Bug fixes
 
 > Users must be able to say: "I had this issue, happy to know it's fixed"
+
 - [Immutable backups] Backups are protected again on file servers whose system language is not English: immutability was silently not applied at all on those (PR [#10182](https://github.com/vatesfr/xen-orchestra/pull/10182))
 - [Immutable backups] Release disks that stayed immutable forever after their metadata was deleted by the retention, or after a merge renamed them, which prevented any further merge or deletion of that disk's backups (PR [#10182](https://github.com/vatesfr/xen-orchestra/pull/10182))
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@
 ### Bug fixes
 
 > Users must be able to say: "I had this issue, happy to know it's fixed"
+- [Immutable backups] Backups are protected again on file servers whose system language is not English: immutability was silently not applied at all on those (PR [#10182](https://github.com/vatesfr/xen-orchestra/pull/10182))
 
 ### Packages to release
 
@@ -33,6 +34,7 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/immutable-backups patch
 - @xen-orchestra/web minor
 
 <!--packages-end-->


### PR DESCRIPTION
### Description

from ticket 58775 

review by commit 
* ensure lift process is really run on start , and not aftzr the immutability check interval
* handle a shell localization error
* on startup do an in depth walk of the remote to get back the vdi without their metadata.json 
* changelog 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
