### PR TITLE
docs(xo): fix wrong page order and restore missing external links

### DIFF
--- a/docs/docs/automation/restapi.md
+++ b/docs/docs/automation/restapi.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # REST API
 
 The Xen Orchestra REST API is the modern, public way to automate your infrastructure. We built it from scratch, next to [our historical JSON-RPC API](../getting-started/architecture.md#apis), to be [REST-like](https://en.wikipedia.org/wiki/Representational_state_transfer) and usable with a plain `curl` command. It is now almost complete: nearly all of Xen Orchestra's capabilities are exposed through it, and it is ready to be used in production. It is also the API we are building the future of Xen Orchestra on, so it is the right choice for any new automation.

--- a/docs/docs/backups-and-dr/backup-features-and-settings.md
+++ b/docs/docs/backups-and-dr/backup-features-and-settings.md
@@ -1,5 +1,6 @@
 ---
 sidebar_label: Features and settings
+sidebar_position: 5
 ---
 
 # Backup features and settings

--- a/docs/docs/backups-and-dr/backup-types/_category_.json
+++ b/docs/docs/backups-and-dr/backup-types/_category_.json
@@ -1,6 +1,6 @@
 {
     "label": "Backup types",
-    "position": 1,
+    "position": 4,
     "link": {
       "type": "generated-index",
       "description": "All the different backup types"

--- a/docs/docs/backups-and-dr/backup_howto.md
+++ b/docs/docs/backups-and-dr/backup_howto.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # Backup strategy guide
 
 This guide explains how to design and implement a backup strategy in Xen Orchestra.

--- a/docs/docs/backups-and-dr/backup_reports.md
+++ b/docs/docs/backups-and-dr/backup_reports.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 7
+---
+
 # Backup reports
 
 At the end of a backup job, Xen Orchestra can send you a report through the channel of your choice: email, XMPP, Slack or Mattermost, and even straight into your Nagios or Icinga 2 monitoring.

--- a/docs/docs/backups-and-dr/backup_troubleshooting.md
+++ b/docs/docs/backups-and-dr/backup_troubleshooting.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 8
+---
+
 # Backup troubleshooting
 
 This page lists the most common errors you can meet with XO backups, what they mean and how to fix them.

--- a/docs/docs/backups-and-dr/backups-in-xo6.md
+++ b/docs/docs/backups-and-dr/backups-in-xo6.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 3
+---
+
 # Backups in XO 6
 
 XO 6 puts backup health where you look every day: on the dashboards. This page covers what you can see and follow from XO 6; creating and editing backup jobs is currently done in XO 5 (see [XO 6 and XO 5](../discover-xen-orchestra/xo6vsxo5.md)).

--- a/docs/docs/backups-and-dr/calculator.md
+++ b/docs/docs/backups-and-dr/calculator.md
@@ -1,5 +1,6 @@
 ---
 sidebar_label: Retention calculator
+sidebar_position: 9
 ---
 
 # Backup retention calculator

--- a/docs/docs/backups-and-dr/intro_backup.md
+++ b/docs/docs/backups-and-dr/intro_backup.md
@@ -1,5 +1,6 @@
 ---
 slug: backup
+sidebar_position: 1
 ---
 
 # Backup overview

--- a/docs/docs/backups-and-dr/scale-and-security/_category_.json
+++ b/docs/docs/backups-and-dr/scale-and-security/_category_.json
@@ -1,6 +1,6 @@
 {
     "label": "Scale and security",
-    "position": 2,
+    "position": 6,
     "link": {
       "type": "generated-index",
       "description": "Scalability, performance, and security for large-scale deployments"

--- a/docs/docs/discover-xen-orchestra/coreconcepts.md
+++ b/docs/docs/discover-xen-orchestra/coreconcepts.md
@@ -1,5 +1,6 @@
 ---
 sidebar_label: Core concepts
+sidebar_position: 4
 ---
 
 # How XO 6 is organized

--- a/docs/docs/discover-xen-orchestra/gettingstarted.md
+++ b/docs/docs/discover-xen-orchestra/gettingstarted.md
@@ -1,5 +1,6 @@
 ---
 sidebar_label: First steps
+sidebar_position: 3
 ---
 
 # XO 6 at a glance

--- a/docs/docs/discover-xen-orchestra/whatsnew.md
+++ b/docs/docs/discover-xen-orchestra/whatsnew.md
@@ -1,5 +1,6 @@
 ---
 sidebar_label: What's new
+sidebar_position: 1
 ---
 
 # What's new in XO 6

--- a/docs/docs/discover-xen-orchestra/xo6vsxo5.md
+++ b/docs/docs/discover-xen-orchestra/xo6vsxo5.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # XO 6 and XO 5
 
 XO 6 and XO 5 are two interfaces to the same Xen Orchestra. They run side by side, on the same server, against the same data: a VM started in one is instantly running in the other, a backup job created in XO 5 immediately shows its health in XO 6. There is no migration step and nothing to synchronize.

--- a/docs/docs/getting-started/architecture.md
+++ b/docs/docs/getting-started/architecture.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 9
+---
+
 # Architecture
 
 Xen Orchestra (XO) is built as **one server and several clients**: the two web interfaces ([XO 6](../discover-xen-orchestra/gettingstarted.md) and XO 5), the command line client `xo-cli`, and anything speaking the [REST API](automation/restapi.md). The server, `xo-server`, is the only piece that talks to your infrastructure.

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 5
+---
+
 # Configuration
 
 Once Xen Orchestra is installed, you can configure some parameters in the configuration file. Let's see how to do that.

--- a/docs/docs/getting-started/install-from-sources.md
+++ b/docs/docs/getting-started/install-from-sources.md
@@ -1,5 +1,6 @@
 ---
 sidebar_label: From source
+sidebar_position: 4
 ---
 
 # Installing XO from source

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -1,5 +1,6 @@
 ---
 sidebar_label: Installation
+sidebar_position: 3
 ---
 
 # Installing XOA

--- a/docs/docs/getting-started/migrate_to_new_xoa.md
+++ b/docs/docs/getting-started/migrate_to_new_xoa.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 7
+---
 # Replace your XOA
 
 Replacing your appliance with a fresh one takes three steps: deploy the new XOA, export the configuration of the old one, and import it into the new one. Everything follows: users, ACLs, connected pools, backup jobs, remotes and settings.

--- a/docs/docs/getting-started/releases.md
+++ b/docs/docs/getting-started/releases.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Releases
 
 Xen Orchestra is distributed in two ways: as a turnkey virtual appliance (**XOA**) and **from the sources** on GitHub. Both contain the same Xen Orchestra, including its two web interfaces ([XO 6 and XO 5](../discover-xen-orchestra/xo6vsxo5.md)), the REST API and the backup engine.

--- a/docs/docs/getting-started/supported_hosts.md
+++ b/docs/docs/getting-started/supported_hosts.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # Host compatibility list
 
 Xen Orchestra connects to hosts running [XCP-ng](https://xcp-ng.org/) or [XenServer](https://www.xenserver.com/) (formerly Citrix Hypervisor), and only those: XO is **agent-less** and talks to the XAPI toolstack directly, so a Xen hypervisor installed from a regular Linux distribution will not work (see the [architecture section](architecture.md)).

--- a/docs/docs/getting-started/troubleshooting.md
+++ b/docs/docs/getting-started/troubleshooting.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 8
+---
+
 # Troubleshooting
 
 This page covers the problems you may encounter with your XOA, and how to get out of them.

--- a/docs/docs/getting-started/updater.md
+++ b/docs/docs/getting-started/updater.md
@@ -1,5 +1,6 @@
 ---
 sidebar_label: Updates
+sidebar_position: 6
 ---
 
 # Updating XOA

--- a/docs/docs/guides/_category_.json
+++ b/docs/docs/guides/_category_.json
@@ -1,5 +1,5 @@
 {
-    "label": "Users and access",
+    "label": "Guides",
     "position": 7,
     "link": {
       "type": "generated-index",

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -1,6 +1,7 @@
 ---
 slug: /
 sidebar_position: 1
+sidebar_label: Introduction
 ---
 
 # Xen Orchestra in a nutshell

--- a/docs/docs/manage-your-infrastructure/advanced.md
+++ b/docs/docs/manage-your-infrastructure/advanced.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 4
+---
+
 # Advanced features
 
 <InterfaceNote />

--- a/docs/docs/manage-your-infrastructure/ipmi-plugin.md
+++ b/docs/docs/manage-your-infrastructure/ipmi-plugin.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 6
+---
+
 # IPMI
 
 ## Categorizing "unknown" IPMI sensors

--- a/docs/docs/manage-your-infrastructure/load_balancing.md
+++ b/docs/docs/manage-your-infrastructure/load_balancing.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 5
+---
+
 # Load balancing
 
 <InterfaceNote />

--- a/docs/docs/manage-your-infrastructure/manage_infrastructure.md
+++ b/docs/docs/manage-your-infrastructure/manage_infrastructure.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # Management in XO 5
 
 <InterfaceNote>This page describes infrastructure management in the XO 5 interface. XO 6 already covers inspection of pools, hosts, networks and storage, host power actions, network and VIF creation.</InterfaceNote>

--- a/docs/docs/manage-your-infrastructure/management.md
+++ b/docs/docs/manage-your-infrastructure/management.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Management in XO 6
 
 This page walks through day-to-day management in XO 6: pools, hosts and VMs. For the general layout and navigation, start with [XO 6 at a glance](../discover-xen-orchestra/gettingstarted.md).

--- a/docs/docs/manage-your-infrastructure/sdn_controller.md
+++ b/docs/docs/manage-your-infrastructure/sdn_controller.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 5
+---
+
 # SDN controller
 
 <InterfaceNote>Private networks are currently created and managed from XO 5. Traffic rules moved ahead in [XO 6](../manage-your-infrastructure/management.md#traffic-rules), with more capabilities than the XO 5 equivalent.</InterfaceNote>

--- a/docs/docs/manage-your-infrastructure/vm-templates.md
+++ b/docs/docs/manage-your-infrastructure/vm-templates.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 3
+---
+
 # VM templates
 
 <InterfaceNote />

--- a/docs/docs/project/intro_project.md
+++ b/docs/docs/project/intro_project.md
@@ -1,6 +1,7 @@
 ---
 slug: project
 sidebar_label: About
+sidebar_position: 1
 ---
 
 # About Xen Orchestra

--- a/docs/docs/project/project-resources.md
+++ b/docs/docs/project/project-resources.md
@@ -1,0 +1,7 @@
+# Project resources
+
+The following resources provide information about the Xen Orchestra project:
+
+* [Xen Orchestra blog](https://xen-orchestra.com/blog/): News, announcements, and articles about Xen Orchestra.
+* [Changelog](https://github.com/vatesfr/xen-orchestra/blob/master/CHANGELOG.md#changelog): A list of changes and updates for Xen Orchestra releases.
+* [Product roadmap](https://docs.vates.tech/product-roadmap/): An overview of planned and upcoming features and improvements.

--- a/docs/docs/support-and-licencing/useful-links.md
+++ b/docs/docs/support-and-licencing/useful-links.md
@@ -1,0 +1,6 @@
+# Bundles and licences
+
+The following resources are available in the Vates VMS documentation:
+
+- [Vates VMS bundle overview](https://docs.vates.tech/pricing-licencing/vms-bundle-overview/) — Learn about the Vates VMS bundle, its features, and what each subscription includes.
+- [Applying Xen Orchestra licenses](https://docs.vates.tech/pricing-licencing/applying-xo-licences/) — Learn how to activate and manage a license on your Xen Orchestra Appliance (XOA).


### PR DESCRIPTION
### Fixing page order

After we changed how the sidebar is generated in [#10354](https://github.com/vatesfr/xen-orchestra/pull/10354) (switching from manual declarations to automatic generation) some pages ended up in the wrong order and had incorrect sidebar titles. This pull request fixes these issues.

### Restoring missing links

The external links (Blog, Changelog, etc.) also disappeared in the process. Since auto-generated sidebars don't easily support external links (and we don't use them in the XCP-ng or Vates VMS documentation) this PR adds dedicated pages for these external resources and restores the links there.

#### Before

<img width="215" height="356" alt="Capture d&#39;écran 2026-09-08 131852" src="https://github.com/user-attachments/assets/db15873d-088a-4476-a0b0-b5b30502526a" />

#### After

<img width="889" height="515" alt="Capture d&#39;écran 2026-09-08 131201" src="https://github.com/user-attachments/assets/83c13e2b-b0fb-46f9-a21b-dd21301bf44e" />

<img width="881" height="430" alt="Capture d&#39;écran 2026-09-08 131613(1)" src="https://github.com/user-attachments/assets/48b1e69c-d402-4db0-a81b-b7def415c84a" />
