### PR TITLE
feat(backup-archive): flag uuid inconsistencies

### DIFF
--- a/@xen-orchestra/backup-archive/src/RemoteDiskLineage.mts
+++ b/@xen-orchestra/backup-archive/src/RemoteDiskLineage.mts
@@ -44,6 +44,9 @@ export class RemoteDiskLineage {
   #activeDiskPaths: Set<string> = new Set()
   // Interrupted merges: normalized parent path { stateFilePath, chain }
   #interruptedMerges: Map<string, { stateFilePath: string; chain?: string[] }> = new Map()
+  // Disks whose parent link is contradicted by the uuids: any merge chain containing one of them
+  // crosses that link and is left alone
+  #inconsistentParentLinks: Set<string> = new Set()
 
   constructor(handler: RemoteHandlerAbstract, vdiDir: string, opts: ResolvedBackupCleanOptions) {
     this.#handler = handler
@@ -94,6 +97,11 @@ export class RemoteDiskLineage {
     }
 
     const uuidToPath = new Map<string, string>()
+    // disk path: its own uuid / the uuid of the parent it claims, to check the chain links once
+    // every disk has been read — a disk is closed as soon as it is scanned, and a parent may be
+    // scanned after its child
+    const uuidOf = new Map<string, string>()
+    const claimedParentUuidOf = new Map<string, string>()
     for (const diskPath of this.#diskPaths) {
       let disk: RemoteDisk | undefined
       try {
@@ -139,9 +147,11 @@ export class RemoteDiskLineage {
           }
         }
         uuidToPath.set(uuid, diskPath)
+        uuidOf.set(diskPath, uuid)
 
         if (disk.isDifferencing()) {
           const parentPath = disk.getParentPath()
+          claimedParentUuidOf.set(diskPath, disk.getParentUuid())
           this.#parentOf.set(diskPath, parentPath)
           if (this.#childOf.has(parentPath)) {
             const error = new Error('this script does not support multiple children', {
@@ -184,6 +194,35 @@ export class RemoteDiskLineage {
       if (!this.#diskPaths.has(parent) || this.#brokenDiskPaths.has(parent)) {
         this.#opts.logWarn('disk broken: parent missing or broken', { child, parent })
         propagateBroken(child)
+        continue
+      }
+
+      // A disk records the uuid of the parent it was chained onto, so a link whose uuids disagree
+      // means the file at that path is not the parent this disk was built from — a rename or a
+      // restore mixed up the directory. Detect it here rather than when the chain is opened: the
+      // merge would fail with NOT_SUPPORTED, and that error aborts the whole clean of this VM
+      // (asyncEach stops on the first error), so every other lineage would stop being merged and
+      // cleaned as well, at every run.
+      //
+      // The link is only reported: the disks are readable and the backups referencing them are
+      // still restorable, and since the parent links do not describe the real topology, deleting
+      // anything here would be a guess. It needs a human to repair it, so the warning names both
+      // disks and both uuids.
+      //
+      // Skipped for a parent under an interrupted merge: its footer already carries the uuid of the
+      // child being merged into it, so the mismatch is expected and that merge must be resumed.
+      if (!mergeParentPaths.has(parent)) {
+        const claimedParentUuid = claimedParentUuidOf.get(child)
+        const parentUuid = uuidOf.get(parent)
+        if (claimedParentUuid !== undefined && parentUuid !== undefined && claimedParentUuid !== parentUuid) {
+          this.#opts.logWarn('inconsistent chain, it will not be merged until repaired', {
+            child,
+            parent,
+            parentUuidExpectedByChild: claimedParentUuid,
+            parentUuid,
+          })
+          this.#inconsistentParentLinks.add(child)
+        }
       }
     }
   }
@@ -331,7 +370,12 @@ export class RemoteDiskLineage {
         await asyncEach(
           toMerge,
           async ({ chain, isResuming }) => {
-            const { finalDiskSize, mergeTargetPath } = await limitedMergeChain([...chain], isResuming)
+            const merged = await limitedMergeChain([...chain], isResuming)
+            if (merged === undefined) {
+              // chain left untouched, its disks are still there
+              return
+            }
+            const { finalDiskSize, mergeTargetPath } = merged
             mergedSizes.set(mergeTargetPath, (mergedSizes.get(mergeTargetPath) ?? 0) + finalDiskSize)
             // parentPath alias deleted by parentDisk.rename(mergeTargetPath)
             // intermediates deleted by childDisk.unlink() when removeUnused=true
@@ -361,11 +405,27 @@ export class RemoteDiskLineage {
 
   /**
    * Merges ancestors into the active child at the end of the chain.
-   * Returns the final size of the merge target and its path.
+   * Returns the final size of the merge target and its path, or undefined when the chain was left
+   * untouched.
    */
-  async #mergeChain(chain: string[], isResuming: boolean): Promise<{ finalDiskSize: number; mergeTargetPath: string }> {
+  async #mergeChain(
+    chain: string[],
+    isResuming: boolean
+  ): Promise<{ finalDiskSize: number; mergeTargetPath: string } | undefined> {
     assert.ok(chain.length >= 2, `look to merge a chain shorter than 2 ${JSON.stringify(chain)}`)
     const parentPath = chain[0]
+
+    // A chain crossing a contradicted parent link cannot be merged: openDiskChain below refuses it,
+    // and that error would abort the clean of the whole VM. Leave this chain as it is until someone
+    // repairs it — every other chain of this directory is still merged and cleaned.
+    //
+    // An interrupted merge is exempt: the parent it was merging into already carries the uuid of its
+    // child, so a mismatch is expected there and resuming is the way out of it.
+    if (!isResuming && chain.some(path => this.#inconsistentParentLinks.has(path))) {
+      this.#opts.logWarn('not merging an inconsistent disk chain', { chain: [...chain] })
+      return undefined
+    }
+
     this.#opts.logInfo('merging disk chain', { chain: [...chain] }) // need a copy here to log full chain
     // The last disk in the chain is the active one that everything gets merged into
     const mergeTargetPath = chain.pop()!

--- a/@xen-orchestra/backup-archive/src/VmIncrementalBackupArchive.integ.mjs
+++ b/@xen-orchestra/backup-archive/src/VmIncrementalBackupArchive.integ.mjs
@@ -7,9 +7,9 @@ import * as uuid from 'uuid'
 import { getHandler } from '@xen-orchestra/fs'
 import { pFromCallback } from 'promise-toolbox'
 // eslint-disable-next-line n/no-missing-import
-import { VmBackupDirectory } from '../dist/VmBackupDirectory.mjs'
-import { RemoteVhdDisk } from '../dist/disks/RemoteVhdDisk.mjs'
-import { MergeRemoteDisk } from '../dist/disks/MergeRemoteDisk.mjs'
+import { VmBackupDirectory } from './VmBackupDirectory.mjs'
+import { RemoteVhdDisk } from './disks/RemoteVhdDisk.mjs'
+import { MergeRemoteDisk } from './disks/MergeRemoteDisk.mjs'
 import { VHDFOOTER, VHDHEADER } from './tests.fixtures.mjs'
 import { VhdFile, Constants, VhdDirectory, VhdAbstract } from 'vhd-lib'
 import { dirname, basename } from 'node:path'
@@ -607,6 +607,92 @@ test('it resumes an interrupted merge without chain field', async () => {
   const remainingVhds = await handler.list(basePath)
   assert.equal(remainingVhds.length, 1)
   assert.equal(remainingVhds.includes('child.vhd'), true)
+})
+
+test('it still resumes an interrupted merge, whose parent already carries the uuid of its child', async () => {
+  // mergeMetadata() copies the child's uuid onto the parent before the cleanup step, so an
+  // interrupted merge legitimately leaves a parent whose uuid contradicts what its child claims.
+  // That must not be mistaken for a corrupted chain: resuming is the way out of it.
+  const ancestor = await generateVhd(`${basePath}/ancestor.vhd`, { blocks: [0, 1] })
+  await generateVhd(`${basePath}/child.vhd`, {
+    header: { parentUnicodeName: 'ancestor.vhd', parentUuid: ancestor.footer.uuid },
+    blocks: [2, 3],
+  })
+  await handler.writeFile(
+    `${rootPath}/metadata.json`,
+    JSON.stringify({ mode: 'delta', size: 12000, vhds: [`${relativePath}/child.vhd`] })
+  )
+
+  // Interrupt the merge in its cleanup step, after mergeMetadata() rewrote the ancestor's footer
+  // with the child's uuid and before the child is removed.
+  const parent = new RemoteVhdDisk({ handler, path: `${basePath}/ancestor.vhd` })
+  const child = new RemoteVhdDisk({ handler, path: `${basePath}/child.vhd` })
+  await parent.init({ force: false })
+  await child.init({ force: false })
+  child.unlink = async () => {
+    throw new Error('simulated interruption')
+  }
+  const merger = new MergeRemoteDisk(handler, { removeUnused: true, writeStateDelay: 0 })
+  await assert.rejects(merger.merge(parent, child), /simulated interruption/)
+
+  const afterCrash = await handler.list(basePath)
+  assert.ok(afterCrash.includes('.ancestor.vhd.merge.json'), 'an interrupted-merge state file should remain')
+  assert.ok(afterCrash.includes('child.vhd'), 'the child should still be there')
+
+  const logged = []
+  await VmBackupDirectory.cleanVm(handler, rootPath, {
+    remove: true,
+    merge: true,
+    logInfo: () => {},
+    logWarn: message => logged.push(message),
+  })
+
+  assert.equal(logged.includes('not merging an inconsistent disk chain'), false, 'the resume must not be declined')
+  const remaining = await handler.list(basePath)
+  assert.equal(remaining.includes('.ancestor.vhd.merge.json'), false, 'state file removed after successful resume')
+  assert.equal(remaining.includes('ancestor.vhd'), false, 'ancestor consolidated into the merge target')
+  assert.equal(remaining.includes('child.vhd'), true, 'merge target remains')
+})
+
+test('it does not merge a chain whose parent uuid is contradicted, and still cleans the rest', async () => {
+  // orphan <- child, but the child claims a parent uuid that is not the orphan's: the file at that
+  // path is not the disk it was built from, so the chain cannot be opened, let alone merged.
+  const orphan = await generateVhd(`${basePath}/orphan.vhd`, { blocks: [0, 1] })
+  await generateVhd(`${basePath}/child.vhd`, {
+    header: {
+      parentUnicodeName: 'orphan.vhd',
+      parentUuid: uniqueIdBuffer(), // NOT orphan.footer.uuid
+    },
+    blocks: [2],
+  })
+
+  // an unrelated VDI directory, with one active disk and one plain orphan to collect
+  await generateVhd(`${basePath2}/keep.vhd`)
+  await generateVhd(`${basePath2}/collectme.vhd`)
+
+  await handler.writeFile(
+    `${rootPath}/metadata.json`,
+    JSON.stringify({
+      mode: 'delta',
+      size: 12000,
+      vhds: [`${relativePath}/child.vhd`, `${relativePath2}/keep.vhd`],
+    })
+  )
+
+  const logged = []
+  const logWarn = message => logged.push(message)
+  await VmBackupDirectory.cleanVm(handler, rootPath, { remove: true, merge: true, logInfo: () => {}, logWarn })
+
+  assert.equal(logged.includes('inconsistent chain, it will not be merged until repaired'), true)
+  assert.equal(logged.includes('not merging an inconsistent disk chain'), true)
+
+  // nothing of the inconsistent chain was merged nor deleted: repairing it is a human decision
+  const remainingVhds = await handler.list(basePath)
+  assert.deepEqual(remainingVhds.sort(), ['child.vhd', 'orphan.vhd'])
+  assert.notEqual(orphan.footer.uuid, undefined)
+
+  // the rest of the VM was still cleaned: the unreferenced disk of the other VDI is gone
+  assert.deepEqual(await handler.list(basePath2), ['keep.vhd'])
 })
 
 // each of the vhd can be a file, a directory, an alias to a file or an alias to a directory

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,6 +29,7 @@
 - [XO6] Fix the VM's VDI tab, which sometimes displays an error (PR [#10156](https://github.com/vatesfr/xen-orchestra/pull/10156))
 - [XO6] Reduce the number of HTTP requests when navigating between pages (PR [#10156](https://github.com/vatesfr/xen-orchestra/pull/10156))
 - [Backups] Don't hide errors during transfers (PR [#10183](https://github.com/vatesfr/xen-orchestra/pull/10183))
+- [Backups] Report a disk chain whose links don't match the disks they point to, and leave it untouched instead of retrying an impossible merge that stopped the whole cleanup of that VM at every run (PR [#TODO](https://github.com/vatesfr/xen-orchestra/pull/TODO))
 
 ### Packages to release
 


### PR DESCRIPTION
we see some ticket with brocken uuid. This change will warn for any inconsistencies

it will also skip the merge phase that would break if eft alone, waiting either for the full chain to be out of protection or for a user to rechain disks manually

waiting for the return of PBT  for advice on merge/do not merge

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
