### PR TITLE
fix(backups): don't destroy the delta base after failed transfer

### DIFF
--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
@@ -436,8 +436,14 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
       disklessVmSnapshots = disklessVmSnapshots.filter(vm => !isInFlightSyncSnapshot(vm))
     }
 
-    // get the datetime of the most recent snapshot across both VDI and diskless VM snapshots
-    const lastSnapshotDateTime = [...this._jobSnapshotVdis, ...disklessVmSnapshots]
+    const isExported = ({ other_config, $VBDs }) =>
+      other_config[EXPORTED_SUCCESSFULLY] !== undefined ||
+      // for VDI snapshots the flag may only have been written on the VM snapshot
+      $VBDs?.some(({ $VM }) => $VM?.other_config?.[EXPORTED_SUCCESSFULLY] !== undefined) === true
+
+    // get the datetime of the most recent exported snapshot across both VDI and diskless VM snapshots
+    const lastExportedSnapshotDateTime = [...this._jobSnapshotVdis, ...disklessVmSnapshots]
+      .filter(isExported)
       .map(({ other_config }) => other_config[DATETIME])
       .sort()
       .pop()
@@ -457,9 +463,9 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
       }
       const retention = settings.snapshotRetention ?? 0
       await asyncMap(getOldEntries(retention, datetimes), async datetime => {
-        // keep the last snapshot across all schedules for delta
+        // keep the last exported snapshot across all schedules for delta
         // since we'll need it to compute delta for next backup
-        if (this.job.mode === 'delta' && datetime === lastSnapshotDateTime) {
+        if (this.job.mode === 'delta' && datetime === lastExportedSnapshotDateTime) {
           return
         }
         const vdis = snapshotPerDatetime[datetime]
@@ -529,7 +535,7 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
         }
         const retention = settings.snapshotRetention ?? 0
         await asyncEach(getOldEntries(retention, datetimes), async datetime => {
-          if (this.job.mode === 'delta' && datetime === lastSnapshotDateTime) {
+          if (this.job.mode === 'delta' && datetime === lastExportedSnapshotDateTime) {
             return
           }
 

--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.mjs
@@ -425,8 +425,7 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
 
     // The synchronized snapshot for this run is taken up-front by the batch
     // phase but transferred later. Until it has been exported, hide it from
-    // retention so it is neither reclaimed nor allowed to steal the delta
-    // base's "most recent" protection. This makes the pre-transfer pass behave
+    // retention so it is not reclaimed. This makes the pre-transfer pass behave
     // like a normal run, where the snapshot does not exist yet.
     if (this._synchronizedSnapshotTimestamp !== undefined) {
       const datetime = formatDateTime(this._synchronizedSnapshotTimestamp)
@@ -436,10 +435,7 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
       disklessVmSnapshots = disklessVmSnapshots.filter(vm => !isInFlightSyncSnapshot(vm))
     }
 
-    const isExported = ({ other_config, $VBDs }) =>
-      other_config[EXPORTED_SUCCESSFULLY] !== undefined ||
-      // for VDI snapshots the flag may only have been written on the VM snapshot
-      $VBDs?.some(({ $VM }) => $VM?.other_config?.[EXPORTED_SUCCESSFULLY] !== undefined) === true
+    const isExported = ({ other_config }) => EXPORTED_SUCCESSFULLY in other_config
 
     // get the datetime of the most recent exported snapshot across both VDI and diskless VM snapshots
     const lastExportedSnapshotDateTime = [...this._jobSnapshotVdis, ...disklessVmSnapshots]
@@ -465,7 +461,11 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
       await asyncMap(getOldEntries(retention, datetimes), async datetime => {
         // keep the last exported snapshot across all schedules for delta
         // since we'll need it to compute delta for next backup
-        if (this.job.mode === 'delta' && datetime === lastExportedSnapshotDateTime) {
+        if (
+          this.job.mode === 'delta' &&
+          lastExportedSnapshotDateTime !== undefined &&
+          datetime === lastExportedSnapshotDateTime
+        ) {
           return
         }
         const vdis = snapshotPerDatetime[datetime]
@@ -656,6 +656,7 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
       await vm.$callAsync('clean_shutdown')
     }
 
+    let exported = false
     try {
       await this._snapshot()
       if (startAfter === 'snapshot') {
@@ -668,6 +669,7 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
       // not the case if offlineBackup
       if (this._exportedVm.is_a_snapshot) {
         await markExportSuccessfull(this._xapi, this._exportedVm.$ref)
+        exported = true
       }
     } finally {
       if (startAfter) {
@@ -676,7 +678,12 @@ export const AbstractXapi = class AbstractXapiVmBackupRunner extends Abstract {
 
       await this._fetchJobSnapshots()
       await this._removeUnusedSnapshots()
-      await this._removeSnapshotData()
+      // only a snapshot that has been exported is worth purging: the snapshot of a
+      // failed run has just been reclaimed by _removeUnusedSnapshots() and
+      // _exportedVm is now a stale reference to a destroyed VM
+      if (exported) {
+        await this._removeSnapshotData()
+      }
     }
     await this._healthCheck()
   }

--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.test.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.test.mjs
@@ -217,6 +217,118 @@ describe('_removeUnusedSnapshots() in the synchronized batch pre-snapshot state'
   })
 })
 
+describe('_removeUnusedSnapshots() after a failed transfer', () => {
+  const BASE_DATETIME = '20260902T090100Z'
+  const FAILED_DATETIME = '20260902T092200Z'
+
+  const makeFailedRunRunner = ({ baseExported = true, freshExported = false } = {}) => {
+    const destroyed = []
+
+    const snapshotVm = $ref => ({
+      $ref,
+      name_label: $ref,
+      is_control_domain: false,
+      $snapshot_of: 'live-vm-ref',
+      other_config: {},
+    })
+    const baseSnapshotVm = snapshotVm('vm-base')
+    const freshSnapshotVm = snapshotVm('vm-failed')
+
+    const vdi = ($ref, datetime, snapshotVmRecord, isExported) => ({
+      $ref,
+      other_config: {
+        [DATETIME]: datetime,
+        [SCHEDULE_ID]: 'schedule-1',
+        ...(isExported ? { [EXPORTED_SUCCESSFULLY]: 'true' } : {}),
+      },
+      $VBDs: [{ $VM: snapshotVmRecord }],
+    })
+    // the base of the last successful run and the snapshot of the run that just failed
+    const baseVdi = vdi('vdi-base', BASE_DATETIME, baseSnapshotVm, baseExported)
+    const freshVdi = vdi('vdi-failed', FAILED_DATETIME, freshSnapshotVm, freshExported)
+
+    const registry = { 'vdi-base': baseVdi, 'vdi-failed': freshVdi }
+
+    const runner = makeRunner({
+      // no synchronized snapshot: this is a plain incremental replication job
+      _synchronizedSnapshotTimestamp: undefined,
+      _vm: { uuid: 'live-uuid', $snapshots: [] },
+      _baseSettings: { snapshotRetention: 0 },
+      _jobSnapshotVdis: [baseVdi, freshVdi],
+      _disklessJobSnapshotVms: [],
+      job: { mode: 'delta', settings: {} },
+      _xapi: {
+        barrier: async () => {},
+        getObject: ref => registry[ref],
+        VM_destroy: async ref => {
+          destroyed.push(ref)
+        },
+        VDI_destroy: async ref => {
+          destroyed.push(ref)
+        },
+      },
+    })
+
+    return { runner, destroyed }
+  }
+
+  it('keeps the last successfully exported snapshot as the delta base', async () => {
+    const { runner, destroyed } = makeFailedRunRunner()
+
+    await runner._removeUnusedSnapshots()
+
+    assert.equal(
+      destroyed.includes('vm-base'),
+      false,
+      'the last exported snapshot is the only usable delta base: destroying it forces a full on the next run'
+    )
+  })
+
+  it('reclaims the snapshot of the failed run (never exported, retention 0)', async () => {
+    const { runner, destroyed } = makeFailedRunRunner()
+
+    await runner._removeUnusedSnapshots()
+
+    assert.deepEqual(destroyed, ['vm-failed'], 'only the never-exported snapshot should be removed')
+  })
+
+  it('keeps the most recent snapshot once the transfer succeeded', async () => {
+    const { runner, destroyed } = makeFailedRunRunner({ freshExported: true })
+
+    await runner._removeUnusedSnapshots()
+
+    assert.deepEqual(destroyed, ['vm-base'], 'the newly exported snapshot should replace the previous base')
+  })
+
+  it('keeps the newest exported snapshot even when several runs failed in a row', async () => {
+    const { runner, destroyed } = makeFailedRunRunner()
+    // a second consecutive failure adds another never-exported snapshot
+    const secondFailedVm = {
+      $ref: 'vm-failed-2',
+      name_label: 'vm-failed-2',
+      is_control_domain: false,
+      $snapshot_of: 'live-vm-ref',
+      other_config: {},
+    }
+    const secondFailedVdi = {
+      $ref: 'vdi-failed-2',
+      other_config: { [DATETIME]: '20260902T092600Z', [SCHEDULE_ID]: 'schedule-1' },
+      $VBDs: [{ $VM: secondFailedVm }],
+    }
+    runner._jobSnapshotVdis.push(secondFailedVdi)
+    const getObject = runner._xapi.getObject
+    runner._xapi.getObject = ref => (ref === 'vdi-failed-2' ? secondFailedVdi : getObject(ref))
+
+    await runner._removeUnusedSnapshots()
+
+    assert.deepEqual(
+      destroyed.sort(),
+      ['vm-failed', 'vm-failed-2'],
+      'both failed snapshots should be reclaimed and the exported base kept'
+    )
+  })
+})
+
 describe('_removeUnusedSnapshots() reclaims orphan / CBT snapshot VDIs (no attached VM)', () => {
   // Guards the `else` branch: snapshot VDIs that are not attached to any user VM
   // (e.g. CBT metadata, orphans) must be reclaimed via VDI_destroy, not VM_destroy.

--- a/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.test.mjs
+++ b/@xen-orchestra/backups/_runners/_vmRunners/_AbstractXapi.test.mjs
@@ -181,12 +181,10 @@ describe('_removeUnusedSnapshots() in the synchronized batch pre-snapshot state'
       name_label: 'base',
       is_control_domain: false,
       $snapshot_of: 'live-vm-ref',
-      // exported successfully by the previous run
-      other_config: { [EXPORTED_SUCCESSFULLY]: 'true' },
     }
     const baseVdi = {
       $ref: 'vdi-base',
-      other_config: { [DATETIME]: BASE_DATETIME, [SCHEDULE_ID]: 'schedule-1' },
+      other_config: { [DATETIME]: BASE_DATETIME, [SCHEDULE_ID]: 'schedule-1', [EXPORTED_SUCCESSFULLY]: 'true' },
       $VBDs: [{ $VM: baseSnapshotVm }],
     }
     const registry = { 'vdi-base': baseVdi }
@@ -435,5 +433,82 @@ describe('_removeUnusedSnapshots() diskless VM snapshots', () => {
     await runner._removeUnusedSnapshots()
 
     assert.deepEqual(destroyed, ['dl-old'], 'the most recent diskless snapshot should be kept in delta mode')
+  })
+})
+
+describe('run() only purges snapshot data for an exported snapshot', () => {
+  // `_removeSnapshotData()` destroys `_exportedVm` and data_destroys its VDIs. It runs
+  // from the `finally` of run(), right after `_removeUnusedSnapshots()` — which now
+  // reclaims the snapshot of a failed run. Calling it then would operate on a stale
+  // reference to a destroyed VM and throw from the `finally`, masking the real error.
+  const makeRunRunner = ({ copyFails = false, isSnapshot = true } = {}) => {
+    const calls = { removeUnusedSnapshots: 0, removeSnapshotData: 0, markExportSuccessfull: 0 }
+
+    const runner = makeRunner({
+      _healthCheckSr: undefined,
+      // cbtDestroySnapshotData is the only configuration in which _removeSnapshotData() acts
+      _settings: { offlineBackup: false, snapshotRetention: 0, preferNbd: true, cbtDestroySnapshotData: true },
+      _vm: {
+        uuid: 'live-uuid',
+        power_state: 'Halted',
+        blocked_operations: {},
+        update_blocked_operations: async () => {},
+        $call: async () => {},
+      },
+      _writers: new Set([{ beforeBackup: async () => {}, afterBackup: async () => {} }]),
+      _xapi: {
+        // used by markExportSuccessfull()
+        VM_getDisks: async () => ['vdi-ref'],
+        setFieldEntry: async () => {
+          calls.markExportSuccessfull++
+        },
+      },
+      _cleanMetadata: async () => {},
+      _fetchJobSnapshots: async () => {},
+      _selectBaseVm: async () => {},
+      _removeUnusedSnapshots: async () => {
+        calls.removeUnusedSnapshots++
+      },
+      _snapshot: async function () {
+        this._exportedVm = { $ref: 'snapshot-ref', is_a_snapshot: isSnapshot }
+      },
+      _copy: async () => {
+        if (copyFails) {
+          throw new Error('transfer failed: target unreachable')
+        }
+      },
+      _removeSnapshotData: async () => {
+        calls.removeSnapshotData++
+      },
+    })
+
+    return { runner, calls }
+  }
+
+  it('does not purge the snapshot data when the transfer failed', async () => {
+    const { runner, calls } = makeRunRunner({ copyFails: true })
+
+    await assert.rejects(runner.run(), /transfer failed/)
+
+    assert.equal(calls.removeSnapshotData, 0, 'the snapshot has just been reclaimed: it must not be purged again')
+    assert.equal(calls.removeUnusedSnapshots, 2, 'retention must still run before the snapshot and in the finally')
+  })
+
+  it('purges the snapshot data when the transfer succeeded', async () => {
+    const { runner, calls } = makeRunRunner()
+
+    await runner.run()
+
+    assert.equal(calls.markExportSuccessfull, 2, 'the exported snapshot and its VDIs should be marked')
+    assert.equal(calls.removeSnapshotData, 1, 'the exported snapshot data should be purged')
+  })
+
+  it('does not purge the snapshot data when the live VM was exported (offline backup)', async () => {
+    const { runner, calls } = makeRunRunner({ isSnapshot: false })
+
+    await runner.run()
+
+    assert.equal(calls.markExportSuccessfull, 0, 'the live VM is not marked as exported')
+    assert.equal(calls.removeSnapshotData, 0, 'there is no snapshot to purge')
   })
 })

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@
 - [Web-core] Fix "console offline" illustration sparks color (PR [#10309](https://github.com/vatesfr/xen-orchestra/pull/10309))
 - [Web-core] Fix 404 illustration color (PR [#10325](https://github.com/vatesfr/xen-orchestra/pull/10325))
 - [Backup-archive] No longer create a `cache.json.gz` file on immutable/S3 remote during cleanup, which could not be deleted afterwards and stayed billed forever (PR [#10243](https://github.com/vatesfr/xen-orchestra/pull/10243))
+- [Backups] Fix orphaned VM on target after failed transfer (PR [#](https://github.com/vatesfr/xen-orchestra/pull/))
 - [Servers] Fix endless connection attempts to a pool which is already connected through another server entry (PR [#10355](https://github.com/vatesfr/xen-orchestra/pull/10355))
 - [Servers] fix a mishandling in the grace period before marking a pool disconnected, this will keep the ui in sync AND not redownload all the xapi object for a transient issue (PR [#10355](https://github.com/vatesfr/xen-orchestra/pull/10355))
 - [Rolling pool update/reboot] VMs are brought back to the host they were running on more reliably, and a VM that cannot be moved back no longer fails the whole operation (PR [#10295](https://github.com/vatesfr/xen-orchestra/pull/10295))

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,7 +23,7 @@
 - [Web-core] Fix "console offline" illustration sparks color (PR [#10309](https://github.com/vatesfr/xen-orchestra/pull/10309))
 - [Web-core] Fix 404 illustration color (PR [#10325](https://github.com/vatesfr/xen-orchestra/pull/10325))
 - [Backup-archive] No longer create a `cache.json.gz` file on immutable/S3 remote during cleanup, which could not be deleted afterwards and stayed billed forever (PR [#10243](https://github.com/vatesfr/xen-orchestra/pull/10243))
-- [Backups] Fix orphaned VM on target after failed transfer (PR [#](https://github.com/vatesfr/xen-orchestra/pull/))
+- [Backups] Fix orphaned VM on target after failed transfer (PR [#10369](https://github.com/vatesfr/xen-orchestra/pull/10369))
 - [Servers] Fix endless connection attempts to a pool which is already connected through another server entry (PR [#10355](https://github.com/vatesfr/xen-orchestra/pull/10355))
 - [Servers] fix a mishandling in the grace period before marking a pool disconnected, this will keep the ui in sync AND not redownload all the xapi object for a transient issue (PR [#10355](https://github.com/vatesfr/xen-orchestra/pull/10355))
 - [Rolling pool update/reboot] VMs are brought back to the host they were running on more reliably, and a VM that cannot be moved back no longer fails the whole operation (PR [#10295](https://github.com/vatesfr/xen-orchestra/pull/10295))


### PR DESCRIPTION
### Description

[XO-2994](https://project.vates.tech/vates-global/browse/XO-2994/)

Customer reported that after a failed replication transfer, the next run was a full and a VM was left orphaned on the target.

This is due to `_removeUnusedSnapshots()` protecting the last snapshot irrelevant of if it was successfully transferred and thus, in the case of a failed transfer, breaking the delta chain

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
