### PR TITLE
feat(xo6/new-vm-form): allow resizing existing template disks when a …

### DIFF
--- a/@xen-orchestra/web-core/lib/tables/column-definitions/input-column.ts
+++ b/@xen-orchestra/web-core/lib/tables/column-definitions/input-column.ts
@@ -12,7 +12,7 @@ type InputConfig = {
 
 export const useInputColumn = defineColumn((config?: HeaderConfig & InputConfig) => ({
   renderHead: () => renderHeadCell(config?.headerLabel),
-  renderBody: (model: Ref<string | number | undefined>, inputProps?: { disabled?: boolean }) =>
+  renderBody: (model: Ref<string | number | undefined>, inputProps?: { disabled?: boolean; min?: number }) =>
     renderBodyCell(() =>
       h(UiInput, {
         accent: 'brand',

--- a/@xen-orchestra/web/src/modules/vm/components/new/NewVmSrTable.vue
+++ b/@xen-orchestra/web/src/modules/vm/components/new/NewVmSrTable.vue
@@ -33,12 +33,14 @@ import UiTableCell from '@core/components/ui/table-cell/UiTableCell.vue'
 import { useFormSelect } from '@core/packages/form-select'
 import { useNewVmSrColumns } from '@core/tables/column-sets/new-vm-sr-columns.ts'
 import { renderBodyCell } from '@core/tables/helpers/render-body-cell.ts'
-import { toRef } from 'vue'
+import { toRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-const { vmState, srs } = defineProps<{
+const { vmState, srs, canResizeExistingDisks, defaultExistingVdis } = defineProps<{
   vmState: VmState
   srs: FrontXoSr[]
+  canResizeExistingDisks: boolean
+  defaultExistingVdis: Vdi[]
 }>()
 
 const emit = defineEmits<{
@@ -65,10 +67,29 @@ const { HeadCells, BodyCells, colspan } = useNewVmSrColumns({
     const size = toRef(vdi, 'size')
     const description = toRef(vdi, 'name_description')
 
+    const isExistingVdi = vmState.existingVdis.includes(vdi)
+    const defaultVdi = isExistingVdi ? defaultExistingVdis[vmState.existingVdis.indexOf(vdi)] : undefined
+    const isDisabled = isExistingVdi ? !canResizeExistingDisks : false
+
+    if (isExistingVdi && defaultVdi) {
+      watch(
+        () => vdi.size,
+        newValue => {
+          if (isExistingVdi && newValue < defaultVdi.size) {
+            vdi.size = defaultVdi.size
+          }
+        }
+      )
+    }
+
     return {
       sr: r => r(srSelectId),
       diskName: r => r(diskName),
-      size: r => r(size, { disabled: !onRemove }),
+      size: r =>
+        r(size, {
+          disabled: isDisabled,
+          min: defaultVdi?.size ?? 1,
+        } as any),
       description: r => r(description),
       remove: r => (onRemove ? r(onRemove) : renderBodyCell()),
     }

--- a/@xen-orchestra/web/src/modules/vm/components/new/NewVmSrTable.vue
+++ b/@xen-orchestra/web/src/modules/vm/components/new/NewVmSrTable.vue
@@ -36,7 +36,7 @@ import { renderBodyCell } from '@core/tables/helpers/render-body-cell.ts'
 import { toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-const props = defineProps<{
+const { vmState, srs, canResizeExistingDisks, defaultExistingVdis } = defineProps<{
   vmState: VmState
   srs: FrontXoSr[]
   canResizeExistingDisks: boolean
@@ -52,7 +52,7 @@ const { t } = useI18n()
 
 const { HeadCells, BodyCells, colspan } = useNewVmSrColumns({
   body: ({ vdi, onRemove }: { vdi: Vdi; onRemove?: () => void }) => {
-    const { id: srSelectId } = useFormSelect(() => props.srs, {
+    const { id: srSelectId } = useFormSelect(() => srs, {
       model: toRef(vdi, 'sr'),
       option: {
         label: sr => {
@@ -67,8 +67,8 @@ const { HeadCells, BodyCells, colspan } = useNewVmSrColumns({
     const size = toRef(vdi, 'size')
     const description = toRef(vdi, 'name_description')
 
-    const defaultVdi = props.defaultExistingVdis.find(d => d.id === vdi.id)
-    const isExistingVdi = defaultVdi !== undefined
+    const isExistingVdi = vmState.existingVdis.includes(vdi)
+    const defaultVdi = isExistingVdi ? defaultExistingVdis[vmState.existingVdis.indexOf(vdi)] : undefined
     const minSize = defaultVdi?.size ?? 1
 
     return {
@@ -76,9 +76,9 @@ const { HeadCells, BodyCells, colspan } = useNewVmSrColumns({
       diskName: r => r(diskName),
       size: r =>
         r(size, {
-          disabled: isExistingVdi ? !props.canResizeExistingDisks : false,
+          disabled: isExistingVdi ? !canResizeExistingDisks : false,
           min: minSize,
-        } as any),
+        }),
       description: r => r(description),
       remove: r => (onRemove ? r(onRemove) : renderBodyCell()),
     }

--- a/@xen-orchestra/web/src/modules/vm/components/new/NewVmSrTable.vue
+++ b/@xen-orchestra/web/src/modules/vm/components/new/NewVmSrTable.vue
@@ -36,7 +36,7 @@ import { renderBodyCell } from '@core/tables/helpers/render-body-cell.ts'
 import { toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-const { vmState, srs, canResizeExistingDisks, defaultExistingVdis } = defineProps<{
+const props = defineProps<{
   vmState: VmState
   srs: FrontXoSr[]
   canResizeExistingDisks: boolean
@@ -52,7 +52,7 @@ const { t } = useI18n()
 
 const { HeadCells, BodyCells, colspan } = useNewVmSrColumns({
   body: ({ vdi, onRemove }: { vdi: Vdi; onRemove?: () => void }) => {
-    const { id: srSelectId } = useFormSelect(() => srs, {
+    const { id: srSelectId } = useFormSelect(() => props.srs, {
       model: toRef(vdi, 'sr'),
       option: {
         label: sr => {
@@ -67,9 +67,8 @@ const { HeadCells, BodyCells, colspan } = useNewVmSrColumns({
     const size = toRef(vdi, 'size')
     const description = toRef(vdi, 'name_description')
 
-    const isExistingVdi = vmState.existingVdis.includes(vdi)
-    const defaultVdi = isExistingVdi ? defaultExistingVdis[vmState.existingVdis.indexOf(vdi)] : undefined
-    const isDisabled = isExistingVdi ? !canResizeExistingDisks : false
+    const defaultVdi = props.defaultExistingVdis.find(d => d.id === vdi.id)
+    const isExistingVdi = defaultVdi !== undefined
     const minSize = defaultVdi?.size ?? 1
 
     return {
@@ -77,7 +76,7 @@ const { HeadCells, BodyCells, colspan } = useNewVmSrColumns({
       diskName: r => r(diskName),
       size: r =>
         r(size, {
-          disabled: isDisabled,
+          disabled: isExistingVdi ? !props.canResizeExistingDisks : false,
           min: minSize,
         } as any),
       description: r => r(description),

--- a/@xen-orchestra/web/src/modules/vm/components/new/NewVmSrTable.vue
+++ b/@xen-orchestra/web/src/modules/vm/components/new/NewVmSrTable.vue
@@ -33,7 +33,7 @@ import UiTableCell from '@core/components/ui/table-cell/UiTableCell.vue'
 import { useFormSelect } from '@core/packages/form-select'
 import { useNewVmSrColumns } from '@core/tables/column-sets/new-vm-sr-columns.ts'
 import { renderBodyCell } from '@core/tables/helpers/render-body-cell.ts'
-import { toRef, watch } from 'vue'
+import { toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const { vmState, srs, canResizeExistingDisks, defaultExistingVdis } = defineProps<{
@@ -70,17 +70,7 @@ const { HeadCells, BodyCells, colspan } = useNewVmSrColumns({
     const isExistingVdi = vmState.existingVdis.includes(vdi)
     const defaultVdi = isExistingVdi ? defaultExistingVdis[vmState.existingVdis.indexOf(vdi)] : undefined
     const isDisabled = isExistingVdi ? !canResizeExistingDisks : false
-
-    if (isExistingVdi && defaultVdi) {
-      watch(
-        () => vdi.size,
-        newValue => {
-          if (isExistingVdi && newValue < defaultVdi.size) {
-            vdi.size = defaultVdi.size
-          }
-        }
-      )
-    }
+    const minSize = defaultVdi?.size ?? 1
 
     return {
       sr: r => r(srSelectId),
@@ -88,7 +78,7 @@ const { HeadCells, BodyCells, colspan } = useNewVmSrColumns({
       size: r =>
         r(size, {
           disabled: isDisabled,
-          min: defaultVdi?.size ?? 1,
+          min: minSize,
         } as any),
       description: r => r(description),
       remove: r => (onRemove ? r(onRemove) : renderBodyCell()),

--- a/@xen-orchestra/web/src/pages/vm/new.vue
+++ b/@xen-orchestra/web/src/pages/vm/new.vue
@@ -192,6 +192,8 @@
             <NewVmSrTable
               :srs="filteredSrs"
               :vm-state
+              :can-resize-existing-disks="canResizeExistingDisks"
+              :default-existing-vdis="defaultExistingVdis"
               @add="addStorageEntry()"
               @remove="index => deleteItem(vmState.vdis, index)"
             />
@@ -634,26 +636,32 @@ const redirectToPool = (poolId: XoPool['id']) => {
   router.push({ name: '/pool/[id]/dashboard', params: { id: poolId } })
 }
 
-function getExistingVdisDiff(vdi1: Vdi, vdi2: Vdi) {
-  const changes: Record<string, unknown> = {}
-  let hasChanged = false
+function getExistingVdisDiff(vdi1: Vdi, vdi2: Vdi, canResizeExistingDisks: boolean = false) {
+  const changes: Partial<Vdi> = {}
 
-  for (const _key in vdi1) {
-    const key = _key as keyof Vdi
-
-    if (vdi1[key] !== vdi2[key]) {
-      hasChanged = true
-      changes[key] = vdi2[key]
-    }
+  if (vdi1.name_label !== vdi2.name_label) {
+    changes.name_label = vdi2.name_label
   }
 
-  return hasChanged ? (changes as Partial<Vdi>) : undefined
+  if (vdi1.name_description !== vdi2.name_description) {
+    changes.name_description = vdi2.name_description
+  }
+
+  if (canResizeExistingDisks && vdi1.size !== vdi2.size) {
+    changes.size = vdi2.size
+  }
+
+  return Object.keys(changes).length > 0 ? changes : undefined
 }
+
+const canResizeExistingDisks = computed(() => {
+  return vmState.installMode !== 'no-config'
+})
 
 const modifiedExistingVdis = computed(() => {
   return vmState.existingVdis.reduce<Partial<Vdi>[]>((acc, vdi, index) => {
     const defaultVdi = defaultExistingVdis.value[index]
-    const changes = getExistingVdisDiff(defaultVdi, vdi)
+    const changes = getExistingVdisDiff(defaultVdi, vdi, canResizeExistingDisks.value)
 
     if (changes) {
       acc.push({ ...changes, userdevice: vdi.userdevice })

--- a/@xen-orchestra/web/src/pages/vm/new.vue
+++ b/@xen-orchestra/web/src/pages/vm/new.vue
@@ -636,27 +636,29 @@ const redirectToPool = (poolId: XoPool['id']) => {
   router.push({ name: '/pool/[id]/dashboard', params: { id: poolId } })
 }
 
-function getExistingVdisDiff(vdi1: Vdi, vdi2: Vdi, canResizeExistingDisks: boolean = false) {
-  const changes: Partial<Vdi> = {}
+function getExistingVdisDiff(vdi1: Vdi, vdi2: Vdi, canResizeExistingDisks: boolean) {
+  const changes: Record<string, unknown> = {}
 
-  if (vdi1.name_label !== vdi2.name_label) {
-    changes.name_label = vdi2.name_label
+  for (const _key in vdi1) {
+    const key = _key as keyof Vdi
+
+    if (key === 'size') {
+      if (canResizeExistingDisks && vdi1[key] !== vdi2[key]) {
+        changes[key] = vdi2[key]
+      }
+      continue
+    }
+
+    if (vdi1[key] !== vdi2[key]) {
+      changes[key] = vdi2[key]
+    }
   }
-
-  if (vdi1.name_description !== vdi2.name_description) {
-    changes.name_description = vdi2.name_description
-  }
-
-  if (canResizeExistingDisks && vdi1.size !== vdi2.size) {
-    changes.size = vdi2.size
-  }
-
   return Object.keys(changes).length > 0 ? changes : undefined
 }
 
-const canResizeExistingDisks = computed(() => {
-  const cloudInitModes: InstallMode[] = ['ssh-key', 'cloud-init-config']
+const cloudInitModes: InstallMode[] = ['ssh-key', 'cloud-init-config']
 
+const canResizeExistingDisks = computed(() => {
   return cloudInitModes.includes(vmState.installMode)
 })
 

--- a/@xen-orchestra/web/src/pages/vm/new.vue
+++ b/@xen-orchestra/web/src/pages/vm/new.vue
@@ -663,6 +663,11 @@ const canResizeExistingDisks = computed(() => {
 const modifiedExistingVdis = computed(() => {
   return vmState.existingVdis.reduce<Partial<Vdi>[]>((acc, vdi, index) => {
     const defaultVdi = defaultExistingVdis.value[index]
+
+    if (!defaultVdi) {
+      return acc
+    }
+
     const changes = getExistingVdisDiff(defaultVdi, vdi, canResizeExistingDisks.value)
 
     if (changes) {

--- a/@xen-orchestra/web/src/pages/vm/new.vue
+++ b/@xen-orchestra/web/src/pages/vm/new.vue
@@ -262,7 +262,7 @@ import {
   type FrontXoVmTemplate,
   useXoVmTemplateCollection,
 } from '@/modules/vm/remote-resources/use-xo-vm-template-collection.ts'
-import type { Vdi, Vif, VifToSend, VmState } from '@/modules/vm/types/new-xo-vm.type.ts'
+import type { InstallMode, Vdi, Vif, VifToSend, VmState } from '@/modules/vm/types/new-xo-vm.type.ts'
 import VtsInputWrapper, { type InputWrapperMessage } from '@core/components/input-wrapper/VtsInputWrapper.vue'
 import VtsResource from '@core/components/resources/VtsResource.vue'
 import VtsResources from '@core/components/resources/VtsResources.vue'
@@ -655,7 +655,9 @@ function getExistingVdisDiff(vdi1: Vdi, vdi2: Vdi, canResizeExistingDisks: boole
 }
 
 const canResizeExistingDisks = computed(() => {
-  return vmState.installMode !== 'no-config'
+  const cloudInitModes: InstallMode[] = ['ssh-key', 'cloud-init-config']
+
+  return cloudInitModes.includes(vmState.installMode)
 })
 
 const modifiedExistingVdis = computed(() => {

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,4 +34,6 @@
 
 <!--packages-start-->
 
+- @xen-orchestra/web minor
+
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@
 > Users must be able to say: "Nice enhancement, I'm eager to test it"
 
 - [XO6] Allow changing which PIF a host uses for its management interface, without deleting and recreating the network config (PR [#10110](https://github.com/vatesfr/xen-orchestra/pull/10110))
+- [XO6/New VM] Allow resizing existing (template) disks when a config drive is used (PR [#10359](https://github.com/vatesfr/xen-orchestra/pull/10359))
 
 ### Bug fixes
 


### PR DESCRIPTION
### Description

[XO-2763](https://project.vates.tech/vates-global/browse/XO-2763/)

 Allow resizing existing (template) disks when a config drive is used

* Enable the existing-disk size input only when the install mode uses a config drive

* Enforce a `min` equal to the disk's original template size in the input, so the user gets immediate feedback (the backend rejects shrinking anyway).

* Include `size` (with `userdevice`) in the `modifiedExistingVdis` diff.

* New disks (manually added) remain always editable regardless of install mode

### Screenshots
Where vmState.installMode = 'ssh-key' or  'cloud-init-config' resizing is available, disk also cannot be resized to the value less that it's min size or 1 by default
<img width="1823" height="295" alt="image" src="https://github.com/user-attachments/assets/ff4134dd-e74e-4e78-a1fb-b7c397498e89" />
For the rest : 'no-config', 'cdrom' or 'netork' install modes, resizing is disabled
<img width="1823" height="295" alt="image" src="https://github.com/user-attachments/assets/1e19cef9-ec83-49a9-a991-8be12efb6596" />



### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
