### PR TITLE
fix(xo-server): handle 'no-bundle' as legacy licence

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -39,5 +39,6 @@
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+- xo-server patch
 
 <!--packages-end-->

--- a/packages/xo-server/src/xo-mixins/authorization.mjs
+++ b/packages/xo-server/src/xo-mixins/authorization.mjs
@@ -127,7 +127,8 @@ export default class Authorization {
       },
     })
     const activeBundleLicenses = xoaLicences?.filter(
-      ({ expires, bundleInfo }) => (expires === undefined || expires > now) && bundleInfo !== undefined
+      ({ expires, bundleInfo }) =>
+        (expires === undefined || expires > now) && bundleInfo !== undefined && bundleInfo.id !== 'no-bundle'
     )
     if (activeBundleLicenses === undefined || activeBundleLicenses.length === 0) {
       return undefined


### PR DESCRIPTION
### Description

before, legacy licence returned a `bundleInfo === undefined`.
now it return a `bundleInfo: {id: 'no-bundle'}`.

This is a 3WXO breaking change.
just adding a small fix to handle `no-bundle` as legacy licence

No changelog, as this is not an XO bug but a 3WXO bug. (3WXO will also implement a workaround at the API level.)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
