### PR TITLE
fix(xo-server): enhance CSP handling for Netdata

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,9 @@
 
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
+- **XO 5**:
+  - [Netdata] Fix `You must enable Javascript` error due to CSP blocking Netdata's inline scripts (PR [#10275](https://github.com/vatesfr/xen-orchestra/pull/10275))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -30,5 +33,7 @@
 > Keep this list alphabetically ordered to avoid merge conflicts
 
 <!--packages-start-->
+
+- xo-server patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,6 +36,7 @@
 - [Warm migration] Fix `Vm target of warm migration not found` error at the end of a migration (PR [#10210](https://github.com/vatesfr/xen-orchestra/pull/10210))
 - **XO 5**:
   - [VM/Console] Fix the page header and tab navigation disappearing permanently in the console tab (PR [#10007](https://github.com/vatesfr/xen-orchestra/pull/10007))
+  - [Netdata] Fix `You must enable Javascript` error due to CSP blocking Netdata's inline scripts (PR [#10275](https://github.com/vatesfr/xen-orchestra/pull/10275))
 
 ### Packages to release
 

--- a/packages/xo-server/src/index.mjs
+++ b/packages/xo-server/src/index.mjs
@@ -162,6 +162,22 @@ const DEFAULT_HELMET_CONFIG = {
     },
   },
 }
+
+// Proxied third-party markup (e.g. Netdata) can't satisfy the hash
+// allowlist above, so it gets a more permissive CSP instead of none,
+// `/v5/netdata` self-proxies to `/netdata` (see config.toml)
+const CSP_EXEMPT_PREFIXES = ['/v5/netdata', '/netdata']
+const CSP_EXEMPT_DIRECTIVES = {
+  directives: {
+    'default-src': ["'self'"],
+    'connect-src': ["'self'"],
+    'script-src': ["'self'", "'unsafe-inline'"],
+    'style-src': ["'self'", "'unsafe-inline'"],
+    'img-src': ["'self'", 'data:'],
+    'object-src': ["'none'"],
+  },
+}
+
 async function createExpressApp(config) {
   const app = createExpress()
 
@@ -173,7 +189,21 @@ async function createExpressApp(config) {
   const helmetConfig = mergeWith({}, isDev ? {} : DEFAULT_HELMET_CONFIG, config.http.helmet, (dst, src) =>
     Array.isArray(dst) ? dst.concat(src) : undefined
   )
-  app.use(helmet(helmetConfig))
+
+  if (isDev) {
+    app.use(helmet(helmetConfig))
+  } else {
+    // CSP picked separately by path, other
+    // helmet headers stay the same
+    const { contentSecurityPolicy, ...restHelmetConfig } = helmetConfig
+    app.use(helmet({ ...restHelmetConfig, contentSecurityPolicy: false }))
+
+    const csp = helmet.contentSecurityPolicy(contentSecurityPolicy)
+    const relaxedCsp = helmet.contentSecurityPolicy(CSP_EXEMPT_DIRECTIVES)
+    app.use((req, res, next) =>
+      (CSP_EXEMPT_PREFIXES.some(prefix => req.url.startsWith(prefix)) ? relaxedCsp : csp)(req, res, next)
+    )
+  }
 
   app.use(compression())
 

--- a/packages/xo-server/src/index.mjs
+++ b/packages/xo-server/src/index.mjs
@@ -190,12 +190,13 @@ async function createExpressApp(config) {
     Array.isArray(dst) ? dst.concat(src) : undefined
   )
 
-  if (isDev) {
+  const { contentSecurityPolicy, ...restHelmetConfig } = helmetConfig
+
+  if (isDev || contentSecurityPolicy === false) {
     app.use(helmet(helmetConfig))
   } else {
     // CSP picked separately by path, other
     // helmet headers stay the same
-    const { contentSecurityPolicy, ...restHelmetConfig } = helmetConfig
     app.use(helmet({ ...restHelmetConfig, contentSecurityPolicy: false }))
 
     const csp = helmet.contentSecurityPolicy(contentSecurityPolicy)

--- a/packages/xo-server/src/index.mjs
+++ b/packages/xo-server/src/index.mjs
@@ -168,22 +168,6 @@ const DEFAULT_HELMET_CONFIG = {
 // `/v5/netdata` self-proxies to `/netdata` (see config.toml)
 const CSP_EXEMPT_PREFIXES = ['/v5/netdata', '/netdata']
 
-// Matches the prefix or a sub-path of it (e.g. `/netdata/v1/info`)
-// but not an unrelated route that starts with the same characters
-// (e.g. `/netdata-test`)
-const isCspExemptPath = path => CSP_EXEMPT_PREFIXES.some(prefix => path === prefix || path.startsWith(prefix + '/'))
-
-const CSP_EXEMPT_DIRECTIVES = {
-  directives: {
-    'default-src': ["'self'"],
-    'connect-src': ["'self'"],
-    'script-src': ["'self'", "'unsafe-inline'"],
-    'style-src': ["'self'", "'unsafe-inline'"],
-    'img-src': ["'self'", 'data:'],
-    'object-src': ["'none'"],
-  },
-}
-
 async function createExpressApp(config) {
   const app = createExpress()
 
@@ -195,19 +179,19 @@ async function createExpressApp(config) {
   const helmetConfig = mergeWith({}, isDev ? {} : DEFAULT_HELMET_CONFIG, config.http.helmet, (dst, src) =>
     Array.isArray(dst) ? dst.concat(src) : undefined
   )
+  app.use(helmet(helmetConfig))
 
-  const { contentSecurityPolicy, ...restHelmetConfig } = helmetConfig
-
-  if (isDev || contentSecurityPolicy === false) {
-    app.use(helmet(helmetConfig))
-  } else {
-    // CSP picked separately by path, other
-    // helmet headers stay the same
-    app.use(helmet({ ...restHelmetConfig, contentSecurityPolicy: false }))
-
-    const csp = helmet.contentSecurityPolicy(contentSecurityPolicy)
-    const relaxedCsp = helmet.contentSecurityPolicy(CSP_EXEMPT_DIRECTIVES)
-    app.use((req, res, next) => (isCspExemptPath(req.path) ? relaxedCsp : csp)(req, res, next))
+  const { contentSecurityPolicy } = helmetConfig
+  if (!isDev && contentSecurityPolicy !== false) {
+    app.use(
+      CSP_EXEMPT_PREFIXES,
+      helmet.contentSecurityPolicy({
+        directives: {
+          ...contentSecurityPolicy.directives,
+          'script-src': ["'self'", "'unsafe-inline'"],
+        },
+      })
+    )
   }
 
   app.use(compression())

--- a/packages/xo-server/src/index.mjs
+++ b/packages/xo-server/src/index.mjs
@@ -167,6 +167,12 @@ const DEFAULT_HELMET_CONFIG = {
 // allowlist above, so it gets a more permissive CSP instead of none,
 // `/v5/netdata` self-proxies to `/netdata` (see config.toml)
 const CSP_EXEMPT_PREFIXES = ['/v5/netdata', '/netdata']
+
+// Matches the prefix or a sub-path of it (e.g. `/netdata/v1/info`)
+// but not an unrelated route that starts with the same characters
+// (e.g. `/netdata-test`)
+const isCspExemptPath = path => CSP_EXEMPT_PREFIXES.some(prefix => path === prefix || path.startsWith(prefix + '/'))
+
 const CSP_EXEMPT_DIRECTIVES = {
   directives: {
     'default-src': ["'self'"],
@@ -201,9 +207,7 @@ async function createExpressApp(config) {
 
     const csp = helmet.contentSecurityPolicy(contentSecurityPolicy)
     const relaxedCsp = helmet.contentSecurityPolicy(CSP_EXEMPT_DIRECTIVES)
-    app.use((req, res, next) =>
-      (CSP_EXEMPT_PREFIXES.some(prefix => req.url.startsWith(prefix)) ? relaxedCsp : csp)(req, res, next)
-    )
+    app.use((req, res, next) => (isCspExemptPath(req.path) ? relaxedCsp : csp)(req, res, next))
   }
 
   app.use(compression())


### PR DESCRIPTION
### Description

Introduced by #10101

- Advanced Live Telemetry displayed a `You must enable Javascript` error on latest but not on stable
- security audit introduced a strict script-src CSP for XO's own inline scripts, applied globally via helmet
- gave netdata paths a separate CSP instead of removing it entirely to keep the intent of the original audit fix

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
