### PR TITLE
fix(fs/s3): improve delete multiple performances

### DIFF
--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -436,18 +436,19 @@ export default class S3Handler extends RemoteHandlerAbstract {
       )
       NextContinuationToken = result.IsTruncated ? result.NextContinuationToken : undefined
       if (supportsDeleteObjects) {
-        const command = new DeleteObjectsCommand({
-          Bucket: this.#bucket,
-          Delete: {
-            // only keep the key: `ETag` and `Size` are also part of `ObjectIdentifier`, where they
-            // mean "delete only if it still matches", and passing the whole listed object would
-            // serialize them in the request. Beyond making the deletion conditional, some
-            // providers reject these elements with a `MalformedXML` error.
-            Objects: (result.Contents ?? []).map(({ Key }) => ({ Key })),
-          },
-        })
         try {
-          await this.#s3.send(command)
+          await this.#s3.send(
+            new DeleteObjectsCommand({
+              Bucket: this.#bucket,
+              Delete: {
+                // only keep the key: `ETag` and `Size` are also part of `ObjectIdentifier`, where they
+                // mean "delete only if it still matches", and passing the whole listed object would
+                // serialize them in the request. Beyond making the deletion conditional, some
+                // providers reject these elements with a `MalformedXML` error.
+                Objects: (result.Contents ?? []).map(({ Key }) => ({ Key })),
+              },
+            })
+          )
           // we catch any error because some providers don't return "NotImplemented" errors when they don't
           // support DeleteObjectsCommand. As we catch any error, we don't store supportsDeleteObjects param
           // because it can be due to network issues

--- a/@xen-orchestra/fs/src/s3.js
+++ b/@xen-orchestra/fs/src/s3.js
@@ -436,15 +436,18 @@ export default class S3Handler extends RemoteHandlerAbstract {
       )
       NextContinuationToken = result.IsTruncated ? result.NextContinuationToken : undefined
       if (supportsDeleteObjects) {
+        const command = new DeleteObjectsCommand({
+          Bucket: this.#bucket,
+          Delete: {
+            // only keep the key: `ETag` and `Size` are also part of `ObjectIdentifier`, where they
+            // mean "delete only if it still matches", and passing the whole listed object would
+            // serialize them in the request. Beyond making the deletion conditional, some
+            // providers reject these elements with a `MalformedXML` error.
+            Objects: (result.Contents ?? []).map(({ Key }) => ({ Key })),
+          },
+        })
         try {
-          await this.#s3.send(
-            new DeleteObjectsCommand({
-              Bucket: this.#bucket,
-              Delete: {
-                Objects: result.Contents ?? [],
-              },
-            })
-          )
+          await this.#s3.send(command)
           // we catch any error because some providers don't return "NotImplemented" errors when they don't
           // support DeleteObjectsCommand. As we catch any error, we don't store supportsDeleteObjects param
           // because it can be due to network issues

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,6 +31,7 @@
 - [XO6] Reduce the number of HTTP requests when navigating between pages (PR [#10156](https://github.com/vatesfr/xen-orchestra/pull/10156))
 - [Backups] Don't hide errors during transfers (PR [#10183](https://github.com/vatesfr/xen-orchestra/pull/10183))
 - [Smart reboot] Fix `suspendBlocked` error when no issue to suspend resident VMs (PR [#10180](https://github.com/vatesfr/xen-orchestra/pull/10180))
+- [Remotes/S3] Fix slow deletions on S3 providers rejecting our batch deletion request with a `MalformedXML` error (e.g. Ceph RadosGW)
 
 ### Packages to release
 
@@ -52,6 +53,7 @@
 - @xen-orchestra/backup-archive patch
 - @xen-orchestra/backups patch
 - @xen-orchestra/disk-transform patch
+- @xen-orchestra/fs patch
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,7 +31,7 @@
 - [XO6] Reduce the number of HTTP requests when navigating between pages (PR [#10156](https://github.com/vatesfr/xen-orchestra/pull/10156))
 - [Backups] Don't hide errors during transfers (PR [#10183](https://github.com/vatesfr/xen-orchestra/pull/10183))
 - [Smart reboot] Fix `suspendBlocked` error when no issue to suspend resident VMs (PR [#10180](https://github.com/vatesfr/xen-orchestra/pull/10180))
-- [Remotes/S3] Fix slow deletions on S3 providers rejecting our batch deletion request with a `MalformedXML` error (e.g. Ceph RadosGW)
+- [Remotes/S3] Fix slow deletions on S3 providers rejecting our batch deletion request with a `MalformedXML` error (e.g. Ceph RadosGW) (PR [#10189](https://github.com/vatesfr/xen-orchestra/pull/10189))
 
 ### Packages to release
 


### PR DESCRIPTION
_rmtree passed result.Contents straight into Delete.Objects. In the current SDK, ObjectIdentifier is [Key, VersionId, ETag, LastModifiedTime, Size] (schemas_0.js:2232) — so the ETag and Size returned by ListObjectsV2 get serialized into the request.

Older SDKs had only Key/VersionId, which is why this used to work. RGW's <Delete> parser rejects those elements → MalformedXML 400.

It's also wrong on AWS: ETag/Size there mean delete only if it still matches, so we were silently issuing conditional deletes.



### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
