### PR TITLE
fix(xo-server): keep localhost proxy targets on wildcard binds

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,6 +30,7 @@
 - [XO server] Fix current_operations format on host and pool objects (PR [#10283](https://github.com/vatesfr/xen-orchestra/pull/10283))
 - [Web-core] Fix "no data" illustration stars color (PR [#10327](https://github.com/vatesfr/xen-orchestra/pull/10327))
 - [Backup] Fix `uncaught exception AssertionError: assert(!this.paused)` in the logs, when a host closes a transfer while XO is writing to a slower destination (PR [#10282](https://github.com/vatesfr/xen-orchestra/pull/10282))
+- [xo-server] If an HTTP proxy was configured, internal routes (`/openmetrics`, `/v5`) were wrongly routed through it when xo-server listened on a wildcard address (PR [#10335](https://github.com/vatesfr/xen-orchestra/pull/10335))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,7 +30,7 @@
 - [XO server] Fix current_operations format on host and pool objects (PR [#10283](https://github.com/vatesfr/xen-orchestra/pull/10283))
 - [Web-core] Fix "no data" illustration stars color (PR [#10327](https://github.com/vatesfr/xen-orchestra/pull/10327))
 - [Backup] Fix `uncaught exception AssertionError: assert(!this.paused)` in the logs, when a host closes a transfer while XO is writing to a slower destination (PR [#10282](https://github.com/vatesfr/xen-orchestra/pull/10282))
-- [xo-server] If an HTTP proxy was configured, internal routes (`/openmetrics`, `/v5`) were wrongly routed through it when xo-server listened on a wildcard address (PR [#10335](https://github.com/vatesfr/xen-orchestra/pull/10335))
+- [xo-server] If an HTTP proxy was configured, internal routes (`/openmetrics`, `/v5`) were wrongly routed through it when xo-server listened on a wildcard address. `localhost` targets are now always reached directly, bypassing the HTTP proxy, whether the configured listen address is a wildcard (`0.0.0.0`, `::`) or a specific one (PR [#10335](https://github.com/vatesfr/xen-orchestra/pull/10335))
 
 ### Packages to release
 

--- a/packages/xo-server/src/_getProxyTargetUrl.mjs
+++ b/packages/xo-server/src/_getProxyTargetUrl.mjs
@@ -1,0 +1,43 @@
+// hostnames on which the server listens on all interfaces: `localhost` is
+// reachable there, rewriting it would produce an unroutable target (0.0.0.0)
+// and route the request through the HTTP proxy if one is configured
+// (https://help.vates.tech/#ticket/zoom/63328)
+const WILDCARD_HOSTNAMES = new Set(['0.0.0.0', '::'])
+
+/**
+ * Resolves a `[http.proxies]` target URL.
+ *
+ * `isLocal` tells whether the configured target points at this very machine
+ * (`localhost`, possibly rewritten to the bound address): such requests must
+ * be sent directly, never through the HTTP proxy agent.
+ *
+ * @param {string} url
+ * @param {'ws:' | 'http:'} protocol
+ * @param {object} userHttpConfig - the `http.listen` entry used by the web UI
+ * @returns {{ targetUrl: URL, isLocal: boolean }}
+ */
+export function getProxyTargetUrl(url, protocol, userHttpConfig) {
+  let target = url
+
+  if (target.includes('[port]')) {
+    target = target.replace(/\[port\]/g, userHttpConfig.port)
+  }
+  let dynamicProtocol = false
+  if (target.includes('[protocol]')) {
+    dynamicProtocol = true
+    target = target.replace(/\[protocol\]/g, protocol)
+  }
+
+  const targetUrl = new URL(target)
+  if (dynamicProtocol && userHttpConfig.key !== undefined) {
+    targetUrl.protocol = targetUrl.protocol === 'ws:' ? 'wss:' : 'https:'
+  }
+
+  const isLocal = targetUrl.hostname === 'localhost'
+  const { hostname } = userHttpConfig
+  if (isLocal && hostname !== undefined && !WILDCARD_HOSTNAMES.has(hostname)) {
+    targetUrl.hostname = hostname
+  }
+
+  return { targetUrl, isLocal }
+}

--- a/packages/xo-server/src/_getProxyTargetUrl.test.mjs
+++ b/packages/xo-server/src/_getProxyTargetUrl.test.mjs
@@ -1,0 +1,66 @@
+import assert from 'assert/strict'
+import test from 'node:test'
+
+import { getProxyTargetUrl } from './_getProxyTargetUrl.mjs'
+
+const { describe, it } = test
+
+describe('getProxyTargetUrl()', () => {
+  it('keeps localhost untouched when no hostname is configured', () => {
+    const { targetUrl, isLocal } = getProxyTargetUrl('http://localhost:9004', 'http:', { port: 80 })
+    assert.equal(targetUrl.href, 'http://localhost:9004/')
+    assert.equal(isLocal, true)
+  })
+
+  // regression test: with the shipped XOA config (hostname = '0.0.0.0'), the
+  // target must not be rewritten to an unroutable address nor become eligible
+  // for the HTTP proxy agent
+  it('keeps localhost untouched when the listen hostname is a wildcard', () => {
+    for (const hostname of ['0.0.0.0', '::']) {
+      const { targetUrl, isLocal } = getProxyTargetUrl('http://localhost:9004', 'http:', { hostname, port: 443 })
+      assert.equal(targetUrl.href, 'http://localhost:9004/')
+      assert.equal(isLocal, true)
+    }
+  })
+
+  it('rewrites localhost to a specific listen hostname, still marked local', () => {
+    const { targetUrl, isLocal } = getProxyTargetUrl('http://localhost:9004', 'http:', {
+      hostname: '192.168.1.5',
+      port: 443,
+    })
+    assert.equal(targetUrl.href, 'http://192.168.1.5:9004/')
+    assert.equal(isLocal, true)
+  })
+
+  it('leaves non-localhost targets alone and marks them non-local', () => {
+    const { targetUrl, isLocal } = getProxyTargetUrl('http://metrics.lan:1234/foo', 'http:', {
+      hostname: '192.168.1.5',
+      port: 443,
+    })
+    assert.equal(targetUrl.href, 'http://metrics.lan:1234/foo')
+    assert.equal(isLocal, false)
+  })
+
+  it('substitutes [port] and [protocol], upgrading the protocol on secure configs', () => {
+    const { targetUrl } = getProxyTargetUrl('[protocol]//localhost:[port]/api', 'http:', {
+      hostname: '0.0.0.0',
+      port: 8443,
+      key: 'dummy',
+    })
+    assert.equal(targetUrl.href, 'https://localhost:8443/api')
+  })
+
+  it('upgrades ws to wss on secure configs', () => {
+    const { targetUrl } = getProxyTargetUrl('[protocol]//localhost:[port]/api', 'ws:', {
+      hostname: '10.0.0.1',
+      port: 8443,
+      key: 'dummy',
+    })
+    assert.equal(targetUrl.href, 'wss://10.0.0.1:8443/api')
+  })
+
+  it('does not upgrade the protocol when it is not dynamic', () => {
+    const { targetUrl } = getProxyTargetUrl('ws://localhost:9001', 'ws:', { hostname: '0.0.0.0', port: 443, key: 'k' })
+    assert.equal(targetUrl.href, 'ws://localhost:9001/')
+  })
+})

--- a/packages/xo-server/src/index.mjs
+++ b/packages/xo-server/src/index.mjs
@@ -16,6 +16,7 @@ import ms from 'ms'
 import once from 'lodash/once.js'
 import proxyAddr from 'proxy-addr'
 import proxyConsole from './proxy-console.mjs'
+import { getProxyTargetUrl } from './_getProxyTargetUrl.mjs'
 import pw from 'pw'
 import serveStatic from 'serve-static'
 import stoppable from 'stoppable'
@@ -685,36 +686,6 @@ const setUpProxies = (express, opts, xo) => {
       })
     })
 
-  /**
-   *
-   * @param {string} url
-   * @param {'ws:' | 'http:'} protocol
-   * @returns {URL} targetUrl
-   */
-  function getTargetUrl(url, protocol) {
-    let target = url
-
-    if (target.includes('[port]')) {
-      target = target.replace(/\[port\]/g, userHttpConfig.port)
-    }
-    let dynamicProtocol = false
-    if (target.includes('[protocol]')) {
-      dynamicProtocol = true
-      target = target.replace(/\[protocol\]/g, protocol)
-    }
-
-    const targetUrl = new URL(target)
-    if (dynamicProtocol && isSecure) {
-      targetUrl.protocol = targetUrl.protocol === 'ws:' ? 'wss:' : 'https:'
-    }
-
-    if (userHttpConfig.hostname !== undefined && targetUrl.hostname === 'localhost') {
-      targetUrl.hostname = userHttpConfig.hostname
-    }
-
-    return targetUrl
-  }
-
   // TODO: sort proxies by descending prefix length.
 
   // HTTP request proxy.
@@ -723,11 +694,11 @@ const setUpProxies = (express, opts, xo) => {
 
     for (const prefix in opts) {
       if (url.startsWith(prefix)) {
-        const target = getTargetUrl(opts[prefix], 'http:')
+        const { targetUrl, isLocal } = getProxyTargetUrl(opts[prefix], 'http:', userHttpConfig)
 
         proxy.web(req, res, {
-          agent: target.hostname === 'localhost' ? undefined : xo.httpAgent,
-          target: target.href + url.slice(prefix.length),
+          agent: isLocal ? undefined : xo.httpAgent,
+          target: targetUrl.href + url.slice(prefix.length),
         })
 
         return
@@ -748,11 +719,11 @@ const setUpProxies = (express, opts, xo) => {
 
     for (const prefix in opts) {
       if (url.startsWith(prefix)) {
-        const target = getTargetUrl(opts[prefix], 'ws:')
+        const { targetUrl, isLocal } = getProxyTargetUrl(opts[prefix], 'ws:', userHttpConfig)
 
         proxy.ws(req, socket, head, {
-          agent: new URL(target).hostname === 'localhost' ? undefined : xo.httpAgent,
-          target: target.href + url.slice(prefix.length),
+          agent: isLocal ? undefined : xo.httpAgent,
+          target: targetUrl.href + url.slice(prefix.length),
         })
 
         return


### PR DESCRIPTION
### Description

Since #9572, `[http.proxies]` targets pointing at `localhost` are rewritten to the hostname of the HTTPS listen config. With the default XOA config (`hostname = '0.0.0.0'`) this produced targets such as `http://0.0.0.0:9004/metrics` and, worse, routed these internal requests through the proxy-aware HTTP agent. On an appliance with an `httpProxy` configured, `/openmetrics` scrapes left the box for the corporate proxy and were denied there. All localhost-based routes were affected: `/openmetrics`, `/v5/*`, the updater websocket.

The rewrite now only happens when the bind address is a specific one (the #9500 case, where `localhost` isn't reachable), and the agent is picked from the original target locality, so requests to the machine itself never go through the HTTP proxy. Target resolution moved to a small helper, `_getProxyTargetUrl.mjs`, with unit tests covering the regression and the #9500 behavior.

Introduced by 82f047ef9d7f1598a668324bea69509ee33c6270 (#9572)
See https://project.vates.tech/vates-global/browse/XO-2965/

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
