### PR TITLE
docs(navbar): make link to vates vms external

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -253,7 +253,7 @@ export default {
       title: 'Xen Orchestra Documentation',
       logo: { alt: 'Xen Orchestra logo', src: 'img/logo.png', href: '/' },
       items: [
-        { to: 'https://docs.vates.tech/', label: 'Vates VMS', position: 'right', target: '_self'},
+        { href: 'https://docs.vates.tech/', label: 'Vates VMS', position: 'right'},
         { to: 'https://docs.xcp-ng.org/', label: 'XCP-ng', position: 'right', target: '_self'},
         { href: '/', label: 'Xen Orchestra', position: 'right' },
       ],


### PR DESCRIPTION
### Summary

For legal reasons, the Vates VMS documentation has to be treated as an external site, relative to the XCP-ng and Xen Orchestra documentations.

As a result, the link to the Vates VMS doc in the header of the XO doc has been converted to an external link.

Clicking the link now opens a new tab instead of loading the page in the same tab. In addition, an ↗️ icon appears next to the link.

### Preview

#### Before

<img width="1889" height="332" alt="Capture d&#39;écran 2026-08-05 132020" src="https://github.com/user-attachments/assets/7512fa06-70fe-4f98-af48-871de0784a19" />


#### After

<img width="1890" height="454" alt="Capture d&#39;écran 2026-08-05 131936" src="https://github.com/user-attachments/assets/b7ed6a3c-a2e7-4bf1-adf9-2ebf7a2996d9" />
