### PR TITLE
feat(xo-lite): add network delete action for host internal networks

### DIFF
--- a/@xen-orchestra/lite/CHANGELOG.md
+++ b/@xen-orchestra/lite/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## **next**
 
+- [Pool/Network] Add the possibility to delete host internal networks
 - [Treeview] Add VM tree actions (PR [#10304](https://github.com/vatesfr/xen-orchestra/pull/10304))
 - [Pool/networks] Add the possibility to create new network or bonded network (PR [#10145](https://github.com/vatesfr/xen-orchestra/pull/10145))
 - [VM] Add VDIs page with table and side panel (PR [#10269](https://github.com/vatesfr/xen-orchestra/pull/10269))

--- a/@xen-orchestra/lite/src/components/pool/network/PoolHostInternalNetworksTable.vue
+++ b/@xen-orchestra/lite/src/components/pool/network/PoolHostInternalNetworksTable.vue
@@ -27,6 +27,7 @@
 
 <script setup lang="ts">
 import type { XenApiNetwork } from '@/libs/xen-api/xen-api.types.ts'
+import { useNetworkDelete } from '@/modules/network/composables/use-network-delete.composable.ts'
 import { useNetworkStore } from '@/stores/xen-api/network.store.ts'
 import VtsRow from '@core/components/table/VtsRow.vue'
 import VtsTable from '@core/components/table/VtsTable.vue'
@@ -80,14 +81,34 @@ const state = useTableState({
 })
 
 const { HeadCells, BodyCells } = useNetworkColumns({
-  exclude: ['status', 'vlan', 'actions'],
-  body: (network: XenApiNetwork) => ({
-    network: r => r({ label: network.name_label }),
-    description: r => r(network.name_description),
-    mtu: r => r(network.MTU),
-    defaultLockingMode: r => r(getLockingMode(network.default_locking_mode)),
-    selectItem: r => r(() => (selectedNetworkId.value = network.uuid)),
-  }),
+  exclude: ['status', 'vlan', 'selectItem'],
+  body: (network: XenApiNetwork) => {
+    const { deleteNetworks, canDeleteNetworks, isDeletingNetworks, deleteNetworksErrorMessage } = useNetworkDelete(
+      () => [network]
+    )
+
+    return {
+      network: r => r({ label: network.name_label }),
+      description: r => r(network.name_description),
+      mtu: r => r(network.MTU),
+      defaultLockingMode: r => r(getLockingMode(network.default_locking_mode)),
+      actions: r =>
+        r({
+          onClick: () => (selectedNetworkId.value = network.uuid),
+          actions: [
+            {
+              label: t('action:delete'),
+              icon: 'action:delete',
+              danger: true,
+              onClick: () => deleteNetworks(),
+              busy: isDeletingNetworks.value,
+              disabled: !canDeleteNetworks.value,
+              hint: deleteNetworksErrorMessage.value,
+            },
+          ],
+        }),
+    }
+  },
 })
 </script>
 

--- a/@xen-orchestra/lite/src/components/pool/network/PoolNetworkSidePanel.vue
+++ b/@xen-orchestra/lite/src/components/pool/network/PoolNetworkSidePanel.vue
@@ -15,6 +15,7 @@
         <MenuItem icon="action:copy" :disabled="!isClipboardSupported" @click="copy()">
           {{ t('action:copy-info-json') }}
         </MenuItem>
+        <NetworkDeleteMenuItem v-if="pifsCount === 0" :network />
       </MenuList>
     </template>
     <template v-if="network" #default>
@@ -96,6 +97,7 @@
 <script setup lang="ts">
 import PifRow from '@/components/pif/PifRow.vue'
 import type { XenApiNetwork } from '@/libs/xen-api/xen-api.types.ts'
+import NetworkDeleteMenuItem from '@/modules/network/components/actions/delete/NetworkDeleteMenuItem.vue'
 import { usePifStore } from '@/stores/xen-api/pif.store.ts'
 import VtsCardRowKeyValue from '@core/components/card/VtsCardRowKeyValue.vue'
 import VtsCardObjectTitle from '@core/components/card-object-title/VtsCardObjectTitle.vue'

--- a/@xen-orchestra/lite/src/libs/xen-api/operations/network-operations.ts
+++ b/@xen-orchestra/lite/src/libs/xen-api/operations/network-operations.ts
@@ -1,8 +1,12 @@
 import type XenApi from '@/libs/xen-api/xen-api.ts'
 import type { XenApiHost, XenApiNetwork, XenApiPif } from '@/libs/xen-api/xen-api.types.ts'
+import type { MaybeArray } from '@core/types/utility.type.ts'
+import { toArray } from '@core/utils/to-array.utils.ts'
 import type { BOND_MODE } from '@vates/types'
 
 export function createNetworkOperations(xenApi: XenApi) {
+  type NetworkRefs = MaybeArray<XenApiNetwork['$ref']>
+
   type BaseNetworkCreateParams = {
     nameLabel: string
     nameDescription?: string
@@ -93,5 +97,8 @@ export function createNetworkOperations(xenApi: XenApi) {
 
       return networkRef
     },
+
+    delete: (networkRefs: NetworkRefs) =>
+      Promise.all(toArray(networkRefs).map(networkRef => xenApi.call('network.destroy', [networkRef]))),
   }
 }

--- a/@xen-orchestra/lite/src/modules/network/components/actions/delete/NetworkDeleteMenuItem.vue
+++ b/@xen-orchestra/lite/src/modules/network/components/actions/delete/NetworkDeleteMenuItem.vue
@@ -1,0 +1,36 @@
+<template>
+  <MenuItem
+    v-tooltip="!canDeleteNetworks && deleteNetworksErrorMessage"
+    icon="action:delete"
+    :disabled="!canDeleteNetworks"
+    :busy="isDeletingNetworks"
+    class="delete"
+    @click="deleteNetworks()"
+  >
+    {{ t('action:delete') }}
+  </MenuItem>
+</template>
+
+<script lang="ts" setup>
+import type { XenApiNetwork } from '@/libs/xen-api/xen-api.types.ts'
+import { useNetworkDelete } from '@/modules/network/composables/use-network-delete.composable.ts'
+import MenuItem from '@core/components/menu/MenuItem.vue'
+import { vTooltip } from '@core/directives/tooltip.directive.ts'
+import { useI18n } from 'vue-i18n'
+
+const { network } = defineProps<{
+  network: XenApiNetwork
+}>()
+
+const { t } = useI18n()
+
+const { deleteNetworks, canDeleteNetworks, isDeletingNetworks, deleteNetworksErrorMessage } = useNetworkDelete(() => [
+  network,
+])
+</script>
+
+<style lang="postcss" scoped>
+.delete {
+  color: var(--color-danger-item-base);
+}
+</style>

--- a/@xen-orchestra/lite/src/modules/network/composables/use-network-delete.composable.ts
+++ b/@xen-orchestra/lite/src/modules/network/composables/use-network-delete.composable.ts
@@ -1,0 +1,50 @@
+import type { XenApiNetwork } from '@/libs/xen-api/xen-api.types.ts'
+import { useNetworkDeleteJob } from '@/modules/network/jobs/network-delete.job.ts'
+import { useDeleteModal } from '@core/composables/modals/use-delete-modal.ts'
+import { useRouteQuery } from '@core/composables/route-query.composable.ts'
+import { toComputed } from '@core/utils/to-computed.util.ts'
+import type { MaybeRefOrGetter } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+export function useNetworkDelete(rawNetworks: MaybeRefOrGetter<XenApiNetwork[]>) {
+  const networks = toComputed(rawNetworks)
+
+  const { t } = useI18n()
+
+  const selectedNetworkId = useRouteQuery('id')
+
+  const {
+    run,
+    canRun: canDeleteNetworks,
+    isRunning: isDeletingNetworks,
+    errorMessage: deleteNetworksErrorMessage,
+  } = useNetworkDeleteJob(networks)
+
+  const { open } = useDeleteModal()
+
+  function deleteNetworks() {
+    const count = networks.value.length
+
+    return open({
+      props: {
+        subject: t('n-internal-networks', { n: count }),
+        confirmLabel: t('action:delete-n-networks', { n: count }),
+      },
+      events: {
+        onConfirm: async () => {
+          try {
+            await run()
+
+            if (networks.value.some(network => network.uuid === selectedNetworkId.value)) {
+              selectedNetworkId.value = ''
+            }
+          } catch (error) {
+            console.error('Error when deleting network:', error)
+          }
+        },
+      },
+    })
+  }
+
+  return { deleteNetworks, canDeleteNetworks, isDeletingNetworks, deleteNetworksErrorMessage }
+}

--- a/@xen-orchestra/lite/src/modules/network/jobs/network-delete-args.ts
+++ b/@xen-orchestra/lite/src/modules/network/jobs/network-delete-args.ts
@@ -1,0 +1,7 @@
+import type { XenApiNetwork } from '@/libs/xen-api/xen-api.types.ts'
+import { defineJobArg } from '@core/packages/job'
+
+export const networksArg = defineJobArg({
+  identify: (network: XenApiNetwork) => network.$ref,
+  toArray: true,
+})

--- a/@xen-orchestra/lite/src/modules/network/jobs/network-delete.job.ts
+++ b/@xen-orchestra/lite/src/modules/network/jobs/network-delete.job.ts
@@ -1,0 +1,42 @@
+import { networksArg } from '@/modules/network/jobs/network-delete-args.ts'
+import { usePifStore } from '@/stores/xen-api/pif.store.ts'
+import { useVifStore } from '@/stores/xen-api/vif.store.ts'
+import { useXenApiStore } from '@/stores/xen-api.store.ts'
+import { defineJob, JobError, JobRunningError } from '@core/packages/job'
+import { useI18n } from 'vue-i18n'
+
+export const useNetworkDeleteJob = defineJob('network.delete', [networksArg], () => {
+  const xapi = useXenApiStore().getXapi()
+  const { t } = useI18n()
+  const { records: vifs } = useVifStore().subscribe()
+  const { getPifsByNetworkRef } = usePifStore().subscribe()
+
+  return {
+    run: networks => xapi.network.delete(networks.map(network => network.$ref)),
+    validate: (isRunning, networks) => {
+      if (networks.length === 0) {
+        throw new JobError(t('job:network-delete:missing-network'))
+      }
+
+      if (isRunning) {
+        throw new JobRunningError(t('job:delete:in-progress'))
+      }
+
+      const nPhysicalPifConnected = networks.reduce(
+        (count, network) => count + getPifsByNetworkRef(network.$ref).filter(pif => pif.physical).length,
+        0
+      )
+
+      if (nPhysicalPifConnected > 0) {
+        throw new JobError(t('job:network-delete:has-n-physical-pif-connected', { n: nPhysicalPifConnected }))
+      }
+
+      const networkRefs = networks.map(network => network.$ref)
+      const nAttachedVif = vifs.value.filter(vif => networkRefs.includes(vif.network) && vif.currently_attached).length
+
+      if (nAttachedVif > 0) {
+        throw new JobError(t('job:network-delete:has-n-vif-attached', { n: nAttachedVif }))
+      }
+    },
+  }
+})

--- a/@xen-orchestra/web-core/lib/components/menu/VtsActionsMenu.vue
+++ b/@xen-orchestra/web-core/lib/components/menu/VtsActionsMenu.vue
@@ -16,6 +16,7 @@
       <MenuItem
         v-for="(action, index) of actions"
         :key="index"
+        :class="{ danger: action.danger }"
         :icon="action.icon"
         :disabled="action.disabled"
         :busy="action.busy"
@@ -67,6 +68,7 @@ type BaseActionItem = {
   icon?: IconName
   disabled?: boolean
   busy?: boolean
+  danger?: boolean
 }
 
 export type LeafActionItem = BaseActionItem & {
@@ -85,3 +87,9 @@ function isGroupAction(action: ActionItem): action is GroupActionItem {
   return 'children' in action
 }
 </script>
+
+<style lang="postcss" scoped>
+.danger {
+  color: var(--color-danger-item-base);
+}
+</style>

--- a/@xen-orchestra/web-core/lib/locales/en.json
+++ b/@xen-orchestra/web-core/lib/locales/en.json
@@ -535,6 +535,7 @@
   "job:migrate:in-progress": "Migrate in progess…",
   "job:network-delete:has-n-physical-pif-connected": "The network has one physical PIF connected | The network has {n} physical PIFs connected",
   "job:network-delete:has-n-vif-attached": "The network has one VIF attached | The network has {n} VIFs attached",
+  "job:network-delete:missing-network": "No networks to delete",
   "job:pbd-plug:missing-pbd": "No PBDs to connect",
   "job:pbd-plug:pbd-connected": "One or several PBDs are already connected",
   "job:pbd-unplug:missing-pbd": "No PBDs to disconnect",

--- a/@xen-orchestra/web-core/lib/locales/fr.json
+++ b/@xen-orchestra/web-core/lib/locales/fr.json
@@ -535,6 +535,7 @@
   "job:migrate:in-progress": "Migration en cours…",
   "job:network-delete:has-n-physical-pif-connected": "Le réseau a un PIF physique connecté | Le réseau a {n} PIFs physiques connectés",
   "job:network-delete:has-n-vif-attached": "Le réseau a un VIF attaché | Le réseau a {n} VIFs attachés",
+  "job:network-delete:missing-network": "Aucun réseau à supprimer",
   "job:pbd-plug:missing-pbd": "Aucun PBD à connecter",
   "job:pbd-plug:pbd-connected": "Un ou plusieurs PBDs sont déjà connectés",
   "job:pbd-unplug:missing-pbd": "Aucun PBD à déconnecter",


### PR DESCRIPTION
### Description

Adds a delete action for host internal networks in XO Lite

<img width="738" height="527" alt="Capture d’écran 2026-09-01 à 11 36 49" src="https://github.com/user-attachments/assets/9853b3aa-8857-40bc-92f0-b1848faebbe2" />
<img width="736" height="526" alt="Capture d’écran 2026-09-01 à 11 36 51" src="https://github.com/user-attachments/assets/247c4fe7-2499-433a-a23e-4aed0ba7a229" />


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
