### PR TITLE
docs(releases.md): document security support

### DIFF
--- a/docs/docs/getting-started/releases.md
+++ b/docs/docs/getting-started/releases.md
@@ -47,3 +47,14 @@ yarn && yarn build
 :::warning
 There is no community support for source installations that are not up to date with `master`.
 :::
+
+## Supported versions for security updates
+
+Security fixes are provided for the following versions of Xen Orchestra:
+
+| Version | Security updates |
+| --- | --- |
+| XOA on the `latest` channel | Yes |
+| XOA on the `stable` channel | Yes |
+| Source installations using the `master` branch | Yes |
+| Other versions | No |


### PR DESCRIPTION
### Goal

Document which Xen Orchestra versions receive security fixes in the actual XO doc, not just in `SECURITY.md`.

Addresses issue https://github.com/vatesfr/xen-orchestra/issues/10294.

### Preview

<img width="1081" height="730" alt="Capture d&#39;écran 2026-09-10 095415" src="https://github.com/user-attachments/assets/11c269b7-fa3d-47e3-bed1-a1e09049abed" />


