### PR TITLE
docs(xo): add redirections following doc url changes

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -15,7 +15,7 @@ Everything goes through XO, and everything that talks to your infrastructure tal
 <Schema label="Xen Orchestra at the center of your infrastructure" legend={[["#6aabf0", "XO"], ["#8e83fe", "XCP-ng"], ["#56c288", "VMs"], ["#e0a94a", "backup"], ["#5ac8c8", "V2V"]]} maxWidth="760px">
 <svg viewBox="0 0 680 380" role="img" aria-label="Users and automation tools drive Xen Orchestra, which manages any number of XCP-ng pools, streams backups to a repository, keeps disaster recovery copies and imports VMware VMs with V2V">
 {/* Who talks to XO: humans and automation. */}
-<a href="/xo6/gettingstarted" aria-label="The XO 6 web interface">
+<a href="/discover-xen-orchestra/gettingstarted" aria-label="The XO 6 web interface">
 <rect x="20" y="12" width="170" height="62" rx="8" fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.28)"/>
 <text x="105" y="37" fontSize="13.5" fill="#c6d2e1" textAnchor="middle">Your team</text>
 <text x="105" y="56" fontSize="11.5" fill="#7a8699" textAnchor="middle">Web UI · any browser</text>
@@ -25,7 +25,7 @@ Everything goes through XO, and everything that talks to your infrastructure tal
 <text x="337" y="37" fontSize="13.5" fill="#c6d2e1" textAnchor="middle">Automation</text>
 <text x="337" y="56" fontSize="11.5" fill="#7a8699" textAnchor="middle">REST API · CLI · Terraform · Ansible</text>
 </a>
-<a href="/backup" aria-label="Backups">
+<a href="/backups-and-dr/backup" aria-label="Backups">
 <rect x="485" y="12" width="175" height="62" rx="8" fill="rgba(224,169,74,0.10)" stroke="#e0a94a"/>
 <text x="572" y="37" fontSize="13.5" fill="#e0a94a" textAnchor="middle">Backup repository</text>
 <text x="572" y="56" fontSize="11.5" fill="#7a8699" textAnchor="middle">S3 · NFS · SMB · Azure</text>
@@ -46,7 +46,7 @@ grows a connection wire to it, the VM is converted (the teal copy
 rides through XO and lands green in Pool 1 while the original
 fades), then the empty cluster and its wire disappear: XO connects
 to VMware only for the migration. */}
-<a className="schema-live" href="/xo5/v2v-migration-guide" aria-label="Migrate from VMware with V2V" opacity="0">
+<a className="schema-live" href="/guides/v2v-migration-guide" aria-label="Migrate from VMware with V2V" opacity="0">
 <animate attributeName="opacity" dur="36s" repeatCount="indefinite"
       values="0;0;1;1;0;0" keyTimes="0;0.111;0.125;0.41;0.45;1"/>
 <rect x="20" y="115" width="140" height="62" rx="8" fill="none" stroke="rgba(255,255,255,0.22)" strokeDasharray="6 5"/>
@@ -66,7 +66,7 @@ grows out of XO toward it, and vanishes with it. */}
 <animate attributeName="opacity" dur="36s" repeatCount="indefinite"
       values="0;0;1;1;0;0" keyTimes="0;0.139;0.15;0.41;0.45;1"/>
 </line>
