### PR TITLE
docs(xo): fix broken links in the xo app

### DIFF
--- a/@xen-orchestra/web/src/shared/constants.ts
+++ b/@xen-orchestra/web/src/shared/constants.ts
@@ -6,8 +6,8 @@ export const XO_LINKS = {
   BLOG: 'https://xen-orchestra.com/blog/',
   COMMUNITY: 'https://xcp-ng.org/forum/category/12/xen-orchestra',
   DOC: 'https://docs.xen-orchestra.com',
-  DOC_SDN_CONTROLLER_MIGRATION: 'https://docs.xen-orchestra.com/xo5/sdn_controller#migration-path',
-  DOC_SDN_CONTROLLER_XAPI_PLUGIN: 'https://docs.xen-orchestra.com/xo5/sdn_controller#xapi-plugin',
+  DOC_SDN_CONTROLLER_MIGRATION: 'https://docs.xen-orchestra.com/manage-your-infrastructure/sdn_controller#migration-path',
+  DOC_SDN_CONTROLLER_XAPI_PLUGIN: 'https://docs.xen-orchestra.com/manage-your-infrastructure/sdn_controller#xapi-plugin',
   TRANSLATION: 'https://translate.vates.tech/engage/xen-orchestra/',
 }
 

--- a/packages/xo-cli/.USAGE.md
+++ b/packages/xo-cli/.USAGE.md
@@ -81,7 +81,7 @@ Usage:
     filter=<filter>
       List only objects that match the filter
 
-      Syntax: https://docs.xen-orchestra.com/xo5/manage_infrastructure#filter-syntax
+      Syntax: https://docs.xen-orchestra.com/manage-your-infrastructure/manage_infrastructure#filter-syntax
 
     limit=<limit>
       Maximum number of objects to list, e.g. `limit=10`

--- a/packages/xo-cli/README.md
+++ b/packages/xo-cli/README.md
@@ -99,7 +99,7 @@ Usage:
     filter=<filter>
       List only objects that match the filter
 
-      Syntax: https://docs.xen-orchestra.com/xo5/manage_infrastructure#filter-syntax
+      Syntax: https://docs.xen-orchestra.com/manage-your-infrastructure/manage_infrastructure#filter-syntax
 
     limit=<limit>
       Maximum number of objects to list, e.g. `limit=10`

--- a/packages/xo-cli/index.mjs
+++ b/packages/xo-cli/index.mjs
@@ -305,7 +305,7 @@ const help = wrap(
     filter=<filter>
       List only objects that match the filter
 
-      Syntax: https://docs.xen-orchestra.com/xo5/manage_infrastructure#filter-syntax
+      Syntax: https://docs.xen-orchestra.com/manage-your-infrastructure/manage_infrastructure#filter-syntax
 
     limit=<limit>
       Maximum number of objects to list, e.g. \`limit=10\`

--- a/packages/xo-server-usage-report/README.md
+++ b/packages/xo-server-usage-report/README.md
@@ -7,7 +7,7 @@
 ## Usage
 
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/xo5/manage_infrastructure#usage-reports).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/manage-your-infrastructure/manage_infrastructure#usage-reports).
 
 ## Contributions
 


### PR DESCRIPTION
Since the XO documentation structure was changed recently, so did the URLs to each documentation pages.
This broke multiple links in the XO app, which pointed to the XO doc.

This PR updates the links to the current URLs, so that the link work as intended.