### PR TITLE
fix(rest-api): fix error code when using the wrong vm state action

### DIFF
--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -73,6 +73,8 @@ import type { CreateActionReturnType } from '../abstract-classes/base-controller
 import { Task } from '@vates/task'
 import { vmExportCompressDeprecated } from '../middlewares/deprecated.middleware.mjs'
 import { ApiError } from '../helpers/error.helper.mjs'
+import { object } from 'zod'
+import { property } from 'lodash'
 
 const IGNORED_VDIS_TAG = '[NOSNAP]'
 
@@ -364,6 +366,16 @@ export class VmController extends XapiXoController<XoVm> {
   ): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
+      const vm = this.getObject(vmId)
+
+      if (vm.power_state !== 'Halted') {
+        throw incorrectState({
+          actual: vm.power_state,
+          expected: 'Halted',
+          object: vm.id,
+          property: 'power_state',
+        })
+      }
       await this.getXapi(vmId).startVm(vmId, { startOnly: true, hostId: body?.hostId as XoHost['id'] })
     }
 
@@ -398,6 +410,17 @@ export class VmController extends XapiXoController<XoVm> {
   async cleanShutdownVm(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
+      const vm = this.getObject(vmId)
+
+      if (vm.power_state !== 'Running') {
+        throw incorrectState({
+          actual: vm.power_state,
+          expected: 'Running',
+          object: vm.id,
+          property: 'power_state',
+        })
+      }
+
       await this.getXapiObject(vmId).$callAsync('clean_shutdown')
     }
 
@@ -430,6 +453,16 @@ export class VmController extends XapiXoController<XoVm> {
   async cleanRebootVm(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
+      const vm = this.getObject(vmId)
+
+      if (vm.power_state !== 'Running') {
+        throw incorrectState({
+          actual: vm.power_state,
+          expected: 'Running',
+          object: vm.id,
+          property: 'power_state',
+        })
+      }
       await this.getXapiObject(vmId).$callAsync('clean_reboot')
     }
 
@@ -461,6 +494,16 @@ export class VmController extends XapiXoController<XoVm> {
   async hardShutdownVm(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
+      const vm = this.getObject(vmId)
+
+      if (vm.power_state === 'Halted') {
+        throw incorrectState({
+          actual: vm.power_state,
+          expected: 'Running || Paused || Suspended',
+          object: vm.id,
+          property: 'power_state',
+        })
+      }
       await this.getXapiObject(vmId).$callAsync('hard_shutdown')
     }
 
@@ -492,6 +535,16 @@ export class VmController extends XapiXoController<XoVm> {
   async hardRebootVm(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
+      const vm = this.getObject(vmId)
+
+      if (vm.power_state === 'Suspended' || vm.power_state === 'Halted') {
+        throw incorrectState({
+          actual: vm.power_state,
+          expected: 'Running || Paused',
+          object: vm.id,
+          property: 'power_state',
+        })
+      }
       await this.getXapiObject(vmId).$callAsync('hard_reboot')
     }
 
@@ -525,14 +578,17 @@ export class VmController extends XapiXoController<XoVm> {
   async pauseVm(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
-      try {
-        await this.getXapiObject(vmId).$callAsync('pause')
-      } catch (error: any) {
-        if (error.code?.startsWith('VM_BAD_POWER_STATE')) {
-          throw new ApiError(error, 409)
-        }
-        throw error
+      const vm = this.getObject(vmId)
+
+      if (vm.power_state !== 'Running') {
+        throw incorrectState({
+          actual: vm.power_state,
+          expected: 'Running',
+          object: vm.id,
+          property: 'power_state',
+        })
       }
+      await this.getXapiObject(vmId).$callAsync('pause')
     }
 
     return this.createAction<void>(action, {
@@ -565,6 +621,16 @@ export class VmController extends XapiXoController<XoVm> {
   async suspendVm(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
+      const vm = this.getObject(vmId)
+
+      if (vm.power_state !== 'Running') {
+        throw incorrectState({
+          actual: vm.power_state,
+          expected: 'Running',
+          object: vm.id,
+          property: 'power_state',
+        })
+      }
       await this.getXapiObject(vmId).$callAsync('suspend')
     }
 
@@ -598,6 +664,17 @@ export class VmController extends XapiXoController<XoVm> {
   async resumeVm(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
+      const vm = this.getObject(vmId)
+
+      if (vm.power_state !== 'Suspended') {
+        throw incorrectState({
+          actual: vm.power_state,
+          expected: 'Suspended',
+          object: vm.id,
+          property: 'power_state',
+        })
+      }
+
       await this.getXapi(vmId).resumeVm(vmId)
     }
 
@@ -631,6 +708,17 @@ export class VmController extends XapiXoController<XoVm> {
   async unpauseVm(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
+      const vm = this.getObject(vmId)
+
+      if (vm.power_state !== 'Paused') {
+        throw incorrectState({
+          actual: vm.power_state,
+          expected: 'Paused',
+          object: vm.id,
+          property: 'power_state',
+        })
+      }
+
       await this.getXapi(vmId).unpauseVm(vmId)
     }
 

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -72,6 +72,7 @@ import type { UnbrandedVmDashboard, UpdateVmRequestBody } from './vm.type.mjs'
 import type { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
 import { Task } from '@vates/task'
 import { vmExportCompressDeprecated } from '../middlewares/deprecated.middleware.mjs'
+import { ApiError } from '../helpers/error.helper.mjs'
 
 const IGNORED_VDIS_TAG = '[NOSNAP]'
 
@@ -524,7 +525,14 @@ export class VmController extends XapiXoController<XoVm> {
   async pauseVm(@Path() id: string, @Query() sync?: boolean): CreateActionReturnType<void> {
     const vmId = id as XoVm['id']
     const action = async () => {
-      await this.getXapiObject(vmId).$callAsync('pause')
+      try {
+        await this.getXapiObject(vmId).$callAsync('pause')
+      } catch (error: any) {
+        if (error.code?.startsWith('VM_BAD_POWER_STATE')) {
+          throw new ApiError(error, 409)
+        }
+        throw error
+      }
     }
 
     return this.createAction<void>(action, {

--- a/@xen-orchestra/rest-api/src/vms/vm.controller.mts
+++ b/@xen-orchestra/rest-api/src/vms/vm.controller.mts
@@ -72,9 +72,6 @@ import type { UnbrandedVmDashboard, UpdateVmRequestBody } from './vm.type.mjs'
 import type { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
 import { Task } from '@vates/task'
 import { vmExportCompressDeprecated } from '../middlewares/deprecated.middleware.mjs'
-import { ApiError } from '../helpers/error.helper.mjs'
-import { object } from 'zod'
-import { property } from 'lodash'
 
 const IGNORED_VDIS_TAG = '[NOSNAP]'
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -66,6 +66,7 @@
 - [Host] Successful evacuation signature fallbacks on older XAPI versions are no longer logged as warnings (PR [#10131](https://github.com/vatesfr/xen-orchestra/pull/10131))
 - [Backups] write the complete disk metadata at once to improve compatibility with immutable backup repository (PR [#10104](https://github.com/vatesfr/xen-orchestra/pull/10104))
 - [XO6/Host] Wrap the Network name in the PIF side panel (PR [#10155](https://github.com/vatesfr/xen-orchestra/pull/10155))
+- [REST-API] Fix error code to show 409 instead of 500 when pausing an already paused vm. (PR [#10172](https://github.com/vatesfr/xen-orchestra/pull/10172))
 
 ### Packages to release
 


### PR DESCRIPTION
### Description

_Short explanation of this PR (feel free to re-use commit message)_

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
