### PR TITLE
fix(rest-api): coerces strings into numbers in external-router when type="number"

### DIFF
--- a/@xen-orchestra/rest-api/src/router/external-router.mts
+++ b/@xen-orchestra/rest-api/src/router/external-router.mts
@@ -61,8 +61,8 @@ export function createExternalRouter(swaggerOpenApiSpec: OpenAPIV3.Document): {
         if (route.security === undefined) route.security = '*'
         await expressAuthentication(req as AuthenticatedRequest, route.security, route.scope === 'acl' ? ['acl'] : [])
 
-        // Coerces query boolean from string to boolean
-        coerceBooleanQueryParams(req.query, route.query)
+        // Coerces query strings to the types declared by the route
+        coerceQueryParams(req.query, route.query)
 
         // Validate inputs, throws if invalid
         paramsSchema?.parse(req.params)
@@ -337,11 +337,19 @@ function extractParametersFromZod(schema: z.ZodType, location: 'path' | 'query')
   return []
 }
 
-function coerceBooleanQueryParams(query: Record<string, unknown>, def: RouteDefinition['query']): void {
+// Express query params are always strings, coerce them to the types declared by the route
+// Exported for testing
+export function coerceQueryParams(query: Record<string, unknown>, def: RouteDefinition['query']): void {
   if (!def) return
   for (const [key, field] of Object.entries(def)) {
-    if (field.type === 'boolean' && typeof query[key] === 'string') {
-      query[key] = query[key] === 'true'
+    const value = query[key]
+    if (typeof value !== 'string') continue
+
+    if (field.type === 'boolean') {
+      query[key] = value === 'true'
+    } else if (field.type === 'number') {
+      // a non-numeric value becomes NaN, which is rejected by the zod validation
+      query[key] = value.trim() === '' ? NaN : Number(value)
     }
   }
 }

--- a/@xen-orchestra/rest-api/src/router/external-router.mts
+++ b/@xen-orchestra/rest-api/src/router/external-router.mts
@@ -346,7 +346,11 @@ export function coerceQueryParams(query: Record<string, unknown>, def: RouteDefi
     if (typeof value !== 'string') continue
 
     if (field.type === 'boolean') {
-      query[key] = value === 'true'
+      if (value.toLowerCase() === 'true') {
+        query[key] = true
+      } else if (value.toLowerCase() === 'false') {
+        query[key] = false
+      }
     } else if (field.type === 'number') {
       // a non-numeric value becomes NaN, which is rejected by the zod validation
       query[key] = value.trim() === '' ? NaN : Number(value)

--- a/@xen-orchestra/rest-api/src/router/external-router.test.mts
+++ b/@xen-orchestra/rest-api/src/router/external-router.test.mts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+// this module depends on the IoC container, which cannot be initialized on its own
+// because of circular imports between the services: load the generated routes first,
+// like `index.mts` does
+import '../open-api/routes/routes.js'
+
+import { coerceQueryParams } from './external-router.mjs'
+import type { RouteDefinition } from './types.mjs'
+
+const def: RouteDefinition['query'] = {
+  bool: { type: 'boolean', optional: true },
+  num: { type: 'number', optional: true },
+  str: { type: 'string', optional: true },
+}
+
+const coerce = (query: Record<string, unknown>) => {
+  coerceQueryParams(query, def)
+  return query
+}
+
+describe('coerceQueryParams', () => {
+  it('coerces booleans', () => {
+    assert.deepEqual(coerce({ bool: 'true' }), { bool: true })
+    assert.deepEqual(coerce({ bool: 'false' }), { bool: false })
+  })
+
+  it('coerces numbers', () => {
+    assert.deepEqual(coerce({ num: '42' }), { num: 42 })
+    assert.deepEqual(coerce({ num: '-4.2' }), { num: -4.2 })
+  })
+
+  it('coerces a non-numeric value to NaN, which fails the validation', () => {
+    assert.ok(Number.isNaN(coerce({ num: 'abc' }).num))
+  })
+
+  it('leaves strings and undeclared params untouched', () => {
+    assert.deepEqual(coerce({ str: '42', other: 'true' }), { str: '42', other: 'true' })
+  })
+})

--- a/@xen-orchestra/rest-api/src/router/external-router.test.mts
+++ b/@xen-orchestra/rest-api/src/router/external-router.test.mts
@@ -24,6 +24,11 @@ describe('coerceQueryParams', () => {
   it('coerces booleans', () => {
     assert.deepEqual(coerce({ bool: 'true' }), { bool: true })
     assert.deepEqual(coerce({ bool: 'false' }), { bool: false })
+    assert.deepEqual(coerce({ bool: 'TRUE' }), { bool: true })
+    assert.deepEqual(coerce({ bool: 'FALSE' }), { bool: false })
+  })
+  it('keeps non-boolean values as strings', () => {
+    assert.deepEqual(coerce({ bool: 'abc' }), { bool: 'abc' })
   })
 
   it('coerces numbers', () => {
@@ -33,6 +38,9 @@ describe('coerceQueryParams', () => {
 
   it('coerces a non-numeric value to NaN, which fails the validation', () => {
     assert.ok(Number.isNaN(coerce({ num: 'abc' }).num))
+  })
+  it('coerces empty strings to NaN, which fails the validation', () => {
+    assert.ok(Number.isNaN(coerce({ num: '' }).num))
   })
 
   it('leaves strings and undeclared params untouched', () => {


### PR DESCRIPTION
fix(rest-api): coerces strings into numbers in external-router when type="number"
### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
