### PR TITLE
fix(xo-server): changing vif mac adress destroy traffic rules

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,7 +37,7 @@
 - [XO server] Fix a random behavior regarding `coresPerSocket` update (PR [#10201](https://github.com/vatesfr/xen-orchestra/pull/10201))
 - [Warm migration] Fix `Vm target of warm migration not found` error at the end of a migration (PR [#10210](https://github.com/vatesfr/xen-orchestra/pull/10210))
 - [XO6] Fix inconsistent spacing in side panel cards (PR [#10279](https://github.com/vatesfr/xen-orchestra/pull/10279))
-- [VIF] Preserve other_config, rate limit, MTU and device when changing a VIF's MAC address (PR [#](https://github.com/vatesfr/xen-orchestra/pull/))
+- [VIF] Preserve other_config, rate limit, MTU and device when changing a VIF's MAC address (PR [#10284](https://github.com/vatesfr/xen-orchestra/pull/10284))
 - **XO 5**:
   - [VM/Console] Fix the page header and tab navigation disappearing permanently in the console tab (PR [#10007](https://github.com/vatesfr/xen-orchestra/pull/10007))
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,6 +37,7 @@
 - [XO server] Fix a random behavior regarding `coresPerSocket` update (PR [#10201](https://github.com/vatesfr/xen-orchestra/pull/10201))
 - [Warm migration] Fix `Vm target of warm migration not found` error at the end of a migration (PR [#10210](https://github.com/vatesfr/xen-orchestra/pull/10210))
 - [XO6] Fix inconsistent spacing in side panel cards (PR [#10279](https://github.com/vatesfr/xen-orchestra/pull/10279))
+- [VIF] Preserve other_config, rate limit, MTU and device when changing a VIF's MAC address (PR [#](https://github.com/vatesfr/xen-orchestra/pull/))
 - **XO 5**:
   - [VM/Console] Fix the page header and tab navigation disappearing permanently in the console tab (PR [#10007](https://github.com/vatesfr/xen-orchestra/pull/10007))
 

--- a/packages/xo-server/src/api/vif.mjs
+++ b/packages/xo-server/src/api/vif.mjs
@@ -162,6 +162,10 @@ export async function set({
     network = xapi.getObject(networkId ?? vif.$network)
     attached == null && (attached = vif.attached)
 
+    const otherConfig =
+      txChecksumming !== undefined ? { ...vif.other_config, 'ethtool-tx': String(txChecksumming) } : vif.other_config
+    const newRateLimit = rateLimit === undefined ? vif.rateLimit : rateLimit
+
     await this.allocIpAddresses(vif.id, null, oldIpAddresses)
     await xapi.deleteVif(vif._xapiId)
 
@@ -176,13 +180,13 @@ export async function set({
           // - Else if the network is changing: config it to 'network_default'
           // - Else: use the old locking mode
           locking_mode: lockingMode ?? (isNetworkChanged ? 'network_default' : vif.lockingMode),
-          qos_algorithm_type: rateLimit != null ? 'ratelimit' : undefined,
-          qos_algorithm_params: rateLimit != null ? { kbps: String(rateLimit) } : undefined,
+          qos_algorithm_type: newRateLimit != null ? 'ratelimit' : undefined,
+          qos_algorithm_params: newRateLimit != null ? { kbps: String(newRateLimit) } : undefined,
           network: network.$ref,
-          other_config: {
-            'ethtool-tx': txChecksumming !== undefined ? String(txChecksumming) : undefined,
-          },
+          other_config: otherConfig,
           VM: vm.$ref,
+          MTU: vif.MTU,
+          device: vif.device,
         },
         {
           MAC: mac,


### PR DESCRIPTION
### Description

([XO-2757](https://project.vates.tech/vates-global/browse/XO-2757/))

When updating a VIF's MAC address, the VIF needs to be deleted and re-created. During this process other_config, rate limit, MTU and device data are lost.

The fix ensures that the missing data is passed along if not replaced during the re-creation.

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