-<a href="/full_replication" aria-label="Full replication">
+<a href="/backups-and-dr/backup-types/full_replication" aria-label="Full replication">
 <rect x="520" y="115" width="140" height="62" rx="8" fill="none" stroke="rgba(255,255,255,0.22)" strokeDasharray="6 5"/>
 <text x="530" y="132" fontSize="12.5" fill="#7a8699">DR site</text>
 <g opacity="0.45">

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -44,11 +44,11 @@ export default {
           },
           {
             to: '/users-and-access/rbac',
-            from: '/xo6/acl-v2',
+            from: ['/xo6/acl-v2', '/rbac'],
           },
           {
             to: '/manage-your-infrastructure/advanced',
-            from: '/advanced',
+            from: ['/advanced', '/xo5/advanced'],
           },
           {
             to: '/manage-your-infrastructure/advanced#alerts',
@@ -60,7 +60,7 @@ export default {
           },
           {
             to: '/getting-started/architecture',
-            from: '/xo5/architecture',
+            from: ['/xo5/architecture', 'architecture'],
           },
           {
             to: '/getting-started/architecture#plugins',
@@ -68,59 +68,63 @@ export default {
           },
           {
             to: '/backups-and-dr/backup_howto',
-            from: '/xo5/backup_howto',
+            from: ['/xo5/backup_howto', 'backup_howto'],
           },
           {
             to: '/backups-and-dr/calculator',
-            from: '/xo5/calculator',
+            from: ['/xo5/calculator', '/calculator'],
           },
           {
             to: '/backups-and-dr/backup_reports',
-            from: '/backup_reports',
+            from: ['/backup_reports', '/xo5/backup_reports'],
           },
           {
             to: '/backups-and-dr/backup_troubleshooting',
-            from: '/backup_troubleshooting',
+            from: ['/backup_troubleshooting', '/xo5/backup_troubleshooting'],
           },
           {
             to: '/backups-and-dr/backup-features-and-settings',
-            from: '/backups',
+            from: ['/backups', '/xo6/backups', '/xo5/backups'],
           },
           {
             to: '/support-and-licencing/community',
-            from: '/xo6/community',
+            from: ['/xo6/community', '/community'],
           },
           {
             to: '/getting-started/configuration',
-            from: '/xo5/configuration',
+            from: ['/xo5/configuration', 'configuration'],
           },
           {
             to: '/users-and-access/credential-encryption',
-            from: '/xo5/credential-encryption',
+            from: ['/xo5/credential-encryption', '/credential-encryption'],
           },
           {
             to: '/backups-and-dr/backup-types/full_backups',
-            from: '/xo5/full_backups',
+            from: ['/xo5/full_backups', '/full_backups'],
           },
           {
             to: '/backups-and-dr/backup-types/full_replication',
-            from: '/xo5/full_replication',
+            from: ['/xo5/full_replication', '/full_replication'],
           },
           {
             to: '/backups-and-dr/scale-and-security/immutability',
-            from: '/xo5/immutability',
+            from: ['/xo5/immutability', '/immutability'],
           },
           {
             to: '/backups-and-dr/backup-types/incremental_backups',
-            from: '/incremental_backups',
+            from: ['/incremental_backups', '/xo5/incremental_backups'],
           },
           {
             to: '/backups-and-dr/backup-types/incremental_replication',
-            from: '/incremental_replication',
+            from: ['/incremental_replication', '/xo5/incremental_replication'],
           },
           {
             to: '/getting-started/installation',
-            from: '/xo5/installation',
+            from: ['/xoa', '/xo5/xoa', 'installation', '/xo5/installation'],
+          },
+          {
+            to: '/getting-started/install-from-sources',
+            from: 'install-from-sources',
           },
           {
             to: '/backups-and-dr/backup-features-and-settings',
@@ -128,11 +132,11 @@ export default {
           },
           {
             to: '/support-and-licencing/support',
-            from: ['/license_management', '/xo5/license_management', '/xo6/support'],
+            from: ['/license_management', '/xo5/license_management', '/xo6/support', '/support'],
           },
           {
             to: '/manage-your-infrastructure/load_balancing',
-            from: '/load_balancing',
+            from: ['/load_balancing', '/xo5/load_balancing'],
           },
           {
             to: '/manage-your-infrastructure/manage_infrastructure',
@@ -148,7 +152,7 @@ export default {
           },
           {
             to: '/backups-and-dr/backup-types/metadata_backup',
-            from: '/metadata_backup',
+            from: ['/metadata_backup', '/xo5/metadata_backup'],
           },
           {
             to: '/getting-started/migrate_to_new_xoa',
@@ -156,15 +160,15 @@ export default {
           },
           {
             to: '/backups-and-dr/backup-types/mirror_backup',
-            from: '/xo5/mirror_backup',
+            from: ['/xo5/mirror_backup', '/mirror_backup'],
           },
           {
             to: '/backups-and-dr/scale-and-security/object-storage-support',
-            from: '/xo5/object-storage-support',
+            from: ['/xo5/object-storage-support', '/object-storage-support'],
           },
           {
             to: '/backups-and-dr/scale-and-security/proxy',
-            from: '/proxy',
+            from: ['/proxy', '/xo5/proxy'],
           },
           {
             to: '/support-and-licencing/support#licensing',
@@ -204,11 +208,11 @@ export default {
           },
           {
             to: '/backups-and-dr/backup-types/rolling_snapshots',
-            from: '/xo5/rolling_snapshots',
+            from: ['/xo5/rolling_snapshots', '/rolling_snapshots'],
           },
           {
             to: '/manage-your-infrastructure/sdn_controller',
-            from: '/sdn_controller',
+            from: ['/sdn_controller', '/xo5/sdn_controller'],
           },
           {
             to: '/getting-started/supported_hosts',
@@ -224,19 +228,71 @@ export default {
           },
           {
             to: '/users-and-access/users',
-            from: '/users',
+            from: ['/users', '/xo5/users'],
           },
           {
             to: '/guides/v2v-migration-guide',
-            from: '/v2v-migration-guide',
+            from: ['/v2v-migration-guide', '/xo5/v2v-migration-guide'],
+          },
+          {
+            to: '/guides/windows-templates',
+            from: ['/windows-templates'],
           },
           {
             to: '/manage-your-infrastructure/vm-templates',
-            from: '/vm-templates',
+            from: ['/vm-templates', '/xo5/vm-templates'],
           },
           {
-            to: '/getting-started/installation',
-            from: ['/xoa', '/xo5/xoa'],
+            to: '/discover-xen-orchestra/whatsnew',
+            from: '/xo6/whatsnew',
+          },
+          {
+            to: '/discover-xen-orchestra/xo6vsxo5',
+            from: '/xo6/xo6vsxo5',
+          },
+          {
+            to: '/discover-xen-orchestra/gettingstarted',
+            from: '/xo6/gettingstarted',
+          },
+          {
+            to: '/discover-xen-orchestra/coreconcepts',
+            from: '/xo6/coreconcepts',
+          },
+          {
+            to: '/manage-your-infrastructure/management',
+            from: '/xo6/management',
+          },
+          {
+            to: '/manage-your-infrastructure/manage_infrastructure',
+            from: '/xo5/manage_infrastructure',
+          },
+          {
+            to: '/manage-your-infrastructure/ipmi-plugin',
+            from: '/xo5/ipmi-plugin',
+          },
+          {
+            to: '/backups-and-dr/backup',
+            from: '/backup',
+          },
+          {
+            to: '/backups-and-dr/scale-and-security/distributed_backups',
+            from: '/distributed_backups',
+          },
+          {
+            to: '/project/project',
+            from: '/project',
+          },
+          {
+            to: '/project/contributing',
+            from: '/contributing',
+          },
+          {
+            to: '/project/licenses',
+            from: '/licenses',
+          },
+          {
+            to: '/project/glossary',
+            from: '/glossary',
           },
         ],
       },

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -60,7 +60,7 @@ export default {
           },
           {
             to: '/getting-started/architecture',
-            from: ['/xo5/architecture', 'architecture'],
+            from: ['/xo5/architecture', '/architecture'],
           },
           {
             to: '/getting-started/architecture#plugins',
@@ -68,7 +68,7 @@ export default {
           },
           {
             to: '/backups-and-dr/backup_howto',
-            from: ['/xo5/backup_howto', 'backup_howto'],
+            from: ['/xo5/backup_howto', '/backup_howto'],
           },
           {
             to: '/backups-and-dr/calculator',
@@ -92,7 +92,7 @@ export default {
           },
           {
             to: '/getting-started/configuration',
-            from: ['/xo5/configuration', 'configuration'],
+            from: ['/xo5/configuration', '/configuration'],
           },
           {
             to: '/users-and-access/credential-encryption',
@@ -120,11 +120,11 @@ export default {
           },
           {
             to: '/getting-started/installation',
-            from: ['/xoa', '/xo5/xoa', 'installation', '/xo5/installation'],
+            from: ['/xoa', '/xo5/xoa', '/installation', '/xo5/installation'],
           },
           {
             to: '/getting-started/install-from-sources',
-            from: 'install-from-sources',
+            from: '/install-from-sources',
           },
           {
             to: '/backups-and-dr/backup-features-and-settings',

--- a/packages/xo-server-usage-report/.USAGE.md
+++ b/packages/xo-server-usage-report/.USAGE.md
@@ -1,2 +1,2 @@
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/xo5/manage_infrastructure#usage-reports).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/manage-your-infrastructure/manage_infrastructure#usage-reports).

--- a/packages/xo-web/src/common/search-bar.js
+++ b/packages/xo-web/src/common/search-bar.js
@@ -65,7 +65,7 @@ export default class SearchBar extends Component {
         <Tooltip content={_('filterSyntaxLinkTooltip')}>
           <a
             className='input-group-addon'
-            href='https://docs.xen-orchestra.com/xo5/manage_infrastructure#live-filter-search'
+            href='https://docs.xen-orchestra.com/manage-your-infrastructure/manage_infrastructure#live-filter-search'
             rel='noopener noreferrer'
             target='_blank'
           >

--- a/packages/xo-web/src/xo-app/home/index.js
+++ b/packages/xo-web/src/xo-app/home/index.js
@@ -1017,7 +1017,7 @@ export default class Home extends Component {
               <Tooltip content={_('filterSyntaxLinkTooltip')}>
                 <a
                   className='input-group-addon'
-                  href='https://docs.xen-orchestra.com/xo5/manage_infrastructure#live-filter-search'
+                  href='https://docs.xen-orchestra.com/manage-your-infrastructure/manage_infrastructure#live-filter-search'
                   rel='noopener noreferrer'
                   target='_blank'
                 >


### PR DESCRIPTION
## Context

Recently, we changed how the sidebar is generated in the XO documentation. Instead of listing every page in sidebars.ts, the sidebar is now automatically generated from the folder structure, as it already is in the XCP-ng and Vates VMS documentation (see https://github.com/vatesfr/xen-orchestra/pull/10354).

## Issue

As a result, the URLs of several pages changed, but the corresponding redirects were missing. 

## Changes

This pull request: 
- adds redirects from the old URLs to the new ones
- updates the (outdated) links to the XO doc within the XO app

These changes should prevent readers from encountering 404 errors.