### PR TITLE
fix(backups): don't hide errors during backup transfers

### DIFF
--- a/@xen-orchestra/backups/_runners/_writers/_AbstractIncrementalWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/_AbstractIncrementalWriter.mjs
@@ -16,8 +16,6 @@ export class AbstractIncrementalWriter extends AbstractWriter {
   async transfer({ deltaExport, ...other }) {
     try {
       return await this._transfer({ deltaExport, ...other })
-    } catch (err) {
-      console.error({ err })
     } finally {
       // ensure all sources are properly closed
       for (const disk of Object.values(deltaExport.disks)) {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,6 +28,7 @@
 - [XO6] Fix the VM's VDI tab, which always displays an empty list on initial load (PR [#10156](https://github.com/vatesfr/xen-orchestra/pull/10156))
 - [XO6] Fix the VM's VDI tab, which sometimes displays an error (PR [#10156](https://github.com/vatesfr/xen-orchestra/pull/10156))
 - [XO6] Reduce the number of HTTP requests when navigating between pages (PR [#10156](https://github.com/vatesfr/xen-orchestra/pull/10156))
+- [Backups] Don't hide errors during transfers (PR [#10183](https://github.com/vatesfr/xen-orchestra/pull/10183))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

introduced by 8432 

It affects both writers, since IncrementalXapiWriter and IncrementalRemoteWriter share this base class — so replication and incremental backup to a remote, not just mirror jobs.

One thing worth knowing before changing it: 6.5.1 accidentally masked this. updateUuidAndChain ran after transfer and was not swallowed, so a failed transfer resurfaced there as ENOENT on the alias that was never created — that's the attempt-1 warning on VM c9f3ec63 in the log. #10123 removed updateUuidAndChain, so on master nothing resurfaces.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
