### PR TITLE
fix(xo-server): task controller leaking memory

### DIFF
--- a/@xen-orchestra/rest-api/src/tasks/task.controller.mts
+++ b/@xen-orchestra/rest-api/src/tasks/task.controller.mts
@@ -39,6 +39,9 @@ import type { CreateActionReturnType } from '../abstract-classes/base-controller
 import { safeParseComplexMatcher } from '../helpers/utils.helper.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { AnyPrivilege, hasPrivilegeOn } from '@xen-orchestra/acl'
+import { createLogger } from '@xen-orchestra/log'
+
+const { warn } = createLogger('xo:rest-api:task-controller')
 
 @Route('tasks')
 @Security('*')
@@ -94,23 +97,46 @@ export class TaskController extends XoController<XoTask> {
       }
 
       const userFilter = filter === undefined ? undefined : safeParseComplexMatcher(filter).createPredicate()
+      const mapper = makeObjectMapper(req)
       const stream = new Transform({
         objectMode: true,
+        // in object mode this is a number of queued events, see `safeWrite()`
+        highWaterMark: this.restApi.xoApp.config.get<number>('rest-api.maxEventsQueuedPerWatchClient'),
         transform([event, object], encoding, callback) {
-          const mapper = makeObjectMapper(req)
           callback(null, JSON.stringify([event, mapper(object)]) + '\n')
         },
       })
 
+      // The producer is an event emitter shared by the whole application, it
+      // cannot be slowed down: a client which stops consuming this stream — a
+      // dropped connection, a sleeping laptop — would otherwise have its events
+      // queued forever, and each of them retains a whole task log.
+      //
+      // Destroy such a client instead, like SSE subscribers are: it reconnects
+      // and refetches the whole collection, so no state is lost.
+      const safeWrite = (event: ['update', XoTask] | ['remove', { id: XoTask['id'] }]) => {
+        if (!stream.write(event)) {
+          warn('too many events queued for this client, the connection is going to be destroyed', {
+            queued: stream.writableLength,
+          })
+          req.destroy()
+        }
+      }
+
+      const onSigTerm = () => {
+        req.destroy()
+      }
+
       stream.on('close', () => {
         this.restApi.tasks.off('update', update).off('remove', remove)
+        // this listener would otherwise retain `req` — and through it this
+        // stream and everything it has buffered — for the whole process life
+        process.off('SIGTERM', onSigTerm)
       })
       req.on('close', () => {
         stream.destroy()
       })
