### PR TITLE
fix(openmetrics): keep the Prometheus secret across xo-server restarts

### DIFF
--- a/@vates/types/src/xo-app.mts
+++ b/@vates/types/src/xo-app.mts
@@ -204,6 +204,8 @@ export type XoApp = {
   backupGuard(poolId: XoPool['id']): Promise<void>
   /* Throw if no authorization */
   checkFeatureAuthorization(featureCode: FeatureCode): Promise<void>
+  /* validate, apply and persist the configuration of a plugin */
+  configurePlugin(id: string, configuration: unknown, mergeWithExisting?: boolean): Promise<void>
   /* connect a server (XCP-ng/XenServer) */
   connectXenServer(id: XoServer['id']): Promise<void>
   // TODO: replace all XoAclBasePrivilege with a more strict type. (discriminate union)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,8 @@
 
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
+- [OpenMetrics] The Prometheus secret no longer changes on every xo-server restart: it is now generated once and saved in the plugin configuration (PR [#10290](https://github.com/vatesfr/xen-orchestra/pull/10290))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,6 +37,7 @@
 
 - @xen-orchestra/web minor
 - xo-server minor
+- xo-server-openmetrics patch
 - xo-web minor
 
 <!--packages-end-->

--- a/docs/docs/xo5/advanced.md
+++ b/docs/docs/xo5/advanced.md
@@ -403,14 +403,14 @@ The OpenMetrics plugin exposes a `/metrics` endpoint that Prometheus can scrape 
 2. Find and enable the **OpenMetrics** plugin.
 3. Configure the following options:
 
-| Option                | Default    | Description                                               |
-| --------------------- | ---------- | --------------------------------------------------------- |
-| **Prometheus secret** | (required) | Bearer token for authentication - you must set this value |
+| Option                | Default     | Description                                                                |
+| --------------------- | ----------- | -------------------------------------------------------------------------- |
+| **Prometheus secret** | (generated) | Bearer token for authentication - generated on first load if left empty |
 
 4. Save and load the plugin.
 
-:::warning
-You must set a **Prometheus secret** before loading the plugin. Without a valid secret, the metrics endpoint authentication is ineffective, potentially exposing sensitive infrastructure data (host resources, VM configurations, network details) to unauthorized access. Use a strong, random string (e.g., generated with `openssl rand -hex 32`).
+:::tip
+If you leave the **Prometheus secret** empty, one is generated the first time the plugin is loaded and saved in the plugin configuration, where you can read it back to configure Prometheus. You can also set your own strong, random string (e.g., generated with `openssl rand -hex 32`). Either way the secret is kept across xo-server restarts.
 :::
 
 ### Prometheus Configuration

--- a/packages/xo-server-openmetrics/src/index.mts
+++ b/packages/xo-server-openmetrics/src/index.mts
@@ -415,6 +415,9 @@ const __dirname = dirname(__filename)
 
 const logger = createLogger('xo:xo-server-openmetrics')
 
+/** Id under which xo-server registers this plugin (directory name minus the `xo-server-` prefix) */
+const PLUGIN_ID = 'openmetrics'
+
 /** Default port for the OpenMetrics HTTP server */
 const DEFAULT_PORT = 9004
 
@@ -481,10 +484,34 @@ export const configurationSchema = {
       type: 'string',
       title: 'Prometheus secret',
       description: 'Add this secret to http_config > authorization > credentials, and set type to Bearer',
-      default: Buffer.from(getRandomValues(new Uint32Array(8))).toString('hex'),
     },
   },
   additionalProperties: false,
+}
+
+/**
+ * Return the Prometheus bearer token, generating and persisting one on first use.
+ *
+ * The secret must survive an xo-server restart. It used to be a random
+ * `default` in `configurationSchema`: that expression is re-evaluated every
+ * time the module is loaded, and xo-server never saves the values it fills in
+ * from schema defaults, so each restart silently invalidated the token
+ * Prometheus was configured with.
+ *
+ * Exported for testability.
+ */
+export async function ensureSecret(
+  configuration: PluginConfiguration | undefined,
+  persist: (configuration: PluginConfiguration) => Promise<void>
+): Promise<string> {
+  const secret = configuration?.secret
+  if (secret !== undefined && secret !== '') {
+    return secret
+  }
+
+  const generated = Buffer.from(getRandomValues(new Uint32Array(8))).toString('hex')
+  await persist({ secret: generated })
+  return generated
 }
 
 // ============================================================================
@@ -779,11 +806,15 @@ class OpenMetricsPlugin {
       return
     }
 
+    const secret = await ensureSecret(this.#configuration, configuration =>
+      this.#xo.configurePlugin(PLUGIN_ID, configuration, true)
+    )
+
     // Port and bindAddress are fixed for security (server is behind xo-server proxy)
     const serverConfig: ServerConfiguration = {
       port: DEFAULT_PORT,
       bindAddress: DEFAULT_BIND_ADDRESS,
-      secret: this.#configuration?.secret ?? '',
+      secret,
     }
 
     logger.info('Starting OpenMetrics server', {

--- a/packages/xo-server-openmetrics/src/index.mts
+++ b/packages/xo-server-openmetrics/src/index.mts
@@ -25,7 +25,7 @@ import { createLogger } from '@xen-orchestra/log'
 import { fork, type ChildProcess } from 'node:child_process'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { getRandomValues } from 'node:crypto'
+import { randomBytes } from 'node:crypto'
 import { performance } from 'node:perf_hooks'
 import v8 from 'node:v8'
 
@@ -509,7 +509,7 @@ export async function ensureSecret(
     return secret
   }
 
-  const generated = Buffer.from(getRandomValues(new Uint32Array(8))).toString('hex')
+  const generated = randomBytes(32).toString('hex')
   await persist({ secret: generated })
   return generated
 }

--- a/packages/xo-server-openmetrics/src/index.test.mts
+++ b/packages/xo-server-openmetrics/src/index.test.mts
@@ -1,0 +1,48 @@
+/**
+ * Tests for the plugin configuration (Prometheus secret handling)
+ */
+
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { configurationSchema, ensureSecret } from './index.mjs'
+
+describe('configurationSchema', () => {
+  it('does not generate the secret as a schema default', () => {
+    // a `default` here is re-evaluated on every module load and never persisted
+    // by xo-server, which used to change the Prometheus secret at each restart
+    assert.equal((configurationSchema.properties.secret as Record<string, unknown>).default, undefined)
+  })
+})
+
+describe('ensureSecret', () => {
+  it('generates and persists a secret when none is configured', async () => {
+    const persisted: unknown[] = []
+    const secret = await ensureSecret(undefined, async configuration => {
+      persisted.push(configuration)
+    })
+
+    assert.match(secret, /^[0-9a-f]{16}$/)
+    assert.deepEqual(persisted, [{ secret }])
+  })
+
+  it('generates and persists a secret when the configured one is empty', async () => {
+    const persisted: unknown[] = []
+    const secret = await ensureSecret({ secret: '' }, async configuration => {
+      persisted.push(configuration)
+    })
+
+    assert.match(secret, /^[0-9a-f]{16}$/)
+    assert.deepEqual(persisted, [{ secret }])
+  })
+
+  it('keeps the configured secret and persists nothing', async () => {
+    const persisted: unknown[] = []
+    const secret = await ensureSecret({ secret: 'cafecafecafecafe' }, async configuration => {
+      persisted.push(configuration)
+    })
+
+    assert.equal(secret, 'cafecafecafecafe')
+    assert.deepEqual(persisted, [])
+  })
+})

--- a/packages/xo-server-openmetrics/src/index.test.mts
+++ b/packages/xo-server-openmetrics/src/index.test.mts
@@ -22,7 +22,7 @@ describe('ensureSecret', () => {
       persisted.push(configuration)
     })
 
-    assert.match(secret, /^[0-9a-f]{16}$/)
+    assert.match(secret, /^[0-9a-f]{64}$/)
     assert.deepEqual(persisted, [{ secret }])
   })
 
@@ -32,7 +32,7 @@ describe('ensureSecret', () => {
       persisted.push(configuration)
     })
 
-    assert.match(secret, /^[0-9a-f]{16}$/)
+    assert.match(secret, /^[0-9a-f]{64}$/)
     assert.deepEqual(persisted, [{ secret }])
   })
 


### PR DESCRIPTION
### Description

Reported on the forum: https://xcp-ng.org/forum/topic/12415

The plugin declared its `secret` with a random `default` in `configurationSchema`. That expression runs when the module is imported, so each xo-server process computes a different one, and xo-server never persists the values ajv fills in from schema defaults. If you copied the secret out of the plugin form without saving the configuration, scraping worked until the next restart and then Prometheus got 401s.

The default is gone. The secret is now generated on the first `load()` and saved through `xo.configurePlugin()`, so it survives a restart. A secret already present in the configuration is left untouched.

Also added the `configurePlugin` signature to `XoApp` so the plugin compiles, and fixed the plugin doc, which said you had to set the secret by hand. Regression test in `packages/xo-server-openmetrics/src/index.test.mts`.

Introduced by #9323

See https://project.vates.tech/vates-global/browse/XO-2887/

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
