### PR TITLE
docs(xo): fix redirections

### DIFF
--- a/@xen-orchestra/web/src/shared/components/modals/FirstConnectionModal.vue
+++ b/@xen-orchestra/web/src/shared/components/modals/FirstConnectionModal.vue
@@ -10,7 +10,7 @@
           <I18nT keypath="popup-first-connection-default-interface">
             <template #documentationLink>
               <UiLink
-                href="https://docs.xen-orchestra.com/configuration#using-xo-5-as-the-default-interface"
+                href="https://docs.xen-orchestra.com/getting-started/configuration#using-xo-5-as-the-default-interface"
                 size="medium"
               >
                 {{ t('popup-first-connection-follow-this-guide') }}

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -84,7 +84,11 @@ export default {
           },
           {
             to: '/backups-and-dr/backup-features-and-settings',
-            from: ['/backups', '/xo6/backups', '/xo5/backups'],
+            from: ['/backups', '/xo5/backups'],
+          },
+          {
+            to: '/backups-and-dr/backups-in-xo6', 
+            from: '/xo6/backups',
           },
           {
             to: '/support-and-licencing/community',
@@ -127,7 +131,7 @@ export default {
             from: '/install-from-sources',
           },
           {
-            to: '/backups-and-dr/backup-features-and-settings',
+            to: '/backups-and-dr/backup',
             from: '/xo5/backup',
           },
           {
@@ -140,11 +144,7 @@ export default {
           },
           {
             to: '/manage-your-infrastructure/manage_infrastructure',
-            from: ['/manage', '/xo5/manage'],
-          },
-          {
-            to: '/manage-your-infrastructure/manage_infrastructure',
-            from: '/manage_infrastructure',
+            from: ['/manage', '/xo5/manage', '/manage_infrastructure'],
           },
           {
             to: '/automation/mcp',
@@ -220,7 +220,7 @@ export default {
           },
           {
             to: '/getting-started/troubleshooting',
-            from: ['/general-troubleshooting', '/xo5/troubleshooting'],
+            from: ['/general-troubleshooting', '/xo5/troubleshooting', '/troubleshooting'],
           },
           {
             to: '/getting-started/updater',
@@ -236,7 +236,7 @@ export default {
           },
           {
             to: '/guides/windows-templates',
-            from: ['/windows-templates'],
+            from: '/windows-templates',
           },
           {
             to: '/manage-your-infrastructure/vm-templates',

--- a/docs/src/clientModules/movedAnchors.ts
+++ b/docs/src/clientModules/movedAnchors.ts
@@ -1,8 +1,8 @@
 /**
  * Old deep links: /xo5/installation#<anchor> used to cover the whole
- * "from the sources" guide, which now lives on /install-from-sources.
+ * "from the sources" guide, which now lives on /getting-started/install-from-sources.
  * The client-redirects plugin preserves the hash when forwarding
- * /xo5/installation to /installation; this module completes the trip
+ * /xo5/installation to /getting-started/installation; this module completes the trip
  * for the anchors that moved to the dedicated sources page.
  */
 const MOVED_TO_SOURCES = new Set([
@@ -26,15 +26,15 @@ const MOVED_TO_SOURCES = new Set([
  * the sections that went elsewhere.
  */
 const MOVED_FROM_XOA: Record<string, string> = {
-  firewall: '/configuration#firewall',
+  firewall: '/getting-started/configuration#firewall',
   timezone: '/configuration#timezone',
   'setting-a-custom-ntp-server': '/configuration#setting-a-custom-ntp-server',
   'restart-the-service': '/configuration#restart-the-service',
-  'technical-support': '/troubleshooting#still-stuck',
+  'technical-support': '/getting-started/troubleshooting#still-stuck',
   'xoa-check': '/troubleshooting#first-reflex-xoa-check',
   'support-tunnel': '/troubleshooting#support-tunnel',
   'ssh-pro-support': '/troubleshooting#support-tunnel',
-  'migrate-from-an-older-xoa': '/migrate_to_new_xoa',
+  'migrate-from-an-older-xoa': '/getting-started/migrate_to_new_xoa',
 }
 
 /**
@@ -59,13 +59,13 @@ export function onRouteDidUpdate({ location }: { location: { pathname: string; h
   }
   const path = location.pathname.replace(/\/+$/, '')
   const anchor = location.hash.replace(/^#/, '')
-  if (path === '/installation' && MOVED_TO_SOURCES.has(anchor)) {
+  if (path === '/getting-started/installation' && MOVED_TO_SOURCES.has(anchor)) {
     window.location.replace(`/install-from-sources#${anchor}`)
   }
-  if (path === '/installation' && MOVED_FROM_XOA[anchor] !== undefined) {
+  if (path === '/getting-started/installation' && MOVED_FROM_XOA[anchor] !== undefined) {
     window.location.replace(MOVED_FROM_XOA[anchor])
   }
-  if (path === '/support' && MOVED_TO_VATES_DOCS[anchor] !== undefined) {
+  if (path === '/support-and-licencing/support' && MOVED_TO_VATES_DOCS[anchor] !== undefined) {
     window.location.replace(MOVED_TO_VATES_DOCS[anchor])
   }
 }

--- a/packages/xo-server-audit/.USAGE.md
+++ b/packages/xo-server-audit/.USAGE.md
@@ -1,2 +1,2 @@
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/getting-started/architecture#plugins).

--- a/packages/xo-server-auth-github/.USAGE.md
+++ b/packages/xo-server-auth-github/.USAGE.md
@@ -8,6 +8,6 @@ same identifier.
 > for more information about the configuration.
 
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/getting-started/architecture#plugins).
 
 ![Registering XO instance in GitHub](github.png)

--- a/packages/xo-server-auth-google/.USAGE.md
+++ b/packages/xo-server-auth-google/.USAGE.md
@@ -26,4 +26,4 @@ Add OAuth 2.0 credentials:
 ### Add the plugin to XO-Server config
 
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/getting-started/architecture#plugins).

--- a/packages/xo-server-auth-ldap/.USAGE.md
+++ b/packages/xo-server-auth-ldap/.USAGE.md
@@ -4,7 +4,7 @@ The first time a user signs in, XO will create a new XO user with the
 same identifier.
 
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/getting-started/architecture#plugins).
 
 ## User email uniqueness
 

--- a/packages/xo-server-auth-oidc/.USAGE.md
+++ b/packages/xo-server-auth-oidc/.USAGE.md
@@ -4,7 +4,7 @@ The first time a user signs in, XO will create a new XO user with the
 same identifier.
 
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/getting-started/architecture#plugins).
 
 > Important: When registering your instance to your identity provider,
 > you must configure its callback URL to

--- a/packages/xo-server-auth-saml/.USAGE.md
+++ b/packages/xo-server-auth-saml/.USAGE.md
@@ -8,7 +8,7 @@ same identifier.
 > for more information about the configuration.
 
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/getting-started/architecture#plugins).
 
 > Important: When registering your instance to your identity provider,
 > you must configure its callback URL to

--- a/packages/xo-server-transport-email/.USAGE.md
+++ b/packages/xo-server-transport-email/.USAGE.md
@@ -1,2 +1,2 @@
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/getting-started/architecture#plugins).

--- a/packages/xo-server-transport-icinga2/.USAGE.md
+++ b/packages/xo-server-transport-icinga2/.USAGE.md
@@ -1,5 +1,5 @@
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/getting-started/architecture#plugins).
 
 ### `Xo#sendIcinga2Status({ status, message })`
 

--- a/packages/xo-server-transport-nagios/.USAGE.md
+++ b/packages/xo-server-transport-nagios/.USAGE.md
@@ -1,5 +1,5 @@
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/getting-started/architecture#plugins).
 
 ### `Xo#sendPassiveCheck( { status, message })`
 

--- a/packages/xo-server-transport-slack/.USAGE.md
+++ b/packages/xo-server-transport-slack/.USAGE.md
@@ -1,5 +1,5 @@
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins). You can also test the configuration plugin if it works.
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/getting-started/architecture#plugins). You can also test the configuration plugin if it works.
 
 ### Slack
 

--- a/packages/xo-server-transport-xmpp/.USAGE.md
+++ b/packages/xo-server-transport-xmpp/.USAGE.md
@@ -1,2 +1,2 @@
 Like all other xo-server plugins, it can be configured directly via
-the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/architecture#plugins).
+the web interface, see [the plugin documentation](https://docs.xen-orchestra.com/getting-started/architecture#plugins).

--- a/packages/xo-web/src/xo-app/backup/new/index.js
+++ b/packages/xo-web/src/xo-app/backup/new/index.js
@@ -128,9 +128,9 @@ export const ReportRecipients = decorate([
   ),
 ])
 
-const SR_BACKEND_FAILURE_LINK = 'https://docs.xen-orchestra.com/backup_troubleshooting#sr_backend_failure_44'
+const SR_BACKEND_FAILURE_LINK = 'https://docs.xen-orchestra.com/backups-and-dr/backup_troubleshooting#sr_backend_failure_44'
 
-export const BACKUP_NG_DOC_LINK = 'https://docs.xen-orchestra.com/backup'
+export const BACKUP_NG_DOC_LINK = 'https://docs.xen-orchestra.com/backups-and-dr/backup'
 
 const ThinProvisionedTip = ({ label }) => (
   <Tooltip content={_(label)}>

--- a/packages/xo-web/src/xo-app/index.js
+++ b/packages/xo-web/src/xo-app/index.js
@@ -483,7 +483,7 @@ export default class XoApp extends Component {
                     {_('disclaimerText3')}
                   </a>{' '}
                   <a
-                    href='https://docs.xen-orchestra.com/installation#banner-and-warnings'
+                    href='https://docs.xen-orchestra.com/getting-started/install-from-sources#about-the-banner'
                     rel='noopener noreferrer'
                     target='_blank'
                   >


### PR DESCRIPTION
Following the overhaul applied by PR https://github.com/vatesfr/xen-orchestra/pull/10354, URLs for the XO doc got changed across the whole documentation.

This new PR:
- adds page redirects that were still missing
- updates redirects that point to the wrong page
- deduplicates redirects
- updates dead or outdated links to the XO doc, within the Xen Orchestra app. 

As a result, this should eliminate or greatly reduce the risk of running into `404 Not Found` errors.

Thanks @olivierlambert for pointing these out!