### PR TITLE
feat(web-core): add UiLinkList component

### DIFF
--- a/@xen-orchestra/lite/src/route-map.d.ts
+++ b/@xen-orchestra/lite/src/route-map.d.ts
@@ -744,6 +744,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/story/web-core/ui/link-list/ui-link-list': RouteRecordInfo<
+      '/story/web-core/ui/link-list/ui-link-list',
+      '/story/web-core/ui/link-list/ui-link-list',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/story/web-core/ui/log-entry-viewer/ui-log-entry-viewer': RouteRecordInfo<
       '/story/web-core/ui/log-entry-viewer/ui-log-entry-viewer',
       '/story/web-core/ui/log-entry-viewer/ui-log-entry-viewer',
@@ -1642,6 +1649,12 @@ declare module 'vue-router/auto-routes' {
     'src/stories/web-core/ui/link/ui-link.story.vue': {
       routes:
         | '/story/web-core/ui/link/ui-link'
+      views:
+        | never
+    }
+    'src/stories/web-core/ui/link-list/ui-link-list.story.vue': {
+      routes:
+        | '/story/web-core/ui/link-list/ui-link-list'
       views:
         | never
     }

--- a/@xen-orchestra/lite/src/route-map.d.ts
+++ b/@xen-orchestra/lite/src/route-map.d.ts
@@ -772,6 +772,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/story/web-core/ui/link-list/ui-link-list': RouteRecordInfo<
+      '/story/web-core/ui/link-list/ui-link-list',
+      '/story/web-core/ui/link-list/ui-link-list',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/story/web-core/ui/log-entry-viewer/ui-log-entry-viewer': RouteRecordInfo<
       '/story/web-core/ui/log-entry-viewer/ui-log-entry-viewer',
       '/story/web-core/ui/log-entry-viewer/ui-log-entry-viewer',
@@ -1702,6 +1709,12 @@ declare module 'vue-router/auto-routes' {
     'src/stories/web-core/ui/link/ui-link.story.vue': {
       routes:
         | '/story/web-core/ui/link/ui-link'
+      views:
+        | never
+    }
+    'src/stories/web-core/ui/link-list/ui-link-list.story.vue': {
+      routes:
+        | '/story/web-core/ui/link-list/ui-link-list'
       views:
         | never
     }

--- a/@xen-orchestra/lite/src/stories/web-core/ui/link-list/ui-link-list.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/link-list/ui-link-list.story.vue
@@ -1,0 +1,41 @@
+<template>
+  <ComponentStory
+    v-slot="{ properties }"
+    :params="[
+      prop('variant').required().enum('horizontal', 'vertical').preset('vertical').widget(),
+      prop('visible-items')
+        .num()
+        .widget()
+        .help('Number of links to display when collapsed. Vertical only, and requires `total-items`'),
+      prop('total-items')
+        .num()
+        .preset(groups.length)
+        .widget()
+        .help('Total number of links. Used to label the button that expands the list'),
+      slot().help('Meant to receive UiLink components'),
+    ]"
+  >
+    <UiLinkList v-bind="properties">
+      <UiLink v-for="group in groups" :key="group.id" icon="table:group" size="small" to="#">
+        {{ group.name }}
+      </UiLink>
+    </UiLinkList>
+  </ComponentStory>
+</template>
+
+<script lang="ts" setup>
+import ComponentStory from '@/components/component-story/ComponentStory.vue'
+import { prop, slot } from '@/libs/story/story-param'
+import UiLink from '@core/components/ui/link/UiLink.vue'
+import UiLinkList from '@core/components/ui/link-list/UiLinkList.vue'
+
+const groups = [
+  { id: '1', name: 'Administrators' },
+  { id: '2', name: 'Developers' },
+  { id: '3', name: 'Support' },
+  { id: '4', name: 'Auditors' },
+  { id: '5', name: 'Operators' },
+  { id: '6', name: 'Guests' },
+  { id: '7', name: 'Contractors' },
+]
+</script>

--- a/@xen-orchestra/lite/src/stories/web-core/ui/link-list/ui-link-list.story.vue
+++ b/@xen-orchestra/lite/src/stories/web-core/ui/link-list/ui-link-list.story.vue
@@ -25,7 +25,7 @@
 
 <script lang="ts" setup>
 import ComponentStory from '@/components/component-story/ComponentStory.vue'
-import { prop, slot } from '@/libs/story/story-param'
+import { prop, slot } from '@/libs/story/story-param.ts'
 import UiLink from '@core/components/ui/link/UiLink.vue'
 import UiLinkList from '@core/components/ui/link-list/UiLinkList.vue'
 

--- a/@xen-orchestra/web-core/lib/components/ui/link-list/UiLinkList.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/link-list/UiLinkList.vue
@@ -18,7 +18,7 @@
 
 <script lang="ts" setup>
 import UiCollapsibleList from '@core/components/ui/collapsible-list/UiCollapsibleList.vue'
-import { toVariants } from '@core/utils/to-variants.util'
+import { toVariants } from '@core/utils/to-variants.util.ts'
 import { computed } from 'vue'
 
 export type UiLinkListProps =

--- a/@xen-orchestra/web-core/lib/components/ui/link-list/UiLinkList.vue
+++ b/@xen-orchestra/web-core/lib/components/ui/link-list/UiLinkList.vue
@@ -1,0 +1,51 @@
+<!-- v2 -->
+<template>
+  <UiCollapsibleList
+    v-if="visibleItems !== undefined"
+    class="ui-link-list"
+    :class="className"
+    tag="div"
+    :total-items
+    :visible-items
+  >
+    <slot />
+  </UiCollapsibleList>
+
+  <div v-else class="ui-link-list" :class="className">
+    <slot />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import UiCollapsibleList from '@core/components/ui/collapsible-list/UiCollapsibleList.vue'
+import { toVariants } from '@core/utils/to-variants.util'
+import { computed } from 'vue'
+
+export type UiLinkListProps =
+  | { variant: 'horizontal' | 'vertical'; visibleItems?: never; totalItems?: never }
+  | { variant: 'vertical'; visibleItems: number; totalItems: number }
+
+const { variant, visibleItems, totalItems } = defineProps<UiLinkListProps>()
+
+defineSlots<{
+  default(): any
+}>()
+
+const className = computed(() => toVariants({ variant }))
+</script>
+
+<style lang="postcss" scoped>
+.ui-link-list {
+  display: flex;
+
+  &.variant--horizontal {
+    flex-wrap: wrap;
+    gap: 1.2rem;
+  }
+
+  &.variant--vertical {
+    flex-direction: column;
+    gap: 0.8rem;
+  }
+}
+</style>

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,4 +31,6 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/web-core minor
+
 <!--packages-end-->


### PR DESCRIPTION
### Description

Adds `UiLinkList`, a web-core component that lays out a list of `UiLink`, either horizontally with wrapping or vertically. Gaps come from the design system: `1.2rem` horizontal, `0.8rem` vertical.

When a vertical list needs to be truncated, the "show more" behaviour is delegated to the existing `UiCollapsibleList` rather than reimplemented. `visibleItems` and `totalItems` are tied together by a discriminated union, so the type rejects a limit given without a total, and rejects collapsing a horizontal list.

```vue
<UiLinkList variant="vertical">
  <UiLink v-for="group in groups" :key="group.id" :to="groupRoute(group)" icon="table:group" size="small">
    {{ group.name }}
  </UiLink>
</UiLinkList>
```

```vue
<!-- collapsed after 5 links, with a "see N more" button -->
<UiLinkList variant="vertical" :visible-items="5" :total-items="groups.length">
  <UiLink v-for="group in groups" :key="group.id" :to="groupRoute(group)" icon="table:group" size="small">
    {{ group.name }}
  </UiLink>
</UiLinkList>
```

### Screenshots

#### Horizontal

<img width="1577" height="127" alt="UiLinkList horizontal" src="https://github.com/user-attachments/assets/f324cb18-3350-4484-a201-2d656907a3d6" />

#### Vertical

<img width="354" height="416" alt="UiLinkList vertical" src="https://github.com/user-attachments/assets/91cad2b9-7aa6-4885-9179-328577cb5c6b" />

#### Vertical + Collapse

<img width="350" height="287" alt="UiLinkList vertical + collapse" src="https://github.com/user-attachments/assets/7876fca0-8742-4761-a42f-05ae614f5235" />

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
