### PR TITLE
fix(xo-server): auto reconnection infinite loop when pool is already connectd

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@
 - [Web-core] Fix 404 illustration color (PR [#10325](https://github.com/vatesfr/xen-orchestra/pull/10325))
 - [Backup-archive] No longer create a `cache.json.gz` file on immutable/S3 remote during cleanup, which could not be deleted afterwards and stayed billed forever (PR [#10243](https://github.com/vatesfr/xen-orchestra/pull/10243))
 - [Servers] Fix endless connection attempts to a pool which is already connected through another server entry (PR [#10355](https://github.com/vatesfr/xen-orchestra/pull/10355))
+- [Servers] fix a mishandling in the grace period before marking a pool disconnected, this will keep the ui in sync AND not redownload all the xapi object for a transient issue (PR [#10355](https://github.com/vatesfr/xen-orchestra/pull/10355))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,7 +22,7 @@
 - [Web-core] Fix "console offline" illustration sparks color (PR [#10309](https://github.com/vatesfr/xen-orchestra/pull/10309))
 - [Web-core] Fix 404 illustration color (PR [#10325](https://github.com/vatesfr/xen-orchestra/pull/10325))
 - [Backup-archive] No longer create a `cache.json.gz` file on immutable/S3 remote during cleanup, which could not be deleted afterwards and stayed billed forever (PR [#10243](https://github.com/vatesfr/xen-orchestra/pull/10243))
-- [Servers] Fix endless connection attempts to a pool which is already connected through another server entry (PR [#XXXX](https://github.com/vatesfr/xen-orchestra/pull/XXXX))
+- [Servers] Fix endless connection attempts to a pool which is already connected through another server entry (PR [#10355](https://github.com/vatesfr/xen-orchestra/pull/10355))
 
 ### Packages to release
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@
 - [Web-core] Fix "console offline" illustration sparks color (PR [#10309](https://github.com/vatesfr/xen-orchestra/pull/10309))
 - [Web-core] Fix 404 illustration color (PR [#10325](https://github.com/vatesfr/xen-orchestra/pull/10325))
 - [Backup-archive] No longer create a `cache.json.gz` file on immutable/S3 remote during cleanup, which could not be deleted afterwards and stayed billed forever (PR [#10243](https://github.com/vatesfr/xen-orchestra/pull/10243))
+- [Servers] Fix endless connection attempts to a pool which is already connected through another server entry (PR [#XXXX](https://github.com/vatesfr/xen-orchestra/pull/XXXX))
 
 ### Packages to release
 
@@ -43,5 +44,6 @@
 - @xen-orchestra/backups patch
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
+- xo-server patch
 
 <!--packages-end-->

--- a/packages/xo-server/src/models/server.test.mjs
+++ b/packages/xo-server/src/models/server.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { serializeError } from '../utils.mjs'
+import { Servers } from './server.mjs'
+
+// Reproduces what a record goes through on its way to the database and back:
+// `Collection#_add` copies it with JSON *before* the model serializes it, then
+// redis stores and returns JSON
+const throughDatabase = record => {
+  const copy = JSON.parse(JSON.stringify(record))
+  Servers.prototype._serialize(copy)
+
+  const stored = JSON.parse(JSON.stringify(copy))
+  Servers.prototype._unserialize(stored)
+  return stored
+}
+
+const makeServer = error => ({ id: 'server-1', enabled: true, error, host: '192.0.2.1' })
+
+describe('Servers', function () {
+  describe('error', function () {
+    it('does not survive the copy made by the collection when it is a raw Error', function () {
+      // hence `serializeError` in `_connectXenServer`: `message`, `name` and
+      // `stack` are not enumerable, JSON copies them away
+      const { error } = throughDatabase(makeServer(new Error('this pool is already connected')))
+
+      assert.equal(error?.message, undefined)
+    })
+
+    it('keeps its message and code once serialized by the caller', function () {
+      const cause = new Error('SESSION_AUTHENTICATION_FAILED(, )')
+      cause.code = 'SESSION_AUTHENTICATION_FAILED'
+
+      const { error } = throughDatabase(makeServer(serializeError(cause)))
+
+      assert.equal(error.message, 'SESSION_AUTHENTICATION_FAILED(, )')
+      assert.equal(error.code, 'SESSION_AUTHENTICATION_FAILED')
+      assert.equal(error.name, 'Error')
+    })
+
+    it('compares equal to a new occurrence of the same error, so a failing server is not rewritten', function () {
+      // `_connectXenServer` skips the database write – and therefore any
+      // reconnection attempt triggered by it – when the error did not change
+      const previousError = throughDatabase(
+        makeServer(serializeError(new Error('this pool is already connected')))
+      ).error
+      const currentError = serializeError(new Error('this pool is already connected'))
+
+      assert.equal(previousError.code, currentError.code)
+      assert.equal(previousError.message, currentError.message)
+    })
+  })
+})

--- a/packages/xo-server/src/xo-mixins/_xen-servers.test.mjs
+++ b/packages/xo-server/src/xo-mixins/_xen-servers.test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { configure } from '@xen-orchestra/log/configure'
+
+import XenServers from './xen-servers.mjs'
+
+configure({ level: 'FATAL', transport: () => {} })
+
+// Minimal XoApp mock: the constructor only registers hooks and watches a config
+// duration, none of which are fired by these tests
+const createMockApp = () => ({
+  config: { watchDuration: () => {} },
+  hooks: { on: () => {} },
+})
+
+const SERVER = { id: 'server-1', enabled: true, host: '192.0.2.1', password: 'secret', username: 'root' }
+
+// `_servers` is normally created on the `core started` hook, and
+// `_autoReconnectXenServer` would start a real reconnection loop
+const createXenServers = (server = SERVER) => {
+  const xenServers = new XenServers(createMockApp(), { safeMode: true })
+
+  const stored = { ...server }
+  const updates = []
+  const reconnected = []
+
+  xenServers._servers = {
+    first: async () => ({ ...stored }),
+    update: async model => {
+      updates.push({ ...model })
+      Object.assign(stored, model)
+    },
+  }
+  xenServers._autoReconnectXenServer = id => reconnected.push(id)
+
+  return { reconnected, updates, xenServers }
+}
+
+describe('updateXenServer', function () {
+  it('does not arm the auto-reconnect loop on the internal error bookkeeping write', async function () {
+    const { reconnected, updates, xenServers } = createXenServers()
+
+    // `_connectXenServer` writes the error of every failed attempt: re-arming
+    // the loop here restarts one which just stopped on a permanent error
+    await xenServers.updateXenServer('server-1', { error: new Error('this pool is already connected') })
+
+    assert.equal(updates.length, 1, 'the error must still be persisted')
+    assert.deepEqual(reconnected, [])
+  })
+
+  it('does not arm the auto-reconnect loop when the error is cleared', async function () {
+    const { reconnected, xenServers } = createXenServers({ ...SERVER, error: { message: 'boom' } })
+
+    await xenServers.updateXenServer('server-1', { error: null })
+
+    assert.deepEqual(reconnected, [])
+  })
+
+  it('does not arm the auto-reconnect loop on an unrelated property', async function () {
+    const { reconnected, updates, xenServers } = createXenServers()
+
+    await xenServers.updateXenServer('server-1', { label: 'new label' })
+
+    assert.equal(updates.length, 1)
+    assert.deepEqual(reconnected, [])
+  })
+
+  it('arms the auto-reconnect loop when the server is enabled', async function () {
+    const { reconnected, xenServers } = createXenServers({ ...SERVER, enabled: false })
+
+    await xenServers.updateXenServer('server-1', { enabled: true })
+
+    assert.deepEqual(reconnected, ['server-1'])
+  })
+
+  it('arms the auto-reconnect loop when the credentials or the address change', async function () {
+    for (const properties of [{ host: '192.0.2.2' }, { password: 'new secret' }, { username: 'admin' }]) {
+      const { reconnected, xenServers } = createXenServers()
+
+      await xenServers.updateXenServer('server-1', properties)
+
+      assert.deepEqual(reconnected, ['server-1'], `expected a reconnection for ${JSON.stringify(properties)}`)
+    }
+  })
+
+  it('does not arm the auto-reconnect loop while the server is already connecting', async function () {
+    const { reconnected, xenServers } = createXenServers({ ...SERVER, enabled: false })
+    xenServers._connectingXenServers.add('server-1')
+
+    await xenServers.updateXenServer('server-1', { enabled: true })
+
+    assert.deepEqual(reconnected, [])
+  })
+})

--- a/packages/xo-server/src/xo-mixins/_xen-servers.test.mjs
+++ b/packages/xo-server/src/xo-mixins/_xen-servers.test.mjs
@@ -25,18 +25,21 @@ const createXapi = ({ $id = 'pool-1' } = {}) => ({
 
 // `_servers` is normally created on the `core started` hook, and
 // `_autoReconnectXenServer` would start a real reconnection loop
-const createXenServers = (server = SERVER) => {
+const createXenServers = (...servers) => {
   const xenServers = new XenServers(createMockApp(), { safeMode: true })
 
-  const stored = { ...server }
+  const stored = { __proto__: null }
+  for (const server of servers.length === 0 ? [SERVER] : servers) {
+    stored[server.id] = { ...server }
+  }
   const updates = []
   const reconnected = []
 
   xenServers._servers = {
-    first: async () => ({ ...stored }),
+    first: async id => (stored[id] === undefined ? undefined : { ...stored[id] }),
     update: async model => {
       updates.push({ ...model })
-      Object.assign(stored, model)
+      Object.assign(stored[model.id], model)
     },
   }
   xenServers._autoReconnectXenServer = id => reconnected.push(id)
@@ -127,6 +130,21 @@ describe('disconnectXenServer', function () {
     await xenServers.disconnectXenServer('server-1')
 
     assert.deepEqual({ ...xenServers._serverIdsByPool }, {})
+  })
+
+  it('does not drop the connection of the server holding the pool', async function () {
+    // a second entry registered on an already connected pool stays `enabled`
+    // but disconnected, with a `PoolAlreadyConnected` error: disconnecting or
+    // deleting it must not release the pool of the server which owns it
+    const { xenServers } = createXenServers(SERVER, { ...SERVER, id: 'server-2' })
+    connect(xenServers)
+    const xapi = xenServers._xapis['server-1']
+
+    await xenServers.disconnectXenServer('server-2')
+
+    assert.deepEqual({ ...xenServers._serverIdsByPool }, { 'pool-1': 'server-1' })
+    assert.equal(xenServers._xapis['server-1'], xapi)
+    assert.equal(xenServers._getXenServerStatus('server-1'), 'connected')
   })
 
   it('leaves the pools of the other servers alone', async function () {

--- a/packages/xo-server/src/xo-mixins/_xen-servers.test.mjs
+++ b/packages/xo-server/src/xo-mixins/_xen-servers.test.mjs
@@ -29,7 +29,9 @@ const createXenServers = (...servers) => {
   const xenServers = new XenServers(createMockApp(), { safeMode: true })
 
   const stored = { __proto__: null }
-  for (const server of servers.length === 0 ? [SERVER] : servers) {
+  const serversToInitialize = servers.length === 0 ? [SERVER] : servers
+
+  for (const server of serversToInitialize) {
     stored[server.id] = { ...server }
   }
   const updates = []

--- a/packages/xo-server/src/xo-mixins/_xen-servers.test.mjs
+++ b/packages/xo-server/src/xo-mixins/_xen-servers.test.mjs
@@ -15,6 +15,14 @@ const createMockApp = () => ({
 
 const SERVER = { id: 'server-1', enabled: true, host: '192.0.2.1', password: 'secret', username: 'root' }
 
+// `poolId` defaults to the pool the connection was opened with, `$id` is the
+// one it currently reports (they differ after a pool UUID change)
+const createXapi = ({ $id = 'pool-1' } = {}) => ({
+  disconnect: async () => {},
+  getObjectByRef: () => ({ uuid: 'host-1' }),
+  pool: { $id, master: 'OpaqueRef:master', uuid: $id },
+})
+
 // `_servers` is normally created on the `core started` hook, and
 // `_autoReconnectXenServer` would start a real reconnection loop
 const createXenServers = (server = SERVER) => {
@@ -90,5 +98,44 @@ describe('updateXenServer', function () {
     await xenServers.updateXenServer('server-1', { enabled: true })
 
     assert.deepEqual(reconnected, [])
+  })
+})
+
+describe('disconnectXenServer', function () {
+  const connect = (xenServers, { poolId = 'pool-1', serverId = 'server-1' } = {}) => {
+    xenServers._xapis[serverId] = createXapi({ $id: poolId })
+    xenServers._serverIdsByPool[poolId] = serverId
+  }
+
+  it('forgets the pool of the server', async function () {
+    const { xenServers } = createXenServers()
+    connect(xenServers)
+
+    await xenServers.disconnectXenServer('server-1')
+
+    assert.deepEqual({ ...xenServers._serverIdsByPool }, {})
+    assert.equal(xenServers._xapis['server-1'], undefined)
+  })
+
+  it('forgets the pool of the server even after a pool UUID change', async function () {
+    const { xenServers } = createXenServers()
+    connect(xenServers, { poolId: 'pool-1' })
+    // `_onXenAdd` re-registers the server under the new identifier
+    delete xenServers._serverIdsByPool['pool-1']
+    xenServers._serverIdsByPool['pool-2'] = 'server-1'
+
+    await xenServers.disconnectXenServer('server-1')
+
+    assert.deepEqual({ ...xenServers._serverIdsByPool }, {})
+  })
+
+  it('leaves the pools of the other servers alone', async function () {
+    const { xenServers } = createXenServers()
+    connect(xenServers)
+    connect(xenServers, { poolId: 'pool-2', serverId: 'server-2' })
+
+    await xenServers.disconnectXenServer('server-1')
+
+    assert.deepEqual({ ...xenServers._serverIdsByPool }, { 'pool-2': 'server-2' })
   })
 })

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -1,5 +1,4 @@
 import assert from 'assert'
-import findKey from 'lodash/findKey.js'
 import pick from 'lodash/pick.js'
 import { asyncEach } from '@vates/async-each'
 import { BaseError } from 'make-error'
@@ -287,8 +286,7 @@ export default class XenServers {
     forEach(newXapiObjects, function handleObject(xapiObject, xapiId) {
       // handle pool UUID change
       if (xapiObject.$type === 'pool' && serverIdsByPool[xapiObject.$id] === undefined) {
-        const obsoletePoolId = findKey(serverIdsByPool, serverId => serverId === conId)
-        delete serverIdsByPool[obsoletePoolId]
+        self._forgetXenServerPool(conId)
         serverIdsByPool[xapiObject.$id] = conId
       }
 
@@ -642,7 +640,7 @@ export default class XenServers {
       xapi.once('disconnected', () => {
         xapi.xo.uninstall()
         delete this._xapis[server.id]
-        delete this._serverIdsByPool[poolId]
+        this._forgetXenServerPool(server.id)
         this._app.emit('server:disconnected', { server, xapi })
 
         // deliberate disconnections set `enabled` to false beforehand, in
@@ -671,6 +669,21 @@ export default class XenServers {
     }
   }
 
+  // Removes every pool this server is registered as the connection of.
+  //
+  // The pool is looked up by server instead of by identifier because a pool
+  // UUID can change during the life of a connection (see `_onXenAdd`): a
+  // mapping left behind would make every subsequent connection to that pool
+  // fail with `PoolAlreadyConnected`, including the ones of this very server.
+  _forgetXenServerPool(serverId) {
+    const serverIdsByPool = this._serverIdsByPool
+    for (const poolId of Object.keys(serverIdsByPool)) {
+      if (serverIdsByPool[poolId] === serverId) {
+        delete serverIdsByPool[poolId]
+      }
+    }
+  }
+
   async disconnectXenServer(id) {
     // throw no such object if the server does not exist
     const server = await this.getXenServer(id)
@@ -692,11 +705,7 @@ export default class XenServers {
     const xapi = this._xapis[id]
     delete this._xapis[id]
 
-    const serverIdsByPool = this._serverIdsByPool
-    const poolId = findKey(serverIdsByPool, _ => _ === xapi)
-    if (poolId !== undefined) {
-      delete serverIdsByPool[id]
-    }
+    this._forgetXenServerPool(id)
 
     return xapi?.disconnect()
   }

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -235,7 +235,19 @@ export default class XenServers {
 
     // an enabled server must not stay disconnected without retries, e.g. after
     // the user fixed its credentials or address
-    if (server.enabled && !this._connectingXenServers.has(id) && this._getXenServerStatus(id) === 'disconnected') {
+    //
+    // only an update which can actually change the outcome of a connection may
+    // (re-)arm the loop: `_connectXenServer` writes `{ error }` on every failed
+    // attempt, and that bookkeeping write must not restart a loop which just
+    // stopped on a permanent error (e.g. PoolAlreadyConnected), which would
+    // retry forever, at full speed since each loop restarts its own backoff
+    const canFixConnection = properties.enabled === true || connectionIdentityChanged
+    if (
+      canFixConnection &&
+      server.enabled &&
+      !this._connectingXenServers.has(id) &&
+      this._getXenServerStatus(id) === 'disconnected'
+    ) {
       this._autoReconnectXenServer(id)
     }
   }

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -25,7 +25,7 @@ import { getRpuTracesConfig, openRpuTrace } from '../_rpuObservability.mjs'
 import xapiObjectToXo from '../xapi-object-to-xo.mjs'
 import XapiStats from '../xapi-stats.mjs'
 import { autoReconnect } from '../_xenServerAutoReconnect.mjs'
-import { camelToSnakeCase, forEach, isEmpty, popProperty } from '../utils.mjs'
+import { camelToSnakeCase, forEach, isEmpty, popProperty, serializeError } from '../utils.mjs'
 import { Servers } from '../models/server.mjs'
 
 // ===================================================================
@@ -654,10 +654,12 @@ export default class XenServers {
       delete this._xapis[server.id]
       xapi.disconnect()::ignoreErrors()
 
+      const serializedError = serializeError(error)
+
       // avoid a database write per auto-reconnect attempt when the error did not change
       const previousError = server.error
-      if (previousError?.code !== error?.code || previousError?.message !== error?.message) {
-        this.updateXenServer(id, { error })::ignoreErrors()
+      if (previousError?.code !== serializedError.code || previousError?.message !== serializedError.message) {
+        this.updateXenServer(id, { error: serializedError })::ignoreErrors()
       }
 
       // permanent errors: retrying is pointless, do not start the loop

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -745,7 +745,7 @@ export default class XenServers {
       lastEventFetchedTimestamp !== undefined &&
       Date.now() > lastEventFetchedTimestamp + this._xapiMarkDisconnectedDelay
     ) {
-      server.error = xapis[server.id].watchEventsError
+      server.error = serializeError(xapis[server.id].watchEventsError)
     }
     server.status = this._getXenServerStatus(server.id)
     if (server.status === 'connected') {

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -622,7 +622,9 @@ export default class XenServers {
       const onEventFetchingError = () => {
         const timeout = setTimeout(() => {
           xapi.xo.uninstall()
-          delete serverIdsByPool[poolId]
+
+          // switch server status from connected to connecting
+          this._forgetXenServerPool(server.id)
         }, this._xapiMarkDisconnectedDelay)
         xapi.once('eventFetchingSuccess', () => {
           xapi.once('eventFetchingError', onEventFetchingError)

--- a/packages/xo-server/src/xo-mixins/xen-servers.mjs
+++ b/packages/xo-server/src/xo-mixins/xen-servers.mjs
@@ -619,23 +619,24 @@ export default class XenServers {
 
       this.updateXenServer(id, { error: null })::ignoreErrors()
 
-      xapi.once('eventFetchingError', function eventFetchingErrorListener() {
+      const onEventFetchingError = () => {
         const timeout = setTimeout(() => {
           xapi.xo.uninstall()
-
-          // switch server status from connected to connecting
           delete serverIdsByPool[poolId]
         }, this._xapiMarkDisconnectedDelay)
         xapi.once('eventFetchingSuccess', () => {
-          xapi.once('eventFetchingError', eventFetchingErrorListener)
+          xapi.once('eventFetchingError', onEventFetchingError)
           if (serverIdsByPool[poolId] === undefined) {
+            // the pool may now be known under another identifier, `install()`
+            // replays the pool object which registers it under the right one
             serverIdsByPool[poolId] = server.id
             xapi.xo.install()
           } else {
             clearTimeout(timeout)
           }
         })
-      })
+      }
+      xapi.once('eventFetchingError', onEventFetchingError)
 
       xapi.once('disconnected', () => {
         xapi.xo.uninstall()


### PR DESCRIPTION
### Description

review by commit

this PR fix multiple issues in the auto reconnection loop that can lead to an infinite reconnection loop.

* don't rearm after a fatal error  before connection setting changed ( does not affect the normal route on non fatal error like newtork issue)
* serialize error correctly in database to ensure the "avoid a database write per auto-reconnect" corectly trigger 
* a lot of more cleanup to ensure that the connection is really dropped even if the host changed its id 
* fix a mishnalding in the grace period before marking a pool disconnected . this will keep the ui in sync AND not redownload all the xapi object for a transient issue 
* fix an error transmitted as raw, so the user was only seeing {}

introduced by #10016
 
journalctl logs are thousands of 
```
Sep 04 04:28:35 xoa xo-server[16575]: 2026-09-04T08:28:35.033Z xo:xo-mixins:xen-servers INFO auto-reconnect stopped {
Sep 04 04:28:35 xoa xo-server[16575]:   serverId: '5c952216-c83e-419d-996a-2db3ae797841',
Sep 04 04:28:35 xoa xo-server[16575]:   outcome: 'permanent error'
Sep 04 04:28:35 xoa xo-server[16575]: }
Sep 04 04:28:35 xoa xo-server[16575]: 2026-09-04T08:28:35.092Z xo:xo-mixins:xen-servers WARN auto-reconnect aborted: permanent error {
Sep 04 04:28:35 xoa xo-server[16575]:   serverId: '5ba2c8f6-2ed4-418a-909e-b28a97c92913',
Sep 04 04:28:35 xoa xo-server[16575]:   error: PoolAlreadyConnected: this pool is already connected
Sep 04 04:28:35 xoa xo-server[16575]:       at XenServers._connectXenServer (file:///usr/local/lib/node_modules/xo-server/src/xo-mixins/xen-servers.mjs:473:15)
Sep 04 04:28:35 xoa xo-server[16575]:       at XenServers.connectXenServer (file:///usr/local/lib/node_modules/xo-server/src/xo-mixins/xen-servers.mjs:423:7)
Sep 04 04:28:35 xoa xo-server[16575]:       at autoReconnect (file:///usr/local/lib/node_modules/xo-server/src/_xenServerAutoReconnect.mjs:49:7) {
Sep 04 04:28:35 xoa xo-server[16575]:     poolId: 'cef643a2-5165-bd30-977a-844f8fb51b1f',
Sep 04 04:28:35 xoa xo-server[16575]:     connectedServerId: 'c236dd57-abe3-4e6c-85a0-ebcc950a5fc3',
Sep 04 04:28:35 xoa xo-server[16575]:     connectingServerId: '5ba2c8f6-2ed4-418a-909e-b28a97c92913'
Sep 04 04:28:35 xoa xo-server[16575]:   }
Sep 04 04:28:35 xoa xo-server[16575]: }
Sep 04 04:28:35 xoa xo-server[16575]: 2026-09-04T08:28:35.093Z xo:xo-mixins:xen-servers INFO auto-reconnect stopped {
Sep 04 04:28:35 xoa xo-server[16575]:   serverId: '5ba2c8f6-2ed4-418a-909e-b28a97c92913',
Sep 04 04:28:35 xoa xo-server[16575]:   outcome: 'permanent error'
Sep 04 04:28:35 xoa xo-server[16575]: }
Sep 04 04:28:35 xoa xo-server[16575]: 2026-09-04T08:28:35.525Z xo:xo-mixins:xen-servers WARN auto-reconnect aborted: permanent error {
Sep 04 04:28:35 xoa xo-server[16575]:   serverId: 'c4fa5380-d329-4fc2-9cee-f433f9d19ff7',
Sep 04 04:28:35 xoa xo-server[16575]:   error: PoolAlreadyConnected: this pool is already connected
Sep 04 04:28:35 xoa xo-server[16575]:       at XenServers._connectXenServer (file:///usr/local/lib/node_modules/xo-server/src/xo-mixins/xen-servers.mjs:473:15)
Sep 04 04:28:35 xoa xo-server[16575]:       at XenServers.connectXenServer (file:///usr/local/lib/node_modules/xo-server/src/xo-mixins/xen-servers.mjs:423:7)
Sep 04 04:28:35 xoa xo-server[16575]:       at autoReconnect (file:///usr/local/lib/node_modules/xo-server/src/_xenServerAutoReconnect.mjs:49:7) {
Sep 04 04:28:35 xoa xo-server[16575]:     poolId: '7fd3954f-016e-0104-6009-eca794cdbb3a',
Sep 04 04:28:35 xoa xo-server[16575]:     connectedServerId: '0c1b05ec-79ca-46d0-b846-9ea06784a3a6',
Sep 04 04:28:35 xoa xo-server[16575]:     connectingServerId: 'c4fa5380-d329-4fc2-9cee-f433f9d19ff7'
Sep 04 04:28:35 xoa xo-server[16575]:   }
Sep 04 04:28:35 xoa xo-server[16575]: }
Sep 04 04:28:35 xoa xo-server[16575]: 2026-09-04T08:28:35.525Z xo:xo-mixins:xen-servers INFO auto-reconnect stopped {
Sep 04 04:28:35 xoa xo-server[16575]:   serverId: 'c4fa5380-d329-4fc2-9cee-f433f9d19ff7',
Sep 04 04:28:35 xoa xo-server[16575]:   outcome: 'permanent error'
Sep 04 04:28:35 xoa xo-server[16575]: }
Sep 04 04:28:35 xoa xo-server[16575]: 2026-09-04T08:28:35.878Z xo:xo-mixins:xen-servers WARN auto-reconnect aborted: permanent error {
Sep 04 04:28:35 xoa xo-server[16575]:   serverId: 'cf2480ad-a500-4ee0-9a0d-99cee25d3dc5',
Sep 04 04:28:35 xoa xo-server[16575]:   error: PoolAlreadyConnected: this pool is already connected
Sep 04 04:28:35 xoa xo-server[16575]:       at XenServers._connectXenServer (file:///usr/local/lib/node_modules/xo-server/src/xo-mixins/xen-servers.mjs:473:15)
Sep 04 04:28:35 xoa xo-server[16575]:       at runNextTicks (node:internal/process/task_queues:64:5)
Sep 04 04:28:35 xoa xo-server[16575]:       at processImmediate (node:internal/timers:452:9)
Sep 04 04:28:35 xoa xo-server[16575]:       at process.callbackTrampoline (node:internal/async_hooks:130:17)
Sep 04 04:28:35 xoa xo-server[16575]:       at XenServers.connectXenServer (file:///usr/local/lib/node_modules/xo-server/src/xo-mixins/xen-servers.mjs:423:7)
Sep 04 04:28:35 xoa xo-server[16575]:       at autoReconnect (file:///usr/local/lib/node_modules/xo-server/src/_xenServerAutoReconnect.mjs:49:7) {
Sep 04 04:28:35 xoa xo-server[16575]:     poolId: '1a1be188-c746-8623-024e-90abf247cc2f',
Sep 04 04:28:35 xoa xo-server[16575]:     connectedServerId: '3a7d2d04-b026-424c-acf8-e436399f648d',
Sep 04 04:28:35 xoa xo-server[16575]:     connectingServerId: 'cf2480ad-a500-4ee0-9a0d-99cee25d3dc5'
Sep 04 04:28:35 xoa xo-server[16575]:   }
Sep 04 04:28:35 xoa xo-server[16575]: }

```
### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
