### PR TITLE
fix(proxy): fetch failed 

### DIFF
--- a/@xen-orchestra/proxy/app/mixins/api.mjs
+++ b/@xen-orchestra/proxy/app/mixins/api.mjs
@@ -68,6 +68,15 @@ export default class Api {
       // not be enough for the API.
       ctx.req.setTimeout(0)
 
+      // Compression is disabled for the whole API.
+      //
+      // A compressor buffers its input, so a streamed response would not reach the
+      // client as it is produced. With brotli — which `fetch` negotiates by default
+      // over HTTPS — nothing at all is emitted before its window fills, not even the
+      // response headers, and the client times out waiting for them.
+      //
+      ctx.compress = false
+
       const profile = await app.authentication.findProfile({
         token: ctx.cookies.get('authenticationToken'),
       })

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,8 @@
 
 > Users must be able to say: "I had this issue, happy to know it's fixed"
 
+- [Backups] Fix error `fetch failed` on backup with proxies (PR [#10346](https://github.com/vatesfr/xen-orchestra/pull/10346))
+
 ### Packages to release
 
 > When modifying a package, add it here with its release type.
@@ -31,4 +33,6 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/proxy patch
+- xo-server patch
 <!--packages-end-->

--- a/packages/xo-server/src/xo-mixins/proxies.mjs
+++ b/packages/xo-server/src/xo-mixins/proxies.mjs
@@ -474,13 +474,19 @@ export default class Proxy {
     const proxy = await this._getProxy(id)
 
     const url = new URL('https://localhost/api/v1')
-
+    const headers = {
+      'Content-Type': 'application/json',
+      Cookie: cookie.serialize('authenticationToken', proxy.authenticationToken),
+    }
+    if (assertType !== 'scalar') {
+      // the proxy streams ndjson and binary responses incrementally; a compressor
+      // buffers them (brotli emits nothing until its window fills), so the response
+      // headers are never flushed and `headersTimeout` fires
+      headers['Accept-Encoding'] = 'identity'
+    }
     const request = {
       body: format.request(0, method, params),
-      headers: {
-        'Content-Type': 'application/json',
-        Cookie: cookie.serialize('authenticationToken', proxy.authenticationToken),
-      },
+      headers,
       method: 'POST',
       dispatcher: this._getAgent(timeout),
     }


### PR DESCRIPTION
### Description

introduced by #10038 

* undici by default accept compression
* the xo-proxy is configured to use compression in brotli 
* brotli compression do not emit any data while filling its internal buffers while the conneciton is active, including headers

depending on the size of job and latency this lead to brotli holding headers more than 60 seconds,thus triggerring the timeout on xoa side

This PR disable compression both on xoa and proxy 


### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
