### PR TITLE
fix(backups/filerestore): restore files from proxy as tgz

### DIFF
--- a/@xen-orchestra/backups/_fileRestore.integ.mjs
+++ b/@xen-orchestra/backups/_fileRestore.integ.mjs
@@ -1,7 +1,8 @@
 import { strict as assert } from 'node:assert'
 import test from 'node:test'
 import { execFile } from 'node:child_process'
-import { copyFile, mkdtemp, rm } from 'node:fs/promises'
+import { copyFile, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { Stream } from 'node:stream'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
@@ -38,6 +39,37 @@ async function createLvmImage(imagePath, vgName, lvName) {
     await pExec('vgchange', ['-an', vgName])
   })
 }
+
+// xo-proxy answers this stream through Koa, which pipes only bodies passing `instanceof Stream`
+// and JSON-serializes anything else: node-tar >= 7 returns a duck-typed (Minipass) stream, which
+// silently turned a proxied file restore into a JSON dump of the tar object. Every format must
+// resolve with a real node stream.
+test('fetchPartitionFiles resolves with a node:stream for every format', async t => {
+  const tmp = await mkdtemp(join(tmpdir(), 'xo-flr-fetch-'))
+  t.after(() => rm(tmp, { recursive: true, force: true }))
+  await writeFile(join(tmp, 'file.txt'), 'hello')
+
+  const adapter = new RemoteAdapter({})
+  // at this point of a real restore the partition is already mounted
+  adapter.getPartition = Disposable.factory(async function* () {
+    yield tmp
+  })
+
+  for (const [format, magic] of [
+    ['tgz', Buffer.from([0x1f, 0x8b])],
+    ['zip', Buffer.from('PK')],
+  ]) {
+    const stream = await adapter.fetchPartitionFiles('disk', 'partition', ['/file.txt'], format)
+    assert.ok(stream instanceof Stream, `${format}: expected a node:stream instance`)
+
+    const chunks = []
+    for await (const chunk of stream) {
+      chunks.push(chunk)
+    }
+    const archive = Buffer.concat(chunks)
+    assert.deepEqual(archive.subarray(0, magic.length), magic, `${format}: unexpected archive header`)
+  }
+})
 
 test('LVM file-restore against real losetup/dmsetup/lvm', { skip }, async t => {
   const tmp = await mkdtemp(join(tmpdir(), 'xo-flr-'))

--- a/@xen-orchestra/backups/_fileRestore.mjs
+++ b/@xen-orchestra/backups/_fileRestore.mjs
@@ -12,6 +12,7 @@ import { compose } from '@vates/compose'
 import { createLogger } from '@xen-orchestra/log'
 import { deduped } from '@vates/disposable/deduped.js'
 import { randomBytes } from 'node:crypto'
+import { Readable } from 'node:stream'
 import { join, resolve } from 'node:path'
 import { execFile } from 'child_process'
 import { finished } from 'node:stream/promises'
@@ -297,7 +298,15 @@ export const fileRestoreMethods = {
         // simultaneous reads. Those saturate the libuv threadpool and starve
         // the underlying vhd/CIFS reads NTFS-3g depends on (FUSE-on-FUSE
         // threadpool deadlock). Serializing keeps a worker free for them.
-        outputStream = tar.c({ cwd: path, gzip: true, jobs: 1 }, paths.map(makeRelative))
+        const pack = tar.c({ cwd: path, gzip: true, jobs: 1 }, paths.map(makeRelative))
+
+        // node-tar >= 7 returns a Minipass stream: it has `pipe()` but is not a `node:stream`
+        // instance. xo-proxy serves this stream through Koa, which pipes only bodies passing
+        // `instanceof Stream` and JSON-serializes anything else — so a file restore through a
+        // proxy answered a JSON dump of the tar object instead of the archive. Wrapping it in a
+        // real node stream also propagates tar errors to the consumer and aborts the tar job
+        // when the client disconnects.
+        outputStream = Readable.from(pack, { objectMode: false })
         resolve(outputStream)
       } else if (format === 'zip') {
         const zip = new ZipFile()

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@
 
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
+- [Backup/File restore] Downloading files as `tgz` through an XO Proxy works again: the archive was replaced by an invalid response, failing with `invalid identifier: undefined instead of number or string` (PR [#10208](https://github.com/vatesfr/xen-orchestra/pull/10208))
 - [Immutable backups] Backups are protected again on file servers whose system language is not English: immutability was silently not applied at all on those (PR [#10182](https://github.com/vatesfr/xen-orchestra/pull/10182))
 - [Immutable backups] Release disks that stayed immutable forever after their metadata was deleted by the retention, or after a merge renamed them, which prevented any further merge or deletion of that disk's backups (PR [#10182](https://github.com/vatesfr/xen-orchestra/pull/10182))
 
@@ -38,6 +39,7 @@
 <!--packages-start-->
 
 - @xen-orchestra/acl minor
+- @xen-orchestra/backups patch
 - @xen-orchestra/immutable-backups patch
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor


### PR DESCRIPTION
### Description

from ticket 59505

node-tar >= 7 returns a Minipass stream: it has `pipe()` but is not a `node:stream`
instance. xo-proxy serves this stream through Koa, which pipes only bodies passing
instanceof Stream` and JSON-serializes anything else — so a file restore through a
proxy answered a JSON dump of the tar object instead of the archive. Wrapping it in a
real node stream also propagates tar errors to the consumer and aborts the tar job
when the client disconnects.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
