### PR TITLE
fix(xo-server): prevent incidental static_memory_min edit

### DIFF
--- a/packages/xo-server/src/xapi/mixins/vm.mjs
+++ b/packages/xo-server/src/xapi/mixins/vm.mjs
@@ -426,7 +426,8 @@ const methods = {
       get: vm => +vm.memory_dynamic_max,
       preprocess: parseSize,
       set(memory, vm) {
-        return vm.$call('set_memory_limits', vm.memory_static_min, memory, memory, memory)
+        const staticMin = Math.min(vm.memory_static_min, memory)
+        return vm.$call('set_memory_limits', staticMin, memory, memory, memory)
       },
     },
 


### PR DESCRIPTION
### Description

**review by commit**

When creating a VM, if both `template` and `memory` were in the parameters and the memory value was lower than the template's static memory minimum, XO would throw a XAPI error MEMORY_CONSTRAINT_VIOLATION_ORDER. (see [matrix thread](https://chat.vates.tech/#/room/!OheqIrkcrqFOUEkYRY:vates.tech/$pVyQEjtZR3oo97gYO7yRpKbWd4A4Q1B70IqhPI5RcPY?via=vates.tech))
After discussing, we decided we should keep an error in this behaviour, but make it more explanatory.

Similarly, when editing a VM's memory boundaries, editing any value to something lower than the static memory min, this would automatically lower the static memory min of that VM. (this was done to respect this inequality enforced by XAPI: static_min <= dynamic_min <= dynamic_max <= static_max) After that, there is no way restore the the static memory min value in XO.

This PR fixes both these behaviours by preventing the modification of `static_memory_min`, and throwing an understandable error when trying to set another memory boundary lower than that.

Not worth a changelog entry IMO

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
