### PR TITLE
feat(load-balancer): vm-to-host affinity

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@
 
 - [IPMI-plugin] Add GET plugins/ipmi-sensors/hosts/{id}/ipmi to get IPMI sensors (PR [#10003](https://github.com/vatesfr/xen-orchestra/pull/10003))
 - [Plugins/load balancer] Added VM-to-host affinity to force VMs to run on a given set of hosts if possible (PR [#10207](https://github.com/vatesfr/xen-orchestra/pull/10207))
+- [Plugins/load balancer] Improved migration decision making (PR [#10207](https://github.com/vatesfr/xen-orchestra/pull/10207))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@
 
 - [REST API] Fix `/users/:id/authentication_tokens` sometimes did not return the token used to make the request (PR [#10233](https://github.com/vatesfr/xen-orchestra/pull/10233))
 - [XO server] Fix a random behavior regarding `coresPerSocket` update (PR [#10201](https://github.com/vatesfr/xen-orchestra/pull/10201))
+- [Plugins/load balancer] Prevent inter-pool migrations triggered by affinity or anti-affinity (PR [#10207](https://github.com/vatesfr/xen-orchestra/pull/10207))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 - [Docs] Improve doc, rename titles, and refactor menu (PR [#10212](https://github.com/vatesfr/xen-orchestra/pull/10212))
 
 - [IPMI-plugin] Add GET plugins/ipmi-sensors/hosts/{id}/ipmi to get IPMI sensors (PR [#10003](https://github.com/vatesfr/xen-orchestra/pull/10003))
+- [Plugins/load balancer] Added VM-to-host affinity to force VMs to run on a given set of hosts if possible (PR [#10207](https://github.com/vatesfr/xen-orchestra/pull/10207))
 
 ### Bug fixes
 
@@ -52,6 +53,7 @@
 - xo-common minor
 - xo-server patch
 - xo-server-ipmi-sensors minor
+- xo-server-load-balancer minor
 - xo-server-netbox patch
 
 <!--packages-end-->

--- a/packages/xo-server-load-balancer/src/density-plan.js
+++ b/packages/xo-server-load-balancer/src/density-plan.js
@@ -1,4 +1,4 @@
-import { clone, filter } from 'lodash'
+import { clone, filter, intersection, keyBy } from 'lodash'
 
 import Plan from './plan'
 import { debug as debugP } from './utils'
@@ -112,26 +112,6 @@ export default class DensityPlan extends Plan {
         debug(`VM (${vm.id}) of Host (${hostId}) does not support pool migration.`)
         return
       }
-
-      for (const tag of vm.tags) {
-        // TODO: Improve this piece of code. We could compute variance to check if the VM
-        // is migratable. But the code must be rewritten:
-        // - All VMs, hosts and stats must be fetched at one place.
-        // - It's necessary to maintain a dictionary of tags for each host.
-        // - ...
-        if (this._affinityTags.includes(tag)) {
-          debug(`VM (${vm.id}) of Host (${hostId}) cannot be migrated. It contains affinity tag '${tag}'.`)
-          return
-        }
-        if (this._antiAffinityTags.includes(tag)) {
-          debug(`VM (${vm.id}) of Host (${hostId}) cannot be migrated. It contains anti-affinity tag '${tag}'.`)
-          return
-        }
-        if (this._vmToHostAffinityTags.includes(tag)) {
-          debug(`VM (${vm.id}) of Host (${hostId}) cannot be migrated. It contains vm-to-host affinity tag '${tag}'.`)
-          return
-        }
-      }
     }
 
     // Sort vms by amount of memory. (+ -> -)
@@ -142,15 +122,57 @@ export default class DensityPlan extends Plan {
       moves: [],
     }
 
+    // per-host counts of affinity/anti-affinity tagged VMs, to check whether a candidate destination
+    // would deteriorate a VM's constraints, instead of blocking its migration entirely.
+    // include the host being emptied too, since counts get decremented on it as VMs are migrated away.
+    const allRelevantHosts = [host, ...filter(destinations.flat(), h => h != null)]
+    const allRunningVms = this._getAllRunningVms()
+    const affinityCountsByHostId = this._affinityTags.length
+      ? keyBy(
+          this._getTaggedHosts({ hosts: allRelevantHosts, tagList: this._affinityTags, vms: allRunningVms }).hosts,
+          'id'
+        )
+      : undefined
+    const antiAffinityCountsByHostId = this._antiAffinityTags.length
+      ? keyBy(
+          this._getTaggedHosts({ hosts: allRelevantHosts, tagList: this._antiAffinityTags, vms: allRunningVms }).hosts,
+          'id'
+        )
+      : undefined
+
     // Try to find a destination for each VM.
     for (const vm of vms) {
       let move
 
+      // don't exclude VMs with meaningful tags entirely: only avoid destinations that would
+      // deteriorate the VM's affinity / anti-affinity / vm-to-host affinity constraints
+      const affinityTags = intersection(vm.tags, this._affinityTags)
+      const antiAffinityTags = intersection(vm.tags, this._antiAffinityTags)
+      const vmToHostAffinityTags = intersection(vm.tags, this._vmToHostAffinityTags)
+
       // Simulate the VM move on a destinations set.
       for (const subDestinations of destinations) {
+        let eligibleDestinations = filter(subDestinations, host => host != null)
+
+        if (affinityTags.length > 0) {
+          eligibleDestinations = filter(eligibleDestinations, host =>
+            affinityTags.some(tag => affinityCountsByHostId[host.id].tags[tag] > 0)
+          )
+        }
+        if (antiAffinityTags.length > 0) {
+          eligibleDestinations = filter(eligibleDestinations, host =>
+            antiAffinityTags.every(tag => antiAffinityCountsByHostId[host.id].tags[tag] === 0)
+          )
+        }
+        if (vmToHostAffinityTags.length > 0) {
+          eligibleDestinations = filter(eligibleDestinations, host =>
+            vmToHostAffinityTags.some(tag => host.tags.includes(tag))
+          )
+        }
+
         move = this._testMigration({
           vm,
-          destinations: subDestinations,
+          destinations: eligibleDestinations,
           hostsAverages,
           vmsAverages,
         })
@@ -158,6 +180,9 @@ export default class DensityPlan extends Plan {
         // Destination found.
         if (move) {
           simulResults.moves.push(move)
+          // keep our local counts in sync so later VMs in this loop aren't checked against stale data
+          this._adjustTagCounts(affinityCountsByHostId, affinityTags, hostId, move.destination.id)
+          this._adjustTagCounts(antiAffinityCountsByHostId, antiAffinityTags, hostId, move.destination.id)
           break
         }
       }

--- a/packages/xo-server-load-balancer/src/density-plan.js
+++ b/packages/xo-server-load-balancer/src/density-plan.js
@@ -17,6 +17,7 @@ export default class DensityPlan extends Plan {
   }
 
   async execute() {
+    await this._processVmToHostAffinity()
     await this._processAffinity()
     await this._processAntiAffinity()
 
@@ -124,6 +125,10 @@ export default class DensityPlan extends Plan {
         }
         if (this._antiAffinityTags.includes(tag)) {
           debug(`VM (${vm.id}) of Host (${hostId}) cannot be migrated. It contains anti-affinity tag '${tag}'.`)
+          return
+        }
+        if (this._vmToHostAffinityTags.includes(tag)) {
+          debug(`VM (${vm.id}) of Host (${hostId}) cannot be migrated. It contains vm-to-host affinity tag '${tag}'.`)
           return
         }
       }

--- a/packages/xo-server-load-balancer/src/density-plan.js
+++ b/packages/xo-server-load-balancer/src/density-plan.js
@@ -1,4 +1,4 @@
-import { clone, filter } from 'lodash'
+import { clone, filter, intersection, keyBy } from 'lodash'
 
 import Plan from './plan'
 import { debug as debugP } from './utils'
@@ -112,26 +112,6 @@ export default class DensityPlan extends Plan {
         debug(`VM (${vm.id}) of Host (${hostId}) does not support pool migration.`)
         return
       }
-
-      for (const tag of vm.tags) {
-        // TODO: Improve this piece of code. We could compute variance to check if the VM
-        // is migratable. But the code must be rewritten:
-        // - All VMs, hosts and stats must be fetched at one place.
-        // - It's necessary to maintain a dictionary of tags for each host.
-        // - ...
-        if (this._affinityTags.includes(tag)) {
-          debug(`VM (${vm.id}) of Host (${hostId}) cannot be migrated. It contains affinity tag '${tag}'.`)
-          return
-        }
-        if (this._antiAffinityTags.includes(tag)) {
-          debug(`VM (${vm.id}) of Host (${hostId}) cannot be migrated. It contains anti-affinity tag '${tag}'.`)
-          return
-        }
-        if (this._vmToHostAffinityTags.includes(tag)) {
-          debug(`VM (${vm.id}) of Host (${hostId}) cannot be migrated. It contains vm-to-host affinity tag '${tag}'.`)
-          return
-        }
-      }
     }
 
     // Sort vms by amount of memory. (+ -> -)
@@ -142,15 +122,51 @@ export default class DensityPlan extends Plan {
       moves: [],
     }
 
+    // per-host counts of affinity/anti-affinity tagged VMs, to check whether a candidate destination
+    // would deteriorate a VM's constraints, instead of blocking its migration entirely.
+    // include the host being emptied too, since counts get decremented on it as VMs are migrated away.
+    const allRelevantHosts = [host, ...filter(destinations.flat(), h => h != null)]
+    const idToHost = keyBy(allRelevantHosts, 'id')
+    const allRunningVms = this._getAllRunningVms()
+    const affinityCountsByHostId = this._affinityTags.length
+      ? keyBy(
+          this._getTaggedHosts({ hosts: allRelevantHosts, tagList: this._affinityTags, vms: allRunningVms }).hosts,
+          'id'
+        )
+      : undefined
+    const antiAffinityCountsByHostId = this._antiAffinityTags.length
+      ? keyBy(
+          this._getTaggedHosts({ hosts: allRelevantHosts, tagList: this._antiAffinityTags, vms: allRunningVms }).hosts,
+          'id'
+        )
+      : undefined
+
     // Try to find a destination for each VM.
     for (const vm of vms) {
       let move
 
+      // don't exclude VMs with meaningful tags entirely: only avoid destinations that would
+      // deteriorate the VM's affinity / anti-affinity / vm-to-host affinity constraints
+      const affinityTags = intersection(vm.tags, this._affinityTags)
+      const antiAffinityTags = intersection(vm.tags, this._antiAffinityTags)
+
       // Simulate the VM move on a destinations set.
       for (const subDestinations of destinations) {
+        const eligibleDestinations = filter(subDestinations, host => {
+          if (host == null) {
+            return false
+          }
+          const params = { vm, sourceHostId: hostId, destinationHostId: host.id }
+          return (
+            !this._wouldDeteriorateAffinity({ ...params, countsByHostId: affinityCountsByHostId }) &&
+            !this._wouldDeteriorateAntiAffinity({ ...params, countsByHostId: antiAffinityCountsByHostId }) &&
+            !this._wouldDeteriorateVmToHostAffinity({ ...params, idToHost })
+          )
+        })
+
         move = this._testMigration({
           vm,
-          destinations: subDestinations,
+          destinations: eligibleDestinations,
           hostsAverages,
           vmsAverages,
         })
@@ -158,6 +174,9 @@ export default class DensityPlan extends Plan {
         // Destination found.
         if (move) {
           simulResults.moves.push(move)
+          // keep our local counts in sync so later VMs in this loop aren't checked against stale data
+          this._adjustTagCounts(affinityCountsByHostId, affinityTags, hostId, move.destination.id)
+          this._adjustTagCounts(antiAffinityCountsByHostId, antiAffinityTags, hostId, move.destination.id)
           break
         }
       }

--- a/packages/xo-server-load-balancer/src/index.js
+++ b/packages/xo-server-load-balancer/src/index.js
@@ -102,6 +102,17 @@ export const configurationSchema = {
             },
           },
 
+          vmToHostAffinityTags: {
+            type: 'array',
+            title: 'VM to host affinity tags',
+            description: 'list of tags shared by VMs and hosts to restrict placement of these VMs to these hosts',
+
+            items: {
+              type: 'string',
+              $type: 'Tag',
+            },
+          },
+
           // when UI will allow it, put balanceVcpu option outside performance mode
           // balanceVcpus is an incorrect name kept for compatibility with past configurationSchema
           balanceVcpus: {

--- a/packages/xo-server-load-balancer/src/performance-plan.js
+++ b/packages/xo-server-load-balancer/src/performance-plan.js
@@ -53,11 +53,14 @@ export default class PerformancePlan extends Plan {
       console.error(error)
     }
 
-    // Step 1 : affinity and anti-affinity
+    // Step 1 : VM to host affinity
+    await this._processVmToHostAffinity()
+
+    // Step 2 : affinity and anti-affinity
     await this._processAffinity()
     await this._processAntiAffinity()
 
-    // Step 2 : optimize host that exceed CPU threshold
+    // Step 3 : optimize host that exceed CPU threshold
     const hosts = this._getHosts()
     const results = await this._getHostStatsAverages({
       hosts,
@@ -82,7 +85,7 @@ export default class PerformancePlan extends Plan {
         })
       }
     } else {
-      // Step 3 : optimize hosts whose load differs too much from the rest of the pool (if option is enabled)
+      // Step 4 : optimize hosts whose load differs too much from the rest of the pool (if option is enabled)
       if (this._performanceSubmode === 'preventive') {
         for (const poolId of this._poolIds) {
           const poolHosts = filter(hosts, host => host.$poolId === poolId)
@@ -123,7 +126,7 @@ export default class PerformancePlan extends Plan {
           }
         }
       }
-      // Step 4 : vCPU prepositioning (if option is enable. Incompatible with step 3 option)
+      // Step 5 : vCPU prepositioning (if option is enable. Incompatible with step 3 option)
       if (this._performanceSubmode === 'vCpuPrepositioning') {
         for (const poolId of this._poolIds) {
           const poolHosts = filter(hosts, host => host.$poolId === poolId)
@@ -223,6 +226,13 @@ export default class PerformancePlan extends Plan {
       if (blockingAntiAffinityTags.length > 0) {
         debug(
           `VM (${vm.id}) of Host (${exceededHost.id}) cannot be migrated. It contains anti-affinity tag(s): ${blockingAntiAffinityTags}.`
+        )
+        continue
+      }
+      const blockingVmToHostAffinityTags = intersection(vm.tags, this._vmToHostAffinityTags)
+      if (blockingVmToHostAffinityTags.length > 0) {
+        debug(
+          `VM (${vm.id}) of Host (${exceededHost.id}) cannot be migrated. It contains vm-to-host affinity tag(s): ${blockingVmToHostAffinityTags}.`
         )
         continue
       }

--- a/packages/xo-server-load-balancer/src/performance-plan.js
+++ b/packages/xo-server-load-balancer/src/performance-plan.js
@@ -1,4 +1,4 @@
-import { filter, intersection } from 'lodash'
+import { filter, intersection, keyBy } from 'lodash'
 
 import Plan from './plan'
 import { debug as debugP } from './utils'
@@ -175,6 +175,25 @@ export default class PerformancePlan extends Plan {
     const vms = filter(this._getAllRunningVms(), vm => vm.$container === exceededHost.id)
     const vmsAverages = await this._getVmsAverages(vms, { [exceededHost.id]: exceededHost })
 
+    // per-host counts of affinity/anti-affinity tagged VMs, to check whether a candidate destination
+    // would deteriorate a VM's constraints, instead of blocking its migration entirely.
+    // include exceededHost too, since counts get decremented on it as VMs are migrated away.
+    const allRunningVms = this._getAllRunningVms()
+    const allRelevantHosts = [exceededHost, ...hosts]
+    const idToHost = keyBy(allRelevantHosts, 'id')
+    const affinityCountsByHostId = this._affinityTags.length
+      ? keyBy(
+          this._getTaggedHosts({ hosts: allRelevantHosts, tagList: this._affinityTags, vms: allRunningVms }).hosts,
+          'id'
+        )
+      : undefined
+    const antiAffinityCountsByHostId = this._antiAffinityTags.length
+      ? keyBy(
+          this._getTaggedHosts({ hosts: allRelevantHosts, tagList: this._antiAffinityTags, vms: allRunningVms }).hosts,
+          'id'
+        )
+      : undefined
+
     // Sort vms by cpu usage. (higher to lower) + use memory otherwise.
     vms.sort((a, b) => {
       const aAverages = vmsAverages[a.id]
@@ -210,34 +229,26 @@ export default class PerformancePlan extends Plan {
         continue
       }
 
-      // TODO: Improve this piece of code. We could compute variance to check if the VM
-      // is migratable. But the code must be rewritten:
-      // - All VMs, hosts and stats must be fetched at one place.
-      // - It's necessary to maintain a dictionary of tags for each host.
-      // - ...
-      const blockingAffinityTags = intersection(vm.tags, this._affinityTags)
-      if (blockingAffinityTags.length > 0) {
-        debug(
-          `VM (${vm.id}) of Host (${exceededHost.id}) cannot be migrated. It contains affinity tag(s): ${blockingAffinityTags}.`
+      // don't exclude VMs with meaningful tags entirely: only avoid destinations that would
+      // deteriorate the VM's affinity / anti-affinity / vm-to-host affinity constraints
+      const affinityTags = intersection(vm.tags, this._affinityTags)
+      const antiAffinityTags = intersection(vm.tags, this._antiAffinityTags)
+      const candidateHosts = filter(hosts, host => {
+        const params = { vm, sourceHostId: exceededHost.id, destinationHostId: host.id }
+        return (
+          !this._wouldDeteriorateAffinity({ ...params, countsByHostId: affinityCountsByHostId }) &&
+          !this._wouldDeteriorateAntiAffinity({ ...params, countsByHostId: antiAffinityCountsByHostId }) &&
+          !this._wouldDeteriorateVmToHostAffinity({ ...params, idToHost })
         )
-        continue
-      }
-      const blockingAntiAffinityTags = intersection(vm.tags, this._antiAffinityTags)
-      if (blockingAntiAffinityTags.length > 0) {
+      })
+      if (candidateHosts.length === 0) {
         debug(
-          `VM (${vm.id}) of Host (${exceededHost.id}) cannot be migrated. It contains anti-affinity tag(s): ${blockingAntiAffinityTags}.`
-        )
-        continue
-      }
-      const blockingVmToHostAffinityTags = intersection(vm.tags, this._vmToHostAffinityTags)
-      if (blockingVmToHostAffinityTags.length > 0) {
-        debug(
-          `VM (${vm.id}) of Host (${exceededHost.id}) cannot be migrated. It contains vm-to-host affinity tag(s): ${blockingVmToHostAffinityTags}.`
+          `VM (${vm.id}) of Host (${exceededHost.id}) cannot be migrated without deteriorating its affinity, anti-affinity or vm-to-host affinity.`
         )
         continue
       }
 
-      hosts.sort((a, b) => {
+      candidateHosts.sort((a, b) => {
         if (a.$poolId !== b.$poolId) {
           // Use host in the same pool first. In other pool if necessary.
           if (a.$poolId === vm.$poolId) {
@@ -251,7 +262,7 @@ export default class PerformancePlan extends Plan {
         return this._sortHosts(hostsAverages[a.id], hostsAverages[b.id])
       })
 
-      const destination = hosts[0]
+      const destination = candidateHosts[0]
 
       const destinationAverages = hostsAverages[destination.id]
       const vmAverages = vmsAverages[vm.id]
@@ -303,6 +314,9 @@ export default class PerformancePlan extends Plan {
           reason,
         })
       )
+      // keep our local counts in sync so later VMs in this loop aren't checked against stale data
+      this._adjustTagCounts(affinityCountsByHostId, affinityTags, exceededHost.id, destination.id)
+      this._adjustTagCounts(antiAffinityCountsByHostId, antiAffinityTags, exceededHost.id, destination.id)
       optimizationCount++
     }
 

--- a/packages/xo-server-load-balancer/src/performance-plan.js
+++ b/packages/xo-server-load-balancer/src/performance-plan.js
@@ -1,4 +1,4 @@
-import { filter, intersection } from 'lodash'
+import { filter, intersection, keyBy } from 'lodash'
 
 import Plan from './plan'
 import { debug as debugP } from './utils'
@@ -175,6 +175,24 @@ export default class PerformancePlan extends Plan {
     const vms = filter(this._getAllRunningVms(), vm => vm.$container === exceededHost.id)
     const vmsAverages = await this._getVmsAverages(vms, { [exceededHost.id]: exceededHost })
 
+    // per-host counts of affinity/anti-affinity tagged VMs, to check whether a candidate destination
+    // would deteriorate a VM's constraints, instead of blocking its migration entirely.
+    // include exceededHost too, since counts get decremented on it as VMs are migrated away.
+    const allRunningVms = this._getAllRunningVms()
+    const allRelevantHosts = [exceededHost, ...hosts]
+    const affinityCountsByHostId = this._affinityTags.length
+      ? keyBy(
+          this._getTaggedHosts({ hosts: allRelevantHosts, tagList: this._affinityTags, vms: allRunningVms }).hosts,
+          'id'
+        )
+      : undefined
+    const antiAffinityCountsByHostId = this._antiAffinityTags.length
+      ? keyBy(
+          this._getTaggedHosts({ hosts: allRelevantHosts, tagList: this._antiAffinityTags, vms: allRunningVms }).hosts,
+          'id'
+        )
+      : undefined
+
     // Sort vms by cpu usage. (higher to lower) + use memory otherwise.
     vms.sort((a, b) => {
       const aAverages = vmsAverages[a.id]
@@ -210,34 +228,48 @@ export default class PerformancePlan extends Plan {
         continue
       }
 
-      // TODO: Improve this piece of code. We could compute variance to check if the VM
-      // is migratable. But the code must be rewritten:
-      // - All VMs, hosts and stats must be fetched at one place.
-      // - It's necessary to maintain a dictionary of tags for each host.
-      // - ...
-      const blockingAffinityTags = intersection(vm.tags, this._affinityTags)
-      if (blockingAffinityTags.length > 0) {
-        debug(
-          `VM (${vm.id}) of Host (${exceededHost.id}) cannot be migrated. It contains affinity tag(s): ${blockingAffinityTags}.`
+      // don't exclude VMs with meaningful tags entirely: only avoid destinations that would
+      // deteriorate the VM's affinity / anti-affinity / vm-to-host affinity constraints
+      let candidateHosts = hosts
+
+      const affinityTags = intersection(vm.tags, this._affinityTags)
+      if (affinityTags.length > 0) {
+        candidateHosts = filter(candidateHosts, host =>
+          affinityTags.some(tag => affinityCountsByHostId[host.id].tags[tag] > 0)
         )
-        continue
-      }
-      const blockingAntiAffinityTags = intersection(vm.tags, this._antiAffinityTags)
-      if (blockingAntiAffinityTags.length > 0) {
-        debug(
-          `VM (${vm.id}) of Host (${exceededHost.id}) cannot be migrated. It contains anti-affinity tag(s): ${blockingAntiAffinityTags}.`
-        )
-        continue
-      }
-      const blockingVmToHostAffinityTags = intersection(vm.tags, this._vmToHostAffinityTags)
-      if (blockingVmToHostAffinityTags.length > 0) {
-        debug(
-          `VM (${vm.id}) of Host (${exceededHost.id}) cannot be migrated. It contains vm-to-host affinity tag(s): ${blockingVmToHostAffinityTags}.`
-        )
-        continue
+        if (candidateHosts.length === 0) {
+          debug(
+            `VM (${vm.id}) of Host (${exceededHost.id}) cannot be migrated. No other host already has a VM sharing its affinity tag(s): ${affinityTags}.`
+          )
+          continue
+        }
       }
 
-      hosts.sort((a, b) => {
+      const antiAffinityTags = intersection(vm.tags, this._antiAffinityTags)
+      if (antiAffinityTags.length > 0) {
+        candidateHosts = filter(candidateHosts, host =>
+          antiAffinityTags.every(tag => antiAffinityCountsByHostId[host.id].tags[tag] === 0)
+        )
+        if (candidateHosts.length === 0) {
+          debug(
+            `VM (${vm.id}) of Host (${exceededHost.id}) cannot be migrated. Every host already has a VM sharing its anti-affinity tag(s): ${antiAffinityTags}.`
+          )
+          continue
+        }
+      }
+
+      const vmToHostAffinityTags = intersection(vm.tags, this._vmToHostAffinityTags)
+      if (vmToHostAffinityTags.length > 0) {
+        candidateHosts = filter(candidateHosts, host => vmToHostAffinityTags.some(tag => host.tags.includes(tag)))
+        if (candidateHosts.length === 0) {
+          debug(
+            `VM (${vm.id}) of Host (${exceededHost.id}) cannot be migrated. No other host shares its vm-to-host affinity tag(s): ${vmToHostAffinityTags}.`
+          )
+          continue
+        }
+      }
+
+      candidateHosts.sort((a, b) => {
         if (a.$poolId !== b.$poolId) {
           // Use host in the same pool first. In other pool if necessary.
           if (a.$poolId === vm.$poolId) {
@@ -251,7 +283,7 @@ export default class PerformancePlan extends Plan {
         return this._sortHosts(hostsAverages[a.id], hostsAverages[b.id])
       })
 
-      const destination = hosts[0]
+      const destination = candidateHosts[0]
 
       const destinationAverages = hostsAverages[destination.id]
       const vmAverages = vmsAverages[vm.id]
@@ -303,6 +335,9 @@ export default class PerformancePlan extends Plan {
           reason,
         })
       )
+      // keep our local counts in sync so later VMs in this loop aren't checked against stale data
+      this._adjustTagCounts(affinityCountsByHostId, affinityTags, exceededHost.id, destination.id)
+      this._adjustTagCounts(antiAffinityCountsByHostId, antiAffinityTags, exceededHost.id, destination.id)
       optimizationCount++
     }
 

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -406,6 +406,18 @@ export default class Plan {
     }
     const vmsAverages = await this._getVmsAverages(allVms, idToHost)
 
+    // per-host counts of affinity/anti-affinity tagged VMs, to check whether a candidate destination
+    // would deteriorate a VM's constraints, instead of excluding it from vCPU prepositioning entirely
+    const affinityCountsByHostId = this._affinityTags.length
+      ? keyBy(this._getTaggedHosts({ hosts: sanitizedHostList, tagList: this._affinityTags, vms: allVms }).hosts, 'id')
+      : undefined
+    const antiAffinityCountsByHostId = this._antiAffinityTags.length
+      ? keyBy(
+          this._getTaggedHosts({ hosts: sanitizedHostList, tagList: this._antiAffinityTags, vms: allVms }).hosts,
+          'id'
+        )
+      : undefined
+
     // 1. Find source host from which to migrate.
     const sources = sortBy(
       // filter to only get hosts for which removing vCPUs is meaningful
@@ -473,14 +485,40 @@ export default class Plan {
         // ex: if we have a host with 19 vCPU and 9 host with 10 vCPU, each with the same number of CPU, then ideal vCPU per host is 10.9, rounding to 10 would make host with 19 vCPU have no destination to send VMs to
         // reversely, we could have a host with 5 vCPU and 9 host with 10 vCPU, and then the 5 vCPU host would have no source to receive VMs from
         let delta = Math.ceil(Math.min(deltaSource, -deltaDestination))
+        // don't exclude VMs with meaningful tags entirely: only avoid a destination that would
+        // deteriorate the VM's affinity / anti-affinity / vm-to-host affinity constraints
         const vms = sortBy(
-          filter(
-            sourceVms,
-            vm =>
-              !this._isVmInCooldown(vm) &&
-              hostsAverages[destinationHost.id].memoryFree >= vmsAverages[vm.id].memory &&
-              vm.CPUs.number <= delta
-          ),
+          filter(sourceVms, vm => {
+            if (
+              this._isVmInCooldown(vm) ||
+              hostsAverages[destinationHost.id].memoryFree < vmsAverages[vm.id].memory ||
+              vm.CPUs.number > delta
+            ) {
+              return false
+            }
+
+            const affinityTags = intersection(vm.tags, this._affinityTags)
+            if (
+              affinityTags.length > 0 &&
+              !affinityTags.some(tag => affinityCountsByHostId[destinationHost.id].tags[tag] > 0)
+            ) {
+              return false
+            }
+
+            const antiAffinityTags = intersection(vm.tags, this._antiAffinityTags)
+            if (
+              antiAffinityTags.length > 0 &&
+              !antiAffinityTags.every(tag => antiAffinityCountsByHostId[destinationHost.id].tags[tag] === 0)
+            ) {
+              return false
+            }
+
+            const vmToHostAffinityTags = intersection(vm.tags, this._vmToHostAffinityTags)
+            return (
+              vmToHostAffinityTags.length === 0 ||
+              vmToHostAffinityTags.some(tag => idToHost[destinationHost.id].tags.includes(tag))
+            )
+          }),
           [vm => -vm.CPUs.number]
         )
 
@@ -521,6 +559,19 @@ export default class Plan {
                 destHostId: destination._xapiId,
                 reason: 'to balance vCPUs over CPUs',
               })
+            )
+            // keep our local counts in sync so later VMs in this loop aren't checked against stale data
+            this._adjustTagCounts(
+              affinityCountsByHostId,
+              intersection(vm.tags, this._affinityTags),
+              sourceHost.id,
+              destinationHost.id
+            )
+            this._adjustTagCounts(
+              antiAffinityCountsByHostId,
+              intersection(vm.tags, this._antiAffinityTags),
+              sourceHost.id,
+              destinationHost.id
             )
             debugVcpuBalancing(`vCPU count per host: ${inspect(hostList, { depth: null })}`)
 
@@ -569,15 +620,10 @@ export default class Plan {
       const host = idToHost[hostId]
       host.vcpuCount += vm.CPUs.number
 
-      if (
-        vm.xenTools &&
-        vm.tags.every(
-          tag =>
-            !this._antiAffinityTags.includes(tag) &&
-            !this._affinityTags.includes(tag) &&
-            !this._vmToHostAffinityTags.includes(tag)
-        )
-      ) {
+      // don't exclude VMs with meaningful tags entirely: _processVcpuPrepositioning avoids
+      // destinations that would deteriorate their affinity / anti-affinity / vm-to-host affinity
+      // constraints instead
+      if (vm.xenTools) {
         host.vms[vm.id] = vm
       }
     }

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -998,7 +998,7 @@ export default class Plan {
             idToHost,
             taggedHosts,
             memoryNeeded: vmsAverages[vm.id].memory,
-            tag,
+            reason: `to free up resources on host to later migrate affinity-tagged VMs to it (${tag})`,
           })
           promises.push(...otherMigrationPromises)
 
@@ -1036,7 +1036,7 @@ export default class Plan {
     return promises
   }
 
-  async _migrateOtherVms({ crowdedHost, hostsAverages, vmsAverages, idToHost, taggedHosts, memoryNeeded, tag }) {
+  async _migrateOtherVms({ crowdedHost, hostsAverages, vmsAverages, idToHost, taggedHosts, memoryNeeded, reason }) {
     const promises = []
 
     const candidateVms = sortBy(
@@ -1089,7 +1089,7 @@ export default class Plan {
           hostsAverages,
           vmAverages,
           promises,
-          reason: `to free up resources on host to later migrate affinity-tagged VMs to it (${tag})`,
+          reason,
         })
       )
 
@@ -1335,6 +1335,7 @@ export default class Plan {
           idToHost,
           taggedHosts,
           memoryNeeded: vmAverages.memory,
+          reason: `to free up resources on host to later migrate VM-to-host-affinity-tagged VMs to it (${vmTags.join(', ')})`,
         })
         promises.push(...otherMigrationPromises)
 
@@ -1344,6 +1345,8 @@ export default class Plan {
           )
           continue
         }
+        // not a real race: destinationHost is a per-iteration local not touched by _migrateOtherVms or any concurrent call
+        // eslint-disable-next-line require-atomic-updates
         destinationHost = crowdedHost
       }
 

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -639,6 +639,19 @@ export default class Plan {
   _processAntiAffinityTag({ tag, vmsAverages, hostsAverages, taggedHosts, idToHost }) {
     const promises = []
 
+    // per-host counts of affinity tagged VMs, to check whether a candidate destination would
+    // deteriorate a VM's affinity constraint, instead of blocking its migration entirely
+    const affinityCountsByHostId = this._affinityTags.length
+      ? keyBy(
+          this._getTaggedHosts({
+            hosts: Object.values(idToHost),
+            tagList: this._affinityTags,
+            vms: this._getAllRunningVms(),
+          }).hosts,
+          'id'
+        )
+      : undefined
+
     while (true) {
       // safety to prevent infinite loop if destination has no VM able to migrate
       let emptyLoop = true
@@ -684,13 +697,27 @@ export default class Plan {
           destinationHost = destination
           debugAntiAffinity(`Host candidate: ${sourceHost.id} -> ${destinationHost.id}.`)
 
-          const vms = filter(
-            sourceVms,
-            vm =>
-              !this._isVmInCooldown(vm) &&
-              hostsAverages[destinationHost.id].memoryFree >= vmsAverages[vm.id].memory &&
-              vm.tags.every(tag => !this._affinityTags.includes(tag) && !this._vmToHostAffinityTags.includes(tag))
-          )
+          // don't exclude VMs with meaningful tags entirely: only avoid a destination that would
+          // deteriorate the VM's affinity / vm-to-host affinity constraints
+          const vms = filter(sourceVms, vm => {
+            if (this._isVmInCooldown(vm) || hostsAverages[destinationHost.id].memoryFree < vmsAverages[vm.id].memory) {
+              return false
+            }
+
+            const affinityTags = intersection(vm.tags, this._affinityTags)
+            if (
+              affinityTags.length > 0 &&
+              !affinityTags.some(tag => affinityCountsByHostId[destinationHost.id].tags[tag] > 0)
+            ) {
+              return false
+            }
+
+            const vmToHostAffinityTags = intersection(vm.tags, this._vmToHostAffinityTags)
+            return (
+              vmToHostAffinityTags.length === 0 ||
+              vmToHostAffinityTags.some(tag => idToHost[destinationHost.id].tags.includes(tag))
+            )
+          })
 
           debugAntiAffinity(
             `Tagged VM ("${tag}") candidates to migrate from host ${sourceHost.id}: ${inspect(mapToArray(vms, 'id'))}.`
@@ -728,6 +755,14 @@ export default class Plan {
             vmAverages: vmsAverages[vm.id],
           })
         )
+        // keep our local affinity counts in sync so later migrations in this loop aren't checked
+        // against stale data
+        this._adjustTagCounts(
+          affinityCountsByHostId,
+          intersection(vm.tags, this._affinityTags),
+          sourceHost.id,
+          destinationHost.id
+        )
         emptyLoop = false
 
         break // Continue with the same tag, the source can be different.
@@ -736,6 +771,18 @@ export default class Plan {
       if (emptyLoop) {
         break
       }
+    }
+  }
+
+  // Keep a per-host tag-count map (as returned by `_getTaggedHosts`) in sync with a migration decided
+  // within the same loop that computed it, so later iterations don't check against stale counts.
+  _adjustTagCounts(countsByHostId, tags, sourceHostId, destinationHostId) {
+    if (countsByHostId === undefined) {
+      return
+    }
+    for (const tag of tags) {
+      countsByHostId[sourceHostId].tags[tag]--
+      countsByHostId[destinationHostId].tags[tag]++
     }
   }
 
@@ -1021,16 +1068,22 @@ export default class Plan {
   async _migrateOtherVms({ crowdedHost, hostsAverages, vmsAverages, idToHost, taggedHosts, memoryNeeded, reason }) {
     const promises = []
 
+    // per-host counts of affinity/anti-affinity tagged VMs, to check whether a candidate destination
+    // would deteriorate a VM's constraints, instead of blocking its migration entirely
+    const allHosts = Object.values(idToHost)
+    const allRunningVms = this._getAllRunningVms()
+    const affinityCountsByHostId = this._affinityTags.length
+      ? keyBy(this._getTaggedHosts({ hosts: allHosts, tagList: this._affinityTags, vms: allRunningVms }).hosts, 'id')
+      : undefined
+    const antiAffinityCountsByHostId = this._antiAffinityTags.length
+      ? keyBy(
+          this._getTaggedHosts({ hosts: allHosts, tagList: this._antiAffinityTags, vms: allRunningVms }).hosts,
+          'id'
+        )
+      : undefined
+
     const candidateVms = sortBy(
-      filter(
-        Object.values(crowdedHost.vms),
-        vm =>
-          vm.xenTools &&
-          !this._isVmInCooldown(vm) &&
-          intersection(vm.tags, this._affinityTags).length === 0 &&
-          intersection(vm.tags, this._antiAffinityTags).length === 0 &&
-          intersection(vm.tags, this._vmToHostAffinityTags).length === 0
-      ),
+      filter(Object.values(crowdedHost.vms), vm => vm.xenTools && !this._isVmInCooldown(vm)),
       [vm => -vmsAverages[vm.id].memory] // try to migrate bigger VMs first to minimize the number of migrations
     )
     debugAffinity(`Candidate VMs to be moved away: ${candidateVms.map(vm => vm.name_label)}`)
@@ -1039,12 +1092,32 @@ export default class Plan {
       // try to migrate vm
 
       const vmAverages = vmsAverages[vm.id]
+      // don't exclude VMs with meaningful tags entirely: only avoid destinations that would
+      // deteriorate the VM's affinity / anti-affinity / vm-to-host affinity constraints
+      const affinityTags = intersection(vm.tags, this._affinityTags)
+      const antiAffinityTags = intersection(vm.tags, this._antiAffinityTags)
+      const vmToHostAffinityTags = intersection(vm.tags, this._vmToHostAffinityTags)
 
       const destinationHost = sortBy(
         taggedHosts.hosts,
         [host => -hostsAverages[host.id].memoryFree, host => hostsAverages[host.id].cpu] // try to migrate to hosts with the most free space first
       ).find(host => {
         if (host.id === crowdedHost.id) {
+          return false
+        }
+        if (affinityTags.length > 0 && !affinityTags.some(tag => affinityCountsByHostId[host.id].tags[tag] > 0)) {
+          return false
+        }
+        if (
+          antiAffinityTags.length > 0 &&
+          !antiAffinityTags.every(tag => antiAffinityCountsByHostId[host.id].tags[tag] === 0)
+        ) {
+          return false
+        }
+        if (
+          vmToHostAffinityTags.length > 0 &&
+          !vmToHostAffinityTags.some(tag => idToHost[host.id].tags.includes(tag))
+        ) {
           return false
         }
         const destinationAverages = hostsAverages[host.id]
@@ -1074,6 +1147,9 @@ export default class Plan {
           reason,
         })
       )
+      // keep our local counts in sync so later VMs in this loop aren't checked against stale data
+      this._adjustTagCounts(affinityCountsByHostId, affinityTags, crowdedHost.id, destinationHost.id)
+      this._adjustTagCounts(antiAffinityCountsByHostId, antiAffinityTags, crowdedHost.id, destinationHost.id)
 
       if (hostsAverages[crowdedHost.id].memoryFree - memoryNeeded > this._thresholds.memoryFree.critical) {
         // wait for the freeing migrations to actually complete before reporting success: up to

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -708,35 +708,18 @@ export default class Plan {
 
         const source = idToHost[sourceHost.id]
         const destination = idToHost[destinationHost.id]
-        debugAntiAffinity(
-          `Migrate VM (${vm.id} "${vm.name_label}") to Host (${destinationHost.id} "${destination.name_label}") from Host (${sourceHost.id} "${source.name_label}").`
-        )
 
-        // 3. Update tags and averages.
+        // 3. Update tags and averages, and migrate.
         // This update can change the source host for the next migration.
-        for (const tag of vm.tags) {
-          if (this._antiAffinityTags.includes(tag)) {
-            sourceHost.tags[tag]--
-            destinationHost.tags[tag]++
-          }
-        }
-
-        const destinationAverages = hostsAverages[destinationHost.id]
-        const vmAverages = vmsAverages[vm.id]
-
-        destinationAverages.cpu += vmAverages.cpu
-        destinationAverages.memoryFree -= vmAverages.memory
-
-        delete sourceHost.vms[vm.id]
-
-        // 4. Migrate.
         promises.push(
-          this._migrateVm({
+          this._migrateVmAndUpdateInfos({
+            destination,
+            source,
+            sourceHost,
+            destinationHost,
             vm,
-            xapiSrc: this.xo.getXapi(source),
-            xapiDest: this.xo.getXapi(destination),
-            srcHostId: source.id,
-            destHostId: destination._xapiId,
+            hostsAverages,
+            vmAverages: vmsAverages[vm.id],
             reason: `to satisfy anti-affinity of tag ${tag}`,
           })
         )
@@ -1112,12 +1095,12 @@ export default class Plan {
     // TODO: add more checks with XAPI method assert_can_migrate
 
     // Update tags and averages
-    debugAffinity(
+    debug(
       `Migrate VM (${vm.id} "${vm.name_label}") to Host (${destination.id} "${destination.name_label}") from Host (${source.id} "${source.name_label}").`
     )
 
     for (const tag of vm.tags) {
-      if (this._affinityTags.includes(tag)) {
+      if (tag in sourceHost.tags) {
         sourceHost.tags[tag]--
         destinationHost.tags[tag]++
       }

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -1,3 +1,4 @@
+import { limitConcurrency } from 'limit-concurrency-decorator'
 import {
   filter,
   groupBy,
@@ -14,6 +15,10 @@ import {
 import { inspect } from 'util'
 
 import { EXECUTION_DELAY, debug, warn } from './utils'
+
+// caps how many `set_affinity` XAPI calls _processVmToHostAffinity fires at once; independent from
+// _concurrentMigrationLimiter, which is dedicated to actual VM migrations
+const MAX_CONCURRENT_AFFINITY_UPDATES = 5
 
 // value is shared with DEFAULT_LOAD_BALANCER_RE_ENABLE_DELAY in packages/xo-server/src/xo-mixins/xen-servers.mjs
 // and loadBalancerReEnableDelay in config.toml
@@ -46,6 +51,7 @@ const numberOrDefault = (value, def) => (value >= 0 ? value : def)
 export const debugAffinity = str => debug(`affinity: ${str}`)
 export const debugAntiAffinity = str => debug(`anti-affinity: ${str}`)
 export const debugVcpuBalancing = str => debug(`vCPU balancing: ${str}`)
+export const debugVmToHostAffinity = str => debug(`vm-to-host affinity: ${str}`)
 
 // ===================================================================
 // Averages.
@@ -139,7 +145,7 @@ export default class Plan {
     xo,
     name,
     poolIds,
-    { excludedHosts, thresholds, balanceVcpus, affinityTags = [], antiAffinityTags = [] },
+    { excludedHosts, thresholds, balanceVcpus, affinityTags = [], antiAffinityTags = [], vmToHostAffinityTags = [] },
     globalOptions,
     concurrentMigrationLimiter
   ) {
@@ -158,6 +164,7 @@ export default class Plan {
     }
     this._affinityTags = affinityTags
     this._antiAffinityTags = antiAffinityTags
+    this._vmToHostAffinityTags = vmToHostAffinityTags
     // balanceVcpus variable name was kept for compatibility with past configuration schema
     this._performanceSubmode =
       balanceVcpus === false ? 'conservative' : balanceVcpus === true ? 'vCpuPrepositioning' : balanceVcpus
@@ -570,7 +577,12 @@ export default class Plan {
 
       if (
         vm.xenTools &&
-        vm.tags.every(tag => !this._antiAffinityTags.includes(tag) && !this._affinityTags.includes(tag))
+        vm.tags.every(
+          tag =>
+            !this._antiAffinityTags.includes(tag) &&
+            !this._affinityTags.includes(tag) &&
+            !this._vmToHostAffinityTags.includes(tag)
+        )
       ) {
         host.vms[vm.id] = vm
       }
@@ -683,7 +695,7 @@ export default class Plan {
             vm =>
               !this._isVmInCooldown(vm) &&
               hostsAverages[destinationHost.id].memoryFree >= vmsAverages[vm.id].memory &&
-              vm.tags.every(tag => !this._affinityTags.includes(tag))
+              vm.tags.every(tag => !this._affinityTags.includes(tag) && !this._vmToHostAffinityTags.includes(tag))
           )
 
           debugAntiAffinity(
@@ -975,7 +987,7 @@ export default class Plan {
             idToHost,
             taggedHosts,
             memoryNeeded: vmsAverages[vm.id].memory,
-            tag,
+            reason: `to free up resources on host to later migrate affinity-tagged VMs to it (${tag})`,
           })
           promises.push(...otherMigrationPromises)
 
@@ -1013,7 +1025,7 @@ export default class Plan {
     return promises
   }
 
-  async _migrateOtherVms({ crowdedHost, hostsAverages, vmsAverages, idToHost, taggedHosts, memoryNeeded, tag }) {
+  async _migrateOtherVms({ crowdedHost, hostsAverages, vmsAverages, idToHost, taggedHosts, memoryNeeded, reason }) {
     const promises = []
 
     const candidateVms = sortBy(
@@ -1023,7 +1035,8 @@ export default class Plan {
           vm.xenTools &&
           !this._isVmInCooldown(vm) &&
           intersection(vm.tags, this._affinityTags).length === 0 &&
-          intersection(vm.tags, this._antiAffinityTags).length === 0
+          intersection(vm.tags, this._antiAffinityTags).length === 0 &&
+          intersection(vm.tags, this._vmToHostAffinityTags).length === 0
       ),
       [vm => -vmsAverages[vm.id].memory] // try to migrate bigger VMs first to minimize the number of migrations
     )
@@ -1064,7 +1077,7 @@ export default class Plan {
           vm,
           hostsAverages,
           vmAverages,
-          reason: `to free up resources on host to later migrate affinity-tagged VMs to it (${tag})`,
+          reason,
         })
       )
 
@@ -1168,5 +1181,193 @@ export default class Plan {
     })
 
     return coalitions
+  }
+
+  // ===================================================================
+  // VM-to-host affinity
+  // ===================================================================
+
+  async _processVmToHostAffinity() {
+    if (!this._vmToHostAffinityTags.length) {
+      return
+    }
+
+    const allHosts = this._getHosts()
+    const idToHost = keyBy(allHosts, 'id')
+
+    // 1 - Check that every tagged VM has a preferred host sharing the same tag, otherwise assign one
+    // this will prevent VMs from booting on a host on which they're not supposed to be
+    const taggedVms = filter(
+      this._getAllRunningVms(),
+      vm => vm.$container in idToHost && intersection(vm.tags, this._vmToHostAffinityTags).length > 0
+    )
+
+    const limitAffinityUpdate = limitConcurrency(MAX_CONCURRENT_AFFINITY_UPDATES)()
+    const affinityResults = await Promise.allSettled(
+      taggedVms.map(vm =>
+        limitAffinityUpdate(() => {
+          // preserve the admin's configured tag order, so ambiguous cases resolve deterministically
+          const vmTags = this._vmToHostAffinityTags.filter(tag => vm.tags.includes(tag))
+
+          const preferredHost = idToHost[vm.affinityHost]
+          if (preferredHost !== undefined && vmTags.some(tag => preferredHost.tags.includes(tag))) {
+            return // preferred host already shares one of the VM's tags
+          }
+
+          // prefer hosts sharing ALL of the VM's tags, otherwise fall back to the first tag (in configured
+          // order) that has a matching host: the VM's tags don't share a common host, so which host wins is
+          // an arbitrary choice, and this should be avoided by the admin
+          let candidateHosts = allHosts.filter(host => vmTags.every(tag => host.tags.includes(tag)))
+          if (candidateHosts.length === 0) {
+            if (vmTags.length > 1) {
+              warn(
+                `vm-to-host affinity: VM (${vm.id} "${vm.name_label}") has VM-to-host affinity tags (${vmTags}) with no host sharing all of them; this must be avoided.`
+              )
+            }
+            const fallbackTag = vmTags.find(tag => allHosts.some(host => host.tags.includes(tag)))
+            candidateHosts = fallbackTag === undefined ? [] : allHosts.filter(host => host.tags.includes(fallbackTag))
+          }
+
+          if (candidateHosts.length === 0) {
+            debugVmToHostAffinity(`No host found with tag(s) ${vmTags} for VM (${vm.id} "${vm.name_label}").`)
+            return
+          }
+
+          // pick randomly among candidates to avoid setting the same preferred host on all matching VMs
+          const candidateHost = candidateHosts[Math.floor(Math.random() * candidateHosts.length)]
+
+          debugVmToHostAffinity(
+            `Setting preferred Host (${candidateHost.id} "${candidateHost.name_label}") for VM (${vm.id} "${vm.name_label}").`
+          )
+          const xapi = this.xo.getXapi(vm)
+          return xapi.getObject(vm.id).set_affinity(xapi.getObject(candidateHost.id).$ref)
+        })
+      )
+    )
+    const failures = taggedVms
+      .map((vm, i) => ({ vm, result: affinityResults[i] }))
+      .filter(({ result }) => result.status === 'rejected')
+    if (failures.length > 0) {
+      warn('vm-to-host affinity: failed to set preferred host for some VMs', {
+        vmIds: failures.map(({ vm }) => vm.id),
+        errors: failures.map(({ result }) => result.reason),
+      })
+    }
+
+    // 2 - get list of VMs which have a tag and are not on the right hosts
+    const misplacedVms = filter(this._getAllRunningVms(), vm => {
+      if (!(vm.$container in idToHost)) {
+        return false
+      }
+
+      const vmTags = intersection(vm.tags, this._vmToHostAffinityTags)
+      if (vmTags.length === 0) {
+        return false
+      }
+
+      const currentHost = idToHost[vm.$container]
+      return !vmTags.some(tag => currentHost.tags.includes(tag))
+    })
+
+    if (misplacedVms.length === 0) {
+      return
+    }
+
+    debugVmToHostAffinity(`Misplaced VMs: ${inspect(mapToArray(misplacedVms, 'id'), { depth: null })}`)
+
+    // 3 - Migrate misplaced VMs if possible.
+    const allVms = filter(this._getAllRunningVms(), vm => vm.$container in idToHost)
+    const vmsAverages = await this._getVmsAverages(allVms, idToHost)
+    const { averages: hostsAverages } = await this._getHostStatsAverages({ hosts: allHosts })
+
+    const taggedHosts = this._getTaggedHosts({
+      hosts: allHosts,
+      tagList: this._vmToHostAffinityTags,
+      vms: allVms,
+      includeUntaggedVms: true,
+    })
+    const hostStructById = keyBy(taggedHosts.hosts, 'id')
+
+    const promises = []
+    for (const vm of misplacedVms) {
+      if (!vm.xenTools) {
+        debugVmToHostAffinity(`VM (${vm.id} "${vm.name_label}") does not support pool migration.`)
+        continue
+      }
+      if (this._isVmInCooldown(vm)) {
+        debugVmToHostAffinity(`VM (${vm.id} "${vm.name_label}") is in cooldown, skipping.`)
+        continue
+      }
+
+      const vmTags = intersection(vm.tags, this._vmToHostAffinityTags)
+      let eligibleHosts = allHosts.filter(host => vmTags.some(tag => host.tags.includes(tag)))
+      // preferring hosts matching more tags, then hosts with more free resources
+      eligibleHosts = sortBy(eligibleHosts, [
+        host => -vmTags.filter(tag => host.tags.includes(tag)).length,
+        host => -hostsAverages[host.id].memoryFree,
+        host => hostsAverages[host.id].cpu,
+      ])
+      if (eligibleHosts.length === 0) {
+        debugVmToHostAffinity(`No eligible host found for misplaced VM (${vm.id} "${vm.name_label}").`)
+        continue
+      }
+
+      const vmAverages = vmsAverages[vm.id]
+
+      // try to find an eligible host with enough free memory and CPU to receive the VM
+      let destinationHost = eligibleHosts.find(host => {
+        const destinationAverages = hostsAverages[host.id]
+        return (
+          destinationAverages.cpu + vmAverages.cpu <= this._thresholds.cpu.critical &&
+          destinationAverages.memoryFree - vmAverages.memory >= this._thresholds.memoryFree.critical
+        )
+      })
+
+      if (destinationHost === undefined) {
+        // no eligible host currently has enough room: try to free up space on the best candidate
+        const crowdedHost = eligibleHosts[0]
+        debugVmToHostAffinity(
+          `No eligible host has enough resources for VM (${vm.id} "${vm.name_label}"), trying to free up space on Host (${crowdedHost.id} "${crowdedHost.name_label}").`
+        )
+
+        const { promises: otherMigrationPromises, success } = await this._migrateOtherVms({
+          crowdedHost: hostStructById[crowdedHost.id],
+          hostsAverages,
+          vmsAverages,
+          idToHost,
+          taggedHosts,
+          memoryNeeded: vmAverages.memory,
+          reason: `to free up resources on host to later migrate VM-to-host-affinity-tagged VMs to it (${vmTags.join(', ')})`,
+        })
+        promises.push(...otherMigrationPromises)
+
+        if (!success) {
+          debugVmToHostAffinity(
+            `Could not free enough resources for VM (${vm.id} "${vm.name_label}"), leaving it on its current host.`
+          )
+          continue
+        }
+        // not a real race: destinationHost is a per-iteration local not touched by _migrateOtherVms or any concurrent call
+        // eslint-disable-next-line require-atomic-updates
+        destinationHost = crowdedHost
+      }
+
+      const matchingTags = vmTags.filter(tag => destinationHost.tags.includes(tag))
+
+      promises.push(
+        this._migrateVmAndUpdateInfos({
+          destination: idToHost[destinationHost.id],
+          source: idToHost[vm.$container],
+          sourceHost: hostStructById[vm.$container],
+          destinationHost: hostStructById[destinationHost.id],
+          vm,
+          hostsAverages,
+          vmAverages,
+          reason: `to satisfy VM-to-host affinity of tag(s) ${matchingTags.join(', ')}`,
+        })
+      )
+    }
+
+    return Promise.allSettled(promises)
   }
 }

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -1095,16 +1095,33 @@ export default class Plan {
     // computing the sum of number of VMs per coalition to avoid doing it multiple times while sorting
     // in case of coalitions, the sum is incorrect as VMs are counted twice, but it gives an approximation without parsing all the VMs again
     const taggedVmCountPerHost = {}
+    // number of coalition-tagged VMs on the host that also share a vm-to-host-affinity tag with their host:
+    // such a VM likely can't be migrated away without deteriorating its vm-to-host affinity, so its host
+    // should be preferred as the destination rather than as a source we could never actually migrate it from
+    const pinnedVmCountPerHost = {}
     for (const host of taggedHosts.hosts) {
       taggedVmCountPerHost[host.id] = coalition.reduce((sum, coalitionTag) => sum + host.tagCounts[coalitionTag], 0)
+      pinnedVmCountPerHost[host.id] = Object.values(host.vms).reduce(
+        (sum, vm) =>
+          sum +
+          (intersection(vm.tags, coalition).length > 0 &&
+          intersection(vm.tags, this._vmToHostAffinityTags, idToHost[host.id].tags).length > 0
+            ? 1
+            : 0),
+        0
+      )
     }
 
     const sortedHosts = sortBy(
       taggedHosts.hosts.filter(host => coalition.some(coalitionTag => host.tagCounts[coalitionTag] > 0)),
-      [host => taggedVmCountPerHost[host.id], host => -hostsAverages[host.id].memoryFree]
+      [
+        host => taggedVmCountPerHost[host.id],
+        host => pinnedVmCountPerHost[host.id],
+        host => -hostsAverages[host.id].memoryFree,
+      ]
     )
 
-    // hosts are sorted from having the less tagged VMs to the most, so we pick destinationHost from the end of the list
+    // hosts are sorted from having the least tagged VMs to the most, so we pick destinationHost from the end of the list
     let destinationHost = sortedHosts.pop()
 
     // Migrate tagged VMs from every other host

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -1081,7 +1081,6 @@ export default class Plan {
           vm,
           hostsAverages,
           vmAverages,
-          promises,
           reason: `to free up resources on host to later migrate affinity-tagged VMs to it (${tag})`,
         })
       )

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -323,6 +323,39 @@ export default class Plan {
   }
 
   // ===================================================================
+  // Migration helpers
+  // ===================================================================
+
+  // Check if VM was recently migrated and is in cooldown period
+  _isVmInCooldown(vm) {
+    const { migrationCooldown, migrationHistory } = this._globalOptions
+    if (migrationCooldown > 0) {
+      const lastMigration = migrationHistory.get(vm.id)
+      if (lastMigration !== undefined && Date.now() - lastMigration < migrationCooldown) {
+        return true
+      }
+    }
+    return false
+  }
+
+  _migrateVm({ vm, xapiSrc, xapiDest, srcHostId, destHostId, reason }) {
+    const { migrationHistory } = this._globalOptions
+    return this._concurrentMigrationLimiter(() => {
+      const task = this.xo.tasks.create({
+        name: `Load balancer migrates VM ${vm.name_label} (${vm.id})`,
+        description: `Migrating VM ${vm.name_label} (${vm.id}) from host ${srcHostId} to host ${destHostId} ${reason}`,
+        objectId: vm.id,
+        type: 'xo:load-balancer:migration',
+      })
+      return task.run(async () =>
+        xapiSrc.migrateVm(vm._xapiId, xapiDest, destHostId).then(() => {
+          migrationHistory.set(vm.id, Date.now())
+        })
+      )
+    })
+  }
+
+  // ===================================================================
   // vCPU pre-positioning helpers
   // ===================================================================
 
@@ -1104,35 +1137,6 @@ export default class Plan {
       srcHostId: sourceHost.id,
       destHostId: destination._xapiId,
       reason,
-    })
-  }
-
-  // Check if VM was recently migrated and is in cooldown period
-  _isVmInCooldown(vm) {
-    const { migrationCooldown, migrationHistory } = this._globalOptions
-    if (migrationCooldown > 0) {
-      const lastMigration = migrationHistory.get(vm.id)
-      if (lastMigration !== undefined && Date.now() - lastMigration < migrationCooldown) {
-        return true
-      }
-    }
-    return false
-  }
-
-  _migrateVm({ vm, xapiSrc, xapiDest, srcHostId, destHostId, reason }) {
-    const { migrationHistory } = this._globalOptions
-    return this._concurrentMigrationLimiter(() => {
-      const task = this.xo.tasks.create({
-        name: `Load balancer migrates VM ${vm.name_label} (${vm.id})`,
-        description: `Migrating VM ${vm.name_label} (${vm.id}) from host ${srcHostId} to host ${destHostId} ${reason}`,
-        objectId: vm.id,
-        type: 'xo:load-balancer:migration',
-      })
-      return task.run(async () =>
-        xapiSrc.migrateVm(vm._xapiId, xapiDest, destHostId).then(() => {
-          migrationHistory.set(vm.id, Date.now())
-        })
-      )
     })
   }
 

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -1084,11 +1084,16 @@ export default class Plan {
       )
 
       if (hostsAverages[crowdedHost.id].memoryFree - memoryNeeded > this._thresholds.memoryFree.critical) {
+        // wait for the freeing migrations to actually complete before reporting success: up to
+        // `maxConcurrentMigrations` migrations can run concurrently, so callers relying on `success`
+        // to migrate onto `crowdedHost` right away must not race the still-in-flight migrations
+        await Promise.allSettled(promises)
         return { promises, success: true }
       }
     }
 
     // not enough VMs were migrated
+    await Promise.allSettled(promises)
     return { promises, success: false }
   }
 

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -1085,11 +1085,16 @@ export default class Plan {
       )
 
       if (hostsAverages[crowdedHost.id].memoryFree - memoryNeeded > this._thresholds.memoryFree.critical) {
+        // wait for the freeing migrations to actually complete before reporting success: up to
+        // `maxConcurrentMigrations` migrations can run concurrently, so callers relying on `success`
+        // to migrate onto `crowdedHost` right away must not race the still-in-flight migrations
+        await Promise.allSettled(promises)
         return { promises, success: true }
       }
     }
 
     // not enough VMs were migrated
+    await Promise.allSettled(promises)
     return { promises, success: false }
   }
 

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -364,6 +364,44 @@ export default class Plan {
     })
   }
 
+  // More co-located same-tag VMs is better: compares against the VM's current host instead of
+  // requiring an absolute count, so a VM with no current affinity-mates is never stuck.
+  _wouldDeteriorateAffinity({ vm, countsByHostId, sourceHostId, destinationHostId }) {
+    const tags = intersection(vm.tags, this._affinityTags)
+    if (tags.length === 0) {
+      return false
+    }
+    return tags.some(tag => {
+      const sourceOtherCount = countsByHostId[sourceHostId].tags[tag] - 1
+      const destinationCount = countsByHostId[destinationHostId].tags[tag]
+      return destinationCount < sourceOtherCount
+    })
+  }
+
+  // Fewer co-located same-tag VMs is better: compares against the VM's current host so that, when
+  // there are more anti-affinity-tagged VMs than hosts, spreading them as evenly as possible stays
+  // allowed instead of requiring a conflict-free destination that may not exist.
+  _wouldDeteriorateAntiAffinity({ vm, countsByHostId, sourceHostId, destinationHostId }) {
+    const tags = intersection(vm.tags, this._antiAffinityTags)
+    return tags.some(tag => {
+      const sourceOtherCount = countsByHostId[sourceHostId].tags[tag] - 1
+      const destinationCount = countsByHostId[destinationHostId].tags[tag]
+      return destinationCount > sourceOtherCount
+    })
+  }
+
+  // Matching more of the VM's vm-to-host affinity tags is better: compares against the VM's current
+  // host so an already-misplaced VM (or a tag matching no host) never gets stuck.
+  _wouldDeteriorateVmToHostAffinity({ vm, idToHost, sourceHostId, destinationHostId }) {
+    const tags = intersection(vm.tags, this._vmToHostAffinityTags)
+    if (tags.length === 0) {
+      return false
+    }
+    const sourceMatches = intersection(tags, idToHost[sourceHostId].tags).length
+    const destinationMatches = intersection(tags, idToHost[destinationHostId].tags).length
+    return sourceMatches > destinationMatches
+  }
+
   // ===================================================================
   // vCPU pre-positioning helpers
   // ===================================================================
@@ -411,6 +449,18 @@ export default class Plan {
       return
     }
     const vmsAverages = await this._getVmsAverages(allVms, idToHost)
+
+    // per-host counts of affinity/anti-affinity tagged VMs, to check whether a candidate destination
+    // would deteriorate a VM's constraints, instead of excluding it from vCPU prepositioning entirely
+    const affinityCountsByHostId = this._affinityTags.length
+      ? keyBy(this._getTaggedHosts({ hosts: sanitizedHostList, tagList: this._affinityTags, vms: allVms }).hosts, 'id')
+      : undefined
+    const antiAffinityCountsByHostId = this._antiAffinityTags.length
+      ? keyBy(
+          this._getTaggedHosts({ hosts: sanitizedHostList, tagList: this._antiAffinityTags, vms: allVms }).hosts,
+          'id'
+        )
+      : undefined
 
     // 1. Find source host from which to migrate.
     const sources = sortBy(
@@ -479,14 +529,25 @@ export default class Plan {
         // ex: if we have a host with 19 vCPU and 9 host with 10 vCPU, each with the same number of CPU, then ideal vCPU per host is 10.9, rounding to 10 would make host with 19 vCPU have no destination to send VMs to
         // reversely, we could have a host with 5 vCPU and 9 host with 10 vCPU, and then the 5 vCPU host would have no source to receive VMs from
         let delta = Math.ceil(Math.min(deltaSource, -deltaDestination))
+        // don't exclude VMs with meaningful tags entirely: only avoid a destination that would
+        // deteriorate the VM's affinity / anti-affinity / vm-to-host affinity constraints
         const vms = sortBy(
-          filter(
-            sourceVms,
-            vm =>
-              !this._isVmInCooldown(vm) &&
-              hostsAverages[destinationHost.id].memoryFree >= vmsAverages[vm.id].memory &&
-              vm.CPUs.number <= delta
-          ),
+          filter(sourceVms, vm => {
+            if (
+              this._isVmInCooldown(vm) ||
+              hostsAverages[destinationHost.id].memoryFree < vmsAverages[vm.id].memory ||
+              vm.CPUs.number > delta
+            ) {
+              return false
+            }
+
+            const params = { vm, sourceHostId: sourceHost.id, destinationHostId: destinationHost.id }
+            return (
+              !this._wouldDeteriorateAffinity({ ...params, countsByHostId: affinityCountsByHostId }) &&
+              !this._wouldDeteriorateAntiAffinity({ ...params, countsByHostId: antiAffinityCountsByHostId }) &&
+              !this._wouldDeteriorateVmToHostAffinity({ ...params, idToHost })
+            )
+          }),
           [vm => -vm.CPUs.number]
         )
 
@@ -527,6 +588,19 @@ export default class Plan {
                 destHostId: destination._xapiId,
                 reason: 'to balance vCPUs over CPUs',
               })
+            )
+            // keep our local counts in sync so later VMs in this loop aren't checked against stale data
+            this._adjustTagCounts(
+              affinityCountsByHostId,
+              intersection(vm.tags, this._affinityTags),
+              sourceHost.id,
+              destinationHost.id
+            )
+            this._adjustTagCounts(
+              antiAffinityCountsByHostId,
+              intersection(vm.tags, this._antiAffinityTags),
+              sourceHost.id,
+              destinationHost.id
             )
             debugVcpuBalancing(`vCPU count per host: ${inspect(hostList, { depth: null })}`)
 
@@ -575,15 +649,10 @@ export default class Plan {
       const host = idToHost[hostId]
       host.vcpuCount += vm.CPUs.number
 
-      if (
-        vm.xenTools &&
-        vm.tags.every(
-          tag =>
-            !this._antiAffinityTags.includes(tag) &&
-            !this._affinityTags.includes(tag) &&
-            !this._vmToHostAffinityTags.includes(tag)
-        )
-      ) {
+      // don't exclude VMs with meaningful tags entirely: _processVcpuPrepositioning avoids
+      // destinations that would deteriorate their affinity / anti-affinity / vm-to-host affinity
+      // constraints instead
+      if (vm.xenTools) {
         host.vms[vm.id] = vm
       }
     }
@@ -645,6 +714,19 @@ export default class Plan {
   _processAntiAffinityTag({ tag, vmsAverages, hostsAverages, taggedHosts, idToHost }) {
     const promises = []
 
+    // per-host counts of affinity tagged VMs, to check whether a candidate destination would
+    // deteriorate a VM's affinity constraint, instead of blocking its migration entirely
+    const affinityCountsByHostId = this._affinityTags.length
+      ? keyBy(
+          this._getTaggedHosts({
+            hosts: Object.values(idToHost),
+            tagList: this._affinityTags,
+            vms: this._getAllRunningVms(),
+          }).hosts,
+          'id'
+        )
+      : undefined
+
     while (true) {
       // safety to prevent infinite loop if destination has no VM able to migrate
       let emptyLoop = true
@@ -690,13 +772,28 @@ export default class Plan {
           destinationHost = destination
           debugAntiAffinity(`Host candidate: ${sourceHost.id} -> ${destinationHost.id}.`)
 
-          const vms = filter(
-            sourceVms,
-            vm =>
-              !this._isVmInCooldown(vm) &&
-              hostsAverages[destinationHost.id].memoryFree >= vmsAverages[vm.id].memory &&
-              vm.tags.every(tag => !this._affinityTags.includes(tag) && !this._vmToHostAffinityTags.includes(tag))
-          )
+          // don't exclude VMs with meaningful tags entirely: only avoid a destination that would
+          // deteriorate the VM's affinity / vm-to-host affinity constraints
+          const vms = filter(sourceVms, vm => {
+            if (this._isVmInCooldown(vm) || hostsAverages[destinationHost.id].memoryFree < vmsAverages[vm.id].memory) {
+              return false
+            }
+
+            return (
+              !this._wouldDeteriorateAffinity({
+                vm,
+                countsByHostId: affinityCountsByHostId,
+                sourceHostId: sourceHost.id,
+                destinationHostId: destinationHost.id,
+              }) &&
+              !this._wouldDeteriorateVmToHostAffinity({
+                vm,
+                idToHost,
+                sourceHostId: sourceHost.id,
+                destinationHostId: destinationHost.id,
+              })
+            )
+          })
 
           debugAntiAffinity(
             `Tagged VM ("${tag}") candidates to migrate from host ${sourceHost.id}: ${inspect(mapToArray(vms, 'id'))}.`
@@ -735,6 +832,14 @@ export default class Plan {
             reason: `to satisfy anti-affinity of tag ${tag}`,
           })
         )
+        // keep our local affinity counts in sync so later migrations in this loop aren't checked
+        // against stale data
+        this._adjustTagCounts(
+          affinityCountsByHostId,
+          intersection(vm.tags, this._affinityTags),
+          sourceHost.id,
+          destinationHost.id
+        )
         emptyLoop = false
 
         break // Continue with the same tag, the source can be different.
@@ -743,6 +848,18 @@ export default class Plan {
       if (emptyLoop) {
         break
       }
+    }
+  }
+
+  // Keep a per-host tag-count map (as returned by `_getTaggedHosts`) in sync with a migration decided
+  // within the same loop that computed it, so later iterations don't check against stale counts.
+  _adjustTagCounts(countsByHostId, tags, sourceHostId, destinationHostId) {
+    if (countsByHostId === undefined) {
+      return
+    }
+    for (const tag of tags) {
+      countsByHostId[sourceHostId].tags[tag]--
+      countsByHostId[destinationHostId].tags[tag]++
     }
   }
 
@@ -971,6 +1088,20 @@ export default class Plan {
       debugAffinity(`VMs to migrate: ${sourceVms.map(vm => vm.name_label)}`)
 
       for (const vm of sourceVms) {
+        if (
+          this._wouldDeteriorateVmToHostAffinity({
+            vm,
+            idToHost,
+            sourceHostId: sourceHost.id,
+            destinationHostId: destinationHost.id,
+          })
+        ) {
+          debug(
+            `affinity: VM (${vm.id} "${vm.name_label}") cannot be migrated to satisfy affinity tag ${tag}: would deteriorate its vm-to-host affinity.`
+          )
+          continue
+        }
+
         // if host can't receive all tagged VMs
         let loopCountdown = sortedHosts.length // a theoretically unnecessary safety against infinite while
         while (
@@ -1028,16 +1159,22 @@ export default class Plan {
   async _migrateOtherVms({ crowdedHost, hostsAverages, vmsAverages, idToHost, taggedHosts, memoryNeeded, reason }) {
     const promises = []
 
+    // per-host counts of affinity/anti-affinity tagged VMs, to check whether a candidate destination
+    // would deteriorate a VM's constraints, instead of blocking its migration entirely
+    const allHosts = Object.values(idToHost)
+    const allRunningVms = this._getAllRunningVms()
+    const affinityCountsByHostId = this._affinityTags.length
+      ? keyBy(this._getTaggedHosts({ hosts: allHosts, tagList: this._affinityTags, vms: allRunningVms }).hosts, 'id')
+      : undefined
+    const antiAffinityCountsByHostId = this._antiAffinityTags.length
+      ? keyBy(
+          this._getTaggedHosts({ hosts: allHosts, tagList: this._antiAffinityTags, vms: allRunningVms }).hosts,
+          'id'
+        )
+      : undefined
+
     const candidateVms = sortBy(
-      filter(
-        Object.values(crowdedHost.vms),
-        vm =>
-          vm.xenTools &&
-          !this._isVmInCooldown(vm) &&
-          intersection(vm.tags, this._affinityTags).length === 0 &&
-          intersection(vm.tags, this._antiAffinityTags).length === 0 &&
-          intersection(vm.tags, this._vmToHostAffinityTags).length === 0
-      ),
+      filter(Object.values(crowdedHost.vms), vm => vm.xenTools && !this._isVmInCooldown(vm)),
       [vm => -vmsAverages[vm.id].memory] // try to migrate bigger VMs first to minimize the number of migrations
     )
     debugAffinity(`Candidate VMs to be moved away: ${candidateVms.map(vm => vm.name_label)}`)
@@ -1046,12 +1183,22 @@ export default class Plan {
       // try to migrate vm
 
       const vmAverages = vmsAverages[vm.id]
+      const affinityTags = intersection(vm.tags, this._affinityTags)
+      const antiAffinityTags = intersection(vm.tags, this._antiAffinityTags)
 
       const destinationHost = sortBy(
         taggedHosts.hosts,
         [host => -hostsAverages[host.id].memoryFree, host => hostsAverages[host.id].cpu] // try to migrate to hosts with the most free space first
       ).find(host => {
         if (host.id === crowdedHost.id) {
+          return false
+        }
+        const params = { vm, sourceHostId: crowdedHost.id, destinationHostId: host.id }
+        if (
+          this._wouldDeteriorateAffinity({ ...params, countsByHostId: affinityCountsByHostId }) ||
+          this._wouldDeteriorateAntiAffinity({ ...params, countsByHostId: antiAffinityCountsByHostId }) ||
+          this._wouldDeteriorateVmToHostAffinity({ ...params, idToHost })
+        ) {
           return false
         }
         const destinationAverages = hostsAverages[host.id]
@@ -1080,6 +1227,9 @@ export default class Plan {
           reason,
         })
       )
+      // keep our local counts in sync so later VMs in this loop aren't checked against stale data
+      this._adjustTagCounts(affinityCountsByHostId, affinityTags, crowdedHost.id, destinationHost.id)
+      this._adjustTagCounts(antiAffinityCountsByHostId, antiAffinityTags, crowdedHost.id, destinationHost.id)
 
       if (hostsAverages[crowdedHost.id].memoryFree - memoryNeeded > this._thresholds.memoryFree.critical) {
         // wait for the freeing migrations to actually complete before reporting success: up to

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -46,6 +46,7 @@ const numberOrDefault = (value, def) => (value >= 0 ? value : def)
 export const debugAffinity = str => debug(`affinity: ${str}`)
 export const debugAntiAffinity = str => debug(`anti-affinity: ${str}`)
 export const debugVcpuBalancing = str => debug(`vCPU balancing: ${str}`)
+export const debugVmToHostAffinity = str => debug(`vm-to-host affinity: ${str}`)
 
 // ===================================================================
 // Averages.
@@ -139,7 +140,7 @@ export default class Plan {
     xo,
     name,
     poolIds,
-    { excludedHosts, thresholds, balanceVcpus, affinityTags = [], antiAffinityTags = [] },
+    { excludedHosts, thresholds, balanceVcpus, affinityTags = [], antiAffinityTags = [], vmToHostAffinityTags = [] },
     globalOptions,
     concurrentMigrationLimiter
   ) {
@@ -158,6 +159,7 @@ export default class Plan {
     }
     this._affinityTags = affinityTags
     this._antiAffinityTags = antiAffinityTags
+    this._vmToHostAffinityTags = vmToHostAffinityTags
     // balanceVcpus variable name was kept for compatibility with past configuration schema
     this._performanceSubmode =
       balanceVcpus === false ? 'conservative' : balanceVcpus === true ? 'vCpuPrepositioning' : balanceVcpus
@@ -569,7 +571,12 @@ export default class Plan {
 
       if (
         vm.xenTools &&
-        vm.tags.every(tag => !this._antiAffinityTags.includes(tag) && !this._affinityTags.includes(tag))
+        vm.tags.every(
+          tag =>
+            !this._antiAffinityTags.includes(tag) &&
+            !this._affinityTags.includes(tag) &&
+            !this._vmToHostAffinityTags.includes(tag)
+        )
       ) {
         host.vms[vm.id] = vm
       }
@@ -682,7 +689,7 @@ export default class Plan {
             vm =>
               !this._isVmInCooldown(vm) &&
               hostsAverages[destinationHost.id].memoryFree >= vmsAverages[vm.id].memory &&
-              vm.tags.every(tag => !this._affinityTags.includes(tag))
+              vm.tags.every(tag => !this._affinityTags.includes(tag) && !this._vmToHostAffinityTags.includes(tag))
           )
 
           debugAntiAffinity(
@@ -1039,7 +1046,8 @@ export default class Plan {
           vm.xenTools &&
           !this._isVmInCooldown(vm) &&
           intersection(vm.tags, this._affinityTags).length === 0 &&
-          intersection(vm.tags, this._antiAffinityTags).length === 0
+          intersection(vm.tags, this._antiAffinityTags).length === 0 &&
+          intersection(vm.tags, this._vmToHostAffinityTags).length === 0
       ),
       [vm => -vmsAverages[vm.id].memory] // try to migrate bigger VMs first to minimize the number of migrations
     )
@@ -1185,5 +1193,176 @@ export default class Plan {
     })
 
     return coalitions
+  }
+
+  // ===================================================================
+  // VM to host affinity
+  // ===================================================================
+  async _processVmToHostAffinity() {
+    if (!this._vmToHostAffinityTags.length) {
+      return
+    }
+
+    const allHosts = this._getHosts()
+    const idToHost = keyBy(allHosts, 'id')
+
+    // 1 - Check that every tagged VM has a preferred host sharing the same tag, otherwise assign one
+    // this will prevent VMs from booting on a host on which they're not supposed to be
+    const taggedVms = filter(
+      this._getAllRunningVms(),
+      vm => intersection(vm.tags, this._vmToHostAffinityTags).length > 0
+    )
+
+    const affinityPromises = []
+    for (const vm of taggedVms) {
+      // preserve the admin's configured tag order, so ambiguous cases resolve deterministically
+      const vmTags = this._vmToHostAffinityTags.filter(tag => vm.tags.includes(tag))
+
+      const preferredHost = idToHost[vm.affinityHost]
+      if (preferredHost !== undefined && vmTags.some(tag => preferredHost.tags.includes(tag))) {
+        continue // preferred host already shares one of the VM's tags
+      }
+
+      // prefer hosts sharing ALL of the VM's tags, otherwise fall back to the first tag (in configured
+      // order) that has a matching host: the VM's tags don't share a common host, so which host wins is
+      // an arbitrary choice, and this should be avoided by the admin
+      let candidateHosts = allHosts.filter(host => vmTags.every(tag => host.tags.includes(tag)))
+      if (candidateHosts.length === 0) {
+        if (vmTags.length > 1) {
+          warn(
+            `vm-to-host affinity: VM (${vm.id} "${vm.name_label}") has VM-to-host affinity tags (${vmTags}) with no host sharing all of them; this must be avoided.`
+          )
+        }
+        const fallbackTag = vmTags.find(tag => allHosts.some(host => host.tags.includes(tag)))
+        candidateHosts = fallbackTag === undefined ? [] : allHosts.filter(host => host.tags.includes(fallbackTag))
+      }
+
+      if (candidateHosts.length === 0) {
+        debugVmToHostAffinity(`No host found with tag(s) ${vmTags} for VM (${vm.id} "${vm.name_label}").`)
+        continue
+      }
+
+      // pick randomly among candidates to avoid setting the same preferred host on all matching VMs
+      const candidateHost = candidateHosts[Math.floor(Math.random() * candidateHosts.length)]
+
+      debugVmToHostAffinity(
+        `Setting preferred Host (${candidateHost.id} "${candidateHost.name_label}") for VM (${vm.id} "${vm.name_label}").`
+      )
+      const xapi = this.xo.getXapi(vm)
+      affinityPromises.push(xapi.getObject(vm.id).set_affinity(xapi.getObject(candidateHost.id).$ref))
+    }
+    await Promise.allSettled(affinityPromises)
+
+    // 2 - get list of VMs which have a tag and are not on the right hosts
+    const misplacedVms = filter(this._getAllRunningVms(), vm => {
+      const vmTags = intersection(vm.tags, this._vmToHostAffinityTags)
+      if (vmTags.length === 0) {
+        return false
+      }
+
+      const currentHost = idToHost[vm.$container]
+      return currentHost === undefined || !vmTags.some(tag => currentHost.tags.includes(tag))
+    })
+
+    if (misplacedVms.length === 0) {
+      return
+    }
+
+    debugVmToHostAffinity(`Misplaced VMs: ${inspect(mapToArray(misplacedVms, 'id'), { depth: null })}`)
+
+    // 3 - Migrate misplaced VMs if possible.
+    const allVms = filter(this._getAllRunningVms(), vm => vm.$container in idToHost)
+    const vmsAverages = await this._getVmsAverages(allVms, idToHost)
+    const { averages: hostsAverages } = await this._getHostStatsAverages({ hosts: allHosts })
+
+    // lightweight per-host bookkeeping, in the shape expected by `_migrateOtherVms`/`_migrateVmAndUpdateInfos`
+    const taggedHosts = {
+      hosts: allHosts.map(host => ({
+        id: host.id,
+        poolId: host.$poolId,
+        tags: {},
+        vms: keyBy(
+          filter(allVms, vm => vm.$container === host.id),
+          'id'
+        ),
+      })),
+    }
+    const hostStructById = keyBy(taggedHosts.hosts, 'id')
+
+    const promises = []
+    for (const vm of misplacedVms) {
+      if (!vm.xenTools) {
+        debugVmToHostAffinity(`VM (${vm.id} "${vm.name_label}") does not support pool migration.`)
+        continue
+      }
+      if (this._isVmInCooldown(vm)) {
+        debugVmToHostAffinity(`VM (${vm.id} "${vm.name_label}") is in cooldown, skipping.`)
+        continue
+      }
+
+      const vmTags = intersection(vm.tags, this._vmToHostAffinityTags)
+      const eligibleHosts = allHosts.filter(host => vmTags.some(tag => host.tags.includes(tag)))
+      if (eligibleHosts.length === 0) {
+        debugVmToHostAffinity(`No eligible host found for misplaced VM (${vm.id} "${vm.name_label}").`)
+        continue
+      }
+
+      const vmAverages = vmsAverages[vm.id]
+
+      // try to find an eligible host with enough free memory and CPU to receive the VM
+      let destinationHost = sortBy(eligibleHosts, [
+        host => -hostsAverages[host.id].memoryFree,
+        host => hostsAverages[host.id].cpu,
+      ]).find(host => {
+        const destinationAverages = hostsAverages[host.id]
+        return (
+          destinationAverages.cpu + vmAverages.cpu <= this._thresholds.cpu.critical &&
+          destinationAverages.memoryFree - vmAverages.memory >= this._thresholds.memoryFree.critical
+        )
+      })
+
+      if (destinationHost === undefined) {
+        // no eligible host currently has enough room: try to free up space on the best candidate
+        const crowdedHost = maxBy(eligibleHosts, host => hostsAverages[host.id].memoryFree)
+        debugVmToHostAffinity(
+          `No eligible host has enough resources for VM (${vm.id} "${vm.name_label}"), trying to free up space on Host (${crowdedHost.id} "${crowdedHost.name_label}").`
+        )
+
+        const { promises: otherMigrationPromises, success } = await this._migrateOtherVms({
+          crowdedHost: hostStructById[crowdedHost.id],
+          hostsAverages,
+          vmsAverages,
+          idToHost,
+          taggedHosts,
+          memoryNeeded: vmAverages.memory,
+        })
+        promises.push(...otherMigrationPromises)
+
+        if (!success) {
+          debugVmToHostAffinity(
+            `Could not free enough resources for VM (${vm.id} "${vm.name_label}"), leaving it on its current host.`
+          )
+          continue
+        }
+        destinationHost = crowdedHost
+      }
+
+      const matchingTags = vmTags.filter(tag => destinationHost.tags.includes(tag))
+
+      promises.push(
+        this._migrateVmAndUpdateInfos({
+          destination: idToHost[destinationHost.id],
+          source: idToHost[vm.$container],
+          sourceHost: hostStructById[vm.$container],
+          destinationHost: hostStructById[destinationHost.id],
+          vm,
+          hostsAverages,
+          vmAverages,
+          reason: `to satisfy VM-to-host affinity of tag(s) ${matchingTags.join(', ')}`,
+        })
+      )
+    }
+
+    return Promise.allSettled(promises)
   }
 }

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -372,8 +372,8 @@ export default class Plan {
       return false
     }
     return tags.some(tag => {
-      const sourceOtherCount = countsByHostId[sourceHostId].tags[tag] - 1
-      const destinationCount = countsByHostId[destinationHostId].tags[tag]
+      const sourceOtherCount = countsByHostId[sourceHostId].tagCounts[tag] - 1
+      const destinationCount = countsByHostId[destinationHostId].tagCounts[tag]
       return destinationCount < sourceOtherCount
     })
   }
@@ -384,8 +384,8 @@ export default class Plan {
   _wouldDeteriorateAntiAffinity({ vm, countsByHostId, sourceHostId, destinationHostId }) {
     const tags = intersection(vm.tags, this._antiAffinityTags)
     return tags.some(tag => {
-      const sourceOtherCount = countsByHostId[sourceHostId].tags[tag] - 1
-      const destinationCount = countsByHostId[destinationHostId].tags[tag]
+      const sourceOtherCount = countsByHostId[sourceHostId].tagCounts[tag] - 1
+      const destinationCount = countsByHostId[destinationHostId].tagCounts[tag]
       return destinationCount > sourceOtherCount
     })
   }
@@ -681,7 +681,7 @@ export default class Plan {
     // 1. Check if we must migrate VMs...
     const tagsDiff = {}
     for (const watchedTag of this._antiAffinityTags) {
-      const getCount = fn => fn(taggedHosts.hosts, host => host.tags[watchedTag]).tags[watchedTag]
+      const getCount = fn => fn(taggedHosts.hosts, host => host.tagCounts[watchedTag]).tagCounts[watchedTag]
       const diff = getCount(maxBy) - getCount(minBy)
       if (diff > 1) {
         tagsDiff[watchedTag] = diff - 1
@@ -732,9 +732,9 @@ export default class Plan {
       let emptyLoop = true
       // 1. Find source host from which to migrate.
       const sources = sortBy(
-        filter(taggedHosts.hosts, host => host.tags[tag] > 1),
+        filter(taggedHosts.hosts, host => host.tagCounts[tag] > 1),
         [
-          host => host.tags[tag],
+          host => host.tagCounts[tag],
           // Find host with the most memory used. Don't forget the "-". ;)
           host => -hostsAverages[host.id].memoryFree,
         ]
@@ -749,9 +749,12 @@ export default class Plan {
 
         // 2. Find destination host.
         const destinations = sortBy(
-          filter(taggedHosts.hosts, host => host.id !== sourceHost.id && host.tags[tag] + 1 < sourceHost.tags[tag]),
+          filter(
+            taggedHosts.hosts,
+            host => host.id !== sourceHost.id && host.tagCounts[tag] + 1 < sourceHost.tagCounts[tag]
+          ),
           [
-            host => host.tags[tag],
+            host => host.tagCounts[tag],
             // Ideally it would be interesting to migrate in the same pool.
             host => host.poolId !== sourceHost.poolId,
             // Find host with the least memory used. Don't forget the "-". ;)
@@ -858,8 +861,8 @@ export default class Plan {
       return
     }
     for (const tag of tags) {
-      countsByHostId[sourceHostId].tags[tag]--
-      countsByHostId[destinationHostId].tags[tag]++
+      countsByHostId[sourceHostId].tagCounts[tag]--
+      countsByHostId[destinationHostId].tagCounts[tag]++
     }
   }
 
@@ -871,15 +874,15 @@ export default class Plan {
 
     const taggedHosts = {}
     for (const host of hosts) {
-      const tags = {}
+      const tagCounts = {}
       for (const tag of tagList) {
-        tags[tag] = 0
+        tagCounts[tag] = 0
       }
 
       const taggedHost = (taggedHosts[host.id] = {
         id: host.id,
         poolId: host.$poolId,
-        tags,
+        tagCounts,
         vms: {},
       })
 
@@ -904,7 +907,7 @@ export default class Plan {
       for (const tag of vm.tags) {
         if (tagList.includes(tag)) {
           tagCount[tag]++
-          taggedHost.tags[tag]++
+          taggedHost.tagCounts[tag]++
           taggedHost.vms[vm.id] = vm
         }
       }
@@ -919,13 +922,13 @@ export default class Plan {
 
     const { hosts } = taggedHosts
     for (const tag in taggedHosts.tagCount) {
-      const k = hosts[0].tags[tag]
+      const k = hosts[0].tagCounts[tag]
 
       let ex = 0
       let ex2 = 0
 
       for (const host of hosts) {
-        const x = host.tags[tag]
+        const x = host.tagCounts[tag]
         const diff = x - k
         ex += diff
         ex2 += diff * diff
@@ -946,15 +949,15 @@ export default class Plan {
       const vmTags = filter(vm.tags, tag => this._antiAffinityTags.includes(tag))
 
       for (const tag of vmTags) {
-        sourceHost.tags[tag]--
-        destinationHost.tags[tag]++
+        sourceHost.tagCounts[tag]--
+        destinationHost.tagCounts[tag]++
       }
 
       const variance = this._computeAntiAffinityVariance(taggedHosts)
 
       for (const tag of vmTags) {
-        sourceHost.tags[tag]++
-        destinationHost.tags[tag]--
+        sourceHost.tagCounts[tag]++
+        destinationHost.tagCounts[tag]--
       }
 
       if (variance < bestVariance) {
@@ -997,7 +1000,7 @@ export default class Plan {
     const spreadTags = []
     for (const watchedTag of this._affinityTags) {
       const taggedHostCount = taggedHosts.hosts.reduce(
-        (accumulator, host) => accumulator + (host.tags[watchedTag] > 0),
+        (accumulator, host) => accumulator + (host.tagCounts[watchedTag] > 0),
         0
       )
       if (taggedHostCount > 1) {
@@ -1062,11 +1065,11 @@ export default class Plan {
     // in case of coalitions, the sum is incorrect as VMs are counted twice, but it gives an approximation without parsing all the VMs again
     const taggedVmCountPerHost = {}
     for (const host of taggedHosts.hosts) {
-      taggedVmCountPerHost[host.id] = coalition.reduce((sum, coalitionTag) => sum + host.tags[coalitionTag], 0)
+      taggedVmCountPerHost[host.id] = coalition.reduce((sum, coalitionTag) => sum + host.tagCounts[coalitionTag], 0)
     }
 
     const sortedHosts = sortBy(
-      taggedHosts.hosts.filter(host => coalition.some(coalitionTag => host.tags[coalitionTag] > 0)),
+      taggedHosts.hosts.filter(host => coalition.some(coalitionTag => host.tagCounts[coalitionTag] > 0)),
       [host => taggedVmCountPerHost[host.id], host => -hostsAverages[host.id].memoryFree]
     )
 
@@ -1263,9 +1266,9 @@ export default class Plan {
     )
 
     for (const tag of vm.tags) {
-      if (tag in sourceHost.tags) {
-        sourceHost.tags[tag]--
-        destinationHost.tags[tag]++
+      if (tag in sourceHost.tagCounts) {
+        sourceHost.tagCounts[tag]--
+        destinationHost.tagCounts[tag]++
       }
     }
 

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -714,36 +714,18 @@ export default class Plan {
 
         const source = idToHost[sourceHost.id]
         const destination = idToHost[destinationHost.id]
-        debugAntiAffinity(
-          `Migrate VM (${vm.id} "${vm.name_label}") to Host (${destinationHost.id} "${destination.name_label}") from Host (${sourceHost.id} "${source.name_label}").`
-        )
 
-        // 3. Update tags and averages.
+        // 3. Update tags and averages, and migrate.
         // This update can change the source host for the next migration.
-        for (const tag of vm.tags) {
-          if (this._antiAffinityTags.includes(tag)) {
-            sourceHost.tags[tag]--
-            destinationHost.tags[tag]++
-          }
-        }
-
-        const destinationAverages = hostsAverages[destinationHost.id]
-        const vmAverages = vmsAverages[vm.id]
-
-        destinationAverages.cpu += vmAverages.cpu
-        destinationAverages.memoryFree -= vmAverages.memory
-
-        delete sourceHost.vms[vm.id]
-
-        // 4. Migrate.
         promises.push(
-          this._migrateVm({
+          this._migrateVmAndUpdateInfos({
+            destination,
+            source,
+            sourceHost,
+            destinationHost,
             vm,
-            xapiSrc: this.xo.getXapi(source),
-            xapiDest: this.xo.getXapi(destination),
-            srcHostId: source.id,
-            destHostId: destination._xapiId,
-            reason: `to satisfy anti-affinity of tag ${tag}`,
+            hostsAverages,
+            vmAverages: vmsAverages[vm.id],
           })
         )
         emptyLoop = false
@@ -1120,12 +1102,12 @@ export default class Plan {
     // TODO: add more checks with XAPI method assert_can_migrate
 
     // Update tags and averages
-    debugAffinity(
+    debug(
       `Migrate VM (${vm.id} "${vm.name_label}") to Host (${destination.id} "${destination.name_label}") from Host (${source.id} "${source.name_label}").`
     )
 
     for (const tag of vm.tags) {
-      if (this._affinityTags.includes(tag)) {
+      if (tag in sourceHost.tags) {
         sourceHost.tags[tag]--
         destinationHost.tags[tag]++
       }
@@ -1198,6 +1180,7 @@ export default class Plan {
   // ===================================================================
   // VM to host affinity
   // ===================================================================
+
   async _processVmToHostAffinity() {
     if (!this._vmToHostAffinityTags.length) {
       return
@@ -1275,18 +1258,13 @@ export default class Plan {
     const vmsAverages = await this._getVmsAverages(allVms, idToHost)
     const { averages: hostsAverages } = await this._getHostStatsAverages({ hosts: allHosts })
 
-    // lightweight per-host bookkeeping, in the shape expected by `_migrateOtherVms`/`_migrateVmAndUpdateInfos`
-    const taggedHosts = {
-      hosts: allHosts.map(host => ({
-        id: host.id,
-        poolId: host.$poolId,
-        tags: {},
-        vms: keyBy(
-          filter(allVms, vm => vm.$container === host.id),
-          'id'
-        ),
-      })),
-    }
+    // reuse the same per-host bookkeeping shape as affinity/anti-affinity
+    const taggedHosts = this._getTaggedHosts({
+      hosts: allHosts,
+      tagList: this._vmToHostAffinityTags,
+      vms: allVms,
+      includeUntaggedVms: true,
+    })
     const hostStructById = keyBy(taggedHosts.hosts, 'id')
 
     const promises = []

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -322,6 +322,39 @@ export default class Plan {
   }
 
   // ===================================================================
+  // Migration helpers
+  // ===================================================================
+
+  // Check if VM was recently migrated and is in cooldown period
+  _isVmInCooldown(vm) {
+    const { migrationCooldown, migrationHistory } = this._globalOptions
+    if (migrationCooldown > 0) {
+      const lastMigration = migrationHistory.get(vm.id)
+      if (lastMigration !== undefined && Date.now() - lastMigration < migrationCooldown) {
+        return true
+      }
+    }
+    return false
+  }
+
+  _migrateVm({ vm, xapiSrc, xapiDest, srcHostId, destHostId, reason }) {
+    const { migrationHistory } = this._globalOptions
+    return this._concurrentMigrationLimiter(() => {
+      const task = this.xo.tasks.create({
+        name: `Load balancer migrates VM ${vm.name_label} (${vm.id})`,
+        description: `Migrating VM ${vm.name_label} (${vm.id}) from host ${srcHostId} to host ${destHostId} ${reason}`,
+        objectId: vm.id,
+        type: 'xo:load-balancer:migration',
+      })
+      return task.run(async () =>
+        xapiSrc.migrateVm(vm._xapiId, xapiDest, destHostId).then(() => {
+          migrationHistory.set(vm.id, Date.now())
+        })
+      )
+    })
+  }
+
+  // ===================================================================
   // vCPU pre-positioning helpers
   // ===================================================================
 
@@ -1103,35 +1136,6 @@ export default class Plan {
       srcHostId: sourceHost.id,
       destHostId: destination._xapiId,
       reason,
-    })
-  }
-
-  // Check if VM was recently migrated and is in cooldown period
-  _isVmInCooldown(vm) {
-    const { migrationCooldown, migrationHistory } = this._globalOptions
-    if (migrationCooldown > 0) {
-      const lastMigration = migrationHistory.get(vm.id)
-      if (lastMigration !== undefined && Date.now() - lastMigration < migrationCooldown) {
-        return true
-      }
-    }
-    return false
-  }
-
-  _migrateVm({ vm, xapiSrc, xapiDest, srcHostId, destHostId, reason }) {
-    const { migrationHistory } = this._globalOptions
-    return this._concurrentMigrationLimiter(() => {
-      const task = this.xo.tasks.create({
-        name: `Load balancer migrates VM ${vm.name_label} (${vm.id})`,
-        description: `Migrating VM ${vm.name_label} (${vm.id}) from host ${srcHostId} to host ${destHostId} ${reason}`,
-        objectId: vm.id,
-        type: 'xo:load-balancer:migration',
-      })
-      return task.run(async () =>
-        xapiSrc.migrateVm(vm._xapiId, xapiDest, destHostId).then(() => {
-          migrationHistory.set(vm.id, Date.now())
-        })
-      )
     })
   }
 

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -669,10 +669,26 @@ export default class Plan {
       return
     }
 
+    // process each pool independently: spreading anti-affinity-tagged VMs must never cross pool
+    // boundaries, since that would force a heavy storage-motion migration.
+    // No pool parallelization because we're limited by the concurrent migration limiter.
     const allHosts = this._getHosts()
-    if (allHosts.length <= 1) {
-      return
+    const promises = []
+    for (const poolId of this._poolIds) {
+      const poolHosts = filter(allHosts, host => host.$poolId === poolId)
+      if (poolHosts.length <= 1) {
+        continue
+      }
+      try {
+        promises.push(...(await this._processAntiAffinityForHosts(poolHosts)))
+      } catch (error) {
+        warn(`anti-affinity: failed to process pool ${poolId}`, { poolId, error })
+      }
     }
+    return Promise.all(promises)
+  }
+
+  async _processAntiAffinityForHosts(allHosts) {
     const idToHost = keyBy(allHosts, 'id')
 
     const allVms = filter(this._getAllRunningVms(), vm => vm.$container in idToHost)
@@ -688,7 +704,7 @@ export default class Plan {
       }
     }
     if (isEmpty(tagsDiff)) {
-      return
+      return []
     }
 
     // 2. Migrate!
@@ -708,7 +724,7 @@ export default class Plan {
 
     // 3. Done!
     debugAntiAffinity(`VM tag count per host after migration: ${inspect(taggedHosts, { depth: null })}.`)
-    return Promise.all(promises)
+    return promises
   }
 
   _processAntiAffinityTag({ tag, vmsAverages, hostsAverages, taggedHosts, idToHost }) {
@@ -982,10 +998,26 @@ export default class Plan {
       return
     }
 
+    // process each pool independently: consolidating affinity-tagged VMs onto a single host must never
+    // cross pool boundaries, since that would force a heavy storage-motion migration.
+    // No pool parallelization because we're limited by the concurrent migration limiter.
     const allHosts = this._getHosts()
-    if (allHosts.length <= 1) {
-      return
+    const promises = []
+    for (const poolId of this._poolIds) {
+      const poolHosts = filter(allHosts, host => host.$poolId === poolId)
+      if (poolHosts.length <= 1) {
+        continue
+      }
+      try {
+        promises.push(...(await this._processAffinityForHosts(poolHosts)))
+      } catch (error) {
+        warn(`affinity: failed to process pool ${poolId}`, { poolId, error })
+      }
     }
+    return Promise.allSettled(promises)
+  }
+
+  async _processAffinityForHosts(allHosts) {
     const idToHost = keyBy(allHosts, 'id')
 
     const allVms = filter(this._getAllRunningVms(), vm => vm.$container in idToHost)
@@ -1008,7 +1040,7 @@ export default class Plan {
       }
     }
     if (spreadTags.length === 0) {
-      return
+      return []
     }
 
     // 2. Check for tag coalitions: when a VM has multiple affinity tags, these tags should be considered as the same tag
@@ -1051,8 +1083,7 @@ export default class Plan {
 
     // 4. Done!
     debugAffinity(`VM tag count per host after migration: ${inspect(taggedHosts, { depth: null })}`)
-    // not returning Promise.all so we still wait for all migrations to end even if one fails
-    return Promise.allSettled(promises)
+    return promises
   }
 
   async _processAffinityTag({ tag, vmsAverages, hostsAverages, taggedHosts, idToHost, coalition }) {
@@ -1345,7 +1376,26 @@ export default class Plan {
       return
     }
 
+    // process each pool independently: a VM must never be migrated to a host in a different pool to
+    // satisfy vm-to-host affinity, since that would force a heavy storage-motion migration.
+    // No pool parallelization because we're limited by the concurrent migration limiter.
     const allHosts = this._getHosts()
+    const promises = []
+    for (const poolId of this._poolIds) {
+      const poolHosts = filter(allHosts, host => host.$poolId === poolId)
+      if (poolHosts.length === 0) {
+        continue
+      }
+      try {
+        promises.push(...(await this._processVmToHostAffinityForHosts(poolHosts)))
+      } catch (error) {
+        warn(`vm-to-host affinity: failed to process pool ${poolId}`, { poolId, error })
+      }
+    }
+    return Promise.allSettled(promises)
+  }
+
+  async _processVmToHostAffinityForHosts(allHosts) {
     const idToHost = keyBy(allHosts, 'id')
 
     // 1 - Check that every tagged VM has a preferred host sharing the same tag, otherwise assign one
@@ -1423,7 +1473,7 @@ export default class Plan {
     })
 
     if (misplacedVms.length === 0) {
-      return
+      return []
     }
 
     debugVmToHostAffinity(`Misplaced VMs: ${inspect(mapToArray(misplacedVms, 'id'), { depth: null })}`)
@@ -1521,6 +1571,6 @@ export default class Plan {
       )
     }
 
-    return Promise.allSettled(promises)
+    return promises
   }
 }

--- a/packages/xo-server-load-balancer/src/plan.js
+++ b/packages/xo-server-load-balancer/src/plan.js
@@ -15,6 +15,8 @@ import { inspect } from 'util'
 
 import { EXECUTION_DELAY, debug, warn } from './utils'
 
+// value is shared with DEFAULT_LOAD_BALANCER_RE_ENABLE_DELAY in packages/xo-server/src/xo-mixins/xen-servers.mjs
+// and loadBalancerReEnableDelay in config.toml
 const MINUTES_OF_HISTORICAL_DATA = 30
 
 // CPU threshold in percent.

--- a/packages/xo-server-load-balancer/src/simple-plan.js
+++ b/packages/xo-server-load-balancer/src/simple-plan.js
@@ -4,6 +4,7 @@ import Plan from './plan'
 
 export default class SimplePlan extends Plan {
   async execute() {
+    await this._processVmToHostAffinity()
     await this._processAffinity()
     await this._processAntiAffinity()
   }


### PR DESCRIPTION
### Description

**review by commit**

**Don't squash. I'd like to merge this PR with a few separate commits. I'll rebase once review is done**

1. This PR starts by a bunch of small changes.

2. The [first big commit](https://github.com/vatesfr/xen-orchestra/pull/10207/changes/ba4d55920c57db53d1721b9a773d85951ac4a114) adds a third affinity behaviour to the load balancer. Tags can now be used to configure:
- VM to VM anti-affinity
- VM to VM affinity
- VM to host affinity (**new**): a same tag can be put on one or more host and one or more VM to force (if possible) the load balancer to put these VMs on one of these hosts. This also changes the VM's preferred host (AKA affinity host), so the VM will try to start on host with its VM-to-host affinity tag.
In case of conflict, VM-to-host affinity has priority over affinity, which has priority over anti-affinity.

3. The [second big commit](https://github.com/vatesfr/xen-orchestra/pull/10207/changes/6451f0e6622a9dcb2095895748fa195c5f2054aa) modifies the VM migration decision process across all the load balancer. By simplicity, we used to never migrate a VM which had an anti-affinity for other reasons than anti-affinity (same for affinity), but adding more and more rules made this more and more constraining.
Now, we prevent VMs with relevant tags from migrating only if it deteriorates affinity or anti-affinity or VM-to-host affinity.
This means for instance that a VM with an anti-affinity tag can now be migrated for other reasons than anti-affinity constraints (performance, affinity or VM-to-host affinity reasons) to another host where there are no other VM with the same anti-affinity tag, or that a VM with VM-to-host affinity can be migrated to any host with its tag for other reasons.

4. [This commit](https://github.com/vatesfr/xen-orchestra/pull/10207/changes/8632af1ec22020a76825d0d8c89b265ff3a25bdd) also makes an important fix: all kind of affinity tags were previously allowed to do inter-pool migrations if a plan was configured on multiple pools, which is very costly in resources and wasn't clearly explained. This commit makes the pools treated separately, so only intra-pool migration are allowed.

[XO-2333](https://project.vates.tech/vates-global/browse/XO-2333/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
