### PR TITLE
fix(xo-server): disable restart toolstack on HA pools

### DIFF
--- a/@xen-orchestra/rest-api/src/hosts/host.service.mts
+++ b/@xen-orchestra/rest-api/src/hosts/host.service.mts
@@ -148,7 +148,15 @@ export class HostService {
     } = {}
   ): Promise<void> {
     const host = this.#restApi.getObject<XoHost>(hostId)
-
+    const pool = this.#restApi.getObject<XoPool>(host.$pool)
+    if (pool.HA_enabled) {
+      throw incorrectState({
+        actual: pool.HA_enabled,
+        expected: false,
+        object: pool.id,
+        property: 'ha_enabled',
+      })
+    }
     if (opts?.bypassBackupCheck) {
       log.warn('host.restartAgent called with argument "bypassBackupCheck" set to true', { hostId })
     } else {

--- a/@xen-orchestra/xapi/host.mjs
+++ b/@xen-orchestra/xapi/host.mjs
@@ -19,6 +19,12 @@ const waitAgentRestart = (xapi, hostRef, prevAgentStartTime) =>
 
 class Host {
   async restartAgent(ref) {
+    const { pool } = this
+
+    if (pool.ha_enabled) {
+      throw new Error('HA must be disabled on the pool to restart the agent')
+    }
+
     const agentStartTime = +(await this.getField('host', ref, 'other_config')).agent_start_time
 
     await this.call('host.restart_agent', ref)

--- a/@xen-orchestra/xapi/host.mjs
+++ b/@xen-orchestra/xapi/host.mjs
@@ -19,12 +19,6 @@ const waitAgentRestart = (xapi, hostRef, prevAgentStartTime) =>
 
 class Host {
   async restartAgent(ref) {
-    const { pool } = this
-
-    if (pool.ha_enabled) {
-      throw new Error('HA must be disabled on the pool to restart the agent')
-    }
-
     const agentStartTime = +(await this.getField('host', ref, 'other_config')).agent_start_time
 
     await this.call('host.restart_agent', ref)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,4 +31,6 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/xapi patch
+
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,8 @@
 
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
+- [XAPI] disable restart toolstack for HA enabled Pools (PR [#10344] (https://github.com/vatesfr/xen-orchestra/pull/10344))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,6 +33,7 @@
 
 <!--packages-start-->
 
-- @xen-orchestra/xapi patch
+- @xen-orchestra/rest-api patch
+- xo-server patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@
 
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
-- [XAPI] disable restart toolstack for HA enabled Pools (PR [#10344] (https://github.com/vatesfr/xen-orchestra/pull/10344))
+- [Host] disable restart toolstack for HA enabled Pools (PR [#10344](https://github.com/vatesfr/xen-orchestra/pull/10344))
 
 ### Packages to release
 

--- a/packages/xo-server/src/api/host.mjs
+++ b/packages/xo-server/src/api/host.mjs
@@ -256,6 +256,15 @@ restart.resolve = {
 // -------------------------------------------------------------------
 
 export async function restartAgent({ bypassBackupCheck = false, host }) {
+  const pool = this.getObject(host.$poolId, 'pool')
+  if (pool.HA_enabled) {
+    throw incorrectState({
+      actual: pool.HA_enabled,
+      expected: false,
+      object: pool.id,
+      property: 'ha_enabled',
+    })
+  }
   if (bypassBackupCheck) {
     log.warn('host.restartAgent with argument "bypassBackupCheck" set to true', { hostId: host.id })
   } else {

--- a/packages/xo-server/src/api/xostor.mjs
+++ b/packages/xo-server/src/api/xostor.mjs
@@ -1,6 +1,7 @@
 import { asyncEach } from '@vates/async-each'
 import { defer } from 'golike-defer'
 import { Task } from '@xen-orchestra/mixins/Tasks.mjs'
+import { incorrectState } from 'xo-common/api-errors.js'
 
 const ENUM_PROVISIONING = {
   Thin: 'thin',
@@ -62,6 +63,10 @@ async function installOrUpdateDependencies(host, method = 'install') {
 }
 
 export async function installDependencies({ host }) {
+  const pool = this.getObject(host.$poolId, 'pool')
+  if (pool.HA_enabled) {
+    throw incorrectState({ actual: pool.HA_enabled, expected: false, object: pool.id, property: 'ha_enabled' })
+  }
   await installOrUpdateDependencies.call(this, host)
   await this.getXapiObject(host).$restartAgent()
 }


### PR DESCRIPTION
### Description

[XO-2916] This PR throws an error and disable restart toolstack for the hosts who belongs to HA enabled pools
Introduced by 3293e69cc292eb8960cebfd9f2df101a74bd050e

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
