### PR TITLE
feat(xo-server,rest-api,xo-web/rpu): persist a recovery record across restarts

### DIFF
--- a/@vates/types/src/common.mts
+++ b/@vates/types/src/common.mts
@@ -795,3 +795,8 @@ export const XAPI_TYPES: readonly string[] = [
   'VTPM',
   'SM',
 ] satisfies readonly XapiXoRecord['type'][]
+
+/** steps of a rolling pool update on one host, in execution order */
+export const RPU_RECOVERY_STEP_NAMES = ['evacuate', 'update', 'reboot', 'enable', 'restoreVms'] as const
+
+export type RPU_RECOVERY_STEP_NAME = (typeof RPU_RECOVERY_STEP_NAMES)[number]

--- a/@vates/types/src/xo-app.mts
+++ b/@vates/types/src/xo-app.mts
@@ -125,6 +125,48 @@ type License = {
   bundleInfo?: { name: string; id: string }
 }
 
+export type PoolRollingUpdateRecoveryStep = {
+  status: 'pending' | 'running' | 'observed-succeeded' | 'failed' | 'not-needed'
+  startedAt?: string
+  finishedAt?: string
+}
+
+export type PoolRollingUpdateRecoveryHost = {
+  status: 'pending' | 'running' | 'succeeded' | 'failed' | 'not-needed'
+  steps: Record<string, PoolRollingUpdateRecoveryStep>
+  lastError: unknown
+}
+
+export type PoolRollingUpdateRecoveryRun = {
+  runId: string
+  poolId: string
+  status: 'preparing' | 'running' | 'interrupted' | 'resuming' | 'failed' | 'blocked' | 'cleaning'
+  attempt: number
+  startedAt: string
+  updatedAt: string
+  finishedAt?: string
+  interruptedAt?: string
+  taskId?: string
+  variant?: 'xcp' | 'xs-cdn' | 'xs-legacy'
+  hostOrder?: string[]
+  hosts: Record<string, PoolRollingUpdateRecoveryHost>
+  conflicts: unknown[]
+  planChanges: unknown[]
+  lastError: unknown
+  /** VM UUID -> UUID of the host it must be started on */
+  haltedPinnedVms: Record<string, string>
+}
+
+/** record unreadable or of an unknown schema version: recovery needs a human */
+export type PoolRollingUpdateRecoveryBlocked = {
+  poolId?: string
+  runId?: string
+  status: 'blocked'
+  blockedReason: string
+}
+
+export type PoolRollingUpdateRecovery = PoolRollingUpdateRecoveryRun | PoolRollingUpdateRecoveryBlocked
+
 export type XoApp = {
   hooks: EventEmitter
   _redis: {
@@ -353,6 +395,7 @@ export type XoApp = {
     pool: XoPool,
     opts?: { bypassBackupCheck?: boolean; rebootVm?: boolean; parentTask?: VatesTask; shutdownPinnedVms?: boolean }
   ): Promise<void>
+  getRollingUpdateRecovery(poolId: XoPool['id']): Promise<PoolRollingUpdateRecovery | undefined>
   setVmResourceSet(vmId: XoVm['id'], resourceSetId: string | null, force?: boolean): Promise<void>
   shareVmResourceSet(vmId: XoVm['id']): Promise<void>
   removeUserFromGroup(userId: XoUser['id'], id: XoGroup['id']): Promise<void>

--- a/@vates/types/src/xo-app.mts
+++ b/@vates/types/src/xo-app.mts
@@ -21,6 +21,7 @@ import type {
 } from './xo.mjs'
 import { VatesTask } from './lib/vates-task.mjs'
 import type { PluginRestRouteDefinition } from './lib/rest-api.mjs'
+import type { RPU_RECOVERY_STEP_NAME } from './common.mjs'
 import {
   Xapi,
   XapiHostStats,
@@ -131,17 +132,25 @@ export type PoolRollingUpdateRecoveryStep = {
   finishedAt?: string
 }
 
+/** error serialized by the recovery recorder: secret-looking keys are redacted */
+export type PoolRollingUpdateRecoveryError = {
+  name?: string
+  message?: string
+  stack?: string
+  code?: string | number
+  [key: string]: unknown
+}
+
 export type PoolRollingUpdateRecoveryHost = {
   status: 'pending' | 'running' | 'succeeded' | 'failed' | 'not-needed'
-  steps: Record<string, PoolRollingUpdateRecoveryStep>
-  lastError: unknown
+  steps: Record<RPU_RECOVERY_STEP_NAME, PoolRollingUpdateRecoveryStep>
+  lastError: PoolRollingUpdateRecoveryError | null
 }
 
 export type PoolRollingUpdateRecoveryRun = {
   runId: string
   poolId: string
-  status: 'preparing' | 'running' | 'interrupted' | 'resuming' | 'failed' | 'blocked' | 'cleaning'
-  attempt: number
+  status: 'preparing' | 'running' | 'interrupted' | 'resuming' | 'failed' | 'cleaning'
   startedAt: string
   updatedAt: string
   finishedAt?: string
@@ -150,9 +159,7 @@ export type PoolRollingUpdateRecoveryRun = {
   variant?: 'xcp' | 'xs-cdn' | 'xs-legacy'
   hostOrder?: string[]
   hosts: Record<string, PoolRollingUpdateRecoveryHost>
-  conflicts: unknown[]
-  planChanges: unknown[]
-  lastError: unknown
+  lastError: PoolRollingUpdateRecoveryError | null
   /** VM UUID -> UUID of the host it must be started on */
   haltedPinnedVms: Record<string, string>
 }

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/pool.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/pool.oa-example.mts
@@ -523,3 +523,58 @@ export const poolMissingPatches = [
     description: 'An open source implementation of SSH protocol versions 1 and 2',
   },
 ]
+
+export const poolRollingUpdateRecovery = {
+  runId: '5cea4373-05a7-47ff-9bd8-fea54a37dd63',
+  poolId: '355ee47d-ff4c-4924-3db2-fd86ae629676',
+  status: 'interrupted',
+  attempt: 1,
+  startedAt: '2026-08-31T14:02:11.000Z',
+  updatedAt: '2026-08-31T14:20:03.000Z',
+  interruptedAt: '2026-08-31T14:18:47.000Z',
+  taskId: '0mf2gtitq',
+  variant: 'xcp',
+  hostOrder: ['b61a5c92-700e-4966-a13b-00633f03eea8', '46522969-d891-4c48-a839-316b767b7b7b'],
+  hosts: {
+    'b61a5c92-700e-4966-a13b-00633f03eea8': {
+      status: 'succeeded',
+      steps: {
+        evacuate: {
+          status: 'observed-succeeded',
+          startedAt: '2026-08-31T14:02:20.000Z',
+          finishedAt: '2026-08-31T14:04:01.000Z',
+        },
+        update: {
+          status: 'observed-succeeded',
+          startedAt: '2026-08-31T14:04:01.000Z',
+          finishedAt: '2026-08-31T14:07:12.000Z',
+        },
+        reboot: {
+          status: 'observed-succeeded',
+          startedAt: '2026-08-31T14:07:12.000Z',
+          finishedAt: '2026-08-31T14:12:44.000Z',
+        },
+        enable: { status: 'observed-succeeded', finishedAt: '2026-08-31T14:12:44.000Z' },
+        restoreVms: { status: 'pending' },
+      },
+      lastError: null,
+    },
+    '46522969-d891-4c48-a839-316b767b7b7b': {
+      status: 'running',
+      steps: {
+        evacuate: { status: 'running', startedAt: '2026-08-31T14:12:50.000Z' },
+        update: { status: 'pending' },
+        reboot: { status: 'pending' },
+        enable: { status: 'pending' },
+        restoreVms: { status: 'pending' },
+      },
+      lastError: null,
+    },
+  },
+  conflicts: [],
+  planChanges: [],
+  lastError: null,
+  haltedPinnedVms: {
+    '883b6265-6d54-c48b-6a24-4b0e6d88801f': 'b61a5c92-700e-4966-a13b-00633f03eea8',
+  },
+}

--- a/@xen-orchestra/rest-api/src/open-api/oa-examples/pool.oa-example.mts
+++ b/@xen-orchestra/rest-api/src/open-api/oa-examples/pool.oa-example.mts
@@ -528,7 +528,6 @@ export const poolRollingUpdateRecovery = {
   runId: '5cea4373-05a7-47ff-9bd8-fea54a37dd63',
   poolId: '355ee47d-ff4c-4924-3db2-fd86ae629676',
   status: 'interrupted',
-  attempt: 1,
   startedAt: '2026-08-31T14:02:11.000Z',
   updatedAt: '2026-08-31T14:20:03.000Z',
   interruptedAt: '2026-08-31T14:18:47.000Z',
@@ -537,7 +536,7 @@ export const poolRollingUpdateRecovery = {
   hostOrder: ['b61a5c92-700e-4966-a13b-00633f03eea8', '46522969-d891-4c48-a839-316b767b7b7b'],
   hosts: {
     'b61a5c92-700e-4966-a13b-00633f03eea8': {
-      status: 'succeeded',
+      status: 'running',
       steps: {
         evacuate: {
           status: 'observed-succeeded',
@@ -571,8 +570,6 @@ export const poolRollingUpdateRecovery = {
       lastError: null,
     },
   },
-  conflicts: [],
-  planChanges: [],
   lastError: null,
   haltedPinnedVms: {
     '883b6265-6d54-c48b-6a24-4b0e6d88801f': 'b61a5c92-700e-4966-a13b-00633f03eea8',

--- a/@xen-orchestra/rest-api/src/pools/pool.controller.mts
+++ b/@xen-orchestra/rest-api/src/pools/pool.controller.mts
@@ -17,7 +17,7 @@ import {
   Tags,
 } from 'tsoa'
 import { inject } from 'inversify'
-import { invalidParameters } from 'xo-common/api-errors.js'
+import { invalidParameters, noSuchObject } from 'xo-common/api-errors.js'
 import { PassThrough } from 'node:stream'
 import { provide } from 'inversify-binding-decorators'
 import { json, type Request as ExRequest, type Response as ExResponse } from 'express'
@@ -42,6 +42,7 @@ import {
 import type { SendObjects } from '../helpers/helper.type.mjs'
 import { XapiXoController } from '../abstract-classes/xapi-xo-controller.mjs'
 import type {
+  PoolRollingUpdateRecovery,
   XapiPoolStats,
   XapiStatsGranularity,
   XcpPatches,
@@ -72,6 +73,7 @@ import {
   poolDashboard,
   poolIds,
   poolMissingPatches,
+  poolRollingUpdateRecovery,
   poolStats,
 } from '../open-api/oa-examples/pool.oa-example.mjs'
 import type {
@@ -704,6 +706,31 @@ export class PoolController extends XapiXoController<XoPool> {
     const { missingPatches } = await this.#poolService.getMissingPatches(pool.id)
 
     return missingPatches
+  }
+
+  /**
+   * Recovery status of an incomplete rolling pool update: run and per-host
+   * step statuses, last error, pinned VMs still halted. 404 when the last
+   * rolling pool update completed successfully (no recovery needed).
+   *
+   * Required privilege:
+   * - resource: pool, action: rolling-update
+   *
+   * @example id "355ee47d-ff4c-4924-3db2-fd86ae629676"
+   */
+  @Example(poolRollingUpdateRecovery)
+  @Extension('x-mcp-exposure', 'allow')
+  @Get('{id}/rolling_update_recovery')
+  @Middlewares(acl({ resource: 'pool', action: 'rolling-update', objectId: 'params.id' }))
+  @Response(forbiddenOperationResp.status, forbiddenOperationResp.description)
+  @Response(notFoundResp.status, notFoundResp.description)
+  async getRollingUpdateRecovery(@Path() id: string): Promise<PoolRollingUpdateRecovery> {
+    const pool = this.getObject(id as XoPool['id'])
+    const recovery = await this.restApi.xoApp.getRollingUpdateRecovery(pool.id)
+    if (recovery === undefined) {
+      throw noSuchObject(id, 'rollingUpdateRecovery')
+    }
+    return recovery
   }
 
   /**

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@
 - [REST API] SSE now supports Non XAPI objects (user, group, acl-privilege, acl-role, proxy, server, backup-repository, backup-job, schedule) (PR [#10278](https://github.com/vatesfr/xen-orchestra/pull/10278))
 - [REST API/SDN Controller, Audit] Traffic rule and audit record routes are now documented in the Swagger/OpenAPI spec (PR [#9895](https://github.com/vatesfr/xen-orchestra/pull/9895))
 - [LDAP] Release plugin for LDAP multidomain management (PR [#10015](https://github.com/vatesfr/xen-orchestra/pull/10015))
+- [RPU] Keep track of an interrupted rolling pool update across xo-server restarts: the pool's Patches tab now shows which hosts were updated, the last error, and the VMs that were shut down for the update and not started again (PR [#10331](https://github.com/vatesfr/xen-orchestra/pull/10331))
 
 ### Bug fixes
 

--- a/packages/xo-server/src/_rpuRecovery.mjs
+++ b/packages/xo-server/src/_rpuRecovery.mjs
@@ -1,0 +1,378 @@
+import { createLogger } from '@xen-orchestra/log'
+import { randomUUID } from 'node:crypto'
+import stringify from 'json-stringify-safe'
+
+import { replacer } from './_rpuObservability.mjs'
+
+const log = createLogger('xo:rpu-recovery')
+
+export const RPU_RECOVERY_SCHEMA_VERSION = 1
+
+// a run in one of these statuses cannot survive a process death: it is flipped
+// to `interrupted` at boot
+const LIVE_RUN_STATUSES = new Set(['preparing', 'running', 'resuming', 'cleaning'])
+
+const STEP_NAMES = ['evacuate', 'update', 'reboot', 'enable', 'restoreVms']
+
+const noop = () => {}
+const asyncNoop = async () => {}
+
+/**
+ * Serializes an error through the RPU observability replacer: secret-looking
+ * keys are scrubbed and the result only contains JSON-safe values.
+ *
+ * @param {any} error
+ * @returns {any} JSON-safe representation, `null` for nullish errors
+ */
+export function filterError(error) {
+  return error == null ? null : JSON.parse(stringify(error, replacer))
+}
+
+/**
+ * Creates the initial `version 1` recovery record of an RPU run: status
+ * `preparing`, nothing done yet.
+ *
+ * `conflicts`, `planChanges`, `original` and `changedByRun` are declared but
+ * left empty: they are filled by the conflict detection and settings
+ * restoration work built on top of this record.
+ *
+ * @param {object} params
+ * @param {string} params.poolId
+ * @param {object} params.options - Operator-consented options (`rebootVm`,
+ *   `bypassBackupCheck`, `shutdownPinnedVms`), impossible to reconstruct later
+ * @returns {object}
+ */
+export function createRpuRecoveryRecord({ poolId, options }) {
+  const now = new Date().toISOString()
+  return {
+    schemaVersion: RPU_RECOVERY_SCHEMA_VERSION,
+    runId: randomUUID(),
+    poolId,
+    status: 'preparing',
+    attempt: 1,
+    startedAt: now,
+    updatedAt: now,
+    options,
+    hosts: {},
+    haltedPinnedVms: {},
+    lastError: null,
+    conflicts: [],
+    planChanges: [],
+    original: {},
+    changedByRun: [],
+  }
+}
+
+function deriveHostStatus(steps) {
+  const statuses = STEP_NAMES.map(name => steps[name]?.status ?? 'pending')
+  if (statuses.includes('failed')) {
+    return 'failed'
+  }
+  if (statuses.includes('running')) {
+    return 'running'
+  }
+  if (statuses.every(status => status === 'not-needed')) {
+    return 'not-needed'
+  }
+  if (statuses.every(status => status === 'observed-succeeded' || status === 'not-needed')) {
+    return 'succeeded'
+  }
+  if (statuses.every(status => status === 'pending')) {
+    return 'pending'
+  }
+  // partially done then stopped in between steps
+  return 'running'
+}
+
+/**
+ * Projects a readable record onto its public view: run identity and status,
+ * dates, current task, per-host steps, conflicts, plan changes, last filtered
+ * error and halted pinned VMs.
+ *
+ * Never exposes the raw intent: options, initial VM placement, original
+ * settings and agent times stay in the record.
+ *
+ * A record of an unknown schema version is reported as `blocked`: acting on a
+ * record this version of the code cannot understand would be unsafe.
+ *
+ * @param {object} record
+ * @returns {object}
+ */
+export function buildRpuRecoveryView(record) {
+  if (record === null || typeof record !== 'object' || record.schemaVersion !== RPU_RECOVERY_SCHEMA_VERSION) {
+    return {
+      poolId: record?.poolId,
+      runId: record?.runId,
+      status: 'blocked',
+      blockedReason: `unknown schema version ${record?.schemaVersion}`,
+    }
+  }
+
+  const hosts = {}
+  for (const hostId of record.hostOrder ?? Object.keys(record.hosts ?? {})) {
+    const { steps = {}, lastError } = record.hosts?.[hostId] ?? {}
+    const viewSteps = {}
+    for (const name of STEP_NAMES) {
+      const { status = 'pending', startedAt, finishedAt } = steps[name] ?? {}
+      viewSteps[name] = { status, startedAt, finishedAt }
+    }
+    hosts[hostId] = {
+      status: deriveHostStatus(steps),
+      steps: viewSteps,
+      lastError: lastError ?? null,
+    }
+  }
+
+  return {
+    runId: record.runId,
+    poolId: record.poolId,
+    status: record.status,
+    attempt: record.attempt,
+    startedAt: record.startedAt,
+    updatedAt: record.updatedAt,
+    finishedAt: record.finishedAt,
+    interruptedAt: record.interruptedAt,
+    taskId: record.taskId,
+    variant: record.variant,
+    hostOrder: record.hostOrder,
+    hosts,
+    conflicts: record.conflicts ?? [],
+    planChanges: record.planChanges ?? [],
+    lastError: record.lastError ?? null,
+    haltedPinnedVms: record.haltedPinnedVms ?? {},
+  }
+}
+
+/**
+ * Public view of a record whose stored value cannot be decoded at all: the
+ * raw value is kept untouched on disk as evidence, the view reports `blocked`.
+ *
+ * @param {string} poolId
+ * @returns {object}
+ */
+export function unreadableRpuRecoveryView(poolId) {
+  return { poolId, status: 'blocked', blockedReason: 'unreadable record' }
+}
+
+/**
+ * Recorder used when a run does not track recovery (rolling pool reboot):
+ * every method is a no-op.
+ */
+export const noopRpuRecorder = Object.freeze({
+  markRunning: noop,
+  setTaskId: noop,
+  setVariant: noop,
+  setPatchInventory: noop,
+  setVmHome: noop,
+  setHostOrder: noop,
+  hostStarting: noop,
+  hostSkipped: noop,
+  hostFailed: noop,
+  stepRunning: noop,
+  stepObserved: noop,
+  stepNotNeeded: noop,
+  stepFailed: noop,
+  recordHaltedPinnedVm: asyncNoop,
+  forgetHaltedPinnedVm: noop,
+  fail: asyncNoop,
+  delete: asyncNoop,
+})
+
+/**
+ * Creates the recorder tracking one RPU run into its recovery record.
+ *
+ * Intent writes are strict (`recordHaltedPinnedVm` rejects on write failure so
+ * the run aborts before the corresponding side effect), tracking writes are
+ * best effort (a write failure is logged once, the run goes on). Writes are
+ * chained so they reach the store in order.
+ *
+ * @param {object} params
+ * @param {object} params.store - LevelDB sublevel, keyed by pool id
+ * @param {object} params.record - Record already persisted by the caller
+ * @returns {object}
+ */
+export function createRpuRecoveryRecorder({ store, record }) {
+  let chain = Promise.resolve()
+  let writeErrorLogged = false
+  const warnOnce = error => {
+    if (!writeErrorLogged) {
+      writeErrorLogged = true
+      log.warn('failed to write the RPU recovery record, recovery tracking is degraded', {
+        error,
+        poolId: record.poolId,
+      })
+    }
+  }
+  const enqueueWrite = () => {
+    record.updatedAt = new Date().toISOString()
+    const promise = chain.then(() => store.put(record.poolId, record))
+    chain = promise.catch(noop)
+    return promise
+  }
+  const write = () => enqueueWrite().catch(warnOnce)
+  const hostEntry = hostId => (record.hosts[hostId] ??= { steps: {} })
+  // `failed` is sticky: the first failure of a step is never downgraded
+  const setStep = (hostId, name, patch) => {
+    const steps = hostEntry(hostId).steps
+    const step = (steps[name] ??= {})
+    if (step.status !== 'failed') {
+      Object.assign(step, patch)
+    }
+  }
+  const setLastError = (hostId, error) => {
+    const filtered = filterError(error)
+    hostEntry(hostId).lastError = filtered
+    record.lastError = filtered
+  }
+
+  return {
+    runId: record.runId,
+
+    markRunning() {
+      record.status = 'running'
+      write()
+    },
+    setTaskId(taskId) {
+      if (taskId !== undefined) {
+        record.taskId = taskId
+        write()
+      }
+    },
+    setVariant(variant) {
+      record.variant = variant
+      write()
+    },
+    setPatchInventory(hasMissingPatchesByHost) {
+      record.hasMissingPatchesByHost = hasMissingPatchesByHost
+      write()
+    },
+    setVmHome(vmHomeById) {
+      record.vmHomeById = vmHomeById
+      write()
+    },
+    setHostOrder(hostIds) {
+      record.hostOrder = hostIds
+      write()
+    },
+    hostStarting(hostId, agentStartTime) {
+      hostEntry(hostId).agentStartedAtBeforeUpdate = agentStartTime
+      write()
+    },
+    hostSkipped(hostId) {
+      for (const name of STEP_NAMES) {
+        setStep(hostId, name, { status: 'not-needed' })
+      }
+      write()
+    },
+    // marks the step being run on this host as failed, if any: single failure
+    // path for everything thrown while handling one host
+    hostFailed(hostId, error) {
+      const steps = hostEntry(hostId).steps
+      const runningStep = STEP_NAMES.find(name => steps[name]?.status === 'running')
+      if (runningStep !== undefined) {
+        setStep(hostId, runningStep, { status: 'failed', finishedAt: new Date().toISOString() })
+      }
+      setLastError(hostId, error)
+      write()
+    },
+    stepRunning(hostId, name) {
+      setStep(hostId, name, { status: 'running', startedAt: new Date().toISOString() })
+      write()
+    },
+    stepObserved(hostId, name) {
+      setStep(hostId, name, { status: 'observed-succeeded', finishedAt: new Date().toISOString() })
+      write()
+    },
+    stepNotNeeded(hostId, name) {
+      setStep(hostId, name, { status: 'not-needed' })
+      write()
+    },
+    stepFailed(hostId, name, error) {
+      setStep(hostId, name, { status: 'failed', finishedAt: new Date().toISOString() })
+      setLastError(hostId, error)
+      write()
+    },
+    // strict: the entry must be on disk before the VM is shut down, otherwise
+    // a crash would leave a halted VM nothing knows about
+    async recordHaltedPinnedVm(vmId, hostId) {
+      record.haltedPinnedVms[vmId] = hostId
+      await enqueueWrite()
+    },
+    forgetHaltedPinnedVm(vmId) {
+      delete record.haltedPinnedVms[vmId]
+      write()
+    },
+    // persists the failure before the caller rethrows; never throws so the
+    // original error is not masked
+    async fail(error) {
+      record.status = 'failed'
+      record.lastError = filterError(error)
+      record.finishedAt = new Date().toISOString()
+      await enqueueWrite().catch(warnOnce)
+    },
+    // a successful run leaves no record behind
+    async delete() {
+      await chain
+      try {
+        await store.del(record.poolId)
+      } catch (error) {
+        log.warn('failed to delete the RPU recovery record after a successful run', { error, poolId: record.poolId })
+      }
+    },
+  }
+}
+
+/**
+ * Creates and persists the recovery record of a new RPU run, then returns its
+ * recorder.
+ *
+ * Strict write: a failure rejects and must abort the RPU before any side
+ * effect. An existing record for this pool is overwritten: refusing would
+ * deadlock the pool as long as there is no explicit close operation.
+ *
+ * @param {object} params
+ * @param {object} params.store - LevelDB sublevel, keyed by pool id
+ * @param {string} params.poolId
+ * @param {object} params.options
+ * @returns {Promise<object>} the recorder
+ */
+export async function startRpuRecoveryRun({ store, poolId, options }) {
+  const record = createRpuRecoveryRecord({ poolId, options })
+  await store.put(poolId, record)
+  return createRpuRecoveryRecorder({ store, record })
+}
+
+/**
+ * Boot reconciliation: a record left in a live status on disk cannot belong to
+ * a running operation anymore since xo-server just started, flip it to
+ * `interrupted`. `interruptedAt` keeps the last time the run was known alive.
+ *
+ * Unreadable or unknown-version records are left untouched: they are reported
+ * as `blocked` at read time and the raw value is evidence.
+ *
+ * Never throws: errors are logged and the remaining records are still
+ * processed.
+ *
+ * @param {object} store - LevelDB sublevel, keyed by pool id
+ * @returns {Promise<void>}
+ */
+export async function reconcileRpuRecoveryAtBoot(store) {
+  try {
+    for await (const poolId of store.createKeyStream()) {
+      try {
+        const record = await store.get(poolId)
+        if (record?.schemaVersion === RPU_RECOVERY_SCHEMA_VERSION && LIVE_RUN_STATUSES.has(record.status)) {
+          record.interruptedAt = record.updatedAt
+          record.status = 'interrupted'
+          record.updatedAt = new Date().toISOString()
+          await store.put(poolId, record)
+          log.info(`interrupted rolling pool update detected on pool ${record.poolId}`)
+        }
+      } catch (error) {
+        log.warn('could not reconcile an RPU recovery record, it will be reported as blocked', { error, poolId })
+      }
+    }
+  } catch (error) {
+    log.warn('could not list the RPU recovery records for reconciliation', { error })
+  }
+}

--- a/packages/xo-server/src/_rpuRecovery.mjs
+++ b/packages/xo-server/src/_rpuRecovery.mjs
@@ -1,4 +1,5 @@
 import { createLogger } from '@xen-orchestra/log'
+import { RPU_RECOVERY_STEP_NAMES } from '@vates/types/common'
 import { randomUUID } from 'node:crypto'
 import stringify from 'json-stringify-safe'
 
@@ -12,8 +13,6 @@ export const RPU_RECOVERY_SCHEMA_VERSION = 1
 // to `interrupted` at boot
 const LIVE_RUN_STATUSES = new Set(['preparing', 'running', 'resuming', 'cleaning'])
 
-const STEP_NAMES = ['evacuate', 'update', 'reboot', 'enable', 'restoreVms']
-
 const noop = () => {}
 const asyncNoop = async () => {}
 
@@ -21,20 +20,30 @@ const asyncNoop = async () => {}
  * Serializes an error through the RPU observability replacer: secret-looking
  * keys are scrubbed and the result only contains JSON-safe values.
  *
+ * Never throws: a value that cannot be serialized (throwing getter or
+ * `toJSON`) is reduced to its string form, and non-object values are wrapped
+ * so the result is always an object.
+ *
  * @param {any} error
- * @returns {any} JSON-safe representation, `null` for nullish errors
+ * @returns {object | null} JSON-safe representation, `null` for nullish errors
  */
 export function filterError(error) {
-  return error == null ? null : JSON.parse(stringify(error, replacer))
+  if (error == null) {
+    return null
+  }
+  let filtered
+  try {
+    filtered = JSON.parse(stringify(error, replacer))
+  } catch (serializationError) {
+    log.warn('could not serialize an error for the RPU recovery record', { error: serializationError })
+    filtered = String(error)
+  }
+  return typeof filtered === 'object' && filtered !== null ? filtered : { message: String(filtered) }
 }
 
 /**
  * Creates the initial `version 1` recovery record of an RPU run: status
  * `preparing`, nothing done yet.
- *
- * `conflicts`, `planChanges`, `original` and `changedByRun` are declared but
- * left empty: they are filled by the conflict detection and settings
- * restoration work built on top of this record.
  *
  * @param {object} params
  * @param {string} params.poolId
@@ -49,22 +58,17 @@ export function createRpuRecoveryRecord({ poolId, options }) {
     runId: randomUUID(),
     poolId,
     status: 'preparing',
-    attempt: 1,
     startedAt: now,
     updatedAt: now,
     options,
     hosts: {},
     haltedPinnedVms: {},
     lastError: null,
-    conflicts: [],
-    planChanges: [],
-    original: {},
-    changedByRun: [],
   }
 }
 
 function deriveHostStatus(steps) {
-  const statuses = STEP_NAMES.map(name => steps[name]?.status ?? 'pending')
+  const statuses = RPU_RECOVERY_STEP_NAMES.map(name => steps[name]?.status ?? 'pending')
   if (statuses.includes('failed')) {
     return 'failed'
   }
@@ -86,11 +90,11 @@ function deriveHostStatus(steps) {
 
 /**
  * Projects a readable record onto its public view: run identity and status,
- * dates, current task, per-host steps, conflicts, plan changes, last filtered
- * error and halted pinned VMs.
+ * dates, current task, per-host steps, last filtered error and halted pinned
+ * VMs.
  *
- * Never exposes the raw intent: options, initial VM placement, original
- * settings and agent times stay in the record.
+ * Never exposes the raw intent: options, initial VM placement and agent times
+ * stay in the record.
  *
  * A record of an unknown schema version is reported as `blocked`: acting on a
  * record this version of the code cannot understand would be unsafe.
@@ -112,7 +116,7 @@ export function buildRpuRecoveryView(record) {
   for (const hostId of record.hostOrder ?? Object.keys(record.hosts ?? {})) {
     const { steps = {}, lastError } = record.hosts?.[hostId] ?? {}
     const viewSteps = {}
-    for (const name of STEP_NAMES) {
+    for (const name of RPU_RECOVERY_STEP_NAMES) {
       const { status = 'pending', startedAt, finishedAt } = steps[name] ?? {}
       viewSteps[name] = { status, startedAt, finishedAt }
     }
@@ -127,7 +131,6 @@ export function buildRpuRecoveryView(record) {
     runId: record.runId,
     poolId: record.poolId,
     status: record.status,
-    attempt: record.attempt,
     startedAt: record.startedAt,
     updatedAt: record.updatedAt,
     finishedAt: record.finishedAt,
@@ -136,8 +139,6 @@ export function buildRpuRecoveryView(record) {
     variant: record.variant,
     hostOrder: record.hostOrder,
     hosts,
-    conflicts: record.conflicts ?? [],
-    planChanges: record.planChanges ?? [],
     lastError: record.lastError ?? null,
     haltedPinnedVms: record.haltedPinnedVms ?? {},
   }
@@ -163,8 +164,7 @@ export const noopRpuRecorder = Object.freeze({
   setTaskId: noop,
   setVariant: noop,
   setPatchInventory: noop,
-  setVmHome: noop,
-  setHostOrder: noop,
+  setPlan: noop,
   hostStarting: noop,
   hostSkipped: noop,
   hostFailed: noop,
@@ -246,12 +246,11 @@ export function createRpuRecoveryRecorder({ store, record }) {
       record.hasMissingPatchesByHost = hasMissingPatchesByHost
       write()
     },
-    setVmHome(vmHomeById) {
+    // one write for the biggest part of the record, right before the first
+    // host is handled
+    setPlan({ hostOrder, vmHomeById }) {
+      record.hostOrder = hostOrder
       record.vmHomeById = vmHomeById
-      write()
-    },
-    setHostOrder(hostIds) {
-      record.hostOrder = hostIds
       write()
     },
     hostStarting(hostId, agentStartTime) {
@@ -259,7 +258,7 @@ export function createRpuRecoveryRecorder({ store, record }) {
       write()
     },
     hostSkipped(hostId) {
-      for (const name of STEP_NAMES) {
+      for (const name of RPU_RECOVERY_STEP_NAMES) {
         setStep(hostId, name, { status: 'not-needed' })
       }
       write()
@@ -268,7 +267,7 @@ export function createRpuRecoveryRecorder({ store, record }) {
     // path for everything thrown while handling one host
     hostFailed(hostId, error) {
       const steps = hostEntry(hostId).steps
-      const runningStep = STEP_NAMES.find(name => steps[name]?.status === 'running')
+      const runningStep = RPU_RECOVERY_STEP_NAMES.find(name => steps[name]?.status === 'running')
       if (runningStep !== undefined) {
         setStep(hostId, runningStep, { status: 'failed', finishedAt: new Date().toISOString() })
       }
@@ -310,14 +309,11 @@ export function createRpuRecoveryRecorder({ store, record }) {
       record.finishedAt = new Date().toISOString()
       await enqueueWrite().catch(warnOnce)
     },
-    // a successful run leaves no record behind
+    // a successful run leaves no record behind: strict, a record left on disk
+    // would report the run as interrupted at the next restart
     async delete() {
       await chain
-      try {
-        await store.del(record.poolId)
-      } catch (error) {
-        log.warn('failed to delete the RPU recovery record after a successful run', { error, poolId: record.poolId })
-      }
+      await store.del(record.poolId)
     },
   }
 }
@@ -347,32 +343,34 @@ export async function startRpuRecoveryRun({ store, poolId, options }) {
  * a running operation anymore since xo-server just started, flip it to
  * `interrupted`. `interruptedAt` keeps the last time the run was known alive.
  *
- * Unreadable or unknown-version records are left untouched: they are reported
- * as `blocked` at read time and the raw value is evidence.
+ * Unknown-version records are left untouched: they are reported as `blocked`
+ * at read time and the raw value is evidence.
  *
- * Never throws: errors are logged and the remaining records are still
- * processed.
+ * Never throws: errors are logged.
  *
  * @param {object} store - LevelDB sublevel, keyed by pool id
  * @returns {Promise<void>}
  */
 export async function reconcileRpuRecoveryAtBoot(store) {
   try {
-    for await (const poolId of store.createKeyStream()) {
-      try {
-        const record = await store.get(poolId)
-        if (record?.schemaVersion === RPU_RECOVERY_SCHEMA_VERSION && LIVE_RUN_STATUSES.has(record.status)) {
-          record.interruptedAt = record.updatedAt
-          record.status = 'interrupted'
-          record.updatedAt = new Date().toISOString()
-          await store.put(poolId, record)
-          log.info(`interrupted rolling pool update detected on pool ${record.poolId}`)
-        }
-      } catch (error) {
-        log.warn('could not reconcile an RPU recovery record, it will be reported as blocked', { error, poolId })
+    for await (const { key: poolId, value: record } of store.createReadStream()) {
+      if (record?.schemaVersion === RPU_RECOVERY_SCHEMA_VERSION && LIVE_RUN_STATUSES.has(record.status)) {
+        const { runId, status, taskId, startedAt } = record
+        record.interruptedAt = record.updatedAt
+        record.status = 'interrupted'
+        record.updatedAt = new Date().toISOString()
+        await store.put(poolId, record)
+        log.info('interrupted rolling pool update detected', {
+          poolId,
+          runId,
+          taskId,
+          status,
+          startedAt,
+          interruptedAt: record.interruptedAt,
+        })
       }
     }
   } catch (error) {
-    log.warn('could not list the RPU recovery records for reconciliation', { error })
+    log.warn('could not reconcile the RPU recovery records', { error })
   }
 }

--- a/packages/xo-server/src/_rpuRecovery.mjs
+++ b/packages/xo-server/src/_rpuRecovery.mjs
@@ -343,34 +343,42 @@ export async function startRpuRecoveryRun({ store, poolId, options }) {
  * a running operation anymore since xo-server just started, flip it to
  * `interrupted`. `interruptedAt` keeps the last time the run was known alive.
  *
- * Unknown-version records are left untouched: they are reported as `blocked`
- * at read time and the raw value is evidence.
+ * Unreadable or unknown-version records are left untouched: they are reported
+ * as `blocked` at read time and the raw value is evidence.
  *
- * Never throws: errors are logged.
+ * Never throws: errors are logged and the remaining records are still
+ * processed.
  *
  * @param {object} store - LevelDB sublevel, keyed by pool id
  * @returns {Promise<void>}
  */
 export async function reconcileRpuRecoveryAtBoot(store) {
   try {
-    for await (const { key: poolId, value: record } of store.createReadStream()) {
-      if (record?.schemaVersion === RPU_RECOVERY_SCHEMA_VERSION && LIVE_RUN_STATUSES.has(record.status)) {
-        const { runId, status, taskId, startedAt } = record
-        record.interruptedAt = record.updatedAt
-        record.status = 'interrupted'
-        record.updatedAt = new Date().toISOString()
-        await store.put(poolId, record)
-        log.info('interrupted rolling pool update detected', {
-          poolId,
-          runId,
-          taskId,
-          status,
-          startedAt,
-          interruptedAt: record.interruptedAt,
-        })
+    // one read per key rather than createReadStream(): a value that fails to
+    // decode would error the whole stream, here it only skips that record
+    for await (const poolId of store.createKeyStream()) {
+      try {
+        const record = await store.get(poolId)
+        if (record?.schemaVersion === RPU_RECOVERY_SCHEMA_VERSION && LIVE_RUN_STATUSES.has(record.status)) {
+          const { runId, status, taskId, startedAt } = record
+          record.interruptedAt = record.updatedAt
+          record.status = 'interrupted'
+          record.updatedAt = new Date().toISOString()
+          await store.put(poolId, record)
+          log.info('interrupted rolling pool update detected', {
+            poolId,
+            runId,
+            taskId,
+            status,
+            startedAt,
+            interruptedAt: record.interruptedAt,
+          })
+        }
+      } catch (error) {
+        log.warn('could not reconcile an RPU recovery record, it will be reported as blocked', { error, poolId })
       }
     }
   } catch (error) {
-    log.warn('could not reconcile the RPU recovery records', { error })
+    log.warn('could not list the RPU recovery records for reconciliation', { error })
   }
 }

--- a/packages/xo-server/src/_rpuRecovery.test.mjs
+++ b/packages/xo-server/src/_rpuRecovery.test.mjs
@@ -1,0 +1,377 @@
+import assert from 'assert/strict'
+import test from 'node:test'
+import { Readable } from 'node:stream'
+
+import {
+  buildRpuRecoveryView,
+  createRpuRecoveryRecord,
+  filterError,
+  noopRpuRecorder,
+  reconcileRpuRecoveryAtBoot,
+  RPU_RECOVERY_SCHEMA_VERSION,
+  startRpuRecoveryRun,
+  unreadableRpuRecoveryView,
+} from './_rpuRecovery.mjs'
+
+const { describe, it } = test
+
+function makeFakeStore() {
+  const data = new Map()
+  return {
+    data,
+    async put(key, value) {
+      // simulate the JSON round trip of the real store
+      data.set(key, JSON.parse(JSON.stringify(value)))
+    },
+    async get(key) {
+      if (!data.has(key)) {
+        const error = new Error('not found')
+        error.notFound = true
+        throw error
+      }
+      return data.get(key)
+    },
+    async del(key) {
+      data.delete(key)
+    },
+    createKeyStream() {
+      return Readable.from([...data.keys()])
+    },
+  }
+}
+
+const OPTIONS = { rebootVm: true, bypassBackupCheck: false, shutdownPinnedVms: true }
+
+describe('createRpuRecoveryRecord()', () => {
+  it('creates a preparing v1 record with declared empty future fields', () => {
+    const record = createRpuRecoveryRecord({ poolId: 'pool1', options: OPTIONS })
+
+    assert.equal(record.schemaVersion, RPU_RECOVERY_SCHEMA_VERSION)
+    assert.equal(typeof record.runId, 'string')
+    assert.equal(record.poolId, 'pool1')
+    assert.equal(record.status, 'preparing')
+    assert.equal(record.attempt, 1)
+    assert.deepEqual(record.options, OPTIONS)
+    assert.deepEqual(record.hosts, {})
+    assert.deepEqual(record.haltedPinnedVms, {})
+    assert.equal(record.lastError, null)
+    assert.deepEqual(record.conflicts, [])
+    assert.deepEqual(record.planChanges, [])
+    assert.deepEqual(record.original, {})
+    assert.deepEqual(record.changedByRun, [])
+  })
+})
+
+describe('filterError()', () => {
+  it('serializes errors and scrubs secret-looking keys', () => {
+    const error = new Error('boom')
+    error.call = { params: { password: 'hunter2', host: 'xcp1' } }
+
+    const filtered = filterError(error)
+
+    assert.equal(filtered.message, 'boom')
+    assert.equal(filtered.call.params.password, '[REDACTED]')
+    assert.equal(filtered.call.params.host, 'xcp1')
+  })
+
+  it('returns null for nullish errors', () => {
+    assert.equal(filterError(undefined), null)
+    assert.equal(filterError(null), null)
+  })
+})
+
+describe('buildRpuRecoveryView()', () => {
+  it('reports an unknown schema version as blocked without touching the record', () => {
+    const view = buildRpuRecoveryView({ schemaVersion: 42, runId: 'r1', poolId: 'pool1', status: 'running' })
+
+    assert.equal(view.status, 'blocked')
+    assert.equal(view.poolId, 'pool1')
+    assert.equal(view.runId, 'r1')
+    assert.match(view.blockedReason, /42/)
+  })
+
+  it('reports a non-object record as blocked', () => {
+    assert.equal(buildRpuRecoveryView(null).status, 'blocked')
+    assert.equal(buildRpuRecoveryView('corrupt').status, 'blocked')
+  })
+
+  it('exposes the public fields and hides the raw intent', () => {
+    const record = createRpuRecoveryRecord({ poolId: 'pool1', options: OPTIONS })
+    record.taskId = 'task1'
+    record.variant = 'xcp'
+    record.hostOrder = ['h1', 'h2']
+    record.vmHomeById = { vm1: 'h1' }
+    record.hasMissingPatchesByHost = { h1: true, h2: false }
+    record.haltedPinnedVms = { vm2: 'h1' }
+    record.hosts.h1 = {
+      agentStartedAtBeforeUpdate: '123',
+      steps: { evacuate: { status: 'observed-succeeded' }, reboot: { status: 'running', startedAt: 'T' } },
+    }
+
+    const view = buildRpuRecoveryView(record)
+
+    assert.equal(view.runId, record.runId)
+    assert.equal(view.status, 'preparing')
+    assert.equal(view.attempt, 1)
+    assert.equal(view.taskId, 'task1')
+    assert.equal(view.variant, 'xcp')
+    assert.deepEqual(view.hostOrder, ['h1', 'h2'])
+    assert.deepEqual(view.haltedPinnedVms, { vm2: 'h1' })
+    assert.deepEqual(view.conflicts, [])
+    assert.deepEqual(view.planChanges, [])
+    assert.equal(view.lastError, null)
+
+    // raw intent is never exposed
+    assert.equal(view.options, undefined)
+    assert.equal(view.vmHomeById, undefined)
+    assert.equal(view.original, undefined)
+    assert.equal(view.changedByRun, undefined)
+    assert.equal(view.hasMissingPatchesByHost, undefined)
+    assert.equal(view.hosts.h1.agentStartedAtBeforeUpdate, undefined)
+
+    // per-host view: every step present, missing ones pending
+    assert.equal(view.hosts.h1.status, 'running')
+    assert.equal(view.hosts.h1.steps.evacuate.status, 'observed-succeeded')
+    assert.equal(view.hosts.h1.steps.reboot.status, 'running')
+    assert.equal(view.hosts.h1.steps.update.status, 'pending')
+    // h2 not started yet but listed through hostOrder
+    assert.equal(view.hosts.h2.status, 'pending')
+  })
+
+  it('derives per-host statuses', () => {
+    const record = createRpuRecoveryRecord({ poolId: 'pool1', options: OPTIONS })
+    record.hostOrder = ['failed', 'skipped', 'done', 'half']
+    const all = (status, names = ['evacuate', 'update', 'reboot', 'enable', 'restoreVms']) =>
+      Object.fromEntries(names.map(name => [name, { status }]))
+    record.hosts.failed = { steps: { ...all('observed-succeeded'), reboot: { status: 'failed' } } }
+    record.hosts.skipped = { steps: all('not-needed') }
+    record.hosts.done = { steps: { ...all('observed-succeeded'), update: { status: 'not-needed' } } }
+    record.hosts.half = { steps: { evacuate: { status: 'observed-succeeded' } } }
+
+    const view = buildRpuRecoveryView(record)
+
+    assert.equal(view.hosts.failed.status, 'failed')
+    assert.equal(view.hosts.skipped.status, 'not-needed')
+    assert.equal(view.hosts.done.status, 'succeeded')
+    assert.equal(view.hosts.half.status, 'running')
+  })
+})
+
+describe('unreadableRpuRecoveryView()', () => {
+  it('is blocked with a reason', () => {
+    const view = unreadableRpuRecoveryView('pool1')
+    assert.equal(view.status, 'blocked')
+    assert.equal(view.poolId, 'pool1')
+    assert.equal(typeof view.blockedReason, 'string')
+  })
+})
+
+describe('startRpuRecoveryRun()', () => {
+  it('persists the record before returning and overwrites any previous record', async () => {
+    const store = makeFakeStore()
+    await store.put('pool1', { schemaVersion: 42, status: 'blocked' })
+
+    const recorder = await startRpuRecoveryRun({ store, poolId: 'pool1', options: OPTIONS })
+
+    const stored = store.data.get('pool1')
+    assert.equal(stored.schemaVersion, RPU_RECOVERY_SCHEMA_VERSION)
+    assert.equal(stored.status, 'preparing')
+    assert.equal(stored.runId, recorder.runId)
+  })
+
+  it('rejects when the record cannot be written', async () => {
+    const store = makeFakeStore()
+    store.put = async () => {
+      throw new Error('disk full')
+    }
+
+    await assert.rejects(startRpuRecoveryRun({ store, poolId: 'pool1', options: OPTIONS }), /disk full/)
+  })
+})
+
+describe('createRpuRecoveryRecorder()', () => {
+  async function makeRecorder() {
+    const store = makeFakeStore()
+    const recorder = await startRpuRecoveryRun({ store, poolId: 'pool1', options: OPTIONS })
+    return { store, recorder, stored: () => store.data.get('pool1') }
+  }
+
+  it('tracks the run progression', async () => {
+    const { recorder, stored } = await makeRecorder()
+
+    recorder.markRunning()
+    recorder.setTaskId('task1')
+    recorder.setVariant('xcp')
+    recorder.setPatchInventory({ h1: true })
+    recorder.setVmHome({ vm1: 'h1' })
+    recorder.setHostOrder(['h1'])
+    recorder.hostStarting('h1', '123')
+    recorder.stepRunning('h1', 'evacuate')
+    recorder.stepObserved('h1', 'evacuate')
+    recorder.stepNotNeeded('h1', 'update')
+    await recorder.recordHaltedPinnedVm('vm2', 'h1')
+
+    const record = stored()
+    assert.equal(record.status, 'running')
+    assert.equal(record.taskId, 'task1')
+    assert.equal(record.variant, 'xcp')
+    assert.deepEqual(record.hasMissingPatchesByHost, { h1: true })
+    assert.deepEqual(record.vmHomeById, { vm1: 'h1' })
+    assert.deepEqual(record.hostOrder, ['h1'])
+    assert.equal(record.hosts.h1.agentStartedAtBeforeUpdate, '123')
+    assert.equal(record.hosts.h1.steps.evacuate.status, 'observed-succeeded')
+    assert.equal(record.hosts.h1.steps.update.status, 'not-needed')
+    assert.deepEqual(record.haltedPinnedVms, { vm2: 'h1' })
+
+    recorder.forgetHaltedPinnedVm('vm2')
+    await recorder.fail(new Error('later'))
+    assert.deepEqual(stored().haltedPinnedVms, {})
+  })
+
+  it('recordHaltedPinnedVm is strict: rejects on write failure', async () => {
+    const { store, recorder } = await makeRecorder()
+    store.put = async () => {
+      throw new Error('disk full')
+    }
+
+    await assert.rejects(recorder.recordHaltedPinnedVm('vm1', 'h1'), /disk full/)
+  })
+
+  it('tracking writes are best effort: a write failure does not throw', async () => {
+    const { store, recorder } = await makeRecorder()
+    store.put = async () => {
+      throw new Error('disk full')
+    }
+
+    // must not reject nor throw
+    recorder.markRunning()
+    recorder.stepRunning('h1', 'evacuate')
+    await recorder.fail(new Error('boom'))
+  })
+
+  it('keeps a failed step failed', async () => {
+    const { recorder, stored } = await makeRecorder()
+
+    recorder.stepRunning('h1', 'restoreVms')
+    recorder.stepFailed('h1', 'restoreVms', new Error('first'))
+    recorder.stepObserved('h1', 'restoreVms')
+    recorder.stepFailed('h1', 'restoreVms', new Error('second'))
+    await recorder.fail(new Error('final'))
+
+    const step = stored().hosts.h1.steps.restoreVms
+    assert.equal(step.status, 'failed')
+    // last error is the most recent one, host and run wide
+    assert.equal(stored().hosts.h1.lastError.message, 'second')
+  })
+
+  it('hostSkipped marks every step not-needed', async () => {
+    const { recorder, stored } = await makeRecorder()
+
+    recorder.hostSkipped('h1')
+    await recorder.recordHaltedPinnedVm('vm1', 'h1')
+
+    const steps = stored().hosts.h1.steps
+    for (const name of ['evacuate', 'update', 'reboot', 'enable', 'restoreVms']) {
+      assert.equal(steps[name].status, 'not-needed')
+    }
+  })
+
+  it('hostFailed marks the running step failed and records the filtered error', async () => {
+    const { recorder, stored } = await makeRecorder()
+
+    recorder.stepRunning('h1', 'reboot')
+    const error = new Error('agent never came back')
+    error.password = 'hunter2'
+    recorder.hostFailed('h1', error)
+    await recorder.fail(error)
+
+    const record = stored()
+    assert.equal(record.hosts.h1.steps.reboot.status, 'failed')
+    assert.equal(record.hosts.h1.lastError.message, 'agent never came back')
+    assert.equal(record.hosts.h1.lastError.password, '[REDACTED]')
+    assert.equal(record.lastError.message, 'agent never came back')
+    assert.equal(record.status, 'failed')
+    assert.equal(typeof record.finishedAt, 'string')
+  })
+
+  it('delete removes the record after a successful run', async () => {
+    const { store, recorder } = await makeRecorder()
+
+    recorder.markRunning()
+    await recorder.delete()
+
+    assert.equal(store.data.has('pool1'), false)
+  })
+
+  it('delete does not throw when the store fails', async () => {
+    const { store, recorder } = await makeRecorder()
+    store.del = async () => {
+      throw new Error('disk error')
+    }
+
+    await recorder.delete()
+  })
+})
+
+describe('reconcileRpuRecoveryAtBoot()', () => {
+  it('flips live statuses to interrupted and leaves settled ones untouched', async () => {
+    const store = makeFakeStore()
+    for (const [poolId, status] of [
+      ['preparing', 'preparing'],
+      ['running', 'running'],
+      ['resuming', 'resuming'],
+      ['cleaning', 'cleaning'],
+      ['failed', 'failed'],
+      ['blocked', 'blocked'],
+      ['interrupted', 'interrupted'],
+    ]) {
+      const record = createRpuRecoveryRecord({ poolId, options: OPTIONS })
+      record.status = status
+      await store.put(poolId, record)
+    }
+    await store.put('unknown-version', { schemaVersion: 42, status: 'running' })
+
+    await reconcileRpuRecoveryAtBoot(store)
+
+    for (const poolId of ['preparing', 'running', 'resuming', 'cleaning']) {
+      const record = store.data.get(poolId)
+      assert.equal(record.status, 'interrupted', poolId)
+      assert.equal(typeof record.interruptedAt, 'string')
+    }
+    for (const poolId of ['failed', 'blocked', 'interrupted']) {
+      assert.equal(store.data.get(poolId).status, poolId)
+    }
+    // unknown version left untouched: blocked at read time, the value is evidence
+    assert.deepEqual(store.data.get('unknown-version'), { schemaVersion: 42, status: 'running' })
+  })
+
+  it('an unreadable record does not stop the reconciliation of the others', async () => {
+    const store = makeFakeStore()
+    const live = createRpuRecoveryRecord({ poolId: 'pool2', options: OPTIONS })
+    live.status = 'running'
+    await store.put('pool1', 'whatever')
+    await store.put('pool2', live)
+    const innerGet = store.get.bind(store)
+    store.get = async key => {
+      if (key === 'pool1') {
+        throw new SyntaxError('Unexpected token')
+      }
+      return innerGet(key)
+    }
+
+    await reconcileRpuRecoveryAtBoot(store)
+
+    assert.equal(store.data.get('pool2').status, 'interrupted')
+  })
+})
+
+describe('noopRpuRecorder', () => {
+  it('accepts every recorder call without effect', async () => {
+    noopRpuRecorder.markRunning()
+    noopRpuRecorder.stepRunning('h1', 'evacuate')
+    noopRpuRecorder.hostFailed('h1', new Error('boom'))
+    await noopRpuRecorder.recordHaltedPinnedVm('vm1', 'h1')
+    await noopRpuRecorder.fail(new Error('boom'))
+    await noopRpuRecorder.delete()
+  })
+})

--- a/packages/xo-server/src/_rpuRecovery.test.mjs
+++ b/packages/xo-server/src/_rpuRecovery.test.mjs
@@ -34,8 +34,8 @@ function makeFakeStore() {
     async del(key) {
       data.delete(key)
     },
-    createReadStream() {
-      return Readable.from([...data].map(([key, value]) => ({ key, value })))
+    createKeyStream() {
+      return Readable.from([...data.keys()])
     },
   }
 }
@@ -349,9 +349,28 @@ describe('reconcileRpuRecoveryAtBoot()', () => {
     assert.deepEqual(store.data.get('unknown-version'), { schemaVersion: 42, status: 'running' })
   })
 
+  it('an unreadable record does not stop the reconciliation of the others', async () => {
+    const store = makeFakeStore()
+    const live = createRpuRecoveryRecord({ poolId: 'pool2', options: OPTIONS })
+    live.status = 'running'
+    await store.put('pool1', 'whatever')
+    await store.put('pool2', live)
+    const innerGet = store.get.bind(store)
+    store.get = async key => {
+      if (key === 'pool1') {
+        throw new SyntaxError('Unexpected token')
+      }
+      return innerGet(key)
+    }
+
+    await reconcileRpuRecoveryAtBoot(store)
+
+    assert.equal(store.data.get('pool2').status, 'interrupted')
+  })
+
   it('a failing store is logged, not thrown', async () => {
     const store = makeFakeStore()
-    store.createReadStream = () =>
+    store.createKeyStream = () =>
       Readable.from(
         (async function* () {
           throw new Error('corrupt')

--- a/packages/xo-server/src/_rpuRecovery.test.mjs
+++ b/packages/xo-server/src/_rpuRecovery.test.mjs
@@ -34,8 +34,8 @@ function makeFakeStore() {
     async del(key) {
       data.delete(key)
     },
-    createKeyStream() {
-      return Readable.from([...data.keys()])
+    createReadStream() {
+      return Readable.from([...data].map(([key, value]) => ({ key, value })))
     },
   }
 }
@@ -43,22 +43,17 @@ function makeFakeStore() {
 const OPTIONS = { rebootVm: true, bypassBackupCheck: false, shutdownPinnedVms: true }
 
 describe('createRpuRecoveryRecord()', () => {
-  it('creates a preparing v1 record with declared empty future fields', () => {
+  it('creates a preparing v1 record', () => {
     const record = createRpuRecoveryRecord({ poolId: 'pool1', options: OPTIONS })
 
     assert.equal(record.schemaVersion, RPU_RECOVERY_SCHEMA_VERSION)
     assert.equal(typeof record.runId, 'string')
     assert.equal(record.poolId, 'pool1')
     assert.equal(record.status, 'preparing')
-    assert.equal(record.attempt, 1)
     assert.deepEqual(record.options, OPTIONS)
     assert.deepEqual(record.hosts, {})
     assert.deepEqual(record.haltedPinnedVms, {})
     assert.equal(record.lastError, null)
-    assert.deepEqual(record.conflicts, [])
-    assert.deepEqual(record.planChanges, [])
-    assert.deepEqual(record.original, {})
-    assert.deepEqual(record.changedByRun, [])
   })
 })
 
@@ -77,6 +72,22 @@ describe('filterError()', () => {
   it('returns null for nullish errors', () => {
     assert.equal(filterError(undefined), null)
     assert.equal(filterError(null), null)
+  })
+
+  it('never throws: an unserializable error is reduced to its string form', () => {
+    const error = new Error('boom')
+    error.details = {
+      toJSON() {
+        throw new Error('nope')
+      },
+    }
+
+    assert.deepEqual(filterError(error), { message: 'Error: boom' })
+  })
+
+  it('wraps non-object values so the result is always an object', () => {
+    assert.deepEqual(filterError('boom'), { message: 'boom' })
+    assert.deepEqual(filterError(42), { message: '42' })
   })
 })
 
@@ -112,20 +123,15 @@ describe('buildRpuRecoveryView()', () => {
 
     assert.equal(view.runId, record.runId)
     assert.equal(view.status, 'preparing')
-    assert.equal(view.attempt, 1)
     assert.equal(view.taskId, 'task1')
     assert.equal(view.variant, 'xcp')
     assert.deepEqual(view.hostOrder, ['h1', 'h2'])
     assert.deepEqual(view.haltedPinnedVms, { vm2: 'h1' })
-    assert.deepEqual(view.conflicts, [])
-    assert.deepEqual(view.planChanges, [])
     assert.equal(view.lastError, null)
 
     // raw intent is never exposed
     assert.equal(view.options, undefined)
     assert.equal(view.vmHomeById, undefined)
-    assert.equal(view.original, undefined)
-    assert.equal(view.changedByRun, undefined)
     assert.equal(view.hasMissingPatchesByHost, undefined)
     assert.equal(view.hosts.h1.agentStartedAtBeforeUpdate, undefined)
 
@@ -203,8 +209,7 @@ describe('createRpuRecoveryRecorder()', () => {
     recorder.setTaskId('task1')
     recorder.setVariant('xcp')
     recorder.setPatchInventory({ h1: true })
-    recorder.setVmHome({ vm1: 'h1' })
-    recorder.setHostOrder(['h1'])
+    recorder.setPlan({ hostOrder: ['h1'], vmHomeById: { vm1: 'h1' } })
     recorder.hostStarting('h1', '123')
     recorder.stepRunning('h1', 'evacuate')
     recorder.stepObserved('h1', 'evacuate')
@@ -303,13 +308,13 @@ describe('createRpuRecoveryRecorder()', () => {
     assert.equal(store.data.has('pool1'), false)
   })
 
-  it('delete does not throw when the store fails', async () => {
+  it('delete is strict: rejects when the store fails', async () => {
     const { store, recorder } = await makeRecorder()
     store.del = async () => {
       throw new Error('disk error')
     }
 
-    await recorder.delete()
+    await assert.rejects(recorder.delete(), /disk error/)
   })
 })
 
@@ -322,7 +327,6 @@ describe('reconcileRpuRecoveryAtBoot()', () => {
       ['resuming', 'resuming'],
       ['cleaning', 'cleaning'],
       ['failed', 'failed'],
-      ['blocked', 'blocked'],
       ['interrupted', 'interrupted'],
     ]) {
       const record = createRpuRecoveryRecord({ poolId, options: OPTIONS })
@@ -338,30 +342,23 @@ describe('reconcileRpuRecoveryAtBoot()', () => {
       assert.equal(record.status, 'interrupted', poolId)
       assert.equal(typeof record.interruptedAt, 'string')
     }
-    for (const poolId of ['failed', 'blocked', 'interrupted']) {
+    for (const poolId of ['failed', 'interrupted']) {
       assert.equal(store.data.get(poolId).status, poolId)
     }
     // unknown version left untouched: blocked at read time, the value is evidence
     assert.deepEqual(store.data.get('unknown-version'), { schemaVersion: 42, status: 'running' })
   })
 
-  it('an unreadable record does not stop the reconciliation of the others', async () => {
+  it('a failing store is logged, not thrown', async () => {
     const store = makeFakeStore()
-    const live = createRpuRecoveryRecord({ poolId: 'pool2', options: OPTIONS })
-    live.status = 'running'
-    await store.put('pool1', 'whatever')
-    await store.put('pool2', live)
-    const innerGet = store.get.bind(store)
-    store.get = async key => {
-      if (key === 'pool1') {
-        throw new SyntaxError('Unexpected token')
-      }
-      return innerGet(key)
-    }
+    store.createReadStream = () =>
+      Readable.from(
+        (async function* () {
+          throw new Error('corrupt')
+        })()
+      )
 
     await reconcileRpuRecoveryAtBoot(store)
-
-    assert.equal(store.data.get('pool2').status, 'interrupted')
   })
 })
 

--- a/packages/xo-server/src/api/pool.mjs
+++ b/packages/xo-server/src/api/pool.mjs
@@ -277,6 +277,22 @@ rollingUpdate.resolve = {
 
 // -------------------------------------------------------------------
 
+export function getRollingUpdateRecovery({ pool }) {
+  return this.getRollingUpdateRecovery(pool.id)
+}
+
+getRollingUpdateRecovery.params = {
+  pool: { type: 'string' },
+}
+
+getRollingUpdateRecovery.resolve = {
+  pool: ['pool', 'pool', 'administrate'],
+}
+
+getRollingUpdateRecovery.description = 'Get the recovery status of an incomplete rolling pool update, if any'
+
+// -------------------------------------------------------------------
+
 export async function rollingReboot({ bypassBackupCheck, pool, shutdownPinnedVms }) {
   await this.rollingPoolReboot(pool, { bypassBackupCheck, shutdownPinnedVms })
 }

--- a/packages/xo-server/src/xapi/mixins/_pool.test.mjs
+++ b/packages/xo-server/src/xapi/mixins/_pool.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test'
 import { Task } from '@xen-orchestra/mixins/Tasks.mjs'
 
 import poolMethods from './pool.mjs'
+import { noopRpuRecorder } from '../../_rpuRecovery.mjs'
 
 const { describe, it } = test
 
@@ -164,7 +165,21 @@ class FakeXapi {
 // the mixin reaches its own methods through `this`
 Object.setPrototypeOf(FakeXapi.prototype, poolMethods)
 
-const rollingPoolReboot = async xapi => {
+// records only the step transitions, the rest of the recorder is a no-op
+const stepSpyRecorder = () => {
+  const steps = []
+  const record = status => (hostId, name) => steps.push({ status, hostId, name })
+  return {
+    ...noopRpuRecorder,
+    steps,
+    stepRunning: record('running'),
+    stepObserved: record('observed'),
+    stepNotNeeded: record('not-needed'),
+    stepFailed: record('failed'),
+  }
+}
+
+const rollingPoolReboot = async (xapi, options) => {
   const events = []
   const parentTask = new Task({
     properties: { name: 'rolling pool reboot', progress: 0 },
@@ -174,7 +189,7 @@ const rollingPoolReboot = async xapi => {
   let error
   await parentTask.run(async () => {
     try {
-      await poolMethods.rollingPoolReboot.call(xapi, parentTask)
+      await poolMethods.rollingPoolReboot.call(xapi, parentTask, options)
     } catch (err) {
       error = err
     }
@@ -224,7 +239,8 @@ describe('rollingPoolReboot', function () {
       [0, 45]
     )
 
-    const { error, strandedVms } = await rollingPoolReboot(xapi)
+    const recorder = stepSpyRecorder()
+    const { error, strandedVms } = await rollingPoolReboot(xapi, { recorder })
 
     assert.equal(error, undefined)
     assert.deepEqual(strandedVms.map(_ => _.vmId).sort(), ['vm-a2', 'vm-b1', 'vm-b2'])
@@ -232,6 +248,11 @@ describe('rollingPoolReboot', function () {
       assert.equal(strandedVm.code, 'HOST_NOT_ENOUGH_FREE_MEMORY')
       assert.equal(strandedVm.hostId, xapi.homeOf.get(strandedVm.vmId))
     }
+
+    // the recovery record must show the hosts whose VMs are not back, and only
+    // once the retry passes have given up on them
+    const failed = recorder.steps.filter(_ => _.status === 'failed' && _.name === 'restoreVms')
+    assert.deepEqual([...new Set(failed.map(_ => _.hostId))].sort(), ['host-A', 'host-B'])
   })
 
   it('skips the VMs destroyed while the pool was rebooting', async function () {
@@ -262,7 +283,8 @@ describe('rollingPoolReboot', function () {
     ])
     xapi.pool.other_config['xo:rpuMigrateVmsBack'] = 'false'
 
-    const { error, taskNames } = await rollingPoolReboot(xapi)
+    const recorder = stepSpyRecorder()
+    const { error, taskNames } = await rollingPoolReboot(xapi, { recorder })
 
     assert.equal(error, undefined)
     assert.equal(xapi.nMigrations, 0)
@@ -272,5 +294,13 @@ describe('rollingPoolReboot', function () {
     // a run which died before reaching it
     assert.ok(taskNames.includes('Skip migrating VMs back'))
     assert.ok(!taskNames.includes('Migrate VMs back'))
+
+    // a skipped phase must not leave `restoreVms` pending, otherwise the
+    // recovery record shows a finished run as still running
+    const notNeeded = recorder.steps.filter(_ => _.status === 'not-needed' && _.name === 'restoreVms')
+    assert.deepEqual(
+      notNeeded.map(_ => _.hostId).sort(),
+      xapi.hosts.map(_ => _.uuid)
+    )
   })
 })

--- a/packages/xo-server/src/xapi/mixins/patching.mjs
+++ b/packages/xo-server/src/xapi/mixins/patching.mjs
@@ -15,6 +15,7 @@ import { Task } from '@xen-orchestra/mixins/Tasks.mjs'
 
 import ensureArray from '../../_ensureArray.mjs'
 import { debounceWithKey, REMOVE_CACHE_ENTRY } from '../../_pDebounceWithKey.mjs'
+import { noopRpuRecorder } from '../../_rpuRecovery.mjs'
 import { forEach, mapFilter, parseXml } from '../../utils.mjs'
 
 import { useUpdateSystem } from '../utils.mjs'
@@ -732,7 +733,7 @@ const methods = {
   async rollingPoolUpdate(
     $defer,
     parentTask,
-    { xsCredentials, force = false, rebootVm = force, shutdownPinnedVms = false } = {}
+    { xsCredentials, force = false, rebootVm = force, shutdownPinnedVms = false, recorder = noopRpuRecorder } = {}
   ) {
     if (some(this.objects.indexes.type.SR, { type: 'linstor' })) {
       await this._updateLinstorPackages()
@@ -742,6 +743,8 @@ const methods = {
     const isXcp = _isXcp(master)
     const isXsWithCdnUpdates = _isXsWithCdnUpdates(master)
     const hosts = Object.values(this.objects.indexes.type.host)
+
+    recorder.setVariant(isXcp ? 'xcp' : isXsWithCdnUpdates ? 'xs-cdn' : 'xs-legacy')
 
     let xsHash
 
@@ -793,11 +796,13 @@ const methods = {
         subtask.set('progress', Math.round((done * 100) / hosts.length))
       })
     })
+    recorder.setPatchInventory(hasMissingPatchesByHost)
 
     await Task.run({ properties: { name: `Updating and rebooting` } }, async () => {
       await this.rollingPoolReboot(parentTask, {
         xsCredentials,
         shutdownPinnedVms,
+        recorder,
         beforeEvacuateVms: () => {
           // On XS < 8.4 and CH, start by installing patches on all hosts
           if (!isXcp && !isXsWithCdnUpdates) {
@@ -808,11 +813,17 @@ const methods = {
         },
         beforeRebootHost: host => {
           if (isXcp || isXsWithCdnUpdates) {
+            recorder.stepRunning(host.uuid, 'update')
             return Task.run(
               { properties: { name: `Installing patches`, hostId: host.uuid, hostName: host.name_label } },
               () => this.installPatches({ hosts: [host], xsHash })
-            )
+            ).then(result => {
+              recorder.stepObserved(host.uuid, 'update')
+              return result
+            })
           }
+          // XS legacy: patches were installed pool-wide before the first evacuation
+          recorder.stepNotNeeded(host.uuid, 'update')
         },
         ignoreHost: host => {
           return !hasMissingPatchesByHost[host.uuid]

--- a/packages/xo-server/src/xapi/mixins/pool.mjs
+++ b/packages/xo-server/src/xapi/mixins/pool.mjs
@@ -9,8 +9,6 @@ import { noopRpuRecorder } from '../../_rpuRecovery.mjs'
 import { parseDateTime } from '@xen-orchestra/xapi'
 import { Task } from '@xen-orchestra/mixins/Tasks.mjs'
 import filter from 'lodash/filter.js'
-import groupBy from 'lodash/groupBy.js'
-import mapValues from 'lodash/mapValues.js'
 
 const log = createLogger('xo:xapi')
 
@@ -159,37 +157,20 @@ const methods = {
       rprProgress += progressStep
       setProgress(parentTask, rprProgress)
     }
-    // Remember on which hosts the running VMs are
-    const vmRefsByHost = mapValues(
-      groupBy(
-        filter(this.objects.all, {
-          $type: 'VM',
-          power_state: 'Running',
-          is_control_domain: false,
-        }),
-        vm => {
-          const hostId = vm.$resident_on?.$id
+    // Remember on which hosts the running VMs are: to migrate them back after
+    // the reboots, and for the recovery record (not reconstructible once the
+    // evacuations have started)
+    const vmRefsByHost = {}
+    const vmHomeById = {}
+    for (const vm of filter(this.objects.all, { $type: 'VM', power_state: 'Running', is_control_domain: false })) {
+      const hostId = vm.$resident_on?.$id
 
-          if (hostId === undefined) {
-            throw new Error('Could not find host of all running VMs')
-          }
-
-          return hostId
-        }
-      ),
-      vms => vms.map(vm => vm.$ref)
-    )
-
-    {
-      // initial VM placement, needed to bring VMs back to their host after a
-      // resume: not reconstructible once the evacuations have started
-      const vmHomeById = {}
-      for (const [hostId, vmRefs] of Object.entries(vmRefsByHost)) {
-        for (const vmRef of vmRefs) {
-          vmHomeById[this.getObject(vmRef).uuid] = hostId
-        }
+      if (hostId === undefined) {
+        throw new Error('Could not find host of all running VMs')
       }
-      recorder.setVmHome(vmHomeById)
+
+      ;(vmRefsByHost[hostId] ??= []).push(vm.$ref)
+      vmHomeById[vm.uuid] = hostId
     }
 
     // Put master in first position to restart it first
@@ -199,7 +180,9 @@ const methods = {
     }
     ;[hosts[0], hosts[indexOfMaster]] = [hosts[indexOfMaster], hosts[0]]
 
-    recorder.setHostOrder(hosts.map(host => host.uuid))
+    // last write before the first host is handled: the host order and the VM
+    // placement are the biggest part of the record, written once
+    recorder.setPlan({ hostOrder: hosts.map(host => host.uuid), vmHomeById })
 
     // Restart all the hosts one by one
     const restartSubtask = new Task({ properties: { name: `Restarting hosts`, progress: 0 } })

--- a/packages/xo-server/src/xapi/mixins/pool.mjs
+++ b/packages/xo-server/src/xapi/mixins/pool.mjs
@@ -5,6 +5,7 @@ import { decorateObject } from '@vates/decorate-with'
 import { defer as deferrable } from 'golike-defer'
 import { incorrectState } from 'xo-common/api-errors.js'
 import { isHostRunning } from '../utils.mjs'
+import { noopRpuRecorder } from '../../_rpuRecovery.mjs'
 import { parseDateTime } from '@xen-orchestra/xapi'
 import { Task } from '@xen-orchestra/mixins/Tasks.mjs'
 import filter from 'lodash/filter.js'
@@ -51,7 +52,7 @@ const methods = {
   async rollingPoolReboot(
     $defer,
     parentTask,
-    { beforeEvacuateVms, beforeRebootHost, ignoreHost, shutdownPinnedVms = false } = {}
+    { beforeEvacuateVms, beforeRebootHost, ignoreHost, shutdownPinnedVms = false, recorder = noopRpuRecorder } = {}
   ) {
     // migrating the VMs back to their host doubles the migrations of the run: a
     // pool can opt out of that phase by setting this key to `false`
@@ -134,6 +135,11 @@ const methods = {
       for (const [vmRef, hostRef] of haltedPinnedVms) {
         try {
           await this.callAsync('VM.start_on', vmRef, hostRef, false, false)
+          try {
+            recorder.forgetHaltedPinnedVm(this.getObject(vmRef).uuid)
+          } catch (error) {
+            log.warn('could not resolve a restarted pinned VM, leaving it in the recovery record', { vmRef, error })
+          }
         } catch (error) {
           log.warn('failed to restart pinned VM after an aborted rolling pool reboot', { vmRef, error })
         }
@@ -174,12 +180,26 @@ const methods = {
       vms => vms.map(vm => vm.$ref)
     )
 
+    {
+      // initial VM placement, needed to bring VMs back to their host after a
+      // resume: not reconstructible once the evacuations have started
+      const vmHomeById = {}
+      for (const [hostId, vmRefs] of Object.entries(vmRefsByHost)) {
+        for (const vmRef of vmRefs) {
+          vmHomeById[this.getObject(vmRef).uuid] = hostId
+        }
+      }
+      recorder.setVmHome(vmHomeById)
+    }
+
     // Put master in first position to restart it first
     const indexOfMaster = hosts.findIndex(host => host.$ref === this.pool.master)
     if (indexOfMaster === -1) {
       throw new Error('Could not find pool master')
     }
     ;[hosts[0], hosts[indexOfMaster]] = [hosts[indexOfMaster], hosts[0]]
+
+    recorder.setHostOrder(hosts.map(host => host.uuid))
 
     // Restart all the hosts one by one
     const restartSubtask = new Task({ properties: { name: `Restarting hosts`, progress: 0 } })
@@ -193,6 +213,9 @@ const methods = {
         const hostName = host.name_label
 
         if (!ignoreHost || !ignoreHost(host)) {
+          // agent_start_time before the update: after a crash, comparing it to
+          // the current value tells whether this host actually rebooted
+          recorder.hostStarting(hostId, host.other_config.agent_start_time)
           await Task.run({ properties: { name: `Restarting host ${hostId}`, hostId, hostName } }, async () => {
             // This is an old metrics reference from before the pool master restart.
             // The references don't seem to change but it's not guaranteed.
@@ -202,6 +225,10 @@ const methods = {
             await this._waitObjectState(metricsRef, metrics => metrics.live)
 
             const getServerTime = async () => parseDateTime(await this.call('host.get_servertime', host.$ref)) * 1e3
+
+            // covers everything up to the host being clear: pinned VM shutdown,
+            // evacuation precondition and the evacuation itself
+            recorder.stepRunning(hostId, 'evacuate')
 
             let pinnedVmRefs = []
             if (shutdownPinnedVms) {
@@ -218,6 +245,10 @@ const methods = {
                     pinnedVmRefs,
                     async vmRef => {
                       const { uuid: vmId, name_label: vmName } = this.getObject(vmRef)
+                      // strict write: the record must know about this VM before
+                      // it goes down, or a crash would leave it halted with
+                      // nothing to restart it
+                      await recorder.recordHaltedPinnedVm(vmId, hostId)
                       await Task.run(
                         { properties: { name: `Shutting down VM ${vmId}`, hostId, hostName, vmId, vmName } },
                         async () => {
@@ -247,6 +278,7 @@ const methods = {
             await Task.run({ properties: { name: `Evacuate`, hostId, hostName } }, async () => {
               await this.clearHost(host)
             })
+            recorder.stepObserved(hostId, 'evacuate')
             rprProgress += progressStepPerHost
             setProgress(parentTask, rprProgress)
             subtaskProgress += subtaskProgressStep
@@ -261,6 +293,7 @@ const methods = {
             }
 
             const rebootTime = await getServerTime()
+            recorder.stepRunning(hostId, 'reboot')
             await Task.run({ properties: { name: `Restart`, hostId, hostName } }, async () => {
               await this.callAsync('host.reboot', host.$ref)
             })
@@ -303,6 +336,10 @@ const methods = {
                 new Error(`Host ${hostId} took too long to restart`)
               )
             })
+            // both observed at once: the wait above checks agent_start_time
+            // (actual reboot) and host.enabled together
+            recorder.stepObserved(hostId, 'reboot')
+            recorder.stepObserved(hostId, 'enable')
 
             if (pinnedVmRefs.length > 0) {
               await Task.run({ properties: { name: `Restart pinned VMs`, hostId, hostName } }, async () => {
@@ -318,6 +355,7 @@ const methods = {
                       () => this.callAsync('VM.start_on', vmRef, host.$ref, false, false)
                     )
                     haltedPinnedVms.delete(vmRef)
+                    recorder.forgetHaltedPinnedVm(vmId)
                   },
                   { concurrency: PINNED_VM_START_CONCURRENCY, stopOnError: false }
                 )
@@ -327,8 +365,14 @@ const methods = {
             setProgress(parentTask, rprProgress)
             subtaskProgress += subtaskProgressStep
             setProgress(restartSubtask, subtaskProgress)
+          }).catch(error => {
+            // single failure path for this host: mark whichever step was
+            // running when it broke
+            recorder.hostFailed(hostId, error)
+            throw error
           })
         } else {
+          recorder.hostSkipped(hostId)
           rprProgress += progressStepPerHost * nStepsSubtask
           setProgress(parentTask, rprProgress)
           subtaskProgress += subtaskProgressStep * nStepsSubtask
@@ -342,13 +386,22 @@ const methods = {
       // one is the emptiest, and serving it frees memory on the ones still to come
       hosts.reverse()
 
-      await this._migrateVmsBack(hosts, vmRefsByHost, ignoreHost, () => {
-        rprProgress += progressStepPerHost
-        setProgress(parentTask, rprProgress)
-      })
+      await this._migrateVmsBack(
+        hosts,
+        vmRefsByHost,
+        ignoreHost,
+        () => {
+          rprProgress += progressStepPerHost
+          setProgress(parentTask, rprProgress)
+        },
+        recorder
+      )
     } else {
       await Task.run({ properties: { name: `Skip migrating VMs back` } }, () => {
         log.info('migrating the VMs back is disabled on this pool', { pool: this.pool.uuid })
+        for (const host of hosts) {
+          recorder.stepNotNeeded(host.uuid, 'restoreVms')
+        }
       })
     }
 
@@ -360,7 +413,7 @@ const methods = {
   //
   // onHostDone is called once per host, whether its VMs moved or not, so that
   // the caller can advance the progress of the whole rolling operation.
-  async _migrateVmsBack(hosts, vmRefsByHost, ignoreHost, onHostDone) {
+  async _migrateVmsBack(hosts, vmRefsByHost, ignoreHost, onHostDone, recorder = noopRpuRecorder) {
     // returns a report entry instead of throwing: a rejected migration is
     // queued for the retry passes below, it aborts nothing
     const migrateVmBack = async (vmRef, host) => {
@@ -408,9 +461,11 @@ const methods = {
         const vmRefs = vmRefsByHost[hostId]
 
         if (vmRefs === undefined) {
+          recorder.stepNotNeeded(hostId, 'restoreVms')
           hostDone()
           continue
         }
+        recorder.stepRunning(hostId, 'restoreVms')
         const oneHostMigrationsTask = new Task({
           properties: { name: `Migrating VMs back to host ${hostId}`, hostId, hostName, progress: 0 },
         })
@@ -435,6 +490,9 @@ const methods = {
             setProgress(oneHostMigrationsTask, (100 * done) / vmRefs.length)
           }
         })
+        // optimistic: a VM still pending is only a failure once the retry
+        // passes below have given up on it
+        recorder.stepObserved(hostId, 'restoreVms')
         hostDone()
       }
 
@@ -468,6 +526,9 @@ const methods = {
         // host and vmRef have no place in a task property
         const strandedVms = pendingVms.map(({ host, vmRef, ...strandedVm }) => strandedVm)
         migrationsSubtask.set('strandedVms', strandedVms)
+        for (const { hostId, message, vmId } of strandedVms) {
+          recorder.stepFailed(hostId, 'restoreVms', new Error(`could not migrate VM ${vmId} back: ${message}`))
+        }
         log.warn('could not migrate all the VMs back to their host', { pool: this.pool.uuid, strandedVms })
       }
     })

--- a/packages/xo-server/src/xo-mixins/pool.mjs
+++ b/packages/xo-server/src/xo-mixins/pool.mjs
@@ -14,6 +14,12 @@ import { Task } from '@vates/task'
 
 import { acquireRpuGuard } from '../_rpuGuard.mjs'
 import { gcRpuTraces, getRpuTracesConfig, openRpuTrace, reconcileRpuTraces } from '../_rpuObservability.mjs'
+import {
+  buildRpuRecoveryView,
+  reconcileRpuRecoveryAtBoot,
+  startRpuRecoveryRun as startRpuRecoveryRunInStore,
+  unreadableRpuRecoveryView,
+} from '../_rpuRecovery.mjs'
 
 const log = createLogger('xo:xo-mixins:pool')
 
@@ -73,6 +79,32 @@ export default class Pools {
     // a heartbeat left pending on disk after a restart belongs to an
     // interrupted run: stamp it so the disk alone is unambiguous
     app.hooks.on('start', () => reconcileRpuTraces(getRpuTracesConfig(app).dir))
+
+    // a recovery record left in a live status belongs to a run killed by the
+    // restart: flip it to `interrupted` before serving any client
+    app.hooks.on('start', async () => {
+      this._rpuRecoveryStore = await app.getStore('rpuRecovery')
+      await reconcileRpuRecoveryAtBoot(this._rpuRecoveryStore)
+    })
+  }
+
+  startRpuRecoveryRun(poolId, options) {
+    return startRpuRecoveryRunInStore({ store: this._rpuRecoveryStore, poolId, options })
+  }
+
+  async getRollingUpdateRecovery(poolId) {
+    let record
+    try {
+      record = await this._rpuRecoveryStore.get(poolId)
+    } catch (error) {
+      if (error.notFound) {
+        return undefined
+      }
+      // undecodable value: report blocked, leave the raw value on disk as evidence
+      log.warn('unreadable RPU recovery record', { error, poolId })
+      return unreadableRpuRecoveryView(poolId)
+    }
+    return buildRpuRecoveryView(record)
   }
 
   async mergeInto($defer, { sources: sourceIds, target, force }) {

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -969,6 +969,10 @@ export default class XenServers {
 
     $defer(acquireRpuGuard(poolId, 'rollingPoolUpdate'))
 
+    // strict write before any side effect: if the record cannot be persisted,
+    // an interruption could not be reported, so the run must not start
+    const recorder = await app.startRpuRecoveryRun(poolId, { rebootVm, bypassBackupCheck, shutdownPinnedVms })
+
     const jobsOfthePool = []
     jobs.forEach(({ id: jobId, vms }) => {
       if (vms.id !== undefined) {
@@ -992,6 +996,8 @@ export default class XenServers {
         }
       }
     })
+
+    recorder.markRunning()
 
     // Disable schedules
     await Promise.all(
@@ -1029,13 +1035,22 @@ export default class XenServers {
     }
     const task = parentTask === undefined ? app.tasks.create(properties) : new Task({ properties })
     trace?.attach(task)
-    await task.run(async () =>
-      this.getXapi(pool).rollingPoolUpdate(task, {
-        xsCredentials: app.apiContext.user.preferences.xsCredentials,
-        rebootVm,
-        shutdownPinnedVms,
-      })
-    )
+    recorder.setTaskId(task.id)
+    try {
+      await task.run(async () =>
+        this.getXapi(pool).rollingPoolUpdate(task, {
+          xsCredentials: app.apiContext.user.preferences.xsCredentials,
+          rebootVm,
+          shutdownPinnedVms,
+          recorder,
+        })
+      )
+    } catch (error) {
+      await recorder.fail(error)
+      throw error
+    }
+    // a successful run needs no recovery
+    await recorder.delete()
   }
 }
 

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -973,70 +973,72 @@ export default class XenServers {
     // an interruption could not be reported, so the run must not start
     const recorder = await app.startRpuRecoveryRun(poolId, { rebootVm, bypassBackupCheck, shutdownPinnedVms })
 
-    const jobsOfthePool = []
-    jobs.forEach(({ id: jobId, vms }) => {
-      if (vms.id !== undefined) {
-        for (const vmId of extractIdsFromSimplePattern(vms)) {
-          // try/catch to avoid `no such object`
-          try {
-            if (app.getObject(vmId).$poolId === poolId) {
-              jobsOfthePool.push(jobId)
-              break
-            }
-          } catch {}
-        }
-      } else {
-        // Smart mode
-        // For smart mode, we take a simplified approach:
-        // - if smart mode is explicitly 'resident' or 'not resident' on pools, we
-        //   check if it concerns this pool
-        // - if not, the job may concern this pool so we add it to `jobsOfThePool`
-        if (vms.$pool === undefined || createPredicate(vms.$pool)(poolId)) {
-          jobsOfthePool.push(jobId)
-        }
-      }
-    })
-
-    recorder.markRunning()
-
-    // Disable schedules
-    await Promise.all(
-      schedules
-        .filter(schedule => jobsOfthePool.includes(schedule.jobId) && schedule.enabled)
-        .map(async schedule => {
-          await app.updateSchedule({ ...schedule, enabled: false })
-          $defer(() => app.updateSchedule({ ...schedule, enabled: true }))
-        })
-    )
-
-    // Disable load balancer
-    await this._suspendRpuLoadBalancer($defer, pool)
-
-    const xapi = this.getXapi(pool)
-    if (await xapi.getField('pool', pool._xapiRef, 'wlb_enabled')) {
-      await xapi.call('pool.set_wlb_enabled', pool._xapiRef, false)
-      $defer(() => xapi.call('pool.set_wlb_enabled', pool._xapiRef, true))
-    }
-
-    const trace = openRpuTrace({ dir: getRpuTracesConfig(app).dir, kind: 'rpu', poolId })
-    $defer(() => trace?.stop())
-    if (trace !== undefined) {
-      log.info(`rolling pool update of pool ${poolId}: trace in ${trace.traceFile}`)
-    }
-
-    const properties = {
-      name: 'Rolling pool update',
-      objectId: poolId,
-      poolId,
-      poolName: pool.name_label,
-      progress: 0,
-      type: 'pool.rolling_update',
-      ...(trace !== undefined && { traceFile: trace.traceFile }),
-    }
-    const task = parentTask === undefined ? app.tasks.create(properties) : new Task({ properties })
-    trace?.attach(task)
-    recorder.setTaskId(task.id)
+    // every failure from here on is persisted before the caller sees it: the
+    // pool state starts changing below (schedules, load balancer, WLB)
     try {
+      const jobsOfthePool = []
+      jobs.forEach(({ id: jobId, vms }) => {
+        if (vms.id !== undefined) {
+          for (const vmId of extractIdsFromSimplePattern(vms)) {
+            // try/catch to avoid `no such object`
+            try {
+              if (app.getObject(vmId).$poolId === poolId) {
+                jobsOfthePool.push(jobId)
+                break
+              }
+            } catch {}
+          }
+        } else {
+          // Smart mode
+          // For smart mode, we take a simplified approach:
+          // - if smart mode is explicitly 'resident' or 'not resident' on pools, we
+          //   check if it concerns this pool
+          // - if not, the job may concern this pool so we add it to `jobsOfThePool`
+          if (vms.$pool === undefined || createPredicate(vms.$pool)(poolId)) {
+            jobsOfthePool.push(jobId)
+          }
+        }
+      })
+
+      recorder.markRunning()
+
+      // Disable schedules
+      await Promise.all(
+        schedules
+          .filter(schedule => jobsOfthePool.includes(schedule.jobId) && schedule.enabled)
+          .map(async schedule => {
+            await app.updateSchedule({ ...schedule, enabled: false })
+            $defer(() => app.updateSchedule({ ...schedule, enabled: true }))
+          })
+      )
+
+      // Disable load balancer
+      await this._suspendRpuLoadBalancer($defer, pool)
+
+      const xapi = this.getXapi(pool)
+      if (await xapi.getField('pool', pool._xapiRef, 'wlb_enabled')) {
+        await xapi.call('pool.set_wlb_enabled', pool._xapiRef, false)
+        $defer(() => xapi.call('pool.set_wlb_enabled', pool._xapiRef, true))
+      }
+
+      const trace = openRpuTrace({ dir: getRpuTracesConfig(app).dir, kind: 'rpu', poolId })
+      $defer(() => trace?.stop())
+      if (trace !== undefined) {
+        log.info(`rolling pool update of pool ${poolId}: trace in ${trace.traceFile}`)
+      }
+
+      const properties = {
+        name: 'Rolling pool update',
+        objectId: poolId,
+        poolId,
+        poolName: pool.name_label,
+        progress: 0,
+        type: 'pool.rolling_update',
+        ...(trace !== undefined && { traceFile: trace.traceFile }),
+      }
+      const task = parentTask === undefined ? app.tasks.create(properties) : new Task({ properties })
+      trace?.attach(task)
+      recorder.setTaskId(task.id)
       await task.run(async () =>
         this.getXapi(pool).rollingPoolUpdate(task, {
           xsCredentials: app.apiContext.user.preferences.xsCredentials,
@@ -1045,12 +1047,13 @@ export default class XenServers {
           recorder,
         })
       )
+      // a successful run needs no recovery: the record must be gone, or the
+      // run would be reported as interrupted at the next restart
+      await recorder.delete()
     } catch (error) {
       await recorder.fail(error)
       throw error
     }
-    // a successful run needs no recovery
-    await recorder.delete()
   }
 }
 

--- a/packages/xo-server/src/xo-mixins/xen-servers.test.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.test.mjs
@@ -38,6 +38,10 @@ function createXenServers({ backupRunning = false } = {}) {
       return []
     },
     async getOptionalPlugin() {},
+    async startRpuRecoveryRun(poolId, options) {
+      calls.push(['startRpuRecoveryRun', poolId, options])
+      return { markRunning() {}, setTaskId() {}, async delete() {}, async fail() {} }
+    },
   }
   // the constructor arms a timeout that rejects if the `core started` hook,
   // never fired here, does not set up the server collection in time
@@ -71,6 +75,7 @@ describe('XenServers.rollingPoolUpdate', function () {
     assert.deepEqual(calls, [
       ['backupGuard', 'pool-1', { bypassBackupCheck: true, operation: 'rollingPoolUpdate' }],
       ['getAllJobs'],
+      ['startRpuRecoveryRun', 'pool-1', { bypassBackupCheck: true, rebootVm: true, shutdownPinnedVms: false }],
       ['xapi.rollingPoolUpdate', { rebootVm: true, shutdownPinnedVms: false }],
     ])
   })

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -1292,6 +1292,14 @@ const messages = {
   rollingPoolUpdateHaWarning: 'High Availability is enabled. This will automatically disable it during the update.',
   rollingPoolUpdateLoadBalancerWarning:
     'Load Balancer plugin is running. This will automatically pause it during the update.',
+  rpuRecoveryIncompleteTitle: 'Incomplete rolling pool update',
+  rpuRecoveryInterrupted:
+    'The last rolling pool update was interrupted by an xo-server restart. Some hosts may not be updated and some VMs may not be on their original host.',
+  rpuRecoveryFailed:
+    'The last rolling pool update failed before completing. Some hosts may not be updated and some VMs may not be on their original host.',
+  rpuRecoveryBlocked: 'The state of the last rolling pool update could not be read. Manual review is required.',
+  rpuRecoveryLastError: 'Last error:',
+  rpuRecoveryHaltedPinnedVms: 'VMs shut down for the update and not started again yet:',
   poolNeedsDefaultSr: 'The pool needs a default SR to install the patches.',
   vmsHaveCds: '{nVms, number} VM{nVms, plural, one {} other {s}} {nVms, plural, one {has} other {have}} CDs',
   ejectCds: 'Eject CDs',

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -501,6 +501,19 @@ subscribeHostMissingPatches.forceRefresh = host => {
   }
 }
 
+const rollingUpdateRecoveryByPool = {}
+export const subscribeRollingUpdateRecovery = (pool, cb) => {
+  const poolId = resolveId(pool)
+
+  if (rollingUpdateRecoveryByPool[poolId] == null) {
+    rollingUpdateRecoveryByPool[poolId] = createSubscription(() =>
+      _call('pool.getRollingUpdateRecovery', { pool: poolId }).catch(() => undefined)
+    )
+  }
+
+  return rollingUpdateRecoveryByPool[poolId](cb)
+}
+
 const proxiesApplianceUpdaterState = {}
 export const subscribeProxyApplianceUpdaterState = (proxyId, cb) => {
   if (proxiesApplianceUpdaterState[proxyId] === undefined) {

--- a/packages/xo-web/src/common/xo/index.js
+++ b/packages/xo-web/src/common/xo/index.js
@@ -507,7 +507,7 @@ export const subscribeRollingUpdateRecovery = (pool, cb) => {
 
   if (rollingUpdateRecoveryByPool[poolId] == null) {
     rollingUpdateRecoveryByPool[poolId] = createSubscription(() =>
-      _call('pool.getRollingUpdateRecovery', { pool: poolId }).catch(() => undefined)
+      _call('pool.getRollingUpdateRecovery', { pool: poolId })
     )
   }
 

--- a/packages/xo-web/src/xo-app/pool/tab-patches.js
+++ b/packages/xo-web/src/xo-app/pool/tab-patches.js
@@ -1,4 +1,5 @@
 import _ from 'intl'
+import Icon from 'icon'
 import React, { Component } from 'react'
 import SortedTable from 'sorted-table'
 import TabButton from 'tab-button'
@@ -9,6 +10,7 @@ import { Col, Container, Row } from 'grid'
 import { createGetObjectsOfType, createSelector } from 'selectors'
 import { FormattedRelative, FormattedTime } from 'react-intl'
 import { getXoaPlan, ENTERPRISE } from 'xoa-plans'
+import { renderXoItemFromId } from 'render-xo-item'
 import {
   installAllPatchesOnPool,
   installPatches,
@@ -17,6 +19,7 @@ import {
   rollingPoolUpdate,
   subscribeCurrentUser,
   subscribeHostMissingPatches,
+  subscribeRollingUpdateRecovery,
 } from 'xo'
 import filter from 'lodash/filter.js'
 import isEmpty from 'lodash/isEmpty.js'
@@ -135,6 +138,63 @@ const INDIVIDUAL_ACTIONS_XCP = [
   },
 ]
 
+// an incomplete update only warrants a warning in these statuses: live
+// statuses mean a run is in progress, absence of record means nothing to do
+const RPU_RECOVERY_VISIBLE_STATUSES = ['blocked', 'failed', 'interrupted']
+
+const RpuRecoveryBanner = ({ recovery }) => {
+  if (recovery == null || !RPU_RECOVERY_VISIBLE_STATUSES.includes(recovery.status)) {
+    return null
+  }
+
+  const { blockedReason, hostOrder = [], hosts = {}, haltedPinnedVms = {}, lastError, status } = recovery
+  const haltedVmIds = Object.keys(haltedPinnedVms)
+
+  return (
+    <Row>
+      <Col>
+        <div className='alert alert-warning'>
+          <h4>
+            <Icon icon='alarm' /> {_('rpuRecoveryIncompleteTitle')}
+          </h4>
+          <p>
+            {status === 'interrupted'
+              ? _('rpuRecoveryInterrupted')
+              : status === 'failed'
+                ? _('rpuRecoveryFailed')
+                : _('rpuRecoveryBlocked')}
+          </p>
+          {blockedReason !== undefined && <p>{blockedReason}</p>}
+          {hostOrder.length > 0 && (
+            <ul>
+              {hostOrder.map(hostId => (
+                <li key={hostId}>
+                  {renderXoItemFromId(hostId)} — {hosts[hostId]?.status}
+                </li>
+              ))}
+            </ul>
+          )}
+          {lastError != null && (
+            <p>
+              <strong>{_('rpuRecoveryLastError')}</strong> {lastError.message ?? String(lastError)}
+            </p>
+          )}
+          {haltedVmIds.length > 0 && (
+            <div>
+              <strong>{_('rpuRecoveryHaltedPinnedVms')}</strong>
+              <ul>
+                {haltedVmIds.map(vmId => (
+                  <li key={vmId}>{renderXoItemFromId(vmId)}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </Col>
+    </Row>
+  )
+}
+
 const INSTALLED_PATCH_COLUMNS = [
   {
     name: _('patchNameLabel'),
@@ -167,8 +227,9 @@ const INSTALLED_PATCH_COLUMNS = [
   },
 ]
 
-@addSubscriptions(({ master }) => ({
+@addSubscriptions(({ master, pool }) => ({
   missingPatches: cb => subscribeHostMissingPatches(master, cb),
+  rollingUpdateRecovery: cb => subscribeRollingUpdateRecovery(pool, cb),
   userPreferences: cb => subscribeCurrentUser(user => cb(user.preferences)),
 }))
 @connectStore(() => {
@@ -224,6 +285,7 @@ export default class TabPatches extends Component {
       missingPatches = [],
       pool,
       poolHosts,
+      rollingUpdateRecovery,
       userPreferences,
     } = this.props
 
@@ -238,6 +300,7 @@ export default class TabPatches extends Component {
     return (
       <Upgrade place='poolPatches' required={2}>
         <Container>
+          <RpuRecoveryBanner recovery={rollingUpdateRecovery} />
           <Row>
             <Col className='text-xs-right'>
               {ROLLING_POOL_UPDATES_AVAILABLE && (


### PR DESCRIPTION
### Description

See : https://project.vates.tech/vates-global/browse/XO-2899/

An xo-server restart in the middle of a rolling pool update currently loses everything: which hosts were done, which VMs were shut down because they cannot be migrated (PCI passthrough, vGPU, SR-IOV VIF), what the operator had asked for. The pinned VMs are the worst part: they only live in an in-memory map restored through `$defer`, so after a crash they stay halted with nothing left to restart them.

This PR makes xo-server persist a `rpuRecovery` record (LevelDB, one per pool) before the first side effect of a rolling pool update, and keep it updated during the run:

- operator options, update variant (xcp / xs-cdn / xs-legacy), host order, initial VM placement;
- per-host step statuses (evacuate, update, reboot, enable, restoreVms), with a strict write of each pinned VM → original host entry *before* the VM is shut down;
- the last error, filtered through the existing RPU observability scrubber so credentials never reach the disk.

A record still in a live status at xo-server boot is flipped to `interrupted`. A successful run deletes its record. An unreadable record or an unknown schema version is reported as `blocked` without touching the stored value.

The status is exposed through `pool.getRollingUpdateRecovery` and `GET /rest/v0/pools/{id}/rolling_update_recovery` (filtered view, never the raw intent, reusing the pool `rolling-update` ACL), and the pool Patches tab shows a warning banner with per-host progress, the last error and the pinned VMs still halted.

This is the first card of the RPU resume-after-failure work: the record only reports for now, resuming an interrupted run comes separately.

Note for DevOps: this updates the generated OpenAPI spec (new `GET /pools/{id}/rolling_update_recovery` endpoint).

## Tests

Tested against a 2-host XCP-ng 8.3 nested pool (3 running VMs, shared NFS SR), xo-server
built from this branch.

| Scenario | Result |
| --- | --- |
| Nominal RPU | record `running` during the run with per-host steps advancing, then `404` + key gone from LevelDB + no banner |
| xo-server `kill -9` during a host evacuation | record flipped to `interrupted` at boot, `interruptedAt` = last known-alive timestamp, per-host progress preserved |
| Failed RPU | `failed` + `lastError`, session id scrubbed, banner shown |
| Corrupted record | both `unknown schema version 99` and `unreadable record` reported as `blocked`, stored value left untouched on disk, boot not blocked |
| Non-admin user | JSON-RPC `not enough permissions`, REST `403` with `missingPrivileges: [{pool, rolling-update}]` |


### Interrupted run : Patches tab

<img width="1500" height="950" alt="01-interrupted-full-page" src="https://github.com/user-attachments/assets/56c7806c-3b4f-4b16-a55a-76cb9b916a10" />

The banner as an operator sees it, in context.

<img width="1255" height="165" alt="02-interrupted-banner" src="https://github.com/user-attachments/assets/98c2531a-ed09-42f4-a2cd-5d3f9c3ae105" />

Close-up: interrupted by an xo-server restart, with the per-host progress.

### Failed run

<img width="1255" height="165" alt="03-failed-banner" src="https://github.com/user-attachments/assets/315339f2-e3c2-49c6-834b-51ba96187184" />

`CANNOT_EVACUATE_HOST(VM_REQUIRES_SR, ...)` surfaced from `lastError`. The failure happens in
the pre-checks, before the host order is known, so the banner degrades to the error alone.

### Blocked record

<img width="1255" height="141" alt="04-blocked-banner" src="https://github.com/user-attachments/assets/53438f67-739f-44a9-9844-09edff666690" />

Record corrupted on purpose in LevelDB: reported as blocked, raw value kept as evidence.

### Pinned VMs still halted

<img width="1255" height="205" alt="05-pinned-vms-banner" src="https://github.com/user-attachments/assets/b216a7cc-b2b8-42f1-ba03-b9a6493054c8" />

Not reproducible on nested hosts (needs `VM_HAS_PCI_ATTACHED` / `VM_HAS_VGPU` /
`VM_HAS_SRIOV_VIF`), so this one was rendered from a record seeded with `haltedPinnedVms`.
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_
