### PR TITLE
fix(xo-server): fix target not found error for warm migration

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@
 
 - [REST API] Fix `/users/:id/authentication_tokens` sometimes did not return the token used to make the request (PR [#10233](https://github.com/vatesfr/xen-orchestra/pull/10233))
 - [XO server] Fix a random behavior regarding `coresPerSocket` update (PR [#10201](https://github.com/vatesfr/xen-orchestra/pull/10201))
+- [Warm migration] Fix `Vm target of warm migration not found` error at the end of a migration (PR [#](https://github.com/vatesfr/xen-orchestra/pull/))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,7 +20,7 @@
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
 - [REST API] Fix `/users/:id/authentication_tokens` sometimes did not return the token used to make the request (PR [#10233](https://github.com/vatesfr/xen-orchestra/pull/10233))
-- [Warm migration] Fix `Vm target of warm migration not found` error at the end of a migration (PR [#](https://github.com/vatesfr/xen-orchestra/pull/))
+- [Warm migration] Fix `Vm target of warm migration not found` error at the end of a migration (PR [#10210](https://github.com/vatesfr/xen-orchestra/pull/10210))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,7 +24,7 @@
 
 - [REST API] Fix `/users/:id/authentication_tokens` sometimes did not return the token used to make the request (PR [#10233](https://github.com/vatesfr/xen-orchestra/pull/10233))
 - [XO server] Fix a random behavior regarding `coresPerSocket` update (PR [#10201](https://github.com/vatesfr/xen-orchestra/pull/10201))
-- [Warm migration] Fix `Vm target of warm migration not found` error at the end of a migration (PR [#](https://github.com/vatesfr/xen-orchestra/pull/))
+- [Warm migration] Fix `Vm target of warm migration not found` error at the end of a migration (PR [#10210](https://github.com/vatesfr/xen-orchestra/pull/10210))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
 - [REST API] Fix `/users/:id/authentication_tokens` sometimes did not return the token used to make the request (PR [#10233](https://github.com/vatesfr/xen-orchestra/pull/10233))
+- [Warm migration] Fix `Vm target of warm migration not found` error at the end of a migration (PR [#](https://github.com/vatesfr/xen-orchestra/pull/))
 
 ### Packages to release
 

--- a/packages/xo-server/src/xo-mixins/migrate-vm.mjs
+++ b/packages/xo-server/src/xo-mixins/migrate-vm.mjs
@@ -29,7 +29,7 @@ export default class MigrateVm {
         },
       },
     }
-    const schedule = { id: 'one-time' }
+    const schedule = { id: 'one-time', name: 'one-time' }
 
     // for now we only support this from the main OA, no proxy
     return createRunner({
@@ -76,26 +76,28 @@ export default class MigrateVm {
     await backup.run()
 
     // find the destination Vm
-    const targets = Object.keys(
-      app.getObjects({
-        filter: obj => {
-          return (
-            'other' in obj &&
+    const targets = new Set(
+      Object.values(
+        app.getObjects({
+          filter: obj =>
+            obj.type === 'VM-snapshot' &&
             obj.other['xo:backup:job'] === jobId &&
             obj.other['xo:backup:sr'] === srId &&
-            obj.other['xo:backup:vm'] === sourceVm.uuid &&
-            'start' in obj.blockedOperations
-          )
-        },
-      })
+            obj.other['xo:backup:vm'] === sourceVm.uuid,
+        })
+      ).map(snapshot => snapshot.$snapshot_of)
     )
-    if (targets.length === 0) {
+
+    if (targets.size === 0) {
       throw new Error(`Vm target of warm migration not found for ${sourceVmId} on SR ${srId} `)
     }
-    if (targets.length > 1) {
+
+    // A transfer is done per run, so the target has one snapshot per run: they are all snapshots
+    // of the same VM and collapse into a single entry, more than one means distinct copies
+    if (targets.size > 1) {
       throw new Error(`Multiple target of warm migration found for ${sourceVmId} on SR ${srId} `)
     }
-    const targetVm = app.getXapiObject(targets[0])
+    const targetVm = app.getXapiObject(targets.values().next().value)
 
     // new vm is ready to start
     // incremental xapi  writer has set this as blocked

--- a/packages/xo-server/src/xo-mixins/migrate-vm.mjs
+++ b/packages/xo-server/src/xo-mixins/migrate-vm.mjs
@@ -75,8 +75,8 @@ export default class MigrateVm {
     // since the source is stopped, there won't be any new change after
     await backup.run()
 
-    // find the destination Vm
-    const targets = new Set(
+    // find the destination Vm and collapse into a single id
+    const targetIds = new Set(
       Object.values(
         app.getObjects({
           filter: obj =>
@@ -88,16 +88,23 @@ export default class MigrateVm {
       ).map(snapshot => snapshot.$snapshot_of)
     )
 
-    if (targets.size === 0) {
+    // the incremental xapi writer blocks `start` on the VM it replicates, checking it here ensures
+    // only a replicated VM is ever considered
+    const targets = Object.keys(
+      app.getObjects({
+        filter: obj => obj.type === 'VM' && targetIds.has(obj.id) && 'start' in obj.blockedOperations,
+      })
+    )
+
+    if (targets.length === 0) {
       throw new Error(`Vm target of warm migration not found for ${sourceVmId} on SR ${srId} `)
     }
 
-    // A transfer is done per run, so the target has one snapshot per run: they are all snapshots
-    // of the same VM and collapse into a single entry, more than one means distinct copies
-    if (targets.size > 1) {
+    // more than one means distinct copies
+    if (targets.length > 1) {
       throw new Error(`Multiple target of warm migration found for ${sourceVmId} on SR ${srId} `)
     }
-    const targetVm = app.getXapiObject(targets.values().next().value)
+    const targetVm = app.getXapiObject(targets[0])
 
     // new vm is ready to start
     // incremental xapi  writer has set this as blocked

--- a/packages/xo-server/src/xo-mixins/migrate-vm.mjs
+++ b/packages/xo-server/src/xo-mixins/migrate-vm.mjs
@@ -78,9 +78,8 @@ export default class MigrateVm {
     // find the destination Vm and collapse into a single id
     const targetIds = new Set(
       Object.values(
-        app.getObjects({
+        app.getObjectsByType('VM-snapshot', {
           filter: obj =>
-            obj.type === 'VM-snapshot' &&
             obj.other['xo:backup:job'] === jobId &&
             obj.other['xo:backup:sr'] === srId &&
             obj.other['xo:backup:vm'] === sourceVm.uuid,
@@ -91,8 +90,8 @@ export default class MigrateVm {
     // the incremental xapi writer blocks `start` on the VM it replicates, checking it here ensures
     // only a replicated VM is ever considered
     const targets = Object.keys(
-      app.getObjects({
-        filter: obj => obj.type === 'VM' && targetIds.has(obj.id) && 'start' in obj.blockedOperations,
+      app.getObjectsByType('VM', {
+        filter: obj => targetIds.has(obj.id) && 'start' in obj.blockedOperations,
       })
     )
 


### PR DESCRIPTION
### Description

Ticket 61569

Introduced by #9806

When performing a warm migration, the task ended in failure with the error `Vm target of warm migration not found`.

This was due to the warm migration's target lookup matching on the three xo:backup:* keys AND `start` in blockedOperations on a single object.
#9806 made the writer snapshot the replicated VM then clear its other_config, so those keys now only exist on the target snapshot while the blocked operations marker stays on the live VM, no single object carries both, so the lookup never matched.

Match the target snapshot on those three keys instead, follow $snapshot_of back to the live VM, and keep the blocked operations check by applying it to that VM rather than to the snapshot. The resolved ids go through a Set first: one snapshot is taken per transfer run, so several can point to the same replica and would otherwise be reported as multiple targets.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
