### PR TITLE
Document the XAPI version constraint on restore

### DIFF
--- a/docs/docs/xo5/metadata_backup.md
+++ b/docs/docs/xo5/metadata_backup.md
@@ -64,6 +64,26 @@ Once saved, the job shows up alongside your other backup jobs, with its modes li
 Restoring pool metadata completely overwrites the XAPI database of a host. Only perform a metadata restore if it is a new server with nothing running on it (eg replacing a host with new hardware).
 :::
 
+:::warning
+**The XAPI version of the target host must match the one the backup was taken from.** If it
+does not, the restore is refused with `RESTORE_INCOMPATIBLE_VERSION` and no data is written.
+This matters most in the situation the feature exists for: rebuilding a host after a failure,
+where a fresh install from the current ISO is usually several XAPI releases ahead of the
+backup.
+
+The backup itself records the version it was taken from, in its `XAPI_Build` field.
+
+To restore onto a rebuilt host:
+
+1. Reinstall XCP-ng.
+2. Bring the host to the XAPI level the backup was taken at. If the backup is at the XAPI
+   version shipped with the original release of your XCP-ng version, the freshly installed
+   host is already at that level and no extra step is needed. Otherwise, install the specific
+   updates for that level.
+3. Restore the pool metadata.
+4. Patch the host to apply the remaining updates.
+:::
+
 Go to **Backup → Restore** and click the **Metadata** filter button: the list switches to the metadata backups available for restore, both XO config backups and pool metadata backups.
 
 <UiDetail src="/img/xo5/metadata-restore-list.png" alt="Restore view filtered on metadata, listing a Xen Orchestra config backup and a pool metadata backup" width={620} />

--- a/docs/docs/xo5/metadata_backup.md
+++ b/docs/docs/xo5/metadata_backup.md
@@ -30,6 +30,26 @@ Once created, the job is displayed with the other classic jobs.
 Restoring pool metadata completely overwrites the XAPI database of a host. Only perform a metadata restore if it is a new server with nothing running on it (eg replacing a host with new hardware).
 :::
 
+:::warning
+**The XAPI version of the target host must match the one the backup was taken from.** If it
+does not, the restore is refused with `RESTORE_INCOMPATIBLE_VERSION` and no data is written.
+This matters most in the situation the feature exists for: rebuilding a host after a failure,
+where a fresh install from the current ISO is usually several XAPI releases ahead of the
+backup.
+
+The backup itself records the version it was taken from, in its `XAPI_Build` field.
+
+To restore onto a rebuilt host:
+
+1. Reinstall XCP-ng.
+2. Bring the host to the XAPI level the backup was taken at. If the backup is at the XAPI
+   version shipped with the original release of your XCP-ng version, the freshly installed
+   host is already at that level and no extra step is needed. Otherwise, install the specific
+   updates for that level.
+3. Restore the pool metadata.
+4. Patch the host to apply the remaining updates.
+:::
+
 If you browse to the Backup NG Restore panel, you will now notice a Metadata filter button:
 
 ![](../assets/metadata-5.png)

--- a/docs/docs/xo5/metadata_backup.md
+++ b/docs/docs/xo5/metadata_backup.md
@@ -71,9 +71,9 @@ This matters most in the situation the feature exists for: rebuilding a host aft
 where a fresh install from the current ISO is usually several XAPI releases ahead of the
 backup.
 
-The backup itself records the version it was taken from, in its `XAPI_Build` field.
+The backup records the XAPI version it was created with in its `XAPI_Build` field.
 
-To restore onto a rebuilt host:
+To restore a backup onto a rebuilt host:
 
 1. Reinstall XCP-ng.
 2. Bring the host to the XAPI level the backup was taken at. If the backup is at the XAPI


### PR DESCRIPTION
The restore section warns that a metadata restore overwrites the whole XAPI database, which is the scary part. It doesn't mention that the restore can be refused before it does anything, and that's the part people actually hit.

If the target host's XAPI version doesn't match the one the backup was taken from, the restore fails with `RESTORE_INCOMPATIBLE_VERSION`. Nothing is written, but you also don't get told what to do about it.

The timing is unkind. This feature exists for the case where a host is gone and you're rebuilding it, and a fresh install from the current ISO is usually several XAPI releases ahead of the backup you're holding. So the default path into this feature is also the path that trips the guard, at the moment when nobody wants to go reverse-engineer a procedure.

What I've added: the error, the `XAPI_Build` field so you can see what level the backup is at, and the staged path (reinstall, bring the host to the backup's XAPI level, restore, then patch to current), with the note that a backup at the release's original XAPI level needs no extra step.

Two things I'd like a second opinion on. The staged procedure comes from a Vates support answer on the forum rather than from me, so it's worth someone confirming it reads correctly here. And I deliberately didn't name a specific XAPI version or link the KB article on package lists, since that changes per release and would go stale on this page.

Related forum thread: https://xcp-ng.org/forum/topic/12394
