### PR TITLE
fix(@vates/types,@xen-orchestra/rest-api): remove ACL type parameters from XoRecord

### DIFF
--- a/@vates/types/src/xo.mts
+++ b/@vates/types/src/xo.mts
@@ -19,7 +19,7 @@ import type {
   VM_POWER_STATE,
 } from './common.mjs'
 import type * as CMType from './lib/complex-matcher.mjs'
-import { XoAclPrivilege, XoAclRole, XoAclSupportedActionsByResource } from './lib/xen-orchestra-acl.mjs'
+import { XoAclBasePrivilege, XoAclRole } from './lib/xen-orchestra-acl.mjs'
 import type { XenApiHost, XenApiPool } from './xen-api.mjs'
 
 type BaseXapiXo = {
@@ -889,10 +889,7 @@ export type XapiXoRecord =
   | XoVtpm
   | XoSm
 
-export type NonXapiXoRecord<
-  TActionsByResource extends XoAclSupportedActionsByResource = never,
-  TResource extends string = never,
-> =
+export type NonXapiXoRecord =
   | AnyXoBackupArchive
   | AnyXoJob
   | AnyXoLog
@@ -905,12 +902,9 @@ export type NonXapiXoRecord<
   | XoTask
   | XoUser
   | XoAclRole
-  | XoAclPrivilege<TActionsByResource, TResource>
+  | XoAclBasePrivilege
 
-export type XoRecord<
-  TActionsByResource extends XoAclSupportedActionsByResource = never,
-  TResource extends string = never,
-> = XapiXoRecord | NonXapiXoRecord<TActionsByResource, TResource>
+export type XoRecord = XapiXoRecord | NonXapiXoRecord
 
 export type AnyXoVm = XoVm | XoVmSnapshot | XoVmTemplate | XoVmController
 

--- a/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/base-controller.mts
@@ -3,13 +3,7 @@ import { createGzip } from 'node:zlib'
 import { pipeline } from 'node:stream/promises'
 import { Readable, type Transform } from 'node:stream'
 import { Request } from 'express'
-import {
-  type AnyPrivilege,
-  hasPrivilegeOn,
-  type SupportedActions,
-  type SupportedActionsByResource,
-  type SupportedResource,
-} from '@xen-orchestra/acl'
+import { type AnyPrivilege, hasPrivilegeOn, type SupportedActions, type SupportedResource } from '@xen-orchestra/acl'
 import type { VatesTask } from '@vates/types/lib/vates/task'
 import type { XapiXoRecord, XoRecord, XoTask } from '@vates/types/xo'
 import type { Xapi } from '@vates/types/lib/xen-orchestra/xapi'
@@ -26,14 +20,13 @@ import { NDJSON_CONTENT_TYPE, safeParseComplexMatcher } from '../helpers/utils.h
 
 const noop = () => {}
 
-export type BaseControllerType<T extends RestXoRecord> = T extends XapiXoRecord
+export type BaseControllerType<T extends XoRecord> = T extends XapiXoRecord
   ? T['type']
   : NonNullable<XoTask['properties']['objectType']>
 
 export type CreateActionReturnType<CbType> = Promise<{ taskId: string } | CbType>
-export type RestXoRecord = XoRecord<SupportedActionsByResource, SupportedResource> | AnyPrivilege
 
-export abstract class BaseController<T extends RestXoRecord, IsSync extends boolean> extends Controller {
+export abstract class BaseController<T extends XoRecord, IsSync extends boolean> extends Controller {
   abstract getObjects(): IsSync extends false ? Promise<Record<T['id'], T>> : Record<T['id'], T>
   abstract getObject(id: T['id']): IsSync extends false ? Promise<T> : T
 
@@ -46,7 +39,7 @@ export abstract class BaseController<T extends RestXoRecord, IsSync extends bool
     this.restApi = restApi
   }
 
-  async sendObjects<Resource extends SupportedResource, Objects extends RestXoRecord = T>(
+  async sendObjects<Resource extends SupportedResource, Objects extends XoRecord = T>(
     objects: Objects[],
     req: Request,
     opts?: {

--- a/@xen-orchestra/rest-api/src/abstract-classes/xo-controller.mts
+++ b/@xen-orchestra/rest-api/src/abstract-classes/xo-controller.mts
@@ -1,14 +1,11 @@
 import type { NonXapiXoRecord } from '@vates/types/xo'
-import type { AnyPrivilege, SupportedActionsByResource, SupportedResource } from '@xen-orchestra/acl'
 
 import { BaseController, type BaseControllerType } from './base-controller.mjs'
 
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { limitAndFilterArray } from '../helpers/utils.helper.mjs'
 
-export abstract class XoController<
-  T extends NonXapiXoRecord<SupportedActionsByResource, SupportedResource> | AnyPrivilege,
-> extends BaseController<T, false> {
+export abstract class XoController<T extends NonXapiXoRecord> extends BaseController<T, false> {
   abstract getAllCollectionObjects(opts: Record<string, unknown>): Promise<T[]>
   abstract getCollectionObject(id: T['id']): Promise<T>
 

--- a/@xen-orchestra/rest-api/src/helpers/object-wrapper.helper.mts
+++ b/@xen-orchestra/rest-api/src/helpers/object-wrapper.helper.mts
@@ -2,10 +2,10 @@ import pick from 'lodash/pick.js'
 import { Request } from 'express'
 
 import { BASE_URL } from '../index.mjs'
-import type { RestXoRecord } from '../abstract-classes/base-controller.mjs'
+import type { XoRecord } from '@vates/types/xo'
 import type { WithHref } from './helper.type.mjs'
 
-export function makeObjectMapper<T extends RestXoRecord>(req: Request, path?: string | ((obj: T) => string)) {
+export function makeObjectMapper<T extends XoRecord>(req: Request, path?: string | ((obj: T) => string)) {
   const makeUrl = (obj: T) => {
     let _path: string
     if (path === undefined) {

--- a/@xen-orchestra/rest-api/src/middlewares/acl.middleware.mts
+++ b/@xen-orchestra/rest-api/src/middlewares/acl.middleware.mts
@@ -2,7 +2,6 @@ import {
   getMissingPrivileges,
   type AnyPrivilegeOnParam,
   type AnyPrivilege,
-  type SupportedActionsByResource,
   type SupportedActions,
   type SupportedResource,
 } from '@xen-orchestra/acl'
@@ -11,7 +10,7 @@ import type { Response, NextFunction } from 'express'
 import type { AuthenticatedRequest, MaybePromise } from '../helpers/helper.type.mjs'
 import { RestApi } from '../rest-api/rest-api.mjs'
 import { iocContainer } from '../ioc/ioc.mjs'
-import type { Branded, NonXapiXoRecord, XoApp, XapiXoRecord, XoRecord, XoAclBasePrivilege } from '@vates/types'
+import type { Branded, NonXapiXoRecord, XapiXoRecord, XoRecord } from '@vates/types'
 import { ServiceIdentifier, ValidateError } from 'tsoa'
 import { ApiError } from '../helpers/error.helper.mjs'
 
@@ -66,8 +65,6 @@ export function autoBindService<Service extends object, Method extends keyof Ser
   }
 }
 
-type RestNonXapiXoRecord = NonXapiXoRecord<SupportedActionsByResource, SupportedResource> | AnyPrivilege
-
 export type AclEntry = {
   [Resource in SupportedResource]: {
     resource: Resource
@@ -89,13 +86,13 @@ export type AclEntry = {
       | {
           objectIds: string[] | ((opts: { req: AuthenticatedRequest; restApi: RestApi }) => XoRecord['id'][])
           getObject?:
-            | ((opts: { restApi: RestApi }) => (id: Branded<any>) => Promise<RestNonXapiXoRecord | XoAclBasePrivilege>)
+            | ((opts: { restApi: RestApi }) => (id: Branded<any>) => Promise<NonXapiXoRecord>)
             | ((opts: { restApi: RestApi }) => (id: Branded<any>) => XapiXoRecord)
         }
       | {
           objectId: string | ((opts: { req: AuthenticatedRequest; restApi: RestApi }) => XoRecord['id'])
           getObject?:
-            | ((opts: { restApi: RestApi }) => (id: Branded<any>) => Promise<RestNonXapiXoRecord | XoAclBasePrivilege>)
+            | ((opts: { restApi: RestApi }) => (id: Branded<any>) => Promise<NonXapiXoRecord>)
             | ((opts: { restApi: RestApi }) => (id: Branded<any>) => XapiXoRecord)
         }
       | {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,6 +32,6 @@
 <!--packages-start-->
 
 - @vates/types major
-- @xen-orchestra/rest-api major
+- @xen-orchestra/rest-api minor
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,4 +31,7 @@
 
 <!--packages-start-->
 
+- @vates/types major
+- @xen-orchestra/rest-api major
+
 <!--packages-end-->


### PR DESCRIPTION
### Description

Removes the two ACL type parameters from `XoRecord` and `NonXapiXoRecord`. They
defaulted to `never`, leaving the privilege member uninhabited, so `XoRecord` was
unusable outside the REST API — XO 6 cannot supply them, they come from
`@xen-orchestra/acl`.

Both types now hold `XoAclBasePrivilege` directly, and the `RestXoRecord` alias is
removed. Nothing changes at runtime, and `AnyPrivilege` is still used as-is in the
controllers.

Introduced by 63d4334837 (#9774).

See [XO-2896](https://project.vates.tech/vates-global/browse/XO-2896/).

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
