### PR TITLE
feat(rest-api): add reclaim space method per vm or backup repository

### DIFF
--- a/@vates/types/src/xo-app.mts
+++ b/@vates/types/src/xo-app.mts
@@ -357,6 +357,10 @@ export type XoApp = {
     | { success: true; readRate: number; writeRate: number }
     | { success: false; step: string; file: string; error: unknown }
   >
+  reclaimSpace(
+    remoteId: XoBackupRepository['id'],
+    opts?: { vmUuid?: XoVm['id']; merge?: boolean; remove?: boolean }
+  ): Promise<{ vmUuid: string; success: boolean; merge?: boolean; size?: number; error?: string }[]>
   /** Remove a server from the DB (XCP-ng/XenServer) */
   unregisterXenServer(id: XoServer['id']): Promise<void>
   updateUser(

--- a/@xen-orchestra/acl/src/actions/backup-repository.mts
+++ b/@xen-orchestra/acl/src/actions/backup-repository.mts
@@ -10,4 +10,5 @@ export default {
     proxy: true,
     url: true,
   },
+  'reclaim-space': true,
 }

--- a/@xen-orchestra/rest-api/src/backup-repositories/backup-repositories.controller.mts
+++ b/@xen-orchestra/rest-api/src/backup-repositories/backup-repositories.controller.mts
@@ -50,7 +50,7 @@ import { BACKUP_DIR } from '@xen-orchestra/backups/_getVmBackupDir.mjs'
 import { getSyncedHandler } from '@xen-orchestra/fs'
 import { Disposable } from 'promise-toolbox'
 import { Task } from '@vates/task'
-import { asyncMap } from '@xen-orchestra/async-map'
+import { asyncEach } from '@vates/async-each'
 import { BackupRepositoryService } from './backup-repository.service.mjs'
 import { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
 import { taskLocation } from '../open-api/oa-examples/task.oa-example.mjs'
@@ -348,46 +348,54 @@ export class BackupRepositoryController extends XoController<XoBackupRepository>
   @SuccessResponse(200, 'OK')
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
-  reclaimSpaceBackupRepository(@Path() id: string, @Body() body: { vmuuid?: string }, @Query() sync?: boolean) {
+  reclaimSpaceBackupRepository(@Path() id: string, @Body() body?: { vmuuid?: string }, @Query() sync?: boolean) {
     const backupRepositoryId = id as XoBackupRepository['id']
     const vmUuid = body?.vmuuid
 
     const action = async () => {
       const remote = await this.restApi.xoApp.getRemote(backupRepositoryId)
-      // const remoteOptions = this.restApi.xoApp.config.get('remoteOptions') as unknown as RemoteHandlerOptions// explain why using as, it was retunring a string
 
       let results: ReclaimSpaceResult['results']
       try {
         results = await Disposable.use(getSyncedHandler(remote), async handler => {
           const adapter = new RemoteAdapter(handler)
-          const vmUuids = vmUuid !== undefined ? [vmUuid] : await adapter.listAllVms()
+          const vmUuids: string[] = vmUuid !== undefined ? [vmUuid] : await adapter.listAllVms()
 
           Task.set('total', vmUuids.length)
           let done = 0
 
-          return asyncMap(vmUuids, async uuid => {
-            //use asyncEach instead concurrency = 2
-            try {
-              await Task.run({ name: `Clean VM ${uuid}`, data: { type: 'VM', id: uuid } }, () =>
-                adapter.cleanVm(`${BACKUP_DIR}/${uuid}`, {
-                  remove: true,
-                  merge: true,
-                  logInfo: Task.info,
-                  logWarn: Task.warning,
+          const results: ReclaimSpaceResult['results'] = []
+
+          await asyncEach(
+            vmUuids,
+            async uuid => {
+              try {
+                await Task.run({ name: `Clean VM ${uuid}`, data: { type: 'VM', id: uuid } }, () =>
+                  adapter.cleanVm(`${BACKUP_DIR}/${uuid}`, {
+                    remove: true,
+                    merge: true,
+                    logInfo: Task.info,
+                    logWarn: Task.warning,
+                  })
+                )
+
+                results.push({
+                  vmUuid: uuid,
+                  success: true,
                 })
-              )
-              return { vmUuid: uuid, success: true }
-            } catch (error: any) {
-              Task.warning(`failed to reclaim space for VM ${uuid}`, { error })
-              return { vmUuid: uuid, success: false, error: error.message }
-            } finally {
-              done++
-              Task.set('progress', Math.round((done / vmUuids.length) * 100))
-            }
-          })
+              } catch (error: any) {
+                throw new ApiError(`failed to reclaim space for VM ${uuid}, error: ${error.message}`, 400)
+              } finally {
+                done++
+                Task.set('progress', Math.round((done / vmUuids.length) * 100))
+              }
+            },
+            { concurrency: 2 }
+          )
+          return results
         })
       } catch (error) {
-        throw new ApiError('Backup repository unreachable', 502)
+        throw new ApiError(`${error}`, 502)
       }
 
       const failures = results.filter(r => !r.success)

--- a/@xen-orchestra/rest-api/src/backup-repositories/backup-repositories.controller.mts
+++ b/@xen-orchestra/rest-api/src/backup-repositories/backup-repositories.controller.mts
@@ -45,22 +45,13 @@ import {
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
-import { RemoteAdapter } from '@xen-orchestra/backups/RemoteAdapter.mjs'
-import { BACKUP_DIR } from '@xen-orchestra/backups/_getVmBackupDir.mjs'
-import { getSyncedHandler } from '@xen-orchestra/fs'
-import { Disposable } from 'promise-toolbox'
-import { Task } from '@vates/task'
-import { asyncEach } from '@vates/async-each'
 import { BackupRepositoryService } from './backup-repository.service.mjs'
 import { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
 import { taskLocation } from '../open-api/oa-examples/task.oa-example.mjs'
 import { ApiError } from '../helpers/error.helper.mjs'
+import type { ReclaimSpaceResult } from './backup-repository.service.mjs'
 
 type BenchmarkRepositoryResult = Awaited<ReturnType<XoApp['testRemote']>>
-
-interface ReclaimSpaceResult {
-  results: Array<{ vmUuid: string; success: boolean; error?: string }>
-}
 
 @Route('backup-repositories')
 @Security('*')
@@ -345,65 +336,16 @@ export class BackupRepositoryController extends XoController<XoBackupRepository>
       getObject: ({ restApi }) => restApi.xoApp.getRemote,
     }),
   ])
-  @SuccessResponse(200, 'OK')
+  @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
+  @Response(200, 'OK')
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
   reclaimSpaceBackupRepository(@Path() id: string, @Body() body?: { vmuuid?: string }, @Query() sync?: boolean) {
     const backupRepositoryId = id as XoBackupRepository['id']
     const vmUuid = body?.vmuuid
 
-    const action = async () => {
-      const remote = await this.restApi.xoApp.getRemote(backupRepositoryId)
-
-      let results: ReclaimSpaceResult['results']
-      try {
-        results = await Disposable.use(getSyncedHandler(remote), async handler => {
-          const adapter = new RemoteAdapter(handler)
-          const vmUuids: string[] = vmUuid !== undefined ? [vmUuid] : await adapter.listAllVms()
-
-          Task.set('total', vmUuids.length)
-          let done = 0
-
-          const results: ReclaimSpaceResult['results'] = []
-
-          await asyncEach(
-            vmUuids,
-            async uuid => {
-              try {
-                await Task.run({ name: `Clean VM ${uuid}`, data: { type: 'VM', id: uuid } }, () =>
-                  adapter.cleanVm(`${BACKUP_DIR}/${uuid}`, {
-                    remove: true,
-                    merge: true,
-                    logInfo: Task.info,
-                    logWarn: Task.warning,
-                  })
-                )
-
-                results.push({
-                  vmUuid: uuid,
-                  success: true,
-                })
-              } catch (error: any) {
-                throw new ApiError(`failed to reclaim space for VM ${uuid}, error: ${error.message}`, 400)
-              } finally {
-                done++
-                Task.set('progress', Math.round((done / vmUuids.length) * 100))
-              }
-            },
-            { concurrency: 2 }
-          )
-          return results
-        })
-      } catch (error) {
-        throw new ApiError(`${error}`, 502)
-      }
-
-      const failures = results.filter(r => !r.success)
-      if (failures.length === results.length && results.length > 0) {
-        throw new ApiError('Reclaim space failed for all VMs', 400, { data: { results } })
-      }
-
-      return { results }
+    const action = () => {
+      return this.#backupRepositoryService.reclaimSpace(backupRepositoryId, vmUuid)
     }
 
     return this.createAction<ReclaimSpaceResult>(action, {

--- a/@xen-orchestra/rest-api/src/backup-repositories/backup-repositories.controller.mts
+++ b/@xen-orchestra/rest-api/src/backup-repositories/backup-repositories.controller.mts
@@ -45,12 +45,22 @@ import {
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
+import { RemoteAdapter } from '@xen-orchestra/backups/RemoteAdapter.mjs'
+import { BACKUP_DIR } from '@xen-orchestra/backups/_getVmBackupDir.mjs'
+import { getSyncedHandler } from '@xen-orchestra/fs'
+import { Disposable } from 'promise-toolbox'
+import { Task } from '@vates/task'
+import { asyncMap } from '@xen-orchestra/async-map'
 import { BackupRepositoryService } from './backup-repository.service.mjs'
 import { CreateActionReturnType } from '../abstract-classes/base-controller.mjs'
 import { taskLocation } from '../open-api/oa-examples/task.oa-example.mjs'
 import { ApiError } from '../helpers/error.helper.mjs'
 
 type BenchmarkRepositoryResult = Awaited<ReturnType<XoApp['testRemote']>>
+
+interface ReclaimSpaceResult {
+  results: Array<{ vmUuid: string; success: boolean; error?: string }>
+}
 
 @Route('backup-repositories')
 @Security('*')
@@ -310,6 +320,89 @@ export class BackupRepositoryController extends XoController<XoBackupRepository>
       statusCode: 200,
       taskProperties: {
         name: 'benchmark backup repository',
+        objectId: backupRepositoryId,
+      },
+    })
+  }
+
+  /**
+   *
+   *
+   * Required privilege:
+   * - resource: backup-repository, action: reclaim-space
+   *
+   * @example id "c4284e12-37c9-7967-b9e8-83ef229c3e03"
+   */
+  @Example('')
+  @Extension('x-mcp-exposure', 'confirm')
+  @Post('{id}/reclaim-space')
+  @Middlewares([
+    json(),
+    acl({
+      resource: 'backup-repository',
+      action: 'reclaim-space',
+      objectId: 'params.id',
+      getObject: ({ restApi }) => restApi.xoApp.getRemote,
+    }),
+  ])
+  @SuccessResponse(200, 'OK')
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
+  @Response(internalServerErrorResp.status, internalServerErrorResp.description)
+  reclaimSpaceBackupRepository(@Path() id: string, @Body() body: { vmuuid?: string }, @Query() sync?: boolean) {
+    const backupRepositoryId = id as XoBackupRepository['id']
+    const vmUuid = body?.vmuuid
+
+    const action = async () => {
+      const remote = await this.restApi.xoApp.getRemote(backupRepositoryId)
+      // const remoteOptions = this.restApi.xoApp.config.get('remoteOptions') as unknown as RemoteHandlerOptions// explain why using as, it was retunring a string
+
+      let results: ReclaimSpaceResult['results']
+      try {
+        results = await Disposable.use(getSyncedHandler(remote), async handler => {
+          const adapter = new RemoteAdapter(handler)
+          const vmUuids = vmUuid !== undefined ? [vmUuid] : await adapter.listAllVms()
+
+          Task.set('total', vmUuids.length)
+          let done = 0
+
+          return asyncMap(vmUuids, async uuid => {
+            //use asyncEach instead concurrency = 2
+            try {
+              await Task.run({ name: `Clean VM ${uuid}`, data: { type: 'VM', id: uuid } }, () =>
+                adapter.cleanVm(`${BACKUP_DIR}/${uuid}`, {
+                  remove: true,
+                  merge: true,
+                  logInfo: Task.info,
+                  logWarn: Task.warning,
+                })
+              )
+              return { vmUuid: uuid, success: true }
+            } catch (error: any) {
+              Task.warning(`failed to reclaim space for VM ${uuid}`, { error })
+              return { vmUuid: uuid, success: false, error: error.message }
+            } finally {
+              done++
+              Task.set('progress', Math.round((done / vmUuids.length) * 100))
+            }
+          })
+        })
+      } catch (error) {
+        throw new ApiError('Backup repository unreachable', 502)
+      }
+
+      const failures = results.filter(r => !r.success)
+      if (failures.length === results.length && results.length > 0) {
+        throw new ApiError('Reclaim space failed for all VMs', 400, { data: { results } })
+      }
+
+      return { results }
+    }
+
+    return this.createAction<ReclaimSpaceResult>(action, {
+      sync,
+      statusCode: 200,
+      taskProperties: {
+        name: vmUuid !== undefined ? `reclaim space (VM ${vmUuid})` : 'reclaim space',
         objectId: backupRepositoryId,
       },
     })

--- a/@xen-orchestra/rest-api/src/backup-repositories/backup-repositories.controller.mts
+++ b/@xen-orchestra/rest-api/src/backup-repositories/backup-repositories.controller.mts
@@ -329,7 +329,7 @@ export class BackupRepositoryController extends XoController<XoBackupRepository>
   @Example(taskLocation)
   @Example(backupRepositoryReclaimSpaceResults)
   @Extension('x-mcp-exposure', 'confirm')
-  @Post('{id}/reclaim-space')
+  @Post('{id}/actions/reclaim-space')
   @Middlewares([
     json(),
     acl({

--- a/@xen-orchestra/rest-api/src/backup-repositories/backup-repositories.controller.mts
+++ b/@xen-orchestra/rest-api/src/backup-repositories/backup-repositories.controller.mts
@@ -324,7 +324,7 @@ export class BackupRepositoryController extends XoController<XoBackupRepository>
    * - resource: backup-repository, action: reclaim-space
    *
    * @example id "c4284e12-37c9-7967-b9e8-83ef229c3e03"
-   * @example body  {"vmuuid": "9d0d04f7-bb1f-8292-3294-17c6371827c5"}
+   * @example body  {"vmuuid": "9d0d04f7-bb1f-8292-3294-17c6371827c5", "merge": true, "remove": true}
    */
   @Example(taskLocation)
   @Example(backupRepositoryReclaimSpaceResults)
@@ -347,14 +347,14 @@ export class BackupRepositoryController extends XoController<XoBackupRepository>
   @Response(502, 'Backup repository unreachable')
   reclaimSpaceBackupRepository(
     @Path() id: string,
-    @Body() body?: { vmuuid?: string },
+    @Body() body?: { vmuuid?: string; merge?: boolean; remove?: boolean },
     @Query() sync?: boolean
   ): CreateActionReturnType<ReclaimSpaceResult[]> {
     const backupRepositoryId = id as XoBackupRepository['id']
     const vmUuid = body?.vmuuid
 
     const action = () => {
-      return this.#backupRepositoryService.reclaimSpace(backupRepositoryId, vmUuid)
+      return this.#backupRepositoryService.reclaimSpace(backupRepositoryId, vmUuid, body?.merge, body?.remove)
     }
 
     return this.createAction<ReclaimSpaceResult[]>(action, {

--- a/@xen-orchestra/rest-api/src/backup-repositories/backup-repositories.controller.mts
+++ b/@xen-orchestra/rest-api/src/backup-repositories/backup-repositories.controller.mts
@@ -41,6 +41,7 @@ import {
   backupRepositoryId,
   backupRepositoryBenchmark,
   backupRepositoryHeath,
+  backupRepositoryReclaimSpaceResults,
 } from '../open-api/oa-examples/backup-repository.oa-example.mjs'
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XoController } from '../abstract-classes/xo-controller.mjs'
@@ -317,14 +318,16 @@ export class BackupRepositoryController extends XoController<XoBackupRepository>
   }
 
   /**
-   *
+   * Reclaim space from disk when a backup doesnt have its metadata
    *
    * Required privilege:
    * - resource: backup-repository, action: reclaim-space
    *
    * @example id "c4284e12-37c9-7967-b9e8-83ef229c3e03"
+   * @example body  {"vmuuid": "9d0d04f7-bb1f-8292-3294-17c6371827c5"}
    */
-  @Example('')
+  @Example(taskLocation)
+  @Example(backupRepositoryReclaimSpaceResults)
   @Extension('x-mcp-exposure', 'confirm')
   @Post('{id}/reclaim-space')
   @Middlewares([
@@ -338,9 +341,15 @@ export class BackupRepositoryController extends XoController<XoBackupRepository>
   ])
   @SuccessResponse(asynchronousActionResp.status, asynchronousActionResp.description)
   @Response(200, 'OK')
+  @Response(badRequestResp.status, 'Reclaim space failed')
   @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
   @Response(internalServerErrorResp.status, internalServerErrorResp.description)
-  reclaimSpaceBackupRepository(@Path() id: string, @Body() body?: { vmuuid?: string }, @Query() sync?: boolean) {
+  @Response(502, 'Backup repository unreachable')
+  reclaimSpaceBackupRepository(
+    @Path() id: string,
+    @Body() body?: { vmuuid?: string },
+    @Query() sync?: boolean
+  ): CreateActionReturnType<ReclaimSpaceResult[]> {
     const backupRepositoryId = id as XoBackupRepository['id']
     const vmUuid = body?.vmuuid
 
@@ -348,7 +357,7 @@ export class BackupRepositoryController extends XoController<XoBackupRepository>
       return this.#backupRepositoryService.reclaimSpace(backupRepositoryId, vmUuid)
     }
 
-    return this.createAction<ReclaimSpaceResult>(action, {
+    return this.createAction<ReclaimSpaceResult[]>(action, {
       sync,
       statusCode: 200,
       taskProperties: {

--- a/@xen-orchestra/rest-api/src/backup-repositories/backup-repository.service.mts
+++ b/@xen-orchestra/rest-api/src/backup-repositories/backup-repository.service.mts
@@ -1,6 +1,7 @@
 import type { AnyXoBackupJob, XoBackupRepository, AnyXoJob, XoVm } from '@vates/types'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { inject } from 'inversify'
+import { ApiError } from '../helpers/error.helper.mjs'
 
 export interface ReclaimSpaceResult {
   vmUuid: string
@@ -57,11 +58,21 @@ export class BackupRepositoryService {
     mergeParam?: boolean,
     remove?: boolean
   ) {
-    const vmuuid = vmUuid as XoVm['id']
-    return await this.#restApi.xoApp.reclaimSpace(backupRepositoryId, {
-      vmUuid: vmuuid,
-      merge: mergeParam,
-      remove: remove,
-    })
+    try {
+      const vmuuid = vmUuid as XoVm['id']
+      return await this.#restApi.xoApp.reclaimSpace(backupRepositoryId, {
+        vmUuid: vmuuid,
+        merge: mergeParam,
+        remove: remove,
+      })
+    } catch (error: any) {
+      // mixin throws incorrectState (xo-common api-error) when a referencing
+      // job is running — surface that as a 409, everything else as 502
+      console.log(error?.message)
+      if (error?.code === 25 || error?.message === 'incorrect state') {
+        throw new ApiError('cannot reclaim space while a backup job is running', 409)
+      }
+      throw new ApiError('Backup repository unreachable', 502, { data: { cause: String(error) } })
+    }
   }
 }

--- a/@xen-orchestra/rest-api/src/backup-repositories/backup-repository.service.mts
+++ b/@xen-orchestra/rest-api/src/backup-repositories/backup-repository.service.mts
@@ -58,7 +58,12 @@ export class BackupRepositoryService {
     return referencingJobs
   }
 
-  async reclaimSpace(backupRepositoryId: XoBackupRepository['id'], vmUuid?: string) {
+  async reclaimSpace(
+    backupRepositoryId: XoBackupRepository['id'],
+    vmUuid?: string,
+    mergeParam?: boolean,
+    remove?: boolean
+  ) {
     const referencingJobs = await this.getReferencingJobs(backupRepositoryId)
     const jobs = await this.#restApi.xoApp.getAllJobs()
     const runningJobs = jobs.filter(
@@ -71,6 +76,7 @@ export class BackupRepositoryService {
     const remote = await this.#restApi.xoApp.getRemote(backupRepositoryId)
 
     let results: ReclaimSpaceResult[]
+
     try {
       results = await Disposable.use(getSyncedHandler(remote), async handler => {
         const adapter = new RemoteAdapter(handler)
@@ -85,11 +91,11 @@ export class BackupRepositoryService {
           vmUuids,
           async uuid => {
             try {
-              await Task.run({ name: `Clean VM ${uuid}`, data: { type: 'VM', id: uuid } }, () =>
+              const { merge, size } = await Task.run({ name: `Clean VM ${uuid}`, data: { type: 'VM', id: uuid } }, () =>
                 adapter.cleanVm(`${BACKUP_DIR}/${uuid}`, {
                   lock: true,
-                  remove: true,
-                  merge: true,
+                  remove: remove ?? true,
+                  merge: mergeParam ?? true,
                   logInfo: Task.info,
                   logWarn: Task.warning,
                 })
@@ -98,6 +104,8 @@ export class BackupRepositoryService {
               results.push({
                 vmUuid: uuid,
                 success: true,
+                merge: merge,
+                size: size,
               })
             } catch (error: any) {
               throw new ApiError(`failed to reclaim space for VM ${uuid}, error: ${error.message}`, 400)

--- a/@xen-orchestra/rest-api/src/backup-repositories/backup-repository.service.mts
+++ b/@xen-orchestra/rest-api/src/backup-repositories/backup-repository.service.mts
@@ -1,14 +1,6 @@
-import type { AnyXoBackupJob, XoBackupRepository, AnyXoJob } from '@vates/types'
+import type { AnyXoBackupJob, XoBackupRepository, AnyXoJob, XoVm } from '@vates/types'
 import { RestApi } from '../rest-api/rest-api.mjs'
-import { provide } from 'inversify-binding-decorators'
 import { inject } from 'inversify'
-import { RemoteAdapter } from '@xen-orchestra/backups/RemoteAdapter.mjs'
-import { BACKUP_DIR } from '@xen-orchestra/backups/_getVmBackupDir.mjs'
-import { getSyncedHandler, HandlerDisposable } from '@xen-orchestra/fs'
-import { Disposable } from 'promise-toolbox'
-import { Task } from '@vates/task'
-import { asyncEach } from '@vates/async-each'
-import { ApiError } from '../helpers/error.helper.mjs'
 
 export interface ReclaimSpaceResult {
   vmUuid: string
@@ -65,76 +57,11 @@ export class BackupRepositoryService {
     mergeParam?: boolean,
     remove?: boolean
   ) {
-    const referencingJobs = await this.getReferencingJobs(backupRepositoryId)
-    const jobs = await this.#restApi.xoApp.getAllJobs()
-    const runningJobs = jobs.filter(
-      job => (job as JobWithRunId).runId !== undefined && referencingJobs.includes(job.id)
-    )
-
-    if (Object.keys(runningJobs).length > 0) {
-      throw new ApiError('cannot reclaim space while a backup job is running', 409)
-    }
-    const remote = await this.#restApi.xoApp.getRemote(backupRepositoryId)
-
-    let handler: HandlerDisposable
-    try {
-      handler = await getSyncedHandler(remote)
-    } catch (error) {
-      throw new ApiError('Backup repository unreachable', 502, { data: { cause: String(error) } })
-    }
-
-    const results = await Disposable.use(handler, async handler => {
-      const adapter = new RemoteAdapter(handler)
-      const vmUuids: string[] = vmUuid !== undefined ? [vmUuid] : await adapter.listAllVms()
-      Task.set('total', vmUuids.length)
-      let done = 0
-
-      const results: ReclaimSpaceResult[] = []
-      await asyncEach(
-        vmUuids,
-        async uuid => {
-          try {
-            const { merge, size } = await Task.run(
-              {
-                properties: { name: `Clean VM ${uuid}`, data: { type: 'VM', id: uuid } },
-              },
-              async () =>
-                await adapter.cleanVm(`${BACKUP_DIR}/${uuid}`, {
-                  lock: true,
-                  remove: remove ?? true,
-                  merge: mergeParam ?? true,
-                  logInfo: Task.info,
-                  logWarn: Task.warning,
-                })
-            )
-
-            results.push({
-              vmUuid: uuid,
-              success: true,
-              merge: merge,
-              size: size,
-            })
-          } catch (error: any) {
-            results.push({
-              vmUuid: uuid,
-              success: false,
-              error: error instanceof Error ? error.message : String(error),
-            })
-          } finally {
-            done++
-            Task.set('progress', Math.round((done / vmUuids.length) * 100))
-          }
-        },
-        { concurrency: 2, stopOnError: false }
-      )
-      return results
+    const vmuuid = vmUuid as XoVm['id']
+    return await this.#restApi.xoApp.reclaimSpace(backupRepositoryId, {
+      vmUuid: vmuuid,
+      merge: mergeParam,
+      remove: remove,
     })
-
-    const failures = results.filter(r => !r.success)
-    if (failures.length === results.length && results.length > 0) {
-      throw new ApiError('Reclaim space failed for all VMs', 400, { data: { results } })
-    }
-
-    return results
   }
 }

--- a/@xen-orchestra/rest-api/src/backup-repositories/backup-repository.service.mts
+++ b/@xen-orchestra/rest-api/src/backup-repositories/backup-repository.service.mts
@@ -59,8 +59,12 @@ export class BackupRepositoryService {
   }
 
   async reclaimSpace(backupRepositoryId: XoBackupRepository['id'], vmUuid?: string) {
+    const referencingJobs = await this.getReferencingJobs(backupRepositoryId)
     const jobs = await this.#restApi.xoApp.getAllJobs()
-    const runningJobs = jobs.filter(job => (job as JobWithRunId).runId !== undefined)
+    const runningJobs = jobs.filter(
+      job => (job as JobWithRunId).runId !== undefined && referencingJobs.includes(job.id)
+    )
+
     if (Object.keys(runningJobs).length > 0) {
       throw new ApiError('cannot reclaim space while a backup job is running', 409)
     }

--- a/@xen-orchestra/rest-api/src/backup-repositories/backup-repository.service.mts
+++ b/@xen-orchestra/rest-api/src/backup-repositories/backup-repository.service.mts
@@ -11,7 +11,9 @@ import { asyncEach } from '@vates/async-each'
 import { ApiError } from '../helpers/error.helper.mjs'
 
 export interface ReclaimSpaceResult {
-  results: Array<{ vmUuid: string; success: boolean; error?: string }>
+  vmUuid: string
+  success: boolean
+  error?: string
 }
 
 export class BackupRepositoryService {
@@ -54,7 +56,7 @@ export class BackupRepositoryService {
   async reclaimSpace(backupRepositoryId: XoBackupRepository['id'], vmUuid?: string) {
     const remote = await this.#restApi.xoApp.getRemote(backupRepositoryId)
 
-    let results: ReclaimSpaceResult['results']
+    let results: ReclaimSpaceResult[]
     try {
       results = await Disposable.use(getSyncedHandler(remote), async handler => {
         const adapter = new RemoteAdapter(handler)
@@ -63,7 +65,7 @@ export class BackupRepositoryService {
         Task.set('total', vmUuids.length)
         let done = 0
 
-        const results: ReclaimSpaceResult['results'] = []
+        const results: ReclaimSpaceResult[] = []
 
         await asyncEach(
           vmUuids,
@@ -103,6 +105,6 @@ export class BackupRepositoryService {
       throw new ApiError('Reclaim space failed for all VMs', 400, { data: { results } })
     }
 
-    return { results }
+    return results
   }
 }

--- a/@xen-orchestra/rest-api/src/backup-repositories/backup-repository.service.mts
+++ b/@xen-orchestra/rest-api/src/backup-repositories/backup-repository.service.mts
@@ -1,4 +1,4 @@
-import type { AnyXoBackupJob, XoBackupRepository } from '@vates/types'
+import type { AnyXoBackupJob, XoBackupRepository, AnyXoJob } from '@vates/types'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { provide } from 'inversify-binding-decorators'
 import { inject } from 'inversify'
@@ -13,7 +13,12 @@ import { ApiError } from '../helpers/error.helper.mjs'
 export interface ReclaimSpaceResult {
   vmUuid: string
   success: boolean
+  merge?: boolean
+  size?: number
   error?: string
+}
+type JobWithRunId = AnyXoJob & {
+  runId?: string
 }
 
 export class BackupRepositoryService {
@@ -54,6 +59,11 @@ export class BackupRepositoryService {
   }
 
   async reclaimSpace(backupRepositoryId: XoBackupRepository['id'], vmUuid?: string) {
+    const jobs = await this.#restApi.xoApp.getAllJobs()
+    const runningJobs = jobs.filter(job => (job as JobWithRunId).runId !== undefined)
+    if (Object.keys(runningJobs).length > 0) {
+      throw new ApiError('cannot reclaim space while a backup job is running', 409)
+    }
     const remote = await this.#restApi.xoApp.getRemote(backupRepositoryId)
 
     let results: ReclaimSpaceResult[]

--- a/@xen-orchestra/rest-api/src/backup-repositories/backup-repository.service.mts
+++ b/@xen-orchestra/rest-api/src/backup-repositories/backup-repository.service.mts
@@ -4,7 +4,7 @@ import { provide } from 'inversify-binding-decorators'
 import { inject } from 'inversify'
 import { RemoteAdapter } from '@xen-orchestra/backups/RemoteAdapter.mjs'
 import { BACKUP_DIR } from '@xen-orchestra/backups/_getVmBackupDir.mjs'
-import { getSyncedHandler } from '@xen-orchestra/fs'
+import { getSyncedHandler, HandlerDisposable } from '@xen-orchestra/fs'
 import { Disposable } from 'promise-toolbox'
 import { Task } from '@vates/task'
 import { asyncEach } from '@vates/async-each'
@@ -75,52 +75,59 @@ export class BackupRepositoryService {
     }
     const remote = await this.#restApi.xoApp.getRemote(backupRepositoryId)
 
-    let results: ReclaimSpaceResult[]
-
+    let handler: HandlerDisposable
     try {
-      results = await Disposable.use(getSyncedHandler(remote), async handler => {
-        const adapter = new RemoteAdapter(handler)
-        const vmUuids: string[] = vmUuid !== undefined ? [vmUuid] : await adapter.listAllVms()
+      handler = await getSyncedHandler(remote)
+    } catch (error) {
+      throw new ApiError('Backup repository unreachable', 502, { data: { cause: String(error) } })
+    }
 
-        Task.set('total', vmUuids.length)
-        let done = 0
+    const results = await Disposable.use(handler, async handler => {
+      const adapter = new RemoteAdapter(handler)
+      const vmUuids: string[] = vmUuid !== undefined ? [vmUuid] : await adapter.listAllVms()
+      Task.set('total', vmUuids.length)
+      let done = 0
 
-        const results: ReclaimSpaceResult[] = []
-
-        await asyncEach(
-          vmUuids,
-          async uuid => {
-            try {
-              const { merge, size } = await Task.run({ name: `Clean VM ${uuid}`, data: { type: 'VM', id: uuid } }, () =>
-                adapter.cleanVm(`${BACKUP_DIR}/${uuid}`, {
+      const results: ReclaimSpaceResult[] = []
+      await asyncEach(
+        vmUuids,
+        async uuid => {
+          try {
+            const { merge, size } = await Task.run(
+              {
+                properties: { name: `Clean VM ${uuid}`, data: { type: 'VM', id: uuid } },
+              },
+              async () =>
+                await adapter.cleanVm(`${BACKUP_DIR}/${uuid}`, {
                   lock: true,
                   remove: remove ?? true,
                   merge: mergeParam ?? true,
                   logInfo: Task.info,
                   logWarn: Task.warning,
                 })
-              )
+            )
 
-              results.push({
-                vmUuid: uuid,
-                success: true,
-                merge: merge,
-                size: size,
-              })
-            } catch (error: any) {
-              throw new ApiError(`failed to reclaim space for VM ${uuid}, error: ${error.message}`, 400)
-            } finally {
-              done++
-              Task.set('progress', Math.round((done / vmUuids.length) * 100))
-            }
-          },
-          { concurrency: 2 }
-        )
-        return results
-      })
-    } catch (error) {
-      throw new ApiError(`${error}`, 502)
-    }
+            results.push({
+              vmUuid: uuid,
+              success: true,
+              merge: merge,
+              size: size,
+            })
+          } catch (error: any) {
+            results.push({
+              vmUuid: uuid,
+              success: false,
+              error: error.message,
+            })
+          } finally {
+            done++
+            Task.set('progress', Math.round((done / vmUuids.length) * 100))
+          }
+        },
+        { concurrency: 2, stopOnError: false }
+      )
+      return results
+    })
 
     const failures = results.filter(r => !r.success)
     if (failures.length === results.length && results.length > 0) {

--- a/@xen-orchestra/rest-api/src/backup-repositories/backup-repository.service.mts
+++ b/@xen-orchestra/rest-api/src/backup-repositories/backup-repository.service.mts
@@ -43,6 +43,7 @@ export class BackupRepositoryService {
     const allJobs = await this.#restApi.xoApp.getAllJobs()
     const referencingJobs: AnyXoBackupJob['id'][] = []
 
+    // checks if a backup job related to this backup repository is running
     for (const job of allJobs) {
       if (job.type === 'backup' || job.type === 'metadataBackup') {
         if (this.isBackupRepositoryReferenced(job.remotes, repositoryId)) {
@@ -117,7 +118,7 @@ export class BackupRepositoryService {
             results.push({
               vmUuid: uuid,
               success: false,
-              error: error.message,
+              error: error instanceof Error ? error.message : String(error),
             })
           } finally {
             done++

--- a/@xen-orchestra/rest-api/src/backup-repositories/backup-repository.service.mts
+++ b/@xen-orchestra/rest-api/src/backup-repositories/backup-repository.service.mts
@@ -2,6 +2,17 @@ import type { AnyXoBackupJob, XoBackupRepository } from '@vates/types'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { provide } from 'inversify-binding-decorators'
 import { inject } from 'inversify'
+import { RemoteAdapter } from '@xen-orchestra/backups/RemoteAdapter.mjs'
+import { BACKUP_DIR } from '@xen-orchestra/backups/_getVmBackupDir.mjs'
+import { getSyncedHandler } from '@xen-orchestra/fs'
+import { Disposable } from 'promise-toolbox'
+import { Task } from '@vates/task'
+import { asyncEach } from '@vates/async-each'
+import { ApiError } from '../helpers/error.helper.mjs'
+
+export interface ReclaimSpaceResult {
+  results: Array<{ vmUuid: string; success: boolean; error?: string }>
+}
 
 export class BackupRepositoryService {
   #restApi: RestApi
@@ -38,5 +49,60 @@ export class BackupRepositoryService {
     }
 
     return referencingJobs
+  }
+
+  async reclaimSpace(backupRepositoryId: XoBackupRepository['id'], vmUuid?: string) {
+    const remote = await this.#restApi.xoApp.getRemote(backupRepositoryId)
+
+    let results: ReclaimSpaceResult['results']
+    try {
+      results = await Disposable.use(getSyncedHandler(remote), async handler => {
+        const adapter = new RemoteAdapter(handler)
+        const vmUuids: string[] = vmUuid !== undefined ? [vmUuid] : await adapter.listAllVms()
+
+        Task.set('total', vmUuids.length)
+        let done = 0
+
+        const results: ReclaimSpaceResult['results'] = []
+
+        await asyncEach(
+          vmUuids,
+          async uuid => {
+            try {
+              await Task.run({ name: `Clean VM ${uuid}`, data: { type: 'VM', id: uuid } }, () =>
+                adapter.cleanVm(`${BACKUP_DIR}/${uuid}`, {
+                  lock: true,
+                  remove: true,
+                  merge: true,
+                  logInfo: Task.info,
+                  logWarn: Task.warning,
+                })
+              )
+
+              results.push({
+                vmUuid: uuid,
+                success: true,
+              })
+            } catch (error: any) {
+              throw new ApiError(`failed to reclaim space for VM ${uuid}, error: ${error.message}`, 400)
+            } finally {
+              done++
+              Task.set('progress', Math.round((done / vmUuids.length) * 100))
+            }
+          },
+          { concurrency: 2 }
+        )
+        return results
+      })
+    } catch (error) {
+      throw new ApiError(`${error}`, 502)
+    }
+
+    const failures = results.filter(r => !r.success)
+    if (failures.length === results.length && results.length > 0) {
+      throw new ApiError('Reclaim space failed for all VMs', 400, { data: { results } })
+    }
+
+    return { results }
   }
 }

--- a/@xen-orchestra/rest-api/src/declarations.d.ts
+++ b/@xen-orchestra/rest-api/src/declarations.d.ts
@@ -1,0 +1,13 @@
+declare module '@xen-orchestra/fs' {
+  export interface RemoteHandler {
+    list(dir: string, opts?: { prependDir?: boolean }): Promise<string[]>
+    [key: string]: unknown
+  }
+
+  export interface HandlerDisposable {
+    value: RemoteHandler
+    dispose: () => Promise<void>
+  }
+
+  export function getSyncedHandler(remote: { url: string }): Promise<HandlerDisposable>
+}

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/backup-repository.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/backup-repository.oa-example.mts
@@ -1,3 +1,5 @@
+import { merge } from 'lodash'
+
 export const backupRepositoryIds = [
   '/rest/v0/backup-repositories/7497c970-6780-4462-a452-fcb8a406ee64',
   '/rest/v0/backup-repositories/f681cef1-617e-4650-ac31-ffdaead076bf',
@@ -46,5 +48,7 @@ export const backupRepositoryReclaimSpaceResults = [
   {
     vmUuid: '9d0d04f7-bb1f-8292-3294-17c6371827x5',
     success: true,
+    merge: true,
+    size: 0,
   },
 ]

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/backup-repository.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/backup-repository.oa-example.mts
@@ -1,5 +1,3 @@
-import { success } from 'zod'
-
 export const backupRepositoryIds = [
   '/rest/v0/backup-repositories/7497c970-6780-4462-a452-fcb8a406ee64',
   '/rest/v0/backup-repositories/f681cef1-617e-4650-ac31-ffdaead076bf',

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/backup-repository.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/backup-repository.oa-example.mts
@@ -1,3 +1,5 @@
+import { success } from 'zod'
+
 export const backupRepositoryIds = [
   '/rest/v0/backup-repositories/7497c970-6780-4462-a452-fcb8a406ee64',
   '/rest/v0/backup-repositories/f681cef1-617e-4650-ac31-ffdaead076bf',
@@ -41,3 +43,10 @@ export const backupRepositoryBenchmark = {
   readRate: 7999965,
   writeRate: 7767798,
 }
+
+export const backupRepositoryReclaimSpaceResults = [
+  {
+    vmUuid: '9d0d04f7-bb1f-8292-3294-17c6371827x5',
+    success: true,
+  },
+]

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -51,7 +51,7 @@
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/vmware-explorer minor
 - @xen-orchestra/web minor
-- xo-server patch
+- xo-server minor
 - xo-server-load-balancer patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@
 - [XO6/Host] Add possibility to shut down and start an host (PR [#10088](https://github.com/vatesfr/xen-orchestra/pull/10088))
 - [REST API] Add `hosts/:id/actions/scan_pifs` endpoint (PR [#10187](https://github.com/vatesfr/xen-orchestra/pull/10187))
 - [XO6/Host] Add possibility to scan PIFs directly from the host (PR [#10191](https://github.com/vatesfr/xen-orchestra/pull/10191))
-- [REST API] Add an endpoint to reclaim space per vm or backup repository: -`POST /rest/V0/backup-repositories/:id/actions/reclaim-space` (PR [#10262](https://github.com/vatesfr/xen-orchestra/pull/10262))
+- [REST API] Add an endpoint to reclaim space per vm or backup repository: `POST /rest/V0/backup-repositories/:id/actions/reclaim-space` (PR [#10262](https://github.com/vatesfr/xen-orchestra/pull/10262))
 
 ### Bug fixes
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@
 - [XO6/Host] Add possibility to shut down and start an host (PR [#10088](https://github.com/vatesfr/xen-orchestra/pull/10088))
 - [REST API] Add `hosts/:id/actions/scan_pifs` endpoint (PR [#10187](https://github.com/vatesfr/xen-orchestra/pull/10187))
 - [XO6/Host] Add possibility to scan PIFs directly from the host (PR [#10191](https://github.com/vatesfr/xen-orchestra/pull/10191))
+- [REST API] Add an endpoint to reclaim space per vm or backup repository: -`POST /rest/V0/backup-repositories/:id/actions/reclaim-space` (PR [#10262](https://github.com/vatesfr/xen-orchestra/pull/10262))
 
 ### Bug fixes
 

--- a/docs/docs/xo6/acl-v2.md
+++ b/docs/docs/xo6/acl-v2.md
@@ -134,19 +134,20 @@ Actions are written using the exact string you pass in a privilege. A parent act
 
 ### XO management resources
 
-| Resource            | Available actions                                                                                                        |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `backup-job`        | `read`                                                                                                                   |
-| `backup-archive`    | `read`                                                                                                                   |
-| `backup-log`        | `read`                                                                                                                   |
-| `backup-repository` | `benchmark`, `create`, `read`, `forget`, `update:enabled`, `update:name`, `update:options`, `update:proxy`, `update:url` |
-| `schedule`          | `read`, `run`                                                                                                            |
-| `restore-log`       | `read`                                                                                                                   |
-| `proxy`             | `read`                                                                                                                   |
-| `server`            | `read`, `create`, `delete`, `connect`, `disconnect`                                                                      |
-| `task`              | `read`, `abort`, `delete`                                                                                                |
-| `alarm`             | `read`                                                                                                                   |
-| `message`           | `read`                                                                                                                   |
+| Resource            | Available actions                                                                                                         |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `backup-job`        | `read`                                                                                                                    |
+| `backup-archive`    | `read`                                                                                                                    |
+| `backup-log`        | `read`                                                                                                                    |
+| `backup-repository` | `benchmark`, `create`, `read`, `forget`, `update:enabled`, `update:name`, `update:options`, `update:proxy`, `update:url`, |
+|                     | `reclaim-space`,                                                                                                          |
+| `schedule`          | `read`, `run`                                                                                                             |
+| `restore-log`       | `read`                                                                                                                    |
+| `proxy`             | `read`                                                                                                                    |
+| `server`            | `read`, `create`, `delete`, `connect`, `disconnect`                                                                       |
+| `task`              | `read`, `abort`, `delete`                                                                                                 |
+| `alarm`             | `read`                                                                                                                    |
+| `message`           | `read`                                                                                                                    |
 
 ### User management resources
 

--- a/packages/xo-server/src/xo-mixins/remotes.mjs
+++ b/packages/xo-server/src/xo-mixins/remotes.mjs
@@ -222,6 +222,7 @@ export default class {
     return ids.includes(remoteId)
   }
 
+  // The caller of this function have to create a parent Task
   async reclaimSpace(remoteId, { vmUuid, merge = true, remove = true } = {}) {
     if (await this.#isReferencedByRunningJob(remoteId)) {
       throw incorrectState({ actual: 'running', expected: 'idle', object: 'backup job referencing this remote' })

--- a/packages/xo-server/src/xo-mixins/remotes.mjs
+++ b/packages/xo-server/src/xo-mixins/remotes.mjs
@@ -4,12 +4,15 @@ import { createLogger } from '@xen-orchestra/log'
 import { format, parse } from 'xo-remote-parser'
 import { DEFAULT_ENCRYPTION_ALGORITHM, getHandler, isLegacyEncryptionAlgorithm } from '@xen-orchestra/fs'
 import { ignoreErrors, timeout, TimeoutError } from 'promise-toolbox'
-import { invalidParameters, noSuchObject } from 'xo-common/api-errors.js'
+import { invalidParameters, noSuchObject, incorrectState } from 'xo-common/api-errors.js'
 import { synchronized } from 'decorator-synchronized'
-
 import patch from '../patch.mjs'
 import { Remotes } from '../models/remote.mjs'
 import Disposable from 'promise-toolbox/Disposable'
+import { RemoteAdapter } from '@xen-orchestra/backups/RemoteAdapter.mjs'
+import { BACKUP_DIR } from '@xen-orchestra/backups/_getVmBackupDir.mjs'
+import { Task } from '@vates/task'
+import { asyncEach } from '@vates/async-each'
 
 // ===================================================================
 
@@ -191,6 +194,83 @@ export default class {
     }
 
     return result
+  }
+
+  // checks if a job referencing this remote is currently running
+  async #isReferencedByRunningJob(remoteId) {
+    const jobs = await this._app.getAllJobs()
+    return jobs.some(job => {
+      if (job.runId === undefined) {
+        return false
+      }
+      if (job.type === 'backup' || job.type === 'metadataBackup') {
+        return this.#isRemoteReferenced(job.remotes, remoteId)
+      }
+      if (job.type === 'mirrorBackup') {
+        return job.sourceRemote === remoteId || this.#isRemoteReferenced(job.remotes, remoteId)
+      }
+      return false
+    })
+  }
+
+  #isRemoteReferenced(idsToCheck, remoteId) {
+    if (idsToCheck === undefined) {
+      return false
+    }
+    const { id } = idsToCheck
+    const ids = typeof id === 'string' ? [id] : id.__or
+    return ids.includes(remoteId)
+  }
+
+  async reclaimSpace(remoteId, { vmUuid, merge = true, remove = true } = {}) {
+    if (await this.#isReferencedByRunningJob(remoteId)) {
+      throw incorrectState({ actual: 'running', expected: 'idle', object: 'backup job referencing this remote' })
+    }
+
+    // validates enabled + S3 feature auth, and gives real (unobfuscated) credentials
+    await this.getRemoteWithCredentials(remoteId)
+
+    // throws if remote.proxy is set — merge must run in this (main) process,
+    // which isn't possible for a proxied remote
+    const handler = await this.getRemoteHandler(remoteId)
+    const adapter = new RemoteAdapter(handler)
+
+    const vmUuids = vmUuid !== undefined ? [vmUuid] : await adapter.listAllVms()
+    Task.set('total', vmUuids.length)
+    let done = 0
+
+    const results = []
+    await asyncEach(
+      vmUuids,
+      async uuid => {
+        try {
+          const { merge: didMerge, size } = await Task.run(
+            { properties: { name: `Clean VM ${uuid}`, data: { type: 'VM', id: uuid } } },
+            () =>
+              adapter.cleanVm(`${BACKUP_DIR}/${uuid}`, {
+                remove,
+                merge,
+                logInfo: Task.info,
+                logWarn: Task.warning,
+              })
+          )
+          results.push({ vmUuid: uuid, success: true, merge: didMerge, size })
+        } catch (error) {
+          results.push({ vmUuid: uuid, success: false, error: error instanceof Error ? error.message : String(error) })
+        } finally {
+          done++
+          Task.set('progress', Math.round((done / vmUuids.length) * 100))
+        }
+      },
+      { concurrency: 2, stopOnError: false }
+    )
+
+    const failures = results.filter(r => !r.success)
+    if (failures.length === results.length && results.length > 0) {
+      throw new Error('reclaim space failed for all VMs')
+    }
+
+    return results
   }
 
   async getAllRemotesInfo() {


### PR DESCRIPTION
### Description

Sometimes some delta backups are deleted on UI, but the disk space is not freed on the backup repository. This problem is caused by the deletion of only vms backups metadata and their cache, but the vhd are still not deleted.
The user can now call this endpoint throught the REST-API to reclaim the space per vms or backup repository, the function checks if the vhds still have their metadata, if not the vhd is deleted.
[XO-2818]

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
