### PR TITLE
feat(xo-server/proxy): check proxy licenses from XOA instead of blocking backups on it

### DIFF
--- a/@xen-orchestra/proxy/app/mixins/appliance.mjs
+++ b/@xen-orchestra/proxy/app/mixins/appliance.mjs
@@ -159,13 +159,4 @@ export default class Appliance {
       },
     })
   }
-
-  // A proxy can be bound to a unique license
-  getSelfLicense() {
-    return Disposable.use(getUpdater(), async updater => {
-      const licenses = await updater.call('getSelfLicenses')
-      const now = Date.now()
-      return licenses.find(({ expires }) => expires === undefined || expires > now)
-    })
-  }
 }

--- a/@xen-orchestra/proxy/app/mixins/backups.mjs
+++ b/@xen-orchestra/proxy/app/mixins/backups.mjs
@@ -10,7 +10,6 @@ import { execFile } from 'child_process'
 import { formatVmBackups } from '@xen-orchestra/backups/formatVmBackups.mjs'
 import { createRunner } from '@xen-orchestra/backups/Backup.mjs'
 import { ImportVmBackup } from '@xen-orchestra/backups/ImportVmBackup.mjs'
-import { JsonRpcError } from 'json-rpc-protocol'
 import { Readable } from 'stream'
 import { RemoteAdapter } from '@xen-orchestra/backups/RemoteAdapter.mjs'
 import { RestoreMetadataBackup } from '@xen-orchestra/backups/RestoreMetadataBackup.mjs'
@@ -105,14 +104,6 @@ export default class Backups {
         }
       }
     })(run)
-    run = (run =>
-      async function () {
-        const license = await app.appliance.getSelfLicense()
-        if (license === undefined) {
-          throw new JsonRpcError('no valid proxy license')
-        }
-        return run.apply(this, arguments)
-      })(run)
 
     run = (run => async (params, onLog) => {
       if (onLog === undefined || !app.config.get('backups').disableWorkers) {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,6 +27,7 @@
 
 - [IPMI-plugin] Add GET plugins/ipmi-sensors/hosts/{id}/ipmi to get IPMI sensors (PR [#10003](https://github.com/vatesfr/xen-orchestra/pull/10003))
 - [VIF] Add VIF name in header on VIF detail page (PR [#10252](https://github.com/vatesfr/xen-orchestra/pull/10252))
+- [Proxy] Check proxy licenses at XOA level instead of blocking backups on it (PR [#10280](https://github.com/vatesfr/xen-orchestra/pull/10280))
 
 ### Bug fixes
 
@@ -58,6 +59,7 @@
 - @vates/types patch
 - @xen-orchestra/acl minor
 - @xen-orchestra/async-map patch
+- @xen-orchestra/proxy minor
 - @xen-orchestra/proxy-cli patch
 - @xen-orchestra/rest-api minor
 - @xen-orchestra/upload-ova patch
@@ -67,7 +69,7 @@
 - xen-api minor
 - xo-cli patch
 - xo-common minor
-- xo-server patch
+- xo-server minor
 - xo-server-ipmi-sensors minor
 - xo-server-netbox patch
 - xo-web patch

--- a/packages/xo-server/src/xo-mixins/proxies.mjs
+++ b/packages/xo-server/src/xo-mixins/proxies.mjs
@@ -28,6 +28,7 @@ import { extractIpFromVmNetworks } from '../_extractIpFromVmNetworks.mjs'
 import { generateToken } from '../utils.mjs'
 
 const DEBOUNCE_TIME_PROXY_STATE = 60000
+const DEBOUNCE_TIME_PROXY_LICENSE = 24 * 60 * 60 * 1000
 
 const synchronizedWrite = synchronized()
 
@@ -68,9 +69,19 @@ async function addProxyVersion(proxy) {
   }
 }
 
+async function addProxyLicense(proxy) {
+  try {
+    const license = await this.getProxyLicense(proxy.id)
+    proxy.license = license
+  } catch (error) {
+    log.debug('addProxyLicense', { error, proxy })
+  }
+}
+
 async function populateProxy(proxy) {
   addProxyUrl.call(this, proxy)
   await addProxyVersion.call(this, proxy)
+  await addProxyLicense.call(this, proxy)
 }
 
 export default class Proxy {
@@ -170,6 +181,7 @@ export default class Proxy {
           productId: this._app.config.get('xo-proxy.licenseProductId'),
         })
         .catch(log.warn)
+      this.getProxyLicense(REMOVE_CACHE_ENTRY, id)
     }
   }
 
@@ -287,6 +299,16 @@ export default class Proxy {
     }
 
     return this.callProxyMethod(id, 'appliance.updater.getState')
+  }
+
+  @decorateWith(debounceWithKey, DEBOUNCE_TIME_PROXY_LICENSE, id => id, false)
+  async getProxyLicense(id) {
+    const { vmUuid } = await this._getProxy(id)
+    const licenses = await this._app.getLicenses?.()
+    return licenses?.find(
+      license =>
+        license.productId === this._app.config.get('xo-proxy.licenseProductId') && license.boundObjectId === vmUuid
+    )
   }
 
   @decorateWith(defer)
@@ -423,6 +445,7 @@ export default class Proxy {
         authenticationToken: proxyAuthenticationToken,
         vmUuid: vm.uuid,
       })
+      this.getProxyLicense(REMOVE_CACHE_ENTRY, proxyId)
     } else {
       proxyId = await this.registerProxy({
         authenticationToken: proxyAuthenticationToken,

--- a/packages/xo-server/src/xo-mixins/proxies.mjs
+++ b/packages/xo-server/src/xo-mixins/proxies.mjs
@@ -71,8 +71,7 @@ async function addProxyVersion(proxy) {
 
 async function addProxyLicense(proxy) {
   try {
-    const license = await this.getProxyLicense(proxy.id)
-    proxy.license = license
+    proxy.license = await this.getProxyLicense(proxy.id)
   } catch (error) {
     log.debug('addProxyLicense', { error, proxy })
   }
@@ -230,6 +229,10 @@ export default class Proxy {
 
     patch(proxy, { address, authenticationToken, name, vmUuid })
     await this._db.update(proxy)
+
+    if (vmUuid !== undefined) {
+      this.getProxyLicense(REMOVE_CACHE_ENTRY, id)
+    }
 
     await populateProxy.call(this, proxy)
     return proxy


### PR DESCRIPTION
### Description

XOA checks each proxy's license itself instead of the proxy checking its own local xoa-updater daemon, removed the blocking check so a license check failure no longer prevents a backup from running

[XO-2768](https://project.vates.tech/vates-global/browse/XO-2768/)

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