-      process.on('SIGTERM', () => {
-        req.destroy()
-      })
+      process.on('SIGTERM', onSigTerm)
 
       const userId = this.restApi.getCurrentUser().id
       const update = async (task: XoTask) => {
@@ -124,7 +150,7 @@ export class TaskController extends XoController<XoTask> {
           hasPrivilegeOn({ user, userPrivileges, action: 'read', resource: 'task', objects: task }) &&
           (userFilter === undefined || userFilter(task))
         ) {
-          stream.write(['update', task])
+          safeWrite(['update', task])
         }
       }
       const remove = async (task: XoTask) => {
@@ -138,7 +164,7 @@ export class TaskController extends XoController<XoTask> {
           hasPrivilegeOn({ user, userPrivileges, action: 'read', resource: 'task', objects: task }) &&
           (userFilter === undefined || userFilter(task))
         ) {
-          stream.write(['remove', { id: task.id }])
+          safeWrite(['remove', { id: task.id }])
         }
       }
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,9 @@
 
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
+- [xo-server] Disconnect user stalling task result and using to much memory (PR [#10237](https://github.com/vatesfr/xen-orchestra/pull/10237))
+- [XO5] Show a task when a user is disconnected because its task flow is stalled (PR [#10237](https://github.com/vatesfr/xen-orchestra/pull/10237))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -38,5 +41,7 @@
 - @xen-orchestra/acl minor
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor
+- xo-server patch
+- xo-web patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -42,6 +42,9 @@
 - **XO 5**:
   - [VM/Console] Fix the page header and tab navigation disappearing permanently in the console tab (PR [#10007](https://github.com/vatesfr/xen-orchestra/pull/10007))
 
+- [xo-server] Disconnect user stalling task result and using to much memory (PR [#10237](https://github.com/vatesfr/xen-orchestra/pull/10237))
+- [XO5] Show a task when a user is disconnected because its task flow is stalled (PR [#10237](https://github.com/vatesfr/xen-orchestra/pull/10237))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -41,9 +41,8 @@
 - [VIF] Preserve other_config, rate limit, MTU and device when changing a VIF's MAC address (PR [#10284](https://github.com/vatesfr/xen-orchestra/pull/10284))
 - **XO 5**:
   - [VM/Console] Fix the page header and tab navigation disappearing permanently in the console tab (PR [#10007](https://github.com/vatesfr/xen-orchestra/pull/10007))
-
-- [xo-server] Disconnect user stalling task result and using to much memory (PR [#10237](https://github.com/vatesfr/xen-orchestra/pull/10237))
-- [XO5] Show a task when a user is disconnected because its task flow is stalled (PR [#10237](https://github.com/vatesfr/xen-orchestra/pull/10237))
+- [xo-server] Disconnect user stalling task result and using too much memory (PR [#10237](https://github.com/vatesfr/xen-orchestra/pull/10237))
+- [XO5/tasks] Show a task when a user is disconnected because its task flow is stalled (PR [#10237](https://github.com/vatesfr/xen-orchestra/pull/10237))
 
 ### Packages to release
 

--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -283,6 +283,9 @@ dashboardCacheTimeout = '1 min'
 # Allow to set a limit of memory per SSE client
 # before destroying the client. In MiB
 maxRamAllocatedPerSseClient = 20
+# Allow to set a limit of events queued for a client watching the tasks
+# collection (`GET /rest/v0/tasks?watch=true`) before destroying the client
+maxEventsQueuedPerWatchClient = 1000
 
 [jsonrpc-api]
 xvaImportFromUrlTimeout = '6s'

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -572,6 +572,25 @@ export const subscribeXoTasks = (() => {
     }
   }, 100)
 
+  // Surfaces a lost tasks stream in the UI: the subscription retries silently,
+  // which used to leave the list frozen with no indication that it was no
+  // longer live. This entry is dropped by the `cache.clear()` below as soon as
+  // the stream is successfully reestablished.
+  const DISCONNECTED_ID = 'xo:tasks-stream-disconnected'
+  function notifyDisconnected(error) {
+    const now = Date.now()
+    cache.set(DISCONNECTED_ID, {
+      id: DISCONNECTED_ID,
+      name: 'XO tasks stream disconnected, retrying…',
+      properties: { name: 'XO tasks stream disconnected, retrying…' },
+      start: now,
+      end: now,
+      status: 'failure',
+      error: error === undefined ? undefined : String(error?.message ?? error),
+    })
+    notify()
+  }
+
   async function run() {
     if (abortController !== undefined) {
       return
@@ -584,39 +603,76 @@ export const subscribeXoTasks = (() => {
         // starts watching collection
         const resWatch = await fetch(basePath + '&ndjson=true&watch=true', { signal: abortController.signal })
 
-        // fetches existing objects
-        const response = await fetch(basePath, { signal: abortController.signal })
-        const objects = await response.json()
-        cache.clear()
-        for (const object of objects) {
-          cache.set(object.id, object)
+        const applyEvent = ([event, object]) => {
+          if (event === 'remove') {
+            cache.delete(object.id)
+          } else {
+            cache.set(object.id, object)
+          }
         }
-        notify()
 
-        // handles events
-        let buf = ''
-        for await (const chunk of resWatch.body) {
-          buf += String.fromCharCode(...chunk)
+        // events received before the existing objects have been fetched cannot
+        // be applied yet: the fetched collection would override them
+        let ready = false
+        const queuedEvents = []
 
-          let i
-          while ((i = buf.indexOf('\n')) !== -1) {
-            const line = buf.slice(0, i)
-            buf = buf.slice(i + 1)
-            const [event, object] = JSON.parse(line)
-            if (event === 'remove') {
-              cache.delete(object.id)
-            } else {
-              cache.set(object.id, object)
+        // this stream must be consumed as soon as possible: events not read are
+        // buffered by the server, which closes the connection when too many of
+        // them pile up
+        const watching = (async () => {
+          // eslint-disable-next-line n/no-unsupported-features/node-builtins
+          const decoder = new TextDecoder()
+          let buf = ''
+          for await (const chunk of resWatch.body) {
+            buf += decoder.decode(chunk, { stream: true })
+
+            let i
+            while ((i = buf.indexOf('\n')) !== -1) {
+              const line = buf.slice(0, i)
+              buf = buf.slice(i + 1)
+              const event = JSON.parse(line)
+              if (ready) {
+                applyEvent(event)
+              } else {
+                queuedEvents.push(event)
+              }
+            }
+            if (ready) {
+              notify()
             }
           }
+        })()
+
+        // fetches existing objects
+        const fetching = (async () => {
+          const response = await fetch(basePath, { signal: abortController.signal })
+          const objects = await response.json()
+          cache.clear()
+          for (const object of objects) {
+            cache.set(object.id, object)
+          }
+
+          for (const event of queuedEvents) {
+            applyEvent(event)
+          }
+          queuedEvents.length = 0
+          ready = true
+
           notify()
-        }
+        })()
+
+        // `Promise.all()` also ensures none of these rejections is unhandled
+        await Promise.all([fetching, watching])
+
+        // the iteration ended without an error: the server closed the stream
+        notifyDisconnected()
       } catch (error) {
         if (error === 'abort') {
           break
         }
 
         console.error('monitor XO tasks', error)
+        notifyDisconnected(error)
       }
 
       await new Promise(resolve => setTimeout(resolve, 10e3))

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -595,13 +595,15 @@ export const subscribeXoTasks = (() => {
     if (abortController !== undefined) {
       return
     }
-    abortController = new AbortController()
     clearTimeout(clearCacheTimeout)
 
     while (true) {
+      abortController = new AbortController()
+      const { signal } = abortController
+      let fetching, watching
       try {
         // starts watching collection
-        const resWatch = await fetch(basePath + '&ndjson=true&watch=true', { signal: abortController.signal })
+        const resWatch = await fetch(basePath + '&ndjson=true&watch=true', { signal })
 
         const applyEvent = ([event, object]) => {
           if (event === 'remove') {
@@ -619,7 +621,7 @@ export const subscribeXoTasks = (() => {
         // this stream must be consumed as soon as possible: events not read are
         // buffered by the server, which closes the connection when too many of
         // them pile up
-        const watching = (async () => {
+        watching = (async () => {
           // eslint-disable-next-line n/no-unsupported-features/node-builtins
           const decoder = new TextDecoder()
           let buf = ''
@@ -644,8 +646,8 @@ export const subscribeXoTasks = (() => {
         })()
 
         // fetches existing objects
-        const fetching = (async () => {
-          const response = await fetch(basePath, { signal: abortController.signal })
+        fetching = (async () => {
+          const response = await fetch(basePath, { signal })
           const objects = await response.json()
           cache.clear()
           for (const object of objects) {
@@ -673,6 +675,10 @@ export const subscribeXoTasks = (() => {
 
         console.error('monitor XO tasks', error)
         notifyDisconnected(error)
+
+        abortController.abort('retry')
+        // eslint-disable-next-line n/no-unsupported-features/es-builtins
+        await Promise.allSettled([fetching, watching])
       }
 
       await new Promise(resolve => setTimeout(resolve, 10e3))


### PR DESCRIPTION
### Description

Defect 1 — backpressure is ignored (the actual leak)

stream.write() returns false when the buffer is full, and the writer is then required to stop until the 'drain' event. Nothing here does. If the HTTP consumer stalls — a slow client, an idle browser tab, a half-open TCP connection, a proxy that stopped reading — every task update in the entire XO instance keeps queueing into the stream's writable buffer indefinitely.

In objectMode there is no hard cap: highWaterMark is advisory, so the buffer grows without bound.
Defect 2 — each queued event carries a full payload

The buffered chunks are ['update', taskLog] tuples. Each taskLog includes a result property which, for backup-related tasks, holds the entire array of backup jobs. This is the multiplier that turns queued events into hundreds of thousands of retained objects.
Defect 3 — per-request SIGTERM listener is never removed

stream.on('close') (:105) unhooks the task listeners and req.on('close') (:108) destroys the stream, but the process.on('SIGTERM', …) closure at :111 retains req — and through it the stalled Transform — for the lifetime of the process. This defeats both cleanup paths and is the mechanism that pins the leaked streams so GC can never reclaim them.

Only ~20 such listeners had accumulated, so this is not the bulk of the memory; it is what makes the leak permanent rather than transient.
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
