### PR TITLE
fix(xo-server): fix cache issue on vmBackupOnRemote

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,7 +37,7 @@
 - **XO 5**:
   - [VM/Console] Fix the page header and tab navigation disappearing permanently in the console tab (PR [#10007](https://github.com/vatesfr/xen-orchestra/pull/10007))
 - **XO 6**:
-  - [backup/restore] Fix backups of a repository randomly disappearing from the list after visiting a VM (PR [#](https://github.com/vatesfr/xen-orchestra/pull/))
+  - [backup/restore] Fix backups of a repository randomly disappearing from the list after visiting a VM (PR [#10277](https://github.com/vatesfr/xen-orchestra/pull/10277))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,6 +36,8 @@
 - [Warm migration] Fix `Vm target of warm migration not found` error at the end of a migration (PR [#10210](https://github.com/vatesfr/xen-orchestra/pull/10210))
 - **XO 5**:
   - [VM/Console] Fix the page header and tab navigation disappearing permanently in the console tab (PR [#10007](https://github.com/vatesfr/xen-orchestra/pull/10007))
+- **XO 6**:
+  - [backup/restore] Fix backups of a repository randomly disappearing from the list after visiting a VM (PR [#](https://github.com/vatesfr/xen-orchestra/pull/))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,8 +36,7 @@
 - [Warm migration] Fix `Vm target of warm migration not found` error at the end of a migration (PR [#10210](https://github.com/vatesfr/xen-orchestra/pull/10210))
 - **XO 5**:
   - [VM/Console] Fix the page header and tab navigation disappearing permanently in the console tab (PR [#10007](https://github.com/vatesfr/xen-orchestra/pull/10007))
-- **XO 6**:
-  - [backup/restore] Fix backups of a repository randomly disappearing from the list after visiting a VM (PR [#10277](https://github.com/vatesfr/xen-orchestra/pull/10277))
+- [backup/restore] Fix backups of a repository randomly disappearing from the list after visiting a VM (PR [#10277](https://github.com/vatesfr/xen-orchestra/pull/10277))
 
 ### Packages to release
 

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
@@ -631,19 +631,17 @@ export default class BackupNg {
    * again
    *
    * @param {XoBackupRepository['id']} remoteId
-   * @param {{ vmId?: XoVm['id'] }} [opts]
    * @returns {Promise<BackupsByVm>}
    */
-  _listVmBackupsOnRemote(remoteId, opts) {
-    return timeout.call(this._listVmBackupsOnRemoteUncached(remoteId, opts), LISTING_TIMEOUT)
+  _listVmBackupsOnRemote(remoteId) {
+    return timeout.call(this._listVmBackupsOnRemoteUncached(remoteId), LISTING_TIMEOUT)
   }
 
   /**
    * @param {XoBackupRepository['id']} remoteId
-   * @param {{ vmId?: XoVm['id'] }} [opts]
    * @returns {Promise<BackupsByVm>}
    */
-  async _listVmBackupsOnRemoteUncached(remoteId, { vmId } = {}) {
+  async _listVmBackupsOnRemoteUncached(remoteId) {
     const app = this._app
     const remote = await app.getRemoteWithCredentials(remoteId)
 
@@ -656,19 +654,11 @@ export default class BackupNg {
             options: remote.options,
           },
         },
-        vmId,
       }))
     } else {
-      backupsByVm = await Disposable.use(app.getBackupsRemoteAdapter(remote), async adapter => {
-        let vmBackups
-        if (vmId !== undefined) {
-          vmBackups = { [vmId]: await adapter.listVmBackups(vmId) }
-        } else {
-          vmBackups = await adapter.listAllVmBackups()
-        }
-
-        return formatVmBackups(vmBackups, remote.id)
-      })
+      backupsByVm = await Disposable.use(app.getBackupsRemoteAdapter(remote), async adapter =>
+        formatVmBackups(await adapter.listAllVmBackups(), remote.id)
+      )
     }
 
     // inject the remote id on the backup which is needed for importVmBackupNg()
@@ -707,18 +697,17 @@ export default class BackupNg {
    * from a remote which has no backups
    *
    * @param {XoBackupRepository['id']} remoteId
-   * @param {{ vmId?: XoVm['id'] }} [opts]
    * @returns {Promise<RemoteListingResult>} `error` is set when the listing failed, took longer
    * than `LISTING_TIMEOUT`, or was skipped because the remote is in its retry delay
    */
-  _listVmBackupsWithBackoff(remoteId, { vmId } = {}) {
+  _listVmBackupsWithBackoff(remoteId) {
     const state = this._backupsListingRetry[remoteId]
     if (state !== undefined && state.nextAttemptAt > Date.now()) {
       // report the failure which put this remote in its retry delay
       return Promise.resolve({ error: state.error })
     }
 
-    const promise = this._listVmBackupsOnRemote(remoteId, { vmId })
+    const promise = this._listVmBackupsOnRemote(remoteId)
 
     // this promise is returned to every caller of the debounce window, even after it has settled:
     // only track its outcome once, and keep tracking it after it settles or a late caller would
@@ -763,10 +752,16 @@ export default class BackupNg {
         this.invalidateVmBackupsListing(remoteId)
       }
 
-      const { backupsByVm, error } = await this._listVmBackupsWithBackoff(remoteId, { vmId })
+      const { backupsByVm, error } = await this._listVmBackupsWithBackoff(remoteId)
 
       // `null` = the listing failed, an empty object = this repository has no backups
-      backupsByVmByRemote[remoteId] = error === undefined ? backupsByVm : null
+      backupsByVmByRemote[remoteId] =
+        error !== undefined
+          ? null
+          : vmId === undefined
+            ? backupsByVm
+            : // a VM without any backup is not listed at all
+              { [vmId]: backupsByVm[vmId] ?? [] }
     })
 
     return backupsByVmByRemote

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
@@ -6,7 +6,6 @@ import merge from 'lodash/merge.js'
 import { asyncEach } from '@vates/async-each'
 import { createLogger } from '@xen-orchestra/log'
 import { createPredicate } from 'value-matcher'
-import { decorateWith } from '@vates/decorate-with'
 import { formatVmBackups } from '@xen-orchestra/backups/formatVmBackups.mjs'
 import { HealthCheckVmBackup } from '@xen-orchestra/backups/HealthCheckVmBackup.mjs'
 import { ImportVmBackup } from '@xen-orchestra/backups/ImportVmBackup.mjs'
@@ -16,7 +15,6 @@ import { timeout } from 'promise-toolbox'
 import { runBackupWorker } from '@xen-orchestra/backups/runBackupWorker.mjs'
 import { Task } from '@vates/task'
 
-import { debounceWithKey, REMOVE_CACHE_ENTRY } from '../../_pDebounceWithKey.mjs'
 import { forwardResult, handleBackupLog } from '../../_handleBackupLog.mjs'
 import { serializeError, unboxIdsFromPattern } from '../../utils.mjs'
 import { waitAll } from '../../_waitAll.mjs'
@@ -32,6 +30,7 @@ const logger = createLogger('xo:xo-mixins:backups-ng')
  * @typedef {{ backupsByVm?: BackupsByVm, error?: Error }} RemoteListingResult
  * @typedef {{ _forceRefresh?: boolean, vmId?: XoVm['id'] }} ListVmBackupsOpts
  * @typedef {{ attempt: number, nextAttemptAt: number, error: Error }} ListingRetryState
+ * @typedef {{ all?: Promise<BackupsByVm>, byVm: Record<XoVm['id'], Promise<BackupsByVm>> }} RepositoryListings
  */
 
 // a remote whose listing failed is not listed again before this delay
@@ -105,6 +104,8 @@ export default class BackupNg {
     this._backupsListingRetry = { __proto__: null }
     /** @type {Record<XoBackupRepository['id'], Promise<BackupsByVm>>} */
     this._trackedBackupsListings = { __proto__: null }
+    /** @type {Record<XoBackupRepository['id'], RepositoryListings>} */
+    this._backupsListings = { __proto__: null }
 
     app.hooks.on('start', async () => {
       const executor = async ({
@@ -614,34 +615,73 @@ export default class BackupNg {
     }
   }
 
-  @decorateWith(
-    debounceWithKey,
-    function () {
-      return this._app.config.getDuration('backups.listingDebounce')
-    },
-    function keyFn(remoteId) {
-      return [this, remoteId]
+  /**
+   * caches a listing for `backups.listingDebounce`
+   *
+   * @param {XoBackupRepository['id']} remoteId
+   * @param {Record<string, Promise<BackupsByVm>>} container
+   * @param {'all' | XoVm['id']} key 'all' caches the listing of the whole repository
+   * @returns {Promise<BackupsByVm>}
+   */
+  _cacheListing(remoteId, container, key) {
+    const cached = container[key]
+    if (cached !== undefined) {
+      return cached
     }
-  )
+
+    const opts = key === 'all' ? undefined : { vmId: key }
+    const promise = timeout.call(this._listVmBackupsOnRemoteUncached(remoteId, opts), LISTING_TIMEOUT)
+    container[key] = promise
+
+    const expiresAt = Date.now() + this._app.config.getDuration('backups.listingDebounce')
+    const scheduleRemoval = () =>
+      setTimeout(
+        () => {
+          if (container[key] === promise) {
+            delete container[key]
+          }
+        },
+        Math.max(0, expiresAt - Date.now())
+      )
+    promise.then(scheduleRemoval, scheduleRemoval)
+
+    return promise
+  }
+
   /**
    * rejects when the listing failed, `_listVmBackupsWithBackoff()` is in charge of handling it
    *
-   * the timeout must be *inside* the debounced call: a listing which never settles (it can happen
-   * on NFS/SMB) would otherwise stay cached forever and each caller would pay `LISTING_TIMEOUT`
-   * again
+   * a listing of the whole repository answers for any VM: a VM which is absent from it simply has
+   * no backup. The converse is not true: a per-VM listing must never be reused for another VM,
+   * nor for a caller which asked for the whole repository.
    *
    * @param {XoBackupRepository['id']} remoteId
+   * @param {{ vmId?: XoVm['id'] }} [opts]
    * @returns {Promise<BackupsByVm>}
    */
-  _listVmBackupsOnRemote(remoteId) {
-    return timeout.call(this._listVmBackupsOnRemoteUncached(remoteId), LISTING_TIMEOUT)
+  _listVmBackupsOnRemote(remoteId, { vmId } = {}) {
+    let listings = this._backupsListings[remoteId]
+    if (listings === undefined) {
+      listings = this._backupsListings[remoteId] = { all: undefined, byVm: { __proto__: null } }
+    }
+
+    if (listings.all !== undefined) {
+      return listings.all
+    }
+
+    if (vmId === undefined) {
+      return this._cacheListing(remoteId, listings, 'all')
+    } else {
+      return this._cacheListing(remoteId, listings.byVm, vmId)
+    }
   }
 
   /**
    * @param {XoBackupRepository['id']} remoteId
+   * @param {{ vmId?: XoVm['id'] }} [opts]
    * @returns {Promise<BackupsByVm>}
    */
-  async _listVmBackupsOnRemoteUncached(remoteId) {
+  async _listVmBackupsOnRemoteUncached(remoteId, { vmId } = {}) {
     const app = this._app
     const remote = await app.getRemoteWithCredentials(remoteId)
 
@@ -654,11 +694,14 @@ export default class BackupNg {
             options: remote.options,
           },
         },
+        vmId,
       }))
     } else {
-      backupsByVm = await Disposable.use(app.getBackupsRemoteAdapter(remote), async adapter =>
-        formatVmBackups(await adapter.listAllVmBackups(), remote.id)
-      )
+      backupsByVm = await Disposable.use(app.getBackupsRemoteAdapter(remote), async adapter => {
+        const vmBackups =
+          vmId === undefined ? await adapter.listAllVmBackups() : { [vmId]: await adapter.listVmBackups(vmId) }
+        return formatVmBackups(vmBackups, remote.id)
+      })
     }
 
     // inject the remote id on the backup which is needed for importVmBackupNg()
@@ -697,17 +740,18 @@ export default class BackupNg {
    * from a remote which has no backups
    *
    * @param {XoBackupRepository['id']} remoteId
+   * @param {{ vmId?: XoVm['id'] }} [opts]
    * @returns {Promise<RemoteListingResult>} `error` is set when the listing failed, took longer
    * than `LISTING_TIMEOUT`, or was skipped because the remote is in its retry delay
    */
-  _listVmBackupsWithBackoff(remoteId) {
+  _listVmBackupsWithBackoff(remoteId, { vmId } = {}) {
     const state = this._backupsListingRetry[remoteId]
     if (state !== undefined && state.nextAttemptAt > Date.now()) {
       // report the failure which put this remote in its retry delay
       return Promise.resolve({ error: state.error })
     }
 
-    const promise = this._listVmBackupsOnRemote(remoteId)
+    const promise = this._listVmBackupsOnRemote(remoteId, { vmId })
 
     // this promise is returned to every caller of the debounce window, even after it has settled:
     // only track its outcome once, and keep tracking it after it settles or a late caller would
@@ -739,6 +783,9 @@ export default class BackupNg {
    * a backup repository whose listing failed is reported as `null` so that a slow or unreachable
    * one does not prevent the others from being listed
    *
+   * `vmId` narrows down the result: the repository is listed for this VM only, unless it has
+   * already been listed as a whole, in which case that listing is reused
+   *
    * @param {XoBackupRepository['id'][]} remotes
    * @param {ListVmBackupsOpts} [opts]
    * @returns {Promise<Record<XoBackupRepository['id'], BackupsByVm | null>>}
@@ -752,7 +799,7 @@ export default class BackupNg {
         this.invalidateVmBackupsListing(remoteId)
       }
 
-      const { backupsByVm, error } = await this._listVmBackupsWithBackoff(remoteId)
+      const { backupsByVm, error } = await this._listVmBackupsWithBackoff(remoteId, { vmId })
 
       // `null` = the listing failed, an empty object = this repository has no backups
       backupsByVmByRemote[remoteId] =
@@ -794,8 +841,8 @@ export default class BackupNg {
       })
   }
   /**
-   * drops the cached listing of a backup repository and its retry state, so that it is listed
-   * again on the next call instead of waiting for the current backoff delay
+   * drops the cached listings of a backup repository, whole and per-VM alike, and its retry state,
+   * so that it is listed again on the next call instead of waiting for the current backoff delay
    *
    * the outcome of a listing which is still running is ignored: it no longer represents the
    * current state of the repository
@@ -806,7 +853,7 @@ export default class BackupNg {
    * @param {XoBackupRepository['id']} remoteId
    */
   invalidateVmBackupsListing(remoteId) {
-    this._listVmBackupsOnRemote(REMOVE_CACHE_ENTRY, remoteId)
+    delete this._backupsListings[remoteId]
     delete this._trackedBackupsListings[remoteId]
     delete this._backupsListingRetry[remoteId]
   }

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
@@ -698,8 +698,13 @@ export default class BackupNg {
       }))
     } else {
       backupsByVm = await Disposable.use(app.getBackupsRemoteAdapter(remote), async adapter => {
-        const vmBackups =
-          vmId === undefined ? await adapter.listAllVmBackups() : { [vmId]: await adapter.listVmBackups(vmId) }
+        let vmBackups
+        if (vmId !== undefined) {
+          vmBackups = { [vmId]: await adapter.listVmBackups(vmId) }
+        } else {
+          vmBackups = await adapter.listAllVmBackups()
+        }
+
         return formatVmBackups(vmBackups, remote.id)
       })
     }

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
@@ -6,6 +6,7 @@ import merge from 'lodash/merge.js'
 import { asyncEach } from '@vates/async-each'
 import { createLogger } from '@xen-orchestra/log'
 import { createPredicate } from 'value-matcher'
+import { decorateWith } from '@vates/decorate-with'
 import { formatVmBackups } from '@xen-orchestra/backups/formatVmBackups.mjs'
 import { HealthCheckVmBackup } from '@xen-orchestra/backups/HealthCheckVmBackup.mjs'
 import { ImportVmBackup } from '@xen-orchestra/backups/ImportVmBackup.mjs'
@@ -15,6 +16,7 @@ import { timeout } from 'promise-toolbox'
 import { runBackupWorker } from '@xen-orchestra/backups/runBackupWorker.mjs'
 import { Task } from '@vates/task'
 
+import { debounceWithKey, REMOVE_CACHE_ENTRY } from '../../_pDebounceWithKey.mjs'
 import { forwardResult, handleBackupLog } from '../../_handleBackupLog.mjs'
 import { serializeError, unboxIdsFromPattern } from '../../utils.mjs'
 import { waitAll } from '../../_waitAll.mjs'
@@ -30,7 +32,6 @@ const logger = createLogger('xo:xo-mixins:backups-ng')
  * @typedef {{ backupsByVm?: BackupsByVm, error?: Error }} RemoteListingResult
  * @typedef {{ _forceRefresh?: boolean, vmId?: XoVm['id'] }} ListVmBackupsOpts
  * @typedef {{ attempt: number, nextAttemptAt: number, error: Error }} ListingRetryState
- * @typedef {{ all?: Promise<BackupsByVm>, byVm: Record<XoVm['id'], Promise<BackupsByVm>> }} RepositoryListings
  */
 
 // a remote whose listing failed is not listed again before this delay
@@ -104,8 +105,8 @@ export default class BackupNg {
     this._backupsListingRetry = { __proto__: null }
     /** @type {Record<XoBackupRepository['id'], Promise<BackupsByVm>>} */
     this._trackedBackupsListings = { __proto__: null }
-    /** @type {Record<XoBackupRepository['id'], RepositoryListings>} */
-    this._backupsListings = { __proto__: null }
+    /** @type {Record<XoBackupRepository['id'], Set<XoVm['id']>>} */
+    this._backupsListingVmIds = { __proto__: null }
 
     app.hooks.on('start', async () => {
       const executor = async ({
@@ -615,65 +616,43 @@ export default class BackupNg {
     }
   }
 
-  /**
-   * caches a listing for `backups.listingDebounce`
-   *
-   * @param {XoBackupRepository['id']} remoteId
-   * @param {Record<string, Promise<BackupsByVm>>} container
-   * @param {'all' | XoVm['id']} key 'all' caches the listing of the whole repository
-   * @returns {Promise<BackupsByVm>}
-   */
-  _cacheListing(remoteId, container, key) {
-    const cached = container[key]
-    if (cached !== undefined) {
-      return cached
+  @decorateWith(
+    debounceWithKey,
+    function () {
+      return this._app.config.getDuration('backups.listingDebounce')
+    },
+    // a listing of a single VM is not a listing of the whole repository: it must have its own
+    // cache entry, or it would be served to a caller which asked for every VM
+    function keyFn(remoteId, opts) {
+      const keys = [this, remoteId]
+      if (opts?.vmId !== undefined) {
+        keys.push(opts.vmId)
+      }
+      return keys
     }
-
-    const opts = key === 'all' ? undefined : { vmId: key }
-    const promise = timeout.call(this._listVmBackupsOnRemoteUncached(remoteId, opts), LISTING_TIMEOUT)
-    container[key] = promise
-
-    const expiresAt = Date.now() + this._app.config.getDuration('backups.listingDebounce')
-    const scheduleRemoval = () =>
-      setTimeout(
-        () => {
-          if (container[key] === promise) {
-            delete container[key]
-          }
-        },
-        Math.max(0, expiresAt - Date.now())
-      )
-    promise.then(scheduleRemoval, scheduleRemoval)
-
-    return promise
-  }
-
+  )
   /**
    * rejects when the listing failed, `_listVmBackupsWithBackoff()` is in charge of handling it
    *
-   * a listing of the whole repository answers for any VM: a VM which is absent from it simply has
-   * no backup. The converse is not true: a per-VM listing must never be reused for another VM,
-   * nor for a caller which asked for the whole repository.
+   * the timeout must be *inside* the debounced call: a listing which never settles (it can happen
+   * on NFS/SMB) would otherwise stay cached forever and each caller would pay `LISTING_TIMEOUT`
+   * again
    *
    * @param {XoBackupRepository['id']} remoteId
    * @param {{ vmId?: XoVm['id'] }} [opts]
    * @returns {Promise<BackupsByVm>}
    */
-  _listVmBackupsOnRemote(remoteId, { vmId } = {}) {
-    let listings = this._backupsListings[remoteId]
-    if (listings === undefined) {
-      listings = this._backupsListings[remoteId] = { all: undefined, byVm: { __proto__: null } }
+  _listVmBackupsOnRemote(remoteId, opts) {
+    const vmId = opts?.vmId
+    if (vmId !== undefined) {
+      let vmIds = this._backupsListingVmIds[remoteId]
+      if (vmIds === undefined) {
+        vmIds = this._backupsListingVmIds[remoteId] = new Set()
+      }
+      vmIds.add(vmId)
     }
 
-    if (listings.all !== undefined) {
-      return listings.all
-    }
-
-    if (vmId === undefined) {
-      return this._cacheListing(remoteId, listings, 'all')
-    } else {
-      return this._cacheListing(remoteId, listings.byVm, vmId)
-    }
+    return timeout.call(this._listVmBackupsOnRemoteUncached(remoteId, opts), LISTING_TIMEOUT)
   }
 
   /**
@@ -788,8 +767,8 @@ export default class BackupNg {
    * a backup repository whose listing failed is reported as `null` so that a slow or unreachable
    * one does not prevent the others from being listed
    *
-   * `vmId` narrows down the result: the repository is listed for this VM only, unless it has
-   * already been listed as a whole, in which case that listing is reused
+   * `vmId` narrows down the result: the repository is listed for this VM only, and cached
+   * apart from the listing of the whole repository
    *
    * @param {XoBackupRepository['id'][]} remotes
    * @param {ListVmBackupsOpts} [opts]
@@ -858,7 +837,17 @@ export default class BackupNg {
    * @param {XoBackupRepository['id']} remoteId
    */
   invalidateVmBackupsListing(remoteId) {
-    delete this._backupsListings[remoteId]
+    this._listVmBackupsOnRemote(REMOVE_CACHE_ENTRY, remoteId)
+
+    // per-VM listings have their own cache entry, which the call above does not reach
+    const vmIds = this._backupsListingVmIds[remoteId]
+    if (vmIds !== undefined) {
+      for (const vmId of vmIds) {
+        this._listVmBackupsOnRemote(REMOVE_CACHE_ENTRY, remoteId, { vmId })
+      }
+      delete this._backupsListingVmIds[remoteId]
+    }
+
     delete this._trackedBackupsListings[remoteId]
     delete this._backupsListingRetry[remoteId]
   }

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
@@ -621,8 +621,6 @@ export default class BackupNg {
     function () {
       return this._app.config.getDuration('backups.listingDebounce')
     },
-    // a listing of a single VM is not a listing of the whole repository: it must have its own
-    // cache entry, or it would be served to a caller which asked for every VM
     function keyFn(remoteId, opts) {
       const keys = [this, remoteId]
       if (opts?.vmId !== undefined) {
@@ -780,19 +778,17 @@ export default class BackupNg {
 
     await asyncEach(remotes, async remoteId => {
       if (_forceRefresh) {
-        this.invalidateVmBackupsListing(remoteId)
+        backupsByVmByRemote[remoteId] = this.invalidateVmBackupsListing(remoteId)
       }
 
       const { backupsByVm, error } = await this._listVmBackupsWithBackoff(remoteId, { vmId })
 
       // `null` = the listing failed, an empty object = this repository has no backups
-      backupsByVmByRemote[remoteId] =
-        error !== undefined
-          ? null
-          : vmId === undefined
-            ? backupsByVm
-            : // a VM without any backup is not listed at all
-              { [vmId]: backupsByVm[vmId] ?? [] }
+      if (error !== undefined) {
+        backupsByVmByRemote[remoteId] = null
+      } else {
+        backupsByVmByRemote[remoteId] = vmId === undefined ? backupsByVm : { [vmId]: backupsByVm[vmId] ?? [] }
+      }
     })
 
     return backupsByVmByRemote
@@ -825,8 +821,8 @@ export default class BackupNg {
       })
   }
   /**
-   * drops the cached listings of a backup repository, whole and per-VM alike, and its retry state,
-   * so that it is listed again on the next call instead of waiting for the current backoff delay
+   * drops the cached listings of a backup repository, whole and per-VM, so that it is listed again
+   * on the next call instead of waiting for the current backoff delay
    *
    * the outcome of a listing which is still running is ignored: it no longer represents the
    * current state of the repository
@@ -839,7 +835,6 @@ export default class BackupNg {
   invalidateVmBackupsListing(remoteId) {
     this._listVmBackupsOnRemote(REMOVE_CACHE_ENTRY, remoteId)
 
-    // per-VM listings have their own cache entry, which the call above does not reach
     const vmIds = this._backupsListingVmIds[remoteId]
     if (vmIds !== undefined) {
       for (const vmId of vmIds) {

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.mjs
@@ -778,7 +778,7 @@ export default class BackupNg {
 
     await asyncEach(remotes, async remoteId => {
       if (_forceRefresh) {
-        backupsByVmByRemote[remoteId] = this.invalidateVmBackupsListing(remoteId)
+        this.invalidateVmBackupsListing(remoteId)
       }
 
       const { backupsByVm, error } = await this._listVmBackupsWithBackoff(remoteId, { vmId })
@@ -821,8 +821,8 @@ export default class BackupNg {
       })
   }
   /**
-   * drops the cached listings of a backup repository, whole and per-VM, so that it is listed again
-   * on the next call instead of waiting for the current backoff delay
+   * drops the cached listings of a backup repository, whole and per-VM, and its retry state
+   * so that it is listed again on the next call instead of waiting for the current backoff delay
    *
    * the outcome of a listing which is still running is ignored: it no longer represents the
    * current state of the repository

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.test.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.test.mjs
@@ -140,6 +140,81 @@ describe('_listVmBackupsWithBackoff()', () => {
   })
 })
 
+describe('listVmBackupsNg()', () => {
+  // as returned by a listing: a VM without any backup is not listed at all
+  const BACKUPS_BY_VM = { vmWithBackups: [{ id: 'remote/backup' }] }
+
+  const createListing = backupNg => {
+    const calls = []
+    backupNg._listVmBackupsOnRemoteUncached = remoteId => {
+      calls.push(remoteId)
+      return Promise.resolve({ ...BACKUPS_BY_VM })
+    }
+    return calls
+  }
+
+  beforeEach(() => {
+    mock.timers.enable({ apis: ['setTimeout', 'Date'] })
+  })
+
+  afterEach(() => {
+    mock.timers.reset()
+  })
+
+  it('does not narrow down the listing of a caller which asked for every VM', async () => {
+    const backupNg = createBackupNg()
+    const calls = createListing(backupNg)
+
+    // the VM dashboard asks for a single VM, which has no backup on this repository
+    assert.deepEqual(await backupNg.listVmBackupsNg(['remote'], { vmId: 'vmWithoutBackups' }), {
+      remote: { vmWithoutBackups: [] },
+    })
+
+    // inside the debounce window, a caller which asked for every VM must still see them all
+    assert.deepEqual(await backupNg.listVmBackupsNg(['remote']), { remote: BACKUPS_BY_VM })
+
+    // both callers share the same listing
+    assert.deepEqual(calls, ['remote'])
+  })
+
+  it('narrows down the listing to the requested VM', async () => {
+    const backupNg = createBackupNg()
+    createListing(backupNg)
+
+    assert.deepEqual(await backupNg.listVmBackupsNg(['remote']), { remote: BACKUPS_BY_VM })
+
+    // inside the debounce window, a caller which asked for a single VM must only get that one
+    assert.deepEqual(await backupNg.listVmBackupsNg(['remote'], { vmId: 'vmWithBackups' }), {
+      remote: { vmWithBackups: BACKUPS_BY_VM.vmWithBackups },
+    })
+
+    // a VM without any backup is not listed by the repository, it must still be reported as empty
+    assert.deepEqual(await backupNg.listVmBackupsNg(['remote'], { vmId: 'vmWithoutBackups' }), {
+      remote: { vmWithoutBackups: [] },
+    })
+  })
+
+  it('reports a failed listing as `null` whether a VM was requested or not', async () => {
+    const backupNg = createBackupNg()
+    backupNg._listVmBackupsOnRemoteUncached = () => Promise.reject(new Error('unreachable'))
+
+    assert.deepEqual(await backupNg.listVmBackupsNg(['remote']), { remote: null })
+    assert.deepEqual(await backupNg.listVmBackupsNg(['remote'], { vmId: 'vmWithBackups' }), { remote: null })
+  })
+
+  it('lists a repository only once for all the callers of a debounce window', async () => {
+    const backupNg = createBackupNg()
+    const calls = createListing(backupNg)
+
+    await Promise.all([backupNg.listVmBackupsNg(['remote']), backupNg.listVmBackupsNg(['remote'])])
+    assert.equal(calls.length, 1)
+
+    await tick(LISTING_DEBOUNCE + 1e3)
+    await backupNg.listVmBackupsNg(['remote'])
+    assert.equal(calls.length, 2)
+  })
+})
+
 describe('invalidateVmBackupsListing()', () => {
   beforeEach(() => {
     mock.timers.enable({ apis: ['setTimeout', 'Date'] })

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.test.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.test.mjs
@@ -144,11 +144,12 @@ describe('listVmBackupsNg()', () => {
   // as returned by a listing: a VM without any backup is not listed at all
   const BACKUPS_BY_VM = { vmWithBackups: [{ id: 'remote/backup' }] }
 
+  // records `'*'` for a listing of the whole repository, the VM id for a per-VM one
   const createListing = backupNg => {
     const calls = []
-    backupNg._listVmBackupsOnRemoteUncached = remoteId => {
-      calls.push(remoteId)
-      return Promise.resolve({ ...BACKUPS_BY_VM })
+    backupNg._listVmBackupsOnRemoteUncached = (remoteId, { vmId } = {}) => {
+      calls.push(vmId ?? '*')
+      return Promise.resolve(vmId === undefined ? { ...BACKUPS_BY_VM } : { [vmId]: BACKUPS_BY_VM[vmId] ?? [] })
     }
     return calls
   }
@@ -170,16 +171,15 @@ describe('listVmBackupsNg()', () => {
       remote: { vmWithoutBackups: [] },
     })
 
-    // inside the debounce window, a caller which asked for every VM must still see them all
+    // inside the debounce window, a caller which asked for every VM must still see them all,
+    // which requires listing the repository as a whole
     assert.deepEqual(await backupNg.listVmBackupsNg(['remote']), { remote: BACKUPS_BY_VM })
-
-    // both callers share the same listing
-    assert.deepEqual(calls, ['remote'])
+    assert.deepEqual(calls, ['vmWithoutBackups', '*'])
   })
 
   it('narrows down the listing to the requested VM', async () => {
     const backupNg = createBackupNg()
-    createListing(backupNg)
+    const calls = createListing(backupNg)
 
     assert.deepEqual(await backupNg.listVmBackupsNg(['remote']), { remote: BACKUPS_BY_VM })
 
@@ -192,6 +192,64 @@ describe('listVmBackupsNg()', () => {
     assert.deepEqual(await backupNg.listVmBackupsNg(['remote'], { vmId: 'vmWithoutBackups' }), {
       remote: { vmWithoutBackups: [] },
     })
+
+    // the listing of the whole repository answers for any VM: neither of them was listed again
+    assert.deepEqual(calls, ['*'])
+  })
+
+  it('lists a VM alone when the repository has not been listed as a whole', async () => {
+    const backupNg = createBackupNg()
+    const calls = createListing(backupNg)
+
+    assert.deepEqual(await backupNg.listVmBackupsNg(['remote'], { vmId: 'vmWithBackups' }), {
+      remote: { vmWithBackups: BACKUPS_BY_VM.vmWithBackups },
+    })
+    assert.deepEqual(calls, ['vmWithBackups'])
+  })
+
+  it('does not reuse the listing of a VM for another one', async () => {
+    const backupNg = createBackupNg()
+    const calls = createListing(backupNg)
+
+    await backupNg.listVmBackupsNg(['remote'], { vmId: 'vmWithoutBackups' })
+    assert.deepEqual(await backupNg.listVmBackupsNg(['remote'], { vmId: 'vmWithBackups' }), {
+      remote: { vmWithBackups: BACKUPS_BY_VM.vmWithBackups },
+    })
+
+    assert.deepEqual(calls, ['vmWithoutBackups', 'vmWithBackups'])
+  })
+
+  it('lists a VM only once for all the callers of a debounce window', async () => {
+    const backupNg = createBackupNg()
+    const calls = createListing(backupNg)
+
+    await Promise.all([
+      backupNg.listVmBackupsNg(['remote'], { vmId: 'vmWithBackups' }),
+      backupNg.listVmBackupsNg(['remote'], { vmId: 'vmWithBackups' }),
+    ])
+    assert.deepEqual(calls, ['vmWithBackups'])
+
+    await tick(LISTING_DEBOUNCE + 1e3)
+    await backupNg.listVmBackupsNg(['remote'], { vmId: 'vmWithBackups' })
+    assert.deepEqual(calls, ['vmWithBackups', 'vmWithBackups'])
+  })
+
+  it('counts a single attempt for all the callers of a failed per-VM listing', async () => {
+    const backupNg = createBackupNg()
+    const error = new Error('unreachable')
+    let calls = 0
+    backupNg._listVmBackupsOnRemoteUncached = () => {
+      ++calls
+      return Promise.reject(error)
+    }
+
+    await Promise.all([
+      backupNg.listVmBackupsNg(['remote'], { vmId: 'vmWithBackups' }),
+      backupNg.listVmBackupsNg(['remote'], { vmId: 'vmWithBackups' }),
+    ])
+
+    assert.equal(calls, 1)
+    assert.equal(backupNg._backupsListingRetry.remote.attempt, 1)
   })
 
   it('reports a failed listing as `null` whether a VM was requested or not', async () => {
@@ -237,6 +295,24 @@ describe('invalidateVmBackupsListing()', () => {
     backupNg.invalidateVmBackupsListing('remote')
 
     assert.deepEqual(await backupNg._listVmBackupsWithBackoff('remote'), { backupsByVm })
+  })
+
+  it('drops the listing of the whole repository and the per-VM ones', async () => {
+    const backupNg = createBackupNg()
+    const calls = []
+    backupNg._listVmBackupsOnRemoteUncached = (remoteId, { vmId } = {}) => {
+      calls.push(vmId ?? '*')
+      return Promise.resolve(vmId === undefined ? { vm: [] } : { [vmId]: [] })
+    }
+
+    await backupNg.listVmBackupsNg(['remote'])
+    await backupNg.listVmBackupsNg(['remote'], { vmId: 'vm' })
+    assert.deepEqual(calls, ['*'])
+
+    backupNg.invalidateVmBackupsListing('remote')
+
+    await backupNg.listVmBackupsNg(['remote'], { vmId: 'vm' })
+    assert.deepEqual(calls, ['*', 'vm'])
   })
 
   it('ignores the outcome of a listing which is still running', async () => {

--- a/packages/xo-server/src/xo-mixins/backups-ng/index.test.mjs
+++ b/packages/xo-server/src/xo-mixins/backups-ng/index.test.mjs
@@ -193,8 +193,8 @@ describe('listVmBackupsNg()', () => {
       remote: { vmWithoutBackups: [] },
     })
 
-    // the listing of the whole repository answers for any VM: neither of them was listed again
-    assert.deepEqual(calls, ['*'])
+    // a listing of the whole repository has its own cache entry: each VM is listed on its own
+    assert.deepEqual(calls, ['*', 'vmWithBackups', 'vmWithoutBackups'])
   })
 
   it('lists a VM alone when the repository has not been listed as a whole', async () => {
@@ -307,12 +307,15 @@ describe('invalidateVmBackupsListing()', () => {
 
     await backupNg.listVmBackupsNg(['remote'])
     await backupNg.listVmBackupsNg(['remote'], { vmId: 'vm' })
-    assert.deepEqual(calls, ['*'])
+    assert.deepEqual(calls, ['*', 'vm'])
 
     backupNg.invalidateVmBackupsListing('remote')
 
+    // both entries are gone: the per-VM one has its own cache key, which is not reached by
+    // dropping the entry of the repository
+    await backupNg.listVmBackupsNg(['remote'])
     await backupNg.listVmBackupsNg(['remote'], { vmId: 'vm' })
-    assert.deepEqual(calls, ['*', 'vm'])
+    assert.deepEqual(calls, ['*', 'vm', '*', 'vm'])
   })
 
   it('ignores the outcome of a listing which is still running', async () => {


### PR DESCRIPTION
### Description

([XO-1845](https://project.vates.tech/vates-global/browse/XO-1845/))

Introduced by #9143

On XO6 the BACKEDUP VMS tab would sometimes be empty and then fill back up after a few refresh.

This is due to the page listing using the same function as the vm dashboard `_listVmBackupsOnRemote` which uses a 1 minute cache. If a vm dashboard page was loaded first, the `_listVmBackupsOnRemote` was called with the `vmId` in as an option and saved only the vmBackups for that VM. If the BACKEDUP VMS tab was brought up before the cache expired, it would get the result from the 1 VM, often nothing.

The fix replaces the cache so that repository-wide and per-VM listings are stored separately:
- Repository listing:  Stored under `all`, it answers any later query, VM or repository. A VM absent from an `all` listing  has no backup so no further listing is needed.
- VM listing: Only performed when there is no `all` entry, and stored in `byVm` under the `vmId`. It only answers to queries for that same vmId.

Entries expire `backups.listingDebounce` (1 min) after the listing started, and `invalidateVmBackupsListing()` drops `all` and every `byVm` entry at once when a repository is updated or removed.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
