### PR TITLE
fix(xapi): don't try to compute progress on Buffer

### DIFF
--- a/@vates/types/src/lib/xen-orchestra-xapi.mts
+++ b/@vates/types/src/lib/xen-orchestra-xapi.mts
@@ -411,7 +411,7 @@ export interface Xapi {
   ): Promise<Readable & { length?: number }>
   VDI_importContent(
     vdiRef: XenApiVdi['$ref'],
-    stream: Readable,
+    stream: Readable | Buffer,
     opts: { cancelToken?: unknown; format: SUPPORTED_VDI_FORMAT }
   ): Promise<void>
   VIF_create(

--- a/@xen-orchestra/xapi/vdi.mjs
+++ b/@xen-orchestra/xapi/vdi.mjs
@@ -266,19 +266,30 @@ class Vdi {
   }
 
   /**
+   * Write the content of a disk into an existing VDI.
    *
-   * @param {string} vdiRef
-   * @param {string | undefined} baseRef
-   * @returns
+   * A XAPI task is created for the transfer and linked to the VDI through its
+   * `other_config` (`xo:import:task` / `xo:import:length`). When `content` is a
+   * stream, its progress is reported on that task since XCP-ng does not do it
+   * for every format.
+   *
+   * @param {string} ref - reference of the destination VDI
+   * @param {import('node:stream').Readable | Buffer} content - disk content, whose
+   * `length` (in bytes) must be known: a stream must carry it as a property, a
+   * Buffer (e.g. the cloud config drive) has it natively
+   * @param {object} opts
+   * @param {import('promise-toolbox').CancelToken} [opts.cancelToken]
+   * @param {'raw' | 'vhd' | 'qcow2'} opts.format - format of `content`, must be
+   * one of `SUPPORTED_VDI_FORMAT`
+   * @returns {Promise<void>}
    */
-
-  async importContent(ref, stream, { cancelToken = CancelToken.none, format }) {
+  async importContent(ref, content, { cancelToken = CancelToken.none, format }) {
     assert.notEqual(format, undefined)
     // now we'll handle the VHD and qcow2 export
     if (!SUPPORTED_VDI_FORMAT.includes(format)) {
       throw new Error(`${format} is not in the allowed import format ${JSON.stringify(SUPPORTED_VDI_FORMAT)}`)
     }
-    if (stream.length === undefined) {
+    if (content.length === undefined) {
       throw new Error(
         'Trying to import a VDI without a length field. Please report this error to the Xen Orchestra team.'
       )
@@ -289,14 +300,19 @@ class Vdi {
     try {
       const taskRef = await this.task_create(`Importing content into VDI ${vdi.name_label} on SR ${sr.name_label}`)
       const uuid = await this.getField('task', taskRef, 'uuid')
-      await vdi.update_other_config({ 'xo:import:task': uuid, 'xo:import:length': stream.length.toString() })
+      await vdi.update_other_config({ 'xo:import:task': uuid, 'xo:import:length': content.length.toString() })
 
       // XCP-ng does not report progress on the import task for every format
-      watchUploadProgress(stream, stream.length, progress => {
-        ignoreErrors.call(this.call('task.set_progress', taskRef, progress))
-      })
+      //
+      // only streams can be observed: a Buffer is sent in one go, leave its task
+      // progress to XAPI
+      if (typeof content.on === 'function') {
+        watchUploadProgress(content, content.length, progress => {
+          ignoreErrors.call(this.call('task.set_progress', taskRef, progress))
+        })
+      }
 
-      await this.putResource(cancelToken, stream, '/import_raw_vdi/', {
+      await this.putResource(cancelToken, content, '/import_raw_vdi/', {
         query: {
           format,
           vdi: ref,

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,4 +31,7 @@
 
 <!--packages-start-->
 
+- @vates/types patch
+- @xen-orchestra/xapi patch
+
 <!--packages-end-->


### PR DESCRIPTION
introduced by 76b45a9b3b9ba636ba3d2148f8575ac4d9f57ff2

watching the import progress can't work with the buffer created by for cloud init drive 
<img width="1063" height="731" alt="image" src="https://github.com/user-attachments/assets/f057f64d-9982-4e5b-87d3-2bdbe5a75a00" />

### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
