### PR TITLE
feat(xo-server/rpu): pace the run on TWINSTOR storage sync

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@
 - [Docs] Improve doc, rename titles, and refactor menu (PR [#10212](https://github.com/vatesfr/xen-orchestra/pull/10212))
 
 - [IPMI-plugin] Add GET plugins/ipmi-sensors/hosts/{id}/ipmi to get IPMI sensors (PR [#10003](https://github.com/vatesfr/xen-orchestra/pull/10003))
+- [RPU/RPR] On a pool backed by TWINSTOR, wait for the replicated storage to be back in sync before rebooting each host, instead of rebooting while a single host holds the only up-to-date copy of the data. A pool whose storage is already not redundant is refused before anything is disabled (PR [#10248](https://github.com/vatesfr/xen-orchestra/pull/10248))
 
 ### Bug fixes
 
@@ -50,7 +51,7 @@
 - xen-api minor
 - xo-cli patch
 - xo-common minor
-- xo-server patch
+- xo-server minor
 - xo-server-ipmi-sensors minor
 - xo-server-netbox patch
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
 - [REST API] Fix `/users/:id/authentication_tokens` sometimes did not return the token used to make the request (PR [#10233](https://github.com/vatesfr/xen-orchestra/pull/10233))
+- [RPU/RPR] Aborting the task now stops the run instead of being ignored: the remaining hosts are no longer rebooted (PR [#10248](https://github.com/vatesfr/xen-orchestra/pull/10248))
 
 ### Packages to release
 

--- a/packages/xo-server/config.toml
+++ b/packages/xo-server/config.toml
@@ -244,6 +244,9 @@ maxUncoalescedVdis = 1
 # The duration XO will wait for a host to be live before assuming it failed to
 # restart
 restartHostTimeout = '20 minutes'
+# The total duration a rolling pool update or reboot may spend waiting for a
+# TWINSTOR storage to be back in sync, for the whole run and not per host
+twinstorSyncTimeout = '2 hours'
 vdiDelayBeforeRemovingCloudConfigDrive = '5 min'
 vdiExportConcurrency = 12
 vmEvacuationConcurrency = 3

--- a/packages/xo-server/docs/rolling-pool-update-reboot.md
+++ b/packages/xo-server/docs/rolling-pool-update-reboot.md
@@ -57,8 +57,64 @@ Old traces are garbage-collected on mtime (`rpu.tracesRetention`, 31 days by def
 | `MESSAGE_PARAMETER_COUNT_MISMATCH(host.evacuate, 1, 3)` (DEBUG)                       | Expected signature fallback on XAPI 8.2. WARN only if every supported signature fails.                                                                                      |
 | Timeout on `Waiting for host to be up`                                                | Host takes too long to boot. `xapiOptions.restartHostTimeout` (default 20 minutes).                                                                                         |
 | Pool stays `disconnected` after the master rebooted, `EHOSTUNREACH`                   | Stale connection error, the retry did not kick in yet. `POST /rest/v0/servers/<id>/actions/connect` reconnects immediately.                                                 |
+| `TWINSTOR storage did not get back in sync in time`                                   | See TWINSTOR pacing below. The message carries the last known replication state.                                                                                            |
+| `unsupported TWINSTOR schema`                                                         | The pool runs a TWINSTOR version newer than this XO. Update XO. See TWINSTOR pacing below.                                                                                  |
+| `incorrectState` on `twinstorStorageState`, before the run starts                     | Pre-flight refusal: the storage was already not redundant, or no SR advertises while a daemon is alive. See TWINSTOR pacing below.                                          |
 
 Note on granularity: `Evacuate` is a single `host.evacuate` XAPI call, there is no per-VM detail in the tree for that phase. When `shutdownPinnedVms` is enabled and pinned VMs are present, per-VM subtasks also appear under `Shut down pinned VMs` and `Restart pinned VMs`.
+
+## TWINSTOR pacing
+
+On a pool whose SR is backed by TWINSTOR, the two hosts hold one replica each. While a replica is catching up, a single host holds the only up-to-date copy of the data, so rebooting the other one takes the storage down under the running VMs. Rebooting is itself what starts the next resync, so this is what paces the whole run.
+
+The daemon advertises the replication state in the SR's `other_config`, refreshed by the pool master. The run waits on it twice per host, before evacuating and again right before rebooting, as a `Waiting for TWINSTOR storage to be in sync before evacuating` / `... before rebooting` task. Its `progress` is the resync percentage and its `twinstorState` property says what is holding it back. The task is only created when a wait is actually needed, so a healthy pool shows none, and pools without a TWINSTOR SR are unaffected.
+
+A host is rebooted only when all four of these hold:
+
+- `twinstor-synced=true` and `twinstor-storage-state=synced`, both, not either
+- `twinstor-updated-at` is less than 5 minutes old, in either direction (a stamp from the future means the clocks disagree)
+- `twinstor-updated-at` is strictly newer than when the previous host was rebooted, which proves the pool master has spoken since that reboot rather than before it
+- every TWINSTOR host is stamping `twinstor-alive`, less than 150 seconds old
+
+`twinstor-schema` is the version of the key set, bumped when the meaning of the keys changes. An unrecognized value fails the run at once instead of after the timeout. Currently supported: `1`.
+
+### Pre-flight check
+
+The same conditions are checked once before the run disables HA, `auto_poweron`, the load balancer and the pool's backup schedules. A pool whose storage is already not redundant is refused there with an `incorrectState` on `twinstorStorageState`, rather than left with everything disabled for hours.
+
+A pool where no SR advertises, but where some host is still stamping `twinstor-alive`, is refused too: the gate has no signal to work with. A host which merely used to run TWINSTOR does not trip this, an uninstall stops the daemon and that clears the stamp.
+
+### Key inventory
+
+Only the SR record gates the run. The daemon keeps the sync keys off the host record on purpose: a rebooting host freezes its own keys with no co-located freshness stamp.
+
+| Object              | Keys                                                                                                                                                                                       | Written by               | Used here                              |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ | -------------------------------------- |
+| `SR.other_config`   | `twinstor-schema`, `twinstor-managed`, `twinstor-version`, `twinstor-synced`, `twinstor-storage-state`, `twinstor-sync-pct`, `twinstor-sync-eta`, `twinstor-drbd-*`, `twinstor-updated-at` | pool master              | yes, this is the gate                  |
+| `host.other_config` | `twinstor-alive`, `twinstor-version`, `twinstor-schema`, `twinstor-storage-state`, `twinstor-drbd-*`                                                                                       | each host                | `twinstor-alive` only                  |
+| `pool.other_config` | `twinstor_setup`                                                                                                                                                                           | first node, during setup | no, cleared once the cluster is formed |
+
+Detection is SR-based, not host-based: uninstalling TWINSTOR destroys the SR and its keys, but leaves `twinstor-version` on the hosts forever, so a host-based check would keep gating a pool which no longer uses TWINSTOR.
+
+### Aborting a run
+
+Aborting (`POST /rest/v0/tasks/<id>/actions/abort`) while the run waits on the storage stops it at once, without rebooting the host it was waiting for. It is honored between two hosts too, so aborting during host 1's reboot means host 2 is never touched. It is not honored once a host is on its way down, there is no un-rebooting it. Cleanups then run as on any failure: HA and `auto_poweron` restored, shut-down pinned VMs started again, evacuated host re-enabled. VMs are left where they were evacuated to.
+
+### Timeout
+
+`xapiOptions.twinstorSyncTimeout` (default 2 hours) is the total a run may spend waiting on the storage, shared by every wait, so it also bounds how long the pool is held with HA disabled. Only waiting is charged to it, not evacuating, patching or rebooting. The advertisement is polled every 10 seconds throughout. On expiry the run fails rather than proceeding.
+
+Note that HA is off for the whole run, so TWINSTOR raises its own `twinstor_ha_disarmed` alert after 30 minutes. During a gated run that is expected.
+
+| `twinstorState` says                                       | What it is                                                                                                                                                                                          |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `a replica is catching up (n%)`                            | A resync genuinely longer than the budget, e.g. a full sync after a disk replacement (~90 min for 500 GB on 1 GbE, proportionally longer on a larger SR). Raise `twinstorSyncTimeout` and relaunch. |
+| `a resync is running but is not making progress`           | The replication link is saturated or broken. Check it on the hosts with `twinstor status` before relaunching.                                                                                       |
+| `only one replica is available`                            | The peer's disk is failed or detached, the storage has no redundant copy. Fix the storage first, the pool must not be rebooted in this state.                                                       |
+| `the TWINSTOR daemon is not running on <host>`             | That host's daemon is stopped or crashed. DRBD keeps replicating without it, but the node has no supervision, fencing or recovery. Start it.                                                        |
+| `has not published its state since the last host rebooted` | The pool master has not refreshed the advertisement since the previous reboot. Normally clears within a minute of its daemon coming back.                                                           |
+| `TWINSTOR state is unknown`                                | The daemon is not running on the pool master, or the host and XO clocks disagree by more than 5 minutes. Both make the advertisement untrustworthy.                                                 |
+| `the TWINSTOR state of the pool could not be read`         | XAPI did not answer. Usually transient while the master reconnects after its own reboot, the run keeps retrying.                                                                                    |
 
 ## Task logs
 
@@ -70,11 +126,15 @@ Rolling pool update and rolling pool reboot task logs have major parts in common
 task.start({ name: 'Rolling pool reboot', poolId: string, poolName: string })
 ├─ task.start({ name: 'Restarting hosts', total: number, progress: number, done: number })
 |  ├─ task.start({ name: `Restarting host ${hostId}`, hostId: string, hostName: string })
+|  |  ├─ task.start({ name: 'Waiting for TWINSTOR storage to be in sync before evacuating', objectId: string, hostId: string, hostName: string, progress: number, twinstorState: string })
+│  │  │  └─ task.end
 |  |  ├─ task.start({ name: 'Shut down pinned VMs', hostId: string, hostName: string })
 |  |  |  ├─ task.start({ name: `Shutting down VM ${vmId}`, hostId: string, hostName: string, vmId: string, vmName: string })
 │  │  │  │  └─ task.end
 │  │  │  └─ task.end
 |  |  ├─ task.start({ name: 'Evacuate', hostId: string, hostName: string })
+│  │  │  └─ task.end
+|  |  ├─ task.start({ name: 'Waiting for TWINSTOR storage to be in sync before rebooting', objectId: string, hostId: string, hostName: string, progress: number, twinstorState: string })
 │  │  │  └─ task.end
 |  |  ├─ task.start({ name: 'Restart', hostId: string, hostName: string })
 │  │  │  └─ task.end
@@ -108,6 +168,8 @@ task.start({ name: 'Rolling pool update', poolId: string, poolName: string })
 │  │  └─ task.end
 │  ├─ task.start({ name: 'Restarting hosts', total: number, progress: number, done: number })
 │  |  ├─ task.start({ name: `Restarting host ${hostId}`, hostId: string, hostName: string })
+│  |  |  ├─ task.start({ name: 'Waiting for TWINSTOR storage to be in sync before evacuating', objectId: string, hostId: string, hostName: string, progress: number, twinstorState: string })
+│  │  │  │  └─ task.end
 │  |  |  ├─ task.start({ name: 'Shut down pinned VMs', hostId: string, hostName: string })
 │  |  |  |  ├─ task.start({ name: `Shutting down VM ${vmId}`, hostId: string, hostName: string, vmId: string, vmName: string })
 │  │  │  │  │  └─ task.end
@@ -115,6 +177,8 @@ task.start({ name: 'Rolling pool update', poolId: string, poolName: string })
 │  |  |  ├─ task.start({ name: 'Evacuate', hostId: string, hostName: string })
 │  │  │  │  └─ task.end
 │  |  |  ├─ task.start({ name: 'Installing patches', hostId: string, hostName: string })
+│  │  │  │  └─ task.end
+│  |  |  ├─ task.start({ name: 'Waiting for TWINSTOR storage to be in sync before rebooting', objectId: string, hostId: string, hostName: string, progress: number, twinstorState: string })
 │  │  │  │  └─ task.end
 │  |  |  ├─ task.start({ name: 'Restart', hostId: string, hostName: string })
 │  │  │  │  └─ task.end

--- a/packages/xo-server/src/xapi/_twinstor.mjs
+++ b/packages/xo-server/src/xapi/_twinstor.mjs
@@ -1,0 +1,142 @@
+// TWINSTOR is a 2-node replicated storage: the SR is backed by a DRBD resource
+// mirrored between the two hosts of the pool. Its daemon advertises the live
+// replication state in `other_config`, under the `twinstor-*` namespace, which
+// XO reads to pace rolling pool updates and reboots.
+//
+// The SR keys are written by the pool master only, each host stamps its own
+// liveness on its own record, and every value is a string.
+
+// SR record
+const SCHEMA = 'twinstor-schema'
+const MANAGED = 'twinstor-managed'
+const SYNCED = 'twinstor-synced'
+const STATE = 'twinstor-storage-state'
+const SYNC_PCT = 'twinstor-sync-pct'
+const SYNC_ETA = 'twinstor-sync-eta'
+const UPDATED_AT = 'twinstor-updated-at'
+
+// host record
+const ALIVE = 'twinstor-alive'
+const VERSION = 'twinstor-version'
+
+// the pool master refreshes UPDATED_AT every minute, this leaves room for a
+// missed beat, for XAPI propagation and for a bit of clock skew
+export const TWINSTOR_STALE_PERIOD = 5 * 60 * 1e3
+
+// same value TWINSTOR uses for the same purpose in its own restart interlock
+export const TWINSTOR_ALIVE_STALE_PERIOD = 150 * 1e3
+
+// the daemon bumps its schema when the meaning of the keys changes, so a
+// `twinstor-synced` from an unknown one cannot be taken at face value
+const SUPPORTED_SCHEMAS = new Set(['1'])
+
+const STATE_DESCRIPTIONS = {
+  degraded: 'only one replica is available, the storage has no redundant copy',
+  'not-ready': 'no up-to-date replica is available',
+  stalled: 'a resync is running but is not making progress',
+  synced: 'both replicas are up to date',
+  syncing: 'a replica is catching up',
+}
+
+// `Number('')` is 0, which would date an advertisement to 1970 or invent a 0%
+// resync: a key which is present but empty is not a number
+function parseNumber(value) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return undefined
+  }
+  const n = Number(value)
+  return Number.isFinite(n) ? n : undefined
+}
+
+function parseStamp(value) {
+  const seconds = parseNumber(value)
+  return seconds === undefined ? undefined : seconds * 1e3
+}
+
+// a stamp far in the future is as unusable as an old one: it means the clocks
+// disagree, so the age cannot be established either way
+const isFresh = (stamp, now, stalePeriod) => stamp !== undefined && Math.abs(now - stamp) < stalePeriod
+
+// any one of the identifying keys is enough: they are written in the same call,
+// but failing to recognize TWINSTOR is the dangerous direction
+export function isTwinstorSr(otherConfig) {
+  return otherConfig?.[MANAGED] === 'true' || otherConfig?.[SYNCED] !== undefined || otherConfig?.[SCHEMA] !== undefined
+}
+
+// true for a host TWINSTOR has ever been installed on, which an uninstall never
+// clears: not usable to decide whether a pool is TWINSTOR-backed
+export function isTwinstorHost(otherConfig) {
+  return otherConfig?.[VERSION] !== undefined
+}
+
+// DRBD keeps replicating in the kernel without the daemon, so the storage can
+// look perfectly healthy while one node has no supervision at all. TWINSTOR
+// refuses to restart even its own daemon in that state, and rebooting the host
+// is a superset of that.
+export function isTwinstorDaemonAlive(
+  otherConfig,
+  { now = Date.now(), stalePeriod = TWINSTOR_ALIVE_STALE_PERIOD } = {}
+) {
+  return isFresh(parseStamp(otherConfig?.[ALIVE]), now, stalePeriod)
+}
+
+// A host which just rebooted leaves the last advertisement frozen at
+// `synced=true`, since that is what allowed the reboot. Age alone does not
+// settle it, so callers must also require the advertisement to have been
+// published after the reboot they are pacing.
+export function parseTwinstorSrState(otherConfig, { now = Date.now(), stalePeriod = TWINSTOR_STALE_PERIOD } = {}) {
+  const updatedAt = parseStamp(otherConfig?.[UPDATED_AT])
+  const isStale = !isFresh(updatedAt, now, stalePeriod)
+  const state = otherConfig?.[STATE]
+  const eta = parseNumber(otherConfig?.[SYNC_ETA])
+
+  // an absent schema is a daemon predating the key set: nothing to be
+  // incompatible with
+  const schema = otherConfig?.[SCHEMA]
+
+  return {
+    // the daemon only republishes the keys it believes changed, against a cache
+    // which outlives a pool-master change and cannot see an outside edit of the
+    // record: requiring the flag and the state to agree makes any such
+    // divergence fail closed
+    isSynced: !isStale && otherConfig?.[SYNCED] === 'true' && state === 'synced',
+    isStale,
+    isSchemaSupported: schema === undefined || SUPPORTED_SCHEMAS.has(schema),
+    schema,
+    state,
+    progress: parseNumber(otherConfig?.[SYNC_PCT]),
+    // the daemon reports -1 for "unknown", which is not an ETA
+    eta: eta !== undefined && eta >= 0 ? eta : undefined,
+    updatedAt,
+  }
+}
+
+export function describeTwinstorState({ isStale, state, progress, eta, updatedAt }, { now = Date.now() } = {}) {
+  if (isStale) {
+    const age =
+      updatedAt === undefined
+        ? 'the pool master never published one'
+        : `the last one is ${Math.round(Math.abs(now - updatedAt) / 6e4)} minutes old`
+    return `TWINSTOR state is unknown (${age}): check that the daemon is running on the pool master and that its clock is in sync with XO`
+  }
+
+  let description = STATE_DESCRIPTIONS[state]
+  if (description === undefined) {
+    return state === undefined ? 'TWINSTOR published no state' : `unrecognized TWINSTOR state ${JSON.stringify(state)}`
+  }
+
+  if (state === 'syncing' || state === 'stalled') {
+    // report whichever half is known
+    const details = []
+    if (progress !== undefined) {
+      details.push(`${progress}%`)
+    }
+    if (eta !== undefined) {
+      details.push(`~${Math.round(eta / 60)} min left`)
+    }
+    if (details.length > 0) {
+      description += ` (${details.join(', ')})`
+    }
+  }
+  return description
+}

--- a/packages/xo-server/src/xapi/_twinstor.test.mjs
+++ b/packages/xo-server/src/xapi/_twinstor.test.mjs
@@ -1,0 +1,212 @@
+import assert from 'assert/strict'
+import test from 'node:test'
+
+import {
+  describeTwinstorState,
+  isTwinstorDaemonAlive,
+  isTwinstorHost,
+  isTwinstorSr,
+  parseTwinstorSrState,
+  TWINSTOR_ALIVE_STALE_PERIOD,
+  TWINSTOR_STALE_PERIOD,
+} from './_twinstor.mjs'
+
+const { describe, it } = test
+
+const NOW = 1_700_000_000_000
+const stamp = (msAgo = 0) => String(Math.round((NOW - msAgo) / 1e3))
+
+const synced = (msAgo = 0) => ({
+  'twinstor-schema': '1',
+  'twinstor-managed': 'true',
+  'twinstor-synced': 'true',
+  'twinstor-storage-state': 'synced',
+  'twinstor-sync-pct': '100',
+  'twinstor-sync-eta': '0',
+  'twinstor-updated-at': stamp(msAgo),
+})
+
+const syncing = (msAgo = 0) => ({
+  'twinstor-schema': '1',
+  'twinstor-managed': 'true',
+  'twinstor-synced': 'false',
+  'twinstor-storage-state': 'syncing',
+  'twinstor-sync-pct': '42',
+  'twinstor-sync-eta': '600',
+  'twinstor-updated-at': stamp(msAgo),
+})
+
+describe('isTwinstorSr', function () {
+  it('detects a TWINSTOR SR', function () {
+    assert.equal(isTwinstorSr(synced()), true)
+  })
+
+  it('falls back on the sync flag when the managed flag is missing', function () {
+    assert.equal(isTwinstorSr({ 'twinstor-synced': 'false' }), true)
+  })
+
+  it('ignores other SRs', function () {
+    assert.equal(isTwinstorSr({ 'some-key': 'true' }), false)
+    assert.equal(isTwinstorSr({}), false)
+    assert.equal(isTwinstorSr(undefined), false)
+  })
+})
+
+describe('parseTwinstorSrState', function () {
+  it('reports a fresh synced advertisement as synced', function () {
+    const state = parseTwinstorSrState(synced(), { now: NOW })
+    assert.equal(state.isSynced, true)
+    assert.equal(state.isStale, false)
+    assert.equal(state.state, 'synced')
+    assert.equal(state.progress, 100)
+  })
+
+  it('reports a running resync', function () {
+    const state = parseTwinstorSrState(syncing(), { now: NOW })
+    assert.equal(state.isSynced, false)
+    assert.equal(state.progress, 42)
+    assert.equal(state.eta, 600)
+  })
+
+  // the case this whole gate exists for: a host which just rebooted leaves the
+  // advertisement frozen on `synced=true`, since that is what allowed its reboot
+  it('never reports a stale advertisement as synced', function () {
+    const state = parseTwinstorSrState(synced(TWINSTOR_STALE_PERIOD), { now: NOW })
+    assert.equal(state.isStale, true)
+    assert.equal(state.isSynced, false)
+  })
+
+  it('rejects a stamp coming from a clock far ahead of XO', function () {
+    const state = parseTwinstorSrState(synced(-TWINSTOR_STALE_PERIOD), { now: NOW })
+    assert.equal(state.isStale, true)
+    assert.equal(state.isSynced, false)
+  })
+
+  it('treats a missing or unparsable stamp as stale', function () {
+    for (const value of [undefined, '', 'not-a-number']) {
+      const state = parseTwinstorSrState({ ...synced(), 'twinstor-updated-at': value }, { now: NOW })
+      assert.equal(state.isStale, true, `stamp: ${value}`)
+      assert.equal(state.isSynced, false, `stamp: ${value}`)
+    }
+  })
+
+  it('discards the -1 the daemon reports for an unknown ETA', function () {
+    const state = parseTwinstorSrState({ ...syncing(), 'twinstor-sync-eta': '-1' }, { now: NOW })
+    assert.equal(state.eta, undefined)
+    assert.equal(state.progress, 42)
+  })
+
+  it('does not report a degraded storage as synced', function () {
+    const otherConfig = { ...synced(), 'twinstor-synced': 'false', 'twinstor-storage-state': 'degraded' }
+    assert.equal(parseTwinstorSrState(otherConfig, { now: NOW }).isSynced, false)
+  })
+
+  it('accepts the schema it knows, and the absence of one', function () {
+    assert.equal(parseTwinstorSrState(synced(), { now: NOW }).isSchemaSupported, true)
+    const legacy = { ...synced(), 'twinstor-schema': undefined }
+    assert.equal(parseTwinstorSrState(legacy, { now: NOW }).isSchemaSupported, true)
+  })
+
+  // the daemon bumps the schema when the meaning of the keys changes, so a
+  // `twinstor-synced` from an unknown one cannot be taken at face value
+  it('rejects a schema it does not know', function () {
+    const future = { ...synced(), 'twinstor-schema': '2' }
+    const state = parseTwinstorSrState(future, { now: NOW })
+    assert.equal(state.isSchemaSupported, false)
+    assert.equal(state.schema, '2')
+  })
+
+  // the daemon republishes only the keys it *believes* changed, against a cache
+  // which outlives a pool-master change: any divergence must fail closed
+  it('requires the sync flag and the state to agree', function () {
+    const flagOnly = { ...synced(), 'twinstor-storage-state': 'syncing' }
+    assert.equal(parseTwinstorSrState(flagOnly, { now: NOW }).isSynced, false)
+    const stateOnly = { ...synced(), 'twinstor-synced': 'false' }
+    assert.equal(parseTwinstorSrState(stateOnly, { now: NOW }).isSynced, false)
+  })
+
+  it('treats a blank number as absent rather than as zero', function () {
+    const blank = { ...syncing(), 'twinstor-sync-pct': '', 'twinstor-sync-eta': ' ' }
+    const state = parseTwinstorSrState(blank, { now: NOW })
+    assert.equal(state.progress, undefined)
+    assert.equal(state.eta, undefined)
+    // an empty stamp must not date the advertisement to the Unix epoch
+    assert.equal(parseTwinstorSrState({ ...synced(), 'twinstor-updated-at': '' }).updatedAt, undefined)
+  })
+
+  it('survives a garbage or absent other_config', function () {
+    for (const otherConfig of [undefined, {}, { 'twinstor-synced': 'yes' }]) {
+      const state = parseTwinstorSrState(otherConfig, { now: NOW })
+      assert.equal(state.isSynced, false)
+      assert.equal(state.isStale, true)
+    }
+  })
+})
+
+describe('isTwinstorHost / isTwinstorDaemonAlive', function () {
+  it('recognizes a host TWINSTOR is or was installed on', function () {
+    assert.equal(isTwinstorHost({ 'twinstor-version': '0.5.0' }), true)
+    assert.equal(isTwinstorHost({}), false)
+  })
+
+  it('reports a freshly stamped daemon as alive', function () {
+    assert.equal(isTwinstorDaemonAlive({ 'twinstor-alive': stamp(60e3) }, { now: NOW }), true)
+  })
+
+  // the stamp is removed on a graceful stop and simply ages out on a crash;
+  // either way DRBD keeps running in the kernel and the pair still looks healthy
+  it('reports a stopped or stale daemon as down', function () {
+    assert.equal(isTwinstorDaemonAlive({}, { now: NOW }), false)
+    assert.equal(isTwinstorDaemonAlive({ 'twinstor-alive': stamp(TWINSTOR_ALIVE_STALE_PERIOD) }, { now: NOW }), false)
+    assert.equal(isTwinstorDaemonAlive({ 'twinstor-alive': '' }, { now: NOW }), false)
+  })
+})
+
+describe('describeTwinstorState', function () {
+  it('describes a running resync with its progress and ETA', function () {
+    const description = describeTwinstorState(parseTwinstorSrState(syncing(), { now: NOW }), { now: NOW })
+    assert.match(description, /catching up/)
+    assert.match(description, /42%/)
+    assert.match(description, /10 min left/)
+  })
+
+  it('describes a degraded storage', function () {
+    const otherConfig = { ...synced(), 'twinstor-synced': 'false', 'twinstor-storage-state': 'degraded' }
+    const description = describeTwinstorState(parseTwinstorSrState(otherConfig, { now: NOW }), { now: NOW })
+    assert.match(description, /no redundant copy/)
+  })
+
+  it('points at the daemon and the clocks when the advertisement is stale', function () {
+    const state = parseTwinstorSrState(synced(10 * 60e3), { now: NOW })
+    const description = describeTwinstorState(state, { now: NOW })
+    assert.match(description, /unknown/)
+    assert.match(description, /10 minutes old/)
+    assert.match(description, /clock/)
+  })
+
+  it('does not claim an ETA it does not have', function () {
+    const otherConfig = { ...syncing(), 'twinstor-sync-eta': '-1' }
+    const description = describeTwinstorState(parseTwinstorSrState(otherConfig, { now: NOW }), { now: NOW })
+    assert.match(description, /\(42%\)/)
+  })
+
+  // the ETA is what tells an operator whether to raise the timeout or go and
+  // look at the replication link: never drop it just because progress is missing
+  it('still reports the ETA when the progress is unknown', function () {
+    const otherConfig = { ...syncing(), 'twinstor-sync-pct': '' }
+    const description = describeTwinstorState(parseTwinstorSrState(otherConfig, { now: NOW }), { now: NOW })
+    assert.match(description, /\(~10 min left\)/)
+  })
+
+  it('describes a stalled resync', function () {
+    const otherConfig = { ...syncing(), 'twinstor-storage-state': 'stalled', 'twinstor-sync-eta': '-1' }
+    const description = describeTwinstorState(parseTwinstorSrState(otherConfig, { now: NOW }), { now: NOW })
+    assert.match(description, /not making progress \(42%\)/)
+  })
+
+  it('does not print a bare "undefined" for a missing state', function () {
+    const otherConfig = { 'twinstor-synced': 'false', 'twinstor-updated-at': stamp() }
+    const description = describeTwinstorState(parseTwinstorSrState(otherConfig, { now: NOW }), { now: NOW })
+    assert.equal(description, 'TWINSTOR published no state')
+  })
+})

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -74,6 +74,7 @@ export default class Xapi extends XapiBase {
     guessVhdSizeOnImport,
     maxUncoalescedVdis,
     restartHostTimeout,
+    twinstorSyncTimeout = '2 hours',
     vdiExportConcurrency,
     vmEvacuationConcurrency,
     vmExportConcurrency,
@@ -87,6 +88,7 @@ export default class Xapi extends XapiBase {
     this._guessVhdSizeOnImport = guessVhdSizeOnImport
     this._maxUncoalescedVdis = maxUncoalescedVdis
     this._restartHostTimeout = parseDuration(restartHostTimeout)
+    this._twinstorSyncTimeout = parseDuration(twinstorSyncTimeout)
     this._vmEvacuationConcurrency = vmEvacuationConcurrency
     this._vmShutdownTimeout = parseDuration(vmShutdownTimeout)
 

--- a/packages/xo-server/src/xapi/mixins/_pool.test.mjs
+++ b/packages/xo-server/src/xapi/mixins/_pool.test.mjs
@@ -1,0 +1,169 @@
+import assert from 'assert/strict'
+import test from 'node:test'
+import { Task } from '@xen-orchestra/mixins/Tasks.mjs'
+
+import poolMethods from './pool.mjs'
+
+const { describe, it } = test
+
+const SR_REF = 'OpaqueRef:sr'
+const HOST_REF = 'OpaqueRef:host'
+const NOW = Date.now()
+const stamp = (msAgo = 0) => String(Math.round((NOW - msAgo) / 1e3))
+
+const SYNCED = {
+  'twinstor-schema': '1',
+  'twinstor-managed': 'true',
+  'twinstor-synced': 'true',
+  'twinstor-storage-state': 'synced',
+  'twinstor-sync-pct': '100',
+  'twinstor-updated-at': stamp(),
+}
+const SYNCING = {
+  ...SYNCED,
+  'twinstor-synced': 'false',
+  'twinstor-storage-state': 'syncing',
+  'twinstor-sync-pct': '30',
+  'twinstor-sync-eta': '300',
+}
+const DAEMON_UP = { 'twinstor-version': '0.5.0', 'twinstor-alive': stamp() }
+
+// the methods reach each other through `this`, so they are mixed in as they would be
+const makeFakeXapi = ({ sr = SYNCED, host = DAEMON_UP, getField } = {}) => ({
+  ...poolMethods,
+  pool: { uuid: 'pool' },
+  getField: getField ?? (async type => (type === 'SR' ? sr : host)),
+  getObject: ref => ({ name_label: ref }),
+})
+
+const makeTwinstorState = ({ publishedBefore = new Map(), syncTimeLeft = 0, pollInterval = 5 } = {}) => ({
+  srRefs: [SR_REF],
+  hostRefs: [HOST_REF],
+  publishedBefore,
+  syncTimeLeft,
+  pollInterval,
+})
+
+describe('_probeTwinstor', function () {
+  it('is ready on a synced pool with a live daemon', async function () {
+    const probe = await makeFakeXapi()._probeTwinstor(makeTwinstorState())
+    assert.equal(probe.isReady, true)
+    assert.equal(probe.published.get(SR_REF), Number(SYNCED['twinstor-updated-at']) * 1e3)
+  })
+
+  it('is not ready while a replica is catching up', async function () {
+    const probe = await makeFakeXapi({ sr: SYNCING })._probeTwinstor(makeTwinstorState())
+    assert.equal(probe.isReady, false)
+    assert.equal(probe.progress, 30)
+    assert.match(probe.blockedBy, /catching up/)
+  })
+
+  // a host which just rebooted leaves the advertisement frozen on `synced=true`
+  it('refuses an advertisement not republished since the last reboot', async function () {
+    const publishedAt = Number(SYNCED['twinstor-updated-at']) * 1e3
+
+    const frozen = await makeFakeXapi()._probeTwinstor(
+      makeTwinstorState({ publishedBefore: new Map([[SR_REF, publishedAt]]) })
+    )
+    assert.equal(frozen.isReady, false)
+    assert.match(frozen.blockedBy, /has not published its state since the last host rebooted/)
+
+    const republished = await makeFakeXapi()._probeTwinstor(
+      makeTwinstorState({ publishedBefore: new Map([[SR_REF, publishedAt - 1e3]]) })
+    )
+    assert.equal(republished.isReady, true)
+  })
+
+  it('refuses to reboot while a daemon is down, however healthy the storage', async function () {
+    const probe = await makeFakeXapi({ host: { 'twinstor-version': '0.5.0' } })._probeTwinstor(makeTwinstorState())
+    assert.equal(probe.isReady, false)
+    assert.match(probe.blockedBy, /daemon is not running/)
+  })
+
+  it('fails immediately on a schema it cannot interpret', async function () {
+    await assert.rejects(
+      () => makeFakeXapi({ sr: { ...SYNCED, 'twinstor-schema': '2' } })._probeTwinstor(makeTwinstorState()),
+      /unsupported TWINSTOR schema/
+    )
+  })
+
+  it('treats an unreadable advertisement as not synced, not as an abort', async function () {
+    const getField = async () => {
+      throw new Error('ECONNRESET')
+    }
+    const probe = await makeFakeXapi({ getField })._probeTwinstor(makeTwinstorState())
+    assert.equal(probe.isReady, false)
+    assert.match(probe.blockedBy, /could not be read/)
+  })
+})
+
+describe('_waitForTwinstorSync', function () {
+  it('does nothing on a pool without TWINSTOR', async function () {
+    const published = await makeFakeXapi()._waitForTwinstorSync(
+      { ...makeTwinstorState(), srRefs: [], hostRefs: [] },
+      {}
+    )
+    assert.equal(published.size, 0)
+  })
+
+  it('returns the accepted advertisement without waiting when already synced', async function () {
+    const published = await makeFakeXapi()._waitForTwinstorSync(makeTwinstorState(), {})
+    assert.equal(published.get(SR_REF), Number(SYNCED['twinstor-updated-at']) * 1e3)
+  })
+
+  it('throws rather than proceeding when the sync does not complete in time', async function () {
+    await assert.rejects(
+      () =>
+        makeFakeXapi({ sr: SYNCING })._waitForTwinstorSync(makeTwinstorState(), {
+          name: 'Waiting for TWINSTOR storage to be in sync',
+        }),
+      error =>
+        /did not get back in sync in time/.test(error.message) && /catching up \(30%, ~5 min left\)/.test(error.message)
+    )
+  })
+
+  it('draws every wait from one shared budget', async function () {
+    const xapi = makeFakeXapi({ sr: SYNCING })
+    const twinstor = makeTwinstorState({ syncTimeLeft: 80, pollInterval: 20 })
+    const properties = { name: 'Waiting for TWINSTOR storage to be in sync' }
+
+    await assert.rejects(() => xapi._waitForTwinstorSync(twinstor, properties))
+    assert.equal(twinstor.syncTimeLeft, 0, 'the first wait consumed the whole budget')
+
+    // with nothing left, the next wait gives up at once rather than starting
+    // another full timeout of its own
+    const startedAt = Date.now()
+    await assert.rejects(() => xapi._waitForTwinstorSync(twinstor, properties))
+    assert.ok(Date.now() - startedAt < 20, 'the second wait did not poll again')
+  })
+
+  it('gives up when the run is aborted, instead of waiting out the timeout', async function () {
+    const parent = new Task({ properties: { name: 'Rolling pool reboot' } })
+    const xapi = makeFakeXapi({ sr: SYNCING })
+
+    await assert.rejects(
+      () =>
+        parent.run(async () => {
+          // abort while the gate is parked in its poll delay
+          setTimeout(() => parent.abort('aborted by the user'), 20)
+          return xapi._waitForTwinstorSync(makeTwinstorState({ syncTimeLeft: 60 * 60e3 }), {
+            name: 'Waiting for TWINSTOR storage to be in sync',
+          })
+        }),
+      error => error === 'aborted by the user'
+    )
+  })
+})
+
+describe('_assertTwinstorReady', function () {
+  it('accepts a synced pool', async function () {
+    await makeFakeXapi()._assertTwinstorReady(makeTwinstorState())
+  })
+
+  it('refuses a run upfront when the storage is not already redundant', async function () {
+    await assert.rejects(
+      () => makeFakeXapi({ sr: SYNCING })._assertTwinstorReady(makeTwinstorState()),
+      error => error.code === 25 /* incorrectState */ && /catching up/.test(error.data.actual)
+    )
+  })
+})

--- a/packages/xo-server/src/xapi/mixins/pool.mjs
+++ b/packages/xo-server/src/xapi/mixins/pool.mjs
@@ -3,9 +3,18 @@ import { cancelable, timeout } from 'promise-toolbox'
 import { createLogger } from '@xen-orchestra/log'
 import { decorateObject } from '@vates/decorate-with'
 import { defer as deferrable } from 'golike-defer'
+import {
+  describeTwinstorState,
+  isTwinstorDaemonAlive,
+  isTwinstorHost,
+  isTwinstorSr,
+  parseTwinstorSrState,
+} from '../_twinstor.mjs'
 import { incorrectState } from 'xo-common/api-errors.js'
 import { isHostRunning } from '../utils.mjs'
 import { parseDateTime } from '@xen-orchestra/xapi'
+// only used for its `signal` support, which pDelay does not have
+import { setTimeout as sleep } from 'node:timers/promises'
 import { Task } from '@xen-orchestra/mixins/Tasks.mjs'
 import filter from 'lodash/filter.js'
 import groupBy from 'lodash/groupBy.js'
@@ -26,6 +35,12 @@ const PINNED_VM_ERROR_CODES = new Set(['VM_HAS_PCI_ATTACHED', 'VM_HAS_VGPU', 'VM
 // just rebooted
 const PINNED_VM_SHUTDOWN_CONCURRENCY = 8
 const PINNED_VM_START_CONCURRENCY = 2
+
+const TWINSTOR_POLL_INTERVAL = 10e3
+
+// without its own bound a read would inherit the XAPI call timeout (an hour)
+// and overrun the sync budget by that much
+const TWINSTOR_PROBE_TIMEOUT = 60e3
 
 const setProgress = (task, progress) => task.set('progress', Math.round(progress))
 
@@ -48,11 +63,179 @@ const methods = {
     })
   },
 
+  // One read of the pool's TWINSTOR advertisement: whether a host may be
+  // rebooted right now, and if not, what is holding it back.
+  async _probeTwinstor({ srRefs, hostRefs, publishedBefore }) {
+    const now = Date.now()
+
+    let srOtherConfigs, hostOtherConfigs
+    try {
+      ;[srOtherConfigs, hostOtherConfigs] = await Promise.all([
+        Promise.all(srRefs.map(ref => timeout.call(this.getField('SR', ref, 'other_config'), TWINSTOR_PROBE_TIMEOUT))),
+        Promise.all(
+          hostRefs.map(ref => timeout.call(this.getField('host', ref, 'other_config'), TWINSTOR_PROBE_TIMEOUT))
+        ),
+      ])
+    } catch (error) {
+      // the pool master may still be reconnecting after its own reboot: an
+      // unreadable advertisement is simply not a synced one
+      log.warn('could not read the TWINSTOR state of the pool', { error })
+      return { isReady: false, blockedBy: `the TWINSTOR state of the pool could not be read: ${error.message}` }
+    }
+
+    const states = srOtherConfigs.map(otherConfig => parseTwinstorSrState(otherConfig, { now }))
+
+    // an advertisement which cannot be read is worth retrying, one which cannot
+    // be interpreted is not: waiting would only delay the same verdict
+    const incompatible = states.find(_ => !_.isSchemaSupported)
+    if (incompatible !== undefined) {
+      throw new Error(`unsupported TWINSTOR schema ${JSON.stringify(incompatible.schema)}, update XO to roll this pool`)
+    }
+
+    // see isTwinstorDaemonAlive: DRBD keeps replicating without the daemon
+    const iDown = hostOtherConfigs.findIndex(otherConfig => !isTwinstorDaemonAlive(otherConfig, { now }))
+    if (iDown !== -1) {
+      return {
+        isReady: false,
+        blockedBy: `the TWINSTOR daemon is not running on ${this.getObject(hostRefs[iDown]).name_label}`,
+      }
+    }
+
+    const iBlocked = states.findIndex((state, i) => {
+      const before = publishedBefore.get(srRefs[i])
+      return !state.isSynced || (before !== undefined && state.updatedAt <= before)
+    })
+    if (iBlocked !== -1) {
+      const state = states[iBlocked]
+      return {
+        isReady: false,
+        blockedBy: state.isSynced
+          ? 'TWINSTOR has not published its state since the last host rebooted'
+          : describeTwinstorState(state, { now }),
+        // a stale advertisement carries a stale percentage, most likely the
+        // 100% which preceded a reboot
+        progress: state.isStale ? undefined : state.progress,
+      }
+    }
+
+    return { isReady: true, published: new Map(srRefs.map((ref, i) => [ref, states[i].updatedAt])) }
+  },
+
+  // Refuse a run upfront rather than once HA, auto power on, the load balancer
+  // and the pool's backup schedules have been disabled. Waiting is only
+  // legitimate later on, when the resync being waited on is one the run caused.
+  async _assertTwinstorReady(twinstor) {
+    if (twinstor.srRefs.length === 0) {
+      return
+    }
+    const { isReady, blockedBy } = await this._probeTwinstor(twinstor)
+    if (!isReady) {
+      throw incorrectState({
+        actual: blockedBy,
+        expected: 'synced',
+        object: this.pool.uuid,
+        property: 'twinstorStorageState',
+      })
+    }
+  },
+
+  // A host may only be rebooted while both replicas are up to date: during a
+  // resync a single host holds the only complete copy of the data. Rebooting is
+  // itself what starts the next resync, so this is the step which paces the
+  // whole run. Returns the advertisement it accepted, which the caller records
+  // before rebooting so the next host is not waved through on a stale one.
+  //
+  // `twinstorSyncTimeout` budgets the whole run rather than one wait, so it also
+  // bounds how long the pool can be held with HA disabled.
+  async _waitForTwinstorSync(twinstor, taskProperties) {
+    if (twinstor.srRefs.length === 0) {
+      return new Map()
+    }
+
+    // by far the common case, on every host but the ones following a reboot:
+    // report nothing rather than adding an instantly resolved task per host
+    const first = await this._probeTwinstor(twinstor)
+    if (first.isReady) {
+      return first.published
+    }
+
+    const task = new Task({ properties: { ...taskProperties, progress: 0 } })
+    const startedAt = Date.now()
+    const deadline = startedAt + twinstor.syncTimeLeft
+    try {
+      return await task.run(async () => {
+        // the one step which can hold for hours, and the only one where the run
+        // is waiting not to have rebooted anything yet
+        const abortSignal = Task.abortSignal
+
+        let probe = first
+        while (!probe.isReady && Date.now() < deadline) {
+          abortSignal?.throwIfAborted()
+          task.set('twinstorState', probe.blockedBy)
+          setProgress(task, probe.progress ?? 0)
+
+          // an abort cuts the delay short, and is raised on the next line with
+          // the run's own reason rather than as a generic AbortError
+          await sleep(twinstor.pollInterval, undefined, { signal: abortSignal }).catch(() => {})
+          abortSignal?.throwIfAborted()
+          probe = await this._probeTwinstor(twinstor)
+        }
+
+        if (!probe.isReady) {
+          throw new Error(`TWINSTOR storage did not get back in sync in time (${probe.blockedBy})`)
+        }
+        setProgress(task, 100)
+        return probe.published
+      })
+    } finally {
+      // charged on every outcome: what the budget bounds is the time the pool
+      // spends held, not whether the wait worked out
+      twinstor.syncTimeLeft = Math.max(0, twinstor.syncTimeLeft - (Date.now() - startedAt))
+    }
+  },
+
   async rollingPoolReboot(
     $defer,
     parentTask,
     { beforeEvacuateVms, beforeRebootHost, ignoreHost, shutdownPinnedVms = false } = {}
   ) {
+    const hosts = filter(this.objects.all, { $type: 'host' })
+
+    // resolved once, while the whole pool is up and its records are all in
+    // cache: re-scanning between reboots could miss an SR whose record has not
+    // been repopulated yet, and silently turn the gate into a no-op
+    const twinstor = {
+      srRefs: filter(this.objects.indexes.type.SR, sr => isTwinstorSr(sr.other_config)).map(sr => sr.$ref),
+      hostRefs: hosts.filter(host => isTwinstorHost(host.other_config)).map(host => host.$ref),
+      // what each SR had published when the last host was rebooted, which the
+      // next advertisement must be newer than to be believed
+      publishedBefore: new Map(),
+      // how much longer this run may spend waiting on the storage, in total
+      syncTimeLeft: this._twinstorSyncTimeout,
+      pollInterval: TWINSTOR_POLL_INTERVAL,
+    }
+    if (twinstor.srRefs.length > 0) {
+      log.info(
+        `pool ${this.pool.uuid} is backed by TWINSTOR, hosts will be rebooted only while both replicas are synced`
+      )
+    } else {
+      // a daemon stamping its liveness right now, on a pool where no SR
+      // advertises, means the gate has no signal rather than that this is an
+      // ordinary pool. A host which merely used to run TWINSTOR does not trip
+      // this: an uninstall stops the daemon, which clears the stamp.
+      const liveHost = hosts.find(host => isTwinstorDaemonAlive(host.other_config))
+      if (liveHost !== undefined) {
+        throw incorrectState({
+          actual: 'no TWINSTOR SR advertises its replication state',
+          expected: 'a TWINSTOR SR advertising its replication state',
+          object: liveHost.uuid,
+          property: 'twinstorStorageState',
+        })
+      }
+    }
+
+    await this._assertTwinstorReady(twinstor)
+
     if (this.pool.ha_enabled) {
       const haSrs = this.pool.$ha_statefiles.map(vdi => vdi.SR)
       const haConfig = this.pool.ha_configuration
@@ -65,8 +248,6 @@ const methods = {
       await this.pool.update_other_config('auto_poweron', 'false')
       $defer(() => this.pool.update_other_config('auto_poweron', 'true'))
     }
-
-    const hosts = filter(this.objects.all, { $type: 'host' })
 
     {
       const deadHost = hosts.find(_ => !isHostRunning(_))
@@ -201,6 +382,15 @@ const methods = {
             await this.barrier(metricsRef)
             await this._waitObjectState(metricsRef, metrics => metrics.live)
 
+            // no point evacuating and patching a host which cannot then be
+            // rebooted
+            await this._waitForTwinstorSync(twinstor, {
+              name: 'Waiting for TWINSTOR storage to be in sync before evacuating',
+              objectId: hostId,
+              hostId,
+              hostName,
+            })
+
             const getServerTime = async () => parseDateTime(await this.call('host.get_servertime', host.$ref)) * 1e3
 
             let pinnedVmRefs = []
@@ -247,6 +437,11 @@ const methods = {
             await Task.run({ properties: { name: `Evacuate`, hostId, hostName } }, async () => {
               await this.clearHost(host)
             })
+            // clearHost leaves the host disabled and only the reboot below
+            // re-enables it, so anything failing in between would leave it in
+            // maintenance mode and take the pinned-VM restart down with it
+            // (VM.start_on refuses a disabled host)
+            $defer.onFailure(() => this.enableHost(hostId))
             rprProgress += progressStepPerHost
             setProgress(parentTask, rprProgress)
             subtaskProgress += subtaskProgressStep
@@ -259,6 +454,21 @@ const methods = {
               subtaskProgress += subtaskProgressStep
               setProgress(restartSubtask, subtaskProgress)
             }
+
+            // evacuating and patching take long enough for the storage to have
+            // lost its redundancy since the check above
+            const twinstorPublished = await this._waitForTwinstorSync(twinstor, {
+              name: 'Waiting for TWINSTOR storage to be in sync before rebooting',
+              objectId: hostId,
+              hostId,
+              hostName,
+            })
+            // this host is about to go down and resync on its way back, so the
+            // advertisement just accepted no longer holds. Nothing clears it,
+            // and it stays young enough to pass a freshness check for minutes,
+            // longer than a host takes to boot: requiring the next one to be
+            // strictly newer is what makes the gate a barrier.
+            twinstor.publishedBefore = twinstorPublished
 
             const rebootTime = await getServerTime()
             await Task.run({ properties: { name: `Restart`, hostId, hostName } }, async () => {

--- a/packages/xo-server/src/xapi/mixins/pool.mjs
+++ b/packages/xo-server/src/xapi/mixins/pool.mjs
@@ -187,6 +187,11 @@ const methods = {
         const hostId = host.uuid
         const hostName = host.name_label
 
+        // the one point where stopping is free: the previous host is back up
+        // and nothing has been done to this one yet. Not applied once a host is
+        // on its way down, there is no un-rebooting it.
+        Task.abortSignal?.throwIfAborted()
+
         if (!ignoreHost || !ignoreHost(host)) {
           await Task.run({ properties: { name: `Restarting host ${hostId}`, hostId, hostName } }, async () => {
             // This is an old metrics reference from before the pool master restart.


### PR DESCRIPTION
### Description

TWINSTOR mirrors the SR between the two hosts of the pool. While a replica is catching up, a single host holds the only up-to-date copy of the data, so rebooting the other one takes the storage down under the running VMs. Rebooting is itself what starts the next resync, so this is what has to pace a rolling pool update or reboot.

Before evacuating a host, and again right before rebooting it, the run now waits for the pool master's advertisement on the SR's `other_config` to report both replicas up to date. It must also be newer than the one current at the previous reboot: a rebooting host leaves it frozen on `synced=true`, since that is what allowed the reboot, and it stays young enough to look fresh for longer than a host takes to boot. Every host must be stamping `twinstor-alive` too, since DRBD replicating without its daemon still reads as a healthy pair.

A pool which is already not redundant is refused before HA, auto power on, the load balancer and the backup schedules are disabled, rather than held with all of that off for hours. An unknown `twinstor-schema` fails the run instead of being guessed on. The wait is bounded by `xapiOptions.twinstorSyncTimeout` over the whole run rather than per host, so that value also bounds how long the pool is held with HA disabled.

Pools without a TWINSTOR SR are unaffected: no task is created and no extra XAPI call is made.

The first commit is independent of TWINSTOR: nothing in RPU/RPR ever looked at `Task.abortSignal`, so aborting the task did nothing and the run rebooted every remaining host anyway. It is now checked between two hosts, and inside the storage wait. It is deliberately not checked once a host is on its way down.

The key inventory, the four gate conditions and a `twinstorState` troubleshooting table are documented in `packages/xo-server/docs/rolling-pool-update-reboot.md`.

**Draft:** not yet exercised against a real TWINSTOR pool. Unit tests cover the gate logic, but the timing behaviour around a master reboot deserves a run on the demo pool before this is merged.

### Checklist

- Commit
  - [x] Title follows [commit conventions](https://bit.ly/commit-conventions)
  - [ ] Reference the relevant issue
  - [x] If bug fix, add `Introduced by` — n/a, abortion was never implemented in RPU/RPR
- Changelog
  - [x] If visible by XOA users, add changelog entry
  - [x] Update "Packages to release" in `CHANGELOG.unreleased.md` (`xo-server` patch -> minor)
- PR
  - [x] If UI changes, add screenshots — n/a, xo-server only
  - [x] If not finished or not tested, open as _Draft_
