### PR TITLE
fix(lite): use UiPanelCard in VDI side panel cards

### DIFF
--- a/@xen-orchestra/lite/src/modules/vdi/components/list/panel/cards/VdiConfigurationCard.vue
+++ b/@xen-orchestra/lite/src/modules/vdi/components/list/panel/cards/VdiConfigurationCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <UiCard class="card-container">
+  <UiPanelCard class="card-container">
     <UiCardTitle>
       {{ t('configuration') }}
     </UiCardTitle>
@@ -46,7 +46,7 @@
         </template>
       </VtsCardRowKeyValue>
     </div>
-  </UiCard>
+  </UiPanelCard>
 </template>
 
 <script setup lang="ts">
@@ -57,9 +57,9 @@ import { useSrStore } from '@/stores/xen-api/sr.store.ts'
 import VtsCardRowKeyValue from '@core/components/card/VtsCardRowKeyValue.vue'
 import VtsCopyButton from '@core/components/copy-button/VtsCopyButton.vue'
 import VtsStatus from '@core/components/status/VtsStatus.vue'
-import UiCard from '@core/components/ui/card/UiCard.vue'
 import UiCardTitle from '@core/components/ui/card-title/UiCardTitle.vue'
 import UiLink from '@core/components/ui/link/UiLink.vue'
+import UiPanelCard from '@core/components/ui/panel-card/UiPanelCard.vue'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 const { vdi, vbd } = defineProps<{
@@ -75,7 +75,6 @@ const isBootable = computed(() => vbd?.bootable ?? false)
 
 <style scoped lang="postcss">
 .card-container {
-  gap: 1.6rem;
   .content {
     display: flex;
     flex-direction: column;

--- a/@xen-orchestra/lite/src/modules/vdi/components/list/panel/cards/VdiInfosCard.vue
+++ b/@xen-orchestra/lite/src/modules/vdi/components/list/panel/cards/VdiInfosCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <UiCard class="card-container">
+  <UiPanelCard class="card-container">
     <UiPanelCardTitle :id="vdi.uuid" size="medium" :label="vdi.name_label" :icon="vdiIcon" />
     <div class="content">
       <VtsCardRowKeyValue truncate align-top>
@@ -37,7 +37,7 @@
         </template>
       </VtsCardRowKeyValue>
     </div>
-  </UiCard>
+  </UiPanelCard>
 </template>
 
 <script lang="ts" setup>
@@ -48,7 +48,7 @@ import VtsCardRowKeyValue from '@core/components/card/VtsCardRowKeyValue.vue'
 import VtsCopyButton from '@core/components/copy-button/VtsCopyButton.vue'
 import VtsStatus from '@core/components/status/VtsStatus.vue'
 import VtsTag from '@core/components/tag/VtsTag.vue'
-import UiCard from '@core/components/ui/card/UiCard.vue'
+import UiPanelCard from '@core/components/ui/panel-card/UiPanelCard.vue'
 import UiPanelCardTitle from '@core/components/ui/panel-card-title/UiPanelCardTitle.vue'
 import UiTagsList from '@core/components/ui/tag/UiTagsList.vue'
 import { useMapper } from '@core/packages/mapper'
@@ -82,7 +82,6 @@ const vbdsStatus = useMapper<VbdAttachmentStatus, (typeof CONNECTION_STATUS)[key
 
 <style scoped lang="postcss">
 .card-container {
-  gap: 1.6rem;
   .content {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
⚠️ Wait for #10289

### Description

`VdiConfigurationCard` and `VdiInfosCard` now use `UiPanelCard` instead of
`UiCard`, like every other side panel card. `UiCard` carries a 2.4rem padding
meant for page cards. The local `gap` rule they declared duplicated one
`UiPanelCard` already provides, and is dropped.

Introduced by #10269

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.