### PR TITLE
docs(advanced.md) fix broken link to kubernetes page

### DIFF
--- a/docs/docs/xo5/advanced.md
+++ b/docs/docs/xo5/advanced.md
@@ -371,7 +371,7 @@ In Xen Orchestra, recipes are ready-to-use automation templates that make it eas
 With just a few clicks, you can launch a complete multi-VM environment, where all nodes are automatically set up and connected.
 
 :::tip
-Currently, the only available recipe is for Kubernetes clusters. [This guide](https://docs.vates.tech/devops-tools/kubernetes/) will walk you through creating one.
+Currently, the only available recipe is for Kubernetes clusters. [This guide](../xo6/kubernetes.md) will walk you through creating one.
 
 Coming soon: We’ll expand the Recipes feature to include EasyVirt DC Scope deployment.
 :::


### PR DESCRIPTION
The documentation for DevOps tools and [Kubernetes](https://docs.xen-orchestra.com/automation/kubernetes) was moved from the [Vates VMS documentation](https://docs.vates.tech/) to the [Xen Orchestra documentation](https://docs.xen-orchestra.com/).

This change broke a link to the Kubernetes page in the Xen Orchestra doc. This pull request fixes that link.