### PR TITLE
fix(xo-server): correct spelling of "across" in migration logic and messages

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,7 +27,6 @@
 - [Servers] fix a mishandling in the grace period before marking a pool disconnected, this will keep the ui in sync AND not redownload all the xapi object for a transient issue (PR [#10355](https://github.com/vatesfr/xen-orchestra/pull/10355))
 - [Rolling pool update/reboot] VMs are brought back to the host they were running on more reliably, and a VM that cannot be moved back no longer fails the whole operation (PR [#10295](https://github.com/vatesfr/xen-orchestra/pull/10295))
 - [XO server] Fix current_operations format on host and pool objects (PR [#10283](https://github.com/vatesfr/xen-orchestra/pull/10283))
-- [Backup] Fix "accross" typo in the *Distribute backups/replications* settings labels (PR [#10372](https://github.com/vatesfr/xen-orchestra/pull/10372))
 
 
 ### Packages to release
@@ -51,6 +50,5 @@
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
 - xo-server minor
-- xo-web patch
 
 <!--packages-end-->

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,6 +27,7 @@
 - [Servers] fix a mishandling in the grace period before marking a pool disconnected, this will keep the ui in sync AND not redownload all the xapi object for a transient issue (PR [#10355](https://github.com/vatesfr/xen-orchestra/pull/10355))
 - [Rolling pool update/reboot] VMs are brought back to the host they were running on more reliably, and a VM that cannot be moved back no longer fails the whole operation (PR [#10295](https://github.com/vatesfr/xen-orchestra/pull/10295))
 - [XO server] Fix current_operations format on host and pool objects (PR [#10283](https://github.com/vatesfr/xen-orchestra/pull/10283))
+- [Backup] Fix "accross" typo in the *Distribute backups/replications* settings labels (PR [#10372](https://github.com/vatesfr/xen-orchestra/pull/10372))
 
 
 ### Packages to release
@@ -50,5 +51,6 @@
 - @xen-orchestra/web minor
 - @xen-orchestra/web-core minor
 - xo-server minor
+- xo-web patch
 
 <!--packages-end-->

--- a/packages/xo-server/src/xapi/index.mjs
+++ b/packages/xo-server/src/xapi/index.mjs
@@ -949,8 +949,8 @@ export default class Xapi extends XapiBase {
     const host = hostXapi.getObject(hostId)
     const targetPool = hostXapi.getObject(host.$pool)
 
-    const accrossPools = vm.$pool !== host.$pool
-    const useStorageMotion = accrossPools || sr !== undefined || !isEmpty(mapVifsNetworks) || !isEmpty(mapVdisSrs)
+    const acrossPools = vm.$pool !== host.$pool
+    const useStorageMotion = acrossPools || sr !== undefined || !isEmpty(mapVifsNetworks) || !isEmpty(mapVdisSrs)
 
     const defaultMigrationNetworkId = targetPool.other_config['xo:migrationNetwork']
     const migrationNetwork =

--- a/packages/xo-web/src/common/intl/messages.js
+++ b/packages/xo-web/src/common/intl/messages.js
@@ -653,10 +653,10 @@ const messages = {
   editJobNotFound: "The job you're trying to edit wasn't found",
   preferNbd: 'Use NBD to transfer disk if available',
   preferNbdInformation: 'A network accessible by XO or the proxy must have NBD enabled.',
-  distributeBackups: 'Distribute backups accross backup repositories',
+  distributeBackups: 'Distribute backups across backup repositories',
   distributeBackupsInformation:
     'This will write exactly one backup archive of each VM instead of writing one per backup repository',
-  distributeReplications: 'Distribute replications accross the storage repositories',
+  distributeReplications: 'Distribute replications across the storage repositories',
   distributeReplicationsInformation:
     'This will write exactly one replication of each VM backup instead of writing one per storage repository',
   nbdConcurrency: 'Number of NBD connection per disk',


### PR DESCRIPTION
Signed-off-by: Dan Pollak <danpollak2@gmail.com>

### Description

Correct spelling of "across"

### Checklist

- Commit
  - Title follows [commit conventions](https://bit.ly/commit-conventions)
  - Reference the relevant issue (`Fixes #007`, `See xoa-support#42`, `See https://...`)
  - If bug fix, add `Introduced by`
- Changelog
  - If visible by XOA users, add changelog entry
  - Update "Packages to release" in `CHANGELOG.unreleased.md`
- PR
  - If UI changes, add screenshots
  - If not finished or not tested, open as _Draft_

### Review process

If you are an external contributor, you can skip this part. Simply create the pull request, and we'll get back to you as soon as possible.

> This 2-passes review process aims to:
>
> - develop skills of junior reviewers
> - limit the workload for senior reviewers
> - limit the number of unnecessary changes by the _author_

1. The _author_ creates a PR.
2. Review process:
   1. The _author_ assigns the _junior reviewer_.
   2. The _junior reviewer_ conducts their review:
      - Resolves their comments if they are addressed.
      - Adds comments if necessary or approves the PR.
   3. The _junior reviewer_ assigns the _senior reviewer_.
   4. The _senior reviewer_ conducts their review:
      - If there are no unresolved comments on the PR → merge.
      - Otherwise, we continue with **3.**
3. The _author_ responds to comments and/or makes corrections, and we go back to **2.**

Notes:

1. The _author_ can request a review at any time, even if the PR is still a _Draft_.
2. In theory, there should not be more than one reviewer at a time.
3. The _author_ should not make any changes:
   - When a reviewer is assigned.
   - Between the _junior_ and _senior_ reviews.
4. If the PR relates to a change in the openAPI specification, a member of the DevOps team must also participate in the review.
