### PR TITLE
fix(replication): improve performances 

### DIFF
--- a/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
@@ -266,7 +266,7 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
             onlyListChangedBlocks: true,
           })
           await diffDisk.init()
-          if (diffDisk.getBlockIndexes().length === 0) {
+          if (diffDisk.getBlockIndexesCount() === 0) {
             debug(' NO CHANGE , source detected ? ', !!sourceUuid)
             // no block modification since the common snapshot, we can chain VM and disk
             // the disk is chained with the active to keep the chain linear
@@ -282,7 +282,7 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
             canChainToTargetVm = false
             debug('checkBaseVdis, data between snapshot and active disk', {
               vdiRef: snapshot.$ref,
-              nbBlocks: diffDisk.getBlockIndexes().length,
+              nbBlocks: diffDisk.getBlockIndexesCount(),
             })
           }
         } catch (error) {

--- a/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
+++ b/@xen-orchestra/backups/_runners/_writers/IncrementalXapiWriter.mjs
@@ -262,6 +262,7 @@ export class IncrementalXapiWriter extends MixinXapiWriter(AbstractIncrementalWr
             xapi: sr.$xapi,
             vdiRef: activeVdi.$ref,
             baseRef: snapshot.$ref,
+            preferNbd: this._settings.preferNbd,
             onlyListChangedBlocks: true,
           })
           await diffDisk.init()


### PR DESCRIPTION
### Description

2 fixes:

* enabling NBD on the target disk will use CBT if possible. CBT differencing is more performant that building an fake export and reading only the BAT
*  we d'o not need the block list, but only the block count, reducing agin the memory consumption 

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
