### PR TITLE
fix(qcow2): improve qcow2 stream index computation (used for backup/replication and export)

### DIFF
--- a/@xen-orchestra/disk-cli/src/commands/transform.mts
+++ b/@xen-orchestra/disk-cli/src/commands/transform.mts
@@ -59,7 +59,7 @@ export async function transformCommand(handlerUrl: string, diskPath: string, ext
       } else if (format === 'vhd') {
         stream = await toVhdStream(disk)
       } else {
-        stream = toQcow2Stream(disk)
+        stream = await toQcow2Stream(disk)
       }
 
       await pipeline(stream, process.stdout, { end: false })

--- a/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.integ.mts
+++ b/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.integ.mts
@@ -83,7 +83,7 @@ describe('QCOW2 Stream Generation', () => {
 
       try {
         // Generate and write the QCOW2 file
-        const stream = toQcow2Stream(disk)
+        const stream = await toQcow2Stream(disk)
         const file = await fs.open(tmpFile, 'w')
         await new Promise((resolve, reject) => {
           const writeStream = file.createWriteStream()
@@ -127,7 +127,7 @@ describe('QCOW2 Stream Generation', () => {
 
     try {
       // Generate and write the QCOW2 file
-      const stream = toQcow2Stream(disk)
+      const stream = await toQcow2Stream(disk)
       const file = await fs.open(tmpFile, 'w')
       await new Promise((resolve, reject) => {
         const writeStream = file.createWriteStream()
@@ -168,7 +168,7 @@ describe('QCOW2 Stream Generation', () => {
     )
     const tmpFile = join(tmpdir(), `test-large-${Date.now()}.qcow2`)
     try {
-      const stream = toQcow2Stream(disk)
+      const stream = await toQcow2Stream(disk)
       const file = await fs.open(tmpFile, 'w')
       await new Promise((resolve, reject) => {
         const writeStream = file.createWriteStream()
@@ -200,7 +200,7 @@ describe('QCOW2 Stream Generation', () => {
     const controller = new AbortController()
     controller.abort()
 
-    const stream = toQcow2Stream(disk, { signal: controller.signal })
+    const stream = await toQcow2Stream(disk, { signal: controller.signal })
     await assert.rejects(
       async () => {
         for await (const _chunk of stream) {
@@ -223,7 +223,7 @@ describe('QCOW2 Stream Generation', () => {
     )
     const controller = new AbortController()
 
-    const stream = toQcow2Stream(disk, { signal: controller.signal })
+    const stream = await toQcow2Stream(disk, { signal: controller.signal })
     let chunksReceived = 0
 
     await assert.rejects(
@@ -255,7 +255,7 @@ describe('QCOW2 Stream Generation', () => {
     )
     const tmpFile = join(tmpdir(), `test-unaligned-${Date.now()}.qcow2`)
     try {
-      const stream = toQcow2Stream(disk)
+      const stream = await toQcow2Stream(disk)
       const file = await fs.open(tmpFile, 'w')
       await new Promise((resolve, reject) => {
         const writeStream = file.createWriteStream()

--- a/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.mts
+++ b/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.mts
@@ -63,34 +63,69 @@ export class QcowStreamGenerator {
   }
 
   /**
-   * Computes the size and structure of the L1/L2 addressing tables
-   * @returns Object containing total size and number of L1 entries
+   * Scans every block index once, building a per-block presence bitmap and a per-L2-group
+   * "has any allocated block" summary, so the rest of the generator never needs to call
+   * `disk.hasBlock()` again. Yields back to the event loop periodically (time-budgeted, not a
+   * fixed count) so a huge virtual disk doesn't block Node for seconds at a stretch — this was
+   * previously done as three separate synchronous full scans (one per caller below), each one
+   * capable of blocking the event loop on its own.
    * @private
    */
-  #computeAddressingSpace(): { size: number; nbL1Entries: number } {
+  async #buildBlockPresenceIndex(): Promise<{
+    bitmap: Uint8Array
+    groupHasData: Uint8Array
+    nbBlocks: number
+    nbL1Entries: number
+  }> {
     const disk = this.#disk
     const nbBlocks = Math.ceil(disk.getVirtualSize() / disk.getBlockSize())
     const nbL2PerL1Entry = CLUSTER_SIZE / L2_ADDRESS_ENTRY_SIZE
     const nbL1Entries = Math.ceil(nbBlocks / nbL2PerL1Entry)
 
-    // L1 table size (aligned to cluster size)
-    let size = Math.ceil((nbL1Entries * 8) / CLUSTER_SIZE) * CLUSTER_SIZE
+    const bitmap = new Uint8Array(Math.ceil(nbBlocks / 8))
+    const groupHasData = new Uint8Array(nbL1Entries)
 
-    // Add size for each L2 table that contains at least one allocated block
-    for (let i = 0; i < nbL1Entries; i++) {
-      for (let j = 0; j < nbL2PerL1Entry; j++) {
-        const blockIndex = i * nbL2PerL1Entry + j
-        if (blockIndex >= nbBlocks) {
-          break // Last L2 table
-        }
-        if (disk.hasBlock(blockIndex)) {
-          size += CLUSTER_SIZE // Each L2 table takes one cluster
-          break // We only need to know if this L2 table has any blocks
+    let lastYield = process.hrtime.bigint()
+    for (let i = 0; i < nbBlocks; i++) {
+      if (disk.hasBlock(i)) {
+        bitmap[i >> 3] |= 1 << (i & 7)
+        groupHasData[Math.floor(i / nbL2PerL1Entry)] = 1
+      }
+      // check the clock every 65536 blocks: cheap enough to not affect throughput, frequent
+      // enough to keep a single stretch of synchronous work under ~15ms
+      if ((i & 0xffff) === 0) {
+        const now = process.hrtime.bigint()
+        if (Number(now - lastYield) / 1e6 > 15) {
+          await new Promise(resolve => setImmediate(resolve))
+          lastYield = process.hrtime.bigint()
         }
       }
     }
 
-    return { size, nbL1Entries }
+    return { bitmap, groupHasData, nbBlocks, nbL1Entries }
+  }
+
+  /**
+   * Computes the size and structure of the L1/L2 addressing tables
+   * @param groupHasData Per-L2-group "has any allocated block" summary from #buildBlockPresenceIndex
+   * @param nbL1Entries Number of L1 entries (= number of possible L2 groups)
+   * @returns Object containing total size
+   * @private
+   */
+  #computeAddressingSpace(groupHasData: Uint8Array, nbL1Entries: number): { size: number } {
+    // L1 table size (aligned to cluster size)
+    let size = Math.ceil((nbL1Entries * 8) / CLUSTER_SIZE) * CLUSTER_SIZE
+
+    // Add size for each L2 table that contains at least one allocated block. Just reading the
+    // precomputed summary — no more per-block hasBlock() calls, so this stays fast regardless
+    // of virtual disk size.
+    for (let i = 0; i < nbL1Entries; i++) {
+      if (groupHasData[i]) {
+        size += CLUSTER_SIZE // Each L2 table takes one cluster
+      }
+    }
+
+    return { size }
   }
 
   /**
@@ -173,7 +208,13 @@ export class QcowStreamGenerator {
   }
 
   /**
-   * Generates the L1/L2 addressing tables
+   * Generates the L1/L2 addressing tables from the precomputed presence bitmap/summary — no
+   * more per-block hasBlock() scanning here, pass 2's inner loop only ever runs for groups
+   * that #buildBlockPresenceIndex already found to have data.
+   * @param bitmap Per-block presence bitmap from #buildBlockPresenceIndex
+   * @param groupHasData Per-L2-group "has any allocated block" summary from #buildBlockPresenceIndex
+   * @param nbBlocks Total number of blocks in the virtual disk
+   * @param nbL1Entries Number of L1 entries
    * @private
    *
    * Based on QCOW2 spec:
@@ -181,13 +222,15 @@ export class QcowStreamGenerator {
    * - L2 tables contain offsets to data clusters
    * - The COPIED flag (bit 63) indicates the cluster is allocated
    */
-  *#yieldAddressingTables(): Generator<Buffer, void, unknown> {
-    const disk = this.#disk
+  *#yieldAddressingTables(
+    bitmap: Uint8Array,
+    groupHasData: Uint8Array,
+    nbBlocks: number,
+    nbL1Entries: number
+  ): Generator<Buffer, void, unknown> {
     const QCOW_OFLAG_COPIED = 1n << 63n // Flag indicating cluster is allocated
-
-    const nbBlocks = Math.ceil(disk.getVirtualSize() / disk.getBlockSize())
     const nbEntriesPerL2Table = CLUSTER_SIZE / 8
-    const nbL1Entries = Math.ceil(nbBlocks / nbEntriesPerL2Table)
+    const hasBlock = (index: number) => (bitmap[index >> 3] & (1 << (index & 7))) !== 0
 
     // Generate L1 table
     const l1Table = getAlignedBuffer(nbL1Entries * 8)
@@ -195,24 +238,20 @@ export class QcowStreamGenerator {
 
     // First pass: determine which L2 tables are needed
     for (let i = 0; i < nbL1Entries; i++) {
-      for (let j = 0; j < nbEntriesPerL2Table; j++) {
-        const blockIndex = i * nbEntriesPerL2Table + j
-        if (blockIndex >= nbBlocks) {
-          break // Last L2 table
-        }
-        if (disk.hasBlock(blockIndex)) {
-          l1Table.writeBigUint64BE(BigInt(l2Offset) | QCOW_OFLAG_COPIED, i * 8)
-          l2Offset += CLUSTER_SIZE
-          break // We only need to know if this L2 table has any blocks
-        }
+      if (groupHasData[i]) {
+        l1Table.writeBigUint64BE(BigInt(l2Offset) | QCOW_OFLAG_COPIED, i * 8)
+        l2Offset += CLUSTER_SIZE
       }
     }
     yield* this.#trackAndYield(l1Table)
 
-    // Second pass: generate L2 tables
+    // Second pass: generate L2 tables — only visits groups already known to have data
     let dataClusterOffset = l2Offset
     for (let i = 0; i < nbL1Entries; i++) {
-      let l2Table: Buffer | undefined
+      if (!groupHasData[i]) {
+        continue
+      }
+      const l2Table = getAlignedBuffer(1) // One cluster per L2 table
 
       for (let j = 0; j < nbEntriesPerL2Table; j++) {
         const blockIndex = i * nbEntriesPerL2Table + j
@@ -220,19 +259,14 @@ export class QcowStreamGenerator {
           break // Last L2 table
         }
 
-        if (disk.hasBlock(blockIndex)) {
-          if (l2Table === undefined) {
-            l2Table = getAlignedBuffer(1) // One cluster per L2 table
-          }
+        if (hasBlock(blockIndex)) {
           // Write cluster offset with COPIED flag
           l2Table.writeBigUint64BE(BigInt(dataClusterOffset) | QCOW_OFLAG_COPIED, j * 8)
           dataClusterOffset += CLUSTER_SIZE
         }
       }
 
-      if (l2Table !== undefined) {
-        yield* this.#trackAndYield(l2Table)
-      }
+      yield* this.#trackAndYield(l2Table)
     }
   }
 
@@ -241,12 +275,15 @@ export class QcowStreamGenerator {
    * @param signal Optional AbortSignal to cancel the stream
    * @returns Readable stream with optional length property
    */
-  stream(signal?: AbortSignal): WithLength<Readable> {
+  async stream(signal?: AbortSignal): Promise<WithLength<Readable>> {
     const disk = this.#disk
     const nbAllocatedBlocks = this.#nbAllocatedBlocks
     const nbTotalBlock = Math.ceil(disk.getVirtualSize() / disk.getBlockSize())
+    // Single cooperative pass over every block: builds the presence bitmap/summary reused by
+    // both the size computation below and the addressing tables generated inside the stream.
+    const { bitmap, groupHasData, nbBlocks, nbL1Entries } = await this.#buildBlockPresenceIndex()
     // Compute table sizes
-    const { size: addressTableSize, nbL1Entries } = this.#computeAddressingSpace()
+    const { size: addressTableSize } = this.#computeAddressingSpace(groupHasData, nbL1Entries)
     const { refCountL1Size, refCountL2Size } = this.#computeRefCountSize(addressTableSize)
 
     // Generate QCOW2 header (spec: The first cluster contains the file header)
@@ -276,7 +313,7 @@ export class QcowStreamGenerator {
       assert.strictEqual(self.#offset, CLUSTER_SIZE, 'header aligned')
       yield* self.#yieldRefCounts(expectedStreamLength / CLUSTER_SIZE)
       assert.strictEqual(self.#offset, CLUSTER_SIZE + refCountL1Size + refCountL2Size, 'refcounts aligned')
-      yield* self.#yieldAddressingTables()
+      yield* self.#yieldAddressingTables(bitmap, groupHasData, nbBlocks, nbL1Entries)
       assert.strictEqual(
         self.#offset,
         CLUSTER_SIZE + refCountL1Size + refCountL2Size + addressTableSize,
@@ -330,7 +367,7 @@ export class QcowStreamGenerator {
  * @param options.signal Optional AbortSignal to cancel the stream
  * @returns Readable stream of QCOW2 data
  */
-export function toQcow2Stream(disk: Disk, { signal }: { signal?: AbortSignal } = {}): Readable {
+export async function toQcow2Stream(disk: Disk, { signal }: { signal?: AbortSignal } = {}): Promise<Readable> {
   const generator = new QcowStreamGenerator(disk)
-  return generator.stream(signal)
+  return await generator.stream(signal)
 }

--- a/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.mts
+++ b/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.mts
@@ -32,7 +32,6 @@ type WithLength<T> = T & { length?: number }
 export class QcowStreamGenerator {
   #disk: Disk
   #offset = 0
-  #nbAllocatedBlocks = 0
 
   /**
    * Creates a new QCOW2 stream generator
@@ -50,7 +49,6 @@ export class QcowStreamGenerator {
       this.#disk = disk
     }
     assert.strictEqual(this.#disk.getBlockSize(), CLUSTER_SIZE)
-    this.#nbAllocatedBlocks = this.#disk.getBlockIndexesCount()
   }
 
   /**
@@ -64,17 +62,24 @@ export class QcowStreamGenerator {
   }
 
   /**
-   * Scans every block index once, building a per-block presence bitmap and a per-L2-group
-   * "has any allocated block" summary, so the rest of the generator never needs to call
-   * `disk.hasBlock()` again. Yields back to the event loop periodically (time-budgeted, not a
-   * fixed count) so a huge virtual disk doesn't block Node for seconds at a stretch — this was
-   * previously done as three separate synchronous full scans (one per caller below), each one
-   * capable of blocking the event loop on its own.
+   * Scans every block index once, building a per-block presence bitmap, a per-L2-group
+   * "has any allocated block" summary and the total allocated block count, so the rest of the
+   * generator never needs to call `disk.hasBlock()` again. Yields back to the event loop
+   * periodically (time-budgeted, not a fixed count) so a huge virtual disk doesn't block Node
+   * for seconds at a stretch — this was previously done as several separate synchronous full
+   * scans (one per caller below, plus `getBlockIndexesCount()`), each one capable of blocking
+   * the event loop on its own.
+   *
+   * Counting here rather than through `disk.getBlockIndexesCount()` matters: on a
+   * `DiskLargerBlock` — which this class instantiates itself for sub-cluster sources — that
+   * method is a full synchronous rescan calling `hasBlock()` on every cluster, and on a plain
+   * `Disk` the default implementation materializes the whole index array.
    * @private
    */
   async #buildBlockPresenceIndex(): Promise<{
     bitmap: Uint8Array
     groupHasData: Uint8Array
+    nbAllocatedBlocks: number
     nbTotalBlocks: number
     nbL1Entries: number
   }> {
@@ -84,12 +89,14 @@ export class QcowStreamGenerator {
 
     const bitmap = new Uint8Array(Math.ceil(nbTotalBlocks / 8))
     const groupHasData = new Uint8Array(nbL1Entries)
+    let nbAllocatedBlocks = 0
 
     let lastYield = process.hrtime.bigint()
     for (let i = 0; i < nbTotalBlocks; i++) {
       if (disk.hasBlock(i)) {
         bitmap[i >> 3] |= 1 << (i & 7)
         groupHasData[Math.floor(i / NB_L2_ENTRIES_PER_CLUSTER)] = 1
+        nbAllocatedBlocks++
       }
       // check the clock every 65536 blocks: cheap enough to not affect throughput, frequent
       // enough to keep a single stretch of synchronous work under ~15ms
@@ -102,7 +109,7 @@ export class QcowStreamGenerator {
       }
     }
 
-    return { bitmap, groupHasData, nbTotalBlocks, nbL1Entries }
+    return { bitmap, groupHasData, nbAllocatedBlocks, nbTotalBlocks, nbL1Entries }
   }
 
   /**
@@ -131,6 +138,7 @@ export class QcowStreamGenerator {
   /**
    * Computes the size of the reference count tables
    * @param addressTableSize Total size of L1/L2 tables
+   * @param nbAllocatedBlocks Number of allocated blocks, from #buildBlockPresenceIndex
    * @returns Object containing sizes for L1 and L2 refcount tables
    * @private
    *
@@ -139,12 +147,12 @@ export class QcowStreamGenerator {
    * - Each entry in the refcount table points to a refcount block
    * - Each refcount block contains (cluster_size / refcount_entry_size) entries
    */
-  #computeRefCountSize(addressTableSize: number): { refCountL1Size: number; refCountL2Size: number } {
-    const disk = this.#disk
-    const nbBlocks = this.#nbAllocatedBlocks
-
+  #computeRefCountSize(
+    addressTableSize: number,
+    nbAllocatedBlocks: number
+  ): { refCountL1Size: number; refCountL2Size: number } {
     // Total clusters needed (header + addressing tables + data clusters)
-    let nbAllocatedClusters = 1 /* header */ + addressTableSize / CLUSTER_SIZE + nbBlocks
+    let nbAllocatedClusters = 1 /* header */ + addressTableSize / CLUSTER_SIZE + nbAllocatedBlocks
 
     // Refcount structure parameters
     const refCountsPerL2Table = Math.floor(CLUSTER_SIZE / 8) // Each L2 refcount table entry is 8 bytes
@@ -276,13 +284,14 @@ export class QcowStreamGenerator {
    */
   async stream(signal?: AbortSignal): Promise<WithLength<Readable>> {
     const disk = this.#disk
-    const nbAllocatedBlocks = this.#nbAllocatedBlocks
-    // Single cooperative pass over every block: builds the presence bitmap/summary reused by
-    // both the size computation below and the addressing tables generated inside the stream.
-    const { bitmap, groupHasData, nbTotalBlocks, nbL1Entries } = await this.#buildBlockPresenceIndex()
+    // Single cooperative pass over every block: builds the presence bitmap/summary and the
+    // allocated block count, reused by both the size computations below and the addressing
+    // tables generated inside the stream.
+    const { bitmap, groupHasData, nbAllocatedBlocks, nbTotalBlocks, nbL1Entries } =
+      await this.#buildBlockPresenceIndex()
     // Compute table sizes
     const { size: addressTableSize } = this.#computeAddressingSpace(groupHasData, nbL1Entries)
-    const { refCountL1Size, refCountL2Size } = this.#computeRefCountSize(addressTableSize)
+    const { refCountL1Size, refCountL2Size } = this.#computeRefCountSize(addressTableSize, nbAllocatedBlocks)
 
     // Generate QCOW2 header (spec: The first cluster contains the file header)
     const header = getAlignedBuffer(1)
@@ -365,7 +374,10 @@ export class QcowStreamGenerator {
  * @param options.signal Optional AbortSignal to cancel the stream
  * @returns Readable stream of QCOW2 data
  */
-export async function toQcow2Stream(disk: Disk, { signal }: { signal?: AbortSignal } = {}): Promise<Readable> {
+export async function toQcow2Stream(
+  disk: Disk,
+  { signal }: { signal?: AbortSignal } = {}
+): Promise<WithLength<Readable>> {
   const generator = new QcowStreamGenerator(disk)
   return await generator.stream(signal)
 }

--- a/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.mts
+++ b/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.mts
@@ -8,6 +8,7 @@ import { Readable } from 'node:stream'
 const REFCOUNT_BYTES = 2 // Size of a reference count entry (spec: refcount_bits=16 default)
 const CLUSTER_SIZE = 64 * 1024 // Standard cluster size (must be power of 2 between 512 and 2M)
 const L2_ADDRESS_ENTRY_SIZE = 8 // Size of L2 table entries (64 bits)
+const NB_L2_ENTRIES_PER_CLUSTER = CLUSTER_SIZE / L2_ADDRESS_ENTRY_SIZE
 
 /**
  * Creates a buffer aligned to cluster size boundaries, initialized with a value
@@ -74,22 +75,21 @@ export class QcowStreamGenerator {
   async #buildBlockPresenceIndex(): Promise<{
     bitmap: Uint8Array
     groupHasData: Uint8Array
-    nbBlocks: number
+    nbTotalBlocks: number
     nbL1Entries: number
   }> {
     const disk = this.#disk
-    const nbBlocks = Math.ceil(disk.getVirtualSize() / disk.getBlockSize())
-    const nbL2PerL1Entry = CLUSTER_SIZE / L2_ADDRESS_ENTRY_SIZE
-    const nbL1Entries = Math.ceil(nbBlocks / nbL2PerL1Entry)
+    const nbTotalBlocks = Math.ceil(disk.getVirtualSize() / disk.getBlockSize())
+    const nbL1Entries = Math.ceil(nbTotalBlocks / NB_L2_ENTRIES_PER_CLUSTER)
 
-    const bitmap = new Uint8Array(Math.ceil(nbBlocks / 8))
+    const bitmap = new Uint8Array(Math.ceil(nbTotalBlocks / 8))
     const groupHasData = new Uint8Array(nbL1Entries)
 
     let lastYield = process.hrtime.bigint()
-    for (let i = 0; i < nbBlocks; i++) {
+    for (let i = 0; i < nbTotalBlocks; i++) {
       if (disk.hasBlock(i)) {
         bitmap[i >> 3] |= 1 << (i & 7)
-        groupHasData[Math.floor(i / nbL2PerL1Entry)] = 1
+        groupHasData[Math.floor(i / NB_L2_ENTRIES_PER_CLUSTER)] = 1
       }
       // check the clock every 65536 blocks: cheap enough to not affect throughput, frequent
       // enough to keep a single stretch of synchronous work under ~15ms
@@ -102,7 +102,7 @@ export class QcowStreamGenerator {
       }
     }
 
-    return { bitmap, groupHasData, nbBlocks, nbL1Entries }
+    return { bitmap, groupHasData, nbTotalBlocks, nbL1Entries }
   }
 
   /**
@@ -229,7 +229,6 @@ export class QcowStreamGenerator {
     nbL1Entries: number
   ): Generator<Buffer, void, unknown> {
     const QCOW_OFLAG_COPIED = 1n << 63n // Flag indicating cluster is allocated
-    const nbEntriesPerL2Table = CLUSTER_SIZE / 8
     const hasBlock = (index: number) => (bitmap[index >> 3] & (1 << (index & 7))) !== 0
 
     // Generate L1 table
@@ -253,8 +252,8 @@ export class QcowStreamGenerator {
       }
       const l2Table = getAlignedBuffer(1) // One cluster per L2 table
 
-      for (let j = 0; j < nbEntriesPerL2Table; j++) {
-        const blockIndex = i * nbEntriesPerL2Table + j
+      for (let j = 0; j < NB_L2_ENTRIES_PER_CLUSTER; j++) {
+        const blockIndex = i * NB_L2_ENTRIES_PER_CLUSTER + j
         if (blockIndex >= nbBlocks) {
           break // Last L2 table
         }
@@ -278,10 +277,9 @@ export class QcowStreamGenerator {
   async stream(signal?: AbortSignal): Promise<WithLength<Readable>> {
     const disk = this.#disk
     const nbAllocatedBlocks = this.#nbAllocatedBlocks
-    const nbTotalBlock = Math.ceil(disk.getVirtualSize() / disk.getBlockSize())
     // Single cooperative pass over every block: builds the presence bitmap/summary reused by
     // both the size computation below and the addressing tables generated inside the stream.
-    const { bitmap, groupHasData, nbBlocks, nbL1Entries } = await this.#buildBlockPresenceIndex()
+    const { bitmap, groupHasData, nbTotalBlocks, nbL1Entries } = await this.#buildBlockPresenceIndex()
     // Compute table sizes
     const { size: addressTableSize } = this.#computeAddressingSpace(groupHasData, nbL1Entries)
     const { refCountL1Size, refCountL2Size } = this.#computeRefCountSize(addressTableSize)
@@ -293,7 +291,7 @@ export class QcowStreamGenerator {
     header.writeBigUint64BE(0n, 8) // backing_file_offset (none)
     header.writeUInt32BE(0, 16) // backing_file_size (none)
     header.writeUInt32BE(Math.log2(CLUSTER_SIZE), 20) // cluster_bits
-    header.writeBigUInt64BE(BigInt(nbTotalBlock * disk.getBlockSize()), 24) //aligned size
+    header.writeBigUInt64BE(BigInt(nbTotalBlocks * disk.getBlockSize()), 24) //aligned size
     header.writeUInt32BE(0, 32) // crypt_method: none
     header.writeUInt32BE(nbL1Entries, 36) // l1_size
     header.writeBigUInt64BE(BigInt(header.length + refCountL1Size + refCountL2Size), 40) // l1_table_offset
@@ -313,7 +311,7 @@ export class QcowStreamGenerator {
       assert.strictEqual(self.#offset, CLUSTER_SIZE, 'header aligned')
       yield* self.#yieldRefCounts(expectedStreamLength / CLUSTER_SIZE)
       assert.strictEqual(self.#offset, CLUSTER_SIZE + refCountL1Size + refCountL2Size, 'refcounts aligned')
-      yield* self.#yieldAddressingTables(bitmap, groupHasData, nbBlocks, nbL1Entries)
+      yield* self.#yieldAddressingTables(bitmap, groupHasData, nbTotalBlocks, nbL1Entries)
       assert.strictEqual(
         self.#offset,
         CLUSTER_SIZE + refCountL1Size + refCountL2Size + addressTableSize,

--- a/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.mts
+++ b/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.mts
@@ -76,7 +76,7 @@ export class QcowStreamGenerator {
    * `Disk` the default implementation materializes the whole index array.
    * @private
    */
-  async #buildBlockPresenceIndex(): Promise<{
+  async #buildBlockPresenceIndex(signal?: AbortSignal): Promise<{
     bitmap: Uint8Array
     groupHasData: Uint8Array
     nbAllocatedBlocks: number
@@ -105,6 +105,7 @@ export class QcowStreamGenerator {
         if (Number(now - lastYield) / 1e6 > 15) {
           await new Promise(resolve => setImmediate(resolve))
           lastYield = process.hrtime.bigint()
+          signal?.throwIfAborted()
         }
       }
     }
@@ -288,7 +289,7 @@ export class QcowStreamGenerator {
     // allocated block count, reused by both the size computations below and the addressing
     // tables generated inside the stream.
     const { bitmap, groupHasData, nbAllocatedBlocks, nbTotalBlocks, nbL1Entries } =
-      await this.#buildBlockPresenceIndex()
+      await this.#buildBlockPresenceIndex(signal)
     // Compute table sizes
     const { size: addressTableSize } = this.#computeAddressingSpace(groupHasData, nbL1Entries)
     const { refCountL1Size, refCountL2Size } = this.#computeRefCountSize(addressTableSize, nbAllocatedBlocks)

--- a/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.test.mts
+++ b/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.test.mts
@@ -3,7 +3,6 @@ import { test } from 'node:test'
 import { DiskSmallerBlock, RandomAccessDisk, type DiskBlock } from '@xen-orchestra/disk-transform'
 import { toQcow2Stream } from './ConsumerQcowStream.mjs'
 
-
 class FullyAllocatedMockDisk extends RandomAccessDisk {
   private blockSize: number
   private virtualSize: number
@@ -72,5 +71,5 @@ test('does not throw RangeError: Invalid array length on large fully-allocated d
   const source = new FullyAllocatedMockDisk(VHD_BLOCK_SIZE, DISK_CAPACITY)
   await source.init()
   const disk = new DiskSmallerBlock(source, QCOW2_CLUSTER_SIZE)
-  assert.doesNotThrow(() => toQcow2Stream(disk))
+  await assert.doesNotReject(() => toQcow2Stream(disk))
 })

--- a/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.test.mts
+++ b/@xen-orchestra/qcow2/src/consumer/ConsumerQcowStream.test.mts
@@ -62,6 +62,73 @@ class FullyAllocatedMockDisk extends RandomAccessDisk {
   }
 }
 
+/**
+ * Sparse disk with a sub-cluster block size, so QcowStreamGenerator wraps it in a
+ * DiskLargerBlock. Only the listed source blocks are allocated.
+ */
+class SparseMockDisk extends RandomAccessDisk {
+  readonly #allocated: Set<number>
+  readonly #blockSize: number
+  readonly #virtualSize: number
+
+  constructor(blockSize: number, virtualSize: number, allocatedIndexes: number[]) {
+    super()
+    this.#blockSize = blockSize
+    this.#virtualSize = virtualSize
+    this.#allocated = new Set(allocatedIndexes)
+  }
+
+  async readBlock(index: number): Promise<DiskBlock> {
+    if (!this.hasBlock(index)) {
+      throw new Error(`Block ${index} not found`)
+    }
+    return { index, data: Buffer.alloc(this.#blockSize, index % 256) }
+  }
+
+  getVirtualSize(): number {
+    return this.#virtualSize
+  }
+  getBlockSize(): number {
+    return this.#blockSize
+  }
+  async init(): Promise<void> {}
+  async close(): Promise<void> {}
+  isDifferencing(): boolean {
+    return false
+  }
+  getBlockIndexes(): number[] {
+    return [...this.#allocated].sort((a, b) => a - b)
+  }
+  hasBlock(index: number): boolean {
+    return this.#allocated.has(index)
+  }
+}
+
+// The allocated block count is derived from the single hasBlock() scan rather than from
+// disk.getBlockIndexesCount(); on the DiskLargerBlock path the two must agree, otherwise the
+// generator's own nbGeneratedBlock / expectedStreamLength assertions fire.
+test('counts allocated blocks consistently on a sparse sub-cluster disk', async () => {
+  const QCOW2_CLUSTER_SIZE = 64 * 1024
+  const SOURCE_BLOCK_SIZE = 512 // blockRatio of 128
+  const NB_CLUSTERS = 4
+  const blocksPerCluster = QCOW2_CLUSTER_SIZE / SOURCE_BLOCK_SIZE
+
+  // clusters 0 and 2 hold data, clusters 1 and 3 are empty
+  const source = new SparseMockDisk(SOURCE_BLOCK_SIZE, NB_CLUSTERS * QCOW2_CLUSTER_SIZE, [
+    0,
+    5,
+    2 * blocksPerCluster + 3,
+  ])
+  await source.init()
+
+  const stream = await toQcow2Stream(source)
+  let length = 0
+  for await (const chunk of stream) {
+    length += chunk.length
+  }
+  assert.strictEqual(length, stream.length)
+})
+
 // Regression test linked to ticket #59102
 test('does not throw RangeError: Invalid array length on large fully-allocated disk', async () => {
   const VHD_BLOCK_SIZE = 2 * 1024 * 1024 // 2097152

--- a/@xen-orchestra/xapi/disks/Xapi.mjs
+++ b/@xen-orchestra/xapi/disks/Xapi.mjs
@@ -98,7 +98,7 @@ export class XapiDiskSource extends DiskPassthrough {
     let source
     let streamSource
     try {
-      // we will only use the stream for bloc list
+      // we will only use the stream for block list
       streamSource = await this.#openExportStream({ onlyListChangedBlocks: true })
       if (streamSource === undefined) {
         throw new Error(`Can't open stream source`)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,6 +32,7 @@
 - [Web-core] Fix "no data" illustration stars color (PR [#10327](https://github.com/vatesfr/xen-orchestra/pull/10327))
 - [Backup] Fix `uncaught exception AssertionError: assert(!this.paused)` in the logs, when a host closes a transfer while XO is writing to a slower destination (PR [#10282](https://github.com/vatesfr/xen-orchestra/pull/10282))
 - [xo-server] If an HTTP proxy was configured, internal routes (`/openmetrics`, `/v5`) were wrongly routed through it when xo-server listened on a wildcard address. `localhost` targets are now always reached directly, bypassing the HTTP proxy, whether the configured listen address is a wildcard (`0.0.0.0`, `::`) or a specific one (PR [#10335](https://github.com/vatesfr/xen-orchestra/pull/10335))
+- [Backups] Fix slow replication startup and fallback to full on qcow2 (PR [#10319](https://github.com/vatesfr/xen-orchestra/pull/10319))
 
 ### Packages to release
 
@@ -51,10 +52,11 @@
 
 - @xen-orchestra/backup-archive patch
 - @xen-orchestra/backups patch
+- @xen-orchestra/qcow2 patch
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+- @xen-orchestra/xapi patch
 - xen-api major
 - xo-server minor
 - xo-web minor
-
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,7 +32,7 @@
 - [Web-core] Fix "no data" illustration stars color (PR [#10327](https://github.com/vatesfr/xen-orchestra/pull/10327))
 - [Backup] Fix `uncaught exception AssertionError: assert(!this.paused)` in the logs, when a host closes a transfer while XO is writing to a slower destination (PR [#10282](https://github.com/vatesfr/xen-orchestra/pull/10282))
 - [xo-server] If an HTTP proxy was configured, internal routes (`/openmetrics`, `/v5`) were wrongly routed through it when xo-server listened on a wildcard address. `localhost` targets are now always reached directly, bypassing the HTTP proxy, whether the configured listen address is a wildcard (`0.0.0.0`, `::`) or a specific one (PR [#10335](https://github.com/vatesfr/xen-orchestra/pull/10335))
-- [Backups] Fix slow replication startup and fallback to full on qcow2 (PR [#10319](https://github.com/vatesfr/xen-orchestra/pull/10319))
+- [Backups] Fix slow replication startup and fallback to full on qcow2 (PR [#10333](https://github.com/vatesfr/xen-orchestra/pull/10333))
 
 ### Packages to release
 
@@ -52,7 +52,8 @@
 
 - @xen-orchestra/backup-archive patch
 - @xen-orchestra/backups patch
-- @xen-orchestra/qcow2 patch
+- @xen-orchestra/disk-cli patch
+- @xen-orchestra/qcow2 minor
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
 - @xen-orchestra/xapi patch

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -1324,7 +1324,7 @@ export default class Xapi extends XapiBase {
       preferNbd,
     })
     await disk.init()
-    const stream = toQcow2Stream(disk)
+    const stream = await toQcow2Stream(disk)
     return stream
   }
 


### PR DESCRIPTION
### Description

fix detected during release , but postponed out of the patch window

the idea is to build a bit index of the clusters to store them efficiently instead of go through all the possible blocks 3 times at different phases of the generation. The memory consumption is 2MB/TB of disk 

this index generation can still be quite long , so we use setImmediate from time to time to le the rest of the nodejs event loop run 

https://project.vates.tech/vates-global/browse/XO-3013/

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
